### PR TITLE
AttachedCharをデフォルトではstandby状態になるように変更

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -1853,6 +1853,9 @@ func (c *Char) clear2() {
 		}
 	} else {
 		c.palfx = nil
+		if c.teamside == -1 {
+			c.setSCF(SCF_standby)
+		}
 	}
 	c.aimg.timegap = -1
 	c.enemyNearClear()


### PR DESCRIPTION
AttachedCharをデフォルトではstandby状態になるように変更
#637

With this change, AttachedChars must be "Tagin" if they are going directly into fight.