### PR TITLE
RatioMatches Extra Code

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -2144,7 +2144,9 @@ for line in content:gmatch('[^\r\n]+') do
 				rmin = tonumber(rmin)
 				rmax = tonumber(rmax) or rmin
 				order = tonumber(order)
-				if rmin == nil or order == nil or rmin < 1 or rmin > 4 or rmax < 1 or rmax > 4 or rmin > rmax then
+				if (rmin and tonumber(rmin)) == nil or (order and tonumber(order)) == nil or (rmin and tonumber(rmin)) < 1
+					or (rmin and tonumber(rmin)) > 4 or (rmax and tonumber(rmax)) < 1 or (rmax and tonumber(rmax)) > 4
+					or (rmin and tonumber(rmin)) > (rmax and tonumber(rmax)) then
 					main.f_warning(main.f_extractText(motif.warning_info.text_ratio_text), motif.titlebgdef)
 					main.t_selOptions[rowName .. 'ratiomatches'] = nil
 					break


### PR DESCRIPTION
I am still crashing on startup without altering this syntax to how it is. Here's the steps any layperson, I.E. me, can perform to reproduce my crash. 1: Fresh bin folder (from a new compilation of the latest IKEMEN) with no modifications. This folder has only Data, External and the latest Ikemen GO exe compiled from github. 2: Then add from the Elecbyte pack repository, the necessary System.def components. 3: Add fonts in from the pack and get my error. Voila!

external/script/main.lua:2147: attempt to compare string with number
stack traceback:
    external/script/main.lua:2147: in main chunk
    [G]: ?

Speaking with Lazin3ss on it, all I could really gather is that something's up with the way the syntax for rmax and rmin is written. After some troubleshooting, this got me back into the program.