### PR TITLE
Reduce memory usage when reloading characters with large sff

### DIFF
--- a/src/system.go
+++ b/src/system.go
@@ -2784,6 +2784,9 @@ func (l *Loader) loadChar(pn int) int {
 		p.clearCachedData()
 	} else {
 		p = newChar(pn, 0)
+		if sys.cgi[pn].sff != nil {
+			sys.cgi[pn].sff.sprites = nil
+		}
 		sys.cgi[pn].sff = nil
 		if len(sys.chars[pn]) > 0 {
 			p.power = sys.chars[pn][0].power


### PR DESCRIPTION
This commit is a workaround for the memory leak(?) issue where the sprite textures are not released immediately when reloading the match...
It significantly reduces memory usage when you need to frequently reload characters with large sff, on windows 10 at least...