### PR TITLE
feat: added State +1

### DIFF
--- a/src/compiler.go
+++ b/src/compiler.go
@@ -4496,6 +4496,9 @@ func (c *Compiler) scanStateDef(line *string, constants map[string]float32) (int
 		}
 		return int32(v), err
 	}
+	if t == "+" && len(*line) == 2 && (*line)[0] == '1' {
+		return int32(-10), err
+	}
 	if t == "-" && len(*line) > 0 && (*line)[0] >= '0' && (*line)[0] <= '9' {
 		t += c.scan(line)
 	}


### PR DESCRIPTION
- Added State +1. This state functions like State -4, except that it is processed after the character's current state. This allows some checks that are not possible in negative states (implements #1187)
- Adjusted air jumping so that it is performed by pressing (not holding) up, as in Mugen. Thus removed obsolete air jump flag from the code
- CtrlOver is in effect after the win poses
- Moved getting up from lie down to the end of action run, to remove the leftover hack in action finish