### PR TITLE
Make != operator work with hitdefattr in all mugenversions

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -511,6 +511,7 @@ const (
 	OC_ex_pos_z
 	OC_ex_vel_z
 	OC_ex_jugglepoints
+	OC_ex_prevanimno
 )
 const (
 	NumVar     = OC_sysvar0 - OC_var0
@@ -1987,6 +1988,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.vel[2] * (c.localscl / oc.localscl))
 	case OC_ex_jugglepoints:
 		sys.bcStack.PushI(c.juggle)
+	case OC_ex_prevanimno:
+		sys.bcStack.PushI(c.prevAnimNo)
 	default:
 		sys.errLog.Printf("%v\n", be[*i-1])
 		c.panic()

--- a/src/char.go
+++ b/src/char.go
@@ -1644,6 +1644,7 @@ type Char struct {
 	player          bool
 	animPN          int
 	animNo          int32
+	prevAnimNo      int32
 	life            int32
 	lifeMax         int32
 	power           int32
@@ -1876,6 +1877,7 @@ func (c *Char) clearCachedData() {
 	c.ownpal = true
 	c.animPN = -1
 	c.animNo = 0
+	c.prevAnimNo = 0
 	c.stchtmp = false
 	c.inguarddist = false
 	c.p1facing = 0
@@ -2443,6 +2445,7 @@ func (c *Char) changeAnimEx(animNo int32, playerNo int, ffx, alt bool) {
 		c.anim = a
 		c.anim.remap = c.remapSpr
 		c.animPN = c.playerNo
+		c.prevAnimNo = c.animNo
 		c.animNo = animNo
 		// If player is in custom state and used ChangeAnim2
 		if alt {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1964,6 +1964,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 		out.append(OC_playeridexist)
+	case "prevanimno":
+		out.append(OC_ex_, OC_ex_prevanimno)
 	case "prevstateno":
 		out.append(OC_prevstateno)
 	case "projcanceltime":

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1788,22 +1788,25 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			}
 			return nil
 		}
-		if sys.cgi[c.playerNo].ver[0] == 1 {
-			if err := eqne(hda); err != nil {
-				return bvNone(), err
-			}
-		} else {
-			if not, err := c.kyuushiki(in); err != nil {
-				if sys.ignoreMostErrors {
-					out.appendValue(BytecodeBool(false))
-				} else {
-					return bvNone(), err
-				}
-			} else if err := hda(); err != nil {
-				return bvNone(), err
-			} else if not && !sys.ignoreMostErrors {
-				return bvNone(), Error("hitdefattr doesn't support '!=' in this mugenversion")
-			}
+		// if sys.cgi[c.playerNo].ver[0] == 1 {
+			// if err := eqne(hda); err != nil {
+				// return bvNone(), err
+			// }
+		// } else {
+			// if not, err := c.kyuushiki(in); err != nil {
+				// if sys.ignoreMostErrors {
+					// out.appendValue(BytecodeBool(false))
+				// } else {
+					// return bvNone(), err
+				// }
+			// } else if err := hda(); err != nil {
+				// return bvNone(), err
+			// } else if not && !sys.ignoreMostErrors {
+				// return bvNone(), Error("hitdefattr doesn't support '!=' in this mugenversion")
+			// }
+		// }
+		if err := eqne(hda); err != nil {
+			return bvNone(), err
 		}
 	case "hitfall":
 		out.append(OC_hitfall)


### PR DESCRIPTION
Doesn't make sense to approve/reject a perfectly valid expression depending on the mugenversion of the character.

I also added a new trigger that I think could be useful, by a suggestion of an user. 👀 