### PR TITLE
feat: add const(data.fall.defence_up) trigger

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -227,6 +227,7 @@ const (
 	OC_const_data_dizzypoints
 	OC_const_data_attack
 	OC_const_data_defence
+	OC_const_data_fall_defence_up
 	OC_const_data_fall_defence_mul
 	OC_const_data_liedown_time
 	OC_const_data_airjuggle
@@ -1440,6 +1441,8 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(c.gi().data.attack)
 	case OC_const_data_defence:
 		sys.bcStack.PushI(c.gi().data.defence)
+	case OC_const_data_fall_defence_up:
+		sys.bcStack.PushI(c.gi().data.fall.defence_up)
 	case OC_const_data_fall_defence_mul:
 		sys.bcStack.PushF(1.0 / c.gi().data.fall.defence_mul)
 	case OC_const_data_liedown_time:

--- a/src/char.go
+++ b/src/char.go
@@ -195,6 +195,7 @@ type CharData struct {
 	attack      int32
 	defence     int32
 	fall        struct {
+		defence_up int32
 		defence_mul float32
 	}
 	liedown struct {
@@ -221,6 +222,7 @@ func (cd *CharData) init() {
 	cd.guardpoints = 1000
 	cd.attack = 100
 	cd.defence = 100
+	cd.fall.defence_up = 50
 	cd.fall.defence_mul = 1.5
 	cd.liedown.time = 60
 	cd.airjuggle = 15
@@ -2164,10 +2166,9 @@ func (c *Char) load(def string) error {
 						c.guardPointsMax = gi.data.guardpoints
 						is.ReadI32("attack", &gi.data.attack)
 						is.ReadI32("defence", &gi.data.defence)
+						is.ReadI32("fall.defence_up", &gi.data.fall.defence_up)
+						gi.data.fall.defence_mul = (float32(gi.data.fall.defence_up) + 100) / 100
 						var i32 int32
-						if is.ReadI32("fall.defence_up", &i32) {
-							gi.data.fall.defence_mul = (float32(i32) + 100) / 100
-						}
 						if is.ReadI32("liedown.time", &i32) {
 							gi.data.liedown.time = Max(1, i32)
 						}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1461,6 +1461,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.append(OC_const_data_attack)
 		case "data.defence":
 			out.append(OC_const_data_defence)
+		case "data.fall.defence_up":
+			out.append(OC_const_data_fall_defence_up)
 		case "data.fall.defence_mul":
 			out.append(OC_const_data_fall_defence_mul)
 		case "data.liedown.time":

--- a/src/script.go
+++ b/src/script.go
@@ -2785,6 +2785,8 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.gi().data.attack)
 		case "data.defence":
 			ln = lua.LNumber(c.gi().data.defence)
+		case "data.fall.defence_up":
+			ln = lua.LNumber(c.gi().data.fall.defence_up)
 		case "data.fall.defence_mul":
 			ln = lua.LNumber(1.0 / c.gi().data.fall.defence_mul)
 		case "data.liedown.time":


### PR DESCRIPTION
- Like Mugen, one could not read the character's fall.defence_up constant directly, having to reverse the fall.defence_mul formula to get it. It is now accessible