### PR TITLE
Default.LegacyGameDistanceSpecの適用を1.0キャラ限定に

### DIFF
--- a/data/common.const
+++ b/data/common.const
@@ -8,7 +8,7 @@ Default.Enable.Score = 1
 Default.Enable.Tag = 1
 
 ; Backward compatibility toggles
-Default.LegacyGameDistanceSpec = 0  ; 1 prevents GameWidth/GameHeight from being affected by stage zoom for non-mugenversion 1.1 chars
+Default.LegacyGameDistanceSpec = 1  ; 1 prevents GameWidth/GameHeight from being affected by stage zoom for mugenversion 1.0 chars
 Default.IgnoreDefeatedEnemies = 1   ; 1 prevents EnemyNear from redirecting defeated enemies
 Input.PauseOnHitPause = 1           ; 1 makes inputs to be retained during hit pause
 

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1159,7 +1159,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushI(int32(c.frontEdgeDist()))
 		case OC_gameheight:
 			// Optional exception preventing GameHeight from being affected by stage zoom.
-			if (c.stCgi().ver[0] == 0 || c.stCgi().ver[0] == 1 && c.stCgi().ver[1] == 0) &&
+			if c.stCgi().ver[0] == 1 && c.stCgi().ver[1] == 0 &&
 				c.gi().constants["default.legacygamedistancespec"] == 1 {
 				sys.bcStack.PushF(c.screenHeight())
 			} else {
@@ -1169,7 +1169,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushI(sys.gameTime + sys.preFightTime)
 		case OC_gamewidth:
 			// Optional exception preventing GameWidth from being affected by stage zoom.
-			if (c.stCgi().ver[0] == 0 || c.stCgi().ver[0] == 1 && c.stCgi().ver[1] == 0) &&
+			if c.stCgi().ver[0] == 1 && c.stCgi().ver[1] == 0 &&
 				c.gi().constants["default.legacygamedistancespec"] == 1 {
 				sys.bcStack.PushF(c.screenWidth())
 			} else {


### PR DESCRIPTION
This option should not be applied to non-1.0 characters. This compatibility issue does not pertain to non-1.0 characters and can cause confusion. #566