### PR TITLE
feat: new AirJumpCount trigger

### DIFF
--- a/data/training.zss
+++ b/data/training.zss
@@ -147,24 +147,19 @@ if gameMode != "training" || isHelper || teamSide != 2 {
 			# Dummy mode: Crouch
 			if map(_iksys_trainingDummyMode) = 1 {
 				assertInput{flag: D}
+			}
 			# Dummy mode: Jump
-			} else if map(_iksys_trainingDummyMode) = 2 {
-				if stateNo = const(StateStand) || vel y <= 0 {
+			if map(_iksys_trainingDummyMode) = [2, 3] {
+				if stateType = S && moveType = I {
 					assertInput{flag: U}
 				}
+			}
 			# Dummy mode: W Jump
-			} else if map(_iksys_trainingDummyMode) = 3 {
-				if map(_iksys_trainingAirJumpNum) = 0 {
-					if stateNo = const(StateStand) || vel y <= 0 {
+			if map(_iksys_trainingDummyMode) = 3 {
+				if airJumpCount < const(movement.airjump.num) {
+					if stateType = A && moveType = I && vel y > 0 {
 						assertInput{flag: U}
-					} else { # 1 frame delay before another assertInput is used to register double jump
-						map(_iksys_trainingAirJumpNum) := 1;
 					}
-				} else if map(_iksys_trainingAirJumpNum) >= const(movement.airjump.num) && stateNo = const(StateJumpUp) {
-					mapAdd{map: "_iksys_trainingAirJumpNum"; value: 1}
-					assertInput{flag: U}
-				} else if stateNo = const(StateStand) {
-					map(_iksys_trainingAirJumpNum) := 0;
 				}
 			}
 			# Button jam

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -518,6 +518,7 @@ const (
 	OC_ex_reversaldefattr
 	OC_ex_bgmlength
 	OC_ex_bgmposition
+	OC_ex_airjumpcount
 )
 const (
 	NumVar     = 60
@@ -2088,6 +2089,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		} else {
 			sys.bcStack.PushI(int32(sys.bgm.streamer.Position()))
 		}
+	case OC_ex_airjumpcount:
+		sys.bcStack.PushI(c.airJumpCount)
 	default:
 		sys.errLog.Printf("%v\n", be[*i-1])
 		c.panic()

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -320,6 +320,7 @@ var triggerMap = map[string]int{
 	"winperfect":        1,
 	// expanded triggers
 	"ailevelf":         1,
+	"airjumpcount":     1,
 	"animelemlength":   1,
 	"animlength":       1,
 	"attack":           1,
@@ -2552,6 +2553,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		}
 	case "ailevelf":
 		out.append(OC_ex_, OC_ex_ailevelf)
+	case "airjumpcount":
+		out.append(OC_ex_, OC_ex_airjumpcount)
 	case "animelemlength":
 		out.append(OC_ex_, OC_ex_animelemlength)
 	case "animlength":

--- a/src/script.go
+++ b/src/script.go
@@ -2687,6 +2687,10 @@ func triggerFunctions(l *lua.LState) {
 		}
 		return 1
 	})
+	luaRegister(l, "airjumpcount", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.airJumpCount))
+		return 1
+	})
 	luaRegister(l, "alive", func(*lua.LState) int {
 		l.Push(lua.LBool(sys.debugWC.alive()))
 		return 1


### PR DESCRIPTION
- Previously available in the source code but not accessible. Returns the number of (conventional) air jumps the character has performed
- Fixed the training dummy not being able to perform double jumps