### PR TITLE
Fix StageVars modified not getting reset on F4, changes in chars' action() code

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5557,9 +5557,9 @@ func (sc angleDraw) Run(c *Char, _ []int32) bool {
 		case angleDraw_value:
 			crun.angleSet(exp[0].evalF(c))
 		case angleDraw_scale:
-			crun.angleScalse[0] *= exp[0].evalF(c)
+			crun.angleScale[0] *= exp[0].evalF(c)
 			if len(exp) > 1 {
-				crun.angleScalse[1] *= exp[1].evalF(c)
+				crun.angleScale[1] *= exp[1].evalF(c)
 			}
 		case angleDraw_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {

--- a/src/char.go
+++ b/src/char.go
@@ -1600,7 +1600,7 @@ type CharSystemVar struct {
 	bindFacing       float32
 	hitPauseTime     int32
 	angle            float32
-	angleScalse      [2]float32
+	angleScale       [2]float32
 	alpha            [2]int32
 	recoverTime      int32
 	systemFlag       SystemCharFlag
@@ -1837,7 +1837,7 @@ func (c *Char) clear2() {
 	c.sysVarRangeSet(0, int32(NumSysVar)-1, 0)
 	c.sysFvarRangeSet(0, int32(NumSysFvar)-1, 0)
 	c.CharSystemVar = CharSystemVar{bindToId: -1,
-		angleScalse: [...]float32{1, 1}, alpha: [...]int32{255, 0},
+		angleScale: [...]float32{1, 1}, alpha: [...]int32{255, 0},
 		width:           [...]float32{c.defFW(), c.defBW()},
 		attackMul:       float32(c.gi().data.attack) * c.ocd().attackRatio / 100,
 		fallDefenseMul:  1,
@@ -5340,7 +5340,7 @@ func (c *Char) action() {
 					}
 				}
 			}
-			c.angleScalse = [...]float32{1, 1}
+			c.angleScale = [...]float32{1, 1}
 			c.attackDist = float32(c.size.attack.dist)
 			c.offset = [2]float32{}
 			for i, hb := range c.hitby {
@@ -5364,7 +5364,7 @@ func (c *Char) action() {
 		c.unsetSF(CSF_noautoturn)
 		if c.gi().ver[0] == 1 {
 			c.unsetSF(CSF_assertspecial | CSF_angledraw)
-			c.angleScalse = [...]float32{1, 1}
+			c.angleScale = [...]float32{1, 1}
 			c.offset = [2]float32{}
 		}
 	}
@@ -5868,7 +5868,7 @@ func (c *Char) cueDraw() {
 		rec := sys.tickNextFrame() && c.acttmp > 0
 		sdf := func() *SprData {
 			sd := &SprData{c.anim, c.getPalfx(), pos,
-				scl, c.alpha, c.sprPriority, Rotation{agl, 0, 0}, c.angleScalse, false,
+				scl, c.alpha, c.sprPriority, Rotation{agl, 0, 0}, c.angleScale, false,
 				c.playerNo == sys.superplayer, c.gi().ver[0] != 1, c.facing, c.localscl / (320 / c.localcoord), 0, 0, [4]float32{0, 0, 0, 0}}
 			if !c.sf(CSF_trans) {
 				sd.alpha[0] = -1

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -3899,10 +3899,10 @@ func (c *Compiler) mapSetSub(is IniSection, sc *StateControllerBase) error {
 					return err
 				}
 				c.token = c.tokenizer(&mapParam)
-				if c.token == ":=" {
+				if c.token == "=" || c.token == ":=" {
 					value = strings.TrimSpace(mapParam)
 				} else {
-					return Error("Missing ':' before '='")
+					return Error("Invalid operator: " + c.token)
 				}
 			} else {
 				b := false

--- a/src/stage.go
+++ b/src/stage.go
@@ -771,7 +771,6 @@ func loadStage(def string, main bool) (*Stage, error) {
 	}
 	s.localscl = float32(sys.gameWidth) / float32(s.stageCamera.localcoord[0])
 	s.stageCamera.localscl = s.localscl
-
 	if sec := defmap["camera"]; len(sec) > 0 {
 		sec[0].ReadI32("startx", &s.stageCamera.startx)
 		//sec[0].ReadI32("starty", &s.stageCamera.starty) //does nothing in mugen
@@ -802,27 +801,6 @@ func loadStage(def string, main bool) (*Stage, error) {
 			sec[0].ReadI32("tensionhigh", &s.stageCamera.tensionhigh)
 		}
 	}
-	if sec := defmap["music"]; len(sec) > 0 {
-		s.bgmusic = sec[0]["bgmusic"]
-		sec[0].ReadI32("bgmratio.life", &s.bgmratiolife)
-		sec[0].ReadI32("bgmtrigger.life", &s.bgmtriggerlife)
-		sec[0].ReadI32("bgmtrigger.alt", &s.bgmtriggeralt)
-	}
-	if sec := defmap["bgdef"]; len(sec) > 0 {
-		if sec[0].LoadFile("spr", []string{def, "", sys.motifDir, "data/"}, func(filename string) error {
-			sff, err := loadSff(filename, false)
-			if err != nil {
-				return err
-			}
-			*s.sff = *sff
-			return nil
-		}); err != nil {
-			return nil, err
-		}
-		sec[0].ReadBool("debugbg", &s.debugbg)
-		sec[0].readI32ForStage("bgclearcolor", &s.bgclearcolor[0], &s.bgclearcolor[1], &s.bgclearcolor[2])
-		sec[0].ReadBool("roundpos", &s.stageprops.roundpos)
-	}
 	reflect := true
 	if sec := defmap["shadow"]; len(sec) > 0 {
 		var tmp int32
@@ -847,6 +825,27 @@ func loadStage(def string, main bool) (*Stage, error) {
 				s.reflection = Clamp(tmp, 0, 255)
 			}
 		}
+	}
+	if sec := defmap["music"]; len(sec) > 0 {
+		s.bgmusic = sec[0]["bgmusic"]
+		sec[0].ReadI32("bgmratio.life", &s.bgmratiolife)
+		sec[0].ReadI32("bgmtrigger.life", &s.bgmtriggerlife)
+		sec[0].ReadI32("bgmtrigger.alt", &s.bgmtriggeralt)
+	}
+	if sec := defmap["bgdef"]; len(sec) > 0 {
+		if sec[0].LoadFile("spr", []string{def, "", sys.motifDir, "data/"}, func(filename string) error {
+			sff, err := loadSff(filename, false)
+			if err != nil {
+				return err
+			}
+			*s.sff = *sff
+			return nil
+		}); err != nil {
+			return nil, err
+		}
+		sec[0].ReadBool("debugbg", &s.debugbg)
+		sec[0].readI32ForStage("bgclearcolor", &s.bgclearcolor[0], &s.bgclearcolor[1], &s.bgclearcolor[2])
+		sec[0].ReadBool("roundpos", &s.stageprops.roundpos)
 	}
 	var bglink *backGround
 	for _, bgsec := range defmap["bg"] {
@@ -939,6 +938,37 @@ func loadStage(def string, main bool) (*Stage, error) {
 	}
 	s.mainstage = main
 	return s, nil
+}
+func (s *Stage) copyStageVars(src *Stage) {
+	s.stageCamera.boundleft = src.stageCamera.boundleft
+	s.stageCamera.boundright = src.stageCamera.boundright
+	s.stageCamera.boundhigh = src.stageCamera.boundhigh
+	s.stageCamera.boundlow = src.stageCamera.boundlow
+	s.stageCamera.verticalfollow = src.stageCamera.verticalfollow
+	s.stageCamera.floortension = src.stageCamera.floortension
+	s.stageCamera.tensionhigh = src.stageCamera.tensionhigh
+	s.stageCamera.tensionlow = src.stageCamera.tensionlow
+	s.stageCamera.tension = src.stageCamera.tension
+	s.stageCamera.startzoom = src.stageCamera.startzoom
+	s.stageCamera.zoomout = src.stageCamera.zoomout
+	s.stageCamera.zoomin = src.stageCamera.zoomin
+	s.stageCamera.ytensionenable = src.stageCamera.ytensionenable
+	s.leftbound = src.leftbound
+	s.rightbound = src.rightbound
+	s.stageCamera.ztopscale = src.stageCamera.ztopscale
+	s.screenleft = src.screenleft
+	s.screenright = src.screenright
+	s.stageCamera.zoffset = src.stageCamera.zoffset
+	s.zoffsetlink = src.zoffsetlink
+	s.scale[0] = src.scale[0]
+	s.scale[1] = src.scale[1]
+	s.sdw.intensity = src.sdw.intensity
+	s.sdw.color = src.sdw.color
+	s.sdw.yscale = src.sdw.yscale
+	s.sdw.fadeend = src.sdw.fadeend
+	s.sdw.fadebgn = src.sdw.fadebgn
+	s.sdw.xshear = src.sdw.xshear
+	s.reflection = src.reflection
 }
 func (s *Stage) getBg(id int32) (bg []*backGround) {
 	if id >= 0 {

--- a/src/system.go
+++ b/src/system.go
@@ -1715,6 +1715,8 @@ func (s *System) fight() (reload bool) {
 		}
 		s.wincnt.update()
 	}()
+	var oldStageVars Stage
+	oldStageVars.copyStageVars(s.stage)
 	var life, pow, gpow, spow, rlife [len(s.chars)]int32
 	var ivar [len(s.chars)][]int32
 	var fvar [len(s.chars)][]float32
@@ -1952,6 +1954,7 @@ func (s *System) fight() (reload bool) {
 				p[0].nextHitScale = make(map[int32][3]*HitScale)
 			}
 		}
+		s.stage.copyStageVars(&oldStageVars)
 		s.resetFrameTime()
 		s.nextRound()
 		s.roundResetFlg, s.introSkipped = false, false
@@ -2029,6 +2032,7 @@ func (s *System) fight() (reload bool) {
 					}
 				}
 				oldWins, oldDraws = s.wins, s.draws
+				oldStageVars.copyStageVars(s.stage)
 				reset()
 			} else {
 				/* End match, or prepare for a new character in turns mode */


### PR DESCRIPTION
First fix is self-explanatory, when modifying StageVars via ModifyStageVar and then pressing F4 to reset the round, modifications persist, so this was fixed. StageVars now get reset on F4 based on the values they had when starting the round.

Map assign in CNS (inside MapSet SCTRL) now can be done via '=' or ':=', like VarSet SCTRL. This only affects the MapSet-related SCTRLs, map assignments done inside a statement only work with ':=' operator.

Latest thing is a major change in chars' `action()` code processing order. The code was divided in three phases: `actionPrepare()`, `actionRunStates()` `actionFinish()`. The idea is then to establish a new base for char action performing in a way that addresses problems like Assert SCTRLs not being able to be redirected (#540), and possible char priority issues. The criteria for the division was the actions performed before and after running the states from a char.