### PR TITLE
Add Explod clip window

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3101,6 +3101,7 @@ const (
 	explod_ignorehitpause
 	explod_bindid
 	explod_space
+	explod_clipwindow
 	explod_redirectid
 )
 
@@ -3271,6 +3272,8 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 			e.bindId = bId
 		case explod_projection:
 			e.projection = Projection(exp[0].evalI(c))
+		case explod_clipwindow:
+			e.window = [4]float32{exp[0].evalF(c) * lclscround, exp[1].evalF(c) * lclscround, exp[2].evalF(c) * lclscround, exp[3].evalF(c) * lclscround}
 		default:
 			palFX(sc).runSub(c, &e.palfxdef, id, exp)
 		}
@@ -3486,6 +3489,10 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				eachExpl(func(e *Explod) { e.projection = Projection(exp[0].evalI(c)) })
 			case explod_focallength:
 				eachExpl(func(e *Explod) { e.fLength = exp[0].evalF(c) })
+			case explod_clipwindow:
+				eachExpl(func(e *Explod) {
+					e.window = [4]float32{exp[0].evalF(c) * lclscround, exp[1].evalF(c) * lclscround, exp[2].evalF(c) * lclscround, exp[3].evalF(c) * lclscround}
+				})
 			case explod_ignorehitpause:
 				if c.stCgi().ikemenver[0] > 0 || c.stCgi().ikemenver[1] > 0 {
 					ihp := exp[0].evalB(c)

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3101,7 +3101,7 @@ const (
 	explod_ignorehitpause
 	explod_bindid
 	explod_space
-	explod_clipwindow
+	explod_window
 	explod_redirectid
 )
 
@@ -3272,7 +3272,7 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 			e.bindId = bId
 		case explod_projection:
 			e.projection = Projection(exp[0].evalI(c))
-		case explod_clipwindow:
+		case explod_window:
 			e.window = [4]float32{exp[0].evalF(c) * lclscround, exp[1].evalF(c) * lclscround, exp[2].evalF(c) * lclscround, exp[3].evalF(c) * lclscround}
 		default:
 			palFX(sc).runSub(c, &e.palfxdef, id, exp)
@@ -3489,7 +3489,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				eachExpl(func(e *Explod) { e.projection = Projection(exp[0].evalI(c)) })
 			case explod_focallength:
 				eachExpl(func(e *Explod) { e.fLength = exp[0].evalF(c) })
-			case explod_clipwindow:
+			case explod_window:
 				eachExpl(func(e *Explod) {
 					e.window = [4]float32{exp[0].evalF(c) * lclscround, exp[1].evalF(c) * lclscround, exp[2].evalF(c) * lclscround, exp[3].evalF(c) * lclscround}
 				})

--- a/src/char.go
+++ b/src/char.go
@@ -911,7 +911,7 @@ func (ai *AfterImage) recAndCue(sd *SprData, rec bool, hitpause bool) {
 			ai.palfx[i/ai.framegap-1].remap = sd.fx.remap
 			sys.sprites.add(&SprData{&img.anim, &ai.palfx[i/ai.framegap-1], img.pos,
 				img.scl, ai.alpha, sd.priority - 2, img.rot, img.ascl,
-				false, sd.bright, sd.oldVer, sd.facing, sd.posLocalscl, img.projection, img.fLength}, 0, 0, 0, 0)
+				false, sd.bright, sd.oldVer, sd.facing, sd.posLocalscl, img.projection, img.fLength, sd.window}, 0, 0, 0, 0)
 		}
 	}
 	if rec || hitpause && ai.ignorehitpause {
@@ -954,6 +954,7 @@ type Explod struct {
 	newPos         [2]float32
 	palfx          *PalFX
 	palfxdef       PalFXDef
+	window         [4]float32
 	localscl       float32
 }
 
@@ -961,6 +962,7 @@ func (e *Explod) clear() {
 	*e = Explod{id: IErr, scale: [...]float32{1, 1}, removetime: -2,
 		postype: PT_P1, relativef: 1, facing: 1, vfacing: 1, localscl: 1, space: Space_none,
 		projection: Projection_Orthographic,
+		window:     [4]float32{0, 0, 0, 0},
 		alpha:      [...]int32{-1, 0}, playerId: -1, bindId: -2, ignorehitpause: true}
 }
 func (e *Explod) setX(x float32) {
@@ -1164,9 +1166,10 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 	}
 	fLength = fLength * e.localscl
 	var epos = [2]float32{e.pos[0] * e.localscl, e.pos[1] * e.localscl}
+	var ewin = [4]float32{e.window[0] * e.localscl * e.facing, e.window[1] * e.localscl * e.vfacing, e.window[2] * e.localscl * e.facing, e.window[3] * e.localscl * e.vfacing}
 	sprs.add(&SprData{e.anim, pfx, epos, [...]float32{e.facing * e.scale[0] * e.localscl,
 		e.vfacing * e.scale[1] * e.localscl}, alp, e.sprpriority, rot, [...]float32{1, 1},
-		screen, playerNo == sys.superplayer, oldVer, e.facing, 1, int32(e.projection), fLength},
+		screen, playerNo == sys.superplayer, oldVer, e.facing, 1, int32(e.projection), fLength, ewin},
 		e.shadow[0]<<16|e.shadow[1]&0xff<<8|e.shadow[0]&0xff, sdwalp, 0, 0)
 	if sys.tickNextFrame() {
 		if e.bindtime > 0 {
@@ -1477,7 +1480,7 @@ func (p *Projectile) cueDraw(oldVer bool, playerNo int) {
 		sd := &SprData{p.ani, p.palfx, [...]float32{p.pos[0] * p.localscl, p.pos[1] * p.localscl},
 			[...]float32{p.facing * p.scale[0] * p.localscl, p.scale[1] * p.localscl}, [2]int32{-1},
 			p.sprpriority, Rotation{p.facing * p.angle, 0, 0}, [...]float32{1, 1}, false, playerNo == sys.superplayer,
-			sys.cgi[playerNo].ver[0] != 1, p.facing, 1, 0, 0}
+			sys.cgi[playerNo].ver[0] != 1, p.facing, 1, 0, 0, [4]float32{0, 0, 0, 0}}
 		p.aimg.recAndCue(sd, sys.tickNextFrame() && notpause, false)
 		sys.sprites.add(sd,
 			p.shadow[0]<<16|p.shadow[1]&255<<8|p.shadow[2]&255, 256, 0, 0)
@@ -5847,7 +5850,7 @@ func (c *Char) cueDraw() {
 		sdf := func() *SprData {
 			sd := &SprData{c.anim, c.getPalfx(), pos,
 				scl, c.alpha, c.sprPriority, Rotation{agl, 0, 0}, c.angleScalse, false,
-				c.playerNo == sys.superplayer, c.gi().ver[0] != 1, c.facing, c.localscl / (320 / c.localcoord), 0, 0}
+				c.playerNo == sys.superplayer, c.gi().ver[0] != 1, c.facing, c.localscl / (320 / c.localcoord), 0, 0, [4]float32{0, 0, 0, 0}}
 			if !c.sf(CSF_trans) {
 				sd.alpha[0] = -1
 			}

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -691,6 +691,10 @@ func (c *Compiler) explodSub(is IniSection,
 	if err := c.palFXSub(is, sc, "palfx."); err != nil {
 		return err
 	}
+	if err := c.paramValue(is, sc, "clipwindow",
+		explod_clipwindow, VT_Float, 4, false); err != nil {
+		return err
+	}
 	return nil
 }
 func (c *Compiler) explod(is IniSection, sc *StateControllerBase,

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -691,8 +691,8 @@ func (c *Compiler) explodSub(is IniSection,
 	if err := c.palFXSub(is, sc, "palfx."); err != nil {
 		return err
 	}
-	if err := c.paramValue(is, sc, "clipwindow",
-		explod_clipwindow, VT_Float, 4, false); err != nil {
+	if err := c.paramValue(is, sc, "window",
+		explod_window, VT_Float, 4, false); err != nil {
 		return err
 	}
 	return nil

--- a/src/system.go
+++ b/src/system.go
@@ -1152,7 +1152,7 @@ func (s *System) action(x, y *float32, scl float32) (leftest, rightest, sclMul f
 	if s.superanim != nil {
 		s.topSprites.add(&SprData{s.superanim, &s.superpmap, s.superpos,
 			[...]float32{s.superfacing, 1}, [2]int32{-1}, 5, Rotation{}, [2]float32{},
-			false, true, s.cgi[s.superplayer].ver[0] != 1, 1, 1, 0, 0}, 0, 0, 0, 0)
+			false, true, s.cgi[s.superplayer].ver[0] != 1, 1, 1, 0, 0, [4]float32{0, 0, 0, 0}}, 0, 0, 0, 0)
 		if s.superanim.loopend {
 			s.superanim = nil
 		}


### PR DESCRIPTION
This commit adds a new Explod parameter clipwindow. 
```
clipwindow = x1, y1, x2, y2 (float)
    This parameter takes four numbers in the format of clsn which forms a rectangle 
    where pixels beyond the rectangle are not rendered. 
```
This makes things a lot easier when making gauges and animations like the gif below.
![goat](https://user-images.githubusercontent.com/33178487/183249991-f18e5d3a-7c76-4295-a896-5ddd904228f3.gif)