### PR TITLE
地面の高さを決める記述でミスがあったので修正

### DIFF
--- a/src/camera.go
+++ b/src/camera.go
@@ -83,8 +83,7 @@ func (c *Camera) Update(scl, x, y float32) {
 	c.Scale = c.BaseScale() * scl
 	c.zoff = (c.screenZoff-240)*scl + float32(sys.gameHeight)
 	for i := 0; i < 2; i++ {
-		c.Offset[i] = sys.stage.bga.offset[i] * sys.stage.localscl *
-			sys.stage.scale[i] * scl
+		c.Offset[i] = sys.stage.bga.offset[i] * sys.stage.localscl * scl
 	}
 	c.ScreenPos[0] = x - c.halfWidth/c.Scale - c.Offset[0]
 	c.ScreenPos[1] = y - (c.GroundLevel()-float32(sys.gameHeight-240)*scl)/

--- a/src/char.go
+++ b/src/char.go
@@ -3834,7 +3834,7 @@ func (c *Char) setHitdefDefault(hd *HitDef, proj bool) {
 		hd.air_animtype = hd.animtype
 	}
 	// if hd.animtype == RA_Back {
-		// hd.animtype = RA_Hard
+	// hd.animtype = RA_Hard
 	// }
 	if hd.air_type == HT_Unknown {
 		if hd.ground_type == HT_Trip {
@@ -5045,10 +5045,10 @@ func (c *Char) bind() {
 				return
 			}
 			// if !math.IsNaN(float64(c.bindPos[0])) {
-				// c.setXV(c.facing * bt.facing * bt.vel[0])
+			// c.setXV(c.facing * bt.facing * bt.vel[0])
 			// }
 			// if !math.IsNaN(float64(c.bindPos[1])) {
-				// c.setYV(bt.vel[1])
+			// c.setYV(bt.vel[1])
 			// }
 		}
 		if !math.IsNaN(float64(c.bindPos[0])) {
@@ -5576,6 +5576,7 @@ func (c *Char) actionFinish() {
 					break
 				}
 				c.changeState(52, -1, -1, false)
+				c.ss.time++
 			}
 			c.setFacing(c.p1facing)
 			c.p1facing = 0
@@ -6482,7 +6483,7 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 					getter.ghv.fatal = true
 					getter.ghv.fallf = true
 					// if getter.ghv.fall.animtype < RA_Back {
-						// getter.ghv.fall.animtype = RA_Back
+					// getter.ghv.fall.animtype = RA_Back
 					// }
 					if getter.kovelocity && !sys.sf(GSF_nokovelocity) {
 						if getter.ss.stateType == ST_A {

--- a/src/char.go
+++ b/src/char.go
@@ -5227,7 +5227,7 @@ func (c *Char) attrCheck(h *HitDef, pid int32, st StateType) bool {
 	}
 	if (len(c.ghv.hitBy) > 0 && c.ghv.hitBy[len(c.ghv.hitBy)-1][0] == pid) || c.ghv.hitshaketime > 0 { // https://github.com/ikemen-engine/Ikemen-GO/issues/320
 		for _, nci := range h.nochainid {
-			if nci >= 0 && c.ghv.hitid == nci {
+			if nci >= 0 && c.ghv.hitid == nci && c.ghv.id == h.attackerID {
 				return false
 			}
 		}
@@ -6889,7 +6889,7 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 		getter.enemyNearClear()
 		for _, c := range cl.runOrder {
 			if c.atktmp != 0 && c.id != getter.id && (c.hitdef.affectteam == 0 ||
-				(getter.teamside != c.teamside) == (c.hitdef.affectteam > 0)) {
+				(getter.teamside != c.hitdef.teamside-1) == (c.hitdef.affectteam > 0)) {
 				dist := -getter.distX(c, getter) * c.facing
 				if c.ss.moveType == MT_A && dist >= 0 && c.hitdef.guard_dist < 0 &&
 					dist <= c.attackDist*(c.localscl/getter.localscl) {

--- a/src/char.go
+++ b/src/char.go
@@ -6015,7 +6015,7 @@ func (c *Char) cueDraw() {
 			c.exitTarget(false)
 		}
 		if sys.supertime < 0 && c.teamside != sys.superplayer&1 {
-			c.superDefenseMul = sys.superp2defmul
+			c.superDefenseMul *= sys.superp2defmul
 		}
 		c.minus = 2
 		c.oldPos = c.pos

--- a/src/stage.go
+++ b/src/stage.go
@@ -394,8 +394,10 @@ func (bg backGround) draw(pos [2]float32, scl, bgscl, lclscl float32,
 	}
 	x := bg.start[0] + bg.xofs - (pos[0]/stgscl[0]+bg.camstartx)*bg.delta[0] +
 		bg.bga.offset[0]
-	y := bg.start[1] - ((pos[1]-(sys.cam.CameraZoomYBound/lscl[1])*(1-bg.zoomdelta[1]))/stgscl[1])*bg.delta[1] + bg.bga.offset[1]
-	ys2 := bg.scaledelta[1] * pos[1] * bg.delta[1] * bgscl
+	yScrollPos := ((pos[1] - (sys.cam.CameraZoomYBound / lclscl)) / stgscl[1]) * bg.delta[1]
+	yScrollPos += ((sys.cam.CameraZoomYBound / lclscl) / stgscl[1]) * Pow(bg.zoomdelta[1], 1.4) / bgscl
+	y := bg.start[1] - yScrollPos + bg.bga.offset[1]
+	ys2 := bg.scaledelta[1] * (pos[1] - sys.cam.CameraZoomYBound) * bg.delta[1] * bgscl
 	ys := ((100-pos[1]*bg.yscaledelta)*bgscl/bg.yscalestart)*bg.scalestart[1] + ys2
 	xs := bg.scaledelta[0] * pos[0] * bg.delta[0] * bgscl
 	x *= bgscl


### PR DESCRIPTION
・地面の高さを決める記述でミスがあったので修正
・zoomdelta周辺の記述をちょっと整理
・ズームアウト時のBGレイヤーのY軸変動をdeltaとzoomdeltaで分けて調整
・ステージのscaleがzoffsetlinkに影響しないように修正
・着地ステートのtimeを修正#779
・SuperpauseのP2defmulが乗算になるように修正#752
・nochainIDを同じキャラの攻撃でのみ有効になるように修正#772
・hitdefのteamsideが有効になるように修正