### PR TITLE
fix: revised player processing priority

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -6223,19 +6223,36 @@ func (cl *CharList) action(x float32, cvmin, cvmax,
 		cl.runOrder[i].actionPrepare()
 	}
 	// Run character state controllers
-	// Process priority based on movetype: A > I > H (or anything else)
+	// Process priority based on movetype and player type
+	// Run actions for attacking players and helpers
 	for i := 0; i < len(cl.runOrder); i++ {
 		if cl.runOrder[i].ss.moveType == MT_A {
 			cl.runOrder[i].actionRun()
 		}
 	}
+	// Run actions for idle players
 	for i := 0; i < len(cl.runOrder); i++ {
-		if cl.runOrder[i].ss.moveType == MT_I {
+		if cl.runOrder[i].helperIndex == 0 && cl.runOrder[i].ss.moveType == MT_I {
 			cl.runOrder[i].actionRun()
 		}
 	}
+	// Run actions for remaining players
 	for i := 0; i < len(cl.runOrder); i++ {
-		cl.runOrder[i].actionRun()
+		if cl.runOrder[i].helperIndex == 0 {
+			cl.runOrder[i].actionRun()
+		}
+	}
+	// Run actions for idle helpers
+	for i := 0; i < len(cl.runOrder); i++ {
+		if cl.runOrder[i].helperIndex != 0 && cl.runOrder[i].ss.moveType == MT_I {
+			cl.runOrder[i].actionRun()
+		}
+	}
+	// Run actions for remaining helpers
+	for i := 0; i < len(cl.runOrder); i++ {
+		if cl.runOrder[i].helperIndex != 0 {
+			cl.runOrder[i].actionRun()
+		}
 	}
 	// Finish performing character actions
 	for i := 0; i < len(cl.runOrder); i++ {

--- a/src/system.go
+++ b/src/system.go
@@ -1171,7 +1171,6 @@ func (s *System) action() {
 				s.intro = s.lifebar.ro.ctrl_time + 1
 			}
 		} else if s.intro > 0 {
-			s.intro--
 			if s.intro == s.lifebar.ro.ctrl_time {
 				for _, p := range s.chars {
 					if len(p) > 0 {
@@ -1181,6 +1180,7 @@ func (s *System) action() {
 					}
 				}
 			}
+			s.intro--
 			if s.intro == 0 {
 				for _, p := range s.chars {
 					if len(p) > 0 {

--- a/src/system.go
+++ b/src/system.go
@@ -1088,6 +1088,7 @@ func (s *System) action() {
 					for i, p := range s.chars {
 						if len(p) > 0 {
 							s.playerClear(i, false)
+							p[0].posReset()
 							p[0].selfState(0, -1, -1, 0, "")
 						}
 					}


### PR DESCRIPTION
- Adjusted process priority so that most of the benefits of processing movetype I before H are kept, but also that a helper that is not attacking is never processed before its root
- Character positions are always reset when skipping the intros