### PR TITLE
Fix a regression in the audio normalizer

### DIFF
--- a/src/sound.go
+++ b/src/sound.go
@@ -79,7 +79,7 @@ func (n *NormalizerLR) process(bai float64, sam *float64) float64 {
 	n.heri += n.herihenka
 	if n.heri < 0 {
 		n.heri = 0
-	} else if n.heri > 0 {
+	} else if n.heri > 1 {
 		n.heri = 1
 	}
 	*sam = s


### PR DESCRIPTION
This issue was introduced when porting Ikemen to Ikemen Go. The original code can be
seen here: https://github.com/Midiman/ikemen/blob/master/src/alpha/sdlplugin/sdlplugin/sdlplugin.cpp#L811