### PR TITLE
・永続ターゲット(Reversaldef marking)がMUGENと同様に機能するように修正

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1344,7 +1344,7 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 	case OC_const_data_defence:
 		sys.bcStack.PushI(c.gi().data.defence)
 	case OC_const_data_fall_defence_mul:
-		sys.bcStack.PushF(c.gi().data.fall.defence_mul)
+		sys.bcStack.PushF(1.0 / c.gi().data.fall.defence_mul)
 	case OC_const_data_liedown_time:
 		sys.bcStack.PushI(c.gi().data.liedown.time)
 	case OC_const_data_airjuggle:

--- a/src/char.go
+++ b/src/char.go
@@ -3178,6 +3178,27 @@ func (c *Char) changeStateEx(no int32, pn int, anim, ctrl int32, ffx bool) {
 		}
 		sys.changeStateNest = 0
 	}
+	if c.hitdef.reversal_attr <= 0 {
+		for i, tid := range c.targets {
+			if t := sys.playerID(tid); t != nil {
+				for {
+					if i >= len(c.targets) {
+						break
+					}
+					if t.ss.moveType != MT_H {
+						c.targets[i] = c.targets[len(c.targets)-1]
+						c.targets = c.targets[:len(c.targets)-1]
+						t.ghv.hitid = -1
+					} else {
+						break
+					}
+				}
+				if i+1 >= len(c.targets) {
+					break
+				}
+			}
+		}
+	}
 }
 func (c *Char) changeState(no, anim, ctrl int32, ffx bool) {
 	c.changeStateEx(no, c.ss.sb.playerNo, anim, ctrl, ffx)
@@ -4971,9 +4992,13 @@ func (c *Char) exitTarget(explremove bool) {
 	if c.hittmp >= 0 {
 		for _, hb := range c.ghv.hitBy {
 			if e := sys.playerID(hb[0]); e != nil {
-				e.removeTarget(c.id)
-				if explremove {
-					c.enemyExplodsRemove(e.playerNo)
+				if e.hitdef.reversal_attr <= 0 {
+					e.removeTarget(c.id)
+					if explremove {
+						c.enemyExplodsRemove(e.playerNo)
+					}
+				} else {
+					c.ghv.hitid = c.ghv.hitid >> 31
 				}
 			}
 		}
@@ -5456,7 +5481,7 @@ func (c *Char) update(cvmin, cvmax,
 				c.ghv.hitshaketime = 0
 				c.ghv.fallf = false
 				c.ghv.fallcount = 0
-				c.ghv.hitid = -1
+				c.ghv.hitid = c.ghv.hitid >> 31
 				// Mugen has a combo delay in lifebar were is active for 1 frame more than it should.
 				if c.comboExtraFrameWindow <= 0 {
 					c.fakeReceivedHits = 0

--- a/src/char.go
+++ b/src/char.go
@@ -3153,6 +3153,23 @@ func (c *Char) stateChange1(no int32, pn int) bool {
 func (c *Char) stateChange2() bool {
 	if c.stchtmp && !c.hitPause() {
 		c.ss.sb.init(c)
+		if c.hitdef.reversal_attr <= 0 {
+			i := 0
+			for i < len(c.targets) {
+				if i >= len(c.targets) {
+					break
+				}
+				if t := sys.playerID(c.targets[i]); t != nil {
+					if t.ss.moveType != MT_H {
+						c.targets[i] = c.targets[len(c.targets)-1]
+						c.targets = c.targets[:len(c.targets)-1]
+						t.ghv.hitid = -1
+					} else {
+						i++
+					}
+				}
+			}
+		}
 		c.stchtmp = false
 		return true
 	}
@@ -3177,27 +3194,6 @@ func (c *Char) changeStateEx(no int32, pn int, anim, ctrl int32, ffx bool) {
 			}
 		}
 		sys.changeStateNest = 0
-	}
-	if c.hitdef.reversal_attr <= 0 {
-		for i, tid := range c.targets {
-			if t := sys.playerID(tid); t != nil {
-				for {
-					if i >= len(c.targets) {
-						break
-					}
-					if t.ss.moveType != MT_H {
-						c.targets[i] = c.targets[len(c.targets)-1]
-						c.targets = c.targets[:len(c.targets)-1]
-						t.ghv.hitid = -1
-					} else {
-						break
-					}
-				}
-				if i+1 >= len(c.targets) {
-					break
-				}
-			}
-		}
 	}
 }
 func (c *Char) changeState(no, anim, ctrl int32, ffx bool) {

--- a/src/script.go
+++ b/src/script.go
@@ -2736,7 +2736,7 @@ func triggerFunctions(l *lua.LState) {
 		case "data.defence":
 			ln = lua.LNumber(c.gi().data.defence)
 		case "data.fall.defence_mul":
-			ln = lua.LNumber(c.gi().data.fall.defence_mul)
+			ln = lua.LNumber(1.0 / c.gi().data.fall.defence_mul)
 		case "data.liedown.time":
 			ln = lua.LNumber(c.gi().data.liedown.time)
 		case "data.airjuggle":


### PR DESCRIPTION
・永続ターゲット(Reversaldef marking)がMUGENと同様に機能するように修正
・Const(Data.Fall.Defence_Mul)トリガーの数値が反転していたのを修正