### PR TITLE
feat: new assertSpecial flags: globalnoko, noailevel, noguardko; changed: noko, nokovelocity

### DIFF
--- a/data/tag.zss
+++ b/data/tag.zss
@@ -228,6 +228,11 @@ if !const(Default.Enable.Tag) || isHelper || teamSide = 0 {
 	}
 	map(_iksys_tagSwitchCooldown) := 0;
 } else if map(_iksys_tagActive) = 1 {
+	# fix characters escaping state 5030
+	if !alive {
+		ctrlSet{value: 0}
+		assertSpecial{flag: noailevel}
+	}
 	# fix erratic camera during intros
 	if roundState = 1 && playerNo != teamLeader {
 		screenBound{value: 0; movecamera: 0, 0}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2602,95 +2602,101 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_ex_)
 		switch c.token {
 		case "nostandguard":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_nostandguard))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_nostandguard))
 		case "nocrouchguard":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_nocrouchguard))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_nocrouchguard))
 		case "noairguard":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_noairguard))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_noairguard))
 		case "noshadow":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_noshadow))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_noshadow))
 		case "invisible":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_invisible))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_invisible))
 		case "unguardable":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_unguardable))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_unguardable))
 		case "nojugglecheck":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_nojugglecheck))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_nojugglecheck))
 		case "noautoturn":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_noautoturn))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_noautoturn))
 		case "nowalk":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_nowalk))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_nowalk))
 		case "nobrake":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_nobrake))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_nobrake))
 		case "nocrouch":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_nocrouch))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_nocrouch))
 		case "nostand":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_nostand))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_nostand))
 		case "nojump":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_nojump))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_nojump))
 		case "noairjump":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_noairjump))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_noairjump))
 		case "nohardcodedkeys":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_nohardcodedkeys))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_nohardcodedkeys))
 		case "nogetupfromliedown":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_nogetupfromliedown))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_nogetupfromliedown))
 		case "nofastrecoverfromliedown":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_nofastrecoverfromliedown))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_nofastrecoverfromliedown))
 		case "nofallcount":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_nofallcount))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_nofallcount))
 		case "nofalldefenceup":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_nofalldefenceup))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_nofalldefenceup))
 		case "noturntarget":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_noturntarget))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_noturntarget))
 		case "noinput":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_noinput))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_noinput))
 		case "nopowerbardisplay":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_nopowerbardisplay))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_nopowerbardisplay))
 		case "autoguard":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_autoguard))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_autoguard))
 		case "animfreeze":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_animfreeze))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_animfreeze))
 		case "postroundinput":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_postroundinput))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_postroundinput))
 		case "nohitdamage":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_nohitdamage))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_nohitdamage))
 		case "noguarddamage":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_noguarddamage))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_noguarddamage))
 		case "nodizzypointsdamage":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_nodizzypointsdamage))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_nodizzypointsdamage))
 		case "noguardpointsdamage":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_noguardpointsdamage))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_noguardpointsdamage))
 		case "noredlifedamage":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_noredlifedamage))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_noredlifedamage))
 		case "nomakedust":
-			out.appendI32Op(OC_ex_isassertedchar, int32(CSF_nomakedust))
-		case "intro":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_intro))
-		case "roundnotover":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_roundnotover))
-		case "nomusic":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_nomusic))
-		case "nobardisplay":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_nobardisplay))
-		case "nobg":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_nobg))
-		case "nofg":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_nofg))
-		case "globalnoshadow":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_globalnoshadow))
-		case "timerfreeze":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_timerfreeze))
-		case "nokosnd":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_nokosnd))
-		case "nokoslow":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_nokoslow))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_nomakedust))
 		case "noko":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_noko))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_noko))
+		case "noguardko":
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_noguardko))
 		case "nokovelocity":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_nokovelocity))
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_nokovelocity))
+		case "noailevel":
+			out.appendI64Op(OC_ex_isassertedchar, int64(CSF_noailevel))
+		case "intro":
+			out.appendI64Op(OC_ex_isassertedglobal, int64(GSF_intro))
+		case "roundnotover":
+			out.appendI64Op(OC_ex_isassertedglobal, int64(GSF_roundnotover))
+		case "nomusic":
+			out.appendI64Op(OC_ex_isassertedglobal, int64(GSF_nomusic))
+		case "nobardisplay":
+			out.appendI64Op(OC_ex_isassertedglobal, int64(GSF_nobardisplay))
+		case "nobg":
+			out.appendI64Op(OC_ex_isassertedglobal, int64(GSF_nobg))
+		case "nofg":
+			out.appendI64Op(OC_ex_isassertedglobal, int64(GSF_nofg))
+		case "globalnoshadow":
+			out.appendI64Op(OC_ex_isassertedglobal, int64(GSF_globalnoshadow))
+		case "timerfreeze":
+			out.appendI64Op(OC_ex_isassertedglobal, int64(GSF_timerfreeze))
+		case "nokosnd":
+			out.appendI64Op(OC_ex_isassertedglobal, int64(GSF_nokosnd))
+		case "nokoslow":
+			out.appendI64Op(OC_ex_isassertedglobal, int64(GSF_nokoslow))
+		case "globalnoko":
+			out.appendI64Op(OC_ex_isassertedglobal, int64(GSF_noko))
 		case "roundnotskip":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_roundnotskip))
+			out.appendI64Op(OC_ex_isassertedglobal, int64(GSF_roundnotskip))
 		case "roundfreeze":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_roundfreeze))
+			out.appendI64Op(OC_ex_isassertedglobal, int64(GSF_roundfreeze))
 		default:
 			return bvNone(), Error("Invalid data: " + c.token)
 		}

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -72,95 +72,101 @@ func (c *Compiler) assertSpecial(is IniSection, sc *StateControllerBase, _ int8)
 		foo := func(data string) error {
 			switch strings.ToLower(data) {
 			case "nostandguard":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_nostandguard)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_nostandguard)))
 			case "nocrouchguard":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_nocrouchguard)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_nocrouchguard)))
 			case "noairguard":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_noairguard)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_noairguard)))
 			case "noshadow":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_noshadow)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_noshadow)))
 			case "invisible":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_invisible)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_invisible)))
 			case "unguardable":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_unguardable)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_unguardable)))
 			case "nojugglecheck":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_nojugglecheck)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_nojugglecheck)))
 			case "noautoturn":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_noautoturn)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_noautoturn)))
 			case "nowalk":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_nowalk)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_nowalk)))
 			case "nobrake":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_nobrake)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_nobrake)))
 			case "nocrouch":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_nocrouch)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_nocrouch)))
 			case "nostand":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_nostand)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_nostand)))
 			case "nojump":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_nojump)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_nojump)))
 			case "noairjump":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_noairjump)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_noairjump)))
 			case "nohardcodedkeys":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_nohardcodedkeys)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_nohardcodedkeys)))
 			case "nogetupfromliedown":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_nogetupfromliedown)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_nogetupfromliedown)))
 			case "nofastrecoverfromliedown":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_nofastrecoverfromliedown)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_nofastrecoverfromliedown)))
 			case "nofallcount":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_nofallcount)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_nofallcount)))
 			case "nofalldefenceup":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_nofalldefenceup)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_nofalldefenceup)))
 			case "noturntarget":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_noturntarget)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_noturntarget)))
 			case "noinput":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_noinput)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_noinput)))
 			case "nopowerbardisplay":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_nopowerbardisplay)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_nopowerbardisplay)))
 			case "autoguard":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_autoguard)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_autoguard)))
 			case "animfreeze":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_animfreeze)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_animfreeze)))
 			case "postroundinput":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_postroundinput)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_postroundinput)))
 			case "nohitdamage":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_nohitdamage)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_nohitdamage)))
 			case "noguarddamage":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_noguarddamage)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_noguarddamage)))
 			case "nodizzypointsdamage":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_nodizzypointsdamage)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_nodizzypointsdamage)))
 			case "noguardpointsdamage":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_noguardpointsdamage)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_noguardpointsdamage)))
 			case "noredlifedamage":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_noredlifedamage)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_noredlifedamage)))
 			case "nomakedust":
-				sc.add(assertSpecial_flag, sc.iToExp(int32(CSF_nomakedust)))
-			case "intro":
-				sc.add(assertSpecial_flag_g, sc.iToExp(int32(GSF_intro)))
-			case "roundnotover":
-				sc.add(assertSpecial_flag_g, sc.iToExp(int32(GSF_roundnotover)))
-			case "nomusic":
-				sc.add(assertSpecial_flag_g, sc.iToExp(int32(GSF_nomusic)))
-			case "nobardisplay":
-				sc.add(assertSpecial_flag_g, sc.iToExp(int32(GSF_nobardisplay)))
-			case "nobg":
-				sc.add(assertSpecial_flag_g, sc.iToExp(int32(GSF_nobg)))
-			case "nofg":
-				sc.add(assertSpecial_flag_g, sc.iToExp(int32(GSF_nofg)))
-			case "globalnoshadow":
-				sc.add(assertSpecial_flag_g, sc.iToExp(int32(GSF_globalnoshadow)))
-			case "timerfreeze":
-				sc.add(assertSpecial_flag_g, sc.iToExp(int32(GSF_timerfreeze)))
-			case "nokosnd":
-				sc.add(assertSpecial_flag_g, sc.iToExp(int32(GSF_nokosnd)))
-			case "nokoslow":
-				sc.add(assertSpecial_flag_g, sc.iToExp(int32(GSF_nokoslow)))
-			case "noko":
-				sc.add(assertSpecial_flag_g, sc.iToExp(int32(GSF_noko)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_nomakedust)))
+			case "noguardko":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_noguardko)))
 			case "nokovelocity":
-				sc.add(assertSpecial_flag_g, sc.iToExp(int32(GSF_nokovelocity)))
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_nokovelocity)))
+			case "noailevel":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(CSF_noailevel)))
+			case "intro":
+				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_intro)))
+			case "roundnotover":
+				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_roundnotover)))
+			case "nomusic":
+				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_nomusic)))
+			case "nobardisplay":
+				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_nobardisplay)))
+			case "nobg":
+				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_nobg)))
+			case "nofg":
+				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_nofg)))
+			case "globalnoshadow":
+				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_globalnoshadow)))
+			case "timerfreeze":
+				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_timerfreeze)))
+			case "nokosnd":
+				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_nokosnd)))
+			case "nokoslow":
+				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_nokoslow)))
+			case "globalnoko":
+				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_noko)))
 			case "roundnotskip":
-				sc.add(assertSpecial_flag_g, sc.iToExp(int32(GSF_roundnotskip)))
+				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_roundnotskip)))
 			case "roundfreeze":
-				sc.add(assertSpecial_flag_g, sc.iToExp(int32(GSF_roundfreeze)))
+				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_roundfreeze)))
+			case "noko":
+				sc.add(assertSpecial_noko, sc.i64ToExp(0))
 			default:
 				return Error("Invalid value: " + data)
 			}

--- a/src/script.go
+++ b/src/script.go
@@ -2680,7 +2680,11 @@ func triggerFunctions(l *lua.LState) {
 	})
 	// vanilla triggers
 	luaRegister(l, "ailevel", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.aiLevel()))
+		if !sys.debugWC.sf(CSF_noailevel) {
+			l.Push(lua.LNumber(sys.debugWC.aiLevel()))
+		} else {
+			l.Push(lua.LNumber(0))
+		}
 		return 1
 	})
 	luaRegister(l, "alive", func(*lua.LState) int {
@@ -3915,6 +3919,14 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LBool(sys.debugWC.sf(CSF_noredlifedamage)))
 		case "nomakedust":
 			l.Push(lua.LBool(sys.debugWC.sf(CSF_nomakedust)))
+		case "noko":
+			l.Push(lua.LBool(sys.debugWC.sf(CSF_noko)))
+		case "noguardko":
+			l.Push(lua.LBool(sys.debugWC.sf(CSF_noguardko)))
+		case "nokovelocity":
+			l.Push(lua.LBool(sys.debugWC.sf(CSF_nokovelocity)))
+		case "noailevel":
+			l.Push(lua.LBool(sys.debugWC.sf(CSF_noailevel)))
 		// GlobalSpecialFlag
 		case "intro":
 			l.Push(lua.LBool(sys.sf(GSF_intro)))
@@ -3936,10 +3948,8 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LBool(sys.sf(GSF_nokosnd)))
 		case "nokoslow":
 			l.Push(lua.LBool(sys.sf(GSF_nokoslow)))
-		case "noko":
+		case "globalnoko":
 			l.Push(lua.LBool(sys.sf(GSF_noko)))
-		case "nokovelocity":
-			l.Push(lua.LBool(sys.sf(GSF_nokovelocity)))
 		case "roundnotskip":
 			l.Push(lua.LBool(sys.sf(GSF_roundnotskip)))
 		case "roundfreeze":


### PR DESCRIPTION
In order to implement new flags compiler has been expanded to support int64 values.

### <a name="changed_assertspecial_globalnoko">GlobalNoKo</a>

While asserted all players won't die from taking damage.

### <a name="changed_assertspecial_noailevel">NoAiLevel</a>

While asserted, makes the player AILevel and AILevelF triggers return 0

### <a name="changed_assertspecial_noguardko">NoGuardKo</a>
	
While asserted player won't die from taking cheap damage

### <a name="changed_assertspecial_noko">NoKo</a>

While asserted player won't die from taking damage

**Note:** [ikemenVersion](Character-features/#def_info_ikemenversion) changes default behaviour of this flag

### <a name="changed_assertspecial_nokovelocity">NoKoVelocity</a>

While asserted player won't be affected by HitDef velocity adjustments upon KO
