### PR TITLE
Reversion of previous change

### DIFF
--- a/data/common1.cns.zss
+++ b/data/common1.cns.zss
@@ -374,8 +374,7 @@ if time = getHitVar(ctrlTime) {
 }
 call HiToLoAndLoToHi();
 if hitOver {
-	if ctrl {changeState{value: $nextState}}
-	ctrlset{value: 1}
+	changeState{value: $nextState; ctrl: 1}
 }
 
 #-------------------------------------------------------------------------------
@@ -498,8 +497,7 @@ if time >= getHitVar(slideTime) {
 if hitOver {
 	velSet{x: 0}
 	DefenceMulSet{value: 1}
-	if ctrl{changeState{value: $nextState}}
-	ctrlset{value: 1}
+	changeState{value: $nextState; ctrl: 1}
 }
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Reverting the previous change as it introduced one frame of delay when guarding attacks after exiting hit stun. While this could also be handled in the common states, I feel that it would be too convoluted. This issue may require a deeper solution.