### PR TITLE
Hitdefのp2statenoでヒットがカウントされない場合があったのを修正

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -6625,6 +6625,14 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 					}
 				}
 			}
+			if ghvset || getter.sf(CSF_gethit) {
+				getter.receivedHits += hd.numhits * hits
+				getter.fakeReceivedHits += hd.numhits * hits
+				if c.teamside != -1 {
+					sys.lifebar.co[c.teamside].combo += hd.numhits * hits
+					sys.lifebar.co[c.teamside].fakeCombo += hd.numhits * hits
+				}
+			}
 		} else {
 			if hd.guard_sparkno != IErr {
 				if hd.reversal_attr > 0 {
@@ -6747,12 +6755,6 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 				sys.envShake.ampl = int32(float32(hd.envshake_ampl) * c.localscl)
 				sys.envShake.phase = hd.envshake_phase
 				sys.envShake.setDefPhase()
-			}
-			getter.receivedHits += hd.numhits * hits
-			getter.fakeReceivedHits += hd.numhits * hits
-			if c.teamside != -1 {
-				sys.lifebar.co[c.teamside].combo += hd.numhits * hits
-				sys.lifebar.co[c.teamside].fakeCombo += hd.numhits * hits
 			}
 			//getter.getcombodmg += hd.hitdamage
 			if hitType > 0 && !proj && getter.sf(CSF_screenbound) &&

--- a/src/char.go
+++ b/src/char.go
@@ -5928,6 +5928,14 @@ func (c *Char) tick() {
 				c.playSound(false, false, false, 11, 0, -1, vo, 0, 1, c.localscl, &c.pos[0], false, 0)
 			}
 			c.setSCF(SCF_ko)
+			for _, cl := range sys.charList.runOrder {
+				for i, p2cl := range cl.p2enemy {
+					if p2cl == c {
+						cl.p2enemy = cl.p2enemy[:i+copy(cl.p2enemy[i:], cl.p2enemy[i+1:])]
+						break
+					}
+				}
+			}
 		}
 		if c.ss.moveType != MT_H {
 			c.recoverTime = c.gi().data.liedown.time

--- a/src/stage.go
+++ b/src/stage.go
@@ -394,11 +394,11 @@ func (bg backGround) draw(pos [2]float32, scl, bgscl, lclscl float32,
 	}
 	x := bg.start[0] + bg.xofs - (pos[0]/stgscl[0]+bg.camstartx)*bg.delta[0] +
 		bg.bga.offset[0]
-	yScrollPos := ((pos[1] - (sys.cam.CameraZoomYBound / lclscl)) / stgscl[1]) * bg.delta[1]
+	yScrollPos := ((pos[1] - (sys.cam.CameraZoomYBound / lclscl)) / stgscl[1]) * bg.delta[1] * bgscl
 	yScrollPos += ((sys.cam.CameraZoomYBound / lclscl) / stgscl[1]) * Pow(bg.zoomdelta[1], 1.4) / bgscl
 	y := bg.start[1] - yScrollPos + bg.bga.offset[1]
 	ys2 := bg.scaledelta[1] * (pos[1] - sys.cam.CameraZoomYBound) * bg.delta[1] * bgscl
-	ys := ((100-pos[1]*bg.yscaledelta)*bgscl/bg.yscalestart)*bg.scalestart[1] + ys2
+	ys := ((100-(pos[1]-sys.cam.CameraZoomYBound)*bg.yscaledelta)*bgscl/bg.yscalestart)*bg.scalestart[1] + ys2
 	xs := bg.scaledelta[0] * pos[0] * bg.delta[0] * bgscl
 	x *= bgscl
 	y = y*bgscl + ((float32(sys.gameHeight)-shakeY)/scly-240)/stgscl[1]


### PR DESCRIPTION
・Hitdefのp2statenoでヒットがカウントされない場合があったのを修正 #810
・フルカラー画像で減算処理した際にPalfxのaddの反転が2重になる場合があったのを修正
・KOした相手をP2情報として残し続けていたのを修正
・hiresとyscaledeltaを使用したステージで視差に誤りが出ていたのを修正