### PR TITLE
Reversaldefでもfall系の記述は反映させるようにした

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1245,7 +1245,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushI(c.palno())
 		case OC_pos_x:
 			var bindVelx float32
-			if c.bindToId > 0 && !math.IsNaN(float64(c.bindPos[0])) {
+			if c.bindToId > 0 && !math.IsNaN(float64(c.bindPos[0])) && c.stCgi().ikemenver[0] == 0 {
 				if sys.playerID(c.bindToId) != nil {
 					bindVelx = c.vel[0]
 				}
@@ -1253,7 +1253,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushF(((c.pos[0]+bindVelx)*(c.localscl/oc.localscl) - sys.cam.Pos[0]/oc.localscl))
 		case OC_pos_y:
 			var bindVely float32
-			if c.bindToId > 0 && !math.IsNaN(float64(c.bindPos[1])) {
+			if c.bindToId > 0 && !math.IsNaN(float64(c.bindPos[1])) && c.stCgi().ikemenver[0] == 0 {
 				if sys.playerID(c.bindToId) != nil {
 					bindVely = c.vel[1]
 				}

--- a/src/char.go
+++ b/src/char.go
@@ -6927,6 +6927,27 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 									getter.mctype = MC_Reversed
 									getter.mctime = -1
 									getter.hitdefContact = true
+
+									fall := getter.ghv.fallf
+									getter.ghv.clear()
+									getter.ghv.attr = c.hitdef.attr
+									getter.ghv.hitid = c.hitdef.id
+									getter.ghv.fall = c.hitdef.fall
+									getter.fallTime = 0
+									getter.ghv.fall.xvelocity = c.hitdef.fall.xvelocity * (c.localscl / getter.localscl)
+									getter.ghv.fall.yvelocity = c.hitdef.fall.yvelocity * (c.localscl / getter.localscl)
+									if c.hitdef.forcenofall {
+										fall = false
+									}
+									if getter.ss.stateType == ST_A {
+										getter.ghv.fallf = c.hitdef.air_fall
+									} else if getter.ss.stateType == ST_L {
+										getter.ghv.fallf = c.hitdef.ground_fall
+									} else {
+										getter.ghv.fallf = c.hitdef.ground_fall
+									}
+									getter.ghv.fallf = getter.ghv.fallf || fall
+
 									getter.targetsOfHitdef = append(getter.targetsOfHitdef, c.id)
 									if getter.hittmp == 0 {
 										getter.hittmp = -1

--- a/src/char.go
+++ b/src/char.go
@@ -6878,7 +6878,8 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 		getter.enemyNearClear()
 		for _, c := range cl.runOrder {
 			if c.atktmp != 0 && c.id != getter.id && (c.hitdef.affectteam == 0 ||
-				(getter.teamside != c.hitdef.teamside-1) == (c.hitdef.affectteam > 0)) {
+				((getter.teamside != c.hitdef.teamside-1) == (c.hitdef.affectteam > 0) && c.hitdef.teamside >= 0) ||
+				((getter.teamside != c.teamside) == (c.hitdef.affectteam > 0) && c.hitdef.teamside < 0)) {
 				dist := -getter.distX(c, getter) * c.facing
 				if c.ss.moveType == MT_A && dist >= 0 && c.hitdef.guard_dist < 0 &&
 					dist <= c.attackDist*(c.localscl/getter.localscl) {


### PR DESCRIPTION
・Reversaldefでもfall系の記述は反映させるようにした#783
・bindされるとposのtriggerに本来のものでなく1F先の情報が表示される仕様は奇妙なのでikemenversionが付いてると起きないようにした
・Hitdefが出てない状態でHitdefのteamsideが参照される場合があったのを修正