### PR TITLE
fix offset controller bug

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6315,9 +6315,9 @@ func (sc offset) Run(c *Char, _ []int32) bool {
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case offset_x:
-			crun.offset[0] = exp[0].evalF(c)
+			crun.offset[0] = exp[0].evalF(c) * crun.localscl
 		case offset_y:
-			crun.offset[1] = exp[0].evalF(c)
+			crun.offset[1] = exp[0].evalF(c) * crun.localscl
 		case offset_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid

--- a/src/char.go
+++ b/src/char.go
@@ -5007,10 +5007,10 @@ func (c *Char) exitTarget(explremove bool) {
 	c.ghv.hitBy = c.ghv.hitBy[:0]
 }
 func (c *Char) offsetX() float32 {
-	return float32(c.size.draw.offset[0])*c.facing + c.offset[0]
+	return float32(c.size.draw.offset[0])*c.facing + c.offset[0]/c.localscl
 }
 func (c *Char) offsetY() float32 {
-	return float32(c.size.draw.offset[1]) + c.offset[1]
+	return float32(c.size.draw.offset[1]) + c.offset[1]/c.localscl
 }
 func (c *Char) projClsnCheck(p *Projectile, gethit bool) bool {
 	if p.ani == nil || c.curFrame == nil || c.scf(SCF_standby) || c.scf(SCF_disabled) {


### PR DESCRIPTION
This commit fixes a bug where the offset value set by the offset controller is scaled incorrectly when 
-  the characters are in different localcoord
- p2 is in p1's state and non zero offset is set by the offset controller.
- p2 get back to it's state by selfstate or getting hit by p1 -> p2's localscl is changed and the offset value is scaled incorrectly.