### PR TITLE
fix: fix gethitvar(animtype) not returning the correct value from the start of HitDef

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1799,7 +1799,7 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_const720p:
 		*sys.bcStack.Top() = c.constp(1280, sys.bcStack.Top().ToF())
 	case OC_ex_gethitvar_animtype:
-		sys.bcStack.PushI(int32(c.gethitAnimtype()))
+		sys.bcStack.PushI(int32(c.ghv.animtype))
 	case OC_ex_gethitvar_air_animtype:
 		sys.bcStack.PushI(int32(c.ghv.airanimtype))
 	case OC_ex_gethitvar_ground_animtype:

--- a/src/char.go
+++ b/src/char.go
@@ -695,6 +695,7 @@ type GetHitVar struct {
 	//hit2           [2]int32
 	attr           int32
 	_type          HitType
+	animtype       Reaction
 	airanimtype    Reaction
 	groundanimtype Reaction
 	airtype        HitType
@@ -6382,6 +6383,7 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 				}
 				ghv.airanimtype = hd.air_animtype
 				ghv.groundanimtype = hd.animtype
+				ghv.animtype = getter.gethitAnimtype()
 				ghv.id = hd.attackerID
 				//ghv.redlife = hd.hitredlife
 				if !math.IsNaN(float64(hd.score[0])) {


### PR DESCRIPTION
GetHitVars should only be updated the instant the characters get hit but gethitvar(animtype) returned up to date value, unlike mugen

Fixes #1063