### PR TITLE
Move core TTF loading code to a platform-specific file

### DIFF
--- a/src/util_desktop.go
+++ b/src/util_desktop.go
@@ -3,13 +3,48 @@
 package main
 
 import (
+	findfont "github.com/flopp/go-findfont"
+	"github.com/ikemen-engine/glfont"
 	"github.com/sqweek/dialog"
 )
 
+// Message box implementation
 func ShowInfoDialog(message, title string) {
 	dialog.Message(message).Title(title).Info()
 }
 
 func ShowErrorDialog(message string) {
 	dialog.Message(message).Title("I.K.E.M.E.N Error").Error()
+}
+
+// TTF font loading
+func LoadFntTtf(f *Fnt, fontfile string, filename string, height int32) {
+	//Search in local directory
+	fileDir := SearchFile(filename, []string{fontfile, sys.motifDir, "", "data/", "font/"})
+	//Search in system directory
+	fp := fileDir
+	if fp = FileExist(fp); len(fp) == 0 {
+		var err error
+		fileDir, err = findfont.Find(fileDir)
+		if err != nil {
+			panic(err)
+		}
+	}
+	//Load ttf
+	if height == -1 {
+		height = int32(f.Size[1])
+	} else {
+		f.Size[1] = uint16(height)
+	}
+	ttf, err := glfont.LoadFont(fileDir, height, int(sys.gameWidth), int(sys.gameHeight), sys.fontShaderVer)
+	if err != nil {
+		panic(err)
+	}
+	f.ttf = ttf
+
+	//Create Ttf dummy palettes
+	f.palettes = make([][256]uint32, 1)
+	for i := 0; i < 256; i++ {
+		f.palettes[0][i] = 0
+	}
 }

--- a/src/util_js.go
+++ b/src/util_js.go
@@ -6,6 +6,7 @@ import (
 	"syscall/js"
 )
 
+// Message box implementation using basic JavaScript alert()
 var alert = js.Global().Get("alert")
 
 func ShowInfoDialog(message, title string) {
@@ -14,4 +15,9 @@ func ShowInfoDialog(message, title string) {
 
 func ShowErrorDialog(message string) {
 	alert.Invoke("I.K.E.M.E.N Error\n\n" + message)
+}
+
+// TTF font loading stub
+func LoadFntTtf(f *Fnt, fontfile string, filename string, height int32) {
+	panic(Error("TrueType fonts are not supported on this platform"))
 }


### PR DESCRIPTION
This allows to disable TTF loading when targeting JavaScript, which does not have the findfont or glfont libraries.