### PR TITLE
fix: tag and lifebar messages minor adjustment

### DIFF
--- a/data/functions.zss
+++ b/data/functions.zss
@@ -45,7 +45,7 @@ ignoreHitPause{
 		map(_iksys_reversalFrame1) := map(_iksys_reversalFrame0);
 		if (moveType = H && !hitOverridden) || stateNo = const(StateDownedGetHit_gettingUp) {
 			map(_iksys_reversalFrame0) := 2;
-		} else if moveType != H && stateNo = [1000, 4999] {
+		} else if stateNo = [1000, 4999] && moveType != H && !inCustomState {
 			map(_iksys_reversalFrame0) := 1;
 		} else {
 			map(_iksys_reversalFrame0) := 0;

--- a/data/tag.zss
+++ b/data/tag.zss
@@ -183,7 +183,11 @@ if time = 0 {
 		tagIn{leader: playerNo}
 		call TagSwitchExplod();
 	}
-	velSet{x: const240p(4); y: -const240p(8.75)}
+	if roundState = 2 {
+		velSet{x: const240p(4); y: -const240p(8.75)}
+	} else {
+		velSet{x: const240p(8.0 - 0.75 * (playerno - teamside)); y: -const240p(8.75)}
+	}
 } else {
 	gravity{}
 	if vel y > 0 && pos y >= 0 {


### PR DESCRIPTION
- Adjusted tag jumping in state so that team members don't all jump to the same position before doing their win poses
- Disabled Reversal message in custom states, for better compatibility with at least a few more characters