### PR TITLE
OC_ex_ constants rearrangement

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -126,8 +126,8 @@ const (
 	OC_ceil
 	OC_ifelse
 	OC_player
-	OC_parent
 	OC_root
+	OC_parent
 	OC_helper
 	OC_target
 	OC_partner
@@ -136,9 +136,21 @@ const (
 	OC_playerid
 	OC_p2
 	OC_rdreset
-	OC_const_
 	OC_st_
+	OC_const_
+	OC_gethitvar_
 	OC_ex_
+)
+const (
+	OC_st_var OpCode = iota
+	OC_st_sysvar
+	OC_st_fvar
+	OC_st_sysfvar
+	OC_st_varadd
+	OC_st_sysvaradd
+	OC_st_fvaradd
+	OC_st_sysfvaradd
+	OC_st_map
 )
 const (
 	OC_const_data_life OpCode = iota
@@ -288,15 +300,51 @@ const (
 	OC_const_stage_constants
 )
 const (
-	OC_st_var OpCode = iota
-	OC_st_sysvar
-	OC_st_fvar
-	OC_st_sysfvar
-	OC_st_varadd
-	OC_st_sysvaradd
-	OC_st_fvaradd
-	OC_st_sysfvaradd
-	OC_st_map
+	OC_gethitvar_animtype OpCode = iota
+	OC_gethitvar_air_animtype
+	OC_gethitvar_ground_animtype
+	OC_gethitvar_fall_animtype
+	OC_gethitvar_airtype
+	OC_gethitvar_groundtype
+	OC_gethitvar_damage
+	OC_gethitvar_hitcount
+	OC_gethitvar_fallcount
+	OC_gethitvar_hitshaketime
+	OC_gethitvar_hittime
+	OC_gethitvar_slidetime
+	OC_gethitvar_ctrltime
+	OC_gethitvar_recovertime
+	OC_gethitvar_xoff
+	OC_gethitvar_yoff
+	OC_gethitvar_xvel
+	OC_gethitvar_yvel
+	OC_gethitvar_yaccel
+	OC_gethitvar_chainid
+	OC_gethitvar_guarded
+	OC_gethitvar_isbound
+	OC_gethitvar_fall
+	OC_gethitvar_fall_damage
+	OC_gethitvar_fall_xvel
+	OC_gethitvar_fall_yvel
+	OC_gethitvar_fall_recover
+	OC_gethitvar_fall_time
+	OC_gethitvar_fall_recovertime
+	OC_gethitvar_fall_kill
+	OC_gethitvar_fall_envshake_time
+	OC_gethitvar_fall_envshake_freq
+	OC_gethitvar_fall_envshake_ampl
+	OC_gethitvar_fall_envshake_phase
+	OC_gethitvar_attr
+	OC_gethitvar_dizzypoints
+	OC_gethitvar_guarddamage
+	OC_gethitvar_guardpoints
+	OC_gethitvar_guardpower
+	OC_gethitvar_hitdamage
+	OC_gethitvar_hitpower
+	OC_gethitvar_id
+	OC_gethitvar_playerno
+	OC_gethitvar_redlife
+	OC_gethitvar_score
 )
 const (
 	OC_ex_ailevel OpCode = iota
@@ -345,51 +393,6 @@ const (
 	OC_ex_gamemode
 	OC_ex_gametime
 	OC_ex_gamewidth
-	OC_ex_gethitvar_animtype
-	OC_ex_gethitvar_air_animtype
-	OC_ex_gethitvar_ground_animtype
-	OC_ex_gethitvar_fall_animtype
-	OC_ex_gethitvar_airtype
-	OC_ex_gethitvar_groundtype
-	OC_ex_gethitvar_damage
-	OC_ex_gethitvar_hitcount
-	OC_ex_gethitvar_fallcount
-	OC_ex_gethitvar_hitshaketime
-	OC_ex_gethitvar_hittime
-	OC_ex_gethitvar_slidetime
-	OC_ex_gethitvar_ctrltime
-	OC_ex_gethitvar_recovertime
-	OC_ex_gethitvar_xoff
-	OC_ex_gethitvar_yoff
-	OC_ex_gethitvar_xvel
-	OC_ex_gethitvar_yvel
-	OC_ex_gethitvar_yaccel
-	OC_ex_gethitvar_chainid
-	OC_ex_gethitvar_guarded
-	OC_ex_gethitvar_isbound
-	OC_ex_gethitvar_fall
-	OC_ex_gethitvar_fall_damage
-	OC_ex_gethitvar_fall_xvel
-	OC_ex_gethitvar_fall_yvel
-	OC_ex_gethitvar_fall_recover
-	OC_ex_gethitvar_fall_time
-	OC_ex_gethitvar_fall_recovertime
-	OC_ex_gethitvar_fall_kill
-	OC_ex_gethitvar_fall_envshake_time
-	OC_ex_gethitvar_fall_envshake_freq
-	OC_ex_gethitvar_fall_envshake_ampl
-	OC_ex_gethitvar_fall_envshake_phase
-	OC_ex_gethitvar_attr
-	OC_ex_gethitvar_dizzypoints
-	OC_ex_gethitvar_guarddamage
-	OC_ex_gethitvar_guardpoints
-	OC_ex_gethitvar_guardpower
-	OC_ex_gethitvar_hitdamage
-	OC_ex_gethitvar_hitpower
-	OC_ex_gethitvar_id
-	OC_ex_gethitvar_playerno
-	OC_ex_gethitvar_redlife
-	OC_ex_gethitvar_score
 	OC_ex_getplayerid
 	OC_ex_groundangle
 	OC_ex_guardbreak
@@ -934,15 +937,15 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			}
 			sys.bcStack.Push(BytecodeSF())
 			i += int(*(*int32)(unsafe.Pointer(&be[i]))) + 4
-		case OC_parent:
-			if c = c.parent(); c != nil {
+		case OC_root:
+			if c = c.root(); c != nil {
 				i += 4
 				continue
 			}
 			sys.bcStack.Push(BytecodeSF())
 			i += int(*(*int32)(unsafe.Pointer(&be[i]))) + 4
-		case OC_root:
-			if c = c.root(); c != nil {
+		case OC_parent:
+			if c = c.parent(); c != nil {
 				i += 4
 				continue
 			}
@@ -1126,6 +1129,8 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			be.run_st(c, &i)
 		case OC_const_:
 			be.run_const(c, &i, oc)
+		case OC_gethitvar_:
+			be.run_gethitvar(c, &i, oc)
 		case OC_ex_:
 			be.run_ex(c, &i, oc)
 		case OC_var:
@@ -1526,6 +1531,104 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 		c.panic()
 	}
 }
+func (be BytecodeExp) run_gethitvar(c *Char, i *int, oc *Char) {
+	(*i)++
+	switch be[*i-1] {
+	case OC_gethitvar_animtype:
+		sys.bcStack.PushI(int32(c.gethitAnimtype()))
+	case OC_gethitvar_air_animtype:
+		sys.bcStack.PushI(int32(c.ghv.airanimtype))
+	case OC_gethitvar_ground_animtype:
+		sys.bcStack.PushI(int32(c.ghv.groundanimtype))
+	case OC_gethitvar_fall_animtype:
+		sys.bcStack.PushI(int32(c.ghv.fall.animtype))
+	case OC_gethitvar_airtype:
+		sys.bcStack.PushI(int32(c.ghv.airtype))
+	case OC_gethitvar_groundtype:
+		sys.bcStack.PushI(int32(c.ghv.groundtype))
+	case OC_gethitvar_damage:
+		sys.bcStack.PushI(c.ghv.damage)
+	case OC_gethitvar_hitcount:
+		sys.bcStack.PushI(c.ghv.hitcount)
+	case OC_gethitvar_fallcount:
+		sys.bcStack.PushI(c.ghv.fallcount)
+	case OC_gethitvar_hitshaketime:
+		sys.bcStack.PushI(c.ghv.hitshaketime)
+	case OC_gethitvar_hittime:
+		sys.bcStack.PushI(c.ghv.hittime)
+	case OC_gethitvar_slidetime:
+		sys.bcStack.PushI(c.ghv.slidetime)
+	case OC_gethitvar_ctrltime:
+		sys.bcStack.PushI(c.ghv.ctrltime)
+	case OC_gethitvar_recovertime:
+		sys.bcStack.PushI(c.recoverTime)
+	case OC_gethitvar_xoff:
+		sys.bcStack.PushF(c.ghv.xoff * (c.localscl / oc.localscl))
+	case OC_gethitvar_yoff:
+		sys.bcStack.PushF(c.ghv.yoff * (c.localscl / oc.localscl))
+	case OC_gethitvar_xvel:
+		sys.bcStack.PushF(c.ghv.xvel * c.facing * (c.localscl / oc.localscl))
+	case OC_gethitvar_yvel:
+		sys.bcStack.PushF(c.ghv.yvel * (c.localscl / oc.localscl))
+	case OC_gethitvar_yaccel:
+		sys.bcStack.PushF(c.ghv.getYaccel(oc) * (c.localscl / oc.localscl))
+	case OC_gethitvar_chainid:
+		sys.bcStack.PushI(c.ghv.chainId())
+	case OC_gethitvar_guarded:
+		sys.bcStack.PushB(c.ghv.guarded)
+	case OC_gethitvar_isbound:
+		sys.bcStack.PushB(c.isBound())
+	case OC_gethitvar_fall:
+		sys.bcStack.PushB(c.ghv.fallf)
+	case OC_gethitvar_fall_damage:
+		sys.bcStack.PushI(c.ghv.fall.damage)
+	case OC_gethitvar_fall_xvel:
+		sys.bcStack.PushF(c.ghv.fall.xvel() * (c.localscl / oc.localscl))
+	case OC_gethitvar_fall_yvel:
+		sys.bcStack.PushF(c.ghv.fall.yvelocity * (c.localscl / oc.localscl))
+	case OC_gethitvar_fall_recover:
+		sys.bcStack.PushB(c.ghv.fall.recover)
+	case OC_gethitvar_fall_time:
+		sys.bcStack.PushI(c.fallTime)
+	case OC_gethitvar_fall_recovertime:
+		sys.bcStack.PushI(c.ghv.fall.recovertime)
+	case OC_gethitvar_fall_kill:
+		sys.bcStack.PushB(c.ghv.fall.kill)
+	case OC_gethitvar_fall_envshake_time:
+		sys.bcStack.PushI(c.ghv.fall.envshake_time)
+	case OC_gethitvar_fall_envshake_freq:
+		sys.bcStack.PushF(c.ghv.fall.envshake_freq)
+	case OC_gethitvar_fall_envshake_ampl:
+		sys.bcStack.PushI(int32(float32(c.ghv.fall.envshake_ampl) * (c.localscl / oc.localscl)))
+	case OC_gethitvar_fall_envshake_phase:
+		sys.bcStack.PushF(c.ghv.fall.envshake_phase * (c.localscl / oc.localscl))
+	case OC_gethitvar_attr:
+		sys.bcStack.PushI(c.ghv.attr)
+	case OC_gethitvar_dizzypoints:
+		sys.bcStack.PushI(c.ghv.dizzypoints)
+	case OC_gethitvar_guarddamage:
+		sys.bcStack.PushI(c.ghv.guarddamage)
+	case OC_gethitvar_guardpoints:
+		sys.bcStack.PushI(c.ghv.guardpoints)
+	case OC_gethitvar_guardpower:
+		sys.bcStack.PushI(c.ghv.guardpower)
+	case OC_gethitvar_hitdamage:
+		sys.bcStack.PushI(c.ghv.hitdamage)
+	case OC_gethitvar_hitpower:
+		sys.bcStack.PushI(c.ghv.hitpower)
+	case OC_gethitvar_id:
+		sys.bcStack.PushI(c.ghv.id)
+	case OC_gethitvar_playerno:
+		sys.bcStack.PushI(int32(c.ghv.playerNo) + 1)
+	case OC_gethitvar_redlife:
+		sys.bcStack.PushI(c.ghv.redlife)
+	case OC_gethitvar_score:
+		sys.bcStack.PushF(c.ghv.score)
+	default:
+		sys.errLog.Printf("%v\n", be[*i-1])
+		c.panic()
+	}
+}
 func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	(*i)++
 	switch be[*i-1] {
@@ -1667,96 +1770,6 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		} else {
 			sys.bcStack.PushF(c.gameWidth())
 		}
-	case OC_ex_gethitvar_animtype:
-		sys.bcStack.PushI(int32(c.gethitAnimtype()))
-	case OC_ex_gethitvar_air_animtype:
-		sys.bcStack.PushI(int32(c.ghv.airanimtype))
-	case OC_ex_gethitvar_ground_animtype:
-		sys.bcStack.PushI(int32(c.ghv.groundanimtype))
-	case OC_ex_gethitvar_fall_animtype:
-		sys.bcStack.PushI(int32(c.ghv.fall.animtype))
-	case OC_ex_gethitvar_airtype:
-		sys.bcStack.PushI(int32(c.ghv.airtype))
-	case OC_ex_gethitvar_groundtype:
-		sys.bcStack.PushI(int32(c.ghv.groundtype))
-	case OC_ex_gethitvar_damage:
-		sys.bcStack.PushI(c.ghv.damage)
-	case OC_ex_gethitvar_hitcount:
-		sys.bcStack.PushI(c.ghv.hitcount)
-	case OC_ex_gethitvar_fallcount:
-		sys.bcStack.PushI(c.ghv.fallcount)
-	case OC_ex_gethitvar_hitshaketime:
-		sys.bcStack.PushI(c.ghv.hitshaketime)
-	case OC_ex_gethitvar_hittime:
-		sys.bcStack.PushI(c.ghv.hittime)
-	case OC_ex_gethitvar_slidetime:
-		sys.bcStack.PushI(c.ghv.slidetime)
-	case OC_ex_gethitvar_ctrltime:
-		sys.bcStack.PushI(c.ghv.ctrltime)
-	case OC_ex_gethitvar_recovertime:
-		sys.bcStack.PushI(c.recoverTime)
-	case OC_ex_gethitvar_xoff:
-		sys.bcStack.PushF(c.ghv.xoff * (c.localscl / oc.localscl))
-	case OC_ex_gethitvar_yoff:
-		sys.bcStack.PushF(c.ghv.yoff * (c.localscl / oc.localscl))
-	case OC_ex_gethitvar_xvel:
-		sys.bcStack.PushF(c.ghv.xvel * c.facing * (c.localscl / oc.localscl))
-	case OC_ex_gethitvar_yvel:
-		sys.bcStack.PushF(c.ghv.yvel * (c.localscl / oc.localscl))
-	case OC_ex_gethitvar_yaccel:
-		sys.bcStack.PushF(c.ghv.getYaccel(oc) * (c.localscl / oc.localscl))
-	case OC_ex_gethitvar_chainid:
-		sys.bcStack.PushI(c.ghv.chainId())
-	case OC_ex_gethitvar_guarded:
-		sys.bcStack.PushB(c.ghv.guarded)
-	case OC_ex_gethitvar_isbound:
-		sys.bcStack.PushB(c.isBound())
-	case OC_ex_gethitvar_fall:
-		sys.bcStack.PushB(c.ghv.fallf)
-	case OC_ex_gethitvar_fall_damage:
-		sys.bcStack.PushI(c.ghv.fall.damage)
-	case OC_ex_gethitvar_fall_xvel:
-		sys.bcStack.PushF(c.ghv.fall.xvel() * (c.localscl / oc.localscl))
-	case OC_ex_gethitvar_fall_yvel:
-		sys.bcStack.PushF(c.ghv.fall.yvelocity * (c.localscl / oc.localscl))
-	case OC_ex_gethitvar_fall_recover:
-		sys.bcStack.PushB(c.ghv.fall.recover)
-	case OC_ex_gethitvar_fall_time:
-		sys.bcStack.PushI(c.fallTime)
-	case OC_ex_gethitvar_fall_recovertime:
-		sys.bcStack.PushI(c.ghv.fall.recovertime)
-	case OC_ex_gethitvar_fall_kill:
-		sys.bcStack.PushB(c.ghv.fall.kill)
-	case OC_ex_gethitvar_fall_envshake_time:
-		sys.bcStack.PushI(c.ghv.fall.envshake_time)
-	case OC_ex_gethitvar_fall_envshake_freq:
-		sys.bcStack.PushF(c.ghv.fall.envshake_freq)
-	case OC_ex_gethitvar_fall_envshake_ampl:
-		sys.bcStack.PushI(int32(float32(c.ghv.fall.envshake_ampl) * (c.localscl / oc.localscl)))
-	case OC_ex_gethitvar_fall_envshake_phase:
-		sys.bcStack.PushF(c.ghv.fall.envshake_phase * (c.localscl / oc.localscl))
-	case OC_ex_gethitvar_attr:
-		sys.bcStack.PushI(c.ghv.attr)
-	case OC_ex_gethitvar_dizzypoints:
-		sys.bcStack.PushI(c.ghv.dizzypoints)
-	case OC_ex_gethitvar_guarddamage:
-		sys.bcStack.PushI(c.ghv.guarddamage)
-	case OC_ex_gethitvar_guardpoints:
-		sys.bcStack.PushI(c.ghv.guardpoints)
-	case OC_ex_gethitvar_guardpower:
-		sys.bcStack.PushI(c.ghv.guardpower)
-	case OC_ex_gethitvar_hitdamage:
-		sys.bcStack.PushI(c.ghv.hitdamage)
-	case OC_ex_gethitvar_hitpower:
-		sys.bcStack.PushI(c.ghv.hitpower)
-	case OC_ex_gethitvar_id:
-		sys.bcStack.PushI(c.ghv.id)
-	case OC_ex_gethitvar_playerno:
-		sys.bcStack.PushI(int32(c.ghv.playerNo) + 1)
-	case OC_ex_gethitvar_redlife:
-		sys.bcStack.PushI(c.ghv.redlife)
-	case OC_ex_gethitvar_score:
-		sys.bcStack.PushF(c.ghv.score)
 	case OC_ex_getplayerid:
 		sys.bcStack.Top().SetI(c.getPlayerID(int(sys.bcStack.Top().ToI())))
 	case OC_ex_groundangle:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -125,84 +125,6 @@ const (
 	OC_floor
 	OC_ceil
 	OC_ifelse
-	OC_time
-	OC_animtime
-	OC_animelemtime
-	OC_animelemno
-	OC_statetype
-	OC_movetype
-	OC_ctrl
-	OC_command
-	OC_random
-	OC_pos_x
-	OC_pos_y
-	OC_vel_x
-	OC_vel_y
-	OC_screenpos_x
-	OC_screenpos_y
-	OC_facing
-	OC_anim
-	OC_animexist
-	OC_selfanimexist
-	OC_alive
-	OC_life
-	OC_lifemax
-	OC_power
-	OC_powermax
-	OC_canrecover
-	OC_roundstate
-	OC_ishelper
-	OC_numhelper
-	OC_numexplod
-	OC_numprojid
-	OC_numproj
-	OC_teammode
-	OC_teamside
-	OC_hitdefattr
-	OC_inguarddist
-	OC_movecontact
-	OC_movehit
-	OC_moveguarded
-	OC_movereversed
-	OC_projcontacttime
-	OC_projhittime
-	OC_projguardedtime
-	OC_projcanceltime
-	OC_backedge
-	OC_backedgedist
-	OC_backedgebodydist
-	OC_frontedge
-	OC_frontedgedist
-	OC_frontedgebodydist
-	OC_leftedge
-	OC_rightedge
-	OC_topedge
-	OC_bottomedge
-	OC_camerapos_x
-	OC_camerapos_y
-	OC_camerazoom
-	OC_gamewidth
-	OC_gameheight
-	OC_screenwidth
-	OC_screenheight
-	OC_stateno
-	OC_prevstateno
-	OC_id
-	OC_playeridexist
-	OC_gametime
-	OC_numtarget
-	OC_numenemy
-	OC_numpartner
-	OC_ailevel
-	OC_palno
-	OC_hitcount
-	OC_uniqhitcount
-	OC_hitpausetime
-	OC_hitover
-	OC_hitshakeover
-	OC_hitfall
-	OC_hitvel_x
-	OC_hitvel_y
 	OC_player
 	OC_parent
 	OC_root
@@ -377,34 +299,52 @@ const (
 	OC_st_map
 )
 const (
-	OC_ex_p2dist_x OpCode = iota
-	OC_ex_p2dist_y
-	OC_ex_p2bodydist_x
-	OC_ex_parentdist_x
-	OC_ex_parentdist_y
-	OC_ex_rootdist_x
-	OC_ex_rootdist_y
-	OC_ex_win
-	OC_ex_winko
-	OC_ex_wintime
-	OC_ex_winperfect
-	OC_ex_winspecial
-	OC_ex_winhyper
-	OC_ex_lose
-	OC_ex_loseko
-	OC_ex_losetime
-	OC_ex_drawgame
-	OC_ex_matchover
-	OC_ex_matchno
-	OC_ex_roundno
-	OC_ex_roundsexisted
-	OC_ex_ishometeam
-	OC_ex_tickspersecond
-	OC_ex_majorversion
-	OC_ex_drawpalno
+	OC_ex_ailevel OpCode = iota
+	OC_ex_ailevelf
+	OC_ex_alive
+	OC_ex_anim
+	OC_ex_animelemlength
+	OC_ex_animelemno
+	OC_ex_animelemtime
+	OC_ex_animexist
+	OC_ex_animlength
+	OC_ex_animtime
+	OC_ex_attack
+	OC_ex_backedge
+	OC_ex_backedgebodydist
+	OC_ex_backedgedist
+	OC_ex_bgmlength
+	OC_ex_bgmposition
+	OC_ex_bottomedge
+	OC_ex_camerapos_x
+	OC_ex_camerapos_y
+	OC_ex_camerazoom
+	OC_ex_canrecover
+	OC_ex_combocount
+	OC_ex_command
+	OC_ex_consecutivewins
 	OC_ex_const240p
 	OC_ex_const480p
 	OC_ex_const720p
+	OC_ex_ctrl
+	OC_ex_defence
+	OC_ex_dizzy
+	OC_ex_dizzypoints
+	OC_ex_dizzypointsmax
+	OC_ex_drawgame
+	OC_ex_drawpalno
+	OC_ex_facing
+	OC_ex_fighttime
+	OC_ex_firstattack
+	OC_ex_float
+	OC_ex_framespercount
+	OC_ex_frontedge
+	OC_ex_frontedgebodydist
+	OC_ex_frontedgedist
+	OC_ex_gameheight
+	OC_ex_gamemode
+	OC_ex_gametime
+	OC_ex_gamewidth
 	OC_ex_gethitvar_animtype
 	OC_ex_gethitvar_air_animtype
 	OC_ex_gethitvar_ground_animtype
@@ -441,78 +381,138 @@ const (
 	OC_ex_gethitvar_fall_envshake_phase
 	OC_ex_gethitvar_attr
 	OC_ex_gethitvar_dizzypoints
+	OC_ex_gethitvar_guarddamage
 	OC_ex_gethitvar_guardpoints
+	OC_ex_gethitvar_guardpower
+	OC_ex_gethitvar_hitdamage
+	OC_ex_gethitvar_hitpower
 	OC_ex_gethitvar_id
 	OC_ex_gethitvar_playerno
 	OC_ex_gethitvar_redlife
 	OC_ex_gethitvar_score
-	OC_ex_gethitvar_hitdamage
-	OC_ex_gethitvar_guarddamage
-	OC_ex_gethitvar_hitpower
-	OC_ex_gethitvar_guardpower
-	OC_ex_ailevelf
-	OC_ex_animelemlength
-	OC_ex_animlength
-	OC_ex_attack
-	OC_ex_combocount
-	OC_ex_consecutivewins
-	OC_ex_defence
-	OC_ex_dizzy
-	OC_ex_dizzypoints
-	OC_ex_dizzypointsmax
-	OC_ex_fighttime
-	OC_ex_firstattack
-	OC_ex_framespercount
-	OC_ex_float
-	OC_ex_gamemode
 	OC_ex_getplayerid
 	OC_ex_groundangle
 	OC_ex_guardbreak
 	OC_ex_guardpoints
 	OC_ex_guardpointsmax
 	OC_ex_helpername
+	OC_ex_hitcount
+	OC_ex_hitdefattr
+	OC_ex_hitfall
+	OC_ex_hitover
 	OC_ex_hitoverridden
+	OC_ex_hitpausetime
+	OC_ex_hitshakeover
+	OC_ex_hitvel_x
+	OC_ex_hitvel_y
+	OC_ex_id
 	OC_ex_incustomstate
 	OC_ex_indialogue
+	OC_ex_inguarddist
 	OC_ex_isassertedchar
 	OC_ex_isassertedglobal
+	OC_ex_ishelper
+	OC_ex_ishometeam
 	OC_ex_ishost
+	OC_ex_jugglepoints
+	OC_ex_leftedge
+	OC_ex_life
+	OC_ex_lifemax
 	OC_ex_localscale
+	OC_ex_lose
+	OC_ex_loseko
+	OC_ex_losetime
+	OC_ex_majorversion
 	OC_ex_maparray
+	OC_ex_matchno
+	OC_ex_matchover
 	OC_ex_max
-	OC_ex_min
 	OC_ex_memberno
+	OC_ex_min
+	OC_ex_movecontact
 	OC_ex_movecountered
+	OC_ex_moveguarded
+	OC_ex_movehit
+	OC_ex_movereversed
+	OC_ex_movetype
+	OC_ex_numenemy
+	OC_ex_numexplod
+	OC_ex_numhelper
+	OC_ex_numpartner
+	OC_ex_numproj
+	OC_ex_numprojid
+	OC_ex_numtarget
+	OC_ex_p2bodydist_x
+	OC_ex_p2dist_x
+	OC_ex_p2dist_y
+	OC_ex_palno
+	OC_ex_parentdist_x
+	OC_ex_parentdist_y
 	OC_ex_pausetime
 	OC_ex_physics
+	OC_ex_playeridexist
 	OC_ex_playerno
+	OC_ex_pos_x
+	OC_ex_pos_y
+	OC_ex_pos_z
+	OC_ex_power
+	OC_ex_powermax
+	OC_ex_prevanim
+	OC_ex_prevstateno
+	OC_ex_projcanceltime
+	OC_ex_projcontacttime
+	OC_ex_projguardedtime
+	OC_ex_projhittime
 	OC_ex_rand
+	OC_ex_random
 	OC_ex_ratiolevel
 	OC_ex_receiveddamage
 	OC_ex_receivedhits
 	OC_ex_redlife
+	OC_ex_reversaldefattr
+	OC_ex_rightedge
+	OC_ex_rootdist_x
+	OC_ex_rootdist_y
 	OC_ex_round
+	OC_ex_roundno
+	OC_ex_roundsexisted
+	OC_ex_roundstate
 	OC_ex_roundtype
 	OC_ex_score
 	OC_ex_scoretotal
+	OC_ex_screenheight
+	OC_ex_screenpos_x
+	OC_ex_screenpos_y
+	OC_ex_screenwidth
+	OC_ex_selfanimexist
 	OC_ex_selfstatenoexist
 	OC_ex_sprpriority
 	OC_ex_stagebackedge
 	OC_ex_stagefrontedge
 	OC_ex_stagetime
 	OC_ex_standby
+	OC_ex_stateno
+	OC_ex_statetype
 	OC_ex_teamleader
+	OC_ex_teammode
+	OC_ex_teamside
 	OC_ex_teamsize
+	OC_ex_tickspersecond
+	OC_ex_time
 	OC_ex_timeelapsed
 	OC_ex_timeremaining
 	OC_ex_timetotal
-	OC_ex_pos_z
+	OC_ex_topedge
+	OC_ex_uniqhitcount
+	OC_ex_vel_x
+	OC_ex_vel_y
 	OC_ex_vel_z
-	OC_ex_jugglepoints
-	OC_ex_prevanim
-	OC_ex_reversaldefattr
-	OC_ex_bgmlength
-	OC_ex_bgmposition
+	OC_ex_win
+	OC_ex_winhyper
+	OC_ex_winko
+	OC_ex_winperfect
+	OC_ex_winspecial
+	OC_ex_wintime
 )
 const (
 	NumVar     = 60
@@ -1122,212 +1122,6 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.Dup()
 		case OC_swap:
 			sys.bcStack.Swap()
-		case OC_ailevel:
-			sys.bcStack.PushI(int32(c.aiLevel()))
-		case OC_alive:
-			sys.bcStack.PushB(c.alive())
-		case OC_anim:
-			sys.bcStack.PushI(c.animNo)
-		case OC_animelemno:
-			*sys.bcStack.Top() = c.animElemNo(sys.bcStack.Top().ToI())
-		case OC_animelemtime:
-			*sys.bcStack.Top() = c.animElemTime(sys.bcStack.Top().ToI())
-		case OC_animexist:
-			*sys.bcStack.Top() = c.animExist(sys.workingChar, *sys.bcStack.Top())
-		case OC_animtime:
-			sys.bcStack.PushI(c.animTime())
-		case OC_backedge:
-			sys.bcStack.PushF(c.backEdge())
-		case OC_backedgebodydist:
-			sys.bcStack.PushI(int32(c.backEdgeBodyDist()))
-		case OC_backedgedist:
-			sys.bcStack.PushI(int32(c.backEdgeDist()))
-		case OC_bottomedge:
-			sys.bcStack.PushF(c.bottomEdge())
-		case OC_camerapos_x:
-			sys.bcStack.PushF(sys.cam.Pos[0] / oc.localscl)
-		case OC_camerapos_y:
-			sys.bcStack.PushF(sys.cam.Pos[1] / oc.localscl)
-		case OC_camerazoom:
-			sys.bcStack.PushF(sys.cam.Scale)
-		case OC_canrecover:
-			sys.bcStack.PushB(c.canRecover())
-		case OC_command:
-			if c.cmd == nil {
-				sys.bcStack.PushB(false)
-			} else {
-				pno := c.playerNo
-				if oc.stCgi().ikemenver[0] > 0 || oc.stCgi().ikemenver[1] > 0 {
-					pno = sys.workingState.playerNo
-				}
-				cmd, ok := c.cmd[pno].Names[sys.stringPool[sys.workingState.playerNo].List[*(*int32)(unsafe.Pointer(&be[i]))]]
-				sys.bcStack.PushB(ok && c.command(pno, cmd))
-			}
-			i += 4
-		case OC_ctrl:
-			sys.bcStack.PushB(c.ctrl())
-		case OC_facing:
-			sys.bcStack.PushI(int32(c.facing))
-		case OC_frontedge:
-			sys.bcStack.PushF(c.frontEdge())
-		case OC_frontedgebodydist:
-			sys.bcStack.PushI(int32(c.frontEdgeBodyDist()))
-		case OC_frontedgedist:
-			sys.bcStack.PushI(int32(c.frontEdgeDist()))
-		case OC_gameheight:
-			// Optional exception preventing GameHeight from being affected by stage zoom.
-			if c.stCgi().ver[0] == 1 && c.stCgi().ver[1] == 0 &&
-				c.gi().constants["default.legacygamedistancespec"] == 1 {
-				sys.bcStack.PushF(c.screenHeight())
-			} else {
-				sys.bcStack.PushF(c.gameHeight())
-			}
-		case OC_gametime:
-			var pfTime int32
-			if sys.netInput != nil {
-				pfTime = sys.netInput.preFightTime
-			} else if sys.fileInput != nil {
-				pfTime = sys.fileInput.pfTime
-			} else {
-				pfTime = sys.preFightTime
-			}
-			sys.bcStack.PushI(sys.gameTime + pfTime)
-		case OC_gamewidth:
-			// Optional exception preventing GameWidth from being affected by stage zoom.
-			if c.stCgi().ver[0] == 1 && c.stCgi().ver[1] == 0 &&
-				c.gi().constants["default.legacygamedistancespec"] == 1 {
-				sys.bcStack.PushF(c.screenWidth())
-			} else {
-				sys.bcStack.PushF(c.gameWidth())
-			}
-		case OC_hitcount:
-			sys.bcStack.PushI(c.hitCount)
-		case OC_hitdefattr:
-			sys.bcStack.PushB(c.hitDefAttr(*(*int32)(unsafe.Pointer(&be[i]))))
-			i += 4
-		case OC_hitfall:
-			sys.bcStack.PushB(c.ghv.fallf)
-		case OC_hitover:
-			sys.bcStack.PushB(c.hitOver())
-		case OC_hitpausetime:
-			sys.bcStack.PushI(c.hitPauseTime)
-		case OC_hitshakeover:
-			sys.bcStack.PushB(c.hitShakeOver())
-		case OC_hitvel_x:
-			sys.bcStack.PushF(c.hitVelX() * (c.localscl / oc.localscl))
-		case OC_hitvel_y:
-			sys.bcStack.PushF(c.hitVelY() * (c.localscl / oc.localscl))
-		case OC_id:
-			sys.bcStack.PushI(c.id)
-		case OC_inguarddist:
-			sys.bcStack.PushB(c.inguarddist)
-		case OC_ishelper:
-			*sys.bcStack.Top() = c.isHelper(*sys.bcStack.Top())
-		case OC_leftedge:
-			sys.bcStack.PushF(c.leftEdge())
-		case OC_life:
-			sys.bcStack.PushI(c.life)
-		case OC_lifemax:
-			sys.bcStack.PushI(c.lifeMax)
-		case OC_movecontact:
-			sys.bcStack.PushI(c.moveContact())
-		case OC_moveguarded:
-			sys.bcStack.PushI(c.moveGuarded())
-		case OC_movehit:
-			sys.bcStack.PushI(c.moveHit())
-		case OC_movereversed:
-			sys.bcStack.PushI(c.moveReversed())
-		case OC_movetype:
-			sys.bcStack.PushB(c.ss.moveType == MoveType(be[i])<<15)
-			i++
-		case OC_numenemy:
-			sys.bcStack.PushI(c.numEnemy())
-		case OC_numexplod:
-			*sys.bcStack.Top() = c.numExplod(*sys.bcStack.Top())
-		case OC_numhelper:
-			*sys.bcStack.Top() = c.numHelper(*sys.bcStack.Top())
-		case OC_numpartner:
-			sys.bcStack.PushI(c.numPartner())
-		case OC_numproj:
-			sys.bcStack.PushI(c.numProj())
-		case OC_numprojid:
-			*sys.bcStack.Top() = c.numProjID(*sys.bcStack.Top())
-		case OC_numtarget:
-			*sys.bcStack.Top() = c.numTarget(*sys.bcStack.Top())
-		case OC_palno:
-			sys.bcStack.PushI(c.palno())
-		case OC_pos_x:
-			var bindVelx float32
-			if c.bindToId > 0 && !math.IsNaN(float64(c.bindPos[0])) && c.stCgi().ikemenver[0] == 0 && c.stCgi().ikemenver[1] == 0 {
-				if sys.playerID(c.bindToId) != nil {
-					bindVelx = c.vel[0]
-				}
-			}
-			sys.bcStack.PushF(((c.pos[0]+bindVelx)*(c.localscl/oc.localscl) - sys.cam.Pos[0]/oc.localscl))
-		case OC_pos_y:
-			var bindVely float32
-			if c.bindToId > 0 && !math.IsNaN(float64(c.bindPos[1])) && c.stCgi().ikemenver[0] == 0 && c.stCgi().ikemenver[1] == 0 {
-				if sys.playerID(c.bindToId) != nil {
-					bindVely = c.vel[1]
-				}
-			}
-			sys.bcStack.PushF((c.pos[1] + bindVely - c.platformPosY) * (c.localscl / oc.localscl))
-		case OC_power:
-			sys.bcStack.PushI(c.getPower())
-		case OC_powermax:
-			sys.bcStack.PushI(c.powerMax)
-		case OC_playeridexist:
-			*sys.bcStack.Top() = sys.playerIDExist(*sys.bcStack.Top())
-		case OC_prevstateno:
-			sys.bcStack.PushI(c.ss.prevno)
-		case OC_projcanceltime:
-			*sys.bcStack.Top() = c.projCancelTime(*sys.bcStack.Top())
-		case OC_projcontacttime:
-			*sys.bcStack.Top() = c.projContactTime(*sys.bcStack.Top())
-		case OC_projguardedtime:
-			*sys.bcStack.Top() = c.projGuardedTime(*sys.bcStack.Top())
-		case OC_projhittime:
-			*sys.bcStack.Top() = c.projHitTime(*sys.bcStack.Top())
-		case OC_random:
-			sys.bcStack.PushI(Rand(0, 999))
-		case OC_rightedge:
-			sys.bcStack.PushF(c.rightEdge())
-		case OC_roundstate:
-			sys.bcStack.PushI(c.roundState())
-		case OC_screenheight:
-			sys.bcStack.PushF(c.screenHeight())
-		case OC_screenpos_x:
-			sys.bcStack.PushF((c.screenPosX()) / oc.localscl)
-		case OC_screenpos_y:
-			sys.bcStack.PushF((c.screenPosY()) / oc.localscl)
-		case OC_screenwidth:
-			sys.bcStack.PushF(c.screenWidth())
-		case OC_selfanimexist:
-			*sys.bcStack.Top() = c.selfAnimExist(*sys.bcStack.Top())
-		case OC_stateno:
-			sys.bcStack.PushI(c.ss.no)
-		case OC_statetype:
-			sys.bcStack.PushB(c.ss.stateType == StateType(be[i]))
-			i++
-		case OC_teammode:
-			if c.teamside == -1 {
-				sys.bcStack.PushB(TM_Single == TeamMode(be[i]))
-			} else {
-				sys.bcStack.PushB(sys.tmode[c.playerNo&1] == TeamMode(be[i]))
-			}
-			i++
-		case OC_teamside:
-			sys.bcStack.PushI(int32(c.teamside) + 1)
-		case OC_time:
-			sys.bcStack.PushI(c.time())
-		case OC_topedge:
-			sys.bcStack.PushF(c.topEdge())
-		case OC_uniqhitcount:
-			sys.bcStack.PushI(c.uniqHitCount)
-		case OC_vel_x:
-			sys.bcStack.PushF(c.vel[0] * (c.localscl / oc.localscl))
-		case OC_vel_y:
-			sys.bcStack.PushF(c.vel[1] * (c.localscl / oc.localscl))
 		case OC_st_:
 			be.run_st(c, &i)
 		case OC_const_:
@@ -1735,58 +1529,144 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	(*i)++
 	switch be[*i-1] {
-	case OC_ex_p2dist_x:
-		sys.bcStack.Push(c.rdDistX(c.p2(), oc))
-	case OC_ex_p2dist_y:
-		sys.bcStack.Push(c.rdDistY(c.p2(), oc))
-	case OC_ex_p2bodydist_x:
-		sys.bcStack.Push(c.p2BodyDistX(oc))
-	case OC_ex_parentdist_x:
-		sys.bcStack.Push(c.rdDistX(c.parent(), oc))
-	case OC_ex_parentdist_y:
-		sys.bcStack.Push(c.rdDistY(c.parent(), oc))
-	case OC_ex_rootdist_x:
-		sys.bcStack.Push(c.rdDistX(c.root(), oc))
-	case OC_ex_rootdist_y:
-		sys.bcStack.Push(c.rdDistY(c.root(), oc))
-	case OC_ex_win:
-		sys.bcStack.PushB(c.win())
-	case OC_ex_winko:
-		sys.bcStack.PushB(c.winKO())
-	case OC_ex_wintime:
-		sys.bcStack.PushB(c.winTime())
-	case OC_ex_winperfect:
-		sys.bcStack.PushB(c.winPerfect())
-	case OC_ex_winspecial:
-		sys.bcStack.PushB(c.winType(WT_S))
-	case OC_ex_winhyper:
-		sys.bcStack.PushB(c.winType(WT_H))
-	case OC_ex_lose:
-		sys.bcStack.PushB(c.lose())
-	case OC_ex_loseko:
-		sys.bcStack.PushB(c.loseKO())
-	case OC_ex_losetime:
-		sys.bcStack.PushB(c.loseTime())
-	case OC_ex_drawgame:
-		sys.bcStack.PushB(c.drawgame())
-	case OC_ex_matchover:
-		sys.bcStack.PushB(sys.matchOver())
-	case OC_ex_matchno:
-		sys.bcStack.PushI(sys.match)
-	case OC_ex_roundno:
-		sys.bcStack.PushI(sys.round)
-	case OC_ex_roundsexisted:
-		sys.bcStack.PushI(c.roundsExisted())
-	case OC_ex_ishometeam:
-		sys.bcStack.PushB(c.teamside == sys.home)
-	case OC_ex_tickspersecond:
-		sys.bcStack.PushI(int32(FPS))
+	case OC_ex_ailevel:
+		sys.bcStack.PushI(int32(c.aiLevel()))
+	case OC_ex_ailevelf:
+		sys.bcStack.PushF(c.aiLevel())
+	case OC_ex_alive:
+		sys.bcStack.PushB(c.alive())
+	case OC_ex_anim:
+		sys.bcStack.PushI(c.animNo)
+	case OC_ex_animelemlength:
+		if f := c.anim.CurrentFrame(); f != nil {
+			sys.bcStack.PushI(f.Time)
+		} else {
+			sys.bcStack.PushI(0)
+		}
+	case OC_ex_animelemno:
+		*sys.bcStack.Top() = c.animElemNo(sys.bcStack.Top().ToI())
+	case OC_ex_animelemtime:
+		*sys.bcStack.Top() = c.animElemTime(sys.bcStack.Top().ToI())
+	case OC_ex_animexist:
+		*sys.bcStack.Top() = c.animExist(sys.workingChar, *sys.bcStack.Top())
+	case OC_ex_animlength:
+		sys.bcStack.PushI(c.anim.totaltime)
+	case OC_ex_animtime:
+		sys.bcStack.PushI(c.animTime())
+	case OC_ex_attack:
+		sys.bcStack.PushF(c.attackMul * 100)
+	case OC_ex_backedge:
+		sys.bcStack.PushF(c.backEdge())
+	case OC_ex_backedgebodydist:
+		sys.bcStack.PushI(int32(c.backEdgeBodyDist()))
+	case OC_ex_backedgedist:
+		sys.bcStack.PushI(int32(c.backEdgeDist()))
+	case OC_ex_bgmlength:
+		if sys.bgm.streamer == nil {
+			sys.bcStack.PushI(0)
+		} else {
+			sys.bcStack.PushI(int32(sys.bgm.streamer.Len()))
+		}
+	case OC_ex_bgmposition:
+		if sys.bgm.streamer == nil {
+			sys.bcStack.PushI(0)
+		} else {
+			sys.bcStack.PushI(int32(sys.bgm.streamer.Position()))
+		}
+	case OC_ex_bottomedge:
+		sys.bcStack.PushF(c.bottomEdge())
+	case OC_ex_camerapos_x:
+		sys.bcStack.PushF(sys.cam.Pos[0] / oc.localscl)
+	case OC_ex_camerapos_y:
+		sys.bcStack.PushF(sys.cam.Pos[1] / oc.localscl)
+	case OC_ex_camerazoom:
+		sys.bcStack.PushF(sys.cam.Scale)
+	case OC_ex_canrecover:
+		sys.bcStack.PushB(c.canRecover())
+	case OC_ex_combocount:
+		sys.bcStack.PushI(c.comboCount())
+	case OC_ex_command:
+		if c.cmd == nil {
+			sys.bcStack.PushB(false)
+		} else {
+			pno := c.playerNo
+			if oc.stCgi().ikemenver[0] > 0 || oc.stCgi().ikemenver[1] > 0 {
+				pno = sys.workingState.playerNo
+			}
+			cmd, ok := c.cmd[pno].Names[sys.stringPool[sys.workingState.playerNo].List[*(*int32)(
+				unsafe.Pointer(&be[*i]))]]
+			sys.bcStack.PushB(ok && c.command(pno, cmd))
+		}
+		*i += 4
+	case OC_ex_consecutivewins:
+		sys.bcStack.PushI(c.consecutiveWins())
 	case OC_ex_const240p:
 		*sys.bcStack.Top() = c.constp(320, sys.bcStack.Top().ToF())
 	case OC_ex_const480p:
 		*sys.bcStack.Top() = c.constp(640, sys.bcStack.Top().ToF())
 	case OC_ex_const720p:
 		*sys.bcStack.Top() = c.constp(1280, sys.bcStack.Top().ToF())
+	case OC_ex_ctrl:
+		sys.bcStack.PushB(c.ctrl())
+	case OC_ex_defence:
+		sys.bcStack.PushF(float32(c.finalDefense * 100))
+	case OC_ex_dizzy:
+		sys.bcStack.PushB(c.scf(SCF_dizzy))
+	case OC_ex_dizzypoints:
+		sys.bcStack.PushI(c.dizzyPoints)
+	case OC_ex_dizzypointsmax:
+		sys.bcStack.PushI(c.dizzyPointsMax)
+	case OC_ex_drawgame:
+		sys.bcStack.PushB(c.drawgame())
+	case OC_ex_drawpalno:
+		sys.bcStack.PushI(c.gi().drawpalno)
+	case OC_ex_facing:
+		sys.bcStack.PushI(int32(c.facing))
+	case OC_ex_fighttime:
+		sys.bcStack.PushI(sys.gameTime)
+	case OC_ex_firstattack:
+		sys.bcStack.PushB(c.firstAttack)
+	case OC_ex_float:
+		*sys.bcStack.Top() = BytecodeFloat(sys.bcStack.Top().ToF())
+	case OC_ex_framespercount:
+		sys.bcStack.PushI(sys.lifebar.ti.framespercount)
+	case OC_ex_frontedge:
+		sys.bcStack.PushF(c.frontEdge())
+	case OC_ex_frontedgebodydist:
+		sys.bcStack.PushI(int32(c.frontEdgeBodyDist()))
+	case OC_ex_frontedgedist:
+		sys.bcStack.PushI(int32(c.frontEdgeDist()))
+	case OC_ex_gameheight:
+		// optional exception preventing GameHeight from being affected by stage zoom.
+		if c.stCgi().ver[0] == 1 && c.stCgi().ver[1] == 0 &&
+			c.gi().constants["default.legacygamedistancespec"] == 1 {
+			sys.bcStack.PushF(c.screenHeight())
+		} else {
+			sys.bcStack.PushF(c.gameHeight())
+		}
+	case OC_ex_gamemode:
+		sys.bcStack.PushB(strings.ToLower(sys.gameMode) ==
+			sys.stringPool[sys.workingState.playerNo].List[*(*int32)(
+				unsafe.Pointer(&be[*i]))])
+		*i += 4
+	case OC_ex_gametime:
+		var pfTime int32
+		if sys.netInput != nil {
+			pfTime = sys.netInput.preFightTime
+		} else if sys.fileInput != nil {
+			pfTime = sys.fileInput.pfTime
+		} else {
+			pfTime = sys.preFightTime
+		}
+		sys.bcStack.PushI(sys.gameTime + pfTime)
+	case OC_ex_gamewidth:
+		// optional exception preventing GameWidth from being affected by stage zoom.
+		if c.stCgi().ver[0] == 1 && c.stCgi().ver[1] == 0 &&
+			c.gi().constants["default.legacygamedistancespec"] == 1 {
+			sys.bcStack.PushF(c.screenWidth())
+		} else {
+			sys.bcStack.PushF(c.gameWidth())
+		}
 	case OC_ex_gethitvar_animtype:
 		sys.bcStack.PushI(int32(c.gethitAnimtype()))
 	case OC_ex_gethitvar_air_animtype:
@@ -1859,8 +1739,16 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(c.ghv.attr)
 	case OC_ex_gethitvar_dizzypoints:
 		sys.bcStack.PushI(c.ghv.dizzypoints)
+	case OC_ex_gethitvar_guarddamage:
+		sys.bcStack.PushI(c.ghv.guarddamage)
 	case OC_ex_gethitvar_guardpoints:
 		sys.bcStack.PushI(c.ghv.guardpoints)
+	case OC_ex_gethitvar_guardpower:
+		sys.bcStack.PushI(c.ghv.guardpower)
+	case OC_ex_gethitvar_hitdamage:
+		sys.bcStack.PushI(c.ghv.hitdamage)
+	case OC_ex_gethitvar_hitpower:
+		sys.bcStack.PushI(c.ghv.hitpower)
 	case OC_ex_gethitvar_id:
 		sys.bcStack.PushI(c.ghv.id)
 	case OC_ex_gethitvar_playerno:
@@ -1869,53 +1757,6 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(c.ghv.redlife)
 	case OC_ex_gethitvar_score:
 		sys.bcStack.PushF(c.ghv.score)
-	case OC_ex_gethitvar_hitdamage:
-		sys.bcStack.PushI(c.ghv.hitdamage)
-	case OC_ex_gethitvar_guarddamage:
-		sys.bcStack.PushI(c.ghv.guarddamage)
-	case OC_ex_gethitvar_hitpower:
-		sys.bcStack.PushI(c.ghv.hitpower)
-	case OC_ex_gethitvar_guardpower:
-		sys.bcStack.PushI(c.ghv.guardpower)
-	case OC_ex_ailevelf:
-		sys.bcStack.PushF(c.aiLevel())
-	case OC_ex_animelemlength:
-		if f := c.anim.CurrentFrame(); f != nil {
-			sys.bcStack.PushI(f.Time)
-		} else {
-			sys.bcStack.PushI(0)
-		}
-	case OC_ex_animlength:
-		sys.bcStack.PushI(c.anim.totaltime)
-	case OC_ex_attack:
-		sys.bcStack.PushF(c.attackMul * 100)
-	case OC_ex_combocount:
-		sys.bcStack.PushI(c.comboCount())
-	case OC_ex_consecutivewins:
-		sys.bcStack.PushI(c.consecutiveWins())
-	case OC_ex_defence:
-		sys.bcStack.PushF(float32(c.finalDefense * 100))
-	case OC_ex_dizzy:
-		sys.bcStack.PushB(c.scf(SCF_dizzy))
-	case OC_ex_dizzypoints:
-		sys.bcStack.PushI(c.dizzyPoints)
-	case OC_ex_dizzypointsmax:
-		sys.bcStack.PushI(c.dizzyPointsMax)
-	case OC_ex_drawpalno:
-		sys.bcStack.PushI(c.gi().drawpalno)
-	case OC_ex_fighttime:
-		sys.bcStack.PushI(sys.gameTime)
-	case OC_ex_firstattack:
-		sys.bcStack.PushB(c.firstAttack)
-	case OC_ex_framespercount:
-		sys.bcStack.PushI(sys.lifebar.ti.framespercount)
-	case OC_ex_float:
-		*sys.bcStack.Top() = BytecodeFloat(sys.bcStack.Top().ToF())
-	case OC_ex_gamemode:
-		sys.bcStack.PushB(strings.ToLower(sys.gameMode) ==
-			sys.stringPool[sys.workingState.playerNo].List[*(*int32)(
-				unsafe.Pointer(&be[*i]))])
-		*i += 4
 	case OC_ex_getplayerid:
 		sys.bcStack.Top().SetI(c.getPlayerID(int(sys.bcStack.Top().ToI())))
 	case OC_ex_groundangle:
@@ -1931,22 +1772,61 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 			sys.stringPool[sys.workingState.playerNo].List[*(*int32)(
 				unsafe.Pointer(&be[*i]))])
 		*i += 4
+	case OC_ex_hitcount:
+		sys.bcStack.PushI(c.hitCount)
+	case OC_ex_hitdefattr:
+		sys.bcStack.PushB(c.hitDefAttr(*(*int32)(unsafe.Pointer(&be[*i]))))
+		*i += 4
+	case OC_ex_hitfall:
+		sys.bcStack.PushB(c.ghv.fallf)
+	case OC_ex_hitover:
+		sys.bcStack.PushB(c.hitOver())
 	case OC_ex_hitoverridden:
 		sys.bcStack.PushB(c.hoIdx >= 0)
+	case OC_ex_hitpausetime:
+		sys.bcStack.PushI(c.hitPauseTime)
+	case OC_ex_hitshakeover:
+		sys.bcStack.PushB(c.hitShakeOver())
+	case OC_ex_hitvel_x:
+		sys.bcStack.PushF(c.hitVelX() * (c.localscl / oc.localscl))
+	case OC_ex_hitvel_y:
+		sys.bcStack.PushF(c.hitVelY() * (c.localscl / oc.localscl))
+	case OC_ex_id:
+		sys.bcStack.PushI(c.id)
 	case OC_ex_incustomstate:
 		sys.bcStack.PushB(c.ss.sb.playerNo != c.playerNo)
 	case OC_ex_indialogue:
 		sys.bcStack.PushB(sys.dialogueFlg)
+	case OC_ex_inguarddist:
+		sys.bcStack.PushB(c.inguarddist)
 	case OC_ex_isassertedchar:
 		sys.bcStack.PushB(c.sf(CharSpecialFlag((*(*int32)(unsafe.Pointer(&be[*i]))))))
 		*i += 4
 	case OC_ex_isassertedglobal:
 		sys.bcStack.PushB(sys.sf(GlobalSpecialFlag((*(*int32)(unsafe.Pointer(&be[*i]))))))
 		*i += 4
+	case OC_ex_ishelper:
+		*sys.bcStack.Top() = c.isHelper(*sys.bcStack.Top())
+	case OC_ex_ishometeam:
+		sys.bcStack.PushB(c.teamside == sys.home)
 	case OC_ex_ishost:
 		sys.bcStack.PushB(c.isHost())
+	case OC_ex_jugglepoints:
+		sys.bcStack.PushI(c.juggle)
+	case OC_ex_leftedge:
+		sys.bcStack.PushF(c.leftEdge())
+	case OC_ex_life:
+		sys.bcStack.PushI(c.life)
+	case OC_ex_lifemax:
+		sys.bcStack.PushI(c.lifeMax)
 	case OC_ex_localscale:
 		sys.bcStack.PushF(c.localscl)
+	case OC_ex_lose:
+		sys.bcStack.PushB(c.lose())
+	case OC_ex_loseko:
+		sys.bcStack.PushB(c.loseKO())
+	case OC_ex_losetime:
+		sys.bcStack.PushB(c.loseTime())
 	case OC_ex_majorversion:
 		sys.bcStack.PushI(int32(c.gi().ver[0]))
 	case OC_ex_maparray:
@@ -1955,23 +1835,102 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_max:
 		v2 := sys.bcStack.Pop()
 		be.max(sys.bcStack.Top(), v2)
+	case OC_ex_matchno:
+		sys.bcStack.PushI(sys.match)
+	case OC_ex_matchover:
+		sys.bcStack.PushB(sys.matchOver())
+	case OC_ex_memberno:
+		sys.bcStack.PushI(int32(c.memberNo) + 1)
 	case OC_ex_min:
 		v2 := sys.bcStack.Pop()
 		be.min(sys.bcStack.Top(), v2)
-	case OC_ex_memberno:
-		sys.bcStack.PushI(int32(c.memberNo) + 1)
+	case OC_ex_movecontact:
+		sys.bcStack.PushI(c.moveContact())
 	case OC_ex_movecountered:
 		sys.bcStack.PushI(c.moveCountered())
+	case OC_ex_moveguarded:
+		sys.bcStack.PushI(c.moveGuarded())
+	case OC_ex_movehit:
+		sys.bcStack.PushI(c.moveHit())
+	case OC_ex_movereversed:
+		sys.bcStack.PushI(c.moveReversed())
+	case OC_ex_movetype:
+		sys.bcStack.PushB(c.ss.moveType == MoveType(be[*i])<<15)
+		*i++
+	case OC_ex_numenemy:
+		sys.bcStack.PushI(c.numEnemy())
+	case OC_ex_numexplod:
+		*sys.bcStack.Top() = c.numExplod(*sys.bcStack.Top())
+	case OC_ex_numhelper:
+		*sys.bcStack.Top() = c.numHelper(*sys.bcStack.Top())
+	case OC_ex_numpartner:
+		sys.bcStack.PushI(c.numPartner())
+	case OC_ex_numproj:
+		sys.bcStack.PushI(c.numProj())
+	case OC_ex_numprojid:
+		*sys.bcStack.Top() = c.numProjID(*sys.bcStack.Top())
+	case OC_ex_numtarget:
+		*sys.bcStack.Top() = c.numTarget(*sys.bcStack.Top())	
+	case OC_ex_p2bodydist_x:
+		sys.bcStack.Push(c.p2BodyDistX(oc))
+	case OC_ex_p2dist_x:
+		sys.bcStack.Push(c.rdDistX(c.p2(), oc))
+	case OC_ex_p2dist_y:
+		sys.bcStack.Push(c.rdDistY(c.p2(), oc))
+	case OC_ex_palno:
+		sys.bcStack.PushI(c.palno())
+	case OC_ex_parentdist_x:
+		sys.bcStack.Push(c.rdDistX(c.parent(), oc))
+	case OC_ex_parentdist_y:
+		sys.bcStack.Push(c.rdDistY(c.parent(), oc))
 	case OC_ex_pausetime:
 		sys.bcStack.PushI(c.pauseTime())
 	case OC_ex_physics:
 		sys.bcStack.PushB(c.ss.physics == StateType(be[*i]))
 		*i++
+	case OC_ex_playeridexist:
+		*sys.bcStack.Top() = sys.playerIDExist(*sys.bcStack.Top())
 	case OC_ex_playerno:
 		sys.bcStack.PushI(int32(c.playerNo) + 1)
+	case OC_ex_pos_x:
+		var bindVelx float32
+		if c.bindToId > 0 && !math.IsNaN(float64(c.bindPos[0])) && c.stCgi().ikemenver[0] == 0 && c.stCgi().ikemenver[1] == 0 {
+			if sys.playerID(c.bindToId) != nil {
+				bindVelx = c.vel[0]
+			}
+		}
+		sys.bcStack.PushF(((c.pos[0]+bindVelx)*(c.localscl/oc.localscl) - sys.cam.Pos[0]/oc.localscl))
+	case OC_ex_pos_y:
+		var bindVely float32
+		if c.bindToId > 0 && !math.IsNaN(float64(c.bindPos[1])) && c.stCgi().ikemenver[0] == 0 && c.stCgi().ikemenver[1] == 0 {
+			if sys.playerID(c.bindToId) != nil {
+				bindVely = c.vel[1]
+			}
+		}
+		sys.bcStack.PushF((c.pos[1] + bindVely - c.platformPosY) * (c.localscl / oc.localscl))
+	case OC_ex_pos_z:
+		sys.bcStack.PushF(c.pos[2] * (c.localscl / oc.localscl))
+	case OC_ex_power:
+		sys.bcStack.PushI(c.getPower())
+	case OC_ex_powermax:
+		sys.bcStack.PushI(c.powerMax)
+	case OC_ex_prevanim:
+		sys.bcStack.PushI(c.prevAnimNo)
+	case OC_ex_prevstateno:
+		sys.bcStack.PushI(c.ss.prevno)
+	case OC_ex_projcanceltime:
+		*sys.bcStack.Top() = c.projCancelTime(*sys.bcStack.Top())
+	case OC_ex_projcontacttime:
+		*sys.bcStack.Top() = c.projContactTime(*sys.bcStack.Top())
+	case OC_ex_projguardedtime:
+		*sys.bcStack.Top() = c.projGuardedTime(*sys.bcStack.Top())
+	case OC_ex_projhittime:
+		*sys.bcStack.Top() = c.projHitTime(*sys.bcStack.Top())
 	case OC_ex_rand:
 		v2 := sys.bcStack.Pop()
 		be.random(sys.bcStack.Top(), v2)
+	case OC_ex_random:
+		sys.bcStack.PushI(Rand(0, 999))
 	case OC_ex_ratiolevel:
 		sys.bcStack.PushI(c.ocd().ratioLevel)
 	case OC_ex_receiveddamage:
@@ -1980,15 +1939,40 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(c.receivedHits)
 	case OC_ex_redlife:
 		sys.bcStack.PushI(c.redLife)
+	case OC_ex_reversaldefattr:
+		sys.bcStack.PushB(c.reversalDefAttr(*(*int32)(unsafe.Pointer(&be[*i]))))
+		*i += 4
+	case OC_ex_rightedge:
+		sys.bcStack.PushF(c.rightEdge())
+	case OC_ex_rootdist_x:
+		sys.bcStack.Push(c.rdDistX(c.root(), oc))
+	case OC_ex_rootdist_y:
+		sys.bcStack.Push(c.rdDistY(c.root(), oc))
 	case OC_ex_round:
 		v2 := sys.bcStack.Pop()
 		be.round(sys.bcStack.Top(), v2)
+	case OC_ex_roundno:
+		sys.bcStack.PushI(sys.round)
+	case OC_ex_roundsexisted:
+		sys.bcStack.PushI(c.roundsExisted())
+	case OC_ex_roundstate:
+		sys.bcStack.PushI(c.roundState())
 	case OC_ex_roundtype:
 		sys.bcStack.PushI(c.roundType())
 	case OC_ex_score:
 		sys.bcStack.PushF(c.score())
 	case OC_ex_scoretotal:
 		sys.bcStack.PushF(c.scoreTotal())
+	case OC_ex_screenheight:
+		sys.bcStack.PushF(c.screenHeight())
+	case OC_ex_screenpos_x:
+		sys.bcStack.PushF((c.screenPosX()) / oc.localscl)
+	case OC_ex_screenpos_y:
+		sys.bcStack.PushF((c.screenPosY()) / oc.localscl)
+	case OC_ex_screenwidth:
+		sys.bcStack.PushF(c.screenWidth())
+	case OC_ex_selfanimexist:
+		*sys.bcStack.Top() = c.selfAnimExist(*sys.bcStack.Top())
 	case OC_ex_selfstatenoexist:
 		*sys.bcStack.Top() = c.selfStatenoExist(*sys.bcStack.Top())
 	case OC_ex_sprpriority:
@@ -2001,39 +1985,56 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(sys.stage.stageTime)
 	case OC_ex_standby:
 		sys.bcStack.PushB(c.scf(SCF_standby))
+	case OC_ex_stateno:
+		sys.bcStack.PushI(c.ss.no)
+	case OC_ex_statetype:
+		sys.bcStack.PushB(c.ss.stateType == StateType(be[*i]))
+		*i++
 	case OC_ex_teamleader:
 		sys.bcStack.PushI(int32(c.teamLeader()))
+	case OC_ex_teammode:
+		if c.teamside == -1 {
+			sys.bcStack.PushB(TM_Single == TeamMode(be[*i]))
+		} else {
+			sys.bcStack.PushB(sys.tmode[c.playerNo&1] == TeamMode(be[*i]))
+		}
+		*i++
+	case OC_ex_teamside:
+		sys.bcStack.PushI(int32(c.teamside) + 1)
 	case OC_ex_teamsize:
 		sys.bcStack.PushI(c.teamSize())
+	case OC_ex_tickspersecond:
+		sys.bcStack.PushI(int32(FPS))
+	case OC_ex_time:
+		sys.bcStack.PushI(c.time())
 	case OC_ex_timeelapsed:
 		sys.bcStack.PushI(timeElapsed())
 	case OC_ex_timeremaining:
 		sys.bcStack.PushI(timeRemaining())
 	case OC_ex_timetotal:
 		sys.bcStack.PushI(timeTotal())
-	case OC_ex_pos_z:
-		sys.bcStack.PushF(c.pos[2] * (c.localscl / oc.localscl))
+	case OC_ex_topedge:
+		sys.bcStack.PushF(c.topEdge())
+	case OC_ex_uniqhitcount:
+		sys.bcStack.PushI(c.uniqHitCount)
+	case OC_ex_vel_x:
+		sys.bcStack.PushF(c.vel[0] * (c.localscl / oc.localscl))
+	case OC_ex_vel_y:
+		sys.bcStack.PushF(c.vel[1] * (c.localscl / oc.localscl))
 	case OC_ex_vel_z:
 		sys.bcStack.PushF(c.vel[2] * (c.localscl / oc.localscl))
-	case OC_ex_jugglepoints:
-		sys.bcStack.PushI(c.juggle)
-	case OC_ex_prevanim:
-		sys.bcStack.PushI(c.prevAnimNo)
-	case OC_ex_reversaldefattr:
-		sys.bcStack.PushB(c.reversalDefAttr(*(*int32)(unsafe.Pointer(&be[*i]))))
-		*i += 4
-	case OC_ex_bgmlength:
-		if sys.bgm.streamer == nil {
-			sys.bcStack.PushI(0)
-		} else {
-			sys.bcStack.PushI(int32(sys.bgm.streamer.Len()))
-		}
-	case OC_ex_bgmposition:
-		if sys.bgm.streamer == nil {
-			sys.bcStack.PushI(0)
-		} else {
-			sys.bcStack.PushI(int32(sys.bgm.streamer.Position()))
-		}
+	case OC_ex_win:
+		sys.bcStack.PushB(c.win())
+	case OC_ex_winhyper:
+		sys.bcStack.PushB(c.winType(WT_H))
+	case OC_ex_winko:
+		sys.bcStack.PushB(c.winKO())
+	case OC_ex_winperfect:
+		sys.bcStack.PushB(c.winPerfect())
+	case OC_ex_winspecial:
+		sys.bcStack.PushB(c.winType(WT_S))
+	case OC_ex_wintime:
+		sys.bcStack.PushB(c.winTime())
 	default:
 		sys.errLog.Printf("%v\n", be[*i-1])
 		c.panic()

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1162,14 +1162,14 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 	case "":
 		return bvNone(), Error("Nothing assigned")
 	// redirections
-	case "root", "player", "parent", "helper", "target", "partner",
+	case "player", "root", "parent", "helper", "target", "partner",
 		"enemy", "enemynear", "playerid", "p2":
 		switch c.token {
-		case "parent":
-			opc = OC_parent
-			c.token = c.tokenizer(in)
 		case "root":
 			opc = OC_root
+			c.token = c.tokenizer(in)
+		case "parent":
+			opc = OC_parent
 			c.token = c.tokenizer(in)
 		case "p2":
 			opc = OC_p2
@@ -1943,100 +1943,100 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "fall.envshake.dir":
 			bv.SetI(0)
 		default:
-			out.append(OC_ex_)
+			out.append(OC_gethitvar_)
 			switch c.token {
 			// mugen gethitvar
 			case "animtype":
-				out.append(OC_ex_gethitvar_animtype)
+				out.append(OC_gethitvar_animtype)
 			case "air.animtype":
-				out.append(OC_ex_gethitvar_air_animtype)
+				out.append(OC_gethitvar_air_animtype)
 			case "ground.animtype":
-				out.append(OC_ex_gethitvar_ground_animtype)
+				out.append(OC_gethitvar_ground_animtype)
 			case "fall.animtype":
-				out.append(OC_ex_gethitvar_fall_animtype)
+				out.append(OC_gethitvar_fall_animtype)
 			case "airtype":
-				out.append(OC_ex_gethitvar_airtype)
+				out.append(OC_gethitvar_airtype)
 			case "groundtype":
-				out.append(OC_ex_gethitvar_groundtype)
+				out.append(OC_gethitvar_groundtype)
 			case "damage":
-				out.append(OC_ex_gethitvar_damage)
+				out.append(OC_gethitvar_damage)
 			case "hitcount":
-				out.append(OC_ex_gethitvar_hitcount)
+				out.append(OC_gethitvar_hitcount)
 			case "fallcount":
-				out.append(OC_ex_gethitvar_fallcount)
+				out.append(OC_gethitvar_fallcount)
 			case "hitshaketime":
-				out.append(OC_ex_gethitvar_hitshaketime)
+				out.append(OC_gethitvar_hitshaketime)
 			case "hittime":
-				out.append(OC_ex_gethitvar_hittime)
+				out.append(OC_gethitvar_hittime)
 			case "slidetime":
-				out.append(OC_ex_gethitvar_slidetime)
+				out.append(OC_gethitvar_slidetime)
 			case "ctrltime":
-				out.append(OC_ex_gethitvar_ctrltime)
+				out.append(OC_gethitvar_ctrltime)
 			case "recovertime":
-				out.append(OC_ex_gethitvar_recovertime)
+				out.append(OC_gethitvar_recovertime)
 			case "xoff":
-				out.append(OC_ex_gethitvar_xoff)
+				out.append(OC_gethitvar_xoff)
 			case "yoff":
-				out.append(OC_ex_gethitvar_yoff)
+				out.append(OC_gethitvar_yoff)
 			case "xvel":
-				out.append(OC_ex_gethitvar_xvel)
+				out.append(OC_gethitvar_xvel)
 			case "yvel":
-				out.append(OC_ex_gethitvar_yvel)
+				out.append(OC_gethitvar_yvel)
 			case "yaccel":
-				out.append(OC_ex_gethitvar_yaccel)
+				out.append(OC_gethitvar_yaccel)
 			case "hitid", "chainid":
-				out.append(OC_ex_gethitvar_chainid)
+				out.append(OC_gethitvar_chainid)
 			case "guarded":
-				out.append(OC_ex_gethitvar_guarded)
+				out.append(OC_gethitvar_guarded)
 			case "isbound":
-				out.append(OC_ex_gethitvar_isbound)
+				out.append(OC_gethitvar_isbound)
 			case "fall":
-				out.append(OC_ex_gethitvar_fall)
+				out.append(OC_gethitvar_fall)
 			case "fall.damage":
-				out.append(OC_ex_gethitvar_fall_damage)
+				out.append(OC_gethitvar_fall_damage)
 			case "fall.xvel":
-				out.append(OC_ex_gethitvar_fall_xvel)
+				out.append(OC_gethitvar_fall_xvel)
 			case "fall.yvel":
-				out.append(OC_ex_gethitvar_fall_yvel)
+				out.append(OC_gethitvar_fall_yvel)
 			case "fall.recover":
-				out.append(OC_ex_gethitvar_fall_recover)
+				out.append(OC_gethitvar_fall_recover)
 			case "fall.time":
-				out.append(OC_ex_gethitvar_fall_time)
+				out.append(OC_gethitvar_fall_time)
 			case "fall.recovertime":
-				out.append(OC_ex_gethitvar_fall_recovertime)
+				out.append(OC_gethitvar_fall_recovertime)
 			case "fall.kill":
-				out.append(OC_ex_gethitvar_fall_kill)
+				out.append(OC_gethitvar_fall_kill)
 			case "fall.envshake.time":
-				out.append(OC_ex_gethitvar_fall_envshake_time)
+				out.append(OC_gethitvar_fall_envshake_time)
 			case "fall.envshake.freq":
-				out.append(OC_ex_gethitvar_fall_envshake_freq)
+				out.append(OC_gethitvar_fall_envshake_freq)
 			case "fall.envshake.ampl":
-				out.append(OC_ex_gethitvar_fall_envshake_ampl)
+				out.append(OC_gethitvar_fall_envshake_ampl)
 			case "fall.envshake.phase":
-				out.append(OC_ex_gethitvar_fall_envshake_phase)
+				out.append(OC_gethitvar_fall_envshake_phase)
 			// expanded gethitvar
 			case "attr":
-				out.append(OC_ex_gethitvar_attr)
+				out.append(OC_gethitvar_attr)
 			case "dizzypoints":
-				out.append(OC_ex_gethitvar_dizzypoints)
+				out.append(OC_gethitvar_dizzypoints)
 			case "guarddamage":
-				out.append(OC_ex_gethitvar_guarddamage)
+				out.append(OC_gethitvar_guarddamage)
 			case "guardpoints":
-				out.append(OC_ex_gethitvar_guardpoints)
+				out.append(OC_gethitvar_guardpoints)
 			case "guardpower":
-				out.append(OC_ex_gethitvar_guardpower)
+				out.append(OC_gethitvar_guardpower)
 			case "hitdamage":
-				out.append(OC_ex_gethitvar_hitdamage)
+				out.append(OC_gethitvar_hitdamage)
 			case "hitpower":
-				out.append(OC_ex_gethitvar_hitpower)
+				out.append(OC_gethitvar_hitpower)
 			case "id":
-				out.append(OC_ex_gethitvar_id)
+				out.append(OC_gethitvar_id)
 			case "playerno":
-				out.append(OC_ex_gethitvar_playerno)
+				out.append(OC_gethitvar_playerno)
 			case "redlife":
-				out.append(OC_ex_gethitvar_redlife)
+				out.append(OC_gethitvar_redlife)
 			case "score":
-				out.append(OC_ex_gethitvar_score)
+				out.append(OC_gethitvar_score)
 			default:
 				return bvNone(), Error("Invalid data: " + c.token)
 			}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -170,8 +170,7 @@ func newCompiler() *Compiler {
 }
 
 var triggerMap = map[string]int{
-	//redirections
-	"player":    0,
+	// mugen redirections
 	"parent":    0,
 	"root":      0,
 	"helper":    0,
@@ -180,10 +179,32 @@ var triggerMap = map[string]int{
 	"enemy":     0,
 	"enemynear": 0,
 	"playerid":  0,
-	"p2":        0,
-	//vanilla triggers
-	"abs":               1,
-	"acos":              1,
+	// expanded redirections
+	"player": 0,
+	"p2":     0,	
+	// mugen math
+	"abs":    1,
+	"acos":   1,
+	"asin":   1,
+	"atan":   1,
+	"ceil":   1,
+	"cond":   1,
+	"cos":    1,
+	"e":      1,
+	"exp":    1,
+	"floor":  1,
+	"ifelse": 1,
+	"ln":     1,
+	"log":    1,
+	"pi":     1,
+	"sin":    1,
+	"tan":    1,
+	// expanded math
+	"float": 1,
+	"max":   1,
+	"min":   1,
+	"round": 1,
+	// mugen triggers
 	"ailevel":           1,
 	"alive":             1,
 	"anim":              1,
@@ -192,8 +213,6 @@ var triggerMap = map[string]int{
 	"animelemtime":      1,
 	"animexist":         1,
 	"animtime":          1,
-	"asin":              1,
-	"atan":              1,
 	"authorname":        1,
 	"backedge":          1,
 	"backedgebodydist":  1,
@@ -202,20 +221,14 @@ var triggerMap = map[string]int{
 	"camerapos":         1,
 	"camerazoom":        1,
 	"canrecover":        1,
-	"ceil":              1,
 	"command":           1,
-	"cond":              1,
 	"const":             1,
 	"const240p":         1,
 	"const480p":         1,
 	"const720p":         1,
-	"cos":               1,
 	"ctrl":              1,
 	"drawgame":          1,
-	"e":                 1,
-	"exp":               1,
 	"facing":            1,
-	"floor":             1,
 	"frontedge":         1,
 	"frontedgebodydist": 1,
 	"frontedgedist":     1,
@@ -233,7 +246,6 @@ var triggerMap = map[string]int{
 	"hitshakeover":      1,
 	"hitvel":            1,
 	"id":                1,
-	"ifelse":            1,
 	"inguarddist":       1,
 	"ishelper":          1,
 	"ishometeam":        1,
@@ -241,9 +253,9 @@ var triggerMap = map[string]int{
 	"leftedge":          1,
 	"life":              1,
 	"lifemax":           1,
-	"ln":                1,
-	"log":               1,
 	"lose":              1,
+	"loseko":            1,
+	"losetime":          1,
 	"matchno":           1,
 	"matchover":         1,
 	"movecontact":       1,
@@ -271,7 +283,6 @@ var triggerMap = map[string]int{
 	"p4name":            1,
 	"palno":             1,
 	"parentdist":        1,
-	"pi":                1,
 	"pos":               1,
 	"power":             1,
 	"powermax":          1,
@@ -294,13 +305,11 @@ var triggerMap = map[string]int{
 	"screenheight":      1,
 	"screenwidth":       1,
 	"selfanimexist":     1,
-	"sin":               1,
 	"stateno":           1,
 	"statetype":         1,
 	"stagevar":          1,
 	"sysfvar":           1,
 	"sysvar":            1,
-	"tan":               1,
 	"teammode":          1,
 	"teamside":          1,
 	"tickspersecond":    1,
@@ -311,7 +320,11 @@ var triggerMap = map[string]int{
 	"var":               1,
 	"vel":               1,
 	"win":               1,
-	//new triggers
+	"winko":             1,
+	"wintime":           1,
+	"winperfect":        1,
+	// expanded triggers
+	"ailevelf":         1,
 	"animelemlength":   1,
 	"animlength":       1,
 	"attack":           1,
@@ -324,11 +337,13 @@ var triggerMap = map[string]int{
 	"dizzy":            1,
 	"dizzypoints":      1,
 	"dizzypointsmax":   1,
+	"drawpalno":        1,
 	"fighttime":        1,
 	"firstattack":      1,
 	"framespercount":   1,
 	"gamemode":         1,
 	"getplayerid":      1,
+	"groundangle":      1,
 	"guardbreak":       1,
 	"guardpoints":      1,
 	"guardpointsmax":   1,
@@ -350,6 +365,7 @@ var triggerMap = map[string]int{
 	"playerno":         1,
 	"prevanim":         1,
 	"ratiolevel":       1,
+	"rand":             1,
 	"receivedhits":     1,
 	"receiveddamage":   1,
 	"redlife":          1,
@@ -369,6 +385,8 @@ var triggerMap = map[string]int{
 	"timeelapsed":      1,
 	"timeremaining":    1,
 	"timetotal":        1,
+	"winhyper":         1,
+	"winspecial":       1,
 }
 
 func (c *Compiler) tokenizer(in *string) string {
@@ -1143,6 +1161,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 	switch c.token {
 	case "":
 		return bvNone(), Error("Nothing assigned")
+	// redirections
 	case "root", "player", "parent", "helper", "target", "partner",
 		"enemy", "enemynear", "playerid", "p2":
 		switch c.token {
@@ -1211,6 +1230,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.appendI32Op(opc, int32(len(be2)))
 		out.append(be2...)
 		return bvNone(), nil
+	// syntax
 	case "-":
 		if len(*in) > 0 && (((*in)[0] >= '0' && (*in)[0] <= '9') ||
 			(*in)[0] == '.') {
@@ -1279,6 +1299,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		if err := c.kakkotojiru(); err != nil {
 			return bvNone(), err
 		}
+	// variables
 	case "var":
 		return bvNone(), _var(false, false)
 	case "fvar":
@@ -1287,6 +1308,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		return bvNone(), _var(true, false)
 	case "sysfvar":
 		return bvNone(), _var(true, true)
+	// math triggers
 	case "ifelse", "cond":
 		cond := c.token == "cond"
 		if err := c.kakkohiraku(in); err != nil {
@@ -1354,59 +1376,270 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				bv = bv3
 			}
 		}
+	case "pi":
+		bv = BytecodeFloat(float32(math.Pi))
+	case "e":
+		bv = BytecodeFloat(float32(math.E))
+	case "abs":
+		if bv, err = c.mathFunc(out, in, rd, OC_abs, out.abs); err != nil {
+			return bvNone(), err
+		}
+	case "exp":
+		if bv, err = c.mathFunc(out, in, rd, OC_exp, out.exp); err != nil {
+			return bvNone(), err
+		}
+	case "ln":
+		if bv, err = c.mathFunc(out, in, rd, OC_ln, out.ln); err != nil {
+			return bvNone(), err
+		}
+	case "log":
+		if err := c.kakkohiraku(in); err != nil {
+			return bvNone(), err
+		}
+		if bv1, err = c.expBoolOr(&be1, in); err != nil {
+			return bvNone(), err
+		}
+		if c.token != "," {
+			return bvNone(), Error("Missing ','")
+		}
+		c.token = c.tokenizer(in)
+		if bv2, err = c.expBoolOr(&be2, in); err != nil {
+			return bvNone(), err
+		}
+		if err := c.kakkotojiru(); err != nil {
+			return bvNone(), err
+		}
+		if bv1.IsNone() || bv2.IsNone() {
+			if rd {
+				out.append(OC_rdreset)
+			}
+			out.append(be1...)
+			out.appendValue(bv1)
+			out.append(be2...)
+			out.appendValue(bv2)
+			out.append(OC_log)
+		} else {
+			out.log(&bv1, bv2)
+			bv = bv1
+		}
+	case "cos":
+		if bv, err = c.mathFunc(out, in, rd, OC_cos, out.cos); err != nil {
+			return bvNone(), err
+		}
+	case "sin":
+		if bv, err = c.mathFunc(out, in, rd, OC_sin, out.sin); err != nil {
+			return bvNone(), err
+		}
+	case "tan":
+		if bv, err = c.mathFunc(out, in, rd, OC_tan, out.tan); err != nil {
+			return bvNone(), err
+		}
+	case "acos":
+		if bv, err = c.mathFunc(out, in, rd, OC_acos, out.acos); err != nil {
+			return bvNone(), err
+		}
+	case "asin":
+		if bv, err = c.mathFunc(out, in, rd, OC_asin, out.asin); err != nil {
+			return bvNone(), err
+		}
+	case "atan":
+		if bv, err = c.mathFunc(out, in, rd, OC_atan, out.atan); err != nil {
+			return bvNone(), err
+		}
+	case "floor":
+		if bv, err = c.mathFunc(out, in, rd, OC_floor, out.floor); err != nil {
+			return bvNone(), err
+		}
+	case "ceil":
+		if bv, err = c.mathFunc(out, in, rd, OC_ceil, out.ceil); err != nil {
+			return bvNone(), err
+		}
+	case "float":
+		if _, err := c.oneArg(out, in, rd, true); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_ex_, OC_ex_float)
+	case "max":
+		if err := c.kakkohiraku(in); err != nil {
+			return bvNone(), err
+		}
+		if bv1, err = c.expBoolOr(&be1, in); err != nil {
+			return bvNone(), err
+		}
+		if c.token != "," {
+			return bvNone(), Error("Missing ','")
+		}
+		c.token = c.tokenizer(in)
+		if bv2, err = c.expBoolOr(&be2, in); err != nil {
+			return bvNone(), err
+		}
+		if err := c.kakkotojiru(); err != nil {
+			return bvNone(), err
+		}
+		if bv1.IsNone() || bv2.IsNone() {
+			if rd {
+				out.append(OC_rdreset)
+			}
+			out.append(be1...)
+			out.appendValue(bv1)
+			out.append(be2...)
+			out.appendValue(bv2)
+			out.append(OC_ex_, OC_ex_max)
+		} else {
+			out.max(&bv1, bv2)
+			bv = bv1
+		}
+	case "min":
+		if err := c.kakkohiraku(in); err != nil {
+			return bvNone(), err
+		}
+		if bv1, err = c.expBoolOr(&be1, in); err != nil {
+			return bvNone(), err
+		}
+		if c.token != "," {
+			return bvNone(), Error("Missing ','")
+		}
+		c.token = c.tokenizer(in)
+		if bv2, err = c.expBoolOr(&be2, in); err != nil {
+			return bvNone(), err
+		}
+		if err := c.kakkotojiru(); err != nil {
+			return bvNone(), err
+		}
+		if bv1.IsNone() || bv2.IsNone() {
+			if rd {
+				out.append(OC_rdreset)
+			}
+			out.append(be1...)
+			out.appendValue(bv1)
+			out.append(be2...)
+			out.appendValue(bv2)
+			out.append(OC_ex_, OC_ex_min)
+		} else {
+			out.min(&bv1, bv2)
+			bv = bv1
+		}
+	case "round":
+		if err := c.kakkohiraku(in); err != nil {
+			return bvNone(), err
+		}
+		if bv1, err = c.expBoolOr(&be1, in); err != nil {
+			return bvNone(), err
+		}
+		if c.token != "," {
+			return bvNone(), Error("Missing ','")
+		}
+		c.token = c.tokenizer(in)
+		if bv2, err = c.expBoolOr(&be2, in); err != nil {
+			return bvNone(), err
+		}
+		if err := c.kakkotojiru(); err != nil {
+			return bvNone(), err
+		}
+		if bv1.IsNone() || bv2.IsNone() {
+			if rd {
+				out.append(OC_rdreset)
+			}
+			out.append(be1...)
+			out.appendValue(bv1)
+			out.append(be2...)
+			out.appendValue(bv2)
+			out.append(OC_ex_, OC_ex_round)
+		} else {
+			out.round(&bv1, bv2)
+			bv = bv1
+		}
+	// triggers
 	case "ailevel":
-		out.append(OC_ailevel)
+		out.append(OC_ex_, OC_ex_ailevel)
+	case "ailevelf":
+		out.append(OC_ex_, OC_ex_ailevelf)
 	case "alive":
-		out.append(OC_alive)
+		out.append(OC_ex_, OC_ex_alive)
 	case "anim":
-		out.append(OC_anim)
+		out.append(OC_ex_, OC_ex_anim)
+	case "animelem":
+		if not, err := c.kyuushiki(in); err != nil {
+			return bvNone(), err
+		} else if not && !sys.ignoreMostErrors {
+			return bvNone(), Error("animelem doesn't support '!='")
+		}
+		if c.token == "-" {
+			return bvNone(), Error("'-' should not be used")
+		}
+		if n, err = c.integer2(in); err != nil {
+			return bvNone(), err
+		}
+		if n <= 0 {
+			return bvNone(), Error("animelem must be greater than 0")
+		}
+		be1.appendValue(BytecodeInt(n))
+		if rd {
+			out.appendI32Op(OC_nordrun, int32(len(be1)))
+		}
+		out.append(be1...)
+		out.append(OC_ex_, OC_ex_animelemtime)
+		if err = c.kyuushikiSuperDX(&be, in, false); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_jsf8, OpCode(len(be)))
+		out.append(be...)
+		return bv, nil
+	case "animelemlength":
+		out.append(OC_ex_, OC_ex_animelemlength)
 	case "animelemno":
 		if _, err := c.oneArg(out, in, rd, true); err != nil {
 			return bvNone(), err
 		}
-		out.append(OC_animelemno)
+		out.append(OC_ex_, OC_ex_animelemno)
 	case "animelemtime":
 		if _, err := c.oneArg(out, in, rd, true); err != nil {
 			return bvNone(), err
 		}
-		out.append(OC_animelemtime)
+		out.append(OC_ex_, OC_ex_animelemtime)
 	case "animexist":
 		if _, err := c.oneArg(out, in, rd, true); err != nil {
 			return bvNone(), err
 		}
-		out.append(OC_animexist)
+		out.append(OC_ex_, OC_ex_animexist)
+	case "animlength":
+		out.append(OC_ex_, OC_ex_animlength)
 	case "animtime":
-		out.append(OC_animtime)
+		out.append(OC_ex_, OC_ex_animtime)
+	case "attack":
+		out.append(OC_ex_, OC_ex_attack)
 	case "authorname":
 		if err := nameSub(OC_const_authorname); err != nil {
 			return bvNone(), err
 		}
 	case "backedge":
-		out.append(OC_backedge)
+		out.append(OC_ex_, OC_ex_backedge)
 	case "backedgebodydist":
-		out.append(OC_backedgebodydist)
+		out.append(OC_ex_, OC_ex_backedgebodydist)
 	case "backedgedist":
-		out.append(OC_backedgedist)
+		out.append(OC_ex_, OC_ex_backedgedist)
 	case "bgmlength":
 		out.append(OC_ex_, OC_ex_bgmlength)
 	case "bgmposition":
 		out.append(OC_ex_, OC_ex_bgmposition)
 	case "bottomedge":
-		out.append(OC_bottomedge)
+		out.append(OC_ex_, OC_ex_bottomedge)
 	case "camerapos":
 		c.token = c.tokenizer(in)
 		switch c.token {
 		case "x":
-			out.append(OC_camerapos_x)
+			out.append(OC_ex_, OC_ex_camerapos_x)
 		case "y":
-			out.append(OC_camerapos_y)
+			out.append(OC_ex_, OC_ex_camerapos_y)
 		default:
 			return bvNone(), Error("Invalid data: " + c.token)
 		}
 	case "camerazoom":
-		out.append(OC_camerazoom)
+		out.append(OC_ex_, OC_ex_camerazoom)
 	case "canrecover":
-		out.append(OC_canrecover)
+		out.append(OC_ex_, OC_ex_canrecover)
+	case "combocount":
+		out.append(OC_ex_, OC_ex_combocount)
 	case "command":
 		if err := eqne(func() error {
 			if err := text(); err != nil {
@@ -1417,11 +1650,14 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				return Error("Command doesn't exist: " + c.token)
 			}
 			i := sys.stringPool[c.playerNo].Add(c.token)
-			out.appendI32Op(OC_command, int32(i))
+			out.append(OC_ex_)
+			out.appendI32Op(OC_ex_command, int32(i))
 			return nil
 		}); err != nil {
 			return bvNone(), err
 		}
+	case "consecutivewins":
+		out.append(OC_ex_, OC_ex_consecutivewins)
 	case "const":
 		if err := c.kakkohiraku(in); err != nil {
 			return bvNone(), err
@@ -1654,23 +1890,43 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		}
 		out.append(OC_ex_, OC_ex_const720p)
 	case "ctrl":
-		out.append(OC_ctrl)
+		out.append(OC_ex_, OC_ex_ctrl)
+	case "defence":
+		out.append(OC_ex_, OC_ex_defence)
+	case "dizzy":
+		out.append(OC_ex_, OC_ex_dizzy)
+	case "dizzypoints":
+		out.append(OC_ex_, OC_ex_dizzypoints)
+	case "dizzypointsmax":
+		out.append(OC_ex_, OC_ex_dizzypointsmax)
 	case "drawgame":
 		out.append(OC_ex_, OC_ex_drawgame)
+	case "drawpalno":
+		out.append(OC_ex_, OC_ex_drawpalno)
 	case "facing":
-		out.append(OC_facing)
+		out.append(OC_ex_, OC_ex_facing)
+	case "fighttime":
+		out.append(OC_ex_, OC_ex_fighttime)
+	case "firstattack":
+		out.append(OC_ex_, OC_ex_firstattack)
+	case "framespercount":
+		out.append(OC_ex_, OC_ex_framespercount)
 	case "frontedge":
-		out.append(OC_frontedge)
+		out.append(OC_ex_, OC_ex_frontedge)
 	case "frontedgebodydist":
-		out.append(OC_frontedgebodydist)
+		out.append(OC_ex_, OC_ex_frontedgebodydist)
 	case "frontedgedist":
-		out.append(OC_frontedgedist)
+		out.append(OC_ex_, OC_ex_frontedgedist)
 	case "gameheight":
-		out.append(OC_gameheight)
+		out.append(OC_ex_, OC_ex_gameheight)
+	case "gamemode":
+		if err := nameSubEx(OC_ex_gamemode); err != nil {
+			return bvNone(), err
+		}
 	case "gametime":
-		out.append(OC_gametime)
+		out.append(OC_ex_, OC_ex_gametime)
 	case "gamewidth":
-		out.append(OC_gamewidth)
+		out.append(OC_ex_, OC_ex_gamewidth)
 	case "gethitvar":
 		if err := c.kakkohiraku(in); err != nil {
 			return bvNone(), err
@@ -1689,6 +1945,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		default:
 			out.append(OC_ex_)
 			switch c.token {
+			// mugen gethitvar
 			case "animtype":
 				out.append(OC_ex_gethitvar_animtype)
 			case "air.animtype":
@@ -1757,12 +2014,21 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				out.append(OC_ex_gethitvar_fall_envshake_ampl)
 			case "fall.envshake.phase":
 				out.append(OC_ex_gethitvar_fall_envshake_phase)
+			// expanded gethitvar
 			case "attr":
 				out.append(OC_ex_gethitvar_attr)
 			case "dizzypoints":
 				out.append(OC_ex_gethitvar_dizzypoints)
+			case "guarddamage":
+				out.append(OC_ex_gethitvar_guarddamage)
 			case "guardpoints":
 				out.append(OC_ex_gethitvar_guardpoints)
+			case "guardpower":
+				out.append(OC_ex_gethitvar_guardpower)
+			case "hitdamage":
+				out.append(OC_ex_gethitvar_hitdamage)
+			case "hitpower":
+				out.append(OC_ex_gethitvar_hitpower)
 			case "id":
 				out.append(OC_ex_gethitvar_id)
 			case "playerno":
@@ -1771,14 +2037,6 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				out.append(OC_ex_gethitvar_redlife)
 			case "score":
 				out.append(OC_ex_gethitvar_score)
-			case "hitdamage":
-				out.append(OC_ex_gethitvar_hitdamage)
-			case "guarddamage":
-				out.append(OC_ex_gethitvar_guarddamage)
-			case "hitpower":
-				out.append(OC_ex_gethitvar_hitpower)
-			case "guardpower":
-				out.append(OC_ex_gethitvar_guardpower)
 			default:
 				return bvNone(), Error("Invalid data: " + c.token)
 			}
@@ -1787,14 +2045,32 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		if err := c.kakkotojiru(); err != nil {
 			return bvNone(), err
 		}
+	case "getplayerid":
+		if _, err := c.oneArg(out, in, rd, true); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_ex_, OC_ex_getplayerid)
+	case "groundangle":
+		out.append(OC_ex_, OC_ex_groundangle)
+	case "guardbreak":
+		out.append(OC_ex_, OC_ex_guardbreak)
+	case "guardpoints":
+		out.append(OC_ex_, OC_ex_guardpoints)
+	case "guardpointsmax":
+		out.append(OC_ex_, OC_ex_guardpointsmax)
+	case "helpername":
+		if err := nameSubEx(OC_ex_helpername); err != nil {
+			return bvNone(), err
+		}
 	case "hitcount":
-		out.append(OC_hitcount)
+		out.append(OC_ex_, OC_ex_hitcount)
 	case "hitdefattr":
 		hda := func() error {
 			if attr, err := c.trgAttr(in); err != nil {
 				return err
 			} else {
-				out.appendI32Op(OC_hitdefattr, attr)
+				out.append(OC_ex_)
+				out.appendI32Op(OC_ex_hitdefattr, attr)
 			}
 			return nil
 		}
@@ -1819,763 +2095,35 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 	case "hitfall":
-		out.append(OC_hitfall)
+		out.append(OC_ex_, OC_ex_hitfall)
 	case "hitover":
-		out.append(OC_hitover)
+		out.append(OC_ex_, OC_ex_hitover)
+	case "hitoverridden":
+		out.append(OC_ex_, OC_ex_hitoverridden)
 	case "hitpausetime":
-		out.append(OC_hitpausetime)
+		out.append(OC_ex_, OC_ex_hitpausetime)
 	case "hitshakeover":
-		out.append(OC_hitshakeover)
+		out.append(OC_ex_, OC_ex_hitshakeover)
 	case "hitvel":
 		c.token = c.tokenizer(in)
 		switch c.token {
 		case "x":
-			out.append(OC_hitvel_x)
+			out.append(OC_ex_, OC_ex_hitvel_x)
 		case "y":
-			out.append(OC_hitvel_y)
+			out.append(OC_ex_, OC_ex_hitvel_y)
 		case "z":
 			bv = BytecodeFloat(0)
 		default:
 			return bvNone(), Error("Invalid data: " + c.token)
 		}
 	case "id":
-		out.append(OC_id)
-	case "inguarddist":
-		out.append(OC_inguarddist)
-	case "ishelper":
-		if _, err := c.oneArg(out, in, rd, true, BytecodeInt(math.MinInt32)); err != nil {
-			return bvNone(), err
-		}
-		out.append(OC_ishelper)
-	case "ishometeam":
-		out.append(OC_ex_, OC_ex_ishometeam)
-	case "leftedge":
-		out.append(OC_leftedge)
-	case "life", "p2life":
-		if c.token == "p2life" {
-			out.appendI32Op(OC_p2, 1)
-		}
-		out.append(OC_life)
-	case "lifemax":
-		out.append(OC_lifemax)
-	case "lose":
-		out.append(OC_ex_, OC_ex_lose)
-	case "loseko":
-		out.append(OC_ex_, OC_ex_loseko)
-	case "losetime":
-		out.append(OC_ex_, OC_ex_losetime)
-	case "matchno":
-		out.append(OC_ex_, OC_ex_matchno)
-	case "matchover":
-		out.append(OC_ex_, OC_ex_matchover)
-	case "movecontact":
-		out.append(OC_movecontact)
-	case "moveguarded":
-		out.append(OC_moveguarded)
-	case "movehit":
-		out.append(OC_movehit)
-	case "movereversed":
-		out.append(OC_movereversed)
-	case "movetype", "p2movetype":
-		trname := c.token
-		if err := eqne2(func(not bool) error {
-			if len(c.token) == 0 {
-				return Error(trname + " value is not specified")
-			}
-			var mt MoveType
-			switch c.token[0] {
-			case 'i':
-				mt = MT_I
-			case 'a':
-				mt = MT_A
-			case 'h':
-				mt = MT_H
-			default:
-				return Error("Invalid value: " + c.token)
-			}
-			if trname == "p2movetype" {
-				out.appendI32Op(OC_p2, 2+Btoi(not))
-			}
-			out.append(OC_movetype, OpCode(mt>>15))
-			if not {
-				out.append(OC_blnot)
-			}
-			return nil
-		}); err != nil {
-			return bvNone(), err
-		}
-	case "name", "p1name", "p2name", "p3name", "p4name", "p5name", "p6name", "p7name", "p8name":
-		opc := OC_const_name
-		switch c.token {
-		case "p2name":
-			opc = OC_const_p2name
-		case "p3name":
-			opc = OC_const_p3name
-		case "p4name":
-			opc = OC_const_p4name
-		case "p5name":
-			opc = OC_const_p5name
-		case "p6name":
-			opc = OC_const_p6name
-		case "p7name":
-			opc = OC_const_p7name
-		case "p8name":
-			opc = OC_const_p8name
-		}
-		if err := nameSub(opc); err != nil {
-			return bvNone(), err
-		}
-	case "numenemy":
-		out.append(OC_numenemy)
-	case "numexplod":
-		if _, err := c.oneArg(out, in, rd, true, BytecodeInt(-1)); err != nil {
-			return bvNone(), err
-		}
-		out.append(OC_numexplod)
-	case "numhelper":
-		if _, err := c.oneArg(out, in, rd, true, BytecodeInt(-1)); err != nil {
-			return bvNone(), err
-		}
-		out.append(OC_numhelper)
-	case "numpartner":
-		out.append(OC_numpartner)
-	case "numproj":
-		out.append(OC_numproj)
-	case "numprojid":
-		if _, err := c.oneArg(out, in, rd, true); err != nil {
-			return bvNone(), err
-		}
-		out.append(OC_numprojid)
-	case "numtarget":
-		if _, err := c.oneArg(out, in, rd, true, BytecodeInt(-1)); err != nil {
-			return bvNone(), err
-		}
-		out.append(OC_numtarget)
-	case "palno":
-		out.append(OC_palno)
-	case "pos":
-		c.token = c.tokenizer(in)
-		switch c.token {
-		case "x":
-			out.append(OC_pos_x)
-		case "y":
-			out.append(OC_pos_y)
-		case "z":
-			out.append(OC_ex_, OC_ex_pos_z)
-		default:
-			return bvNone(), Error("Invalid data: " + c.token)
-		}
-	case "power":
-		out.append(OC_power)
-	case "powermax":
-		out.append(OC_powermax)
-	case "playeridexist":
-		if _, err := c.oneArg(out, in, rd, true); err != nil {
-			return bvNone(), err
-		}
-		out.append(OC_playeridexist)
-	case "prevanim":
-		out.append(OC_ex_, OC_ex_prevanim)
-	case "prevstateno":
-		out.append(OC_prevstateno)
-	case "projcanceltime":
-		if _, err := c.oneArg(out, in, rd, true); err != nil {
-			return bvNone(), err
-		}
-		out.append(OC_projcanceltime)
-	case "projcontacttime":
-		if _, err := c.oneArg(out, in, rd, true); err != nil {
-			return bvNone(), err
-		}
-		out.append(OC_projcontacttime)
-	case "projguardedtime":
-		if _, err := c.oneArg(out, in, rd, true); err != nil {
-			return bvNone(), err
-		}
-		out.append(OC_projguardedtime)
-	case "projhittime":
-		if _, err := c.oneArg(out, in, rd, true); err != nil {
-			return bvNone(), err
-		}
-		out.append(OC_projhittime)
-	case "random":
-		out.append(OC_random)
-
-	case "reversaldefattr":
-		hda := func() error {
-			if attr, err := c.trgAttr(in); err != nil {
-				return err
-			} else {
-				out.append(OC_ex_)
-				out.appendI32Op(OC_ex_reversaldefattr, attr)
-			}
-			return nil
-		}
-		if err := eqne(hda); err != nil {
-			return bvNone(), err
-		}
-	case "rightedge":
-		out.append(OC_rightedge)
-	case "roundno":
-		out.append(OC_ex_, OC_ex_roundno)
-	case "roundsexisted":
-		out.append(OC_ex_, OC_ex_roundsexisted)
-	case "roundstate":
-		out.append(OC_roundstate)
-	case "screenheight":
-		out.append(OC_screenheight)
-	case "screenpos":
-		c.token = c.tokenizer(in)
-		switch c.token {
-		case "x":
-			out.append(OC_screenpos_x)
-		case "y":
-			out.append(OC_screenpos_y)
-		default:
-			return bvNone(), Error("Invalid data: " + c.token)
-		}
-	case "screenwidth":
-		out.append(OC_screenwidth)
-	case "selfanimexist":
-		if _, err := c.oneArg(out, in, rd, true); err != nil {
-			return bvNone(), err
-		}
-		out.append(OC_selfanimexist)
-	case "stateno", "p2stateno":
-		if c.token == "p2stateno" {
-			out.appendI32Op(OC_p2, 1)
-		}
-		out.append(OC_stateno)
-	case "statetype", "p2statetype":
-		trname := c.token
-		if err := eqne2(func(not bool) error {
-			if len(c.token) == 0 {
-				return Error(trname + " value is not specified")
-			}
-			var st StateType
-			switch c.token[0] {
-			case 's':
-				st = ST_S
-			case 'c':
-				st = ST_C
-			case 'a':
-				st = ST_A
-			case 'l':
-				st = ST_L
-			default:
-				return Error("Invalid value: " + c.token)
-			}
-			if trname == "p2statetype" {
-				out.appendI32Op(OC_p2, 2+Btoi(not))
-			}
-			out.append(OC_statetype, OpCode(st))
-			if not {
-				out.append(OC_blnot)
-			}
-			return nil
-		}); err != nil {
-			return bvNone(), err
-		}
-	case "stagevar":
-		if err := c.kakkohiraku(in); err != nil {
-			return bvNone(), err
-		}
-		svname := c.token
-		c.token = c.tokenizer(in)
-		if err := c.kakkotojiru(); err != nil {
-			return bvNone(), err
-		}
-		isStr := false
-		switch svname {
-		case "info.name":
-			opc = OC_const_stagevar_info_name
-			isStr = true
-		case "info.displayname":
-			opc = OC_const_stagevar_info_displayname
-			isStr = true
-		case "info.author":
-			opc = OC_const_stagevar_info_author
-			isStr = true
-		case "camera.boundleft":
-			opc = OC_const_stagevar_camera_boundleft
-		case "camera.boundright":
-			opc = OC_const_stagevar_camera_boundright
-		case "camera.boundhigh":
-			opc = OC_const_stagevar_camera_boundhigh
-		case "camera.boundlow":
-			opc = OC_const_stagevar_camera_boundlow
-		case "camera.verticalfollow":
-			opc = OC_const_stagevar_camera_verticalfollow
-		case "camera.floortension":
-			opc = OC_const_stagevar_camera_floortension
-		case "camera.tensionhigh":
-			opc = OC_const_stagevar_camera_tensionhigh
-		case "camera.tensionlow":
-			opc = OC_const_stagevar_camera_tensionlow
-		case "camera.tension":
-			opc = OC_const_stagevar_camera_tension
-		case "camera.startzoom":
-			opc = OC_const_stagevar_camera_startzoom
-		case "camera.zoomout":
-			opc = OC_const_stagevar_camera_zoomout
-		case "camera.zoomin":
-			opc = OC_const_stagevar_camera_zoomin
-		case "camera.ytension.enable":
-			opc = OC_const_stagevar_camera_ytension_enable
-		case "playerinfo.leftbound":
-			opc = OC_const_stagevar_playerinfo_leftbound
-		case "playerinfo.rightbound":
-			opc = OC_const_stagevar_playerinfo_rightbound
-		case "scaling.topscale":
-			opc = OC_const_stagevar_scaling_topscale
-		case "bound.screenleft":
-			opc = OC_const_stagevar_bound_screenleft
-		case "bound.screenright":
-			opc = OC_const_stagevar_bound_screenright
-		case "stageinfo.zoffset":
-			opc = OC_const_stagevar_stageinfo_zoffset
-		case "stageinfo.zoffsetlink":
-			opc = OC_const_stagevar_stageinfo_zoffsetlink
-		case "stageinfo.xscale":
-			opc = OC_const_stagevar_stageinfo_xscale
-		case "stageinfo.yscale":
-			opc = OC_const_stagevar_stageinfo_yscale
-		case "shadow.intensity":
-			opc = OC_const_stagevar_shadow_intensity
-		case "shadow.color.r":
-			opc = OC_const_stagevar_shadow_color_r
-		case "shadow.color.g":
-			opc = OC_const_stagevar_shadow_color_g
-		case "shadow.color.b":
-			opc = OC_const_stagevar_shadow_color_b
-		case "shadow.yscale":
-			opc = OC_const_stagevar_shadow_yscale
-		case "shadow.fade.range.begin":
-			opc = OC_const_stagevar_shadow_fade_range_begin
-		case "shadow.fade.range.end":
-			opc = OC_const_stagevar_shadow_fade_range_end
-		case "shadow.xshear":
-			opc = OC_const_stagevar_shadow_xshear
-		case "reflection.intensity":
-			opc = OC_const_stagevar_reflection_intensity
-		default:
-			return bvNone(), Error("Invalid data: " + svname)
-		}
-		if isStr {
-			if err := nameSub(opc); err != nil {
-				return bvNone(), err
-			}
-		} else {
-			out.append(OC_const_)
-			out.append(opc)
-		}
-	case "teammode":
-		if err := eqne(func() error {
-			if len(c.token) == 0 {
-				return Error("teammode value is not specified")
-			}
-			var tm TeamMode
-			switch c.token {
-			case "single":
-				tm = TM_Single
-			case "simul":
-				tm = TM_Simul
-			case "turns":
-				tm = TM_Turns
-			case "tag":
-				tm = TM_Tag
-			default:
-				return Error("Invalid value: " + c.token)
-			}
-			out.append(OC_teammode, OpCode(tm))
-			return nil
-		}); err != nil {
-			return bvNone(), err
-		}
-	case "teamside":
-		out.append(OC_teamside)
-	case "tickspersecond":
-		out.append(OC_ex_, OC_ex_tickspersecond)
-	case "time", "statetime":
-		out.append(OC_time)
-	case "topedge":
-		out.append(OC_topedge)
-	case "uniqhitcount":
-		out.append(OC_uniqhitcount)
-	case "vel":
-		c.token = c.tokenizer(in)
-		switch c.token {
-		case "x":
-			out.append(OC_vel_x)
-		case "y":
-			out.append(OC_vel_y)
-		case "z":
-			out.append(OC_ex_, OC_ex_vel_z)
-		default:
-			return bvNone(), Error("Invalid data: " + c.token)
-		}
-	case "win":
-		out.append(OC_ex_, OC_ex_win)
-	case "winko":
-		out.append(OC_ex_, OC_ex_winko)
-	case "wintime":
-		out.append(OC_ex_, OC_ex_wintime)
-	case "winperfect":
-		out.append(OC_ex_, OC_ex_winperfect)
-	case "winspecial":
-		out.append(OC_ex_, OC_ex_winspecial)
-	case "winhyper":
-		out.append(OC_ex_, OC_ex_winhyper)
-	case "animelem":
-		if not, err := c.kyuushiki(in); err != nil {
-			return bvNone(), err
-		} else if not && !sys.ignoreMostErrors {
-			return bvNone(), Error("animelem doesn't support '!='")
-		}
-		if c.token == "-" {
-			return bvNone(), Error("'-' should not be used")
-		}
-		if n, err = c.integer2(in); err != nil {
-			return bvNone(), err
-		}
-		if n <= 0 {
-			return bvNone(), Error("animelem must be greater than 0")
-		}
-		be1.appendValue(BytecodeInt(n))
-		if rd {
-			out.appendI32Op(OC_nordrun, int32(len(be1)))
-		}
-		out.append(be1...)
-		out.append(OC_animelemtime)
-		if err = c.kyuushikiSuperDX(&be, in, false); err != nil {
-			return bvNone(), err
-		}
-		out.append(OC_jsf8, OpCode(len(be)))
-		out.append(be...)
-		return bv, nil
-	case "timemod":
-		if not, err := c.kyuushiki(in); err != nil {
-			return bvNone(), err
-		} else if not && !sys.ignoreMostErrors {
-			return bvNone(), Error("timemod doesn't support '!='")
-		}
-		if c.token == "-" {
-			return bvNone(), Error("'-' should not be used")
-		}
-		if n, err = c.integer2(in); err != nil {
-			return bvNone(), err
-		}
-		if n <= 0 {
-			return bvNone(), Error("timemod must be greater than 0")
-		}
-		out.append(OC_time)
-		out.appendValue(BytecodeInt(n))
-		out.append(OC_mod)
-		if err = c.kyuushikiSuperDX(out, in, true); err != nil {
-			return bvNone(), err
-		}
-		return bv, nil
-	case "p2dist":
-		c.token = c.tokenizer(in)
-		switch c.token {
-		case "x":
-			out.append(OC_ex_, OC_ex_p2dist_x)
-		case "y":
-			out.append(OC_ex_, OC_ex_p2dist_y)
-		case "z":
-			bv = BytecodeFloat(0)
-		default:
-			return bvNone(), Error("Invalid data: " + c.token)
-		}
-	case "p2bodydist":
-		c.token = c.tokenizer(in)
-		switch c.token {
-		case "x":
-			out.append(OC_ex_, OC_ex_p2bodydist_x)
-		case "y":
-			out.append(OC_ex_, OC_ex_p2dist_y)
-		case "z":
-			bv = BytecodeFloat(0)
-		default:
-			return bvNone(), Error("Invalid data: " + c.token)
-		}
-	case "rootdist":
-		c.token = c.tokenizer(in)
-		switch c.token {
-		case "x":
-			out.append(OC_ex_, OC_ex_rootdist_x)
-		case "y":
-			out.append(OC_ex_, OC_ex_rootdist_y)
-		case "z":
-			bv = BytecodeFloat(0)
-		default:
-			return bvNone(), Error("Invalid data: " + c.token)
-		}
-	case "parentdist":
-		c.token = c.tokenizer(in)
-		switch c.token {
-		case "x":
-			out.append(OC_ex_, OC_ex_parentdist_x)
-		case "y":
-			out.append(OC_ex_, OC_ex_parentdist_y)
-		case "z":
-			bv = BytecodeFloat(0)
-		default:
-			return bvNone(), Error("Invalid data: " + c.token)
-		}
-	case "pi":
-		bv = BytecodeFloat(float32(math.Pi))
-	case "e":
-		bv = BytecodeFloat(float32(math.E))
-	case "abs":
-		if bv, err = c.mathFunc(out, in, rd, OC_abs, out.abs); err != nil {
-			return bvNone(), err
-		}
-	case "exp":
-		if bv, err = c.mathFunc(out, in, rd, OC_exp, out.exp); err != nil {
-			return bvNone(), err
-		}
-	case "ln":
-		if bv, err = c.mathFunc(out, in, rd, OC_ln, out.ln); err != nil {
-			return bvNone(), err
-		}
-	case "log":
-		if err := c.kakkohiraku(in); err != nil {
-			return bvNone(), err
-		}
-		if bv1, err = c.expBoolOr(&be1, in); err != nil {
-			return bvNone(), err
-		}
-		if c.token != "," {
-			return bvNone(), Error("Missing ','")
-		}
-		c.token = c.tokenizer(in)
-		if bv2, err = c.expBoolOr(&be2, in); err != nil {
-			return bvNone(), err
-		}
-		if err := c.kakkotojiru(); err != nil {
-			return bvNone(), err
-		}
-		if bv1.IsNone() || bv2.IsNone() {
-			if rd {
-				out.append(OC_rdreset)
-			}
-			out.append(be1...)
-			out.appendValue(bv1)
-			out.append(be2...)
-			out.appendValue(bv2)
-			out.append(OC_log)
-		} else {
-			out.log(&bv1, bv2)
-			bv = bv1
-		}
-	case "cos":
-		if bv, err = c.mathFunc(out, in, rd, OC_cos, out.cos); err != nil {
-			return bvNone(), err
-		}
-	case "sin":
-		if bv, err = c.mathFunc(out, in, rd, OC_sin, out.sin); err != nil {
-			return bvNone(), err
-		}
-	case "tan":
-		if bv, err = c.mathFunc(out, in, rd, OC_tan, out.tan); err != nil {
-			return bvNone(), err
-		}
-	case "acos":
-		if bv, err = c.mathFunc(out, in, rd, OC_acos, out.acos); err != nil {
-			return bvNone(), err
-		}
-	case "asin":
-		if bv, err = c.mathFunc(out, in, rd, OC_asin, out.asin); err != nil {
-			return bvNone(), err
-		}
-	case "atan":
-		if bv, err = c.mathFunc(out, in, rd, OC_atan, out.atan); err != nil {
-			return bvNone(), err
-		}
-	case "floor":
-		if bv, err = c.mathFunc(out, in, rd, OC_floor, out.floor); err != nil {
-			return bvNone(), err
-		}
-	case "ceil":
-		if bv, err = c.mathFunc(out, in, rd, OC_ceil, out.ceil); err != nil {
-			return bvNone(), err
-		}
-	case "float":
-		if _, err := c.oneArg(out, in, rd, true); err != nil {
-			return bvNone(), err
-		}
-		out.append(OC_ex_, OC_ex_float)
-	case "max":
-		if err := c.kakkohiraku(in); err != nil {
-			return bvNone(), err
-		}
-		if bv1, err = c.expBoolOr(&be1, in); err != nil {
-			return bvNone(), err
-		}
-		if c.token != "," {
-			return bvNone(), Error("Missing ','")
-		}
-		c.token = c.tokenizer(in)
-		if bv2, err = c.expBoolOr(&be2, in); err != nil {
-			return bvNone(), err
-		}
-		if err := c.kakkotojiru(); err != nil {
-			return bvNone(), err
-		}
-		if bv1.IsNone() || bv2.IsNone() {
-			if rd {
-				out.append(OC_rdreset)
-			}
-			out.append(be1...)
-			out.appendValue(bv1)
-			out.append(be2...)
-			out.appendValue(bv2)
-			out.append(OC_ex_, OC_ex_max)
-		} else {
-			out.max(&bv1, bv2)
-			bv = bv1
-		}
-	case "min":
-		if err := c.kakkohiraku(in); err != nil {
-			return bvNone(), err
-		}
-		if bv1, err = c.expBoolOr(&be1, in); err != nil {
-			return bvNone(), err
-		}
-		if c.token != "," {
-			return bvNone(), Error("Missing ','")
-		}
-		c.token = c.tokenizer(in)
-		if bv2, err = c.expBoolOr(&be2, in); err != nil {
-			return bvNone(), err
-		}
-		if err := c.kakkotojiru(); err != nil {
-			return bvNone(), err
-		}
-		if bv1.IsNone() || bv2.IsNone() {
-			if rd {
-				out.append(OC_rdreset)
-			}
-			out.append(be1...)
-			out.appendValue(bv1)
-			out.append(be2...)
-			out.appendValue(bv2)
-			out.append(OC_ex_, OC_ex_min)
-		} else {
-			out.min(&bv1, bv2)
-			bv = bv1
-		}
-	case "rand":
-		if err := c.kakkohiraku(in); err != nil {
-			return bvNone(), err
-		}
-		if bv1, err = c.expBoolOr(&be1, in); err != nil {
-			return bvNone(), err
-		}
-		if c.token != "," {
-			return bvNone(), Error("Missing ','")
-		}
-		c.token = c.tokenizer(in)
-		if bv2, err = c.expBoolOr(&be2, in); err != nil {
-			return bvNone(), err
-		}
-		if err := c.kakkotojiru(); err != nil {
-			return bvNone(), err
-		}
-		if rd {
-			out.append(OC_rdreset)
-		}
-		out.append(be1...)
-		out.appendValue(bv1)
-		out.append(be2...)
-		out.appendValue(bv2)
-		out.append(OC_ex_, OC_ex_rand)
-	case "round":
-		if err := c.kakkohiraku(in); err != nil {
-			return bvNone(), err
-		}
-		if bv1, err = c.expBoolOr(&be1, in); err != nil {
-			return bvNone(), err
-		}
-		if c.token != "," {
-			return bvNone(), Error("Missing ','")
-		}
-		c.token = c.tokenizer(in)
-		if bv2, err = c.expBoolOr(&be2, in); err != nil {
-			return bvNone(), err
-		}
-		if err := c.kakkotojiru(); err != nil {
-			return bvNone(), err
-		}
-		if bv1.IsNone() || bv2.IsNone() {
-			if rd {
-				out.append(OC_rdreset)
-			}
-			out.append(be1...)
-			out.appendValue(bv1)
-			out.append(be2...)
-			out.appendValue(bv2)
-			out.append(OC_ex_, OC_ex_round)
-		} else {
-			out.round(&bv1, bv2)
-			bv = bv1
-		}
-	case "ailevelf":
-		out.append(OC_ex_, OC_ex_ailevelf)
-	case "animelemlength":
-		out.append(OC_ex_, OC_ex_animelemlength)
-	case "animlength":
-		out.append(OC_ex_, OC_ex_animlength)
-	case "attack":
-		out.append(OC_ex_, OC_ex_attack)
-	case "combocount":
-		out.append(OC_ex_, OC_ex_combocount)
-	case "consecutivewins":
-		out.append(OC_ex_, OC_ex_consecutivewins)
-	case "jugglepoints":
-		out.append(OC_ex_, OC_ex_jugglepoints)
-	case "defence":
-		out.append(OC_ex_, OC_ex_defence)
-	case "dizzy":
-		out.append(OC_ex_, OC_ex_dizzy)
-	case "dizzypoints":
-		out.append(OC_ex_, OC_ex_dizzypoints)
-	case "dizzypointsmax":
-		out.append(OC_ex_, OC_ex_dizzypointsmax)
-	case "fighttime":
-		out.append(OC_ex_, OC_ex_fighttime)
-	case "firstattack":
-		out.append(OC_ex_, OC_ex_firstattack)
-	case "framespercount":
-		out.append(OC_ex_, OC_ex_framespercount)
-	case "gamemode":
-		if err := nameSubEx(OC_ex_gamemode); err != nil {
-			return bvNone(), err
-		}
-	case "getplayerid":
-		if _, err := c.oneArg(out, in, rd, true); err != nil {
-			return bvNone(), err
-		}
-		out.append(OC_ex_, OC_ex_getplayerid)
-	case "groundangle":
-		out.append(OC_ex_, OC_ex_groundangle)
-	case "guardbreak":
-		out.append(OC_ex_, OC_ex_guardbreak)
-	case "guardpoints":
-		out.append(OC_ex_, OC_ex_guardpoints)
-	case "guardpointsmax":
-		out.append(OC_ex_, OC_ex_guardpointsmax)
-	case "helpername":
-		if err := nameSubEx(OC_ex_helpername); err != nil {
-			return bvNone(), err
-		}
-	case "hitoverridden":
-		out.append(OC_ex_, OC_ex_hitoverridden)
+		out.append(OC_ex_, OC_ex_id)
 	case "incustomstate":
 		out.append(OC_ex_, OC_ex_incustomstate)
 	case "indialogue":
 		out.append(OC_ex_, OC_ex_indialogue)
+	case "inguarddist":
+		out.append(OC_ex_, OC_ex_inguarddist)
 	case "isasserted":
 		if err := c.kakkohiraku(in); err != nil {
 			return bvNone(), err
@@ -2679,10 +2227,34 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		if err := c.kakkotojiru(); err != nil {
 			return bvNone(), err
 		}
+	case "ishelper":
+		if _, err := c.oneArg(out, in, rd, true, BytecodeInt(math.MinInt32)); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_ex_, OC_ex_ishelper)
+	case "ishometeam":
+		out.append(OC_ex_, OC_ex_ishometeam)
 	case "ishost":
 		out.append(OC_ex_, OC_ex_ishost)
+	case "jugglepoints":
+		out.append(OC_ex_, OC_ex_jugglepoints)
+	case "leftedge":
+		out.append(OC_ex_, OC_ex_leftedge)
+	case "life", "p2life":
+		if c.token == "p2life" {
+			out.appendI32Op(OC_p2, 1)
+		}
+		out.append(OC_ex_, OC_ex_life)
+	case "lifemax":
+		out.append(OC_ex_, OC_ex_lifemax)
 	case "localscale":
 		out.append(OC_ex_, OC_ex_localscale)
+	case "lose":
+		out.append(OC_ex_, OC_ex_lose)
+	case "loseko":
+		out.append(OC_ex_, OC_ex_loseko)
+	case "losetime":
+		out.append(OC_ex_, OC_ex_losetime)
 	case "majorversion":
 		out.append(OC_ex_, OC_ex_majorversion)
 	case "map":
@@ -2713,10 +2285,135 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.appendI32Op(OC_ex_maparray, int32(sys.stringPool[c.playerNo].Add(strings.ToLower(m))))
 		}
 		return bvNone(), nil
+	case "matchno":
+		out.append(OC_ex_, OC_ex_matchno)
+	case "matchover":
+		out.append(OC_ex_, OC_ex_matchover)
 	case "memberno":
 		out.append(OC_ex_, OC_ex_memberno)
+	case "movecontact":
+		out.append(OC_ex_, OC_ex_movecontact)
 	case "movecountered":
 		out.append(OC_ex_, OC_ex_movecountered)
+	case "moveguarded":
+		out.append(OC_ex_, OC_ex_moveguarded)
+	case "movehit":
+		out.append(OC_ex_, OC_ex_movehit)
+	case "movereversed":
+		out.append(OC_ex_, OC_ex_movereversed)
+	case "movetype", "p2movetype":
+		trname := c.token
+		if err := eqne2(func(not bool) error {
+			if len(c.token) == 0 {
+				return Error(trname + " value is not specified")
+			}
+			var mt MoveType
+			switch c.token[0] {
+			case 'i':
+				mt = MT_I
+			case 'a':
+				mt = MT_A
+			case 'h':
+				mt = MT_H
+			default:
+				return Error("Invalid value: " + c.token)
+			}
+			if trname == "p2movetype" {
+				out.appendI32Op(OC_p2, 2+Btoi(not))
+			}
+			out.append(OC_ex_, OC_ex_movetype, OpCode(mt>>15))
+			if not {
+				out.append(OC_blnot)
+			}
+			return nil
+		}); err != nil {
+			return bvNone(), err
+		}
+	case "name", "p1name", "p2name", "p3name", "p4name", "p5name", "p6name", "p7name", "p8name":
+		opc := OC_const_name
+		switch c.token {
+		case "p2name":
+			opc = OC_const_p2name
+		case "p3name":
+			opc = OC_const_p3name
+		case "p4name":
+			opc = OC_const_p4name
+		case "p5name":
+			opc = OC_const_p5name
+		case "p6name":
+			opc = OC_const_p6name
+		case "p7name":
+			opc = OC_const_p7name
+		case "p8name":
+			opc = OC_const_p8name
+		}
+		if err := nameSub(opc); err != nil {
+			return bvNone(), err
+		}
+	case "numenemy":
+		out.append(OC_ex_, OC_ex_numenemy)
+	case "numexplod":
+		if _, err := c.oneArg(out, in, rd, true, BytecodeInt(-1)); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_ex_, OC_ex_numexplod)
+	case "numhelper":
+		if _, err := c.oneArg(out, in, rd, true, BytecodeInt(-1)); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_ex_, OC_ex_numhelper)
+	case "numpartner":
+		out.append(OC_ex_, OC_ex_numpartner)
+	case "numproj":
+		out.append(OC_ex_, OC_ex_numproj)
+	case "numprojid":
+		if _, err := c.oneArg(out, in, rd, true); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_ex_, OC_ex_numprojid)
+	case "numtarget":
+		if _, err := c.oneArg(out, in, rd, true, BytecodeInt(-1)); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_ex_, OC_ex_numtarget)
+	case "p2bodydist":
+		c.token = c.tokenizer(in)
+		switch c.token {
+		case "x":
+			out.append(OC_ex_, OC_ex_p2bodydist_x)
+		case "y":
+			out.append(OC_ex_, OC_ex_p2dist_y)
+		case "z":
+			bv = BytecodeFloat(0)
+		default:
+			return bvNone(), Error("Invalid data: " + c.token)
+		}
+	case "p2dist":
+		c.token = c.tokenizer(in)
+		switch c.token {
+		case "x":
+			out.append(OC_ex_, OC_ex_p2dist_x)
+		case "y":
+			out.append(OC_ex_, OC_ex_p2dist_y)
+		case "z":
+			bv = BytecodeFloat(0)
+		default:
+			return bvNone(), Error("Invalid data: " + c.token)
+		}
+	case "palno":
+		out.append(OC_ex_, OC_ex_palno)
+	case "parentdist":
+		c.token = c.tokenizer(in)
+		switch c.token {
+		case "x":
+			out.append(OC_ex_, OC_ex_parentdist_x)
+		case "y":
+			out.append(OC_ex_, OC_ex_parentdist_y)
+		case "z":
+			bv = BytecodeFloat(0)
+		default:
+			return bvNone(), Error("Invalid data: " + c.token)
+		}
 	case "pausetime":
 		out.append(OC_ex_, OC_ex_pausetime)
 	case "physics":
@@ -2742,8 +2439,80 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		}); err != nil {
 			return bvNone(), err
 		}
+	case "playeridexist":
+		if _, err := c.oneArg(out, in, rd, true); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_ex_, OC_ex_playeridexist)
 	case "playerno":
 		out.append(OC_ex_, OC_ex_playerno)
+	case "pos":
+		c.token = c.tokenizer(in)
+		switch c.token {
+		case "x":
+			out.append(OC_ex_, OC_ex_pos_x)
+		case "y":
+			out.append(OC_ex_, OC_ex_pos_y)
+		case "z":
+			out.append(OC_ex_, OC_ex_pos_z)
+		default:
+			return bvNone(), Error("Invalid data: " + c.token)
+		}
+	case "power":
+		out.append(OC_ex_, OC_ex_power)
+	case "powermax":
+		out.append(OC_ex_, OC_ex_powermax)
+	case "prevanim":
+		out.append(OC_ex_, OC_ex_prevanim)
+	case "prevstateno":
+		out.append(OC_ex_, OC_ex_prevstateno)
+	case "projcanceltime":
+		if _, err := c.oneArg(out, in, rd, true); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_ex_, OC_ex_projcanceltime)
+	case "projcontacttime":
+		if _, err := c.oneArg(out, in, rd, true); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_ex_, OC_ex_projcontacttime)
+	case "projguardedtime":
+		if _, err := c.oneArg(out, in, rd, true); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_ex_, OC_ex_projguardedtime)
+	case "projhittime":
+		if _, err := c.oneArg(out, in, rd, true); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_ex_, OC_ex_projhittime)
+	case "rand":
+		if err := c.kakkohiraku(in); err != nil {
+			return bvNone(), err
+		}
+		if bv1, err = c.expBoolOr(&be1, in); err != nil {
+			return bvNone(), err
+		}
+		if c.token != "," {
+			return bvNone(), Error("Missing ','")
+		}
+		c.token = c.tokenizer(in)
+		if bv2, err = c.expBoolOr(&be2, in); err != nil {
+			return bvNone(), err
+		}
+		if err := c.kakkotojiru(); err != nil {
+			return bvNone(), err
+		}
+		if rd {
+			out.append(OC_rdreset)
+		}
+		out.append(be1...)
+		out.appendValue(bv1)
+		out.append(be2...)
+		out.appendValue(bv2)
+		out.append(OC_ex_, OC_ex_rand)
+	case "random":
+		out.append(OC_ex_, OC_ex_random)
 	case "ratiolevel":
 		out.append(OC_ex_, OC_ex_ratiolevel)
 	case "receiveddamage":
@@ -2752,12 +2521,64 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_ex_, OC_ex_receivedhits)
 	case "redlife":
 		out.append(OC_ex_, OC_ex_redlife)
+	case "reversaldefattr":
+		hda := func() error {
+			if attr, err := c.trgAttr(in); err != nil {
+				return err
+			} else {
+				out.append(OC_ex_)
+				out.appendI32Op(OC_ex_reversaldefattr, attr)
+			}
+			return nil
+		}
+		if err := eqne(hda); err != nil {
+			return bvNone(), err
+		}
+	case "rightedge":
+		out.append(OC_ex_, OC_ex_rightedge)
+	case "rootdist":
+		c.token = c.tokenizer(in)
+		switch c.token {
+		case "x":
+			out.append(OC_ex_, OC_ex_rootdist_x)
+		case "y":
+			out.append(OC_ex_, OC_ex_rootdist_y)
+		case "z":
+			bv = BytecodeFloat(0)
+		default:
+			return bvNone(), Error("Invalid data: " + c.token)
+		}
+	case "roundno":
+		out.append(OC_ex_, OC_ex_roundno)
+	case "roundsexisted":
+		out.append(OC_ex_, OC_ex_roundsexisted)
+	case "roundstate":
+		out.append(OC_ex_, OC_ex_roundstate)
 	case "roundtype":
 		out.append(OC_ex_, OC_ex_roundtype)
 	case "score":
 		out.append(OC_ex_, OC_ex_score)
 	case "scoretotal":
 		out.append(OC_ex_, OC_ex_scoretotal)
+	case "screenheight":
+		out.append(OC_ex_, OC_ex_screenheight)
+	case "screenpos":
+		c.token = c.tokenizer(in)
+		switch c.token {
+		case "x":
+			out.append(OC_ex_, OC_ex_screenpos_x)
+		case "y":
+			out.append(OC_ex_, OC_ex_screenpos_y)
+		default:
+			return bvNone(), Error("Invalid data: " + c.token)
+		}
+	case "screenwidth":
+		out.append(OC_ex_, OC_ex_screenwidth)
+	case "selfanimexist":
+		if _, err := c.oneArg(out, in, rd, true); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_ex_, OC_ex_selfanimexist)
 	case "selfstatenoexist":
 		if _, err := c.oneArg(out, in, rd, true); err != nil {
 			return bvNone(), err
@@ -2783,22 +2604,225 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_ex_, OC_ex_stagefrontedge)
 	case "stagetime":
 		out.append(OC_ex_, OC_ex_stagetime)
+	case "stagevar":
+		if err := c.kakkohiraku(in); err != nil {
+			return bvNone(), err
+		}
+		svname := c.token
+		c.token = c.tokenizer(in)
+		if err := c.kakkotojiru(); err != nil {
+			return bvNone(), err
+		}
+		isStr := false
+		switch svname {
+		case "info.name":
+			opc = OC_const_stagevar_info_name
+			isStr = true
+		case "info.displayname":
+			opc = OC_const_stagevar_info_displayname
+			isStr = true
+		case "info.author":
+			opc = OC_const_stagevar_info_author
+			isStr = true
+		case "camera.boundleft":
+			opc = OC_const_stagevar_camera_boundleft
+		case "camera.boundright":
+			opc = OC_const_stagevar_camera_boundright
+		case "camera.boundhigh":
+			opc = OC_const_stagevar_camera_boundhigh
+		case "camera.boundlow":
+			opc = OC_const_stagevar_camera_boundlow
+		case "camera.verticalfollow":
+			opc = OC_const_stagevar_camera_verticalfollow
+		case "camera.floortension":
+			opc = OC_const_stagevar_camera_floortension
+		case "camera.tensionhigh":
+			opc = OC_const_stagevar_camera_tensionhigh
+		case "camera.tensionlow":
+			opc = OC_const_stagevar_camera_tensionlow
+		case "camera.tension":
+			opc = OC_const_stagevar_camera_tension
+		case "camera.startzoom":
+			opc = OC_const_stagevar_camera_startzoom
+		case "camera.zoomout":
+			opc = OC_const_stagevar_camera_zoomout
+		case "camera.zoomin":
+			opc = OC_const_stagevar_camera_zoomin
+		case "camera.ytension.enable":
+			opc = OC_const_stagevar_camera_ytension_enable
+		case "playerinfo.leftbound":
+			opc = OC_const_stagevar_playerinfo_leftbound
+		case "playerinfo.rightbound":
+			opc = OC_const_stagevar_playerinfo_rightbound
+		case "scaling.topscale":
+			opc = OC_const_stagevar_scaling_topscale
+		case "bound.screenleft":
+			opc = OC_const_stagevar_bound_screenleft
+		case "bound.screenright":
+			opc = OC_const_stagevar_bound_screenright
+		case "stageinfo.zoffset":
+			opc = OC_const_stagevar_stageinfo_zoffset
+		case "stageinfo.zoffsetlink":
+			opc = OC_const_stagevar_stageinfo_zoffsetlink
+		case "stageinfo.xscale":
+			opc = OC_const_stagevar_stageinfo_xscale
+		case "stageinfo.yscale":
+			opc = OC_const_stagevar_stageinfo_yscale
+		case "shadow.intensity":
+			opc = OC_const_stagevar_shadow_intensity
+		case "shadow.color.r":
+			opc = OC_const_stagevar_shadow_color_r
+		case "shadow.color.g":
+			opc = OC_const_stagevar_shadow_color_g
+		case "shadow.color.b":
+			opc = OC_const_stagevar_shadow_color_b
+		case "shadow.yscale":
+			opc = OC_const_stagevar_shadow_yscale
+		case "shadow.fade.range.begin":
+			opc = OC_const_stagevar_shadow_fade_range_begin
+		case "shadow.fade.range.end":
+			opc = OC_const_stagevar_shadow_fade_range_end
+		case "shadow.xshear":
+			opc = OC_const_stagevar_shadow_xshear
+		case "reflection.intensity":
+			opc = OC_const_stagevar_reflection_intensity
+		default:
+			return bvNone(), Error("Invalid data: " + svname)
+		}
+		if isStr {
+			if err := nameSub(opc); err != nil {
+				return bvNone(), err
+			}
+		} else {
+			out.append(OC_const_)
+			out.append(opc)
+		}
 	case "standby":
 		out.append(OC_ex_, OC_ex_standby)
+	case "stateno", "p2stateno":
+		if c.token == "p2stateno" {
+			out.appendI32Op(OC_p2, 1)
+		}
+		out.append(OC_ex_, OC_ex_stateno)
+	case "statetype", "p2statetype":
+		trname := c.token
+		if err := eqne2(func(not bool) error {
+			if len(c.token) == 0 {
+				return Error(trname + " value is not specified")
+			}
+			var st StateType
+			switch c.token[0] {
+			case 's':
+				st = ST_S
+			case 'c':
+				st = ST_C
+			case 'a':
+				st = ST_A
+			case 'l':
+				st = ST_L
+			default:
+				return Error("Invalid value: " + c.token)
+			}
+			if trname == "p2statetype" {
+				out.appendI32Op(OC_p2, 2+Btoi(not))
+			}
+			out.append(OC_ex_, OC_ex_statetype, OpCode(st))
+			if not {
+				out.append(OC_blnot)
+			}
+			return nil
+		}); err != nil {
+			return bvNone(), err
+		}
 	case "teamleader":
 		out.append(OC_ex_, OC_ex_teamleader)
+	case "teammode":
+		if err := eqne(func() error {
+			if len(c.token) == 0 {
+				return Error("teammode value is not specified")
+			}
+			var tm TeamMode
+			switch c.token {
+			case "single":
+				tm = TM_Single
+			case "simul":
+				tm = TM_Simul
+			case "turns":
+				tm = TM_Turns
+			case "tag":
+				tm = TM_Tag
+			default:
+				return Error("Invalid value: " + c.token)
+			}
+			out.append(OC_ex_, OC_ex_teammode, OpCode(tm))
+			return nil
+		}); err != nil {
+			return bvNone(), err
+		}
+	case "teamside":
+		out.append(OC_ex_, OC_ex_teamside)
 	case "teamsize":
 		out.append(OC_ex_, OC_ex_teamsize)
+	case "tickspersecond":
+		out.append(OC_ex_, OC_ex_tickspersecond)
+	case "time", "statetime":
+		out.append(OC_ex_, OC_ex_time)
 	case "timeelapsed":
 		out.append(OC_ex_, OC_ex_timeelapsed)
-	case "timeremaining":
+	case "timemod":
+		if not, err := c.kyuushiki(in); err != nil {
+			return bvNone(), err
+		} else if not && !sys.ignoreMostErrors {
+			return bvNone(), Error("timemod doesn't support '!='")
+		}
+		if c.token == "-" {
+			return bvNone(), Error("'-' should not be used")
+		}
+		if n, err = c.integer2(in); err != nil {
+			return bvNone(), err
+		}
+		if n <= 0 {
+			return bvNone(), Error("timemod must be greater than 0")
+		}
+		out.append(OC_ex_, OC_ex_time)
+		out.appendValue(BytecodeInt(n))
+		out.append(OC_mod)
+		if err = c.kyuushikiSuperDX(out, in, true); err != nil {
+			return bvNone(), err
+		}
+		return bv, nil
+	case "timeremaining", "timeleft": // timeleft is deprecated, will be removed once add004 updates
 		out.append(OC_ex_, OC_ex_timeremaining)
-	case "timeleft":
-		out.append(OC_ex_, OC_ex_timeremaining) // Only here for backwards compatibility purposes, going to be deprecated once Add004 updates.
 	case "timetotal":
 		out.append(OC_ex_, OC_ex_timetotal)
-	case "drawpalno":
-		out.append(OC_ex_, OC_ex_drawpalno)
+	case "topedge":
+		out.append(OC_ex_, OC_ex_topedge)
+	case "uniqhitcount":
+		out.append(OC_ex_, OC_ex_uniqhitcount)
+	case "vel":
+		c.token = c.tokenizer(in)
+		switch c.token {
+		case "x":
+			out.append(OC_ex_, OC_ex_vel_x)
+		case "y":
+			out.append(OC_ex_, OC_ex_vel_y)
+		case "z":
+			out.append(OC_ex_, OC_ex_vel_z)
+		default:
+			return bvNone(), Error("Invalid data: " + c.token)
+		}
+	case "win":
+		out.append(OC_ex_, OC_ex_win)
+	case "winhyper":
+		out.append(OC_ex_, OC_ex_winhyper)
+	case "winko":
+		out.append(OC_ex_, OC_ex_winko)
+	case "winperfect":
+		out.append(OC_ex_, OC_ex_winperfect)
+	case "winspecial":
+		out.append(OC_ex_, OC_ex_winspecial)
+	case "wintime":
+		out.append(OC_ex_, OC_ex_wintime)
 	case "=", "!=", ">", ">=", "<", "<=", "&", "&&", "^", "^^", "|", "||",
 		"+", "*", "**", "/", "%":
 		if !sys.ignoreMostErrors || len(c.maeOp) > 0 {
@@ -2814,7 +2838,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		l := len(c.token)
 		if l >= 7 && c.token[:7] == "projhit" || l >= 11 &&
 			(c.token[:11] == "projguarded" || c.token[:11] == "projcontact") {
-			trname, opc, id := c.token, OC_projhittime, int32(0)
+			trname, opc, id := c.token, OC_ex_projhittime, int32(0)
 			if trname[:7] == "projhit" {
 				id = Atoi(trname[7:])
 				trname = trname[:7]
@@ -2822,9 +2846,9 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				id = Atoi(trname[11:])
 				trname = trname[:11]
 				if trname == "projguarded" {
-					opc = OC_projguardedtime
+					opc = OC_ex_projguardedtime
 				} else {
-					opc = OC_projcontacttime
+					opc = OC_ex_projcontacttime
 				}
 			}
 			if not, err := c.kyuushiki(in); err != nil {
@@ -2843,7 +2867,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				out.appendI32Op(OC_nordrun, int32(len(be1)))
 			}
 			out.append(be1...)
-			out.append(opc)
+			out.append(OC_ex_, opc)
 			out.appendValue(BytecodeInt(0))
 			out.append(OC_eq)
 			be.append(OC_pop)


### PR DESCRIPTION
standard trigger constants prefixed with OC_ has been grouped with OC_ex_ constants. Also OC_ex_ ones now follow alphabetical order. Math, redirections and vars still use the old convention. It's a cosmetic change for consistency sake only - should not affect anything.