### PR TITLE
・explodのsuperpausetimeとpausemovetimeが最大値を超えるとオーバーフローしていたのを修正

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3204,8 +3204,14 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 			}
 		case explod_supermovetime:
 			e.supermovetime = exp[0].evalI(c)
+			if e.supermovetime >= 0 {
+				e.supermovetime = Max(e.supermovetime, e.supermovetime+1)
+			}
 		case explod_pausemovetime:
 			e.pausemovetime = exp[0].evalI(c)
+			if e.pausemovetime >= 0 {
+				e.pausemovetime = Max(e.pausemovetime, e.pausemovetime+1)
+			}
 		case explod_sprpriority:
 			e.sprpriority = exp[0].evalI(c)
 		case explod_ontop:
@@ -4316,12 +4322,12 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 		case projectile_supermovetime:
 			p.supermovetime = exp[0].evalI(c)
 			if p.supermovetime >= 0 {
-				p.supermovetime++
+				p.supermovetime = Max(p.supermovetime, p.supermovetime+1)
 			}
 		case projectile_pausemovetime:
 			p.pausemovetime = exp[0].evalI(c)
 			if p.pausemovetime >= 0 {
-				p.pausemovetime++
+				p.pausemovetime = Max(p.pausemovetime, p.pausemovetime+1)
 			}
 		case projectile_ownpal:
 			op = exp[0].evalB(c)

--- a/src/char.go
+++ b/src/char.go
@@ -254,7 +254,7 @@ type CharSize struct {
 		pos [2]float32
 	}
 	shadowoffset float32
-	draw struct {
+	draw         struct {
 		offset [2]float32
 	}
 	z struct {
@@ -1076,9 +1076,9 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 	}
 	p := false
 	if sys.super > 0 {
-		p = e.supermovetime >= 0 && e.time >= e.supermovetime+1
+		p = (e.supermovetime >= 0 && e.time >= e.supermovetime) || e.supermovetime < -2
 	} else if sys.pause > 0 {
-		p = e.pausemovetime >= 0 && e.time >= e.pausemovetime+1
+		p = (e.pausemovetime >= 0 && e.time >= e.pausemovetime) || e.pausemovetime < -2
 	}
 	act := !p
 	if act && !e.ignorehitpause {
@@ -1280,11 +1280,11 @@ func (p *Projectile) setPos(pos [2]float32) {
 func (p *Projectile) paused(playerNo int) bool {
 	//if !sys.chars[playerNo][0].pause() {
 	if sys.super > 0 {
-		if p.supermovetime == 0 {
+		if p.supermovetime == 0 || p.supermovetime < -1 {
 			return true
 		}
 	} else if sys.pause > 0 {
-		if p.pausemovetime == 0 {
+		if p.pausemovetime == 0 || p.pausemovetime < -1 {
 			return true
 		}
 	}


### PR DESCRIPTION
・explodのsuperpausetimeとpausemovetimeが最大値を超えるとオーバーフローしていたのを修正
・explodとprojectileのsuperpausetimeとpausemovetimeがマイナスに入力されていた場合の動作を修正