### PR TITLE
Keyboard input for the Kinc library

### DIFF
--- a/src/input.go
+++ b/src/input.go
@@ -6,15 +6,7 @@ import (
 	"os"
 	"strings"
 	"time"
-
-	glfw "github.com/fyne-io/glfw-js"
 )
-
-var KeyUnknown = StringToKey("")
-var KeyEscape  = StringToKey("ESCAPE")
-var KeyEnter   = StringToKey("RETURN")
-var KeyInsert  = StringToKey("INSERT")
-var KeyF12     = StringToKey("F12")
 
 var ModAlt          = NewModifierKey(false, true, false)
 var ModCtrlAlt      = NewModifierKey(true,  true, false)
@@ -110,16 +102,17 @@ func NewShortcutKey(key Key, ctrl, alt, shift bool) *ShortcutKey {
 func (sk ShortcutKey) Test(k Key, m ModifierKey) bool {
 	return k == sk.Key && (m & ModCtrlAltShift) == sk.Mod
 }
-func keyCallback(_ *glfw.Window, key Key, _ int, action glfw.Action, mk ModifierKey) {
-	if key == KeyUnknown {
-		return
-	}
-	switch action {
-	case glfw.Release:
+
+func OnKeyReleased(key Key, mk ModifierKey) {
+	if key != KeyUnknown {
 		sys.keyState[key] = false
 		sys.keyInput = KeyUnknown
 		sys.keyString = ""
-	case glfw.Press:
+	}
+}
+
+func OnKeyPressed(key Key, mk ModifierKey) {
+	if key != KeyUnknown {
 		sys.keyState[key] = true
 		sys.keyInput = key
 		sys.esc = sys.esc ||
@@ -139,8 +132,8 @@ func keyCallback(_ *glfw.Window, key Key, _ int, action glfw.Action, mk Modifier
 	}
 }
 
-func charCallback(_ *glfw.Window, char rune, mk ModifierKey) {
-	sys.keyString = string(char)
+func OnTextEntered(s string) {
+	sys.keyString = s
 }
 
 func JoystickState(joy, button int) bool {

--- a/src/input.go
+++ b/src/input.go
@@ -85,11 +85,11 @@ type ShortcutScript struct {
 	DebugKey bool
 }
 type ShortcutKey struct {
-	Key glfw.Key
-	Mod glfw.ModifierKey
+	Key Key
+	Mod ModifierKey
 }
 
-func NewShortcutKey(key glfw.Key, ctrl, alt, shift bool) *ShortcutKey {
+func NewShortcutKey(key Key, ctrl, alt, shift bool) *ShortcutKey {
 	sk := &ShortcutKey{}
 	sk.Key = key
 	sk.Mod = 0
@@ -104,11 +104,11 @@ func NewShortcutKey(key glfw.Key, ctrl, alt, shift bool) *ShortcutKey {
 	}
 	return sk
 }
-func (sk ShortcutKey) Test(k glfw.Key, m glfw.ModifierKey) bool {
+func (sk ShortcutKey) Test(k Key, m ModifierKey) bool {
 	return k == sk.Key &&
 		m&(glfw.ModShift|glfw.ModControl|glfw.ModAlt) == sk.Mod
 }
-func keyCallback(_ *glfw.Window, key glfw.Key, _ int, action glfw.Action, mk glfw.ModifierKey) {
+func keyCallback(_ *glfw.Window, key Key, _ int, action glfw.Action, mk ModifierKey) {
 	if key == glfw.KeyUnknown {
 		return
 	}
@@ -137,13 +137,13 @@ func keyCallback(_ *glfw.Window, key glfw.Key, _ int, action glfw.Action, mk glf
 	}
 }
 
-func charCallback(_ *glfw.Window, char rune, mk glfw.ModifierKey) {
+func charCallback(_ *glfw.Window, char rune, mk ModifierKey) {
 	sys.keyString = string(char)
 }
 
 func JoystickState(joy, button int) bool {
 	if joy < 0 {
-		return sys.keyState[glfw.Key(button)]
+		return sys.keyState[Key(button)]
 	}
 	if joy >= input.GetMaxJoystickCount() {
 		return false

--- a/src/input_glfw.go
+++ b/src/input_glfw.go
@@ -10,8 +10,8 @@ type Input struct {
 	joystick []glfw.Joystick
 }
 
-type Key glfw.Key
-type ModifierKey glfw.ModifierKey
+type Key = glfw.Key
+type ModifierKey = glfw.ModifierKey
 
 var KeyToStringLUT = map[glfw.Key]string {
 	glfw.KeyEnter: "RETURN",

--- a/src/input_glfw.go
+++ b/src/input_glfw.go
@@ -13,6 +13,14 @@ type Input struct {
 type Key = glfw.Key
 type ModifierKey = glfw.ModifierKey
 
+const (
+	KeyUnknown = glfw.KeyUnknown
+	KeyEscape  = glfw.KeyEscape
+	KeyEnter   = glfw.KeyEnter
+	KeyInsert  = glfw.KeyInsert
+	KeyF12     = glfw.KeyF12
+)
+
 var KeyToStringLUT = map[glfw.Key]string {
 	glfw.KeyEnter: "RETURN",
 	glfw.KeyEscape: "ESCAPE",

--- a/src/input_glfw.go
+++ b/src/input_glfw.go
@@ -155,6 +155,19 @@ func KeyToString(k glfw.Key) string {
 	return ""
 }
 
+func NewModifierKey(ctrl, alt, shift bool) (mod glfw.ModifierKey) {
+	if ctrl {
+		mod |= glfw.ModControl
+	}
+	if alt {
+		mod |= glfw.ModAlt
+	}
+	if shift {
+		mod |= glfw.ModShift
+	}
+	return
+}
+
 var input = Input{
 	joystick: []glfw.Joystick{glfw.Joystick1, glfw.Joystick2, glfw.Joystick3,
 		glfw.Joystick4, glfw.Joystick5, glfw.Joystick6, glfw.Joystick7,

--- a/src/input_kinc.go
+++ b/src/input_kinc.go
@@ -4,16 +4,25 @@ package main
 
 /*
 #include <kinc/input/gamepad.h>
+#include <kinc/input/keyboard.h>
 
 typedef void (*button_callback_t)(int gamepad, int button, float value);
 typedef void (*axis_callback_t)(int gamepad, int axis, float value);
+typedef void (*key_callback_t)(int key);
+typedef void (*char_callback_t)(unsigned ch);
 
 #if _WIN32
 extern __declspec(dllexport) void axis_callback(int gamepad, int axis, float value);
 extern __declspec(dllexport) void button_callback(int gamepad, int button, float value);
+extern __declspec(dllexport) void key_down_callback(int key);
+extern __declspec(dllexport) void key_up_callback(int key);
+extern __declspec(dllexport) void char_callback(unsigned ch);
 #else
 extern void axis_callback(int gamepad, int axis, float value);
 extern void button_callback(int gamepad, int button, float value);
+extern void key_down_callback(int key);
+extern void key_up_callback(int key);
+extern void char_callback(unsigned ch);
 #endif
 */
 import "C"
@@ -31,6 +40,167 @@ type Joystick struct {
 
 type Input struct {
 	joysticks [MAX_JOYSTICK_COUNT]Joystick
+}
+
+type Key C.int
+type ModifierKey C.int
+
+const (
+	KeyUnknown = C.KINC_KEY_UNKNOWN
+	KeyEscape  = C.KINC_KEY_ESCAPE
+	KeyEnter   = C.KINC_KEY_RETURN
+	KeyInsert  = C.KINC_KEY_INSERT
+	KeyF12     = C.KINC_KEY_F12
+)
+
+var KeyToStringLUT = map[Key]string {
+	C.KINC_KEY_RETURN: "RETURN",
+	C.KINC_KEY_ESCAPE: "ESCAPE",
+	C.KINC_KEY_BACKSPACE: "BACKSPACE",
+	C.KINC_KEY_TAB: "TAB",
+	C.KINC_KEY_SPACE: "SPACE",
+	C.KINC_KEY_QUOTE: "QUOTE",
+	C.KINC_KEY_COMMA: "COMMA",
+	C.KINC_KEY_HYPHEN_MINUS: "MINUS",
+	C.KINC_KEY_PERIOD: "PERIOD",
+	C.KINC_KEY_SLASH: "SLASH",
+	C.KINC_KEY_0: "0",
+	C.KINC_KEY_1: "1",
+	C.KINC_KEY_2: "2",
+	C.KINC_KEY_3: "3",
+	C.KINC_KEY_4: "4",
+	C.KINC_KEY_5: "5",
+	C.KINC_KEY_6: "6",
+	C.KINC_KEY_7: "7",
+	C.KINC_KEY_8: "8",
+	C.KINC_KEY_9: "9",
+	C.KINC_KEY_SEMICOLON: "SEMICOLON",
+	C.KINC_KEY_EQUALS: "EQUALS",
+	C.KINC_KEY_OPEN_BRACKET: "LBRACKET",
+	C.KINC_KEY_BACK_SLASH: "BACKSLASH",
+	C.KINC_KEY_CLOSE_BRACKET: "RBRACKET",
+	C.KINC_KEY_BACK_QUOTE: "BACKQUOTE",
+	C.KINC_KEY_A: "a",
+	C.KINC_KEY_B: "b",
+	C.KINC_KEY_C: "c",
+	C.KINC_KEY_D: "d",
+	C.KINC_KEY_E: "e",
+	C.KINC_KEY_F: "f",
+	C.KINC_KEY_G: "g",
+	C.KINC_KEY_H: "h",
+	C.KINC_KEY_I: "i",
+	C.KINC_KEY_J: "j",
+	C.KINC_KEY_K: "k",
+	C.KINC_KEY_L: "l",
+	C.KINC_KEY_M: "m",
+	C.KINC_KEY_N: "n",
+	C.KINC_KEY_O: "o",
+	C.KINC_KEY_P: "p",
+	C.KINC_KEY_Q: "q",
+	C.KINC_KEY_R: "r",
+	C.KINC_KEY_S: "s",
+	C.KINC_KEY_T: "t",
+	C.KINC_KEY_U: "u",
+	C.KINC_KEY_V: "v",
+	C.KINC_KEY_W: "w",
+	C.KINC_KEY_X: "x",
+	C.KINC_KEY_Y: "y",
+	C.KINC_KEY_Z: "z",
+	C.KINC_KEY_CAPS_LOCK: "CAPSLOCK",
+	C.KINC_KEY_F1: "F1",
+	C.KINC_KEY_F2: "F2",
+	C.KINC_KEY_F3: "F3",
+	C.KINC_KEY_F4: "F4",
+	C.KINC_KEY_F5: "F5",
+	C.KINC_KEY_F6: "F6",
+	C.KINC_KEY_F7: "F7",
+	C.KINC_KEY_F8: "F8",
+	C.KINC_KEY_F9: "F9",
+	C.KINC_KEY_F10: "F10",
+	C.KINC_KEY_F11: "F11",
+	C.KINC_KEY_F12: "F12",
+	C.KINC_KEY_PRINT_SCREEN: "PRINTSCREEN",
+	C.KINC_KEY_SCROLL_LOCK: "SCROLLLOCK",
+	C.KINC_KEY_PAUSE: "PAUSE",
+	C.KINC_KEY_INSERT: "INSERT",
+	C.KINC_KEY_HOME: "HOME",
+	C.KINC_KEY_PAGE_UP: "PAGEUP",
+	C.KINC_KEY_DELETE: "DELETE",
+	C.KINC_KEY_END: "END",
+	C.KINC_KEY_PAGE_DOWN: "PAGEDOWN",
+	C.KINC_KEY_RIGHT: "RIGHT",
+	C.KINC_KEY_LEFT: "LEFT",
+	C.KINC_KEY_DOWN: "DOWN",
+	C.KINC_KEY_UP: "UP",
+	C.KINC_KEY_NUM_LOCK: "NUMLOCKCLEAR",
+	C.KINC_KEY_DIVIDE: "KP_DIVIDE",
+	C.KINC_KEY_MULTIPLY: "KP_MULTIPLY",
+	C.KINC_KEY_SUBTRACT: "KP_MINUS",
+	C.KINC_KEY_ADD: "KP_PLUS",
+	//C.KINC_KEY_NUMPAD_ENTER: "KP_ENTER",
+	C.KINC_KEY_NUMPAD_1: "KP_1",
+	C.KINC_KEY_NUMPAD_2: "KP_2",
+	C.KINC_KEY_NUMPAD_3: "KP_3",
+	C.KINC_KEY_NUMPAD_4: "KP_4",
+	C.KINC_KEY_NUMPAD_5: "KP_5",
+	C.KINC_KEY_NUMPAD_6: "KP_6",
+	C.KINC_KEY_NUMPAD_7: "KP_7",
+	C.KINC_KEY_NUMPAD_8: "KP_8",
+	C.KINC_KEY_NUMPAD_9: "KP_9",
+	C.KINC_KEY_NUMPAD_0: "KP_0",
+	C.KINC_KEY_DECIMAL: "KP_PERIOD",
+	//C.KINC_KEY_NUMPAD_EQUAL: "KP_EQUALS",
+	C.KINC_KEY_F13: "F13",
+	C.KINC_KEY_F14: "F14",
+	C.KINC_KEY_F15: "F15",
+	C.KINC_KEY_F16: "F16",
+	C.KINC_KEY_F17: "F17",
+	C.KINC_KEY_F18: "F18",
+	C.KINC_KEY_F19: "F19",
+	C.KINC_KEY_F20: "F20",
+	C.KINC_KEY_F21: "F21",
+	C.KINC_KEY_F22: "F22",
+	C.KINC_KEY_F23: "F23",
+	C.KINC_KEY_F24: "F24",
+	C.KINC_KEY_CONTEXT_MENU: "MENU",
+	//C.KINC_KEY_LEFT_CONTROL: "LCTRL",
+	//C.KINC_KEY_LEFT_SHIFT: "LSHIFT",
+	//C.KINC_KEY_LEFT_ALT: "LALT",
+	//C.KINC_KEY_LEFT_SUPER: "LGUI",
+	//C.KINC_KEY_RIGHT_CONTROL: "RCTRL",
+	//C.KINC_KEY_RIGHT_SHIFT: "RSHIFT",
+	//C.KINC_KEY_RIGHT_ALT: "RALT",
+	//C.KINC_KEY_RIGHT_SUPER: "RGUI",
+}
+
+var StringToKeyLUT = map[string]Key {}
+
+func init() {
+	for k, v := range KeyToStringLUT {
+		StringToKeyLUT[v] = k
+	}
+}
+
+func StringToKey(s string) Key {
+	if key, ok := StringToKeyLUT[s]; ok {
+		return key
+	}
+	return C.KINC_KEY_UNKNOWN
+}
+
+func KeyToString(k Key) string {
+	if s, ok := KeyToStringLUT[k]; ok {
+		return s
+	}
+	return ""
+}
+
+func NewModifierKey(ctrl, alt, shift bool) (mod ModifierKey) {
+	// TODO: implement modifiers
+	if ctrl || alt || shift {
+		mod = 1
+	}
+	return
 }
 
 var input *Input = newInput()
@@ -53,9 +223,27 @@ func axis_callback(gamepad int32, axis int32, value float32) {
 	}
 }
 
+//export key_down_callback
+func key_down_callback(key int32) {
+	OnKeyPressed(Key(key), 0)
+}
+
+//export key_up_callback
+func key_up_callback(key int32) {
+	OnKeyReleased(Key(key), 0)
+}
+
+//export char_callback
+func char_callback(ch uint32) {
+	OnTextEntered(string(rune(ch)))
+}
+
 func newInput() *Input {
 	C.kinc_gamepad_set_axis_callback((C.axis_callback_t)(C.axis_callback))
 	C.kinc_gamepad_set_button_callback((C.button_callback_t)(C.button_callback))
+	C.kinc_keyboard_set_key_down_callback((C.key_callback_t)(C.key_down_callback))
+	C.kinc_keyboard_set_key_up_callback((C.key_callback_t)(C.key_up_callback))
+	C.kinc_keyboard_set_key_press_callback((C.char_callback_t)(C.char_callback))
 	return &Input{}
 }
 

--- a/src/script.go
+++ b/src/script.go
@@ -69,7 +69,7 @@ func systemScriptInit(l *lua.LState) {
 	luaRegister(l, "addHotkey", func(*lua.LState) int {
 		l.Push(lua.LBool(func() bool {
 			k := StringToKey(strArg(l, 1))
-			if k == glfw.KeyUnknown {
+			if k == KeyUnknown {
 				return false
 			}
 			sk := *NewShortcutKey(k, boolArg(l, 2), boolArg(l, 3), boolArg(l, 4))
@@ -1356,7 +1356,7 @@ func systemScriptInit(l *lua.LState) {
 	})
 	luaRegister(l, "getKey", func(*lua.LState) int {
 		var s string
-		if sys.keyInput != glfw.KeyUnknown {
+		if sys.keyInput != KeyUnknown {
 			s = KeyToString(sys.keyInput)
 		}
 		if l.GetTop() == 0 {
@@ -1371,8 +1371,8 @@ func systemScriptInit(l *lua.LState) {
 	})
 	luaRegister(l, "getKeyText", func(*lua.LState) int {
 		s := ""
-		if sys.keyInput != glfw.KeyUnknown {
-			if sys.keyInput == glfw.KeyInsert {
+		if sys.keyInput != KeyUnknown {
+			if sys.keyInput == KeyInsert {
 				s, _ = sys.window.GetClipboardString()
 			} else {
 				s = sys.keyString
@@ -1645,7 +1645,7 @@ func systemScriptInit(l *lua.LState) {
 		return 0
 	})
 	luaRegister(l, "resetKey", func(*lua.LState) int {
-		sys.keyInput = glfw.KeyUnknown
+		sys.keyInput = KeyUnknown
 		sys.keyString = ""
 		return 0
 	})

--- a/src/script.go
+++ b/src/script.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	glfw "github.com/fyne-io/glfw-js"
 	lua "github.com/yuin/gopher-lua"
 )
 
@@ -684,7 +683,7 @@ func systemScriptInit(l *lua.LState) {
 	})
 	luaRegister(l, "enterReplay", func(*lua.LState) int {
 		if sys.vRetrace >= 0 {
-			glfw.SwapInterval(1) //broken frame skipping when set to 0
+			sys.window.SetSwapInterval(1) //broken frame skipping when set to 0
 		}
 		sys.chars = [len(sys.chars)][]*Char{}
 		sys.fileInput = OpenFileInput(strArg(l, 1))
@@ -706,7 +705,7 @@ func systemScriptInit(l *lua.LState) {
 	})
 	luaRegister(l, "exitReplay", func(*lua.LState) int {
 		if sys.vRetrace >= 0 {
-			glfw.SwapInterval(sys.vRetrace)
+			sys.window.SetSwapInterval(sys.vRetrace)
 		}
 		if sys.fileInput != nil {
 			sys.fileInput.Close()
@@ -2531,7 +2530,7 @@ func systemScriptInit(l *lua.LState) {
 		} else {
 			sys.vRetrace = 0
 		}
-		glfw.SwapInterval(sys.vRetrace)
+		sys.window.SetSwapInterval(sys.vRetrace)
 		return 0
 	})
 	luaRegister(l, "updateVolume", func(l *lua.LState) int {

--- a/src/system.go
+++ b/src/system.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/faiface/beep"
 	"github.com/faiface/beep/speaker"
-	glfw "github.com/fyne-io/glfw-js"
 	lua "github.com/yuin/gopher-lua"
 )
 
@@ -71,7 +70,7 @@ var sys = System{
 	mainThreadTask:        make(chan func(), 65536),
 	workpal:               make([]uint32, 256),
 	errLog:                log.New(NewLogWriter(), "", log.LstdFlags),
-	keyInput:              glfw.KeyUnknown,
+	keyInput:              KeyUnknown,
 	wavChannels:           256,
 	comboExtraFrameWindow: 1,
 	fontShaderVer:         120,

--- a/src/system.go
+++ b/src/system.go
@@ -53,7 +53,7 @@ var sys = System{
 	allPalFX:          *newPalFX(),
 	bgPalFX:           *newPalFX(),
 	sel:               *newSelect(),
-	keyState:          make(map[glfw.Key]bool),
+	keyState:          make(map[Key]bool),
 	match:             1,
 	listenPort:        "7500",
 	loader:            *newLoader(),
@@ -124,7 +124,7 @@ type System struct {
 	allPalFX, bgPalFX       PalFX
 	lifebar                 Lifebar
 	sel                     Select
-	keyState                map[glfw.Key]bool
+	keyState                map[Key]bool
 	netInput                *NetInput
 	fileInput               *FileInput
 	aiInput                 [MaxSimul*2 + MaxAttachedChar]AiInput
@@ -262,7 +262,7 @@ type System struct {
 	allowDebugMode          bool
 	commonAir               string
 	commonCmd               string
-	keyInput                glfw.Key
+	keyInput                Key
 	keyString               string
 	timerCount              []int32
 	cmdFlags                map[string]string

--- a/src/system_glfw.go
+++ b/src/system_glfw.go
@@ -131,3 +131,16 @@ func (w *Window) shouldClose() bool {
 func (w *Window) Close() {
 	glfw.Terminate()
 }
+
+func keyCallback(_ *glfw.Window, key Key, _ int, action glfw.Action, mk ModifierKey) {
+	switch action {
+	case glfw.Release:
+		OnKeyReleased(key, mk)
+	case glfw.Press:
+		OnKeyPressed(key, mk)
+	}
+}
+
+func charCallback(_ *glfw.Window, char rune, mk ModifierKey) {
+	OnTextEntered(string(char))
+}

--- a/src/system_glfw.go
+++ b/src/system_glfw.go
@@ -88,6 +88,10 @@ func (w *Window) SetIcon(icon []image.Image) {
 	w.Window.SetIcon(icon)
 }
 
+func (w *Window) SetSwapInterval(interval int) {
+	glfw.SwapInterval(interval)
+}
+
 func (w *Window) GetSize() (int, int) {
 	return w.Window.GetSize()
 }

--- a/src/system_kinc.go
+++ b/src/system_kinc.go
@@ -33,7 +33,9 @@ type Window struct {
 func (s *System) newWindow(w, h int) (*Window, error) {
 	ret := &Window{width: w, height: h}
 	handle := C.kinc_init(C.CString(s.windowTitle), C.int(w), C.int(h), nil, nil)
-	C.kinc_window_set_close_callback(handle, (C.close_callback_t)(C.close_callback), unsafe.Pointer(&ret.closing))
+	C.kinc_window_set_close_callback(handle, (C.close_callback_t)(C.close_callback),
+		unsafe.Pointer(&ret.closing))
+	// TODO: add keyboard input callbacks
 	return ret, nil
 }
 

--- a/src/system_kinc.go
+++ b/src/system_kinc.go
@@ -53,6 +53,10 @@ func (w *Window) SetIcon(icon []image.Image) {
 	// TODO
 }
 
+func (w *Window) SetSwapInterval(interval int) {
+	// TODO
+}
+
 func (w *Window) GetSize() (int, int) {
         return w.width, w.height
 }


### PR DESCRIPTION
This PR implements keyboard input for the Kinc backend.

This also means that GLFW is no longer used outside of the specific `_glfw.go` files, so it should be now possible to implement other backends (SDL maybe?).