### PR TITLE
Fix envshake intensity

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5265,7 +5265,7 @@ func (sc envShake) Run(c *Char, _ []int32) bool {
 		case envShake_phase:
 			sys.envShake.phase = MaxF(0, exp[0].evalF(c)*float32(math.Pi)/180) * c.localscl
 		case envShake_freq:
-			sys.envShake.freq = exp[0].evalF(c)
+			sys.envShake.freq = MaxF(0, exp[0].evalF(c)*float32(math.Pi)/180)
 		}
 		return true
 	})

--- a/src/stage.go
+++ b/src/stage.go
@@ -48,7 +48,7 @@ func (es *EnvShake) next() {
 }
 func (es *EnvShake) getOffset() float32 {
 	if es.time > 0 {
-		return float32(es.ampl) * 0.5 * float32(math.Sin(float64(es.phase)))
+		return float32(es.ampl) * float32(math.Sin(float64(es.phase)))
 	}
 	return 0
 }


### PR DESCRIPTION
In mugen 1.1, envshake has a stronger movement effect than in Ikemen GO. This problem is best exemplifed by Mortal Kombat Project's Bell Tower stage. This stage has a special stage fatality that makes high use of envshake SCTRL to control the camera (probably to compensate for mugen limitations). Without these changes, camera will fail to follow the player.

Test case: https://files.catbox.moe/u1sbc0.7z

How to test the stage:
- Go to round 2
- Press shift + F2 to set p2 life to 1
- Perform an uppercut on p2 to activate the stage fatality