### PR TITLE
Implement SFF caching

### DIFF
--- a/src/image.go
+++ b/src/image.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"runtime"
 	"unsafe"
 )
 
@@ -1021,7 +1022,23 @@ func newSff() (s *Sff) {
 	}
 	return
 }
+
+// A simple SFF cache storing shallow copies
+type SffCacheEntry struct {
+	sffData  Sff
+	refCount int
+}
+
+var SffCache = map[string]*SffCacheEntry {}
+
 func loadSff(filename string, char bool) (*Sff, error) {
+	// If this SFF is already in the cache, just return a copy
+	if cached, ok := SffCache[filename]; ok {
+		cached.refCount++
+		s := cached.sffData
+		return &s, nil
+	}
+
 	s := newSff()
 	f, err := os.Open(filename)
 	if err != nil {
@@ -1150,6 +1167,17 @@ func loadSff(filename string, char bool) (*Sff, error) {
 			shofs += 28
 		}
 	}
+
+	// Store a copy of this SFF in the cache
+	SffCache[filename] = &SffCacheEntry{ *s, 1 }
+	runtime.SetFinalizer(s, func (s *Sff) {
+		cached := SffCache[filename]
+		cached.refCount--
+		if cached.refCount == 0 {
+			delete(SffCache, filename)
+		}
+	})
+
 	return s, nil
 }
 func preloadSff(filename string, char bool, preloadSpr map[[2]int16]bool) (*Sff, []int32, error) {


### PR DESCRIPTION
The cache keeps a copy of all SFF objects (not the actual sprite data) so that they can be immediately reused when the same file is loaded again. A reference count is kept so that the last GC’ed version of an SFF will cause the cached copy to be deleted, too.