### PR TITLE
ZSS expansion: For/While loops, Switches, Break/Continue controls

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -71,7 +71,7 @@ const (
 type OpCode byte
 
 const (
-	OC_var OpCode = iota + 110
+	OC_var OpCode = iota
 	OC_sysvar
 	OC_fvar
 	OC_sysfvar
@@ -217,10 +217,6 @@ const (
 	OC_const_
 	OC_st_
 	OC_ex_
-	OC_var0     = 0
-	OC_sysvar0  = 60
-	OC_fvar0    = 65
-	OC_sysfvar0 = 105
 )
 const (
 	OC_const_data_life OpCode = iota
@@ -363,7 +359,7 @@ const (
 	OC_const_stage_constants
 )
 const (
-	OC_st_var OpCode = iota + OC_var*2
+	OC_st_var OpCode = iota
 	OC_st_sysvar
 	OC_st_fvar
 	OC_st_sysfvar
@@ -371,14 +367,6 @@ const (
 	OC_st_sysvaradd
 	OC_st_fvaradd
 	OC_st_sysfvaradd
-	OC_st_var0        = OC_var0
-	OC_st_sysvar0     = OC_sysvar0
-	OC_st_fvar0       = OC_fvar0
-	OC_st_sysfvar0    = OC_sysfvar0
-	OC_st_var0add     = OC_var + OC_var0
-	OC_st_sysvar0add  = OC_var + OC_sysvar0
-	OC_st_fvar0add    = OC_var + OC_fvar0
-	OC_st_sysfvar0add = OC_var + OC_sysfvar0
 	OC_st_map
 )
 const (
@@ -519,10 +507,10 @@ const (
 	OC_ex_selfcommand
 )
 const (
-	NumVar     = OC_sysvar0 - OC_var0
-	NumSysVar  = OC_fvar0 - OC_sysvar0
-	NumFvar    = OC_sysfvar0 - OC_fvar0
-	NumSysFvar = OC_var - OC_sysfvar0
+	NumVar     = 60
+	NumSysVar  = 5
+	NumFvar    = 40
+	NumSysFvar = 5
 )
 
 type StringPool struct {
@@ -1332,13 +1320,6 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 		case OC_localvar:
 			sys.bcStack.Push(sys.bcVar[uint8(be[i])])
 			i++
-		default:
-			vi := be[i-1]
-			if vi < OC_sysvar0+NumSysVar {
-				sys.bcStack.PushI(c.ivar[vi-OC_var0])
-			} else {
-				sys.bcStack.PushF(c.fvar[vi-OC_fvar0])
-			}
 		}
 		c = oc
 	}
@@ -1375,24 +1356,6 @@ func (be BytecodeExp) run_st(c *Char, i *int) {
 		v := sys.bcStack.Pop().ToF()
 		sys.bcStack.Push(c.mapSet(sys.stringPool[sys.workingState.playerNo].List[*(*int32)(unsafe.Pointer(&be[*i]))], v, 0))
 		*i += 4
-	default:
-		vi := be[*i-1]
-		if vi < OC_st_sysvar0+NumSysVar {
-			c.ivar[vi-OC_st_var0] = sys.bcStack.Top().ToI()
-			sys.bcStack.Top().SetI(c.ivar[vi-OC_st_var0])
-		} else if vi < OC_st_sysfvar0+NumSysFvar {
-			c.fvar[vi-OC_st_fvar0] = sys.bcStack.Top().ToF()
-			sys.bcStack.Top().SetF(c.fvar[vi-OC_st_fvar0])
-		} else if vi < OC_st_sysvar0add+NumSysVar {
-			c.ivar[vi-OC_st_var0add] += sys.bcStack.Top().ToI()
-			sys.bcStack.Top().SetI(c.ivar[vi-OC_st_var0add])
-		} else if vi < OC_st_sysfvar0add+NumSysFvar {
-			c.fvar[vi-OC_st_fvar0add] += sys.bcStack.Top().ToF()
-			sys.bcStack.Top().SetF(c.fvar[vi-OC_st_fvar0add])
-		} else {
-			sys.errLog.Printf("%v\n", be[*i-1])
-			c.panic()
-		}
 	}
 }
 func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -2179,7 +2179,7 @@ func (b StateBlock) Run(c *Char, ps []int32) (changeState bool) {
 				}
 				// Update control variable if loop should keep going
 				if b.forAssign && !interrupt {
-					sys.bcVar[b.forCtrlVar.vari].SetI(b.forBegin + b.forIncrement)
+					sys.bcVar[b.forCtrlVar.vari].SetI(b.forBegin)
 				}
 			}
 			if interrupt {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -2085,6 +2085,7 @@ type StateBlock struct {
 	ctrls               []StateController
 	// Loop fields
 	loopBlock           bool
+	nestedInLoop        bool
 	forLoop             bool
 	forAssign           bool
 	forCtrlVar          varAssign
@@ -2148,6 +2149,15 @@ func (b StateBlock) Run(c *Char, ps []int32) (changeState bool) {
 						}
 					}
 					if sc.Run(c, ps) {
+						if sys.loopBreak {
+							sys.loopBreak = false
+							interrupt = true
+							break
+						}
+						if sys.loopContinue {
+							sys.loopContinue = false
+							break
+						}
 						return true
 					}
 				}
@@ -2217,6 +2227,20 @@ type varAssign struct {
 func (va varAssign) Run(c *Char, _ []int32) (changeState bool) {
 	sys.bcVar[va.vari] = va.be.run(c)
 	return false
+}
+
+type LoopBreak struct{}
+
+func (lb LoopBreak) Run(c *Char, _ []int32) (stop bool) {
+	sys.loopBreak = true
+	return true
+}
+
+type LoopContinue struct{}
+
+func (lc LoopContinue) Run(c *Char, _ []int32) (stop bool) {
+	sys.loopContinue = true
+	return true
 }
 
 type StateControllerBase []byte

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1030,46 +1030,13 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		return bv, nil
 	}
 	_var := func(sys, f bool) error {
-		bv1, err := c.oneArg(out, in, rd, false)
+		_, err := c.oneArg(out, in, rd, true)
 		if err != nil {
 			return err
 		}
 		var oc OpCode
 		c.token = c.tokenizer(in)
-		set, _else := c.token == ":=", false
-		if !bv1.IsNone() && bv1.ToI() >= 0 {
-			switch [...]bool{sys, f} {
-			case [...]bool{false, false}:
-				if bv1.ToI() < int32(NumVar) {
-					oc = OC_var0 + OpCode(bv1.ToI()) // OC_st_var0と同じ値
-				} else {
-					_else = true
-				}
-			case [...]bool{false, true}:
-				if bv1.ToI() < int32(NumFvar) {
-					oc = OC_fvar0 + OpCode(bv1.ToI()) // OC_st_fvar0と同じ値
-				} else {
-					_else = true
-				}
-			case [...]bool{true, false}:
-				if bv1.ToI() < int32(NumSysVar) {
-					oc = OC_sysvar0 + OpCode(bv1.ToI()) // OC_st_sysvar0と同じ値
-				} else {
-					_else = true
-				}
-			case [...]bool{true, true}:
-				if bv1.ToI() < int32(NumSysFvar) {
-					oc = OC_sysfvar0 + OpCode(bv1.ToI()) // OC_st_sysfvar0と同じ値
-				} else {
-					_else = true
-				}
-			}
-		} else {
-			_else = true
-		}
-		if _else {
-			out.appendValue(bv1)
-		}
+		set := c.token == ":="
 		if set {
 			c.token = c.tokenizer(in)
 			var be2 BytecodeExp
@@ -1084,19 +1051,26 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.append(be2...)
 			out.append(OC_st_)
 		}
-		if _else {
-			switch [...]bool{sys, f} {
-			case [...]bool{false, false}:
-				oc = OC_var
-			case [...]bool{false, true}:
-				oc = OC_fvar
-			case [...]bool{true, false}:
-				oc = OC_sysvar
-			case [...]bool{true, true}:
-				oc = OC_sysfvar
-			}
+		switch [...]bool{sys, f} {
+		case [...]bool{false, false}:
+			oc = OC_var
 			if set {
-				oc += OC_st_var - OC_var
+				oc = OC_st_var
+			}
+		case [...]bool{false, true}:
+			oc = OC_fvar
+			if set {
+				oc = OC_st_fvar
+			}
+		case [...]bool{true, false}:
+			oc = OC_sysvar
+			if set {
+				oc = OC_st_sysvar
+			}
+		case [...]bool{true, true}:
+			oc = OC_sysfvar
+			if set {
+				oc = OC_st_sysfvar
 			}
 		}
 		out.append(oc)

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -4279,16 +4279,19 @@ func (c *Compiler) readSentenceLine(line *string) (s string, assign bool,
 	c.token = ""
 	offset := 0
 	for {
-		i := strings.IndexAny((*line)[offset:], ";#\"{}")
+		i := strings.IndexAny((*line)[offset:], ":;#\"{}")
 		if i < 0 {
-			assign = assign || strings.Contains((*line)[offset:], ":=")
 			s, *line = *line, ""
 			return
 		}
 		i += offset
-		assign = assign || strings.Contains((*line)[offset:i], ":=")
 		switch (*line)[i] {
-		case ';', '{', '}':
+		case ':', ';', '{', '}':
+			if (*line)[i] == ':' && len(*line) > i+1 && (*line)[i+1] == '=' {
+				assign = true
+				offset = i+1
+				continue
+			}
 			c.token = (*line)[i : i+1]
 			s, *line = (*line)[:i], (*line)[i+1:]
 		case '#':
@@ -4306,7 +4309,6 @@ func (c *Compiler) readSentenceLine(line *string) (s string, assign bool,
 	return
 }
 func (c *Compiler) readSentence(line *string) (s string, a bool, err error) {
-
 	if s, a, err = c.readSentenceLine(line); err != nil {
 		return
 	}
@@ -4435,48 +4437,50 @@ func (c *Compiler) scanStateDef(line *string, constants map[string]float32) (int
 	v := Atoi(t)
 	return v, err
 }
-func (c *Compiler) subBlock(line *string, root bool,
-	sbc *StateBytecode, numVars *int32, ignorehitpause bool) (*StateBlock, error) {
-	bl := newStateBlock()
+// Sets attributes to a StateBlock, like IgnoreHitPause, Persistent
+func (c *Compiler) blockAttribSet(line *string, bl *StateBlock, sbc *StateBytecode,
+	inheritIhp bool) error {
 	// Inherit ignorehitpause from parent block
-	if ignorehitpause {
+	if inheritIhp {
 		bl.ignorehitpause, bl.ctrlsIgnorehitpause = -1, true
+		// Avoid re-reading ignorehitpause
+		if c.token == "ignorehitpause" {
+			c.scan(line)
+		}
 	}
-	ihpRead := false
 	for {
 		switch c.token {
 		case "ignorehitpause":
-			if ihpRead {
-				return nil, c.yokisinaiToken()
+			if bl.ignorehitpause >= -1 {
+				return c.yokisinaiToken()
 			}
 			bl.ignorehitpause, bl.ctrlsIgnorehitpause = -1, true
 			c.scan(line)
-			ihpRead = true
 			continue
 		case "persistent":
 			if sbc == nil {
-				return nil, Error("persistent cannot be used in a function")
+				return Error("persistent cannot be used in a function")
 			}
 			if c.stateNo < 0 {
-				return nil, Error("persistent cannot be used in a negative state")
+				return Error("persistent cannot be used in a negative state")
 			}
 			if bl.persistentIndex >= 0 {
-				return nil, c.yokisinaiToken()
+				return c.yokisinaiToken()
 			}
 			c.scan(line)
 			if err := c.needToken("("); err != nil {
-				return nil, err
+				return err
 			}
 			var err error
 			if bl.persistent, err = c.scanI32(line); err != nil {
-				return nil, err
+				return err
 			}
 			c.scan(line)
 			if err := c.needToken(")"); err != nil {
-				return nil, err
+				return err
 			}
 			if bl.persistent == 1 {
-				return nil, Error("persistent(1) is meaningless")
+				return Error("persistent(1) is meaningless")
 			}
 			if bl.persistent <= 0 {
 				bl.persistent = math.MaxInt32
@@ -4488,9 +4492,19 @@ func (c *Compiler) subBlock(line *string, root bool,
 		}
 		break
 	}
+	return nil
+}
+func (c *Compiler) subBlock(line *string, root bool,
+	sbc *StateBytecode, numVars *int32, inheritIhp bool) (*StateBlock, error) {
+	bl := newStateBlock()
+	if err := c.blockAttribSet(line, bl, sbc, inheritIhp); err != nil {
+		return nil, err
+	}
+	compileMain, compileElse := true, false
 	switch c.token {
 	case "{":
 	case "if":
+		compileElse = true
 		expr, _, err := c.readSentence(line)
 		if err != nil {
 			return nil, err
@@ -4503,12 +4517,19 @@ func (c *Compiler) subBlock(line *string, root bool,
 		if err := c.needToken("{"); err != nil {
 			return nil, err
 		}
+	case "switch":
+		compileMain = false
+		if err := c.switchBlock(line, bl, sbc, numVars); err != nil {
+			return nil, err
+		}
 	default:
 		return nil, c.yokisinaiToken()
 	}
-	if err := c.stateBlock(line, bl, false,
-		sbc, &bl.ctrls, numVars); err != nil {
-		return nil, err
+	if compileMain {
+		if err := c.stateBlock(line, bl, false,
+			sbc, &bl.ctrls, numVars); err != nil {
+			return nil, err
+		}
 	}
 	if root {
 		if len(bl.trigger) > 0 {
@@ -4529,11 +4550,11 @@ func (c *Compiler) subBlock(line *string, root bool,
 	} else {
 		c.scan(line)
 	}
-	if len(bl.trigger) > 0 && c.token == "else" {
+	if compileElse && len(bl.trigger) > 0 && c.token == "else" {
 		c.scan(line)
 		var err error
 		if bl.elseBlock, err = c.subBlock(line, root,
-			sbc, numVars, ignorehitpause); err != nil {
+			sbc, numVars, inheritIhp); err != nil {
 			return nil, err
 		}
 		if bl.elseBlock.ignorehitpause >= -1 {
@@ -4541,6 +4562,106 @@ func (c *Compiler) subBlock(line *string, root bool,
 		}
 	}
 	return bl, nil
+}
+func (c *Compiler) switchBlock(line *string, bl *StateBlock,
+	sbc *StateBytecode, numVars *int32) error {
+	// In this implementation of switch, we convert the statement to an if-elseif-else chain of blocks
+	header, _, err := c.readSentence(line)
+	if err != nil {
+		return err
+	}
+	if err := c.needToken("{"); err != nil {
+		return err
+	}
+	c.scan(line)
+	compileCaseBlock := func(sbl *StateBlock, expr *string) error {
+		if err := c.blockAttribSet(line, sbl, sbc,
+			bl != nil && bl.ctrlsIgnorehitpause); err != nil {
+			return err
+		}
+		otk := c.token
+		if sbl.trigger, err = c.fullExpression(expr, VT_Bool); err != nil {
+			return err
+		}
+		c.token = otk
+		// Compile the inner block for this case
+		if err := c.stateBlock(line, sbl, false,
+			sbc, &sbl.ctrls, numVars); err != nil {
+			return err
+		}
+		return nil
+	}
+	// Start examining the cases
+	var readNextCase func(*StateBlock) (*StateBlock, error)
+	readNextCase = func(def *StateBlock) (*StateBlock, error) {
+		expr := ""
+		switch c.token {
+			case "case":
+			case "default":
+				if def != nil {
+					return nil, Error("Default already defined")
+				}
+				c.scan(line)
+				expr = "1"
+				def = newStateBlock()
+				if err := compileCaseBlock(def, &expr); err != nil {
+					return nil, err
+				}
+				// See if default is the last case defined in this switch statement,
+				// return default block if that's the case
+				if c.token == "}" {
+					return def, nil
+				}
+			default:
+				return nil, Error("Expected case or default")
+		}
+		// We loop through all possible expressions in this case, separated by ;
+		// Creating an equality/or expression string in the process
+		for {
+			caseValue, _, err := c.readSentence(line)
+			if err != nil {
+				return nil, err
+			}
+			// We create an equality expression that looks like this: header = caseValue
+			// and we append it to the case block expression. Colon at the end is also removed
+			expr += header + " = " + caseValue
+			if c.token == ";" {
+				// We'll have another expression to test for this case, so we append an OR operator
+				expr += " || "
+				continue
+			}
+			// We finished reading the case, check for colon existence
+			if err := c.needToken(":"); err != nil {
+				return nil, err
+			}
+			break
+		}
+		// Create a new state block for this case
+		sbl := newStateBlock()
+		if err := compileCaseBlock(sbl, &expr); err != nil {
+			return nil, err
+		}
+		// Switch has finished
+		if c.token == "}" {
+			// Assign default block as the latest else in the chain
+			if def != nil {
+				sbl.elseBlock = def
+			}
+		// If not, we have another case to check
+		} else if sbl.elseBlock, err = readNextCase(def); err != nil {
+			return nil, err
+		}
+		return sbl, nil
+	}
+	if sbl, err := readNextCase(nil); err != nil {
+		return err
+	} else {
+		if bl != nil && sbl.ignorehitpause >= -1 {
+			bl.ignorehitpause = -1
+		}
+		bl.ctrls = append(bl.ctrls, *sbl)
+	}
+	return nil
 }
 func (c *Compiler) callFunc(line *string, root bool,
 	ctrls *[]StateController, ret []uint8) error {
@@ -4631,12 +4752,12 @@ func (c *Compiler) stateBlock(line *string, bl *StateBlock, root bool,
 				return c.yokisinaiToken()
 			}
 			return nil
-		case "}":
+		case "}", "case", "default":
 			if root {
 				return c.yokisinaiToken()
 			}
 			return nil
-		case "if", "ignorehitpause", "persistent":
+		case "if", "ignorehitpause", "persistent", "switch":
 			if sbl, err := c.subBlock(line, root, sbc, numVars,
 				bl != nil && bl.ctrlsIgnorehitpause); err != nil {
 				return err

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1935,23 +1935,7 @@ func (c *Compiler) varSetSub(is IniSection,
 			}
 		}
 		if v || fv {
-			if len(ve) == 2 && ve[0] == OC_int8 && int8(ve[1]) >= 0 &&
-				(v && ve[1] < NumVar || fv && ve[1] < NumFvar) {
-				if oc == OC_st_var {
-					if v {
-						oc = OC_st_var0 + ve[1]
-					} else {
-						oc = OC_st_fvar0 + ve[1]
-					}
-				} else {
-					if v {
-						oc = OC_st_var0add + ve[1]
-					} else {
-						oc = OC_st_fvar0add + ve[1]
-					}
-				}
-				ve = nil
-			} else if oc == OC_st_var {
+			if oc == OC_st_var {
 				if v {
 					oc = OC_st_var
 				} else {
@@ -2003,66 +1987,35 @@ func (c *Compiler) varSetSub(is IniSection,
 		if err != nil {
 			return err
 		}
-		_else := false
 		if !bv.IsNone() {
-			i := bv.ToI()
-			if i >= 0 && (!sys && v && i < int32(NumVar) ||
-				!sys && fv && i < int32(NumFvar) || sys && v && i < int32(NumSysVar) ||
-				sys && fv && i < int32(NumSysFvar)) {
+			be.appendValue(bv)
+		}
+		if oc == OC_st_var {
+			if sys {
 				if v {
-					if oc == OC_st_var {
-						oc = OC_st_var0 + OpCode(i)
-					} else {
-						oc = OC_st_var0add + OpCode(i)
-					}
-					if sys {
-						oc += NumVar
-					}
+					oc = OC_st_sysvar
 				} else {
-					if oc == OC_st_var {
-						oc = OC_st_fvar0 + OpCode(i)
-					} else {
-						oc = OC_st_fvar0add + OpCode(i)
-					}
-					if sys {
-						oc += NumFvar
-					}
+					oc = OC_st_sysfvar
 				}
 			} else {
-				be.appendValue(bv)
-				_else = true
+				if v {
+					oc = OC_st_var
+				} else {
+					oc = OC_st_fvar
+				}
 			}
 		} else {
-			_else = true
-		}
-		if _else {
-			if oc == OC_st_var {
-				if sys {
-					if v {
-						oc = OC_st_sysvar
-					} else {
-						oc = OC_st_sysfvar
-					}
+			if sys {
+				if v {
+					oc = OC_st_sysvaradd
 				} else {
-					if v {
-						oc = OC_st_var
-					} else {
-						oc = OC_st_fvar
-					}
+					oc = OC_st_sysfvaradd
 				}
 			} else {
-				if sys {
-					if v {
-						oc = OC_st_sysvaradd
-					} else {
-						oc = OC_st_sysfvaradd
-					}
+				if v {
+					oc = OC_st_varadd
 				} else {
-					if v {
-						oc = OC_st_varadd
-					} else {
-						oc = OC_st_fvaradd
-					}
+					oc = OC_st_fvaradd
 				}
 			}
 		}

--- a/src/system.go
+++ b/src/system.go
@@ -355,6 +355,8 @@ type System struct {
 	stereoEffects   bool
 	panningRange    float32
 	windowCentered  bool
+	loopBreak       bool
+	loopContinue    bool
 }
 
 // Initialize stuff, this is called after the config int at main.go


### PR DESCRIPTION
This is a series of commits that attempt modify the bytecode compiler in order to expand the syntax in ZSS and bring it to more standard programming conventions. New statements were added, prominently loops and switches.

**New statements added:**

Switches:
```coffeescript
switch life {
    case 1000:
        text{text: "Your life is full"}
    case 500; 250:
        text{text: "Your life is in halves"}
    case 100:
    default:
        text{text: "You cannot recover life"}
}
```
In switches, the cases can be in any order, including the default one. Cases can have more than one expression, and adding code inside them is optional, meaning, you can add cases where nothing happens. Switch can help make code more understandable, and it's a great tool to code AI in specific.

For loops:
```coffeescript
for i = 0; 20; 2 {
    map(collector) := map(collector) +  1;
}
```
`exp1` and `exp2` are the range of the iteration, in integers. `exp3` is an optional incremental expression, and can be positive or negative, but its inclusion is necessary to perform iterations from a greater number to a lower one. Control var declaration can be avoided to perform looping in a strict range. After the loop has finished, if a control variable was present, its value will be kept.

While loops:
```coffeescript
while map(collector) < 20 {
    map(collector) := map(collector) + 1;
}
```
`While` will iterate a state block indefinitely until the header expression returns false.

Break/Continue:
```coffeescript
let i = 0
while $i < 10 {
    if $i = 8 {
        break;
    }
    let i = $i + 1;
    if $i > 5 {
        continue;
    }
    map(collector) := map(collector) + 1;
}
```
Break/continue statements are useful to control the flow of the loop blocks. They're expected to be inside a loop block and have a semicolon at the end, else the compiler will throw an error.

NOTE: Changing states inside loops will also break them.

--------------------------------------------------------------------------

On another note, "Var0" OpCode implementation to handle var getting/setting was removed as it was considered duplicate behavior that bloated the codebase. There are already OpCodes and methods to get/set vars that are more understandable at first sight.

In fact, removing it has freed 145 OpCode spaces in `OC_` group. This could be a good opportunity to organize things there.