### PR TITLE
Add support for "CommonFx" files

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -1332,6 +1332,7 @@ function main.f_commandLine()
 	local roundTime = config.RoundTime
 	if main.flags['-loadmotif'] == nil then
 		loadLifebar(main.lifebarDef)
+		loadCommonFx()
 	end
 	setLifebarElements({guardbar = config.BarGuard, stunbar = config.BarStun, redlifebar = config.BarRedLife})
 	local frames = framespercount()
@@ -1519,6 +1520,7 @@ main.txt_loading = main.f_createTextImg(motif.title_info, 'loading')
 main.txt_loading:draw()
 refresh()
 loadLifebar(main.lifebarDef)
+loadCommonFx()
 main.f_loadingRefresh(main.txt_loading)
 main.timeFramesPerCount = framespercount()
 main.f_updateRoundsNum()

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -2357,7 +2357,7 @@ func (sc stateDef) Run(c *Char) {
 				}
 			}
 		case stateDef_anim:
-			c.changeAnim(exp[1].evalI(c), exp[0].evalB(c))
+			c.changeAnim(exp[1].evalI(c), string(*(*[]byte)(unsafe.Pointer(&exp[0]))))
 		case stateDef_ctrl:
 			//in mugen fatal blow ignores statedef ctrl
 			if !c.ghv.fatal {
@@ -2480,7 +2480,7 @@ const (
 
 func (sc playSnd) Run(c *Char, _ []int32) bool {
 	crun := c
-	f, lw, lp := false, false, false
+	f, lw, lp := "", false, false
 	var g, n, ch, vo, pri int32 = -1, 0, -1, 100, 0
 	var p, fr float32 = 0, 1
 	x := &c.pos[0]
@@ -2488,7 +2488,7 @@ func (sc playSnd) Run(c *Char, _ []int32) bool {
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case playSnd_value:
-			f = exp[0].evalB(c)
+			f = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
 			g = exp[1].evalI(c)
 			if len(exp) > 2 {
 				n = exp[2].evalI(c)
@@ -2541,7 +2541,7 @@ const (
 func (sc changeState) Run(c *Char, _ []int32) bool {
 	crun := c
 	var v, a, ctrl int32 = -1, -1, -1
-	fflg := false
+	ffx := ""
 	changeState := true
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
@@ -2551,7 +2551,7 @@ func (sc changeState) Run(c *Char, _ []int32) bool {
 			ctrl = exp[0].evalI(c)
 		case changeState_anim:
 			a = exp[1].evalI(c)
-			fflg = exp[0].evalB(c)
+			ffx = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
 		case changeState_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				changeState = rid.id == c.id
@@ -2562,7 +2562,7 @@ func (sc changeState) Run(c *Char, _ []int32) bool {
 		}
 		return true
 	})
-	crun.changeState(v, a, ctrl, fflg)
+	crun.changeState(v, a, ctrl, ffx)
 	return changeState
 }
 
@@ -2571,7 +2571,7 @@ type selfState changeState
 func (sc selfState) Run(c *Char, _ []int32) bool {
 	crun := c
 	var v, a, r, ctrl int32 = -1, -1, -1, -1
-	fflg := false
+	ffx := ""
 	changeState := true
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
@@ -2581,7 +2581,7 @@ func (sc selfState) Run(c *Char, _ []int32) bool {
 			ctrl = exp[0].evalI(c)
 		case changeState_anim:
 			a = exp[1].evalI(c)
-			fflg = exp[0].evalB(c)
+			ffx = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
 		case changeState_readplayerid:
 			if rpid := sys.playerID(exp[0].evalI(c)); rpid != nil {
 				r = int32(rpid.playerNo)
@@ -2598,7 +2598,7 @@ func (sc selfState) Run(c *Char, _ []int32) bool {
 		}
 		return true
 	})
-	crun.selfState(v, a, r, ctrl, fflg)
+	crun.selfState(v, a, r, ctrl, ffx)
 	return changeState
 }
 
@@ -2626,7 +2626,7 @@ func (sc tagIn) Run(c *Char, _ []int32) bool {
 		case tagIn_stateno:
 			sn := exp[0].evalI(c)
 			if sn >= 0 {
-				crun.changeState(sn, -1, -1, false)
+				crun.changeState(sn, -1, -1, "")
 				if tagSCF == -1 {
 					tagSCF = 1
 				}
@@ -2684,7 +2684,7 @@ func (sc tagIn) Run(c *Char, _ []int32) bool {
 		partner := crun.partnerV2(partnerNo)
 		partner.unsetSCF(SCF_standby)
 		if partnerStateNo >= 0 {
-			partner.changeState(partnerStateNo, -1, -1, false)
+			partner.changeState(partnerStateNo, -1, -1, "")
 		}
 		if partnerCtrlSetting != -1 {
 			if partnerCtrlSetting == 1 {
@@ -2719,7 +2719,7 @@ func (sc tagOut) Run(c *Char, _ []int32) bool {
 		case tagOut_stateno:
 			sn := exp[0].evalI(c)
 			if sn >= 0 {
-				crun.changeState(sn, -1, -1, false)
+				crun.changeState(sn, -1, -1, "")
 				if tagSCF == -1 {
 					tagSCF = 1
 				}
@@ -2758,7 +2758,7 @@ func (sc tagOut) Run(c *Char, _ []int32) bool {
 		partner := crun.partnerV2(partnerNo)
 		partner.setSCF(SCF_standby)
 		if partnerStateNo >= 0 {
-			partner.changeState(partnerStateNo, -1, -1, false)
+			partner.changeState(partnerStateNo, -1, -1, "")
 		}
 	}
 	return false
@@ -2817,7 +2817,7 @@ func (sc changeAnim) Run(c *Char, _ []int32) bool {
 			if r != -1 {
 				pn = r
 			}
-			crun.changeAnimEx(exp[1].evalI(c), pn, exp[0].evalB(c), false)
+			crun.changeAnimEx(exp[1].evalI(c), pn, string(*(*[]byte)(unsafe.Pointer(&exp[0]))), false)
 			if setelem {
 				crun.setAnimElem(elem)
 			}
@@ -2851,7 +2851,7 @@ func (sc changeAnim2) Run(c *Char, _ []int32) bool {
 			elem = exp[0].evalI(c)
 			setelem = true
 		case changeAnim_value:
-			crun.changeAnim2(exp[1].evalI(c), exp[0].evalB(c))
+			crun.changeAnim2(exp[1].evalI(c), string(*(*[]byte)(unsafe.Pointer(&exp[0]))))
 			if setelem {
 				crun.setAnimElem(elem)
 			}
@@ -3498,7 +3498,7 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 				}
 			}
 		case explod_anim:
-			e.anim = crun.getAnim(exp[1].evalI(c), exp[0].evalB(c), false)
+			e.anim = crun.getAnim(exp[1].evalI(c), string(*(*[]byte)(unsafe.Pointer(&exp[0]))), false)
 		case explod_angle:
 			e.rot.angle = exp[0].evalF(c)
 		case explod_yangle:
@@ -3714,7 +3714,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				eachExpl(func(e *Explod) { e.alpha = [...]int32{s, d} })
 			case explod_anim:
 				if c.stCgi().ikemenver[0] > 0 || c.stCgi().ikemenver[1] > 0 {
-					anim := crun.getAnim(exp[1].evalI(c), exp[0].evalB(c), false)
+					anim := crun.getAnim(exp[1].evalI(c), string(*(*[]byte)(unsafe.Pointer(&exp[0]))), false)
 					eachExpl(func(e *Explod) { e.anim = anim })
 				}
 			case explod_angle:
@@ -3811,7 +3811,7 @@ func (sc gameMakeAnim) Run(c *Char, _ []int32) bool {
 		case gameMakeAnim_under:
 			e.ontop = !exp[0].evalB(c)
 		case gameMakeAnim_anim:
-			e.anim = crun.getAnim(exp[1].evalI(c), exp[0].evalB(c), false)
+			e.anim = crun.getAnim(exp[1].evalI(c), string(*(*[]byte)(unsafe.Pointer(&exp[0]))), false)
 		}
 		return true
 	})
@@ -4131,26 +4131,14 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 	case hitDef_numhits:
 		hd.numhits = exp[0].evalI(c)
 	case hitDef_hitsound:
-		n := exp[1].evalI(c)
-		if n < 0 {
-			hd.hitsound[0] = IErr
-		} else if exp[0].evalB(c) {
-			hd.hitsound[0] = ^n
-		} else {
-			hd.hitsound[0] = n
-		}
+		hd.hitsound_ffx = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
+		hd.hitsound[0] = exp[1].evalI(c)
 		if len(exp) > 2 {
 			hd.hitsound[1] = exp[2].evalI(c)
 		}
 	case hitDef_guardsound:
-		n := exp[1].evalI(c)
-		if n < 0 {
-			hd.guardsound[0] = IErr
-		} else if exp[0].evalB(c) {
-			hd.guardsound[0] = ^n
-		} else {
-			hd.guardsound[0] = n
-		}
+		hd.guardsound_ffx = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
+		hd.guardsound[0] = exp[1].evalI(c)
 		if len(exp) > 2 {
 			hd.guardsound[1] = exp[2].evalI(c)
 		}
@@ -4183,23 +4171,11 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 	case hitDef_fall_recovertime:
 		hd.fall.recovertime = exp[0].evalI(c)
 	case hitDef_sparkno:
-		n := exp[1].evalI(c)
-		if n < 0 {
-			hd.sparkno = IErr
-		} else if exp[0].evalB(c) {
-			hd.sparkno = ^n
-		} else {
-			hd.sparkno = n
-		}
+		hd.sparkno_ffx = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
+		hd.sparkno = exp[1].evalI(c)
 	case hitDef_guard_sparkno:
-		n := exp[1].evalI(c)
-		if n < 0 {
-			hd.guard_sparkno = IErr
-		} else if exp[0].evalB(c) {
-			hd.guard_sparkno = ^n
-		} else {
-			hd.guard_sparkno = n
-		}
+		hd.guard_sparkno_ffx = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
+		hd.guard_sparkno = exp[1].evalI(c)
 	case hitDef_sparkxy:
 		hd.sparkxy[0] = exp[0].evalF(c)
 		if len(exp) > 1 {
@@ -4356,16 +4332,16 @@ func (sc hitDef) Run(c *Char, _ []int32) bool {
 	crun := c
 	crun.hitdef.clear()
 	crun.hitdef.playerNo = sys.workingState.playerNo
-	crun.hitdef.sparkno = ^c.gi().data.sparkno
-	crun.hitdef.guard_sparkno = ^c.gi().data.guard.sparkno
+	crun.hitdef.sparkno = c.gi().data.sparkno
+	crun.hitdef.guard_sparkno = c.gi().data.guard.sparkno
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		if id == hitDef_redirectid {
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
 				crun.hitdef.clear()
 				crun.hitdef.playerNo = sys.workingState.playerNo
-				crun.hitdef.sparkno = ^c.gi().data.sparkno
-				crun.hitdef.guard_sparkno = ^c.gi().data.guard.sparkno
+				crun.hitdef.sparkno = c.gi().data.sparkno
+				crun.hitdef.guard_sparkno = c.gi().data.guard.sparkno
 			} else {
 				return false
 			}
@@ -4510,13 +4486,13 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 			p.priorityPoints = p.priority
 		case projectile_projhitanim:
 			p.hitanim = exp[1].evalI(c)
-			p.hitanim_fflg = exp[0].evalB(c)
+			p.hitanim_ffx = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
 		case projectile_projremanim:
 			p.remanim = Max(-1, exp[1].evalI(c))
-			p.remanim_fflg = exp[0].evalB(c)
+			p.remanim_ffx = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
 		case projectile_projcancelanim:
 			p.cancelanim = Max(-1, exp[1].evalI(c))
-			p.cancelanim_fflg = exp[0].evalB(c)
+			p.cancelanim_ffx = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
 		case projectile_velocity:
 			p.velocity[0] = exp[0].evalF(c) * lclscround
 			if len(exp) > 1 {
@@ -4562,7 +4538,7 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 			}
 		case projectile_projanim:
 			p.anim = exp[1].evalI(c)
-			p.anim_fflg = exp[0].evalB(c)
+			p.anim_ffx = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
 		case projectile_supermovetime:
 			p.supermovetime = exp[0].evalI(c)
 			if p.supermovetime >= 0 {
@@ -4608,15 +4584,15 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 	}
 	crun.setHitdefDefault(&p.hitdef, true)
 	if p.hitanim == -1 {
-		p.hitanim_fflg = p.anim_fflg
+		p.hitanim_ffx = p.anim_ffx
 	}
 	if p.remanim == IErr {
 		p.remanim = p.hitanim
-		p.remanim_fflg = p.hitanim_fflg
+		p.remanim_ffx = p.hitanim_ffx
 	}
 	if p.cancelanim == IErr {
 		p.cancelanim = p.remanim
-		p.cancelanim_fflg = p.remanim_fflg
+		p.cancelanim_ffx = p.remanim_ffx
 	}
 	if p.aimg.time != 0 {
 		p.aimg.setupPalFX()
@@ -5512,7 +5488,7 @@ func (sc superPause) Run(c *Char, _ []int32) bool {
 	crun := c
 	var t, mt int32 = 30, 0
 	uh := true
-	sys.superanim, sys.superpmap.remap = crun.getAnim(100, true, false), nil
+	sys.superanim, sys.superpmap.remap = crun.getAnim(100, "f", false), nil
 	sys.superpos, sys.superfacing = [...]float32{crun.pos[0] * crun.localscl, crun.pos[1] * crun.localscl}, crun.facing
 	sys.superpausebg, sys.superendcmdbuftime, sys.superdarken = true, 0, true
 	sys.superp2defmul = crun.gi().constants["super.targetdefencemul"]
@@ -5529,9 +5505,9 @@ func (sc superPause) Run(c *Char, _ []int32) bool {
 		case superPause_darken:
 			sys.superdarken = exp[0].evalB(c)
 		case superPause_anim:
-			f := exp[0].evalB(c)
-			if sys.superanim = crun.getAnim(exp[1].evalI(c), f, false); sys.superanim != nil {
-				if f {
+			ffx := string(*(*[]byte)(unsafe.Pointer(&exp[0])))
+			if sys.superanim = crun.getAnim(exp[1].evalI(c), ffx, false); sys.superanim != nil {
+				if ffx == "f" {
 					sys.superpmap.remap = nil
 				} else {
 					sys.superpmap.remap = crun.getPalMap()
@@ -5557,12 +5533,13 @@ func (sc superPause) Run(c *Char, _ []int32) bool {
 				n = exp[2].evalI(c)
 			}
 			vo := int32(100)
-			crun.playSound(exp[0].evalB(c), false, false, exp[1].evalI(c), n, -1,
+			ffx := string(*(*[]byte)(unsafe.Pointer(&exp[0])))
+			crun.playSound(ffx, false, false, exp[1].evalI(c), n, -1,
 				vo, 0, 1, 1, nil, false, 0)
 		case superPause_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				sys.superanim, sys.superpmap.remap = crun.getAnim(30, true, false), nil
+				sys.superanim, sys.superpmap.remap = crun.getAnim(30, "f", false), nil
 				sys.superpos, sys.superfacing = [...]float32{crun.pos[0] * crun.localscl, crun.pos[1] * crun.localscl}, crun.facing
 			} else {
 				return false

--- a/src/char.go
+++ b/src/char.go
@@ -511,10 +511,14 @@ type HitDef struct {
 	guard_pausetime            int32
 	guard_shaketime            int32
 	sparkno                    int32
+	sparkno_ffx                string
 	guard_sparkno              int32
+	guard_sparkno_ffx          string
 	sparkxy                    [2]float32
 	hitsound                   [2]int32
+	hitsound_ffx                string
 	guardsound                 [2]int32
+	guardsound_ffx              string
 	ground_type                HitType
 	air_type                   HitType
 	ground_slidetime           int32
@@ -584,19 +588,23 @@ type HitDef struct {
 
 func (hd *HitDef) clear() {
 	*hd = HitDef{
-		hitflag:       int32(ST_S | ST_C | ST_A | ST_F),
-		affectteam:    1,
-		teamside:      -1,
-		animtype:      RA_Light,
-		air_animtype:  RA_Unknown,
-		priority:      4,
-		bothhittype:   AT_Hit,
-		sparkno:       IErr,
-		guard_sparkno: IErr,
-		hitsound:      [...]int32{IErr, 0},
-		guardsound:    [...]int32{IErr, 0},
-		ground_type:   HT_High,
-		air_type:      HT_Unknown,
+		hitflag:           int32(ST_S | ST_C | ST_A | ST_F),
+		affectteam:        1,
+		teamside:          -1,
+		animtype:          RA_Light,
+		air_animtype:      RA_Unknown,
+		priority:          4,
+		bothhittype:       AT_Hit,
+		sparkno:           -1,
+		sparkno_ffx:       "f",
+		guard_sparkno:     -1,
+		guard_sparkno_ffx: "f",
+		hitsound:          [...]int32{-1, 0},
+		hitsound_ffx:      "f",
+		guardsound:        [...]int32{-1, 0},
+		guardsound_ffx:    "f",
+		ground_type:       HT_High,
+		air_type:          HT_Unknown,
 		// Both default to 20, not documented in Mugen docs.
 		air_hittime:  20,
 		down_hittime: 20,
@@ -1224,13 +1232,13 @@ type Projectile struct {
 	hitdef          HitDef
 	id              int32
 	anim            int32
-	anim_fflg       bool
+	anim_ffx        string
 	hitanim         int32
-	hitanim_fflg    bool
+	hitanim_ffx     string
 	remanim         int32
-	remanim_fflg    bool
+	remanim_ffx     string
 	cancelanim      int32
-	cancelanim_fflg bool
+	cancelanim_ffx  string
 	scale           [2]float32
 	angle           float32
 	clsnScale       [2]float32
@@ -1306,11 +1314,11 @@ func (p *Projectile) update(playerNo int) {
 		if p.anim >= 0 {
 			if p.hits < 0 && p.remove {
 				if p.hits == -1 {
-					if p.hitanim != p.anim || p.hitanim_fflg != p.anim_fflg {
-						p.ani = sys.chars[playerNo][0].getAnim(p.hitanim, p.hitanim_fflg, true)
+					if p.hitanim != p.anim || p.hitanim_ffx != p.anim_ffx {
+						p.ani = sys.chars[playerNo][0].getAnim(p.hitanim, p.hitanim_ffx, true)
 					}
-				} else if p.cancelanim != p.anim || p.cancelanim_fflg != p.anim_fflg {
-					p.ani = sys.chars[playerNo][0].getAnim(p.cancelanim, p.cancelanim_fflg, true)
+				} else if p.cancelanim != p.anim || p.cancelanim_ffx != p.anim_ffx {
+					p.ani = sys.chars[playerNo][0].getAnim(p.cancelanim, p.cancelanim_ffx, true)
 				}
 			} else if p.pos[0] < sys.xmin/p.localscl-float32(p.edgebound) ||
 				p.pos[0] > sys.xmax/p.localscl+float32(p.edgebound) ||
@@ -1322,8 +1330,8 @@ func (p *Projectile) update(playerNo int) {
 				p.velocity[1] < 0 && p.pos[1] < float32(p.heightbound[0]) ||
 				p.removetime == 0 ||
 				p.removetime <= -2 && (p.ani == nil || p.ani.loopend) {
-				if p.remanim != p.anim || p.remanim_fflg != p.anim_fflg {
-					p.ani = sys.chars[playerNo][0].getAnim(p.remanim, p.remanim_fflg, true)
+				if p.remanim != p.anim || p.remanim_ffx != p.anim_ffx {
+					p.ani = sys.chars[playerNo][0].getAnim(p.remanim, p.remanim_ffx, true)
 				}
 			} else {
 				rem = false
@@ -2114,13 +2122,7 @@ func (c *Char) load(def string) error {
 						}
 						is.ReadI32("airjuggle", &gi.data.airjuggle)
 						is.ReadI32("sparkno", &gi.data.sparkno)
-						if gi.data.sparkno < 0 {
-							gi.data.sparkno = ^IErr
-						}
 						is.ReadI32("guard.sparkno", &gi.data.guard.sparkno)
-						if gi.data.guard.sparkno < 0 {
-							gi.data.guard.sparkno = ^IErr
-						}
 						is.ReadI32("ko.echo", &gi.data.ko.echo)
 						if is.ReadI32("volume", &i32) {
 							gi.data.volume = i32/2 + 256
@@ -2134,7 +2136,6 @@ func (c *Char) load(def string) error {
 				case "size":
 					if size {
 						size = false
-
 						is.ReadF32("xscale", &c.size.xscale)
 						is.ReadF32("yscale", &c.size.yscale)
 						is.ReadF32("ground.back", &c.size.ground.back)
@@ -2477,7 +2478,7 @@ func (c *Char) setSprPriority(sprpriority int32) {
 func (c *Char) setJuggle(juggle int32) {
 	c.juggle = juggle
 }
-func (c *Char) changeAnimEx(animNo int32, playerNo int, ffx, alt bool) {
+func (c *Char) changeAnimEx(animNo int32, playerNo int, ffx string, alt bool) {
 	if a := sys.chars[playerNo][0].getAnim(animNo, ffx, true); a != nil {
 		c.anim = a
 		c.anim.remap = c.remapSpr
@@ -2507,10 +2508,10 @@ func (c *Char) changeAnimEx(animNo int32, playerNo int, ffx, alt bool) {
 		}
 	}
 }
-func (c *Char) changeAnim(animNo int32, ffx bool) {
+func (c *Char) changeAnim(animNo int32, ffx string) {
 	c.changeAnimEx(animNo, c.playerNo, ffx, false)
 }
-func (c *Char) changeAnim2(animNo int32, ffx bool) {
+func (c *Char) changeAnim2(animNo int32, ffx string) {
 	c.changeAnimEx(animNo, c.ss.sb.playerNo, ffx, true)
 }
 func (c *Char) setAnimElem(e int32) {
@@ -3135,33 +3136,33 @@ func (c *Char) winPerfect() bool {
 func (c *Char) winType(wt WinType) bool {
 	return c.win() && sys.winTrigger[c.playerNo&1] == wt
 }
-func (c *Char) playSound(f, lowpriority, loop bool, g, n, chNo, vol int32,
+func (c *Char) playSound(ffx string, lowpriority, loop bool, g, n, chNo, vol int32,
 	p, freqmul, ls float32, x *float32, log bool, priority int32) {
 	if g < 0 {
 		return
 	}
 	var s *Sound
-	if f {
-		if sys.ffx["f"].fsnd != nil {
-			s = sys.ffx["f"].fsnd.Get([...]int32{g, n})
-		}
-	} else {
+	if ffx == "" || ffx == "s" {
 		if c.gi().snd != nil {
 			s = c.gi().snd.Get([...]int32{g, n})
+		}
+	} else {
+		if sys.ffx[ffx] != nil && sys.ffx[ffx].fsnd != nil {
+			s = sys.ffx[ffx].fsnd.Get([...]int32{g, n})
 		}
 	}
 	if s == nil {
 		if log {
-			if f {
-				sys.appendToConsole(c.warn() + fmt.Sprintf("F sound %v,%v doesn't exist", g, n))
+			if ffx != "" {
+				sys.appendToConsole(c.warn() + fmt.Sprintf("%v sound %v,%v doesn't exist", strings.ToUpper(ffx), g, n))
 			} else {
 				sys.appendToConsole(c.warn() + fmt.Sprintf("sound %v,%v doesn't exist", g, n))
 			}
 		}
 		if !sys.ignoreMostErrors {
 			str := "Sound doesn't exist: "
-			if f {
-				str += "F:"
+			if ffx != "" {
+				str += ffx + ":"
 			} else {
 				str += fmt.Sprintf("P%v:", c.playerNo+1)
 			}
@@ -3173,7 +3174,7 @@ func (c *Char) playSound(f, lowpriority, loop bool, g, n, chNo, vol int32,
 		ch.Play(s, loop, freqmul)
 		vol = Clamp(vol, -25600, 25600)
 		//if c.gi().ver[0] == 1 {
-		if f {
+		if ffx != "" {
 			ch.SetVolume(float32(vol * 64 / 25))
 		} else {
 			ch.SetVolume(float32(c.gi().data.volume * vol / 100))
@@ -3198,9 +3199,9 @@ func (c *Char) turn() {
 		if e := sys.charList.enemyNear(c, 0, true, true, false); c.rdDistX(e, c).ToF() < 0 && !e.sf(CSF_noturntarget) {
 			switch c.ss.stateType {
 			case ST_S:
-				c.changeAnim(5, false)
+				c.changeAnim(5, "")
 			case ST_C:
-				c.changeAnim(6, false)
+				c.changeAnim(6, "")
 			}
 			c.setFacing(-c.facing)
 		}
@@ -3261,7 +3262,7 @@ func (c *Char) stateChange2() bool {
 	}
 	return false
 }
-func (c *Char) changeStateEx(no int32, pn int, anim, ctrl int32, ffx bool) {
+func (c *Char) changeStateEx(no int32, pn int, anim, ctrl int32, ffx string) {
 	if c.minus <= 0 && (c.ss.stateType == ST_S || c.ss.stateType == ST_C) && !c.sf(CSF_noautoturn) {
 		c.turn()
 	}
@@ -3282,10 +3283,10 @@ func (c *Char) changeStateEx(no int32, pn int, anim, ctrl int32, ffx bool) {
 		sys.changeStateNest = 0
 	}
 }
-func (c *Char) changeState(no, anim, ctrl int32, ffx bool) {
+func (c *Char) changeState(no, anim, ctrl int32, ffx string) {
 	c.changeStateEx(no, c.ss.sb.playerNo, anim, ctrl, ffx)
 }
-func (c *Char) selfState(no, anim, readplayerid, ctrl int32, ffx bool) {
+func (c *Char) selfState(no, anim, readplayerid, ctrl int32, ffx string) {
 	var playerno int
 	if readplayerid >= 0 {
 		playerno = int(readplayerid)
@@ -3306,7 +3307,7 @@ func (c *Char) destroy() {
 			if t := sys.playerID(tid); t != nil {
 				if t.bindToId == c.id {
 					if t.ss.moveType == MT_H {
-						t.selfState(5050, -1, -1, -1, false)
+						t.selfState(5050, -1, -1, -1, "")
 					}
 				}
 				t.gethitBindClear()
@@ -3447,7 +3448,7 @@ func (c *Char) helperInit(h *Char, st int32, pt PosType, x, y float32,
 			h.mapArray[key] = value
 		}
 	}
-	h.changeStateEx(st, c.playerNo, 0, 1, false)
+	h.changeStateEx(st, c.playerNo, 0, 1, "")
 	// Prepare newly created helper so it can be successfully run later via actionRun() in charList.action()
 	h.actionPrepare()
 }
@@ -3582,36 +3583,38 @@ func (c *Char) enemyExplodsRemove(en int) {
 	remove(&sys.topexplDrawlist[en], false)
 	remove(&sys.underexplDrawlist[en], true)
 }
-func (c *Char) getAnim(n int32, ffx, log bool) (a *Animation) {
+func (c *Char) getAnim(n int32, ffx string, log bool) (a *Animation) {
 	if n == -2 {
 		return &Animation{}
 	}
 	if n < 0 {
 		return nil
 	}
-	if ffx {
-		a = sys.ffx["f"].fat.get(n)
+	if ffx != "" && ffx != "s" {
+		if sys.ffx[ffx] != nil && sys.ffx[ffx].fat != nil {
+			a = sys.ffx[ffx].fat.get(n)
+		}
 	} else {
 		a = c.gi().anim.get(n)
 	}
 	if a == nil {
 		if log {
-			if ffx {
-				sys.appendToConsole(c.warn() + fmt.Sprintf("changed to invalid F action %v", n))
+			if ffx != "" && ffx != "s" {
+				sys.appendToConsole(c.warn() + fmt.Sprintf("changed to invalid %v action %v", strings.ToUpper(ffx), n))
 			} else {
 				sys.appendToConsole(c.warn() + fmt.Sprintf("changed to invalid action %v", n))
 			}
 		}
 		if !sys.ignoreMostErrors {
 			str := "存在しないアニメ: "
-			if ffx {
-				str += "F:"
+			if ffx != "" && ffx != "s" {
+				str += strings.ToUpper(ffx) + ":"
 			} else {
 				str += fmt.Sprintf("P%v:", c.playerNo+1)
 			}
 			sys.errLog.Printf("%v%v\n", str, n)
 		}
-	} else if ffx {
+	} else if ffx != "" && ffx != "s" {
 		a.start_scale[0] /= c.localscl
 		a.start_scale[1] /= c.localscl
 	}
@@ -3762,7 +3765,7 @@ func (c *Char) projInit(p *Projectile, pt PosType, x, y float32,
 	if p.anim < -1 {
 		p.anim = 0
 	}
-	p.ani = c.getAnim(p.anim, p.anim_fflg, true)
+	p.ani = c.getAnim(p.anim, p.anim_ffx, true)
 	if p.ani == nil && c.anim != nil {
 		p.ani = &Animation{}
 		*p.ani = *c.anim
@@ -4238,7 +4241,7 @@ func (c *Char) targetDrop(excludeid int32, keepone bool) {
 			} else if t := sys.playerID(tid); t != nil {
 				if t.isBound() {
 					if c.sf(CSF_gethit) {
-						t.selfState(5050, -1, -1, -1, false)
+						t.selfState(5050, -1, -1, -1, "")
 					}
 					t.setBindTime(0)
 				}
@@ -4569,7 +4572,7 @@ func (c *Char) over() bool {
 }
 func (c *Char) makeDust(x, y float32) {
 	if e, i := c.newExplod(); e != nil {
-		e.anim = c.getAnim(120, true, false)
+		e.anim = c.getAnim(120, "f", false)
 		if e.anim != nil {
 			e.anim.start_scale[0] *= c.localscl
 			e.anim.start_scale[1] *= c.localscl
@@ -5052,7 +5055,7 @@ func (c *Char) bind() {
 			if bt.sf(CSF_destroy) {
 				sys.appendToConsole(c.warn() + fmt.Sprintf("SelfState 5050, helper destroyed: %v", bt.name))
 				if c.ss.moveType == MT_H {
-					c.selfState(5050, -1, -1, -1, false)
+					c.selfState(5050, -1, -1, -1, "")
 				}
 				c.setBindTime(0)
 				return
@@ -5349,7 +5352,7 @@ func (c *Char) actionPrepare() {
 				if !c.sf(CSF_nohardcodedkeys) {
 					if !c.sf(CSF_nojump) && !sys.roundEnd() && c.ss.stateType == ST_S && c.cmd[0].Buffer.U > 0 {
 						if c.ss.no != 40 {
-							c.changeState(40, -1, -1, false)
+							c.changeState(40, -1, -1, "")
 						}
 					} else if !c.sf(CSF_noairjump) && c.ss.stateType == ST_A && c.scf(SCF_airjump) &&
 						c.pos[1] <= float32(c.gi().movement.airjump.height) &&
@@ -5358,7 +5361,7 @@ func (c *Char) actionPrepare() {
 						if c.ss.no != 45 || c.ss.time > 0 {
 							c.airJumpCount++
 							c.unsetSCF(SCF_airjump)
-							c.changeState(45, -1, -1, false)
+							c.changeState(45, -1, -1, "")
 						}
 					} else {
 						if !c.sf(CSF_nocrouch) && c.ss.stateType == ST_S && c.cmd[0].Buffer.D > 0 {
@@ -5366,25 +5369,25 @@ func (c *Char) actionPrepare() {
 								if c.ss.no != 100 {
 									c.vel[0] = 0
 								}
-								c.changeState(10, -1, -1, false)
+								c.changeState(10, -1, -1, "")
 							}
 						} else if !c.sf(CSF_nostand) && c.ss.stateType == ST_C && c.cmd[0].Buffer.D < 0 {
 							if c.ss.no != 12 {
-								c.changeState(12, -1, -1, false)
+								c.changeState(12, -1, -1, "")
 							}
 						} else if !c.sf(CSF_nowalk) && c.ss.stateType == ST_S &&
 							(c.cmd[0].Buffer.F > 0 || !(c.inguarddist && c.scf(SCF_guard)) &&
 								c.cmd[0].Buffer.B > 0) {
 							if c.ss.no != 20 {
-								c.changeState(20, -1, -1, false)
+								c.changeState(20, -1, -1, "")
 							}
 						} else if !c.sf(CSF_nobrake) && c.ss.no == 20 &&
 							c.cmd[0].Buffer.B < 0 && c.cmd[0].Buffer.F < 0 {
-							c.changeState(0, -1, -1, false)
+							c.changeState(0, -1, -1, "")
 						}
 						if c.inguarddist && c.scf(SCF_guard) && c.cmd[0].Buffer.B > 0 &&
 							!c.inGuardState() {
-							c.changeState(120, -1, -1, false)
+							c.changeState(120, -1, -1, "")
 						}
 					}
 				}
@@ -5392,12 +5395,12 @@ func (c *Char) actionPrepare() {
 				switch c.ss.no {
 				case 11:
 					if !c.sf(CSF_nostand) {
-						c.changeState(12, -1, -1, false)
+						c.changeState(12, -1, -1, "")
 					}
 				case 20:
 					if !c.sf(CSF_nobrake) && c.cmd[0].Buffer.U < 0 && c.cmd[0].Buffer.D < 0 &&
 						c.cmd[0].Buffer.B < 0 && c.cmd[0].Buffer.F < 0 {
-						c.changeState(0, -1, -1, false)
+						c.changeState(0, -1, -1, "")
 					}
 				}
 			}
@@ -5494,7 +5497,7 @@ func (c *Char) actionRun() {
 			for c.ss.no == 140 && (c.anim == nil || len(c.anim.frames) == 0 ||
 				c.ss.time >= c.anim.totaltime) {
 				c.changeState(Btoi(c.ss.stateType == ST_C)*11+
-					Btoi(c.ss.stateType == ST_A)*51, -1, -1, false)
+					Btoi(c.ss.stateType == ST_A)*51, -1, -1, "")
 			}
 			if c.ss.no != 5120 || c.ss.time != 0 {
 				c.ss.time++
@@ -5579,7 +5582,7 @@ func (c *Char) actionFinish() {
 	if !c.pauseBool {
 		if !c.hitPause() {
 			if c.ss.no == 5110 && c.recoverTime <= 0 && c.alive() && !c.sf(CSF_nogetupfromliedown) {
-				c.changeState(5120, -1, -1, false)
+				c.changeState(5120, -1, -1, "")
 			}
 			if c.ss.no == 5120 && c.ss.time == 0 {
 				c.ss.time++
@@ -5590,7 +5593,7 @@ func (c *Char) actionFinish() {
 					c.ss.no == 105 {
 					break
 				}
-				c.changeState(52, -1, -1, false)
+				c.changeState(52, -1, -1, "")
 				c.ss.time++
 			}
 			c.setFacing(c.p1facing)
@@ -5854,7 +5857,7 @@ func (c *Char) tick() {
 			}
 		} else if c.ss.stateType == ST_L {
 			if c.pos[1] == 0 {
-				c.changeStateEx(5080, pn, -1, 0, false)
+				c.changeStateEx(5080, pn, -1, 0, "")
 				if c.recoverTime > 0 {
 					c.recoverTime--
 				}
@@ -5862,30 +5865,30 @@ func (c *Char) tick() {
 					c.pos[1] += 15 / c.localscl
 				}
 			} else {
-				c.changeStateEx(5020, pn, -1, 0, false)
+				c.changeStateEx(5020, pn, -1, 0, "")
 			}
 		} else if c.ghv.guarded && (c.ghv.damage < c.life || sys.sf(GSF_noko)) {
 			switch c.ss.stateType {
 			case ST_S:
-				c.selfState(150, -1, -1, 0, false)
+				c.selfState(150, -1, -1, 0, "")
 			case ST_C:
-				c.selfState(152, -1, -1, 0, false)
+				c.selfState(152, -1, -1, 0, "")
 			case ST_A:
-				c.selfState(154, -1, -1, 0, false)
+				c.selfState(154, -1, -1, 0, "")
 			}
 		} else if c.ghv._type == HT_Trip {
-			c.changeStateEx(5070, pn, -1, 0, false)
+			c.changeStateEx(5070, pn, -1, 0, "")
 		} else {
 			if c.ghv.forcestand && c.ss.stateType == ST_C {
 				c.ss.stateType = ST_S
 			}
 			switch c.ss.stateType {
 			case ST_S:
-				c.changeStateEx(5000, pn, -1, 0, false)
+				c.changeStateEx(5000, pn, -1, 0, "")
 			case ST_C:
-				c.changeStateEx(5010, pn, -1, 0, false)
+				c.changeStateEx(5010, pn, -1, 0, "")
 			case ST_A:
-				c.changeStateEx(5020, pn, -1, 0, false)
+				c.changeStateEx(5020, pn, -1, 0, "")
 			}
 		}
 		if c.hoIdx >= 0 {
@@ -5914,10 +5917,10 @@ func (c *Char) tick() {
 			if c.helperIndex == 0 && (c.alive() || c.ss.no == 0) && c.life <= 0 &&
 				c.ss.moveType != MT_H && !sys.sf(GSF_noko) {
 				c.ghv.fallf = true
-				c.selfState(5030, -1, -1, -1, false)
+				c.selfState(5030, -1, -1, -1, "")
 				c.ss.time = 1
 			} else if c.ss.no == 5150 && c.ss.time >= 90 && c.alive() {
-				c.selfState(5120, -1, -1, -1, false)
+				c.selfState(5120, -1, -1, -1, "")
 			}
 		}
 	}
@@ -5925,7 +5928,7 @@ func (c *Char) tick() {
 		if c.life <= 0 && !sys.sf(GSF_noko) {
 			if !sys.sf(GSF_nokosnd) && c.alive() {
 				vo := int32(100)
-				c.playSound(false, false, false, 11, 0, -1, vo, 0, 1, c.localscl, &c.pos[0], false, 0)
+				c.playSound("", false, false, 11, 0, -1, vo, 0, 1, c.localscl, &c.pos[0], false, 0)
 			}
 			c.setSCF(SCF_ko)
 		}
@@ -6534,11 +6537,7 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 				}
 			}
 		}
-		hitspark := func(p1, p2 *Char, animNo int32) {
-			ffx := animNo < 0
-			if ffx {
-				animNo ^= -1
-			}
+		hitspark := func(p1, p2 *Char, animNo int32, ffx string) {
 			off := pos
 			if !proj {
 				off[0] = p2.pos[0]*p2.localscl - p1.pos[0]*p1.localscl
@@ -6569,7 +6568,7 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 				e.supermovetime = -1
 				e.pausemovetime = -1
 				e.localscl = 1
-				if !ffx {
+				if ffx == "" || ffx == "s" {
 					e.scale = [...]float32{c.localscl, c.localscl}
 				} else if e.anim != nil {
 					e.anim.start_scale[0] *= c.localscl
@@ -6580,21 +6579,16 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 			}
 		}
 		if Abs(hitType) == 1 {
-			if hd.sparkno != IErr {
+			if hd.sparkno >= 0 {
 				if hd.reversal_attr > 0 {
-					hitspark(getter, c, hd.sparkno)
+					hitspark(getter, c, hd.sparkno, hd.sparkno_ffx)
 				} else {
-					hitspark(c, getter, hd.sparkno)
+					hitspark(c, getter, hd.sparkno, hd.sparkno_ffx)
 				}
 			}
-			if hd.hitsound[0] != IErr {
-				sg := hd.hitsound[0]
-				f := sg < 0
-				if f {
-					sg ^= -1
-				}
+			if hd.hitsound[0] >= 0 {
 				vo := int32(100)
-				c.playSound(f, false, false, sg, hd.hitsound[1],
+				c.playSound(hd.hitsound_ffx, false, false, hd.hitsound[0], hd.hitsound[1],
 					-1, vo, 0, 1, getter.localscl, &getter.pos[0], true, 0)
 			}
 			if hitType > 0 {
@@ -6626,21 +6620,16 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 				}
 			}
 		} else {
-			if hd.guard_sparkno != IErr {
+			if hd.guard_sparkno >= 0 {
 				if hd.reversal_attr > 0 {
-					hitspark(getter, c, hd.guard_sparkno)
+					hitspark(getter, c, hd.guard_sparkno, hd.guard_sparkno_ffx)
 				} else {
-					hitspark(c, getter, hd.guard_sparkno)
+					hitspark(c, getter, hd.guard_sparkno, hd.guard_sparkno_ffx)
 				}
 			}
-			if hd.guardsound[0] != IErr {
-				sg := hd.guardsound[0]
-				f := sg < 0
-				if f {
-					sg ^= -1
-				}
+			if hd.guardsound[0] >= 0 {
 				vo := int32(100)
-				c.playSound(f, false, false, sg, hd.guardsound[1],
+				c.playSound(hd.guardsound_ffx, false, false, hd.guardsound[0], hd.guardsound[1],
 					-1, vo, 0, 1, getter.localscl, &getter.pos[0], true, 0)
 			}
 			if hitType > 0 {

--- a/src/char.go
+++ b/src/char.go
@@ -1144,7 +1144,7 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 		sprs = &sys.bottomSprites
 	}
 	var pfx *PalFX
-	if e.palfx != nil && (e.anim.sff != sys.lifebar.fsff || e.ownpal) {
+	if e.palfx != nil && (e.anim.sff != sys.ffx["f"].fsff || e.ownpal) {
 		pfx = e.palfx
 	} else {
 		pfx = &PalFX{}
@@ -3142,8 +3142,8 @@ func (c *Char) playSound(f, lowpriority, loop bool, g, n, chNo, vol int32,
 	}
 	var s *Sound
 	if f {
-		if sys.lifebar.fsnd != nil {
-			s = sys.lifebar.fsnd.Get([...]int32{g, n})
+		if sys.ffx["f"].fsnd != nil {
+			s = sys.ffx["f"].fsnd.Get([...]int32{g, n})
 		}
 	} else {
 		if c.gi().snd != nil {
@@ -3490,7 +3490,7 @@ func (c *Char) insertExplodEx(i int, rp [2]int32) {
 	}
 	e.anim.UpdateSprite()
 	if e.ownpal {
-		if e.anim.sff != sys.lifebar.fsff {
+		if e.anim.sff != sys.ffx["f"].fsff {
 			remap := make([]int, len(e.palfx.remap))
 			copy(remap, e.palfx.remap)
 			e.palfx = newPalFX()
@@ -3590,7 +3590,7 @@ func (c *Char) getAnim(n int32, ffx, log bool) (a *Animation) {
 		return nil
 	}
 	if ffx {
-		a = sys.lifebar.fat.get(n)
+		a = sys.ffx["f"].fat.get(n)
 	} else {
 		a = c.gi().anim.get(n)
 	}

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -195,19 +195,9 @@ func (c *Compiler) playSnd(is IniSection, sc *StateControllerBase, _ int8) (Stat
 		f := false
 		if err := c.stateParam(is, "value", func(data string) error {
 			f = true
-			fflg := false
-			if len(data) > 1 {
-				if strings.ToLower(data)[0] == 'f' || strings.ToLower(data)[0] == 's' {
-					re := regexp.MustCompile("[^a-z]")
-					m := re.Split(strings.ToLower(data)[1:], -1)
-					if _, ok := triggerMap[m[0]]; ok || m[0] == "" {
-						fflg = strings.ToLower(data)[0] == 'f'
-						data = data[1:]
-					}
-				}
-			}
+			prefix := c.getDataPrefix(&data, false)
 			return c.scAdd(sc, playSnd_value, data, VT_Int, 2,
-				sc.iToExp(Btoi(fflg))...)
+				sc.beToExp(BytecodeExp(prefix))...)
 		}); err != nil {
 			return err
 		}
@@ -269,19 +259,9 @@ func (c *Compiler) changeStateSub(is IniSection,
 		return err
 	}
 	if err := c.stateParam(is, "anim", func(data string) error {
-		fflg := false
-		if len(data) > 1 {
-			if strings.ToLower(data)[0] == 'f' {
-				re := regexp.MustCompile("[^a-z]")
-				m := re.Split(strings.ToLower(data)[1:], -1)
-				if _, ok := triggerMap[m[0]]; ok || m[0] == "" {
-					fflg = true
-					data = data[1:]
-				}
-			}
-		}
+		prefix := c.getDataPrefix(&data, false) 
 		return c.scAdd(sc, changeState_anim, data, VT_Int, 1,
-			sc.iToExp(Btoi(fflg))...)
+			sc.beToExp(BytecodeExp(prefix))...)
 	}); err != nil {
 		return err
 	}
@@ -401,19 +381,9 @@ func (c *Compiler) changeAnimSub(is IniSection,
 		return err
 	}
 	if err := c.stateParam(is, "value", func(data string) error {
-		fflg := false
-		if len(data) > 1 {
-			if strings.ToLower(data)[0] == 'f' {
-				re := regexp.MustCompile("[^a-z]")
-				m := re.Split(strings.ToLower(data)[1:], -1)
-				if _, ok := triggerMap[m[0]]; ok || m[0] == "" {
-					fflg = true
-					data = data[1:]
-				}
-			}
-		}
+		prefix := c.getDataPrefix(&data, false)
 		return c.scAdd(sc, changeAnim_value, data, VT_Int, 1,
-			sc.iToExp(Btoi(fflg))...)
+			sc.beToExp(BytecodeExp(prefix))...)
 	}); err != nil {
 		return err
 	}
@@ -722,19 +692,9 @@ func (c *Compiler) explod(is IniSection, sc *StateControllerBase,
 			return err
 		}
 		if err := c.stateParam(is, "anim", func(data string) error {
-			fflg := false
-			if len(data) > 1 {
-				if strings.ToLower(data)[0] == 'f' {
-					re := regexp.MustCompile("[^a-z]")
-					m := re.Split(strings.ToLower(data)[1:], -1)
-					if _, ok := triggerMap[m[0]]; ok || m[0] == "" {
-						fflg = true
-						data = data[1:]
-					}
-				}
-			}
+			prefix := c.getDataPrefix(&data, false)
 			return c.scAdd(sc, explod_anim, data, VT_Int, 1,
-				sc.iToExp(Btoi(fflg))...)
+				sc.beToExp(BytecodeExp(prefix))...)
 		}); err != nil {
 			return err
 		}
@@ -772,19 +732,9 @@ func (c *Compiler) modifyExplod(is IniSection, sc *StateControllerBase,
 			return err
 		}
 		if err := c.stateParam(is, "anim", func(data string) error {
-			fflg := false
-			if len(data) > 1 {
-				if strings.ToLower(data)[0] == 'f' {
-					re := regexp.MustCompile("[^a-z]")
-					m := re.Split(strings.ToLower(data)[1:], -1)
-					if _, ok := triggerMap[m[0]]; ok || m[0] == "" {
-						fflg = true
-						data = data[1:]
-					}
-				}
-			}
+			prefix := c.getDataPrefix(&data, false)
 			return c.scAdd(sc, explod_anim, data, VT_Int, 1,
-				sc.iToExp(Btoi(fflg))...)
+				sc.beToExp(BytecodeExp(prefix))...)
 		}); err != nil {
 			return err
 		}
@@ -832,19 +782,9 @@ func (c *Compiler) gameMakeAnim(is IniSection, sc *StateControllerBase, _ int8) 
 		b := false
 		anim := func(data string) error {
 			b = true
-			fflg := true
-			if len(data) > 1 {
-				if strings.ToLower(data)[0] == 's' {
-					re := regexp.MustCompile("[^a-z]")
-					m := re.Split(strings.ToLower(data)[1:], -1)
-					if _, ok := triggerMap[m[0]]; ok || m[0] == "" {
-						fflg = false
-						data = data[1:]
-					}
-				}
-			}
+			prefix := c.getDataPrefix(&data, true)
 			return c.scAdd(sc, gameMakeAnim_anim, data, VT_Int, 1,
-				sc.iToExp(Btoi(fflg))...)
+				sc.beToExp(BytecodeExp(prefix))...)
 		}
 		if err := c.stateParam(is, "anim", func(data string) error {
 			return anim(data)
@@ -1290,18 +1230,8 @@ func (c *Compiler) hitDefSub(is IniSection,
 		return err
 	}
 	hsnd := func(id byte, data string) error {
-		fflg := true
-		if len(data) > 1 {
-			if strings.ToLower(data)[0] == 'f' || strings.ToLower(data)[0] == 's' {
-				re := regexp.MustCompile("[^a-z]")
-				m := re.Split(strings.ToLower(data)[1:], -1)
-				if _, ok := triggerMap[m[0]]; ok || m[0] == "" {
-					fflg = strings.ToLower(data)[0] == 'f'
-					data = data[1:]
-				}
-			}
-		}
-		return c.scAdd(sc, id, data, VT_Int, 2, sc.iToExp(Btoi(fflg))...)
+		prefix := c.getDataPrefix(&data, true)
+		return c.scAdd(sc, id, data, VT_Int, 2, sc.beToExp(BytecodeExp(prefix))...)
 	}
 	if err := c.stateParam(is, "hitsound", func(data string) error {
 		return hsnd(hitDef_hitsound, data)
@@ -1395,18 +1325,9 @@ func (c *Compiler) hitDefSub(is IniSection,
 		return err
 	}
 	sprk := func(id byte, data string) error {
-		fflg := true
-		if len(data) > 1 {
-			if strings.ToLower(data)[0] == 's' {
-				re := regexp.MustCompile("[^a-z]")
-				m := re.Split(strings.ToLower(data)[1:], -1)
-				if _, ok := triggerMap[m[0]]; ok || m[0] == "" {
-					fflg = false
-					data = data[1:]
-				}
-			}
-		}
-		return c.scAdd(sc, id, data, VT_Int, 1, sc.iToExp(Btoi(fflg))...)
+		prefix := c.getDataPrefix(&data, true)
+		return c.scAdd(sc, id, data, VT_Int, 1,
+			sc.beToExp(BytecodeExp(prefix))...)
 	}
 	if err := c.stateParam(is, "sparkno", func(data string) error {
 		return sprk(hitDef_sparkno, data)
@@ -1699,53 +1620,23 @@ func (c *Compiler) projectile(is IniSection, sc *StateControllerBase,
 			return err
 		}
 		if err := c.stateParam(is, "projhitanim", func(data string) error {
-			fflg := false
-			if len(data) > 1 {
-				if strings.ToLower(data)[0] == 'f' {
-					re := regexp.MustCompile("[^a-z]")
-					m := re.Split(strings.ToLower(data)[1:], -1)
-					if _, ok := triggerMap[m[0]]; ok || m[0] == "" {
-						fflg = true
-						data = data[1:]
-					}
-				}
-			}
+			prefix := c.getDataPrefix(&data, false)
 			return c.scAdd(sc, projectile_projhitanim, data, VT_Int, 1,
-				sc.iToExp(Btoi(fflg))...)
+				sc.beToExp(BytecodeExp(prefix))...)
 		}); err != nil {
 			return err
 		}
 		if err := c.stateParam(is, "projremanim", func(data string) error {
-			fflg := false
-			if len(data) > 1 {
-				if strings.ToLower(data)[0] == 'f' {
-					re := regexp.MustCompile("[^a-z]")
-					m := re.Split(strings.ToLower(data)[1:], -1)
-					if _, ok := triggerMap[m[0]]; ok || m[0] == "" {
-						fflg = true
-						data = data[1:]
-					}
-				}
-			}
+			prefix := c.getDataPrefix(&data, false)
 			return c.scAdd(sc, projectile_projremanim, data, VT_Int, 1,
-				sc.iToExp(Btoi(fflg))...)
+				sc.beToExp(BytecodeExp(prefix))...)
 		}); err != nil {
 			return err
 		}
 		if err := c.stateParam(is, "projcancelanim", func(data string) error {
-			fflg := false
-			if len(data) > 1 {
-				if strings.ToLower(data)[0] == 'f' {
-					re := regexp.MustCompile("[^a-z]")
-					m := re.Split(strings.ToLower(data)[1:], -1)
-					if _, ok := triggerMap[m[0]]; ok || m[0] == "" {
-						fflg = true
-						data = data[1:]
-					}
-				}
-			}
+			prefix := c.getDataPrefix(&data, false)
 			return c.scAdd(sc, projectile_projcancelanim, data, VT_Int, 1,
-				sc.iToExp(Btoi(fflg))...)
+				sc.beToExp(BytecodeExp(prefix))...)
 		}); err != nil {
 			return err
 		}
@@ -1800,19 +1691,9 @@ func (c *Compiler) projectile(is IniSection, sc *StateControllerBase,
 			return err
 		}
 		if err := c.stateParam(is, "projanim", func(data string) error {
-			fflg := false
-			if len(data) > 1 {
-				if strings.ToLower(data)[0] == 'f' {
-					re := regexp.MustCompile("[^a-z]")
-					m := re.Split(strings.ToLower(data)[1:], -1)
-					if _, ok := triggerMap[m[0]]; ok || m[0] == "" {
-						fflg = true
-						data = data[1:]
-					}
-				}
-			}
+			prefix := c.getDataPrefix(&data, false)
 			return c.scAdd(sc, projectile_projanim, data, VT_Int, 1,
-				sc.iToExp(Btoi(fflg))...)
+				sc.beToExp(BytecodeExp(prefix))...)
 		}); err != nil {
 			return err
 		}
@@ -2636,19 +2517,9 @@ func (c *Compiler) superPause(is IniSection, sc *StateControllerBase, _ int8) (S
 			return err
 		}
 		if err := c.stateParam(is, "anim", func(data string) error {
-			fflg := true
-			if len(data) > 1 {
-				if strings.ToLower(data)[0] == 'f' || strings.ToLower(data)[0] == 's' {
-					re := regexp.MustCompile("[^a-z]")
-					m := re.Split(strings.ToLower(data)[1:], -1)
-					if _, ok := triggerMap[m[0]]; ok || m[0] == "" {
-						fflg = strings.ToLower(data)[0] == 'f'
-						data = data[1:]
-					}
-				}
-			}
+			prefix := c.getDataPrefix(&data, true)
 			return c.scAdd(sc, superPause_anim, data, VT_Int, 1,
-				sc.iToExp(Btoi(fflg))...)
+				sc.beToExp(BytecodeExp(prefix))...)
 		}); err != nil {
 			return err
 		}
@@ -2669,19 +2540,9 @@ func (c *Compiler) superPause(is IniSection, sc *StateControllerBase, _ int8) (S
 			return err
 		}
 		if err := c.stateParam(is, "sound", func(data string) error {
-			fflg := true
-			if len(data) > 1 {
-				if strings.ToLower(data)[0] == 'f' || strings.ToLower(data)[0] == 's' {
-					re := regexp.MustCompile("[^a-z]")
-					m := re.Split(strings.ToLower(data)[1:], -1)
-					if _, ok := triggerMap[m[0]]; ok || m[0] == "" {
-						fflg = strings.ToLower(data)[0] == 'f'
-						data = data[1:]
-					}
-				}
-			}
+			prefix := c.getDataPrefix(&data, true)
 			return c.scAdd(sc, superPause_sound, data, VT_Int, 2,
-				sc.iToExp(Btoi(fflg))...)
+				sc.beToExp(BytecodeExp(prefix))...)
 		}); err != nil {
 			return err
 		}
@@ -4429,17 +4290,8 @@ func (c *Compiler) text(is IniSection, sc *StateControllerBase, _ int8) (StateCo
 			return err
 		}
 		if err := c.stateParam(is, "font", func(data string) error {
-			fflg := false
-			if len(data) > 1 {
-				if strings.ToLower(data)[0] == 'f' {
-					re := regexp.MustCompile("[^a-z]")
-					m := re.Split(strings.ToLower(data)[1:], -1)
-					if _, ok := triggerMap[m[0]]; ok || m[0] == "" {
-						fflg = true
-						data = data[1:]
-					}
-				}
-			}
+			prefix := c.getDataPrefix(&data, false)
+			fflg := prefix == "f"
 			return c.scAdd(sc, text_font, data, VT_Int, 1,
 				sc.iToExp(Btoi(fflg))...)
 		}); err != nil {

--- a/src/main.go
+++ b/src/main.go
@@ -187,6 +187,7 @@ type configSettings struct {
 	CommonAir                  string
 	CommonCmd                  string
 	CommonConst                string
+	CommonFx                   []string
 	CommonLua                  []string
 	CommonStates               []string
 	ControllerStickSensitivity float32
@@ -339,6 +340,7 @@ func setupConfig() configSettings {
 		sys.commonCmd = "\n" + string(cmd)
 	}
 	sys.commonConst = tmp.CommonConst
+	sys.commonFx = tmp.CommonFx
 	sys.commonLua = tmp.CommonLua
 	sys.commonStates = tmp.CommonStates
 	sys.clipboardRows = tmp.DebugClipboardRows

--- a/src/resources/defaultConfig.json
+++ b/src/resources/defaultConfig.json
@@ -13,6 +13,7 @@
     "CommonAir": "data/common.air",
     "CommonCmd": "data/common.cmd",
     "CommonConst": "data/common.const",
+    "CommonFx": [],
     "CommonLua": [
         "loop()"
     ],

--- a/src/script.go
+++ b/src/script.go
@@ -385,7 +385,11 @@ func systemScriptInit(l *lua.LState) {
 				if l.GetTop() >= 4 {
 					ffx = boolArg(l, 4)
 				}
-				c[0].changeAnim(an, ffx)
+				preffix := ""
+				if ffx {
+					preffix = "f"
+				}
+				c[0].changeAnim(an, preffix)
 				if l.GetTop() >= 3 {
 					c[0].setAnimElem(int32(numArg(l, 3)))
 				}
@@ -412,7 +416,7 @@ func systemScriptInit(l *lua.LState) {
 						ch.unsetSCF(SCF_disabled)
 					}
 				}
-				c[0].changeState(st, -1, -1, false)
+				c[0].changeState(st, -1, -1, "")
 				l.Push(lua.LBool(true))
 				return 1
 			}
@@ -473,7 +477,11 @@ func systemScriptInit(l *lua.LState) {
 		if l.GetTop() >= 11 {
 			priority = int32(numArg(l, 11))
 		}
-		sys.chars[pn-1][0].playSound(f, lw, lp, g, n, ch, vo, p, fr, ls, x, false, priority)
+		preffix := ""
+		if f {
+			preffix = "f"
+		}
+		sys.chars[pn-1][0].playSound(preffix, lw, lp, g, n, ch, vo, p, fr, ls, x, false, priority)
 		return 0
 	})
 	luaRegister(l, "charSndStop", func(l *lua.LState) int {
@@ -1438,6 +1446,15 @@ func systemScriptInit(l *lua.LState) {
 		l.Push(newUserData(l, w))
 		return 1
 	})
+	luaRegister(l, "loadCommonFx", func(l *lua.LState) int {
+		var err error
+		for _, def := range(sys.commonFx) {
+			if err = loadFightFx(def); err != nil {
+				l.RaiseError("\nCan't load %v: %v\n", def, err.Error())
+			}
+		}
+		return 0
+	})
 	luaRegister(l, "loadDebugFont", func(l *lua.LState) int {
 		ts := NewTextSprite()
 		f, err := loadFnt(strArg(l, 1), -1)
@@ -1767,7 +1784,7 @@ func systemScriptInit(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "selfState", func(*lua.LState) int {
-		sys.debugWC.selfState(int32(numArg(l, 1)), -1, -1, 1, false)
+		sys.debugWC.selfState(int32(numArg(l, 1)), -1, -1, 1, "")
 		return 0
 	})
 	luaRegister(l, "setAccel", func(*lua.LState) int {

--- a/src/system.go
+++ b/src/system.go
@@ -52,6 +52,7 @@ var sys = System{
 	allPalFX:          *newPalFX(),
 	bgPalFX:           *newPalFX(),
 	ffx:               make(map[string]*FightFx),
+	ffxRegexp:         "^(f)|^(s)",
 	sel:               *newSelect(),
 	keyState:          make(map[Key]bool),
 	match:             1,
@@ -124,6 +125,7 @@ type System struct {
 	allPalFX, bgPalFX       PalFX
 	lifebar                 Lifebar
 	ffx                     map[string]*FightFx
+	ffxRegexp               string
 	sel                     Select
 	keyState                map[Key]bool
 	netInput                *NetInput
@@ -262,8 +264,6 @@ type System struct {
 	loseTag                 bool
 	allowDebugKeys          bool
 	allowDebugMode          bool
-	commonAir               string
-	commonCmd               string
 	keyInput                Key
 	keyString               string
 	timerCount              []int32
@@ -276,6 +276,14 @@ type System struct {
 	windowTitle             string
 	screenshotFolder        string
 	//FLAC_FrameWait          int
+	
+	// Common Files
+	commonAir    string
+	commonCmd    string
+	commonConst  string
+	commonFx     []string
+	commonLua    []string
+	commonStates []string
 
 	// Resolution variables
 	fullscreen            bool
@@ -330,9 +338,6 @@ type System struct {
 	matchData       *lua.LTable
 	consecutiveWins [2]int32
 	teamLeader      [2]int
-	commonConst     string
-	commonLua       []string
-	commonStates    []string
 	gameSpeed       float32
 	maxPowerMode    bool
 	clsnText        []ClsnText
@@ -847,7 +852,7 @@ func (s *System) nextRound() {
 	}
 	for _, p := range s.chars {
 		if len(p) > 0 {
-			p[0].selfState(5900, 0, -1, 0, false)
+			p[0].selfState(5900, 0, -1, 0, "")
 		}
 	}
 }
@@ -1077,7 +1082,7 @@ func (s *System) action() {
 					for i, p := range s.chars {
 						if len(p) > 0 {
 							s.playerClear(i, false)
-							p[0].selfState(0, -1, -1, 0, false)
+							p[0].selfState(0, -1, -1, 0, "")
 						}
 					}
 					ox := newx
@@ -1172,7 +1177,7 @@ func (s *System) action() {
 							if p[0].ss.no == 0 {
 								p[0].setCtrl(true)
 							} else {
-								p[0].selfState(0, -1, -1, 1, false)
+								p[0].selfState(0, -1, -1, 1, "")
 							}
 						}
 					}
@@ -1368,11 +1373,11 @@ func (s *System) action() {
 							if !p[0].scf(SCF_over) && !p[0].hitPause() && p[0].alive() && p[0].animNo != 5 {
 								p[0].setSCF(SCF_over)
 								if p[0].win() {
-									p[0].selfState(180, -1, -1, 1, false)
+									p[0].selfState(180, -1, -1, 1, "")
 								} else if p[0].lose() {
-									p[0].selfState(170, -1, -1, 1, false)
+									p[0].selfState(170, -1, -1, 1, "")
 								} else {
-									p[0].selfState(175, -1, -1, 1, false)
+									p[0].selfState(175, -1, -1, 1, "")
 								}
 							}
 						}

--- a/src/system.go
+++ b/src/system.go
@@ -51,6 +51,7 @@ var sys = System{
 	soundChannels:     newSoundChannels(16),
 	allPalFX:          *newPalFX(),
 	bgPalFX:           *newPalFX(),
+	ffx:               make(map[string]*FightFx),
 	sel:               *newSelect(),
 	keyState:          make(map[Key]bool),
 	match:             1,
@@ -122,6 +123,7 @@ type System struct {
 	soundChannels           *SoundChannels
 	allPalFX, bgPalFX       PalFX
 	lifebar                 Lifebar
+	ffx                     map[string]*FightFx
 	sel                     Select
 	keyState                map[Key]bool
 	netInput                *NetInput


### PR DESCRIPTION
This PR introduces a new feature called "CommonFx". Just like most of the other common files, CommonFx is a file array located in `config.json` for general resource  files that can be accessed by all characters in a match. In this case, CommonFx expects definition (.def) files containing information for a "FightFx" package, including .sff, .air and .snd files. A prefix and anim scale can be defined in an info section.

A package .def looks something like this:
```ini
; Example for a Mortal Kombat effects package 
[Info]
prefix = MK ; Obligatory
fx.scale = 1

[Files]
air = mk.air
sff = mk.sff
snd = mk.snd
```
This package can then be accessed by adding/changing the prefix in valid parameters (usually anim/sound ones) from SCTRLs in a character's code:
```coffeescript
playSnd{value: MK5,0}
explod{anim: MK40}
```
This way, characters can access new effects without having to override FightFx from lifebar.

The only obligatory parameter is "Prefix" from [Info] section. This parameter must be any string except for "F" and "S", since these are reserved for the system to call lifebar FightFx and own char files, respectively.

If two packages share the same prefix, the newest package loaded will override the previous one, including all its resource files, no matter if they're empty or not.