### PR TITLE
New BGCtrls: RemapPal, PalFX

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -7421,6 +7421,8 @@ const (
 	modifyBGCtrl_value
 	modifyBGCtrl_x
 	modifyBGCtrl_y
+	modifyBGCtrl_src
+	modifyBGCtrl_dst
 	modifyBGCtrl_redirectid
 )
 
@@ -7429,6 +7431,7 @@ func (sc modifyBGCtrl) Run(c *Char, _ []int32) bool {
 	var cid int32
 	t, v := [3]int32{IErr, IErr, IErr}, [3]int32{IErr, IErr, IErr}
 	x, y := float32(math.NaN()), float32(math.NaN())
+	s, d := [2]int32{IErr, IErr}, [2]int32{IErr, IErr}
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case modifyBGCtrl_id:
@@ -7453,6 +7456,16 @@ func (sc modifyBGCtrl) Run(c *Char, _ []int32) bool {
 			x = exp[0].evalF(c)
 		case modifyBGCtrl_y:
 			y = exp[0].evalF(c)
+		case modifyBGCtrl_src:
+			if len(exp) > 1 {
+				s[0] = exp[0].evalI(c)
+				s[1] = exp[1].evalI(c)
+			}
+		case modifyBGCtrl_dst:
+			if len(exp) > 1 {
+				d[0] = exp[0].evalI(c)
+				d[1] = exp[1].evalI(c)
+			}
 		case modifyBGCtrl_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				//crun = rid
@@ -7462,7 +7475,7 @@ func (sc modifyBGCtrl) Run(c *Char, _ []int32) bool {
 		}
 		return true
 	})
-	sys.stage.modifyBGCtrl(cid, t, v, x, y)
+	sys.stage.modifyBGCtrl(cid, t, v, x, y, s, d)
 	return false
 }
 

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -4169,6 +4169,14 @@ func (c *Compiler) modifyBGCtrl(is IniSection, sc *StateControllerBase, _ int8) 
 			modifyBGCtrl_y, VT_Float, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "source",
+			modifyBGCtrl_src, VT_Int, 2, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "dest",
+			modifyBGCtrl_dst, VT_Int, 2, false); err != nil {
+			return err
+		}
 		return nil
 	})
 	return *ret, err

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -4170,11 +4170,31 @@ func (c *Compiler) modifyBGCtrl(is IniSection, sc *StateControllerBase, _ int8) 
 			return err
 		}
 		if err := c.paramValue(is, sc, "source",
-			modifyBGCtrl_src, VT_Int, 2, false); err != nil {
+			modifyBGCtrl_source, VT_Int, 2, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "dest",
-			modifyBGCtrl_dst, VT_Int, 2, false); err != nil {
+			modifyBGCtrl_dest, VT_Int, 2, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "add",
+			modifyBGCtrl_add, VT_Int, 3, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "mul",
+			modifyBGCtrl_mul, VT_Int, 3, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "sinadd",
+			modifyBGCtrl_sinadd, VT_Int, 4, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "invertall",
+			modifyBGCtrl_invertall, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "color",
+			modifyBGCtrl_color, VT_Float, 1, false); err != nil {
 			return err
 		}
 		return nil

--- a/src/stage.go
+++ b/src/stage.go
@@ -60,9 +60,10 @@ const (
 	BT_Anim
 	BT_Visible
 	BT_Enable
+	BT_PalFX
 	BT_PosSet
 	BT_PosAdd
-	BT_RemapPal	
+	BT_RemapPal
 	BT_SinX
 	BT_SinY
 	BT_VelSet
@@ -100,6 +101,7 @@ func (bga *bgAction) action() {
 
 type backGround struct {
 	typ                int
+	palfx              *PalFX
 	anim               Animation
 	bga                bgAction
 	id                 int32
@@ -134,7 +136,7 @@ type backGround struct {
 }
 
 func newBackGround(sff *Sff) *backGround {
-	return &backGround{anim: *newAnimation(sff), delta: [...]float32{1, 1}, zoomdelta: [...]float32{1, math.MaxFloat32},
+	return &backGround{palfx: newPalFX(), anim: *newAnimation(sff), delta: [...]float32{1, 1}, zoomdelta: [...]float32{1, math.MaxFloat32},
 		xscale: [...]float32{1, 1}, rasterx: [...]float32{1, 1}, yscalestart: 100, scalestart: [...]float32{1, 1}, xbottomzoomdelta: math.MaxFloat32,
 		zoomscaledelta: [...]float32{math.MaxFloat32, math.MaxFloat32}, actionno: -1, visible: true, active: true, autoresizeparallax: false,
 		startrect: [...]int32{-32768, -32768, 65535, 65535}}
@@ -334,12 +336,14 @@ func readBackGround(is IniSection, link *backGround,
 	return bg
 }
 func (bg *backGround) reset() {
+	bg.palfx.clear()
 	bg.anim.Reset()
 	bg.bga.clear()
 	bg.bga.vel = bg.startv
 	bg.bga.radius = bg.startrad
 	bg.bga.sintime = bg.startsint
 	bg.bga.sinlooptime = bg.startsinlt
+	bg.palfx.time = -1
 }
 func (bg backGround) draw(pos [2]float32, scl, bgscl, lclscl float32,
 	stgscl [2]float32, shakeY float32, isStage bool) {
@@ -420,7 +424,7 @@ func (bg backGround) draw(pos [2]float32, scl, bgscl, lclscl float32,
 	if rect[0] < sys.scrrect[2] && rect[1] < sys.scrrect[3] && rect[0]+rect[2] > 0 && rect[1]+rect[3] > 0 {
 		bg.anim.Draw(&rect, x, y, sclx, scly, bg.xscale[0]*bgscl*(bg.scalestart[0]+xs)*xs3, xbs*bgscl*(bg.scalestart[0]+xs)*xs3, ys*ys3,
 			xras*x/(AbsF(ys*ys3)*lscl[1]*float32(bg.anim.spr.Size[1])*bg.scalestart[1])*sclx_recip*bg.scalestart[1],
-			Rotation{}, float32(sys.gameWidth)/2, &sys.bgPalFX, true, 1, false, 1, 0, 0)
+			Rotation{}, float32(sys.gameWidth)/2, bg.palfx, true, 1, false, 1, 0, 0)
 	}
 }
 
@@ -435,6 +439,11 @@ type bgCtrl struct {
 	v            [3]int32
 	src          [2]int32
 	dst          [2]int32
+	add          [3]int32
+	mul          [3]int32
+	sinadd       [4]int32
+	invall       bool
+	color        float32
 	positionlink bool
 	idx          int
 	sctrlid      int32
@@ -446,7 +455,8 @@ func newBgCtrl() *bgCtrl {
 func (bgc *bgCtrl) read(is IniSection, idx int) {
 	bgc.idx = idx
 	xy := false
-	srcdst := false	
+	srcdst := false
+	palfx := false
 	switch strings.ToLower(is["type"]) {
 	case "anim":
 		bgc._type = BT_Anim
@@ -456,15 +466,27 @@ func (bgc *bgCtrl) read(is IniSection, idx int) {
 		bgc._type = BT_Enable
 	case "null":
 		bgc._type = BT_Null
-	case "remappal":
-		bgc._type = BT_RemapPal
-		srcdst = true
+	case "palfx":
+		bgc._type = BT_PalFX
+		palfx = true
+		// Default values for PalFX
+		bgc.add = [3]int32{0, 0, 0}
+		bgc.mul = [3]int32{256, 256, 256}
+		bgc.sinadd = [4]int32{0, 0, 0, 0}
+		bgc.invall = false
+		bgc.color = 1
 	case "posset":
 		bgc._type = BT_PosSet
 		xy = true
 	case "posadd":
 		bgc._type = BT_PosAdd
 		xy = true
+	case "remappal":
+		bgc._type = BT_RemapPal
+		srcdst = true
+		// Default values for RemapPal
+		bgc.src = [2]int32{-1, 0}
+		bgc.dst = [2]int32{-1, 0}
 	case "sinx":
 		bgc._type = BT_SinX
 	case "siny":
@@ -486,7 +508,24 @@ func (bgc *bgCtrl) read(is IniSection, idx int) {
 	} else if srcdst {
 		is.readI32ForStage("source", &bgc.src[0], &bgc.src[1])
 		is.readI32ForStage("dest", &bgc.dst[0], &bgc.dst[1])
-	}else if is.ReadF32("value", &bgc.x) {
+	} else if palfx {
+		is.readI32ForStage("add", &bgc.add[0], &bgc.add[1], &bgc.add[2])
+		is.readI32ForStage("mul", &bgc.mul[0], &bgc.mul[1], &bgc.mul[2])
+		if is.readI32ForStage("sinadd", &bgc.sinadd[0], &bgc.sinadd[1], &bgc.sinadd[2], &bgc.sinadd[3]) {
+			if bgc.sinadd[3] < 0 {
+				for i := 0; i < 4; i++ {
+					bgc.sinadd[i] = -bgc.sinadd[i]
+				}
+			}
+		}
+		var tmp int32
+		if is.ReadI32("invertall", &tmp) {
+			bgc.invall = tmp != 0
+		}
+		if is.ReadF32("color", &bgc.color) {
+			bgc.color = ClampF(bgc.color / 256, 0, 1)
+		}
+	} else if is.ReadF32("value", &bgc.x) {
 		is.readI32ForStage("value", &bgc.v[0], &bgc.v[1], &bgc.v[2])
 	}
 	is.ReadI32("sctrlid", &bgc.sctrlid)
@@ -1017,18 +1056,16 @@ func (s *Stage) runBgCtrl(bgc *bgCtrl) {
 		for i := range bgc.bg {
 			bgc.bg[i].visible, bgc.bg[i].active = bgc.v[0] != 0, bgc.v[0] != 0
 		}
-	case BT_RemapPal:
-		if bgc.src[0] >= 0 && bgc.src[1] >= 0 && bgc.dst[0] >= 0 && bgc.dst[1] >= 0 {
-			si, ok := s.sff.palList.PalTable[[...]int16{int16(bgc.src[0]), int16(bgc.src[1])}]
-			if !ok || si < 0 {
-				return
-			}
-			var di int
-			di, ok = s.sff.palList.PalTable[[...]int16{int16(bgc.dst[0]), int16(bgc.dst[1])}]
-			if !ok || di < 0 {
-				return
-			}
-			s.sff.palList.Remap(si, di)
+	case BT_PalFX:
+		for i := range bgc.bg {
+			bgc.bg[i].palfx.add = bgc.add
+			bgc.bg[i].palfx.mul = bgc.mul
+			bgc.bg[i].palfx.sinadd[0] = bgc.sinadd[0]
+			bgc.bg[i].palfx.sinadd[1] = bgc.sinadd[1]
+			bgc.bg[i].palfx.sinadd[2] = bgc.sinadd[2]
+			bgc.bg[i].palfx.cycletime = bgc.sinadd[3]
+			bgc.bg[i].palfx.invertall = bgc.invall
+			bgc.bg[i].palfx.color = bgc.color
 		}
 	case BT_PosSet:
 		for i := range bgc.bg {
@@ -1063,6 +1100,26 @@ func (s *Stage) runBgCtrl(bgc *bgCtrl) {
 			if bgc.yEnable() {
 				s.bga.pos[1] += bgc.y
 			}
+		}
+	case BT_RemapPal:
+		if bgc.src[0] >= 0 && bgc.src[1] >= 0 && bgc.dst[1] >= 0 {
+			// Get source pal
+			si, ok := s.sff.palList.PalTable[[...]int16{int16(bgc.src[0]), int16(bgc.src[1])}]
+			if !ok || si < 0 {
+				return
+			}
+			var di int
+			if bgc.dst[0] < 0 {
+				// Set dest pal to source pal (remap gets reset)
+				di = si
+			} else {
+				// Get dest pal
+				di, ok = s.sff.palList.PalTable[[...]int16{int16(bgc.dst[0]), int16(bgc.dst[1])}]
+				if !ok || di < 0 {
+					return
+				}
+			}
+			s.sff.palList.Remap(si, di)
 		}
 	case BT_SinX, BT_SinY:
 		ii := Btoi(bgc._type == BT_SinY)
@@ -1126,6 +1183,10 @@ func (s *Stage) action() {
 	s.bga.action()
 	link, zlink := 0, -1
 	for i, b := range s.bg {
+		b.palfx.step()
+		if sys.bgPalFX.time != 0 {
+			b.palfx.synthesize(sys.bgPalFX)
+		}
 		if b.active {
 			s.bg[i].bga.action()
 			if i > 0 && b.positionlink {
@@ -1209,7 +1270,8 @@ func (s *Stage) reset() {
 	s.stageTime = 0
 }
 
-func (s *Stage) modifyBGCtrl(id int32, t, v [3]int32, x, y float32, src, dst [2]int32) {
+func (s *Stage) modifyBGCtrl(id int32, t, v [3]int32, x, y float32, src, dst [2]int32,
+	add, mul [3]int32, sinadd [4]int32, invall int32, color float32) {
 	for i := range s.bgc {
 		if id == s.bgc[i].sctrlid {
 			if t[0] != IErr {
@@ -1221,14 +1283,10 @@ func (s *Stage) modifyBGCtrl(id int32, t, v [3]int32, x, y float32, src, dst [2]
 			if t[2] != IErr {
 				s.bgc[i].looptime = t[2]
 			}
-			if v[0] != IErr {
-				s.bgc[i].v[0] = v[0]
-			}
-			if v[1] != IErr {
-				s.bgc[i].v[1] = v[1]
-			}
-			if v[2] != IErr {
-				s.bgc[i].v[2] = v[2]
+			for j := 0; j < 3; j++ {
+				if v[j] != IErr {
+					s.bgc[i].v[j] = v[j]
+				}
 			}
 			if !math.IsNaN(float64(x)) {
 				s.bgc[i].x = x
@@ -1236,14 +1294,37 @@ func (s *Stage) modifyBGCtrl(id int32, t, v [3]int32, x, y float32, src, dst [2]
 			if !math.IsNaN(float64(y)) {
 				s.bgc[i].y = y
 			}
-			if src[0] != IErr && src[1] != IErr {
-				s.bgc[i].src[0] = src[0]
-				s.bgc[i].src[1] = src[1]
+			for j := 0; j < 2; j++ {
+				if src[j] != IErr {
+					s.bgc[i].src[j] = src[j]
+				}
 			}
-			if dst[0] != IErr && dst[1] != IErr {
-				s.bgc[i].dst[0] = dst[0]
-				s.bgc[i].dst[1] = dst[1]
+			for j := 0; j < 2; j++ {
+				if dst[j] != IErr {
+					s.bgc[i].dst[j] = dst[j]
+				}
 			}
+			for j := 0; j < 3; j++ {
+				if add[j] != IErr {
+					s.bgc[i].add[j] = add[j]
+				}
+			}
+			for j := 0; j < 3; j++ {
+				if mul[j] != IErr {
+					s.bgc[i].mul[j] = mul[j]
+				}
+			}
+			for j := 0; j < 4; j++ {
+				if sinadd[j] != IErr {
+					s.bgc[i].sinadd[j] = sinadd[j]
+				}
+			}
+			if invall != IErr {
+				s.bgc[i].invall = invall != 0
+			}
+			if !math.IsNaN(float64(color)) {
+				s.bgc[i].color = color
+			} 
 			s.reload = true
 		}
 	}


### PR DESCRIPTION
- **RemapPal**: Remaps a palette from stage sff file to another palette from the same file. This can be used to perform static palette changes without having to duplicate sprites.
- **PalFX**: Applies palette effects to individual background elements. It works in a different layer than BGPalFX, meaning BGPalFX will be applied over BG elems' PalFX instead of substituting them. Due to the nature of BGCtrls, PalFX is permanently applied to its BG element the moment `time` triggers it (though it can be overriden by a new PalFX definition).

In both cases, BGCtrls can be modified via ModifyBGCtrl SCTRL.