### PR TITLE
gametimeをmugenと同じ仕様に修正

### DIFF
--- a/external/script/global.lua
+++ b/external/script/global.lua
@@ -257,7 +257,7 @@ function loop()
 				menu.f_init()
 			end
 		--demo mode
-		elseif gamemode('demo') and ((motif.attract_mode.enabled == 1 and main.credits > 0 and not sndPlaying(motif.files.snd_data, motif.attract_mode.credits_snd[1], motif.attract_mode.credits_snd[2])) or (motif.attract_mode.enabled == 0 and main.f_input(main.t_players, {'pal'})) or gametime() >= motif.demo_mode.fight_endtime) then
+		elseif gamemode('demo') and ((motif.attract_mode.enabled == 1 and main.credits > 0 and not sndPlaying(motif.files.snd_data, motif.attract_mode.credits_snd[1], motif.attract_mode.credits_snd[2])) or (motif.attract_mode.enabled == 0 and main.f_input(main.t_players, {'pal'})) or fighttime() >= motif.demo_mode.fight_endtime) then
 			endMatch()
 		--challenger
 		elseif gamemode('arcade') then

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -462,6 +462,7 @@ const (
 	OC_ex_dizzy
 	OC_ex_dizzypoints
 	OC_ex_dizzypointsmax
+	OC_ex_fighttime
 	OC_ex_firstattack
 	OC_ex_framespercount
 	OC_ex_float
@@ -1165,7 +1166,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 				sys.bcStack.PushF(c.gameHeight())
 			}
 		case OC_gametime:
-			sys.bcStack.PushI(sys.gameTime)
+			sys.bcStack.PushI(sys.gameTime + sys.preFightTime)
 		case OC_gamewidth:
 			// Backward compatibility exception. 1.0 characters often use it to
 			// display elements that weren't designed to be affected by zooming.
@@ -1872,6 +1873,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(c.dizzyPointsMax)
 	case OC_ex_drawpalno:
 		sys.bcStack.PushI(c.gi().drawpalno)
+	case OC_ex_fighttime:
+		sys.bcStack.PushI(sys.gameTime)
 	case OC_ex_firstattack:
 		sys.bcStack.PushB(c.firstAttack)
 	case OC_ex_framespercount:
@@ -7512,7 +7515,7 @@ func (sc modifyBGCtrl) Run(c *Char, _ []int32) bool {
 		case modifyBGCtrl_invertall:
 			invall = exp[0].evalI(c)
 		case modifyBGCtrl_color:
-			color = ClampF(exp[0].evalF(c) / 256, 0, 1)
+			color = ClampF(exp[0].evalF(c)/256, 0, 1)
 		case modifyBGCtrl_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				//crun = rid

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -319,6 +319,7 @@ var triggerMap = map[string]int{
 	"dizzy":            1,
 	"dizzypoints":      1,
 	"dizzypointsmax":   1,
+	"fighttime":        1,
 	"firstattack":      1,
 	"framespercount":   1,
 	"gamemode":         1,
@@ -2510,6 +2511,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_ex_, OC_ex_dizzypoints)
 	case "dizzypointsmax":
 		out.append(OC_ex_, OC_ex_dizzypointsmax)
+	case "fighttime":
+		out.append(OC_ex_, OC_ex_fighttime)
 	case "firstattack":
 		out.append(OC_ex_, OC_ex_firstattack)
 	case "framespercount":

--- a/src/script.go
+++ b/src/script.go
@@ -1053,6 +1053,8 @@ func systemScriptInit(l *lua.LState) {
 				sys.dialogueBarsFlg = false
 				sys.noSoundFlg = false
 				sys.postMatchFlg = false
+				sys.preFightTime += sys.gameTime
+				sys.gameTime = 0
 				sys.consoleText = []string{}
 				sys.stageLoopNo = 0
 				return 2
@@ -2956,7 +2958,7 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "gametime", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.gameTime))
+		l.Push(lua.LNumber(sys.gameTime + sys.preFightTime))
 		return 1
 	})
 	luaRegister(l, "gamewidth", func(*lua.LState) int {
@@ -3683,6 +3685,10 @@ func triggerFunctions(l *lua.LState) {
 	})
 	luaRegister(l, "dizzypointsmax", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.dizzyPointsMax))
+		return 1
+	})
+	luaRegister(l, "fighttime", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.gameTime))
 		return 1
 	})
 	luaRegister(l, "firstattack", func(*lua.LState) int {

--- a/src/system.go
+++ b/src/system.go
@@ -316,6 +316,7 @@ type System struct {
 
 	gameMode        string
 	frameCounter    int32
+	preFightTime    int32
 	motifDir        string
 	captureNum      int
 	roundType       [2]RoundType
@@ -526,6 +527,9 @@ func (s *System) await(fps int) bool {
 
 func (s *System) update() bool {
 	s.frameCounter++
+	if s.gameTime == 0 {
+		s.preFightTime = s.frameCounter
+	}
 	if s.fileInput != nil {
 		if s.anyHardButton() {
 			s.await(FPS * 4)
@@ -555,7 +559,7 @@ func (s *System) tickSound() {
 		if s.bgm.ctrl != nil && s.bgm.streamer != nil {
 			s.bgm.ctrl.Paused = false
 			// if s.bgm.bgmLoopEnd > 0 && s.bgm.streamer.Position() >= s.bgm.bgmLoopEnd {
-				// s.bgm.streamer.Seek(s.bgm.bgmLoopStart)
+			// s.bgm.streamer.Seek(s.bgm.bgmLoopStart)
 			// }
 		}
 		speaker.Unlock()


### PR DESCRIPTION
・gametimeをmugenと同じ仕様に修正
・これまでのikemenのgametimeと同じ仕様のトリガーとして"fighttime"を追加

gametime
Returns the count of frames since the game was started (excluding debug pause time)

fighttime
Returns the count of frames since the start of the fight (excluding debug pause time)