### PR TITLE
fix: Statedefs defaulting to 0 juggle points

### DIFF
--- a/data/dizzy.zss
+++ b/data/dizzy.zss
@@ -389,8 +389,9 @@ ignoreHitPause if !const(Default.Enable.Dizzy) || isHelper || teamSide = 0 {
 	}
 
 	# Set dizzy flag
-	if !dizzy {
-		if dizzyPoints = 0 && moveType = H && !inCustomState {
+	if dizzyPoints = 0 {
+		if !dizzy && moveType = H && !inCustomState &&
+			(getHitVar(attr) != [const(AttrStandingHyperAttack), const(AttrAerialHyperProjectile)] || getHitVar(dizzyPoints) < 0) {
 			dizzySet{value: 1}
 		}
 	}

--- a/src/char.go
+++ b/src/char.go
@@ -5941,7 +5941,6 @@ func (c *Char) tick() {
 	if c.mctime < 0 {
 		c.mctime = 1
 		if c.mctype == MC_Hit {
-			c.juggle = 0
 			c.hitCount += c.hitdef.numhits
 		}
 	}
@@ -6871,6 +6870,7 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 				} else {
 					*jug -= c.juggle
 				}
+				c.juggle = 0
 			}
 			if hd.palfx.time > 0 && getter.palfx != nil {
 				getter.palfx.clear2(true)

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -3894,15 +3894,10 @@ func (c *Compiler) stateDef(is IniSection, sbc *StateBytecode) error {
 			stateDef_facep2, VT_Bool, 1, false); err != nil {
 			return err
 		}
-		b = false
 		if err := c.stateParam(is, "juggle", func(data string) error {
-			b = true
 			return c.scAdd(sc, stateDef_juggle, data, VT_Int, 1)
 		}); err != nil {
 			return err
-		}
-		if !b {
-			sc.add(stateDef_juggle, sc.iToExp(0))
 		}
 		if err := c.paramValue(is, sc, "velset",
 			stateDef_velset, VT_Float, 3, false); err != nil {
@@ -4497,6 +4492,7 @@ func (c *Compiler) scanStateDef(line *string, constants map[string]float32) (int
 		return int32(v), err
 	}
 	if t == "+" && len(*line) == 2 && (*line)[0] == '1' {
+		c.scan(line)
 		return int32(-10), err
 	}
 	if t == "-" && len(*line) > 0 && (*line)[0] >= '0' && (*line)[0] <= '9' {
@@ -5172,7 +5168,11 @@ func (c *Compiler) stateCompileZ(states map[int32]StateBytecode,
 			}
 			c.scan(&line)
 			if existInThisFile[c.stateNo] {
-				return errmes(Error(fmt.Sprintf("State %v overloaded", c.stateNo)))
+				if c.stateNo == -10 {
+					return errmes(Error(fmt.Sprintf("State +1 overloaded")))
+				} else {
+					return errmes(Error(fmt.Sprintf("State %v overloaded", c.stateNo)))
+				}
 			}
 			existInThisFile[c.stateNo] = true
 			is := NewIniSection()


### PR DESCRIPTION
- Fixed juggle points being interpreted as 0 if the juggle line is omitted from a Statedef. This eliminates many infinite combos in characters using Mugen's default juggle system (fixes #764)
- Fixed juggle point subtraction. Previously, if a move connected but did not knock down, the player's juggle points were reset. Now they are stored and are only reset when the target is knocked down
- Fixed State +1 crashing when used in the ZSS language
- If a character's dizzy points are brought down to zero without the character being dizzied (for instance in a custom state), the next hit will only dizzy if it's not a super move or if it specifically deals dizzy damage