### PR TITLE
Targetbind後に同じキャラが攻撃を当てるとbindが外れる仕様がなかったのを修正

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -6343,6 +6343,8 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 					} else {
 						getter.bindPos[1] = float32(math.NaN())
 					}
+				} else if getter.bindToId == c.id || getter.bindToId == -c.id {
+					getter.setBindTime(0)
 				}
 			} else if hitType == 1 {
 				absdamage = hd.hitdamage


### PR DESCRIPTION
Targetbind後に同じキャラが攻撃を当てるとbindが外れる仕様がなかったのを修正
#730