### PR TITLE
fix: small training dummy behavior adjustment

### DIFF
--- a/data/training.zss
+++ b/data/training.zss
@@ -1,7 +1,8 @@
 # Mugen style Training Mode global code
 # maps set via Pause Menu (menu.lua)
 # _iksys_trainingDummyControl: 0 - cooperative, 1 - ai, 2 - manual
-# _iksys_trainingGuardMode: 0 - none, 1 - auto
+# _iksys_trainingGuardMode: 0 - none, 1 - auto, 2 - all, 3 - random
+# _iksys_trainingFallRecovery: 0 - none, 1 - ground, 2 - air, 3 - random
 # _iksys_trainingDummyMode: 0 - stand, 1 - crouch, 2 - jump, 3 - wjump
 # _iksys_trainingDistance: 0 - any, 1 - close, 2 - medium, 3 - far
 # _iksys_trainingButtonJam: 0 - none, 1-9 - a/b/c/x/y/z/s/d/w
@@ -36,7 +37,7 @@ if gameMode != "training" || isHelper || teamSide != 2 {
 	map(_iksys_trainingAirJumpNum) := 0;
 } else if roundState = 2 {
 	ignoreHitPause{
-		assertSpecial{flag: noKo}
+		assertSpecial{flag: globalNoKo}
 	}
 	# Life and Power recovery
 	for i = 1; player(1),numPartner + 1; 1 {
@@ -68,26 +69,28 @@ if gameMode != "training" || isHelper || teamSide != 2 {
 		}
 		# Fall Recovery
 		if map(_iksys_trainingFallRecovery) {
-			if moveType = H && stateType = A && hitFall && stateNo != [const(StateAirGetHit_fallRecoveryOnGroundStillFalling), const(StateAirGetHit_fallRecoveryInAir)] {
-				if (map(_iksys_trainingFallRecovery) = 1 && pos y >= const(movement.air.gethit.groundrecover.ground.threshold)) # Ground recovery
-				|| (map(_iksys_trainingFallRecovery) = 2 && pos y < const(movement.air.gethit.groundrecover.ground.threshold)) # Air recovery
-				|| (map(_iksys_trainingFallRecovery) = 3 && random < 100) { # Random recovery
-					if time % 2 {
-						assertInput{flag: x; flag2: y; flag3: z} # Ideally one would specifically force the character's "recovery" command
-					} else {
-						assertInput{flag: a; flag2: b; flag3: c}
-					}
-					# Random direction
-					if map(_iksys_trainingFallRecovery) = 3 {
-						if random < 333 {
-							assertInput{flag: L}
-						} else if random < 500 {
-							assertInput{flag: R}
+			if stateNo != [const(StateAirGetHit_fallRecoveryOnGroundStillFalling), const(StateAirGetHit_fallRecoveryInAir)] {
+				if moveType = H && stateType = A && hitFall && !getHitVar(isbound) && (pos y || vel y) {
+					if (map(_iksys_trainingFallRecovery) = 1 && pos y >= const(movement.air.gethit.groundrecover.ground.threshold)) # Ground recovery
+					|| (map(_iksys_trainingFallRecovery) = 2 && pos y < const(movement.air.gethit.groundrecover.ground.threshold)) # Air recovery
+					|| (map(_iksys_trainingFallRecovery) = 3 && random < 100) { # Random recovery
+						if time % 2 {
+							assertInput{flag: x; flag2: y; flag3: z} # Ideally one would specifically force the character's "recovery" command
+						} else {
+							assertInput{flag: a; flag2: b; flag3: c}
 						}
-						if random < 333 {
-							assertInput{flag: U}
-						} else if random < 500 {
-							assertInput{flag: D}
+						# Random direction
+						if map(_iksys_trainingFallRecovery) = 3 {
+							if random < 333 {
+								assertInput{flag: L}
+							} else if random < 500 {
+								assertInput{flag: R}
+							}
+							if random < 333 {
+								assertInput{flag: U}
+							} else if random < 500 {
+								assertInput{flag: D}
+							}
 						}
 					}
 				}
@@ -105,21 +108,23 @@ if gameMode != "training" || isHelper || teamSide != 2 {
 				if p2BodyDist x > const240p(130) {
 					let dir = 1;
 					map(_iksys_trainingDirection) := 1;
-				} else if p2BodyDist x < const240p(80) && backEdgeBodyDist >= const240p(10) {
+				} else if p2BodyDist x < const240p(80) && backEdgeBodyDist > const240p(10) {
 					let dir = -1;
 					map(_iksys_trainingDirection) := -1;
 				}
 			# Far
-			} else if map(_iksys_trainingDistance) = 3 && backEdgeBodyDist > const240p(10) {
-				let dir = -1;
-				map(_iksys_trainingDirection) := -1;
+			} else if map(_iksys_trainingDistance) = 3 {
+				if p2BodyDist x < const240p(260) && backEdgeBodyDist > const240p(10) {
+					let dir = -1;
+					map(_iksys_trainingDirection) := -1;
+				}
 			}
 		}
 		if map(_iksys_trainingDirection) != 0 {
 			# if adjusting position is no longer needed
 			if $dir = 0 {
 				# maintain assertion only if dummy and nearest P1 are moving in the same direction
-				if vel x * enemyNear,vel x >= 0 || enemyNear,backEdgeBodyDist = 0 {
+				if vel x * p2,vel x >= 0 || backEdgeBodyDist = 0 || p2,backEdgeBodyDist = 0 {
 					map(_iksys_trainingDirection) := 0;
 				}
 			}


### PR DESCRIPTION
- Adjusted automatic Fall Recovery triggers so that it will not make the training dummy tech throws
- Fixed Ikemenversion = 1 characters on P1's side being killable in training mode
- Setting the dummy to "far" will make it stay away a certain distance instead of always walking to the corner (only noticeable with zoom out)
- Dummy won't keep walking back against the corner when trying to stay away from the player