### PR TITLE
Zoomステコンにstageboundパラメータを追加

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6590,6 +6590,7 @@ const (
 	zoom_redirectid
 	zoom_camerabound
 	zoom_time
+	zoom_stagebound
 )
 
 func (sc zoom) Run(c *Char, _ []int32) bool {
@@ -6607,6 +6608,8 @@ func (sc zoom) Run(c *Char, _ []int32) bool {
 			sys.zoomScale = exp[0].evalF(c)
 		case zoom_camerabound:
 			sys.zoomCameraBound = exp[0].evalB(c)
+		case zoom_stagebound:
+			sys.zoomStageBound = exp[0].evalB(c)
 		case zoom_lag:
 			sys.zoomlag = exp[0].evalF(c)
 		case zoom_time:

--- a/src/char.go
+++ b/src/char.go
@@ -1869,6 +1869,7 @@ func (c *Char) clear2() {
 	}
 	c.aimg.timegap = -1
 	c.enemyNearClear()
+	c.p2enemy = c.p2enemy[:0]
 	c.targets = c.targets[:0]
 	c.cpucmd = -1
 }

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -3458,6 +3458,10 @@ func (c *Compiler) zoom(is IniSection, sc *StateControllerBase, _ int8) (StateCo
 			zoom_time, VT_Int, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "stagebound",
+			zoom_stagebound, VT_Bool, 1, false); err != nil {
+			return err
+		}
 		return nil
 	})
 	return *ret, err

--- a/src/system.go
+++ b/src/system.go
@@ -218,6 +218,7 @@ type System struct {
 	zoomPosYLag             float32
 	enableZoomtime          int32
 	zoomCameraBound         bool
+	zoomStageBound          bool
 	zoomPos                 [2]float32
 	debugWC                 *Char
 	cam                     Camera
@@ -1017,6 +1018,7 @@ func (s *System) action() {
 			s.enableZoomtime--
 		} else {
 			s.zoomCameraBound = true
+			s.zoomStageBound = true
 		}
 		if s.super > 0 {
 			s.super--
@@ -2024,9 +2026,14 @@ func (s *System) fight() (reload bool) {
 					s.zoomPosYLag += ((s.zoomPos[1] - s.zoomPosYLag) * (1 - s.zoomlag))
 					s.drawScale = s.drawScale / (s.drawScale + (s.zoomScale*scl-s.drawScale)*s.zoomlag) * s.zoomScale * scl
 				}
-				if s.zoomCameraBound {
+				if s.zoomStageBound {
 					dscl = MaxF(s.cam.MinScale, s.drawScale/s.cam.BaseScale())
-					dx = s.cam.XBound(dscl, x+ClampF(s.zoomPosXLag/scl, -s.cam.halfWidth/scl*2*(1-1/s.zoomScale), s.cam.halfWidth/scl*2*(1-1/s.zoomScale)))
+					if s.zoomCameraBound {
+						dx = x + ClampF(s.zoomPosXLag/scl, -s.cam.halfWidth/scl*2*(1-1/s.zoomScale), s.cam.halfWidth/scl*2*(1-1/s.zoomScale))
+					} else {
+						dx = x + s.zoomPosXLag/scl
+					}
+					dx = s.cam.XBound(dscl, dx)
 				} else {
 					dscl = s.drawScale / s.cam.BaseScale()
 					dx = x + s.zoomPosXLag/scl


### PR DESCRIPTION
・Zoomステコンにstageboundパラメータを追加
デフォルトは1
これを0にするとステージ端の限界を無視してズームするようになる
また、cameraboundが無効になる
・P2の敵情報がラウンド間でリセットされていなかったのを修正