### PR TITLE
feat: add Fall Recovery option to the training dummy

### DIFF
--- a/data/training.zss
+++ b/data/training.zss
@@ -66,6 +66,33 @@ if gameMode != "training" || isHelper || teamSide != 2 {
 				assertSpecial{flag: autoGuard}
 			}
 		}
+		# Fall Recovery
+		if map(_iksys_trainingFallRecovery) {
+			if moveType = H && stateType = A && hitFall && stateNo != [const(StateAirGetHit_fallRecoveryOnGroundStillFalling), const(StateAirGetHit_fallRecoveryInAir)] {
+				if (map(_iksys_trainingFallRecovery) = 1 && pos y >= const(movement.air.gethit.groundrecover.ground.threshold)) # Ground recovery
+				|| (map(_iksys_trainingFallRecovery) = 2 && pos y < const(movement.air.gethit.groundrecover.ground.threshold)) # Air recovery
+				|| (map(_iksys_trainingFallRecovery) = 3 && random < 100) { # Random recovery
+					if time % 2 {
+						assertInput{flag: x; flag2: y; flag3: z} # Ideally one would specifically force the character's "recovery" command
+					} else {
+						assertInput{flag: a; flag2: b; flag3: c}
+					}
+					# Random direction
+					if map(_iksys_trainingFallRecovery) = 3 {
+						if random < 333 {
+							assertInput{flag: L}
+						} else if random < 500 {
+							assertInput{flag: R}
+						}
+						if random < 333 {
+							assertInput{flag: U}
+						} else if random < 500 {
+							assertInput{flag: D}
+						}
+					}
+				}
+			}
+		}
 		# Distance
 		let dir = 0;
 		if map(_iksys_trainingDistance) != 0 {

--- a/external/script/menu.lua
+++ b/external/script/menu.lua
@@ -22,17 +22,23 @@ menu.t_valuename = {
 		{itemname = '7', displayname = motif.training_info.menu_valuename_ailevel_7},
 		{itemname = '8', displayname = motif.training_info.menu_valuename_ailevel_8},
 	},
+	dummymode = {
+		{itemname = 'stand', displayname = motif.training_info.menu_valuename_dummymode_stand},
+		{itemname = 'crouch', displayname = motif.training_info.menu_valuename_dummymode_crouch},
+		{itemname = 'jump', displayname = motif.training_info.menu_valuename_dummymode_jump},
+		{itemname = 'wjump', displayname = motif.training_info.menu_valuename_dummymode_wjump},
+	},
 	guardmode = {
 		{itemname = 'none', displayname = motif.training_info.menu_valuename_guardmode_none},
 		{itemname = 'auto', displayname = motif.training_info.menu_valuename_guardmode_auto},
 		{itemname = 'all', displayname = motif.training_info.menu_valuename_guardmode_all},
 		{itemname = 'random', displayname = motif.training_info.menu_valuename_guardmode_random},
 	},
-	dummymode = {
-		{itemname = 'stand', displayname = motif.training_info.menu_valuename_dummymode_stand},
-		{itemname = 'crouch', displayname = motif.training_info.menu_valuename_dummymode_crouch},
-		{itemname = 'jump', displayname = motif.training_info.menu_valuename_dummymode_jump},
-		{itemname = 'wjump', displayname = motif.training_info.menu_valuename_dummymode_wjump},
+	fallrecovery = {
+		{itemname = 'none', displayname = motif.training_info.menu_valuename_fallrecovery_none},
+		{itemname = 'ground', displayname = motif.training_info.menu_valuename_fallrecovery_ground},
+		{itemname = 'air', displayname = motif.training_info.menu_valuename_fallrecovery_air},
+		{itemname = 'random', displayname = motif.training_info.menu_valuename_fallrecovery_random},
 	},
 	distance = {
 		{itemname = 'any', displayname = motif.training_info.menu_valuename_distance_any},
@@ -128,6 +134,13 @@ menu.t_itemname = {
 		end
 		return true
 	end,
+	--Dummy Mode
+	['dummymode'] = function(t, item, cursorPosY, moveTxt, section)
+		if menu.f_valueChanged(t.items[item], motif[section]) then
+			charMapSet(2, '_iksys_trainingDummyMode', menu.dummymode - 1)
+		end
+		return true
+	end,
 	--Guard Mode
 	['guardmode'] = function(t, item, cursorPosY, moveTxt, section)
 		if menu.f_valueChanged(t.items[item], motif[section]) then
@@ -135,10 +148,10 @@ menu.t_itemname = {
 		end
 		return true
 	end,
-	--Dummy Mode
-	['dummymode'] = function(t, item, cursorPosY, moveTxt, section)
+	--Fall Recovery
+	['fallrecovery'] = function(t, item, cursorPosY, moveTxt, section)
 		if menu.f_valueChanged(t.items[item], motif[section]) then
-			charMapSet(2, '_iksys_trainingDummyMode', menu.dummymode - 1)
+			charMapSet(2, '_iksys_trainingFallRecovery', menu.fallrecovery - 1)
 		end
 		return true
 	end,
@@ -303,11 +316,14 @@ menu.t_vardisplay = {
 	['ailevel'] = function()
 		return menu.t_valuename.ailevel[menu.ailevel or config.Difficulty].displayname
 	end,
+	['dummymode'] = function()
+		return menu.t_valuename.dummymode[menu.dummymode or 1].displayname
+	end,
 	['guardmode'] = function()
 		return menu.t_valuename.guardmode[menu.guardmode or 1].displayname
 	end,
-	['dummymode'] = function()
-		return menu.t_valuename.dummymode[menu.dummymode or 1].displayname
+	['fallrecovery'] = function()
+		return menu.t_valuename.fallrecovery[menu.fallrecovery or 1].displayname
 	end,
 	['distance'] = function()
 		return menu.t_valuename.distance[menu.distance or 1].displayname
@@ -456,8 +472,9 @@ function menu.f_trainingReset()
 	player(2)
 	setAILevel(0)
 	charMapSet(2, '_iksys_trainingDummyControl', 0)
-	charMapSet(2, '_iksys_trainingGuardMode', 0)
 	charMapSet(2, '_iksys_trainingDummyMode', 0)
+	charMapSet(2, '_iksys_trainingGuardMode', 0)
+	charMapSet(2, '_iksys_trainingFallRecovery', 0)
 	charMapSet(2, '_iksys_trainingDistance', 0)
 	charMapSet(2, '_iksys_trainingButtonJam', 0)
 end

--- a/external/script/motif.lua
+++ b/external/script/motif.lua
@@ -1476,14 +1476,18 @@ local motif =
 		menu_valuename_ailevel_6 = "6", --Ikemen feature
 		menu_valuename_ailevel_7 = "7", --Ikemen feature
 		menu_valuename_ailevel_8 = "8", --Ikemen feature
-		menu_valuename_guardmode_none = "None", --Ikemen feature
-		menu_valuename_guardmode_auto = "Auto", --Ikemen feature
-		menu_valuename_guardmode_all = "All", --Ikemen feature
-		menu_valuename_guardmode_random = "Random", --Ikemen feature
 		menu_valuename_dummymode_stand = "Stand", --Ikemen feature
 		menu_valuename_dummymode_crouch = "Crouch", --Ikemen feature
 		menu_valuename_dummymode_jump = "Jump", --Ikemen feature
 		menu_valuename_dummymode_wjump = "W Jump", --Ikemen feature
+		menu_valuename_guardmode_none = "None", --Ikemen feature
+		menu_valuename_guardmode_auto = "Auto", --Ikemen feature
+		menu_valuename_guardmode_all = "All", --Ikemen feature
+		menu_valuename_guardmode_random = "Random", --Ikemen feature
+		menu_valuename_fallrecovery_none = "None", --Ikemen feature
+		menu_valuename_fallrecovery_ground = "Ground", --Ikemen feature
+		menu_valuename_fallrecovery_air = "Air", --Ikemen feature
+		menu_valuename_fallrecovery_random = "Random", --Ikemen feature
 		menu_valuename_distance_any = "Any", --Ikemen feature
 		menu_valuename_distance_close = "Close", --Ikemen feature
 		menu_valuename_distance_medium = "Medium", --Ikemen feature
@@ -1500,8 +1504,9 @@ local motif =
 		menu_valuename_buttonjam_w = "W", --Ikemen feature
 		--menu_itemname_dummycontrol = "Dummy Control", --Ikemen feature
 		--menu_itemname_ailevel = "AI Level", --Ikemen feature
-		--menu_itemname_guardmode = "Guard Mode", --Ikemen feature
 		--menu_itemname_dummymode = "Dummy Mode", --Ikemen feature
+		--menu_itemname_guardmode = "Guard Mode", --Ikemen feature
+		--menu_itemname_fallrecovery = "Fall Recovery", --Ikemen feature
 		--menu_itemname_distance = "Distance", --Ikemen feature
 		--menu_itemname_buttonjam = "Button Jam", --Ikemen feature
 	},
@@ -2214,8 +2219,9 @@ function motif.setBaseTrainingInfo()
 	motif.training_info.menu_itemname_menutraining = "Training Menu"
 	motif.training_info.menu_itemname_menutraining_dummycontrol = "Dummy Control"
 	motif.training_info.menu_itemname_menutraining_ailevel = "AI Level"
-	motif.training_info.menu_itemname_menutraining_guardmode = "Guard Mode"
 	motif.training_info.menu_itemname_menutraining_dummymode = "Dummy Mode"
+	motif.training_info.menu_itemname_menutraining_guardmode = "Guard Mode"
+	motif.training_info.menu_itemname_menutraining_fallrecovery = "Fall Recovery"
 	motif.training_info.menu_itemname_menutraining_distance = "Distance"
 	motif.training_info.menu_itemname_menutraining_buttonjam = "Button Jam"
 	motif.training_info.menu_itemname_menutraining_back = "Back"
@@ -2238,8 +2244,9 @@ function motif.setBaseTrainingInfo()
 		"menutraining",
 		"menutraining_dummycontrol",
 		"menutraining_ailevel",
-		"menutraining_guardmode",
 		"menutraining_dummymode",
+		"menutraining_guardmode",
+		"menutraining_fallrecovery",
 		"menutraining_distance",
 		"menutraining_buttonjam",
 		"menutraining_back",


### PR DESCRIPTION
- Dummy can now be set to recover automatically from a fall. This is currently achieved by making the dummy jam buttons when appropriate
- A common feature of training modes. Previously, players had to resort to external means to practice or debug using this feature
- Fall Recovery can be set to None, Ground, Air or Random
- Dummy mode (standing, crouching, etc) moved above guard mode in the menu for a more logical order