### PR TITLE
fix: fix anim scale set to 0 and defaults (#1065)

### DIFF
--- a/src/anim.go
+++ b/src/anim.go
@@ -94,30 +94,19 @@ func ReadAnimFrame(line string) *AnimFrame {
 	case len(a) > 0 && a[0] == 'a':
 		af.SrcAlpha, af.DstAlpha = 255, 255
 	}
-	if len(ary) < 8 {
+	if len(ary) < 8 || (len(ary) == 8 && !IsNumeric(ary[7])) {
 		return af
 	}
 	af.Ex = make([][]float32, 3)
-	var f float32
-	if f = float32(Atof(ary[7])); f == 0 {
-		f = 1
-	}
-	af.Ex[2] = append(af.Ex[2], f) // X-Scale
-	if len(ary) < 9 {
+	af.Ex[2] = append(af.Ex[2], float32(Atof(ary[7]))) // X-Scale
+	if len(ary) < 9 || (len(ary) == 9 && !IsNumeric(ary[8])) {
 		return af
 	}
-	if f = float32(Atof(ary[8])); f == 0 {
-		f = 1
-	}
-	af.Ex[2] = append(af.Ex[2], f) // Y-Scale
-	if len(ary) < 10 {
+	af.Ex[2] = append(af.Ex[2], float32(Atof(ary[8]))) // Y-Scale
+	if len(ary) < 10 || !IsNumeric(ary[9]) {
 		return af
 	}
-	f = float32(Atof(ary[9]))
-	af.Ex[2] = append(af.Ex[2], f) // Angle
-	if len(ary) < 11 {
-		return af
-	}
+	af.Ex[2] = append(af.Ex[2], float32(Atof(ary[9]))) // Angle
 	return af
 }
 func (af *AnimFrame) Clsn1() []float32 {

--- a/src/common.go
+++ b/src/common.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"unicode"
 )
@@ -108,6 +109,10 @@ func Pow(x, y float32) float32 {
 }
 func IsFinite(f float32) bool {
 	return math.Abs(float64(f)) <= math.MaxFloat64
+}
+func IsNumeric(s string) bool {
+    _, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
+    return err == nil
 }
 func Atoi(str string) int32 {
 	var n int64


### PR DESCRIPTION
In mugen, for anim and angle parameters, leaving the value unassigned only defaults to 0 when comma follows. There is also no restriction for setting scaling parameters to 0.

Fixes: #1065