### PR TITLE
fix: common1 const compatibility with 1.0 chars, conflicting state numbers

### DIFF
--- a/data/common.const
+++ b/data/common.const
@@ -192,22 +192,22 @@ StateContinueScreenAnimation = 5500
 StateInitialize = 5900
 
 ; dizzy.zss states
-StateDizzy = 5300
-StateDizzyFallDown_standCrouch = 5301
-StateDizzyFallDown_air = 5302
-StateDizzyLyingDown = 5303
-StateDizzyBirdsHelper = 5310
+StateDizzy = 6565300
+StateDizzyFallDown_standCrouch = 6565301
+StateDizzyFallDown_air = 6565302
+StateDizzyLyingDown = 6565303
+StateDizzyBirdsHelper = 6565310
 
 ; guardbreak.zss states
-StateGuardBreakHit = 5400
-StateGuardBreakRecover = 5401
+StateGuardBreakHit = 6565400
+StateGuardBreakRecover = 6565401
 
 ; tag.zss states
-StateTagEnteringScreen = 5600
-StateTagLeavingScreen = 5610
-StateTagWaitingOutside = 5611
-StateTagJumpingIn = 5620
-StateTagLanding = 5621
+StateTagEnteringScreen = 6565600
+StateTagLeavingScreen = 6565610
+StateTagWaitingOutside = 6565611
+StateTagJumpingIn = 6565620
+StateTagLanding = 6565621
 
 ; fightfx.air
 FxLightHitSpark = 0

--- a/data/common1.cns.zss
+++ b/data/common1.cns.zss
@@ -28,8 +28,7 @@ if cond(anim = 5, animTime = 0, anim != 0) {
 if time = 0 {
 	velSet{y: 0}
 }
-if time = 4 || abs(vel x) < ifElse(majorVersion = 1,
-	const(movement.stand.friction.threshold), 2) {
+if time = 4 || abs(vel x) < const(movement.stand.friction.threshold) {
 	velSet{x: 0}
 }
 if !alive {
@@ -175,7 +174,7 @@ if time = 0 {
 } else if time = 3 {
 	ctrlSet{value: 1}
 }
-if majorVersion = 1 && abs(vel x) < const(movement.stand.friction.threshold) {
+if abs(vel x) < const(movement.stand.friction.threshold) {
 	velSet{x: 0}
 }
 if animTime = 0 {
@@ -209,18 +208,14 @@ if vel y > 0 && pos y >= 0 {
 # Hop backwards (land)
 [StateDef 106; type: S; physics: S; ctrl: 0; anim: 47;]
 
-if majorVersion = 1 && abs(vel x) < const(movement.stand.friction.threshold) {
+if abs(vel x) < const(movement.stand.friction.threshold) {
 	velSet{x: 0}
 }
 if time = 0 {
 	velSet{y: 0}
 	posSet{y: 0}
 } else if time = 2 {
-	if majorVersion = 1 {
-		makeDust{pos: 0, 0; spacing: 1}
-	} else {
-		makeDust{pos: -5, -2; spacing: 1}
-	}
+	makeDust{pos: 0, 0; spacing: 1}
 } else if time = 7 {
 	changeState{value: 0; ctrl: 1}
 }
@@ -573,7 +568,7 @@ if anim = 5000 || anim = 5010 {
 # Air get-hit (knocked away)
 [StateDef 5030; type: A; movetype: H; physics: N; ctrl: 0;]
 
-if majorVersion = 1 && anim != [5000, 5199] && selfAnimExist(5030) {
+if anim != [5000, 5199] && selfAnimExist(5030) {
 	changeAnim{value: 5030}
 }
 if time = 0 {
@@ -657,8 +652,7 @@ if alive && canRecover && command = "recovery" {
 		changeState{value: 5210}
 	}
 }
-if vel y > 0 && pos y >= cond(anim = [5051, 5059] || anim = [5061, 5069], 0,
-	ifElse(majorVersion = 1, const(movement.air.gethit.groundlevel), 25)) {
+if vel y > 0 && pos y >= cond(anim = [5051, 5059] || anim = [5061, 5069], 0, const(movement.air.gethit.groundlevel)) {
 	changeState{value: 5100}
 }
 
@@ -836,7 +830,7 @@ if time = 0 {
 	sysVar(0) := 0;
 }
 velMul{x: .85}
-if majorVersion = 1 && abs(vel x) < const(movement.down.friction.threshold) {
+if abs(vel x) < const(movement.down.friction.threshold) {
 	velSet{x: 0}
 }
 if time = 0 {
@@ -948,13 +942,9 @@ if time = 0 {
 	}
 } else {
 	if time = 4 {
-		if majorVersion = 1 {
-			velMul{
-				x: const(velocity.air.gethit.airrecover.mul.x);
-				y: const(velocity.air.gethit.airrecover.mul.y);
-			}
-		} else {
-			velMul{x: .8; y: .8}
+		velMul{
+			x: const(velocity.air.gethit.airrecover.mul.x);
+			y: const(velocity.air.gethit.airrecover.mul.y);
 		}
 		velAdd{
 			x: const(velocity.air.gethit.airrecover.add.x);


### PR DESCRIPTION
- Fix the issue where some of the const settings in MUGEN 1.0 and later could not be loaded in common1.cns.zss even when set for winmugen characters.
- Change the state numbers in dizzy.zss, guardbreak.zss, and tag.zss to be less conflicting numbers with existing characters. #545