### PR TITLE
Bugfixes: challenger mode, char processing priority, ChangeAnim's ReadPlayerID palette bug

### DIFF
--- a/external/script/global.lua
+++ b/external/script/global.lua
@@ -260,7 +260,7 @@ function loop()
 		elseif gamemode('demo') and ((motif.attract_mode.enabled == 1 and main.credits > 0 and not sndPlaying(motif.files.snd_data, motif.attract_mode.credits_snd[1], motif.attract_mode.credits_snd[2])) or (motif.attract_mode.enabled == 0 and main.f_input(main.t_players, {'pal'})) or fighttime() >= motif.demo_mode.fight_endtime) then
 			endMatch()
 		--challenger
-		elseif gamemode('arcade') then
+		elseif motif.challenger_info.enabled ~= 0 and gamemode('arcade') then
 			if start.challenger > 0 then
 				start.f_challenger()
 			else

--- a/src/char.go
+++ b/src/char.go
@@ -6019,8 +6019,14 @@ func (cl *CharList) action(x float32, cvmin, cvmax,
 		cl.runOrder[i].actionPrepare()
 	}
 	// Run character state controllers
+	// Process priority based on movetype: A > I > H (or anything else)
 	for i := 0; i < len(cl.runOrder); i++ {
 		if cl.runOrder[i].ss.moveType == MT_A {
+			cl.runOrder[i].actionRun()
+		}
+	}
+	for i := 0; i < len(cl.runOrder); i++ {
+		if cl.runOrder[i].ss.moveType == MT_I {
 			cl.runOrder[i].actionRun()
 		}
 	}

--- a/src/char.go
+++ b/src/char.go
@@ -2448,6 +2448,17 @@ func (c *Char) changeAnimEx(animNo int32, playerNo int, ffx, alt bool) {
 		if alt {
 			c.animPN = playerNo
 			a.sff = sys.cgi[c.playerNo].sff
+		// Fix palette if anim doesn't belong to char and sff header version is 1.x
+		} else if c.playerNo != playerNo && c.anim.sff.header.Ver0 == 1 {
+			di := c.anim.sff.palList.PalTable[[...]int16{1,1}]
+			spr := c.anim.sff.GetSprite(0, 0)
+			if spr != nil {
+				c.anim.sff.palList.Remap(spr.palidx, di)
+			}
+			spr = c.anim.sff.GetSprite(9000, 0)
+			if spr != nil {
+				c.anim.sff.palList.Remap(spr.palidx, di)
+			}
 		}
 		c.clsnScale = [...]float32{sys.chars[c.animPN][0].size.xscale,
 			sys.chars[c.animPN][0].size.yscale}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -4416,7 +4416,7 @@ func (c *Compiler) scanStateDef(line *string, constants map[string]float32) (int
 func (c *Compiler) subBlock(line *string, root bool,
 	sbc *StateBytecode, numVars *int32, ignorehitpause bool) (*StateBlock, error) {
 	bl := newStateBlock()
-	// Inherit ignorehitpause from partner block
+	// Inherit ignorehitpause from parent block
 	if ignorehitpause {
 		bl.ignorehitpause, bl.ctrlsIgnorehitpause = -1, true
 	}


### PR DESCRIPTION
For ChangeAnim's ReadPlayerID bug, when a character got into another player's animation, but that player sff was V1, animations were getting wrong palette colors due to improper palette handling after anim change. A basic fix was included that seems to work fine, but might change in the future depending on how this new parameter will evolve.

Giving more process priority to characters with Idle movetype fixes a problem where they can't get GetHitVar values from a character in GetHit movetype. Chars in Attack movetype still get the highest priority, following previous Ikemen GO behavior.