### PR TITLE
・ステージのtileのxでマイナス値が指定された時の挙動が異なっていたのを修正

### DIFF
--- a/src/anim.go
+++ b/src/anim.go
@@ -500,14 +500,14 @@ func (a *Animation) UpdateSprite() {
 		nextDrawidx = a.loopstart
 	}
 	for _, i := range a.interpolate_offset {
-		if nextDrawidx == i {
+		if nextDrawidx == i && (a.frames[a.drawidx].Time >= 0) {
 			a.interpolate_offset_x = float32(a.frames[nextDrawidx].X-a.frames[a.drawidx].X) / float32(a.curFrame().Time) * float32(a.time)
 			a.interpolate_offset_y = float32(a.frames[nextDrawidx].Y-a.frames[a.drawidx].Y) / float32(a.curFrame().Time) * float32(a.time)
 			break
 		}
 	}
 	for _, i := range a.interpolate_scale {
-		if nextDrawidx == i {
+		if nextDrawidx == i && (a.frames[a.drawidx].Time >= 0) {
 			var drawframe_scale_x, nextframe_scale_x, drawframe_scale_y, nextframe_scale_y float32 = 1, 1, 1, 1
 			if len(a.frames[a.drawidx].Ex) > 2 {
 				if len(a.frames[a.drawidx].Ex[2]) > 0 {
@@ -533,7 +533,7 @@ func (a *Animation) UpdateSprite() {
 	a.scale_x *= a.start_scale[0]
 	a.scale_y *= a.start_scale[1]
 	for _, i := range a.interpolate_angle {
-		if nextDrawidx == i {
+		if nextDrawidx == i && (a.frames[a.drawidx].Time >= 0) {
 			var drawframe_angle, nextframe_angle float32 = 0, 0
 			if len(a.frames[a.drawidx].Ex) > 2 {
 				if len(a.frames[a.drawidx].Ex[2]) > 2 {
@@ -552,7 +552,7 @@ func (a *Animation) UpdateSprite() {
 	if byte(a.interpolate_blend_srcalpha) != 1 ||
 		byte(a.interpolate_blend_dstalpha) != 255 {
 		for _, i := range a.interpolate_blend {
-			if nextDrawidx == i {
+			if nextDrawidx == i && (a.frames[a.drawidx].Time >= 0) {
 				a.interpolate_blend_srcalpha += (float32(a.frames[nextDrawidx].SrcAlpha) - a.interpolate_blend_srcalpha) / float32(a.curFrame().Time) * float32(a.time)
 				a.interpolate_blend_dstalpha += (float32(a.frames[nextDrawidx].DstAlpha) - a.interpolate_blend_dstalpha) / float32(a.curFrame().Time) * float32(a.time)
 				if byte(a.interpolate_blend_srcalpha) == 1 && byte(a.interpolate_blend_dstalpha) == 255 {
@@ -716,12 +716,12 @@ func (a *Animation) Draw(window *[4]int32, x, y, xcs, ycs, xs, xbs, ys,
 	}
 	rp := RenderParams{
 		a.spr.Tex, paltex, a.spr.Size,
-		x*sys.widthScale,
-		y*sys.heightScale, a.tile, xs*sys.widthScale, xcs*xbs*h*sys.widthScale,
-		ys*sys.heightScale, 1, xcs*rxadd*sys.widthScale/sys.heightScale, rot,
-		trans, int32(a.mask), pfx, window, rcx, rcy, projectionMode, fLength*sys.heightScale,
-		xs*posLocalscl*(float32(a.frames[a.drawidx].X)+a.interpolate_offset_x)*a.start_scale[0]*(1/a.scale_x)*sys.widthScale,
-		ys*posLocalscl*(float32(a.frames[a.drawidx].Y)+a.interpolate_offset_y)*a.start_scale[1]*(1/a.scale_y)*sys.heightScale,
+		x * sys.widthScale,
+		y * sys.heightScale, a.tile, xs * sys.widthScale, xcs * xbs * h * sys.widthScale,
+		ys * sys.heightScale, 1, xcs * rxadd * sys.widthScale / sys.heightScale, rot,
+		trans, int32(a.mask), pfx, window, rcx, rcy, projectionMode, fLength * sys.heightScale,
+		xs * posLocalscl * (float32(a.frames[a.drawidx].X) + a.interpolate_offset_x) * a.start_scale[0] * (1 / a.scale_x) * sys.widthScale,
+		ys * posLocalscl * (float32(a.frames[a.drawidx].Y) + a.interpolate_offset_y) * a.start_scale[1] * (1 / a.scale_y) * sys.heightScale,
 	}
 	RenderSprite(rp)
 }
@@ -737,14 +737,14 @@ func (a *Animation) ShadowDraw(x, y, xscl, yscl, vscl float32, rot Rotation,
 
 	rp := RenderParams{
 		a.spr.Tex, nil, a.spr.Size,
-		AbsF(xscl*h)*float32(a.spr.Offset[0])*sys.widthScale,
-		AbsF(yscl*v)*float32(a.spr.Offset[1])*sys.heightScale, a.tile,
-		xscl*h*sys.widthScale, xscl*h*sys.widthScale,
-		yscl*v*sys.heightScale, vscl, 0, rot, 0, int32(a.mask), nil, &sys.scrrect,
-		(x+float32(sys.gameWidth)/2)*sys.widthScale, y*sys.heightScale,
+		AbsF(xscl*h) * float32(a.spr.Offset[0]) * sys.widthScale,
+		AbsF(yscl*v) * float32(a.spr.Offset[1]) * sys.heightScale, a.tile,
+		xscl * h * sys.widthScale, xscl * h * sys.widthScale,
+		yscl * v * sys.heightScale, vscl, 0, rot, 0, int32(a.mask), nil, &sys.scrrect,
+		(x + float32(sys.gameWidth)/2) * sys.widthScale, y * sys.heightScale,
 		projectionMode, fLength,
-		xscl*posLocalscl*h*(float32(a.frames[a.drawidx].X)+a.interpolate_offset_x)*(1/a.scale_x),
-		yscl*posLocalscl*vscl*v*(float32(a.frames[a.drawidx].Y)+a.interpolate_offset_y)*(1/a.scale_y),
+		xscl * posLocalscl * h * (float32(a.frames[a.drawidx].X) + a.interpolate_offset_x) * (1 / a.scale_x),
+		yscl * posLocalscl * vscl * v * (float32(a.frames[a.drawidx].Y) + a.interpolate_offset_y) * (1 / a.scale_y),
 	}
 
 	var draw func()

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -3443,6 +3443,9 @@ func (c *Compiler) forceFeedback(is IniSection, sc *StateControllerBase, _ int8)
 			if len(data) == 0 {
 				return Error("Value not specified")
 			}
+			if data[0] == '"' {
+				data = data[1 : len(data)-1]
+			}
 			var wf int32
 			switch strings.ToLower(data) {
 			case "sine":

--- a/src/shaders/sprite.fs.glsl
+++ b/src/shaders/sprite.fs.glsl
@@ -29,7 +29,7 @@ void main(void) {
 	} else {
 		// Colormap sprites use the old “buggy” Mugen way
 		if (int(255.25*c.r) == mask) {
-			c.a = 0.0;
+			final_mul = vec4(0.0);
 		} else {
 			c = texture2D(pal, vec2(c.r*0.9966, 0.5));
 		}

--- a/src/stage.go
+++ b/src/stage.go
@@ -257,6 +257,9 @@ func readBackGround(is IniSection, link *backGround,
 		if bg.typ == 2 {
 			bg.anim.tile.y = 0
 		}
+		if bg.anim.tile.x < 0 {
+			bg.anim.tile.x = math.MaxInt32
+		}
 	}
 	if bg.typ == 2 {
 		if !is.readI32ForStage("width", &bg.width[0], &bg.width[1]) {
@@ -413,7 +416,7 @@ func (bg backGround) draw(pos [2]float32, scl, bgscl, lclscl float32,
 	rect[1] = int32(math.Floor(float64(startrect1)))
 	rect[2] = int32(math.Floor(float64(startrect0 + (float32(rect[2]) * sys.widthScale * wscl[0]) - float32(rect[0]))))
 	rect[3] = int32(math.Floor(float64(startrect1 + (float32(rect[3]) * sys.heightScale * wscl[1]) - float32(rect[1]))))
-	if rect[0] < sys.scrrect[2] && rect[1] < sys.scrrect[3] && rect[0] + rect[2] > 0 && rect[1] + rect[3] > 0 {
+	if rect[0] < sys.scrrect[2] && rect[1] < sys.scrrect[3] && rect[0]+rect[2] > 0 && rect[1]+rect[3] > 0 {
 		bg.anim.Draw(&rect, x, y, sclx, scly, bg.xscale[0]*bgscl*(bg.scalestart[0]+xs)*xs3, xbs*bgscl*(bg.scalestart[0]+xs)*xs3, ys*ys3,
 			xras*x/(AbsF(ys*ys3)*lscl[1]*float32(bg.anim.spr.Size[1])*bg.scalestart[1])*sclx_recip*bg.scalestart[1],
 			Rotation{}, float32(sys.gameWidth)/2, &sys.bgPalFX, true, 1, false, 1, 0, 0)


### PR DESCRIPTION
・ステージのtileのxでマイナス値が指定された時の挙動が異なっていたのを修正
・Trans=sub時にマスク部分の透明度が逆転する場合があったのを修正
・ForceFeedbackのwaveformを"で括っていても読み込むようにした（書き間違えてるキャラが無視できないほど多いため）
・AIRのtimeが-1に指定されてる場合でもInterpolate系統が適応されていたのを修正