### PR TITLE
add camerabound parameter for zoom

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6346,6 +6346,7 @@ const (
 	zoom_scale
 	zoom_lag
 	zoom_redirectid
+	zoom_camerabound
 )
 
 func (sc zoom) Run(c *Char, _ []int32) bool {
@@ -6361,6 +6362,8 @@ func (sc zoom) Run(c *Char, _ []int32) bool {
 		case zoom_scale:
 			sys.zoomScale = exp[0].evalF(c)
 			sys.enableZoomstate = true
+		case zoom_camerabound:
+			sys.zoomCameraBound = exp[0].evalB(c)
 		case zoom_lag:
 			sys.zoomlag = exp[0].evalF(c)
 		case zoom_redirectid:

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -3417,6 +3417,10 @@ func (c *Compiler) zoom(is IniSection, sc *StateControllerBase, _ int8) (StateCo
 			zoom_lag, VT_Float, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "camerabound",
+			zoom_camerabound, VT_Bool, 1, false); err != nil {
+			return err
+		}
 		return nil
 	})
 	return *ret, err

--- a/src/system.go
+++ b/src/system.go
@@ -218,6 +218,7 @@ type System struct {
 	zoomPosXLag             float32
 	zoomPosYLag             float32
 	enableZoomstate         bool
+	zoomCameraBound         bool
 	zoomPos                 [2]float32
 	debugWC                 *Char
 	cam                     Camera
@@ -1114,6 +1115,7 @@ func (s *System) action(x, y *float32, scl float32) (leftest, rightest,
 			s.envcol_time--
 		}
 		s.enableZoomstate = false
+		s.zoomCameraBound = true
 		if s.super > 0 {
 			s.super--
 		} else if s.pause > 0 {
@@ -2109,8 +2111,13 @@ func (s *System) fight() (reload bool) {
 					s.zoomPosYLag += ((s.zoomPos[1] - s.zoomPosYLag) * (1 - s.zoomlag))
 					s.drawScale = s.drawScale / (s.drawScale + (s.zoomScale*scl-s.drawScale)*s.zoomlag) * s.zoomScale * scl
 				}
-				dscl = MaxF(s.cam.MinScale, s.drawScale/s.cam.BaseScale())
-				dx = s.cam.XBound(dscl, x+s.zoomPosXLag/scl)
+				if s.zoomCameraBound {
+					dscl = MaxF(s.cam.MinScale, s.drawScale/s.cam.BaseScale())
+					dx = s.cam.XBound(dscl, x+s.zoomPosXLag/scl)
+				} else {
+					dscl = s.drawScale / s.cam.BaseScale()
+					dx = x + s.zoomPosXLag/scl
+				}
 				dy = y + s.zoomPosYLag
 			} else {
 				s.zoomlag = 0


### PR DESCRIPTION
This commit adds a new parameter camerabound for zoom. Setting it to 0 allows the camera to move beyond the boundary set by the stage.