### PR TITLE
Fixed: Skip doesn't work properly with slots

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -2002,6 +2002,7 @@ local section = 0
 local row = 0
 local slot = false
 local content = main.f_fileRead(motif.files.select)
+local csCell = 0
 content = content:gsub('([^\r\n;]*)%s*;[^\r\n]*', '%1')
 content = content:gsub('\n%s*\n', '\n')
 for line in content:gmatch('[^\r\n]+') do
@@ -2032,12 +2033,11 @@ for line in content:gmatch('[^\r\n]+') do
 	elseif lineCase:match('^%s*%[%w+%]$') then
 		section = -1
 	elseif section == 1 then --[Characters]
-		local csCell = #main.t_selChars
 		local csCol = (csCell % motif.select_info.columns) + 1
 		local csRow = math.floor(csCell / motif.select_info.columns) + 1
 		while not slot and motif.select_info['cell_' .. csCol .. '_' .. csRow .. '_skip'] == 1 do
 			main.f_addChar('skipslot', true, true, false)
-			csCell = #main.t_selChars
+			csCell = csCell + 1
 			csCol = (csCell % motif.select_info.columns) + 1
 			csRow = math.floor(csCell / motif.select_info.columns) + 1
 		end
@@ -2048,8 +2048,12 @@ for line in content:gmatch('[^\r\n]+') do
 			slot = true
 		elseif slot and lineCase:match('^%s*}%s*$') then --end of 'multiple chars in one slot' assignment
 			slot = false
+			csCell = csCell + 1
 		else
 			main.f_addChar(line, true, true, slot)
+			if not slot then
+				csCell = csCell + 1
+			end
 		end
 	elseif section == 2 then --[ExtraStages]
 		--store 'unlock' param and get rid of everything that follows it


### PR DESCRIPTION
Fixes #722 .

Instead of using the #main.t_selChars to check which character slot we are at, it now manually increases the value. It was previously assumed that slotted characters wouldn't count towards the total, which was a wrong assumption.