### PR TITLE
Fix stage zoom behaviour when verticalfollow is 0

### DIFF
--- a/src/camera.go
+++ b/src/camera.go
@@ -57,13 +57,9 @@ func (c *Camera) Init() {
 	c.halfWidth = float32(sys.gameWidth) / 2
 	c.XMin = c.boundL - c.halfWidth/c.BaseScale()
 	c.XMax = c.boundR + c.halfWidth/c.BaseScale()
-	if c.verticalfollow > 0 {
-		c.boundH = MinF(0, float32(c.boundhigh)*c.localscl+
-			float32(sys.gameHeight)-c.drawOffsetY-
-			float32(sys.gameWidth)*float32(c.localcoord[1])/float32(c.localcoord[0]))
-	} else {
-		c.boundH = 0
-	}
+	c.boundH = MinF(0, float32(c.boundhigh)*c.localscl+
+		float32(sys.gameHeight)-c.drawOffsetY-
+		float32(sys.gameWidth)*float32(c.localcoord[1])/float32(c.localcoord[0]))
 	if c.boundhigh > 0 {
 		c.boundH += float32(c.boundhigh) * c.localscl
 	}


### PR DESCRIPTION
Vertical bounds need to be computed even when verticalfollow is 0, because they
are needed to apply the zoom level. Without this fix, one would need to set
verticalfollow to e.g. 0.0001 in order for zoomout to have any effect.