### PR TITLE
feat: text sctrl localcoord support

### DIFF
--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -4337,6 +4337,10 @@ func (c *Compiler) text(is IniSection, sc *StateControllerBase, _ int8) (StateCo
 		}); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "localcoord",
+			text_localcoord, VT_Float, 2, false); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "bank",
 			text_bank, VT_Int, 1, false); err != nil {
 			return err

--- a/src/font.go
+++ b/src/font.go
@@ -548,6 +548,8 @@ type TextSprite struct {
 	frgba            [4]float32 //ttf fonts
 	removetime       int32      //text sctrl
 	layerno          int16      //text sctrl
+	localScale       float32    //text sctrl
+	offsetX          int32      //text sctrl
 }
 
 func NewTextSprite() *TextSprite {
@@ -561,9 +563,20 @@ func NewTextSprite() *TextSprite {
 		frgba:      [...]float32{1.0, 1.0, 1.0, 1.0},
 		removetime: 1,
 		layerno:    1,
+		localScale: 1,
+		offsetX:    0,
 	}
 	ts.palfx.setColor(255, 255, 255)
 	return ts
+}
+
+func (ts *TextSprite) SetLocalcoord(lx, ly float32) {
+	v := lx
+	if lx*3 > ly*4 {
+		v = ly * 4 / 3
+	}
+	ts.localScale = float32(v / 320)
+	ts.offsetX = -int32(math.Floor(float64(lx) / (float64(v) / 320) - 320) / 2)
 }
 
 func (ts *TextSprite) SetWindow(x, y, w, h float32) {


### PR DESCRIPTION
Fixes #1177 (discussion #1178)
Fixes #1124 (discussion #1125)

- character font defaults to the character's localcoord
- lifebar font defaults to the lifebar's localcoord
- debug font defaults to the screen's localcoord and respects the debug font scale (it should look the same as the debug text).
- a custom localcoord can be assigned using the new "localcoord" parameter. "localcoord = 320, 240" is equivalent to the previous implementation.