### PR TITLE
Fixed transition between get hit and idle states

### DIFF
--- a/data/common1.cns.zss
+++ b/data/common1.cns.zss
@@ -357,12 +357,15 @@ call HiToLoAndLoToHi();
 [Function GuardShaking(anim)]
 changeAnim{value: $anim}
 if hitShakeOver {
-	changeState{value: 151 + 2 * (command = "holddown")}
+	changeState{value: 151 + 2 * (command = "holddown"); ctrl: hitover}
 }
 call HiToLoAndLoToHi();
 
 #-------------------------------------------------------------------------------
 [Function GuardKnockedBack(nextState)]
+if ctrl && hitover {
+	changeState{value: $nextState;}
+}
 if time = 0 {
 	hitVelSet{x: 1}
 }
@@ -374,7 +377,7 @@ if time = getHitVar(ctrlTime) {
 }
 call HiToLoAndLoToHi();
 if hitOver {
-	changeState{value: $nextState; ctrl: 1}
+	ctrlset{value: 1}
 }
 
 #-------------------------------------------------------------------------------
@@ -485,6 +488,9 @@ if time = 0 {
 
 #-------------------------------------------------------------------------------
 [Function GetHitKnockedBack(lAnim, nextState)]
+if ctrl {
+	changeState{value: $nextState}
+}
 if time = 0 {
 	hitVelSet{x: 1}
 }
@@ -497,7 +503,7 @@ if time >= getHitVar(slideTime) {
 if hitOver {
 	velSet{x: 0}
 	DefenceMulSet{value: 1}
-	changeState{value: $nextState; ctrl: 1}
+	ctrlset{value: 1}
 }
 
 #-------------------------------------------------------------------------------
@@ -516,7 +522,7 @@ if anim = 5000 || anim = 5010 {
 	forceFeedback{time: 15; waveform: sinesquare; ampl: 140}
 }
 if hitShakeOver {
-	changeState{value: ifElse(getHitVar(yVel) || getHitVar(fall), 5030, 5001)}
+	changeState{value: ifElse(getHitVar(yVel) || getHitVar(fall), 5030, 5001); ctrl: hitOver}
 }
 
 #-------------------------------------------------------------------------------
@@ -534,7 +540,7 @@ if (time = 0 && (getHitVar(yVel) || getHitVar(fall))) || pos y != 0 {
 	stateTypeSet{stateType: A}
 }
 if hitShakeOver {
-	changeState{value: ifElse(getHitVar(yVel) || getHitVar(fall), 5030, 5011)}
+	changeState{value: ifElse(getHitVar(yVel) || getHitVar(fall), 5030, 5011); ctrl: hitOver}
 }
 if anim = 5020 {
 	forceFeedback{time: 6; waveform: square}

--- a/data/common1.cns.zss
+++ b/data/common1.cns.zss
@@ -357,15 +357,12 @@ call HiToLoAndLoToHi();
 [Function GuardShaking(anim)]
 changeAnim{value: $anim}
 if hitShakeOver {
-	changeState{value: 151 + 2 * (command = "holddown"); ctrl: hitover}
+	changeState{value: 151 + 2 * (command = "holddown")}
 }
 call HiToLoAndLoToHi();
 
 #-------------------------------------------------------------------------------
 [Function GuardKnockedBack(nextState)]
-if ctrl && hitover {
-	changeState{value: $nextState;}
-}
 if time = 0 {
 	hitVelSet{x: 1}
 }
@@ -377,6 +374,7 @@ if time = getHitVar(ctrlTime) {
 }
 call HiToLoAndLoToHi();
 if hitOver {
+	if ctrl {changeState{value: $nextState}}
 	ctrlset{value: 1}
 }
 
@@ -488,9 +486,6 @@ if time = 0 {
 
 #-------------------------------------------------------------------------------
 [Function GetHitKnockedBack(lAnim, nextState)]
-if ctrl {
-	changeState{value: $nextState}
-}
 if time = 0 {
 	hitVelSet{x: 1}
 }
@@ -503,6 +498,7 @@ if time >= getHitVar(slideTime) {
 if hitOver {
 	velSet{x: 0}
 	DefenceMulSet{value: 1}
+	if ctrl{changeState{value: $nextState}}
 	ctrlset{value: 1}
 }
 
@@ -522,7 +518,7 @@ if anim = 5000 || anim = 5010 {
 	forceFeedback{time: 15; waveform: sinesquare; ampl: 140}
 }
 if hitShakeOver {
-	changeState{value: ifElse(getHitVar(yVel) || getHitVar(fall), 5030, 5001); ctrl: hitOver}
+	changeState{value: ifElse(getHitVar(yVel) || getHitVar(fall), 5030, 5001)}
 }
 
 #-------------------------------------------------------------------------------
@@ -540,7 +536,7 @@ if (time = 0 && (getHitVar(yVel) || getHitVar(fall))) || pos y != 0 {
 	stateTypeSet{stateType: A}
 }
 if hitShakeOver {
-	changeState{value: ifElse(getHitVar(yVel) || getHitVar(fall), 5030, 5011); ctrl: hitOver}
+	changeState{value: ifElse(getHitVar(yVel) || getHitVar(fall), 5030, 5011)}
 }
 if anim = 5020 {
 	forceFeedback{time: 6; waveform: square}


### PR DESCRIPTION
Mugen has long had an issue where characters who have just exited a hit state cannot block in the same frame, appearing to be in the idle state but actually being unable to act. Hitting them in that frame (correctly) counts as a combo, even.
These changes attempt to keep the gameplay intact, but now keeping the character in a get hit animation while they are unable to move, so that the screen reflects what is truly happening.
This inadvertently fixes issue #597 because the character no longer falsely goes through an idle state.