### PR TITLE
Fix IgnoreHitPause leaking to adjacent blocks in ZSS

### DIFF
--- a/src/compiler.go
+++ b/src/compiler.go
@@ -4640,7 +4640,7 @@ func (c *Compiler) stateBlock(line *string, bl *StateBlock, root bool,
 			return nil
 		case "if", "ignorehitpause", "persistent":
 			if sbl, err := c.subBlock(line, root, sbc, numVars,
-				bl != nil && bl.ignorehitpause >= -1); err != nil {
+				bl != nil && bl.ctrlsIgnorehitpause); err != nil {
 				return err
 			} else {
 				if bl != nil && sbl.ignorehitpause >= -1 {


### PR DESCRIPTION
For example, having this code:

```coffeescript
if movetype = A {
    ignorehitpause if 1 {
        text{
            text: "Foo";
            pos: 100,100;
        }
    }
    
    if 1 {
        text{
            text: "Bar";
            pos: 100,200;
        }
    }
}
```
will make "Bar" text render in hitpauses due to first block's ignorehitpause getting applied to the second block too (by mistake). This change attemps to fix this issue.