### PR TITLE
Fix an old regression in rectangle filling transparency handling

### DIFF
--- a/src/render.go
+++ b/src/render.go
@@ -716,7 +716,7 @@ func FillRect(rect [4]int32, color uint32, trans int32) {
 		gl.BlendEquation(gl.FUNC_ADD)
 		fill(1)
 	} else if trans == -2 {
-		gl.BlendFunc(gl.ZERO, gl.ONE_MINUS_SRC_COLOR)
+		gl.BlendFunc(gl.ONE, gl.ONE)
 		gl.BlendEquation(gl.FUNC_REVERSE_SUBTRACT)
 		fill(1)
 	} else if trans <= 0 {


### PR DESCRIPTION
In [this commit](https://github.com/ikemen-engine/Ikemen-GO/commit/e23161f57c1cc2de8f74107a107c923c2cd87141#diff-0d62a85b439ea91ae235e4018009720f110b12f7ce5c2f5d75816411a716f395L329) from 2018, @NeatUnsou changed the rendering method in `rmMainSub()` so that it does not necessarily use additive blending, which allowed the `alpha = -2` case to be handled properly: the final colour is `dst - src`, whereas it used to be `dst - src * dst`.

However when the blend equation change was reflected in `FillRect` in [this commit](https://github.com/ikemen-engine/Ikemen-GO/commit/a57a61a1e87cd9a50df1b557e50312df7b26824c#diff-0d62a85b439ea91ae235e4018009720f110b12f7ce5c2f5d75816411a716f395L701) the blend function was not modified, so the final blended colour is still `dst - src * dst`.