### PR TITLE
Trials Mode Functionality

### DIFF
--- a/data/training.zss
+++ b/data/training.zss
@@ -25,7 +25,7 @@ if playerId($pid),ctrl = 0 {
 #===============================================================================
 [StateDef -4]
 
-if gameMode != "training" || isHelper || teamSide != 2 {
+if (gameMode != "training" && gameMode != "trials") || isHelper || teamSide != 2 {
 	# Do nothing, not training more or statedef executed by helper or not P2
 } else if roundState = 0 {
 	# Round start reset

--- a/external/script/motif.lua
+++ b/external/script/motif.lua
@@ -2582,8 +2582,8 @@ local anim = ''
 local facing = ''
 function motif.f_loadSprData(t, v, sprdata, createlocalsprdata)
 	-- new optional arguments sprdata and createlocalsprdata
-	-- sprdata: can be specified to load a specific .sff. Useful for external modules.
-	-- createlocalsprdata: will export this function's output to a desired variable instead of inserting it back into t[data]. Useful if you want save sprite data in a variable inside of your module.
+	-- sprdata: can be specified to load a specific .sff. Useful for external modules. If unspecified, it will just load the .sff called out in motif.files.spr_data
+	-- createlocalsprdata: bool, will export this function's output to a desired variable instead of inserting it back into t[data]. Useful if you want save sprite data in a variable inside of your module.
 	local localsprdata = {}
 	local animParam = v.s .. 'anim'
 	local sprParam = v.s .. 'spr'

--- a/src/char.go
+++ b/src/char.go
@@ -1495,7 +1495,7 @@ const (
 
 type ParsedTrials struct {
 	trialspresent       bool
-	trialnames          []string
+	trialname           []string
 	numoftrials         int32
 	currentTrial        int32
 	currenttrialStep    int32
@@ -1503,12 +1503,14 @@ type ParsedTrials struct {
 	trialdummymode      []string
 	trialguardmode      []string
 	trialdummybuttonjam []string
-	trialsteps          [][]string
+	trialstepname       [][]string
 	trialglyphs         [][]string
 	trialstateno        [][]int32
 	trialanimno         [][]int32
 	trialisthrow        [][]bool
+	trialisnohit        [][]bool
 	trialishelper       [][]bool
+	trialiscounterhit   [][]bool
 	trialprojid         [][]int32
 	trialspecialbool    [][]bool
 	trialspecialstr     [][]string
@@ -1969,8 +1971,7 @@ func (c *Char) load(def string) error {
 						trials, _ = LoadText(file)
 						return nil
 					})
-					var triallines []string
-					triallines = SplitAndTrim(trials, "\n")
+					triallines := SplitAndTrim(trials, "\n")
 					gi.trialslist.numoftrials = 0
 					gi.trialslist.currentTrial = 1
 					gi.trialslist.currenttrialStep = 0
@@ -1986,13 +1987,15 @@ func (c *Char) load(def string) error {
 					gi.trialslist.trialguardmode = make([]string, gi.trialslist.numoftrials)
 					gi.trialslist.trialdummybuttonjam = make([]string, gi.trialslist.numoftrials)
 					gi.trialslist.trialnumsteps = make([]int32, gi.trialslist.numoftrials)
-					gi.trialslist.trialnames = make([]string, gi.trialslist.numoftrials)
-					gi.trialslist.trialsteps = make([][]string, gi.trialslist.numoftrials)
+					gi.trialslist.trialname = make([]string, gi.trialslist.numoftrials)
+					gi.trialslist.trialstepname = make([][]string, gi.trialslist.numoftrials)
 					gi.trialslist.trialglyphs = make([][]string, gi.trialslist.numoftrials)
 					gi.trialslist.trialstateno = make([][]int32, gi.trialslist.numoftrials)
 					gi.trialslist.trialanimno = make([][]int32, gi.trialslist.numoftrials)
 					gi.trialslist.trialisthrow = make([][]bool, gi.trialslist.numoftrials)
+					gi.trialslist.trialisnohit = make([][]bool, gi.trialslist.numoftrials)
 					gi.trialslist.trialishelper = make([][]bool, gi.trialslist.numoftrials)
+					gi.trialslist.trialiscounterhit = make([][]bool, gi.trialslist.numoftrials)
 					gi.trialslist.trialprojid = make([][]int32, gi.trialslist.numoftrials)
 					gi.trialslist.trialspecialbool = make([][]bool, gi.trialslist.numoftrials)
 					gi.trialslist.trialspecialstr = make([][]string, gi.trialslist.numoftrials)
@@ -2012,9 +2015,9 @@ func (c *Char) load(def string) error {
 								gi.trialslist.trialnumsteps[ii] = int32(stepstemp)
 							}
 							if is[(currenttrial+".name")] != "" {
-								gi.trialslist.trialnames[ii] = is[(currenttrial + ".name")]
+								gi.trialslist.trialname[ii] = is[(currenttrial + ".name")]
 							} else {
-								gi.trialslist.trialnames[ii] = ("Trial " + strconv.Itoa(ii+1))
+								gi.trialslist.trialname[ii] = ("Trial " + strconv.Itoa(ii+1))
 							}
 							if is[(currenttrial+".dummymode")] != "" {
 								gi.trialslist.trialdummymode[ii] = strings.ToLower(is[(currenttrial + ".dummymode")])
@@ -2026,28 +2029,32 @@ func (c *Char) load(def string) error {
 							} else {
 								gi.trialslist.trialguardmode[ii] = "none"
 							}
-							if is[(currenttrial+".dummybutton")] != "" {
-								gi.trialslist.trialdummybuttonjam[ii] = strings.ToLower(is[(currenttrial + ".dummybutton")])
+							if is[(currenttrial+".dummybuttonjam")] != "" {
+								gi.trialslist.trialdummybuttonjam[ii] = strings.ToLower(is[(currenttrial + ".dummybuttonjam")])
 							} else {
 								gi.trialslist.trialdummybuttonjam[ii] = "none"
 							}
-							gi.trialslist.trialsteps[ii] = make([]string, gi.trialslist.trialnumsteps[ii])
+							gi.trialslist.trialstepname[ii] = make([]string, gi.trialslist.trialnumsteps[ii])
 							gi.trialslist.trialglyphs[ii] = make([]string, gi.trialslist.trialnumsteps[ii])
 							gi.trialslist.trialstateno[ii] = make([]int32, gi.trialslist.trialnumsteps[ii])
 							gi.trialslist.trialanimno[ii] = make([]int32, gi.trialslist.trialnumsteps[ii])
 							gi.trialslist.trialisthrow[ii] = make([]bool, gi.trialslist.trialnumsteps[ii])
+							gi.trialslist.trialisnohit[ii] = make([]bool, gi.trialslist.trialnumsteps[ii])
 							gi.trialslist.trialishelper[ii] = make([]bool, gi.trialslist.trialnumsteps[ii])
+							gi.trialslist.trialiscounterhit[ii] = make([]bool, gi.trialslist.trialnumsteps[ii])
 							gi.trialslist.trialprojid[ii] = make([]int32, gi.trialslist.trialnumsteps[ii])
 							gi.trialslist.trialspecialbool[ii] = make([]bool, gi.trialslist.trialnumsteps[ii])
 							gi.trialslist.trialspecialstr[ii] = make([]string, gi.trialslist.trialnumsteps[ii])
 							gi.trialslist.trialspecialval[ii] = make([]int32, gi.trialslist.trialnumsteps[ii])
 							for k := 0; k < int(gi.trialslist.trialnumsteps[ii]); k++ {
 								currenttrialplusstep := currenttrial + "." + strconv.Itoa(k+1)
-								gi.trialslist.trialsteps[ii][k] = is[(currenttrialplusstep + ".text")]
+								gi.trialslist.trialstepname[ii][k] = is[(currenttrialplusstep + ".text")]
 								gi.trialslist.trialglyphs[ii][k] = is[(currenttrialplusstep + ".glyphs")]
 								gi.trialslist.trialanimno[ii][k] = int32(math.NaN())
 								gi.trialslist.trialisthrow[ii][k] = false
+								gi.trialslist.trialisnohit[ii][k] = false
 								gi.trialslist.trialishelper[ii][k] = false
+								gi.trialslist.trialiscounterhit[ii][k] = false
 								gi.trialslist.trialprojid[ii][k] = int32(math.NaN())
 								gi.trialslist.trialspecialbool[ii][k] = false
 								gi.trialslist.trialspecialstr[ii][k] = is[(currenttrialplusstep + ".specialstr")]
@@ -2064,19 +2071,27 @@ func (c *Char) load(def string) error {
 									gi.trialslist.trialanimno[ii][k] = int32(temp)
 								}
 								if is[(currenttrialplusstep+".isthrow")] != "" {
-									temp, _ := strconv.ParseInt(is[(currenttrialplusstep+".isthrow")], 10, 32)
-									if temp != 0 {
+									temp := strings.ToLower(is[(currenttrialplusstep + ".isthrow")])
+									if temp == "true" {
 										gi.trialslist.trialisthrow[ii][k] = true
-									} else {
-										gi.trialslist.trialisthrow[ii][k] = false
+									}
+								}
+								if is[(currenttrialplusstep+".isnohit")] != "" {
+									temp := strings.ToLower(is[(currenttrialplusstep + ".isnohit")])
+									if temp == "true" {
+										gi.trialslist.trialisnohit[ii][k] = true
+									}
+								}
+								if is[(currenttrialplusstep+".iscounterhit")] != "" {
+									temp := strings.ToLower(is[(currenttrialplusstep + ".iscounterhit")])
+									if temp == "true" {
+										gi.trialslist.trialiscounterhit[ii][k] = true
 									}
 								}
 								if is[(currenttrialplusstep+".ishelper")] != "" {
-									temp, _ := strconv.ParseInt(is[(currenttrialplusstep+".ishelper")], 10, 32)
-									if temp != 0 {
+									temp := strings.ToLower(is[(currenttrialplusstep + ".ishelper")])
+									if temp == "true" {
 										gi.trialslist.trialishelper[ii][k] = true
-									} else {
-										gi.trialslist.trialishelper[ii][k] = false
 									}
 								}
 								if is[(currenttrialplusstep+".projid")] != "" {
@@ -2084,11 +2099,9 @@ func (c *Char) load(def string) error {
 									gi.trialslist.trialprojid[ii][k] = int32(temp)
 								}
 								if is[(currenttrialplusstep+".specialbool")] != "" {
-									temp, _ := strconv.ParseInt(is[(currenttrialplusstep+".specialbool")], 10, 32)
-									if temp != 0 {
+									temp := strings.ToLower(is[(currenttrialplusstep + ".specialbool")])
+									if temp == "true" {
 										gi.trialslist.trialspecialbool[ii][k] = true
-									} else {
-										gi.trialslist.trialspecialbool[ii][k] = false
 									}
 								}
 								if is[(currenttrialplusstep+".specialval")] != "" {

--- a/src/char.go
+++ b/src/char.go
@@ -2032,6 +2032,14 @@ func (c *Char) load(def string) error {
 								currenttrialplusstep := currenttrial + "." + strconv.Itoa(k+1)
 								gi.trialslist.trialsteps[ii][k] = is[(currenttrialplusstep + ".text")]
 								gi.trialslist.trialglyphs[ii][k] = is[(currenttrialplusstep + ".glyphs")]
+								gi.trialslist.trialanimno[ii][k] = int32(math.NaN())
+								gi.trialslist.trialisthrow[ii][k] = false
+								gi.trialslist.trialishelper[ii][k] = false
+								gi.trialslist.trialprojid[ii][k] = int32(math.NaN())
+								gi.trialslist.trialspecialbool[ii][k] = false
+								gi.trialslist.trialspecialstr[ii][k] = is[(currenttrialplusstep + ".specialstr")]
+								gi.trialslist.trialspecialval[ii][k] = int32(math.NaN())
+
 								if is[(currenttrialplusstep+".stateno")] != "" {
 									temp, _ := strconv.ParseInt(is[(currenttrialplusstep+".stateno")], 10, 32)
 									gi.trialslist.trialstateno[ii][k] = int32(temp)
@@ -2041,8 +2049,6 @@ func (c *Char) load(def string) error {
 								if is[(currenttrialplusstep+".anim")] != "" {
 									temp, _ := strconv.ParseInt(is[(currenttrialplusstep+".anim")], 10, 32)
 									gi.trialslist.trialanimno[ii][k] = int32(temp)
-								} else {
-									gi.trialslist.trialanimno[ii][k] = int32(math.NaN())
 								}
 								if is[(currenttrialplusstep+".isthrow")] != "" {
 									temp, _ := strconv.ParseInt(is[(currenttrialplusstep+".isthrow")], 10, 32)
@@ -2051,8 +2057,6 @@ func (c *Char) load(def string) error {
 									} else {
 										gi.trialslist.trialisthrow[ii][k] = false
 									}
-								} else {
-									gi.trialslist.trialisthrow[ii][k] = false
 								}
 								if is[(currenttrialplusstep+".ishelper")] != "" {
 									temp, _ := strconv.ParseInt(is[(currenttrialplusstep+".ishelper")], 10, 32)
@@ -2061,14 +2065,10 @@ func (c *Char) load(def string) error {
 									} else {
 										gi.trialslist.trialishelper[ii][k] = false
 									}
-								} else {
-									gi.trialslist.trialishelper[ii][k] = false
 								}
 								if is[(currenttrialplusstep+".projid")] != "" {
 									temp, _ := strconv.ParseInt(is[(currenttrialplusstep+".projid")], 10, 32)
 									gi.trialslist.trialprojid[ii][k] = int32(temp)
-								} else {
-									gi.trialslist.trialprojid[ii][k] = int32(math.NaN())
 								}
 								if is[(currenttrialplusstep+".specialbool")] != "" {
 									temp, _ := strconv.ParseInt(is[(currenttrialplusstep+".specialbool")], 10, 32)
@@ -2077,19 +2077,10 @@ func (c *Char) load(def string) error {
 									} else {
 										gi.trialslist.trialspecialbool[ii][k] = false
 									}
-								} else {
-									gi.trialslist.trialspecialbool[ii][k] = false
-								}
-								if is[(currenttrialplusstep+".specialstr")] != "" {
-									gi.trialslist.trialspecialstr[ii][k] = strings.ToLower(is[(currenttrialplusstep + ".specialstr")])
-								} else {
-									gi.trialslist.trialspecialstr[ii][k] = ""
 								}
 								if is[(currenttrialplusstep+".specialval")] != "" {
 									temp, _ := strconv.ParseInt(is[(currenttrialplusstep+".specialval")], 10, 32)
 									gi.trialslist.trialspecialval[ii][k] = int32(temp)
-								} else {
-									gi.trialslist.trialspecialval[ii][k] = int32(math.NaN())
 								}
 							}
 							ii++

--- a/src/script.go
+++ b/src/script.go
@@ -3071,8 +3071,8 @@ func triggerFunctions(l *lua.LState) {
 		case "currenttrial":
 			l.Push(lua.LNumber(sys.cgi[0].trialslist.currentTrial))
 		case "currenttrialname":
-			l.Push(lua.LString(sys.cgi[0].trialslist.trialnames[int(numArg(l, 2))]))
-		case "currenttrialstep":
+			l.Push(lua.LString(sys.cgi[0].trialslist.trialname[int(numArg(l, 2))]))
+		case "currenttrialstepname":
 			l.Push(lua.LNumber(sys.cgi[0].trialslist.currenttrialStep))
 		case "currenttrialdummymode":
 			l.Push(lua.LString(sys.cgi[0].trialslist.trialdummymode[int(numArg(l, 2))]))
@@ -3083,7 +3083,7 @@ func triggerFunctions(l *lua.LState) {
 		case "currenttrialnumofsteps":
 			l.Push(lua.LNumber(sys.cgi[0].trialslist.trialnumsteps[int(numArg(l, 2))]))
 		case "currenttrialtext":
-			l.Push(lua.LString(sys.cgi[0].trialslist.trialsteps[int(numArg(l, 2))][int(numArg(l, 3))]))
+			l.Push(lua.LString(sys.cgi[0].trialslist.trialstepname[int(numArg(l, 2))][int(numArg(l, 3))]))
 		case "currenttrialglyphs":
 			l.Push(lua.LString(sys.cgi[0].trialslist.trialglyphs[int(numArg(l, 2))][int(numArg(l, 3))]))
 		case "currenttrialstateno":
@@ -3092,8 +3092,12 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LNumber(sys.cgi[0].trialslist.trialanimno[int(numArg(l, 2))][int(numArg(l, 3))]))
 		case "currenttrialisthrow":
 			l.Push(lua.LBool(sys.cgi[0].trialslist.trialisthrow[int(numArg(l, 2))][int(numArg(l, 3))]))
+		case "currenttrialisnohit":
+			l.Push(lua.LBool(sys.cgi[0].trialslist.trialisnohit[int(numArg(l, 2))][int(numArg(l, 3))]))
 		case "currenttrialishelper":
 			l.Push(lua.LBool(sys.cgi[0].trialslist.trialishelper[int(numArg(l, 2))][int(numArg(l, 3))]))
+		case "currenttrialiscounterhit":
+			l.Push(lua.LBool(sys.cgi[0].trialslist.trialiscounterhit[int(numArg(l, 2))][int(numArg(l, 3))]))
 		case "currenttrialprojid":
 			l.Push(lua.LNumber(sys.cgi[0].trialslist.trialprojid[int(numArg(l, 2))][int(numArg(l, 3))]))
 		case "currenttrialspecialbool":

--- a/src/script.go
+++ b/src/script.go
@@ -3053,6 +3053,49 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(ln)
 		return 1
 	})
+	luaRegister(l, "gettrialinfo", func(*lua.LState) int {
+		switch strArg(l, 1) {
+		case "trialspresent":
+			l.Push(lua.LBool(sys.cgi[0].trialslist.trialspresent))
+		case "numoftrials":
+			l.Push(lua.LNumber(sys.cgi[0].trialslist.numoftrials))
+		case "currenttrial":
+			l.Push(lua.LNumber(sys.cgi[0].trialslist.currentTrial))
+		case "currenttrialname":
+			l.Push(lua.LString(sys.cgi[0].trialslist.trialnames[int(numArg(l, 2))]))
+		case "currenttrialstep":
+			l.Push(lua.LNumber(sys.cgi[0].trialslist.currenttrialStep))
+		case "currenttrialdummymode":
+			l.Push(lua.LString(sys.cgi[0].trialslist.trialdummymode[int(numArg(l, 2))]))
+		case "currenttrialguardmode":
+			l.Push(lua.LString(sys.cgi[0].trialslist.trialguardmode[int(numArg(l, 2))]))
+		case "currenttrialdummybuttonjam":
+			l.Push(lua.LString(sys.cgi[0].trialslist.trialdummybuttonjam[int(numArg(l, 2))]))
+		case "currenttrialnumofsteps":
+			l.Push(lua.LNumber(sys.cgi[0].trialslist.trialnumsteps[int(numArg(l, 2))]))
+		case "currenttrialtext":
+			l.Push(lua.LString(sys.cgi[0].trialslist.trialsteps[int(numArg(l, 2))][int(numArg(l, 3))]))
+		case "currenttrialglyphs":
+			l.Push(lua.LString(sys.cgi[0].trialslist.trialglyphs[int(numArg(l, 2))][int(numArg(l, 3))]))
+		case "currenttrialstateno":
+			l.Push(lua.LNumber(sys.cgi[0].trialslist.trialstateno[int(numArg(l, 2))][int(numArg(l, 3))]))
+		case "currenttrialanimno":
+			l.Push(lua.LNumber(sys.cgi[0].trialslist.trialanimno[int(numArg(l, 2))][int(numArg(l, 3))]))
+		case "currenttrialisthrow":
+			l.Push(lua.LBool(sys.cgi[0].trialslist.trialisthrow[int(numArg(l, 2))][int(numArg(l, 3))]))
+		case "currenttrialishelper":
+			l.Push(lua.LBool(sys.cgi[0].trialslist.trialishelper[int(numArg(l, 2))][int(numArg(l, 3))]))
+		case "currenttrialprojid":
+			l.Push(lua.LNumber(sys.cgi[0].trialslist.trialprojid[int(numArg(l, 2))][int(numArg(l, 3))]))
+		case "currenttrialspecialbool":
+			l.Push(lua.LBool(sys.cgi[0].trialslist.trialspecialbool[int(numArg(l, 2))][int(numArg(l, 3))]))
+		case "currenttrialspecialstr":
+			l.Push(lua.LString(sys.cgi[0].trialslist.trialspecialstr[int(numArg(l, 2))][int(numArg(l, 3))]))
+		case "currenttrialspecialval":
+			l.Push(lua.LNumber(sys.cgi[0].trialslist.trialspecialval[int(numArg(l, 2))][int(numArg(l, 3))]))
+		}
+		return 1
+	})
 	luaRegister(l, "hitcount", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.hitCount))
 		return 1

--- a/src/script.go
+++ b/src/script.go
@@ -1377,6 +1377,10 @@ func systemScriptInit(l *lua.LState) {
 		l.Push(lua.LString(sys.listenPort))
 		return 1
 	})
+	luaRegister(l, "getLifeBarTimer", func(*lua.LState) int {
+		l.Push(lua.LString(sys.timerVal))
+		return 1
+	})
 	luaRegister(l, "getMatchMaxDrawGames", func(l *lua.LState) int {
 		tn := int(numArg(l, 1))
 		if tn < 1 || tn > 2 {

--- a/src/script.go
+++ b/src/script.go
@@ -802,6 +802,10 @@ func systemScriptInit(l *lua.LState) {
 		l.Push(newUserData(l, fnt))
 		return 1
 	})
+	luaRegister(l, "freezeLifeBarTimer", func(*lua.LState) int {
+		sys.timerFrozen = boolArg(l, 1)
+		return 0
+	})
 	// Execute a match of gameplay
 	luaRegister(l, "game", func(l *lua.LState) int {
 		// Anonymous function to load characters and stages, and/or wait for them to finish loading
@@ -1029,6 +1033,7 @@ func systemScriptInit(l *lua.LState) {
 				tbl.RawSetString("p2score", lua.LNumber(sc[1]))
 				sys.timerStart = 0
 				sys.timerRounds = []int32{}
+				sys.timerFrozen = false
 				sys.scoreStart = [2]float32{}
 				sys.scoreRounds = [][2]float32{}
 				sys.timerCount = []int32{}

--- a/src/system.go
+++ b/src/system.go
@@ -321,6 +321,8 @@ type System struct {
 	roundType       [2]RoundType
 	timerStart      int32
 	timerRounds     []int32
+	timerFrozen     bool
+	timerVal        string
 	scoreStart      [2]float32
 	scoreRounds     [][2]float32
 	matchData       *lua.LTable
@@ -2046,8 +2048,8 @@ func (s *System) fight() (reload bool) {
 								}
 							}
 						}
-					//} else {
-					//	s.chars[i][0].life = 0
+						//} else {
+						//	s.chars[i][0].life = 0
 					}
 				}
 				// If match isn't over, presumably this is turns mode,


### PR DESCRIPTION
This pull request modifies four Go files to enable a universal Trials Mode, while the Trials Mode itself ships in an externalized Lua module. Changes to the engine are detailed below. 

In char.go, functionality has been added to read and parse a "trials.def" file in the character's folder, which needs to be referenced in the character's definition file. A template can be found in the notes section of the Trials Mode module. After it is parsed, this trials information is stored in an array so it can later be retrieved in Lua via the "gettrialsinfo()" function, defined in script.go. 

Additionally, minor changes were made to lifebar.go and system.go to enable the [timer] functionality even when round time is set to infinite. This is useful in Trials Mode but could also be used in other modes where a timer without being restricted by round time. New state controller: freezeLifeBarTimer(bool), which can be used to freeze and unfreeze the timer, and new trigger: getLifeBarTimer(), which can be used to retrieved the timer value. Note that setLifeBarTimer() will continue to work without issue.