### PR TITLE
New features: Map assignation, Stage shadow xshear (missing mugen feature), ModifyStageVar SCTRL

### DIFF
--- a/data/common.cmd
+++ b/data/common.cmd
@@ -1,4 +1,9 @@
 [Command]
+name = "recovery"
+command = 
+time = 1
+
+[Command]
 name = "TagShiftBack"
 command = d
 time = 1

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -348,6 +348,7 @@ const (
 	OC_st_sysvar0add  = OC_var + OC_sysvar0
 	OC_st_fvar0add    = OC_var + OC_fvar0
 	OC_st_sysfvar0add = OC_var + OC_sysfvar0
+	OC_st_map
 )
 const (
 	OC_ex_p2dist_x OpCode = iota
@@ -1313,6 +1314,10 @@ func (be BytecodeExp) run_st(c *Char, i *int) {
 	case OC_st_sysfvaradd:
 		v := sys.bcStack.Pop().ToF()
 		*sys.bcStack.Top() = c.sysFvarAdd(sys.bcStack.Top().ToI(), v)
+	case OC_st_map:
+		v := sys.bcStack.Pop().ToF()
+		sys.bcStack.Push(c.mapSet(sys.stringPool[sys.workingState.playerNo].List[*(*int32)(unsafe.Pointer(&be[*i]))], v, 0))
+		*i += 4
 	default:
 		vi := be[*i-1]
 		if vi < OC_st_sysvar0+NumSysVar {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -328,6 +328,37 @@ const (
 	OC_const_stagevar_info_author
 	OC_const_stagevar_info_displayname
 	OC_const_stagevar_info_name
+	OC_const_stagevar_camera_boundleft
+	OC_const_stagevar_camera_boundright
+	OC_const_stagevar_camera_boundhigh
+	OC_const_stagevar_camera_boundlow
+	OC_const_stagevar_camera_verticalfollow
+	OC_const_stagevar_camera_floortension
+	OC_const_stagevar_camera_tensionhigh
+	OC_const_stagevar_camera_tensionlow
+	OC_const_stagevar_camera_tension
+	OC_const_stagevar_camera_startzoom
+	OC_const_stagevar_camera_zoomout
+	OC_const_stagevar_camera_zoomin
+	OC_const_stagevar_camera_ytension_enable
+	OC_const_stagevar_playerinfo_leftbound
+	OC_const_stagevar_playerinfo_rightbound
+	OC_const_stagevar_scaling_topscale
+	OC_const_stagevar_bound_screenleft
+	OC_const_stagevar_bound_screenright
+	OC_const_stagevar_stageinfo_zoffset
+	OC_const_stagevar_stageinfo_zoffsetlink
+	OC_const_stagevar_stageinfo_xscale
+	OC_const_stagevar_stageinfo_yscale
+	OC_const_stagevar_shadow_intensity
+	OC_const_stagevar_shadow_color_r
+	OC_const_stagevar_shadow_color_g
+	OC_const_stagevar_shadow_color_b
+	OC_const_stagevar_shadow_yscale
+	OC_const_stagevar_shadow_fade_range_begin
+	OC_const_stagevar_shadow_fade_range_end
+	OC_const_stagevar_shadow_xshear
+	OC_const_stagevar_reflection_intensity
 	OC_const_constants
 	OC_const_stage_constants
 )
@@ -1598,6 +1629,68 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 			sys.stringPool[sys.workingState.playerNo].List[*(*int32)(
 				unsafe.Pointer(&be[*i]))])
 		*i += 4
+	case OC_const_stagevar_camera_boundleft:
+		sys.bcStack.PushI(sys.stage.stageCamera.boundleft)
+	case OC_const_stagevar_camera_boundright:
+		sys.bcStack.PushI(sys.stage.stageCamera.boundright)
+	case OC_const_stagevar_camera_boundhigh:
+		sys.bcStack.PushI(sys.stage.stageCamera.boundhigh)
+	case OC_const_stagevar_camera_boundlow:
+		sys.bcStack.PushI(sys.stage.stageCamera.boundlow)
+	case OC_const_stagevar_camera_verticalfollow:
+		sys.bcStack.PushF(sys.stage.stageCamera.verticalfollow)
+	case OC_const_stagevar_camera_floortension:
+		sys.bcStack.PushI(sys.stage.stageCamera.floortension)
+	case OC_const_stagevar_camera_tensionhigh:
+		sys.bcStack.PushI(sys.stage.stageCamera.tensionhigh)
+	case OC_const_stagevar_camera_tensionlow:
+		sys.bcStack.PushI(sys.stage.stageCamera.tensionlow)
+	case OC_const_stagevar_camera_tension:
+		sys.bcStack.PushI(sys.stage.stageCamera.tension)
+	case OC_const_stagevar_camera_startzoom:
+		sys.bcStack.PushF(sys.stage.stageCamera.startzoom)
+	case OC_const_stagevar_camera_zoomout:
+		sys.bcStack.PushF(sys.stage.stageCamera.zoomout)
+	case OC_const_stagevar_camera_zoomin:
+		sys.bcStack.PushF(sys.stage.stageCamera.zoomin)
+	case OC_const_stagevar_camera_ytension_enable:
+		sys.bcStack.PushB(sys.stage.stageCamera.ytensionenable)
+	case OC_const_stagevar_playerinfo_leftbound:
+		sys.bcStack.PushF(sys.stage.leftbound)
+	case OC_const_stagevar_playerinfo_rightbound:
+		sys.bcStack.PushF(sys.stage.rightbound)
+	case OC_const_stagevar_scaling_topscale:
+		sys.bcStack.PushF(sys.stage.stageCamera.ztopscale)
+	case OC_const_stagevar_bound_screenleft:
+		sys.bcStack.PushI(sys.stage.screenleft)
+	case OC_const_stagevar_bound_screenright:
+		sys.bcStack.PushI(sys.stage.screenright)
+	case OC_const_stagevar_stageinfo_zoffset:
+		sys.bcStack.PushI(sys.stage.stageCamera.zoffset)
+	case OC_const_stagevar_stageinfo_zoffsetlink:
+		sys.bcStack.PushI(sys.stage.zoffsetlink)
+	case OC_const_stagevar_stageinfo_xscale:
+		sys.bcStack.PushF(sys.stage.scale[0])
+	case OC_const_stagevar_stageinfo_yscale:
+		sys.bcStack.PushF(sys.stage.scale[1])
+	case OC_const_stagevar_shadow_intensity:
+		sys.bcStack.PushI(sys.stage.sdw.intensity)
+	case OC_const_stagevar_shadow_color_r:
+		sys.bcStack.PushI(int32((sys.stage.sdw.color & 0xFF0000) >> 16))
+	case OC_const_stagevar_shadow_color_g:
+		sys.bcStack.PushI(int32((sys.stage.sdw.color & 0xFF00) >> 8))
+	case OC_const_stagevar_shadow_color_b:
+		sys.bcStack.PushI(int32(sys.stage.sdw.color & 0xFF))
+	case OC_const_stagevar_shadow_yscale:
+		sys.bcStack.PushF(sys.stage.sdw.yscale)
+	case OC_const_stagevar_shadow_fade_range_begin:
+		sys.bcStack.PushI(sys.stage.sdw.fadebgn)
+	case OC_const_stagevar_shadow_fade_range_end:
+		sys.bcStack.PushI(sys.stage.sdw.fadeend)
+	case OC_const_stagevar_shadow_xshear:
+		sys.bcStack.PushF(sys.stage.sdw.xshear)
+	case OC_const_stagevar_reflection_intensity:
+		sys.bcStack.PushI(sys.stage.reflection)
 	case OC_const_constants:
 		sys.bcStack.PushF(c.gi().constants[sys.stringPool[sys.workingState.playerNo].List[*(*int32)(
 			unsafe.Pointer(&be[*i]))]])

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -7748,6 +7748,125 @@ const (
 	removePlatform_name
 )
 
+type modifyStageVar StateControllerBase
+
+const (
+	modifyStageVar_camera_boundleft byte = iota
+	modifyStageVar_camera_boundright
+	modifyStageVar_camera_boundhigh
+	modifyStageVar_camera_boundlow
+	modifyStageVar_camera_verticalfollow
+	modifyStageVar_camera_floortension
+	modifyStageVar_camera_tensionhigh
+	modifyStageVar_camera_tensionlow
+	modifyStageVar_camera_tension
+	modifyStageVar_camera_startzoom
+	modifyStageVar_camera_zoomout
+	modifyStageVar_camera_zoomin
+	modifyStageVar_camera_ytension_enable
+	modifyStageVar_playerinfo_leftbound
+	modifyStageVar_playerinfo_rightbound
+	modifyStageVar_scaling_topscale
+	modifyStageVar_bound_screenleft
+	modifyStageVar_bound_screenright
+	modifyStageVar_stageinfo_zoffset
+	modifyStageVar_stageinfo_zoffsetlink
+	modifyStageVar_stageinfo_xscale
+	modifyStageVar_stageinfo_yscale
+	modifyStageVar_shadow_intensity
+	modifyStageVar_shadow_color
+	modifyStageVar_shadow_yscale
+	modifyStageVar_shadow_fade_range
+	modifyStageVar_shadow_xshear
+	modifyStageVar_reflection_intensity
+	modifyStageVar_redirectid
+)
+
+func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
+	//crun := c
+	s := *&sys.stage
+	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
+		switch id {
+		case modifyStageVar_camera_boundleft:
+			s.stageCamera.boundleft = exp[0].evalI(c)
+		case modifyStageVar_camera_boundright:
+			s.stageCamera.boundright = exp[0].evalI(c)
+		case modifyStageVar_camera_boundhigh:
+			s.stageCamera.boundhigh = exp[0].evalI(c)
+		case modifyStageVar_camera_boundlow:
+			s.stageCamera.boundlow = exp[0].evalI(c)
+		case modifyStageVar_camera_verticalfollow:
+			s.stageCamera.verticalfollow = exp[0].evalF(c)
+		case modifyStageVar_camera_floortension:
+			s.stageCamera.floortension = exp[0].evalI(c)
+		case modifyStageVar_camera_tensionhigh:
+			s.stageCamera.tensionhigh = exp[0].evalI(c)
+		case modifyStageVar_camera_tensionlow:
+			s.stageCamera.tensionlow = exp[0].evalI(c)
+		case modifyStageVar_camera_tension:
+			s.stageCamera.tension = exp[0].evalI(c)
+		case modifyStageVar_camera_startzoom:
+			s.stageCamera.startzoom = exp[0].evalF(c)
+		case modifyStageVar_camera_zoomout:
+			s.stageCamera.zoomout = exp[0].evalF(c)
+		case modifyStageVar_camera_zoomin:
+			s.stageCamera.zoomin = exp[0].evalF(c)
+		case modifyStageVar_camera_ytension_enable:
+			s.stageCamera.ytensionenable = exp[0].evalB(c)
+		case modifyStageVar_playerinfo_leftbound:
+			s.leftbound = exp[0].evalF(c)
+		case modifyStageVar_playerinfo_rightbound:
+			s.rightbound = exp[0].evalF(c)
+		case modifyStageVar_scaling_topscale:
+			if s.ver[0] == 0 { //mugen 1.0+ removed support for topscale
+				s.stageCamera.ztopscale = exp[0].evalF(c)
+			}
+		case modifyStageVar_bound_screenleft:
+			s.screenleft = exp[0].evalI(c)
+		case modifyStageVar_bound_screenright:
+			s.screenright = exp[0].evalI(c)
+		case modifyStageVar_stageinfo_zoffset:
+			s.stageCamera.zoffset = exp[0].evalI(c)
+		case modifyStageVar_stageinfo_zoffsetlink:
+			s.zoffsetlink = exp[0].evalI(c)
+		case modifyStageVar_stageinfo_xscale:
+			s.scale[0] = exp[0].evalF(c)
+		case modifyStageVar_stageinfo_yscale:
+			s.scale[1] = exp[0].evalF(c)
+		case modifyStageVar_shadow_intensity:
+			s.sdw.intensity = Clamp(exp[0].evalI(c), 0, 255)
+		case modifyStageVar_shadow_color:
+			// mugen 1.1 removed support for color
+			if (s.ver[0] != 1 || s.ver[1] != 1) && (s.sff.header.Ver0 != 2 || s.sff.header.Ver2 != 1) {
+				r := Clamp(exp[0].evalI(c), 0, 255)
+				g := Clamp(exp[1].evalI(c), 0, 255)
+				b := Clamp(exp[2].evalI(c), 0, 255)
+				s.sdw.color = uint32(r<<16 | g<<8 | b)
+			}
+		case modifyStageVar_shadow_yscale:
+			s.sdw.yscale = exp[0].evalF(c)
+		case modifyStageVar_shadow_fade_range:
+			s.sdw.fadeend = exp[0].evalI(c)
+			s.sdw.fadebgn = exp[1].evalI(c)
+		case modifyStageVar_shadow_xshear:
+			s.sdw.xshear = exp[0].evalF(c)
+		case modifyStageVar_reflection_intensity:
+			s.reflection = Clamp(exp[0].evalI(c), 0, 255)
+		case modifyStageVar_redirectid:
+			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
+				//crun = rid
+			} else {
+				return false
+			}
+		}
+		return true
+	})
+	sys.stage.reload = true // Stage will have to be reloaded if it's re-selected
+	sys.cam.stageCamera = s.stageCamera
+	sys.cam.Init()
+	return false
+}
+
 // StateDef data struct
 type StateBytecode struct {
 	stateType StateType

--- a/src/char.go
+++ b/src/char.go
@@ -4732,9 +4732,9 @@ func (c *Char) scaleHit(baseDamage, id int32, index int) int32 {
 }
 
 // MapSet() sets a map to a specific value.
-func (c *Char) mapSet(s string, Value float32, scType int32) {
+func (c *Char) mapSet(s string, Value float32, scType int32) BytecodeValue {
 	if s == "" {
-		return
+		return BytecodeSF()
 	}
 	key := strings.ToLower(s)
 	switch scType {
@@ -4795,6 +4795,7 @@ func (c *Char) mapSet(s string, Value float32, scType int32) {
 			}
 		}
 	}
+	return BytecodeFloat(Value)
 }
 
 func (c *Char) appendLifebarAction(text string, snd, spr [2]int32, anim, time int32, timemul float32, top bool) {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2050,18 +2050,89 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 		var opc OpCode
+		isStr := false
 		switch svname {
 		case "info.name":
 			opc = OC_const_stagevar_info_name
+			isStr = true
 		case "info.displayname":
 			opc = OC_const_stagevar_info_displayname
+			isStr = true
 		case "info.author":
 			opc = OC_const_stagevar_info_author
+			isStr = true
+		case "camera.boundleft":
+			opc = OC_const_stagevar_camera_boundleft
+		case "camera.boundright":
+			opc = OC_const_stagevar_camera_boundright
+		case "camera.boundhigh":
+			opc = OC_const_stagevar_camera_boundhigh
+		case "camera.boundlow":
+			opc = OC_const_stagevar_camera_boundlow
+		case "camera.verticalfollow":
+			opc = OC_const_stagevar_camera_verticalfollow
+		case "camera.floortension":
+			opc = OC_const_stagevar_camera_floortension
+		case "camera.tensionhigh":
+			opc = OC_const_stagevar_camera_tensionhigh
+		case "camera.tensionlow":
+			opc = OC_const_stagevar_camera_tensionlow
+		case "camera.tension":
+			opc = OC_const_stagevar_camera_tension
+		case "camera.startzoom":
+			opc = OC_const_stagevar_camera_startzoom
+		case "camera.zoomout":
+			opc = OC_const_stagevar_camera_zoomout
+		case "camera.zoomin":
+			opc = OC_const_stagevar_camera_zoomin
+		case "camera.ytension.enable":
+			opc = OC_const_stagevar_camera_ytension_enable
+		case "playerinfo.leftbound":
+			opc = OC_const_stagevar_playerinfo_leftbound
+		case "playerinfo.rightbound":
+			opc = OC_const_stagevar_playerinfo_rightbound
+		case "scaling.topscale":
+			opc = OC_const_stagevar_scaling_topscale
+		case "bound.screenleft":
+			opc = OC_const_stagevar_bound_screenleft
+		case "bound.screenright":
+			opc = OC_const_stagevar_bound_screenright
+		case "stageinfo.zoffset":
+			opc = OC_const_stagevar_stageinfo_zoffset
+		case "stageinfo.zoffsetlink":
+			opc = OC_const_stagevar_stageinfo_zoffsetlink
+		case "stageinfo.xscale":
+			opc = OC_const_stagevar_stageinfo_xscale
+		case "stageinfo.yscale":
+			opc = OC_const_stagevar_stageinfo_yscale
+		case "shadow.intensity":
+			opc = OC_const_stagevar_shadow_intensity
+		case "shadow.color.r":
+			opc = OC_const_stagevar_shadow_color_r
+		case "shadow.color.g":
+			opc = OC_const_stagevar_shadow_color_g
+		case "shadow.color.b":
+			opc = OC_const_stagevar_shadow_color_b
+		case "shadow.yscale":
+			opc = OC_const_stagevar_shadow_yscale
+		case "shadow.fade.range.begin":
+			opc = OC_const_stagevar_shadow_fade_range_begin
+		case "shadow.fade.range.end":
+			opc = OC_const_stagevar_shadow_fade_range_end
+		case "shadow.xshear":	
+			opc = OC_const_stagevar_shadow_xshear
+		case "reflection.intensity":
+			opc = OC_const_stagevar_reflection_intensity
 		default:
 			return bvNone(), Error("Invalid data: " + svname)
 		}
-		if err := nameSub(opc); err != nil {
-			return bvNone(), err
+		if isStr {
+			if err := nameSub(opc); err != nil {
+				return bvNone(), err
+			}
+		} else {
+			out.append(OC_const_)
+			out.append(opc)
 		}
 	case "teammode":
 		if err := eqne(func() error {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -164,6 +164,7 @@ func newCompiler() *Compiler {
 		"targetredlifeadd":     c.targetRedLifeAdd,
 		"targetscoreadd":       c.targetScoreAdd,
 		"text":                 c.text,
+		"modifystagevar":       c.modifyStageVar,
 	}
 	return c
 }

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -4921,16 +4921,20 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 	}
 
 	// Load the command file
-	if err := LoadFile(&cmd, []string{def, "", sys.motifDir, "data/"}, func(filename string) error {
-		str, err := LoadText(filename)
-		if err != nil {
-			return err
+	if len(cmd) > 0 {
+		if err := LoadFile(&cmd, []string{def, "", sys.motifDir, "data/"}, func(filename string) error {
+			str, err := LoadText(filename)
+			if err != nil {
+				return err
+			}
+			str = str + sys.commonCmd
+			lines, i = SplitAndTrim(str, "\n"), 0
+			return nil
+		}); err != nil {
+			return nil, err
 		}
-		str = str + sys.commonCmd
-		lines, i = SplitAndTrim(str, "\n"), 0
-		return nil
-	}); err != nil {
-		return nil, err
+	} else {
+		lines, i = SplitAndTrim(sys.commonCmd, "\n"), 0
 	}
 
 	// Initialize command list data
@@ -5040,9 +5044,11 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 		}
 	}
 	// Compile states in command file
-	if err := c.stateCompile(states, cmd, def, sys.cgi[pn].ikemenver[0] == 0 &&
-		sys.cgi[pn].ikemenver[1] == 0, constants); err != nil {
-		return nil, err
+	if len(cmd) > 0 {
+		if err := c.stateCompile(states, cmd, def, sys.cgi[pn].ikemenver[0] == 0 &&
+			sys.cgi[pn].ikemenver[1] == 0, constants); err != nil {
+			return nil, err
+		}
 	}
 	// Compile states in common state file
 	if len(stcommon) > 0 {

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -4461,7 +4461,6 @@ func (c *Compiler) text(is IniSection, sc *StateControllerBase, _ int8) (StateCo
 	})
 	return *ret, err
 }
-
 // Handles "createPlatform" parameters.
 func (c *Compiler) createPlatform(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*text)(sc), c.stateSec(is, func() error {
@@ -4536,7 +4535,128 @@ func (c *Compiler) createPlatform(is IniSection, sc *StateControllerBase, _ int8
 	})
 	return *ret, err
 }
-
+func (c *Compiler) modifyStageVar(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+	ret, err := (*modifyStageVar)(sc), c.stateSec(is, func() error {
+		if err := c.paramValue(is, sc, "redirectid",
+			modifyStageVar_redirectid, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "camera.ytension.enable",
+			modifyStageVar_camera_ytension_enable, VT_Bool, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "camera.boundleft",
+			modifyStageVar_camera_boundleft, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "camera.boundright",
+			modifyStageVar_camera_boundright, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "camera.boundhigh",
+			modifyStageVar_camera_boundhigh, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "camera.boundlow",
+			modifyStageVar_camera_boundlow, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "camera.verticalfollow",
+			modifyStageVar_camera_verticalfollow, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "camera.floortension",
+			modifyStageVar_camera_floortension, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "camera.tensionhigh",
+			modifyStageVar_camera_tensionhigh, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "camera.tensionlow",
+			modifyStageVar_camera_tensionlow, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "camera.tension",
+			modifyStageVar_camera_tension, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "camera.startzoom",
+			modifyStageVar_camera_startzoom, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "camera.zoomout",
+			modifyStageVar_camera_zoomout, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "camera.zoomin",
+			modifyStageVar_camera_zoomin, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "playerinfo.leftbound",
+			modifyStageVar_playerinfo_leftbound, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "playerinfo.rightbound",
+			modifyStageVar_playerinfo_rightbound, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "scaling.topscale",
+			modifyStageVar_scaling_topscale, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "bound.screenleft",
+			modifyStageVar_bound_screenleft, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "bound.screenright",
+			modifyStageVar_bound_screenright, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "stageinfo.zoffset",
+			modifyStageVar_stageinfo_zoffset, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "stageinfo.zoffsetlink",
+			modifyStageVar_stageinfo_zoffsetlink, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "stageinfo.xscale",
+			modifyStageVar_stageinfo_xscale, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "stageinfo.yscale",
+			modifyStageVar_stageinfo_yscale, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "shadow.intensity",
+			modifyStageVar_shadow_intensity, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "shadow.color",
+			modifyStageVar_shadow_color, VT_Int, 3, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "shadow.yscale",
+			modifyStageVar_shadow_yscale, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "shadow.fade.range",
+			modifyStageVar_shadow_fade_range, VT_Int, 2, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "shadow.xshear",
+			modifyStageVar_shadow_xshear, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "reflection.intensity",
+			modifyStageVar_reflection_intensity, VT_Int, 1, false); err != nil {
+			return err
+		}
+		return nil
+	})
+	return *ret, err
+}
 // It's just a Null... Has no effect whatsoever.
 func (c *Compiler) null(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	return nullStateController, nil

--- a/src/script.go
+++ b/src/script.go
@@ -3483,16 +3483,78 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "stagevar", func(*lua.LState) int {
-		var s string
 		switch strArg(l, 1) {
 		case "info.name":
-			s = sys.stage.name
+			l.Push(lua.LString(sys.stage.name))
 		case "info.displayname":
-			s = sys.stage.displayname
+			l.Push(lua.LString(sys.stage.displayname))
 		case "info.author":
-			s = sys.stage.author
+			l.Push(lua.LString(sys.stage.author))
+		case "camera.boundleft":
+			l.Push(lua.LNumber(sys.stage.stageCamera.boundleft))
+		case "camera.boundright":
+			l.Push(lua.LNumber(sys.stage.stageCamera.boundright))
+		case "camera.boundhigh":
+			l.Push(lua.LNumber(sys.stage.stageCamera.boundhigh))
+		case "camera.boundlow":
+			l.Push(lua.LNumber(sys.stage.stageCamera.boundlow))
+		case "camera.verticalfollow":
+			l.Push(lua.LNumber(sys.stage.stageCamera.verticalfollow))
+		case "camera.floortension":
+			l.Push(lua.LNumber(sys.stage.stageCamera.floortension))
+		case "camera.tensionhigh":
+			l.Push(lua.LNumber(sys.stage.stageCamera.tensionhigh))
+		case "camera.tensionlow":
+			l.Push(lua.LNumber(sys.stage.stageCamera.tensionlow))
+		case "camera.tension":
+			l.Push(lua.LNumber(sys.stage.stageCamera.tension))
+		case "camera.startzoom":
+			l.Push(lua.LNumber(sys.stage.stageCamera.startzoom))
+		case "camera.zoomout":
+			l.Push(lua.LNumber(sys.stage.stageCamera.zoomout))
+		case "camera.zoomin":
+			l.Push(lua.LNumber(sys.stage.stageCamera.zoomin))
+		case "camera.ytension.enable":
+			l.Push(lua.LBool(sys.stage.stageCamera.ytensionenable))
+		case "playerinfo.leftbound":
+			l.Push(lua.LNumber(sys.stage.leftbound))
+		case "playerinfo.rightbound":
+			l.Push(lua.LNumber(sys.stage.rightbound))
+		case "scaling.topscale":
+			l.Push(lua.LNumber(sys.stage.stageCamera.ztopscale))
+		case "bound.screenleft":
+			l.Push(lua.LNumber(sys.stage.screenleft))
+		case "bound.screenright":
+			l.Push(lua.LNumber(sys.stage.screenright))
+		case "stageinfo.zoffset":
+			l.Push(lua.LNumber(sys.stage.stageCamera.zoffset))
+		case "stageinfo.zoffsetlink":
+			l.Push(lua.LNumber(sys.stage.zoffsetlink))
+		case "stageinfo.xscale":
+			l.Push(lua.LNumber(sys.stage.scale[0]))
+		case "stageinfo.yscale":
+			l.Push(lua.LNumber(sys.stage.scale[1]))
+		case "shadow.intensity":
+			l.Push(lua.LNumber(sys.stage.sdw.intensity))
+		case "shadow.color.r":
+			l.Push(lua.LNumber(int32((sys.stage.sdw.color & 0xFF0000) >> 16)))
+		case "shadow.color.g":
+			l.Push(lua.LNumber(int32((sys.stage.sdw.color & 0xFF00) >> 8)))
+		case "shadow.color.b":
+			l.Push(lua.LNumber(int32(sys.stage.sdw.color & 0xFF)))
+		case "shadow.yscale":
+			l.Push(lua.LNumber(sys.stage.sdw.yscale))
+		case "shadow.fade.range.begin":
+			l.Push(lua.LNumber(sys.stage.sdw.fadebgn))
+		case "shadow.fade.range.end":
+			l.Push(lua.LNumber(sys.stage.sdw.fadeend))
+		case "shadow.xshear":
+			l.Push(lua.LNumber(sys.stage.sdw.xshear))
+		case "reflection.intensity":
+			l.Push(lua.LNumber(sys.stage.reflection))
+		default:
+			l.Push(lua.LString(""))
 		}
-		l.Push(lua.LString(s))
 		return 1
 	})
 	luaRegister(l, "sysfvar", func(*lua.LState) int {

--- a/src/script.go
+++ b/src/script.go
@@ -2757,8 +2757,6 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.size.air.back)
 		case "size.air.front":
 			ln = lua.LNumber(c.size.air.front)
-		case "size.z.width":
-			ln = lua.LNumber(c.size.z.width)
 		case "size.height":
 			ln = lua.LNumber(c.size.height)
 		case "size.attack.dist":
@@ -2785,6 +2783,10 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.size.draw.offset[0])
 		case "size.draw.offset.y":
 			ln = lua.LNumber(c.size.draw.offset[1])
+		case "size.z.width":
+			ln = lua.LNumber(c.size.z.width)
+		case "size.z.enable":
+			ln = lua.LNumber(Btoi(c.size.z.enable))
 		case "velocity.walk.fwd.x":
 			ln = lua.LNumber(c.gi().velocity.walk.fwd)
 		case "velocity.walk.back.x":

--- a/src/stage.go
+++ b/src/stage.go
@@ -584,6 +584,7 @@ type stageShadow struct {
 	yscale    float32
 	fadeend   int32
 	fadebgn   int32
+	xshear    float32
 }
 type stagePlayer struct {
 	startx, starty, startz int32
@@ -843,6 +844,7 @@ func loadStage(def string, main bool) (*Stage, error) {
 		sec[0].ReadF32("yscale", &s.sdw.yscale)
 		sec[0].ReadBool("reflect", &reflect)
 		sec[0].readI32ForStage("fade.range", &s.sdw.fadeend, &s.sdw.fadebgn)
+		sec[0].ReadF32("xshear", &s.sdw.xshear)
 	}
 	if reflect {
 		if sec := defmap["reflection"]; len(sec) > 0 {


### PR DESCRIPTION
Details of all changes can be read on the commit themselves, but, to summarize the changes:
- Inline map assignation (`map(something) := 10`) is now possible in ZSS, and in MapSet SCTRLs in CNS.
- All [Files] parameters in chars are now optional, improving AttachedChar portability a lot.
- A missing feature from mugen 1.1 was added: Stage [Shadow] xshear.
- Code related to camera and stage was modified to create a better base for a new SCTRL. Also, bug related to camera tracking and frame rendering when playing with an odd GameFramerate/GameSpeed value was fixed. To reproduce the bug in Ikemen GO 0.98.2, set GameFramerate to an odd number like 55 or 26, then, in a stage with a high boundhigh value and a verticalfollow of 1,  try to add Y Vel to a character. You'll see the character starts to stutter and the camera will not be able to keep up to its speed.
- A new SCTRL was added: ModifyStageVar. This SCTRL is meant to be used primarily by AttachedChars, but characters could make use of it too to create stage effects or situations. The SCTRL lets a character modify various stage parameters from the .def file in real time.
- StageVar() was expanded to allow returning values from the parameters modifable with ModifyStageVar.