### PR TITLE
fix: helper remapPal during first frame of the match, omitting source/dest and assignment to -1 (#1058, #1001)

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6282,10 +6282,6 @@ func (sc remapPal) Run(c *Char, _ []int32) bool {
 			if len(exp) > 1 {
 				src[1] = exp[1].evalI(c)
 			}
-			if src[0] == -1 {
-				src[0] = 1
-				src[1] = 1
-			}
 		case remapPal_dest:
 			dst := [...]int32{exp[0].evalI(c), -1}
 			if len(exp) > 1 {

--- a/src/char.go
+++ b/src/char.go
@@ -3492,6 +3492,9 @@ func (c *Char) helperInit(h *Char, st int32, pt PosType, x, y float32,
 	h.vel = [3]float32{}
 	if h.ownpal {
 		h.palfx = newPalFX()
+		if c.getPalfx().remap == nil {
+			c.palfx.remap = c.gi().sff.palList.GetPalMap()
+		}
 		tmp := c.getPalfx().remap
 		h.palfx.remap = make([]int, len(tmp))
 		copy(h.palfx.remap, tmp)
@@ -4669,6 +4672,14 @@ func (c *Char) hitFallSet(f int32, xv, yv float32) {
 	}
 }
 func (c *Char) remapPal(pfx *PalFX, src [2]int32, dst [2]int32) {
+	if dst[0] == -1 {
+		pfx.remap = nil
+		return
+	}
+	if src[0] == -1 {
+		c.forceRemapPal(pfx, dst)
+		return
+	}
 	if src[0] < 0 || src[1] < 0 || dst[0] < 0 || dst[1] < 0 {
 		return
 	}


### PR DESCRIPTION
- fix helper remapPal during first frame of the match
	Fixes #1058
- fix helper remapPal omitting source/dest and assignment to -1
	Fixes #1001