### PR TITLE
Add general paths search support to system.def file 'Module'

### DIFF
--- a/external/script/motif.lua
+++ b/external/script/motif.lua
@@ -2500,6 +2500,7 @@ for _, v in ipairs({
 	{group = 'files', param = 'select', dirs = {motif.fileDir, '', 'data/'}},
 	{group = 'files', param = 'fight', dirs = {motif.fileDir, '', 'data/'}},
 	{group = 'files', param = 'glyphs', dirs = {motif.fileDir, '', 'data/'}},
+	{group = 'files', param = 'module', dirs = {motif.fileDir, '', 'data/'}},	
 	{group = 'music', param = 'title_bgm', dirs = {motif.fileDir, '', 'data/', 'sound/'}},
 	{group = 'music', param = 'select_bgm', dirs = {motif.fileDir, '', 'data/', 'sound/'}},
 	{group = 'music', param = 'vs_bgm', dirs = {motif.fileDir, '', 'data/', 'sound/'}},


### PR DESCRIPTION
This change increases motif/screenpack portability by letting the external module file defined in _[Files]_ section at _system.def_ to be detected inside the motif subdirectory (or data folder). Without this, the full path to the module has to be declared for it to work.