### PR TITLE
New trigger reversalattr

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -511,6 +511,7 @@ const (
 	OC_ex_pos_z
 	OC_ex_vel_z
 	OC_ex_jugglepoints
+	OC_ex_reversalattr
 )
 const (
 	NumVar     = OC_sysvar0 - OC_var0
@@ -1987,6 +1988,9 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.vel[2] * (c.localscl / oc.localscl))
 	case OC_ex_jugglepoints:
 		sys.bcStack.PushI(c.juggle)
+	case OC_ex_reversalattr:
+		sys.bcStack.PushB(c.reversalAttr(*(*int32)(unsafe.Pointer(&be[*i]))))
+		*i += 4
 	default:
 		sys.errLog.Printf("%v\n", be[*i-1])
 		c.panic()

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -511,7 +511,7 @@ const (
 	OC_ex_pos_z
 	OC_ex_vel_z
 	OC_ex_jugglepoints
-	OC_ex_reversalattr
+	OC_ex_reversaldefattr
 )
 const (
 	NumVar     = OC_sysvar0 - OC_var0
@@ -1988,8 +1988,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.vel[2] * (c.localscl / oc.localscl))
 	case OC_ex_jugglepoints:
 		sys.bcStack.PushI(c.juggle)
-	case OC_ex_reversalattr:
-		sys.bcStack.PushB(c.reversalAttr(*(*int32)(unsafe.Pointer(&be[*i]))))
+	case OC_ex_reversaldefattr:
+		sys.bcStack.PushB(c.reversalDefAttr(*(*int32)(unsafe.Pointer(&be[*i]))))
 		*i += 4
 	default:
 		sys.errLog.Printf("%v\n", be[*i-1])

--- a/src/char.go
+++ b/src/char.go
@@ -650,6 +650,10 @@ func (hd *HitDef) testAttr(attr int32) bool {
 	attr &= hd.attr
 	return attr&int32(ST_MASK) != 0 && attr&^int32(ST_MASK)&^(-1<<31) != 0
 }
+func (hd *HitDef) testReversalAttr(attr int32) bool {
+	attr &= hd.reversal_attr
+	return attr&int32(ST_MASK) != 0 && attr&^int32(ST_MASK)&^(-1<<31) != 0
+}
 
 type GetHitVar struct {
 	hitBy [][2]int32
@@ -2972,6 +2976,9 @@ func (c *Char) projHitTime(pid BytecodeValue) BytecodeValue {
 		return BytecodeInt(-1)
 	}
 	return BytecodeInt(c.gi().pctime)
+}
+func (c *Char) reversalAttr(attr int32) bool {
+	return c.hitdef.testReversalAttr(attr)
 }
 func (c *Char) rightEdge() float32 {
 	return sys.cam.ScreenPos[0]/c.localscl + c.gameWidth()

--- a/src/char.go
+++ b/src/char.go
@@ -2977,7 +2977,7 @@ func (c *Char) projHitTime(pid BytecodeValue) BytecodeValue {
 	}
 	return BytecodeInt(c.gi().pctime)
 }
-func (c *Char) reversalAttr(attr int32) bool {
+func (c *Char) reversalDefAttr(attr int32) bool {
 	return c.hitdef.testReversalAttr(attr)
 }
 func (c *Char) rightEdge() float32 {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -284,7 +284,7 @@ var triggerMap = map[string]int{
 	"projhit":           1,
 	"projhittime":       1,
 	"random":            1,
-	"reversalattr":      1,
+	"reversaldefattr":   1,
 	"rightedge":         1,
 	"rootdist":          1,
 	"roundno":           1,
@@ -1987,13 +1987,13 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 	case "random":
 		out.append(OC_random)
 
-	case "reversalattr":
+	case "reversaldefattr":
 		hda := func() error {
 			if attr, err := c.trgAttr(in); err != nil {
 				return err
 			} else {
 				out.append(OC_ex_)
-				out.appendI32Op(OC_ex_reversalattr, attr)
+				out.appendI32Op(OC_ex_reversaldefattr, attr)
 			}
 			return nil
 		}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -284,6 +284,7 @@ var triggerMap = map[string]int{
 	"projhit":           1,
 	"projhittime":       1,
 	"random":            1,
+	"reversalattr":      1,
 	"rightedge":         1,
 	"rootdist":          1,
 	"roundno":           1,
@@ -1985,6 +1986,20 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_projhittime)
 	case "random":
 		out.append(OC_random)
+
+	case "reversalattr":
+		hda := func() error {
+			if attr, err := c.trgAttr(in); err != nil {
+				return err
+			} else {
+				out.append(OC_ex_)
+				out.appendI32Op(OC_ex_reversalattr, attr)
+			}
+			return nil
+		}
+		if err := eqne(hda); err != nil {
+			return bvNone(), err
+		}
 	case "rightedge":
 		out.append(OC_rightedge)
 	case "roundno":


### PR DESCRIPTION
This commit adds a new trigger `reversalattr` which is similar to `hitdefattr`. It checks the attribute parameter of the player's currently-active ReversalDef.