### PR TITLE
Fix binding explod position

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -1159,6 +1159,8 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 				e.pos[1] = c.drawPos[1]*c.localscl/e.localscl + c.offsetY()*c.localscl/e.localscl + e.offset[1]
 			} else {
 				e.bindtime = 0
+				e.setX(e.pos[0])
+				e.setY(e.pos[1])
 			}
 		}
 	} else {


### PR DESCRIPTION
This commit fixes binding explod position when binding helper is destroyed during ko slow

Testing kfm:
[kfm.zip](https://github.com/ikemen-engine/Ikemen-GO/files/10703894/kfm.zip)
Simply press F1 during the match to reproduce the problem.
