### PR TITLE
Fix PS3 controller detection

### DIFF
--- a/src/script.go
+++ b/src/script.go
@@ -1315,6 +1315,17 @@ func systemScriptInit(l *lua.LState) {
 						} else if axes[i] < -0.5 && i < 4 {
 							s = strconv.Itoa(-i*2 - 1)
 						}
+					} else if joystick[joy].GetGamepadName() == "PS3 Controller" {
+						if (len(axes) == 8 && i != 3 && i != 4 && i != 6 && i != 7) ||
+							(len(axes) == 6 && i != 2 && i != 5) {
+							// 8 axes in Windows (need to skip 3, 4, 6, 7) and
+							// 6 axes in Linux (need to skip 2 and 5)
+							if axes[i] < -0.2 {
+								s = strconv.Itoa(-i*2 - 1)
+							} else if axes[i] > 0.2 {
+								s = strconv.Itoa(-i*2 - 2)
+							}
+						}
 					} else if joystick[joy].GetGamepadName() != "PS4 Controller" || !(i == 3 || i == 4) {
 						if axes[i] < -0.2 {
 							s = strconv.Itoa(-i*2 - 1)


### PR DESCRIPTION
Joystick configuration is done by observing transitions from "some button is pressed" to "all buttons are released" state. See function "f_keyCfg" in "external/script/options.lua": https://github.com/ikemen-engine/Ikemen-GO/blob/0.98.2/external/script/options.lua#L1754-L1761

But right now "getJoystickKey" function returns "-11" for an idle PS3 controller with no buttons pressed (because axes 2 and
5 have -1.0 value in this state). The game does not see the "all buttons are released" state and this breaks the joystick configuration process.

This patch fixes the problem by just skipping axes 2 and 5. So that the "getJoystickKey" function returns "" in an idle state
as expected.

Only tested in Linux. I'm not sure what is the PS3 controller support status in Windows.