### PR TITLE
fix: RoundState 4 and Offset

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6710,15 +6710,17 @@ const (
 
 func (sc offset) Run(c *Char, _ []int32) bool {
 	crun := c
+	var lclscround float32 = 1.0
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case offset_x:
-			crun.offset[0] = exp[0].evalF(c) * crun.localscl
+			crun.offset[0] = exp[0].evalF(c) * lclscround
 		case offset_y:
-			crun.offset[1] = exp[0].evalF(c) * crun.localscl
+			crun.offset[1] = exp[0].evalF(c) * lclscround
 		case offset_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
+				lclscround = c.localscl / crun.localscl
 			} else {
 				return false
 			}

--- a/src/char.go
+++ b/src/char.go
@@ -2839,7 +2839,7 @@ func (c *Char) constp(coordinate, value float32) BytecodeValue {
 	return BytecodeFloat(c.stCgi().localcoord[0] / coordinate * value)
 }
 func (c *Char) ctrl() bool {
-	return c.scf(SCF_ctrl) && c.roundState() != 4 && !c.scf(SCF_standby) &&
+	return c.scf(SCF_ctrl) && !c.scf(SCF_standby) &&
 		!c.scf(SCF_dizzy) && !c.scf(SCF_guardbreak)
 }
 func (c *Char) drawgame() bool {
@@ -5294,10 +5294,10 @@ func (c *Char) exitTarget(explremove bool) {
 	c.ghv.hitBy = c.ghv.hitBy[:0]
 }
 func (c *Char) offsetX() float32 {
-	return float32(c.size.draw.offset[0])*c.facing + c.offset[0]/c.localscl
+	return float32(c.size.draw.offset[0])*c.facing + c.offset[0]
 }
 func (c *Char) offsetY() float32 {
-	return float32(c.size.draw.offset[1]) + c.offset[1]/c.localscl
+	return float32(c.size.draw.offset[1]) + c.offset[1]
 }
 func (c *Char) projClsnCheck(p *Projectile, gethit bool) bool {
 	if p.ani == nil || c.curFrame == nil || c.scf(SCF_standby) || c.scf(SCF_disabled) {
@@ -5974,7 +5974,7 @@ func (c *Char) tick() {
 			if c.pos[1] == 0 {
 				c.changeStateEx(5080, pn, -1, 0, "")
 				if c.ghv.yvel != 0 {
-					c.downHitOffset = 15 / c.localscl // This value could be unhardcoded
+					c.downHitOffset = 15 * (c.gi().localcoord[0] / 320) // This value could be unhardcoded
 				}
 				if c.recoverTime > 0 {
 					c.recoverTime--

--- a/src/system.go
+++ b/src/system.go
@@ -1328,6 +1328,9 @@ func (s *System) action() {
 					}
 				}
 			}
+			if !s.sf(GSF_roundnotover) || s.intro != -(s.lifebar.ro.over_time-s.lifebar.ro.fadeout_time-1) {
+				s.intro--
+			}
 			if s.intro == -s.lifebar.ro.over_hittime && s.finish != FT_NotYet {
 				inclWinCount()
 			}
@@ -1341,11 +1344,11 @@ func (s *System) action() {
 			}
 			rs4t := -(s.lifebar.ro.over_hittime + s.lifebar.ro.over_waittime)
 			if s.winskipped || s.intro >= rs4t-s.lifebar.ro.over_wintime {
-				if s.intro == rs4t-1 {
+				if s.intro == rs4t {
 					if s.waitdown > 0 {
 						for _, p := range s.chars {
 							if len(p) > 0 && !p[0].over() {
-								s.intro = rs4t
+								s.intro = rs4t+1
 							}
 						}
 					}
@@ -1396,9 +1399,6 @@ func (s *System) action() {
 					s.waitdown = 0
 				}
 				s.waitdown--
-			}
-			if !s.sf(GSF_roundnotover) || s.intro != -(s.lifebar.ro.over_time-s.lifebar.ro.fadeout_time-1) {
-				s.intro--
 			}
 		} else if s.intro < 0 {
 			s.intro = 0


### PR DESCRIPTION
- Made RoundState 4 detection closer to Mugen: it will only switch from 3 to 4 when every character is ready for it
- Removed ctrl flag limitation in roundstate 4 as it does not exist in Mugen
- Fixed Offset Sctrl not accounting for RedirectID localcoord
- Fixed the recently added down hit offset varying with screen aspect ratio
- Fixes #1110