### PR TITLE
fix: hittime, hitshaketime reset if movetype != H (#1034)

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -5734,6 +5734,12 @@ func (c *Char) update(cvmin, cvmax,
 			if c.inGuardState() {
 				c.setSCF(SCF_guard)
 			}
+			if c.ghv.hitshaketime > 0 {
+				c.ghv.hitshaketime--
+			}
+			if c.ghv.hitshaketime <= 0 && c.ghv.hittime >= 0 {
+				c.ghv.hittime--
+			}
 			if c.ss.moveType == MT_H {
 				if c.ghv.guarded {
 					c.receivedHits = 0
@@ -5741,12 +5747,6 @@ func (c *Char) update(cvmin, cvmax,
 					c.fakeCombo = false
 					c.fakeReceivedHits = 0
 					c.fakeComboDmg = 0
-				}
-				if c.ghv.hitshaketime > 0 {
-					c.ghv.hitshaketime--
-				}
-				if c.ghv.hitshaketime <= 0 && c.ghv.hittime >= 0 {
-					c.ghv.hittime--
 				}
 				if c.ghv.fallf {
 					c.fallTime++
@@ -5761,8 +5761,6 @@ func (c *Char) update(cvmin, cvmax,
 				}
 				c.superDefenseMul = 1
 				c.fallDefenseMul = 1
-				c.ghv.hittime = -1
-				c.ghv.hitshaketime = 0
 				c.ghv.fallf = false
 				c.ghv.fallcount = 0
 				c.ghv.hitid = c.ghv.hitid >> 31


### PR DESCRIPTION
In mugen hittime and hitshaketime counts down even if movetype != H.

Fixes: #1034