### PR TITLE
Tweaks to lowestを巻き戻し

### DIFF
--- a/src/camera.go
+++ b/src/camera.go
@@ -60,7 +60,7 @@ func (c *Camera) Init() {
 	c.XMin = c.boundL - c.halfWidth/c.BaseScale()
 	c.XMax = c.boundR + c.halfWidth/c.BaseScale()
 	c.boundH = MinF(0, float32(c.boundhigh-c.localcoord[1])*c.localscl+float32(sys.gameHeight)-c.drawOffsetY)
-	c.boundLo = MaxF(0, float32(c.boundlow)*c.localscl-float32(sys.gameHeight)-c.drawOffsetY)
+	c.boundLo = MaxF(0, float32(c.boundlow)*c.localscl-c.drawOffsetY)
 	if c.boundhigh > 0 {
 		c.boundH += float32(c.boundhigh) * c.localscl
 	}

--- a/src/char.go
+++ b/src/char.go
@@ -5628,7 +5628,7 @@ func (c *Char) update(cvmin, cvmax,
 	}
 	if c.sf(CSF_movecamera_y) && !c.scf(SCF_standby) {
 		*highest = MinF(c.drawPos[1]*c.localscl, *highest)
-		*lowest = MaxF(c.drawPos[1]*c.localscl, *lowest)
+		//*lowest = MaxF(c.drawPos[1]*c.localscl, *lowest)
 	}
 }
 func (c *Char) tick() {
@@ -5968,9 +5968,10 @@ func (cl *CharList) update(cvmin, cvmax,
 	// Find lowest character available and set it as initial highest
 	for _, c := range ro {
 		if c.sf(CSF_movecamera_y) && !c.scf(SCF_standby) {
-			*highest = MaxF(c.drawPos[1]*c.localscl, *highest)
+			*lowest = MaxF(c.drawPos[1]*c.localscl, *lowest)
 		}
 	}
+	*highest = *lowest
 	for _, c := range ro {
 		c.update(cvmin, cvmax, highest, lowest, leftest, rightest)
 	}


### PR DESCRIPTION
As discussed in #620, this PR attempts to address a problem introduced in commit 51e3e24ddd4acad749a8f30e373fcede80a90daa and partly fixed by 70a87c95c960a4d9186b4a1c28a59af9014e49d1. Seeing "lowest" is necessary for tensionhigh and tensionlow to work properly (which former commit wasn't taking in account), it was needed to be reintroduced, but the priority problem was still present when not using tensionhigh/tensionlow. With these changes, camera should work properly for both modes.

Also, `c.boundLo` now has its value correctly set.