### PR TITLE
・攻撃判定の処理時にHitdefattrを持つキャラの優先度が高くなるようにした。

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -3152,7 +3152,7 @@ func (c *Char) stateChange2() bool {
 					break
 				}
 				if t := sys.playerID(c.targets[i]); t != nil {
-					if t.ss.moveType != MT_H {
+					if t.ss.moveType != MT_H && !t.stchtmp {
 						c.targets[i] = c.targets[len(c.targets)-1]
 						c.targets = c.targets[:len(c.targets)-1]
 						t.ghv.hitid = -1
@@ -6519,7 +6519,6 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 	if getter.scf(SCF_standby) || getter.scf(SCF_disabled) {
 		return
 	}
-
 	if proj {
 		for i, pr := range sys.projs {
 			if len(sys.projs[i]) == 0 {
@@ -6790,9 +6789,30 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 	}
 }
 func (cl *CharList) getHit() {
-	for _, c := range cl.runOrder {
-		cl.clsn(c, false)
+
+	sortedOrder := []int{}
+	for i, c := range cl.runOrder {
+		if c.hitdef.attr > 0 {
+			sortedOrder = append(sortedOrder, i)
+		}
 	}
+	soNum := []int{}
+	soCount := 0
+	for i := 0; i < len(cl.runOrder); i++ {
+		if soCount < len(sortedOrder) {
+			if sortedOrder[soCount] == i {
+				soCount++
+				continue
+			}
+		}
+		soNum = append(soNum, i)
+	}
+	sortedOrder = append(sortedOrder, soNum...)
+
+	for i := 0; i < len(cl.runOrder); i++ {
+		cl.clsn(cl.runOrder[sortedOrder[i]], false)
+	}
+
 	for _, c := range cl.runOrder {
 		cl.clsn(c, true)
 	}

--- a/src/system.go
+++ b/src/system.go
@@ -2046,8 +2046,8 @@ func (s *System) fight() (reload bool) {
 								}
 							}
 						}
-					//} else {
-					//	s.chars[i][0].life = 0
+						//} else {
+						//	s.chars[i][0].life = 0
 					}
 				}
 				// If match isn't over, presumably this is turns mode,


### PR DESCRIPTION
・攻撃判定の処理時にHitdefattrを持つキャラの優先度が高くなるようにした。
・Reversaldefでp2statenoを指定するとターゲットが取れない場合があったのを修正