### PR TITLE
・zoomout時にY軸の地面側にスクロールが入る1.1の仕様を実装

### DIFF
--- a/src/camera.go
+++ b/src/camera.go
@@ -45,6 +45,7 @@ type Camera struct {
 	zoff                        float32
 	screenZoff                  float32
 	halfWidth                   float32
+	CameraZoomYBound            float32
 }
 
 func newCamera() *Camera {
@@ -52,8 +53,8 @@ func newCamera() *Camera {
 }
 func (c *Camera) Init() {
 	c.ZoomEnable = c.ZoomActive && (c.stageCamera.zoomin != 1 || c.stageCamera.zoomout != 1)
-	c.boundL = float32(c.boundleft-c.startx)*c.localscl - ((1-c.zoomout)*100*c.zoomout)*(1/c.zoomout)*(1/c.zoomout)*1.6
-	c.boundR = float32(c.boundright-c.startx)*c.localscl + ((1-c.zoomout)*100*c.zoomout)*(1/c.zoomout)*(1/c.zoomout)*1.6
+	c.boundL = float32(c.boundleft-c.startx)*c.localscl - ((1-c.zoomout)*100*c.zoomout)*(1/c.zoomout)*(1/c.zoomout)*1.6*(float32(sys.gameWidth)/320)
+	c.boundR = float32(c.boundright-c.startx)*c.localscl + ((1-c.zoomout)*100*c.zoomout)*(1/c.zoomout)*(1/c.zoomout)*1.6*(float32(sys.gameWidth)/320)
 	c.halfWidth = float32(sys.gameWidth) / 2
 	c.XMin = c.boundL - c.halfWidth/c.BaseScale()
 	c.XMax = c.boundR + c.halfWidth/c.BaseScale()
@@ -107,9 +108,11 @@ func (c *Camera) YBound(scl, y float32) float32 {
 		return 0
 	} else {
 		tmp := MaxF(0, 240-c.screenZoff)
-		return MaxF(0, c.boundH) + MinF(0, tmp*(1/scl-1),
-			MaxF(c.boundH-240+MaxF(float32(sys.gameHeight)/scl,
+		c.CameraZoomYBound = ((tmp / (scl)) - tmp) - c.drawOffsetY*(1-scl)*1.21
+		Bound := MaxF(0, c.boundH-c.CameraZoomYBound) + MinF(0, tmp*(1/scl-1),
+			MaxF(c.boundH-c.CameraZoomYBound-240+MaxF(float32(sys.gameHeight)/scl,
 				tmp+c.screenZoff/scl), y+240*(1-MinF(1, scl))))
+		return Bound + c.CameraZoomYBound
 	}
 }
 func (c *Camera) BaseScale() float32 {

--- a/src/system.go
+++ b/src/system.go
@@ -1474,9 +1474,9 @@ func (s *System) draw(x, y, scl float32) {
 	s.brightnessOld = s.brightness
 	s.brightness = 0x100 >> uint(Btoi(s.super > 0 && s.superdarken))
 	bgx, bgy := x/s.stage.localscl, y/s.stage.localscl
-	fade := func(rect [4]int32, color uint32, alpha int32) {
-		FillRect(rect, color, alpha>>uint(Btoi(s.clsnDraw))+Btoi(s.clsnDraw)*128)
-	}
+	//fade := func(rect [4]int32, color uint32, alpha int32) {
+	//	FillRect(rect, color, alpha>>uint(Btoi(s.clsnDraw))+Btoi(s.clsnDraw)*128)
+	//}
 	if s.envcol_time == 0 {
 		c := uint32(0)
 		if s.sf(GSF_nobg) {
@@ -1507,39 +1507,39 @@ func (s *System) draw(x, y, scl float32) {
 			}
 			s.shadows.draw(x, y, scl*s.cam.BaseScale())
 		}
-		off := s.envShake.getOffset()
-		yofs, yofs2 := float32(s.gameHeight), float32(0)
-		if scl > 1 && s.cam.verticalfollow > 0 {
-			yofs = s.cam.screenZoff + float32(s.gameHeight-240)
-			yofs2 = (240 - s.cam.screenZoff) * (1 - 1/scl)
-		}
-		yofs *= 1/scl - 1
-		rect := s.scrrect
-		if off < (yofs-y+s.cam.boundH)*scl {
-			rect[3] = (int32(math.Ceil(float64(((yofs-y+s.cam.boundH)*scl-off)*
-				float32(s.scrrect[3])))) + s.gameHeight - 1) / s.gameHeight
-			fade(rect, 0, 255)
-		}
-		if off > (-y+yofs2)*scl {
-			rect[3] = (int32(math.Ceil(float64(((y-yofs2)*scl+off)*
-				float32(s.scrrect[3])))) + s.gameHeight - 1) / s.gameHeight
-			rect[1] = s.scrrect[3] - rect[3]
-			fade(rect, 0, 255)
-		}
-		bl, br := MinF(x, s.cam.boundL), MaxF(x, s.cam.boundR)
-		xofs := float32(s.gameWidth) * (1/scl - 1) / 2
-		rect = s.scrrect
-		if x-xofs < bl {
-			rect[2] = (int32(math.Ceil(float64((bl-(x-xofs))*scl*
-				float32(s.scrrect[2])))) + s.gameWidth - 1) / s.gameWidth
-			fade(rect, 0, 255)
-		}
-		if x+xofs > br {
-			rect[2] = (int32(math.Ceil(float64(((x+xofs)-br)*scl*
-				float32(s.scrrect[2])))) + s.gameWidth - 1) / s.gameWidth
-			rect[0] = s.scrrect[2] - rect[2]
-			fade(rect, 0, 255)
-		}
+		//off := s.envShake.getOffset()
+		//yofs, yofs2 := float32(s.gameHeight), float32(0)
+		//if scl > 1 && s.cam.verticalfollow > 0 {
+		//	yofs = s.cam.screenZoff + float32(s.gameHeight-240)
+		//	yofs2 = (240 - s.cam.screenZoff) * (1 - 1/scl)
+		//}
+		//yofs *= 1/scl - 1
+		//rect := s.scrrect
+		//if off < (yofs-y+s.cam.boundH)*scl {
+		//	rect[3] = (int32(math.Ceil(float64(((yofs-y+s.cam.boundH)*scl-off)*
+		//		float32(s.scrrect[3])))) + s.gameHeight - 1) / s.gameHeight
+		//	fade(rect, 0, 255)
+		//}
+		//if off > (-y+yofs2)*scl {
+		//	rect[3] = (int32(math.Ceil(float64(((y-yofs2)*scl+off)*
+		//		float32(s.scrrect[3])))) + s.gameHeight - 1) / s.gameHeight
+		//	rect[1] = s.scrrect[3] - rect[3]
+		//	fade(rect, 0, 255)
+		//}
+		//bl, br := MinF(x, s.cam.boundL), MaxF(x, s.cam.boundR)
+		//xofs := float32(s.gameWidth) * (1/scl - 1) / 2
+		//rect = s.scrrect
+		//if x-xofs < bl {
+		//	rect[2] = (int32(math.Ceil(float64((bl-(x-xofs))*scl*
+		//		float32(s.scrrect[2])))) + s.gameWidth - 1) / s.gameWidth
+		//	fade(rect, 0, 255)
+		//}
+		//if x+xofs > br {
+		//	rect[2] = (int32(math.Ceil(float64(((x+xofs)-br)*scl*
+		//		float32(s.scrrect[2])))) + s.gameWidth - 1) / s.gameWidth
+		//	rect[0] = s.scrrect[2] - rect[2]
+		//	fade(rect, 0, 255)
+		//}
 		s.lifebar.draw(-1)
 		s.lifebar.draw(0)
 	} else {


### PR DESCRIPTION
・zoomout時にY軸の地面側にスクロールが入る1.1の仕様を実装
・zoomoutによるステージ端の変動処理が縦横比変更に対応できていなかったのを修正
・boundlowが0以外だとズームアウト時に背景が少しズレるのを修正
・cutlowで反映される値に制限がなかったのを修正
・画面外を黒く塗りつぶす処理をコメントアウト