### PR TITLE
fix: OGG Files playing at 2x speed, OGG loop crash

### DIFF
--- a/build/get.cmd
+++ b/build/get.cmd
@@ -10,7 +10,7 @@ if not exist go.mod (
 	go mod init github.com/ikemen-engine/Ikemen-GO/src
 )
 
-go get -v -u github.com/faiface/beep
+go get -v -u github.com/samhocevar/beep
 go get -v -u github.com/flopp/go-findfont
 go get -v -u github.com/go-gl/gl/v2.1/gl
 go get -v -u github.com/go-gl/glfw/v3.3/glfw

--- a/build/get.sh
+++ b/build/get.sh
@@ -10,7 +10,7 @@ if [ ! -f ./go.mod ]; then
 	echo ""
 fi
 
-go get -v -u github.com/faiface/beep
+go get -v -u github.com/samhocevar/beep
 go get -v -u github.com/flopp/go-findfont
 go get -v -u github.com/go-gl/gl/v2.1/gl
 go get -v -u github.com/go-gl/glfw/v3.3/glfw

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,13 @@ module github.com/ikemen-engine/Ikemen-GO
 go 1.20
 
 require (
-	github.com/faiface/beep v1.1.0
 	github.com/flopp/go-findfont v0.1.0
 	github.com/fyne-io/gl-js v0.0.0-20220802150000-8e339395f381
 	github.com/fyne-io/glfw-js v0.0.0-20220517201726-bebc2019cd33
+	github.com/go-gl/gl v0.0.0-20211210172815-726fda9656d6
 	github.com/go-gl/mathgl v1.0.0
 	github.com/ikemen-engine/glfont v0.0.0-20230122001504-a74730561e23
+	github.com/samhocevar/beep v1.1.1-0.20230329173724-81a811327e2e
 	github.com/sqweek/dialog v0.0.0-20220809060634-e981b270ebbf
 	github.com/yuin/gopher-lua v0.0.0-20220504180219-658193537a64
 	golang.org/x/mobile v0.0.0-20221110043201-43a038452099
@@ -16,14 +17,13 @@ require (
 
 require (
 	github.com/TheTitanrain/w32 v0.0.0-20180517000239-4f5cfb03fabf // indirect
-	github.com/go-gl/gl v0.0.0-20211210172815-726fda9656d6 // indirect
 	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20211213063430-748e38ca8aec // indirect
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/gopherjs/gopherjs v0.0.0-20211219123610-ec9572f70e60 // indirect
 	github.com/hajimehoshi/go-mp3 v0.3.0 // indirect
 	github.com/hajimehoshi/oto v0.7.1 // indirect
-	github.com/jfreymuth/oggvorbis v1.0.1 // indirect
-	github.com/jfreymuth/vorbis v1.0.0 // indirect
+	github.com/jfreymuth/oggvorbis v1.0.2 // indirect
+	github.com/jfreymuth/vorbis v1.0.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6 // indirect
 	golang.org/x/image v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,6 @@ github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5y
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/faiface/beep v1.1.0 h1:A2gWP6xf5Rh7RG/p9/VAW2jRSDEGQm5sbOb38sf5d4c=
-github.com/faiface/beep v1.1.0/go.mod h1:6I8p6kK2q4opL/eWb+kAkk38ehnTunWeToJB+s51sT4=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/flopp/go-findfont v0.1.0 h1:lPn0BymDUtJo+ZkV01VS3661HL6F4qFlkhcJN55u6mU=
 github.com/flopp/go-findfont v0.1.0/go.mod h1:wKKxRDjD024Rh7VMwoU90i6ikQRCr+JTHB5n4Ejkqvw=
@@ -198,10 +196,10 @@ github.com/icza/mighty v0.0.0-20180919140131-cfd07d671de6/go.mod h1:xQig96I1VNBD
 github.com/ikemen-engine/glfont v0.0.0-20230122001504-a74730561e23 h1:qLKMExG3q4lNJabvxuJjvOYdaYz1t32Ee/N/6+fkE00=
 github.com/ikemen-engine/glfont v0.0.0-20230122001504-a74730561e23/go.mod h1:7QcK+eKEO2FnoZx0L8YmI1hB+YxL3XzmFVuCbxI/BW4=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/jfreymuth/oggvorbis v1.0.1 h1:NT0eXBgE2WHzu6RT/6zcb2H10Kxj6Fm3PccT0LE6bqw=
-github.com/jfreymuth/oggvorbis v1.0.1/go.mod h1:NqS+K+UXKje0FUYUPosyQ+XTVvjmVjps1aEZH1sumIk=
-github.com/jfreymuth/vorbis v1.0.0 h1:SmDf783s82lIjGZi8EGUUaS7YxPHgRj4ZXW/h7rUi7U=
-github.com/jfreymuth/vorbis v1.0.0/go.mod h1:8zy3lUAm9K/rJJk223RKy6vjCZTWC61NA2QD06bfOE0=
+github.com/jfreymuth/oggvorbis v1.0.2 h1:MjAb64MjsqlUBBOlyqyZvB7H7om58F6I9iP4skamaII=
+github.com/jfreymuth/oggvorbis v1.0.2/go.mod h1:hTCEBUJIOM8voBYPIa/TZima67oFAM1eB2Lzjq/nVK0=
+github.com/jfreymuth/vorbis v1.0.1 h1:iA3VC/w+H0rHzPVrv1dkwxMMjk3LJTlSXlpYw6800u0=
+github.com/jfreymuth/vorbis v1.0.1/go.mod h1:DoftRo4AznKnShRl1GxiTFCseHr4zR9BN3TWXyuzrqQ=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
@@ -246,6 +244,8 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/samhocevar/beep v1.1.1-0.20230329173724-81a811327e2e h1:BuJK6JcCy7jfUct/S99JlZo+s5fzDbE7qUAYobiFkhU=
+github.com/samhocevar/beep v1.1.1-0.20230329173724-81a811327e2e/go.mod h1:tI9pC5qotIRg1dbd0nzIoqDqvCJzcFR3B+LYGWbAbsw=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shurcooL/go v0.0.0-20200502201357-93f07166e636/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=

--- a/src/sound.go
+++ b/src/sound.go
@@ -7,13 +7,13 @@ import (
 	"math"
 	"os"
 
-	"github.com/faiface/beep"
-	"github.com/faiface/beep/effects"
+	"github.com/samhocevar/beep"
+	"github.com/samhocevar/beep/effects"
 
-	"github.com/faiface/beep/mp3"
-	"github.com/faiface/beep/speaker"
-	"github.com/faiface/beep/vorbis"
-	"github.com/faiface/beep/wav"
+	"github.com/samhocevar/beep/mp3"
+	"github.com/samhocevar/beep/speaker"
+	"github.com/samhocevar/beep/vorbis"
+	"github.com/samhocevar/beep/wav"
 )
 
 const (

--- a/src/system.go
+++ b/src/system.go
@@ -16,8 +16,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/faiface/beep"
-	"github.com/faiface/beep/speaker"
+	"github.com/samhocevar/beep"
+	"github.com/samhocevar/beep/speaker"
 	lua "github.com/yuin/gopher-lua"
 )
 


### PR DESCRIPTION
Switch the beep dependency to a more active fork
Fixes #58
Fixes #609