### PR TITLE
Tiling optimisation

### DIFF
--- a/src/gl.go
+++ b/src/gl.go
@@ -2,9 +2,95 @@ package main
 
 import (
 	"runtime"
+	"strings"
 
 	gl "github.com/fyne-io/gl-js"
 )
+
+// ------------------------------------------------------------------
+// ShaderProgram
+
+type ShaderProgram struct {
+	// Program
+	program gl.Program
+	// Attribute locations (sprite shaders)
+	aPos gl.Attrib
+	aUv  gl.Attrib
+	// Attribute locations (postprocess shaders)
+	aVert gl.Attrib
+	// Common uniforms used by most shaders
+	uModelView  gl.Uniform
+	uProjection gl.Uniform
+	uTexture    gl.Uniform
+	uAlpha      gl.Uniform
+	// Additional uniforms
+	u map[string]gl.Uniform
+}
+
+func newShaderProgram(vert, frag, id string) (s *ShaderProgram) {
+	vertObj := compileShader(gl.VERTEX_SHADER, vert)
+	fragObj := compileShader(gl.FRAGMENT_SHADER, frag)
+	prog := linkProgram(vertObj, fragObj)
+	gl.ObjectLabel(prog, id)
+
+	s = &ShaderProgram{program: prog}
+	s.aPos = gl.GetAttribLocation(s.program, "position")
+	s.aUv = gl.GetAttribLocation(s.program, "uv")
+	s.aVert = gl.GetAttribLocation(s.program, "VertCoord")
+
+	s.uModelView = gl.GetUniformLocation(s.program, "modelview")
+	s.uProjection = gl.GetUniformLocation(s.program, "projection")
+	s.uTexture = gl.GetUniformLocation(s.program, "tex")
+	s.uAlpha = gl.GetUniformLocation(s.program, "alpha")
+	s.u = make(map[string]gl.Uniform)
+	return
+}
+
+func (s *ShaderProgram) RegisterUniforms(names ...string) {
+	for _, name := range names {
+		s.u[name] = gl.GetUniformLocation(s.program, name)
+	}
+}
+
+func (s *ShaderProgram) UseProgram() {
+	gl.UseProgram(s.program)
+}
+
+func compileShader(shaderType gl.Enum, src string) (shader gl.Shader) {
+	shader = gl.CreateShader(shaderType)
+	if !strings.Contains(src, "gl_TexCoord") {
+		src = "#version 100\nprecision highp float;\n" + src
+	}
+	gl.ShaderSource(shader, src)
+	gl.CompileShader(shader)
+	ok := gl.GetShaderi(shader, gl.COMPILE_STATUS)
+	if ok == 0 {
+		log := gl.GetShaderInfoLog(shader)
+		gl.DeleteShader(shader)
+		panic(Error("Shader compile error: " + log))
+	}
+	return
+}
+
+func linkProgram(v, f gl.Shader) (program gl.Program) {
+	program = gl.CreateProgram()
+	gl.AttachShader(program, v)
+	gl.AttachShader(program, f)
+	gl.LinkProgram(program)
+	// Mark shaders for deletion when the program is deleted
+	gl.DeleteShader(v)
+	gl.DeleteShader(f)
+	ok := gl.GetProgrami(program, gl.LINK_STATUS)
+	if ok == 0 {
+		log := gl.GetProgramInfoLog(program)
+		gl.DeleteProgram(program)
+		panic(Error("Link error: " + log))
+	}
+	return
+}
+
+// ------------------------------------------------------------------
+// Texture
 
 type Texture struct {
 	handle gl.Texture
@@ -13,7 +99,11 @@ type Texture struct {
 // Generate a new texture name
 func newTexture() (t *Texture) {
 	t = &Texture{gl.CreateTexture()}
-	runtime.SetFinalizer(t, (*Texture).finalizer)
+	runtime.SetFinalizer(t, func (t *Texture) {
+		sys.mainThreadTask <- func() {
+			gl.DeleteTexture(t.handle)
+		}
+	})
 	return
 }
 
@@ -33,16 +123,9 @@ func (t *Texture) SetData(width, height, depth int32, filter bool, data []byte) 
 
 	gl.BindTexture(gl.TEXTURE_2D, t.handle)
 	gl.PixelStorei(gl.UNPACK_ALIGNMENT, 1)
-	gl.TexImage2D(gl.TEXTURE_2D, 0, int(width), int(height),
-		format, gl.UNSIGNED_BYTE, data)
+	gl.TexImage2D(gl.TEXTURE_2D, 0, int(width), int(height), format, gl.UNSIGNED_BYTE, data)
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, interp)
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, interp)
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
-}
-
-func (t *Texture) finalizer() {
-	sys.mainThreadTask <- func() {
-		gl.DeleteTexture(t.handle)
-	}
 }

--- a/src/image.go
+++ b/src/image.go
@@ -1339,17 +1339,10 @@ func captureScreen() {
 		}
 		img.Pix[j] = pixdata[i]
 	}
-	var filename string
 	for i := sys.captureNum; i < 999; i++ {
-		if i < 10 {
-			filename = fmt.Sprintf("ikemen00%d.png", i)
-		} else if i < 100 {
-			filename = fmt.Sprintf("ikemen0%d.png", i)
-		} else {
-			filename = fmt.Sprintf("ikemen%d.png", i)
-		}
-		if _, err := os.Stat(sys.screenshotFolder + filename); os.IsNotExist(err) {
-			file, _ := os.Create(sys.screenshotFolder + filename)
+		filename := fmt.Sprintf("%sikemen%03d.png", sys.screenshotFolder, i)
+		if _, err := os.Stat(filename); os.IsNotExist(err) {
+			file, _ := os.Create(filename)
 			defer file.Close()
 			png.Encode(file, img)
 			sys.captureNum = i

--- a/src/render.go
+++ b/src/render.go
@@ -241,8 +241,10 @@ func drawQuads(s *ShaderProgram, modelview mgl.Mat4, x1, y1, x2, y2, x3, y3, x4,
 	gl.DrawArrays(gl.TRIANGLE_STRIP, 0, 4)
 }
 
-func rmTileHSub(s *ShaderProgram, modelview mgl.Mat4, x1, y1, x2, y2, x3, y3, x4, y4, xtw, xbw, xts, xbs float32,
+func rmTileHSub(s *ShaderProgram, modelview mgl.Mat4, x1, y1, x2, y2, x3, y3, x4, y4, width float32,
 	tl Tiling, rcx float32) {
+	xtw, xbw := x3-x4, x2-x1
+	xts, xbs := xtw/width, xbw/width
 	topdist := xtw + xts*float32(tl.sx)
 	if AbsF(topdist) >= 0.01 {
 		botdist := xbw + xbs*float32(tl.sx)
@@ -375,8 +377,8 @@ func rmTileSub(s *ShaderProgram, modelview mgl.Mat4, rp RenderParams) {
 			}
 			if (0 > y1d || 0 > y4d) &&
 				(y1d > float32(-sys.scrrect[3]) || y4d > float32(-sys.scrrect[3])) {
-				rmTileHSub(s, modelview, x1d, y1d, x2d, y2d, x3d, y3d, x4d, y4d, x3d-x4d, x2d-x1d,
-					(x3d-x4d)/float32(rp.size[0]), (x2d-x1d)/float32(rp.size[0]), rp.tile, rp.rcx)
+				rmTileHSub(s, modelview, x1d, y1d, x2d, y2d, x3d, y3d, x4d, y4d,
+					float32(rp.size[0]), rp.tile, rp.rcx)
 			}
 		}
 	}
@@ -392,8 +394,8 @@ func rmTileSub(s *ShaderProgram, modelview mgl.Mat4, rp RenderParams) {
 			}
 			if (0 > y1 || 0 > y4) &&
 				(y1 > float32(-sys.scrrect[3]) || y4 > float32(-sys.scrrect[3])) {
-				rmTileHSub(s, modelview, x1, y1, x2, y2, x3, y3, x4, y4, x3-x4, x2-x1,
-					(x3-x4)/float32(rp.size[0]), (x2-x1)/float32(rp.size[0]), rp.tile, rp.rcx)
+				rmTileHSub(s, modelview, x1, y1, x2, y2, x3, y3, x4, y4,
+					float32(rp.size[0]), rp.tile, rp.rcx)
 			}
 			if rp.tile.y != 1 && n != 0 {
 				n--

--- a/src/render.go
+++ b/src/render.go
@@ -137,6 +137,9 @@ var identFragShader string
 // Render initialization.
 // Creates the default shaders, the framebuffer and enables MSAA.
 func RenderInit() {
+	sys.errLog.Printf("Using OpenGL %v (%v)",
+		gl.GetString(gl.VERSION), gl.GetString(gl.RENDERER))
+
 	compile := func(shaderType gl.Enum, src string) (shader gl.Shader) {
 		shader = gl.CreateShader(shaderType)
 		gl.ShaderSource(shader, "#version 100\nprecision highp float;\n"+src)

--- a/src/render.go
+++ b/src/render.go
@@ -236,20 +236,11 @@ func drawQuads(s *ShaderProgram, modelview mgl.Mat4, x1, y1, x2, y2, x3, y3, x4,
 		gl.Uniform4f(u, x1, x2, x4, x3)
 	}
 	vertexPosition := f32.Bytes(binary.LittleEndian, x2, y2, x3, y3, x1, y1, x4, y4)
-	gl.BindBuffer(gl.ARRAY_BUFFER, vertexBuffer)
 	gl.BufferData(gl.ARRAY_BUFFER, vertexPosition, gl.STATIC_DRAW)
-	gl.EnableVertexAttribArray(s.aPos)
-	gl.VertexAttribPointer(s.aPos, 2, gl.FLOAT, false, 0, 0)
-
-	gl.BindBuffer(gl.ARRAY_BUFFER, uvBuffer)
-	gl.EnableVertexAttribArray(s.aUv)
-	gl.VertexAttribPointer(s.aUv, 2, gl.FLOAT, false, 0, 0)
 
 	gl.DrawArrays(gl.TRIANGLE_STRIP, 0, 4)
-
-	gl.DisableVertexAttribArray(s.aPos)
-	gl.DisableVertexAttribArray(s.aUv)
 }
+
 func rmTileHSub(s *ShaderProgram, modelview mgl.Mat4, x1, y1, x2, y2, x3, y3, x4, y4, xtw, xbw, xts, xbs float32,
 	tl Tiling, rcx float32) {
 	topdist := xtw + xts*float32(tl.sx)
@@ -428,10 +419,22 @@ func rmMainSub(s *ShaderProgram, rp RenderParams) {
 
 	modelview := mgl.Translate3D(0, float32(sys.scrrect[3]), 0)
 
+	gl.BindBuffer(gl.ARRAY_BUFFER, uvBuffer)
+	gl.EnableVertexAttribArray(s.aUv)
+	gl.VertexAttribPointer(s.aUv, 2, gl.FLOAT, false, 0, 0)
+
+	// Keep vertexBuffer bound so that it can be updated in drawQuads()
+	gl.BindBuffer(gl.ARRAY_BUFFER, vertexBuffer)
+	gl.EnableVertexAttribArray(s.aPos)
+	gl.VertexAttribPointer(s.aPos, 2, gl.FLOAT, false, 0, 0)
+
 	renderWithBlending(func(a float32) {
 		gl.Uniform1f(s.uAlpha, a)
 		rmTileSub(s, modelview, rp)
 	}, rp.trans, rp.paltex != nil)
+
+	gl.DisableVertexAttribArray(s.aPos)
+	gl.DisableVertexAttribArray(s.aUv)
 
 	gl.Disable(gl.SCISSOR_TEST)
 }

--- a/src/render.go
+++ b/src/render.go
@@ -73,7 +73,7 @@ var rbo_depth gl.Renderbuffer
 
 // MSAA
 var fbo_f gl.Framebuffer
-var fbo_f_texture gl.Texture
+var fbo_f_texture *Texture
 
 var postVertBuffer gl.Buffer
 var postShaderSelect []*ShaderProgram
@@ -162,13 +162,8 @@ func RenderInit() {
 	gl.BindTexture(gl.TEXTURE_2D, gl.NoTexture)
 
 	if sys.multisampleAntialiasing {
-		fbo_f_texture = gl.CreateTexture()
-		gl.BindTexture(gl.TEXTURE_2D, fbo_f_texture)
-		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
-		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
-		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
-		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
-		gl.TexImage2D(gl.TEXTURE_2D, 0, int(sys.scrrect[2]), int(sys.scrrect[3]), gl.RGBA, gl.UNSIGNED_BYTE, nil)
+		fbo_f_texture = newTexture()
+		fbo_f_texture.SetData(sys.scrrect[2], sys.scrrect[3], 32, false, nil)
 	} else {
 		rbo_depth = gl.CreateRenderbuffer()
 		gl.ObjectLabel(rbo_depth, "Depth Renderbuffer")
@@ -186,7 +181,7 @@ func RenderInit() {
 
 		fbo_f = gl.CreateFramebuffer()
 		gl.BindFramebuffer(gl.FRAMEBUFFER, fbo_f)
-		gl.FramebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, fbo_f_texture, 0)
+		gl.FramebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, fbo_f_texture.handle, 0)
 	} else {
 		gl.FramebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, fbo_texture, 0)
 		gl.FramebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, rbo_depth)
@@ -218,7 +213,7 @@ func unbindFB() {
 	postShader.UseProgram()
 
 	if sys.multisampleAntialiasing {
-		gl.BindTexture(gl.TEXTURE_2D, fbo_f_texture)
+		gl.BindTexture(gl.TEXTURE_2D, fbo_f_texture.handle)
 	} else {
 		gl.BindTexture(gl.TEXTURE_2D, fbo_texture)
 	}


### PR DESCRIPTION
The goal of this PR is to simplify the tiling logic, so that one day tiled sprites can be rendered with one single draw call instead of Golang loops with state changes.

It’s not done yet, but you can see that `rmTileHSub()` is already a lot simpler: [old](https://github.com/ikemen-engine/Ikemen-GO/blob/8d6db7d15d93cbba0d9acaaecac2dce9cf39a698/src/render.go#L332) vs. [new](https://github.com/samhocevar-forks/ikemen-go/blob/bb96e3cecdcd4fcd0fa58a02b75067c5a9879567/src/render.go#L245).