### PR TITLE
fix: zoom affecting non-stage BG elements scaling, tension correction issues, helpers spawned with movetype A/I not being run in the same frame, pos updating/screenbound/binding 1f delay

### DIFF
--- a/src/camera.go
+++ b/src/camera.go
@@ -132,24 +132,27 @@ func (c *Camera) action(x, y *float32, leftest, rightest, lowest, highest,
 	vmin, vmax float32, pause bool) (sclMul float32) {
 	tension := MaxF(0, c.halfWidth/c.Scale-float32(c.tension)*c.localscl)
 	tmp, vx := (leftest+rightest)/2, vmin+vmax
-	if vx == 0 || (vx < 0) == (tmp < 0) {
-		vel := float32(3)
-		if sys.intro > sys.lifebar.ro.ctrl_time+1 {
-			vel = c.halfWidth
-		} else if pause {
-			vel = 2
-		}
-		if tmp < 0 {
-			vx -= vel
-		} else {
-			vx += vel
-		}
+	// Set base horizontal vel
+	vel := float32(3)
+	if sys.intro > sys.lifebar.ro.ctrl_time+1 {
+		vel = c.halfWidth
+	} else if pause {
+		vel = 2
 	}
+	vel *= 2
+	// Apply base vel to average vel
+	if tmp < 0 {
+		vx -= vel
+	} else {
+		vx += vel
+	}
+	// Interpolate horizontal vel through GameSpeed/Turbo
 	if sys.debugPaused() {
 		vx = 0
 	} else {
 		vx *= MinF(1, sys.turbo)
 	}
+	// Make sure chars will stay behind tension limits if one of them isn't in a corner
 	if vx < 0 {
 		tmp = MaxF(leftest+tension, tmp)
 		if vx < tmp {

--- a/src/char.go
+++ b/src/char.go
@@ -6191,9 +6191,7 @@ func (cl *CharList) action(x float32, cvmin, cvmax,
 		}
 	}
 	for i := 0; i < len(cl.runOrder); i++ {
-		if cl.runOrder[i].ss.moveType != MT_A && cl.runOrder[i].ss.moveType != MT_I {
-			cl.runOrder[i].actionRun()
-		}
+		cl.runOrder[i].actionRun()
 	}
 	// Finish performing character actions
 	// Process priority based on movetype: A > I > H (or anything else)

--- a/src/stage.go
+++ b/src/stage.go
@@ -394,11 +394,12 @@ func (bg backGround) draw(pos [2]float32, scl, bgscl, lclscl float32,
 	}
 	x := bg.start[0] + bg.xofs - (pos[0]/stgscl[0]+bg.camstartx)*bg.delta[0] +
 		bg.bga.offset[0]
-	yScrollPos := ((pos[1] - (sys.cam.CameraZoomYBound / lclscl)) / stgscl[1]) * bg.delta[1] * bgscl
-	yScrollPos += ((sys.cam.CameraZoomYBound / lclscl) / stgscl[1]) * Pow(bg.zoomdelta[1], 1.4) / bgscl
+	zoomybound := sys.cam.CameraZoomYBound * float32(Btoi(isStage))
+	yScrollPos := ((pos[1] - (zoomybound / lclscl)) / stgscl[1]) * bg.delta[1] * bgscl
+	yScrollPos += ((zoomybound / lclscl) / stgscl[1]) * Pow(bg.zoomdelta[1], 1.4) / bgscl
 	y := bg.start[1] - yScrollPos + bg.bga.offset[1]
-	ys2 := bg.scaledelta[1] * (pos[1] - sys.cam.CameraZoomYBound) * bg.delta[1] * bgscl
-	ys := ((100-(pos[1]-sys.cam.CameraZoomYBound)*bg.yscaledelta)*bgscl/bg.yscalestart)*bg.scalestart[1] + ys2
+	ys2 := bg.scaledelta[1] * (pos[1] - zoomybound) * bg.delta[1] * bgscl
+	ys := ((100-(pos[1]-zoomybound)*bg.yscaledelta)*bgscl/bg.yscalestart)*bg.scalestart[1] + ys2
 	xs := bg.scaledelta[0] * pos[0] * bg.delta[0] * bgscl
 	x *= bgscl
 	y = y*bgscl + ((float32(sys.gameHeight)-shakeY)/scly-240)/stgscl[1]


### PR DESCRIPTION
- **fix: CameraZoomYBound affecting non-stage BG elements**
	Fixes #998
- **fix(camera): tension not properly correcting cam based on char Vel X**
	This commit fixes a problem where, if P1 has a greater negative Vel X than P2's positive (or neutral) Vel X, camera will tend to horizontally track on that side of the screen, leaving the character on the other side free to go inside tension limit until average min/max vel gets into 0. This happened due to camera's base tracking vel not being taken into account when average vel is different from 0.
	Camera's base tracking velocity was also increased to match MUGEN's tension correction velocity.

	Fixes #1026
- **fix(char/processing): excluded helpers spawned with Movetypes A/I in the same frame**
	Fixes #1027
- **fix(char): move pos update, screenbound and binding into actionRun()**
	Vel and Screenbound now doesn't get applied with 1f delay, and moving binding back to actionRun() should fix most bind regressions. a4c009c97eaee8106339303462c9d43164eabe83 and b875c24e51d911d9cac3150bb9a7ba8887b35f43 changes should be re-checked in any case, since they were founded above 1f-delay pos updating.
	
	Fixes #725, #786, #787, #1042