### PR TITLE
fix(char): playerpush upon KO

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -5537,11 +5537,11 @@ func (c *Char) actionPrepare() {
 			c.inputFlag = 0
 			c.setSF(CSF_stagebound)
 			if c.player {
-				if c.alive() || !c.scf(SCF_over) || !c.scf(SCF_ko_round_middle) {
+				if c.alive() || c.ss.no != 5150 || c.numPartner() == 0 {
 					c.setSF(CSF_screenbound | CSF_movecamera_x | CSF_movecamera_y)
-					if (c.alive() || !c.scf(SCF_over)) && c.roundState() > 0 {
-						c.setSF(CSF_playerpush)
-					}
+				}
+				if c.roundState() > 0 && (c.alive() || c.numPartner() == 0) {
+					c.setSF(CSF_playerpush)
 				}
 			}
 			c.angleScale = [...]float32{1, 1}


### PR DESCRIPTION
- Player pushing and screenbound upon KO works more like Mugen 1.1
- Single players are always pushable and screenbound
- Simul (and tag) players are pushable while alive, and screenbound while not in the KO state itself