### PR TITLE
Remove calls to gl.ObjectLabel()

### DIFF
--- a/src/gl.go
+++ b/src/gl.go
@@ -31,7 +31,6 @@ func newShaderProgram(vert, frag, id string) (s *ShaderProgram) {
 	vertObj := compileShader(gl.VERTEX_SHADER, vert)
 	fragObj := compileShader(gl.FRAGMENT_SHADER, frag)
 	prog := linkProgram(vertObj, fragObj)
-	gl.ObjectLabel(prog, id)
 
 	s = &ShaderProgram{program: prog}
 	s.aPos = gl.GetAttribLocation(s.program, "position")

--- a/src/render.go
+++ b/src/render.go
@@ -140,7 +140,6 @@ func RenderInit() {
 
 	gl.ActiveTexture(gl.TEXTURE0)
 	fbo_texture = gl.CreateTexture()
-	gl.ObjectLabel(fbo_texture, "Main Framebuffer Texture")
 
 	if sys.multisampleAntialiasing {
 		gl.BindTexture(gl.TEXTURE_2D_MULTISAMPLE, fbo_texture)
@@ -166,14 +165,12 @@ func RenderInit() {
 		fbo_f_texture.SetData(sys.scrrect[2], sys.scrrect[3], 32, false, nil)
 	} else {
 		rbo_depth = gl.CreateRenderbuffer()
-		gl.ObjectLabel(rbo_depth, "Depth Renderbuffer")
 		gl.BindRenderbuffer(gl.RENDERBUFFER, rbo_depth)
 		gl.RenderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT16, int(sys.scrrect[2]), int(sys.scrrect[3]))
 		gl.BindRenderbuffer(gl.RENDERBUFFER, gl.NoRenderbuffer)
 	}
 
 	fbo = gl.CreateFramebuffer()
-	gl.ObjectLabel(fbo, "Main Framebuffer")
 	gl.BindFramebuffer(gl.FRAMEBUFFER, fbo)
 
 	if sys.multisampleAntialiasing {


### PR DESCRIPTION
This function only appeared in OpenGL 4.3, and some drivers appear to still provide only OpenGL 4.2. Since its main purpose is for debugging, we should just remove it until there is a way to query for the exact OpenGL version (will require a patch to the Go GL library we use).