### PR TITLE
Background sprite hiding when window off-screen

### DIFF
--- a/src/stage.go
+++ b/src/stage.go
@@ -402,9 +402,11 @@ func (bg backGround) draw(pos [2]float32, scl, bgscl, lclscl float32,
 	rect[1] = int32(math.Floor(float64(startrect1)))
 	rect[2] = int32(math.Floor(float64(startrect0 + (float32(rect[2]) * sys.widthScale * wscl[0]) - float32(rect[0]))))
 	rect[3] = int32(math.Floor(float64(startrect1 + (float32(rect[3]) * sys.heightScale * wscl[1]) - float32(rect[1]))))
-	bg.anim.Draw(&rect, x, y, sclx, scly, bg.xscale[0]*bgscl*(bg.scalestart[0]+xs)*xs3, xbs*bgscl*(bg.scalestart[0]+xs)*xs3, ys*ys3,
-		xras*x/(AbsF(ys*ys3)*lscl[1]*float32(bg.anim.spr.Size[1])*bg.scalestart[1])*sclx_recip*bg.scalestart[1],
-		Rotation{}, float32(sys.gameWidth)/2, &sys.bgPalFX, true, 1, false, 1, 0, 0)
+	if rect[0] < sys.scrrect[2] && rect[1] < sys.scrrect[3] && rect[0] + rect[2] > 0 && rect[1] + rect[3] > 0 {
+		bg.anim.Draw(&rect, x, y, sclx, scly, bg.xscale[0]*bgscl*(bg.scalestart[0]+xs)*xs3, xbs*bgscl*(bg.scalestart[0]+xs)*xs3, ys*ys3,
+			xras*x/(AbsF(ys*ys3)*lscl[1]*float32(bg.anim.spr.Size[1])*bg.scalestart[1])*sclx_recip*bg.scalestart[1],
+			Rotation{}, float32(sys.gameWidth)/2, &sys.bgPalFX, true, 1, false, 1, 0, 0)
+	}
 }
 
 type bgCtrl struct {


### PR DESCRIPTION
Due to a bug, whenever a window moves off-screen, at least in the x-direction and to the left, if it moves far enough off-screen, the bounding box goes haywire, where it will now assume the maximum size (width).

Before:
![ikemen001](https://user-images.githubusercontent.com/646757/173161178-59500656-3083-452d-a320-7bb99fab2940.png)

After:
![ikemen002](https://user-images.githubusercontent.com/646757/173161191-ae74c08b-ea8b-452d-b303-8ac997d36fb2.png)

This fix was made after trying to figuring out what went wrong with one of my stages, [Butter Building](https://area91.garycxjk.com/mugen/stages/nintendo/kirby/kabutterbuilding). As a side note, only the non-zoom version works properly, due to sprite positions not being rounded down to the pixel. The main issues were with the Shotzo (the cannons). To give them the illusion that they turn with the tower, I used `window` / `maskwindow` which have a very high delta, so that they'd immediately hide the Shotzo sprites whenever they should be invisible.
