### PR TITLE
fix: basic actions processed after current state

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -5449,79 +5449,7 @@ func (c *Char) actionPrepare() {
 		}
 	}
 	c.acttmp = -int8(Btoi(c.pauseBool)) * 2
-	c.unsetSCF(SCF_guard)
-	if sys.autoguard[c.playerNo] {
-		c.setSF(CSF_autoguard)
-	}
-	if !c.ctrlOver() &&
-		((c.scf(SCF_ctrl) || c.ss.no == 52) &&
-			c.ss.moveType == MT_I || c.inGuardState()) && c.cmd != nil &&
-		(c.cmd[0].Buffer.B > 0 || c.sf(CSF_autoguard)) &&
-		(c.ss.stateType == ST_S && !c.sf(CSF_nostandguard) ||
-			c.ss.stateType == ST_C && !c.sf(CSF_nocrouchguard) ||
-			c.ss.stateType == ST_A && !c.sf(CSF_noairguard)) {
-		c.setSCF(SCF_guard)
-	}
 	if !c.pauseBool {
-		if c.keyctrl[0] && c.cmd != nil {
-			if c.ctrl() && !c.ctrlOver() && (c.key >= 0 || c.helperIndex == 0) {
-				if !c.sf(CSF_nohardcodedkeys) {
-					if !c.sf(CSF_nojump) && (!sys.roundEnd() || c.sf(CSF_postroundinput)) && c.ss.stateType == ST_S && c.cmd[0].Buffer.U > 0 {
-						if c.ss.no != 40 {
-							c.changeState(40, -1, -1, "")
-						}
-					} else if !c.sf(CSF_noairjump) && c.ss.stateType == ST_A && c.cmd[0].Buffer.Ub == 1 &&
-						c.pos[1] <= float32(c.gi().movement.airjump.height) &&
-						c.airJumpCount < c.gi().movement.airjump.num {
-						if c.ss.no != 45 || c.ss.time > 0 {
-							c.airJumpCount++
-							c.changeState(45, -1, -1, "")
-						}
-					} else {
-						if !c.sf(CSF_nocrouch) && c.ss.stateType == ST_S && c.cmd[0].Buffer.D > 0 {
-							if c.ss.no != 10 {
-								if c.ss.no != 100 {
-									c.vel[0] = 0
-								}
-								c.changeState(10, -1, -1, "")
-							}
-						} else if !c.sf(CSF_nostand) && c.ss.stateType == ST_C && c.cmd[0].Buffer.D < 0 {
-							if c.ss.no != 12 {
-								c.changeState(12, -1, -1, "")
-							}
-						} else if !c.sf(CSF_nowalk) && c.ss.stateType == ST_S &&
-							(c.cmd[0].Buffer.F > 0 || !(c.inguarddist && c.scf(SCF_guard)) &&
-								c.cmd[0].Buffer.B > 0) {
-							if c.ss.no != 20 {
-								c.changeState(20, -1, -1, "")
-							}
-						} else if !c.sf(CSF_nobrake) && c.ss.no == 20 &&
-							c.cmd[0].Buffer.B < 0 && c.cmd[0].Buffer.F < 0 {
-							c.changeState(0, -1, -1, "")
-						}
-						if c.inguarddist && c.scf(SCF_guard) && c.cmd[0].Buffer.B > 0 &&
-							!c.inGuardState() {
-							c.changeState(120, -1, -1, "")
-						}
-					}
-				}
-			} else {
-				switch c.ss.no {
-				case 11:
-					if !c.sf(CSF_nostand) {
-						c.changeState(12, -1, -1, "")
-					}
-				case 20:
-					if !c.sf(CSF_nobrake) && c.cmd[0].Buffer.U < 0 && c.cmd[0].Buffer.D < 0 &&
-						c.cmd[0].Buffer.B < 0 && c.cmd[0].Buffer.F < 0 {
-						c.changeState(0, -1, -1, "")
-					}
-				}
-			}
-		}
-		if c.ss.stateType != ST_A {
-			c.airJumpCount = 0
-		}
 		if !c.hitPause() {
 			if !sys.roundEnd() {
 				if c.alive() && c.life > 0 {
@@ -5609,6 +5537,80 @@ func (c *Char) actionRun() {
 		c.stateChange2()
 		c.minus = 0
 		c.ss.sb.run(c)
+	}
+	if !c.pauseBool {
+		c.unsetSCF(SCF_guard)
+		if sys.autoguard[c.playerNo] {
+			c.setSF(CSF_autoguard)
+		}
+		if !c.ctrlOver() &&
+			((c.scf(SCF_ctrl) || c.ss.no == 52) &&
+				c.ss.moveType == MT_I || c.inGuardState()) && c.cmd != nil &&
+			(c.cmd[0].Buffer.B > 0 || c.sf(CSF_autoguard)) &&
+			(c.ss.stateType == ST_S && !c.sf(CSF_nostandguard) ||
+				c.ss.stateType == ST_C && !c.sf(CSF_nocrouchguard) ||
+				c.ss.stateType == ST_A && !c.sf(CSF_noairguard)) {
+			c.setSCF(SCF_guard)
+		}
+		if c.keyctrl[0] && c.cmd != nil {
+			if c.ctrl() && !c.ctrlOver() && (c.key >= 0 || c.helperIndex == 0) {
+				if !c.sf(CSF_nohardcodedkeys) {
+					if !c.sf(CSF_nojump) && (!sys.roundEnd() || c.sf(CSF_postroundinput)) && c.ss.stateType == ST_S && c.cmd[0].Buffer.U > 0 {
+						if c.ss.no != 40 {
+							c.changeState(40, -1, -1, "")
+						}
+					} else if !c.sf(CSF_noairjump) && c.ss.stateType == ST_A && c.cmd[0].Buffer.Ub == 1 &&
+						c.pos[1] <= float32(c.gi().movement.airjump.height) &&
+						c.airJumpCount < c.gi().movement.airjump.num {
+						if c.ss.no != 45 || c.ss.time > 0 {
+							c.airJumpCount++
+							c.changeState(45, -1, -1, "")
+						}
+					} else {
+						if !c.sf(CSF_nocrouch) && c.ss.stateType == ST_S && c.cmd[0].Buffer.D > 0 {
+							if c.ss.no != 10 {
+								if c.ss.no != 100 {
+									c.vel[0] = 0
+								}
+								c.changeState(10, -1, -1, "")
+							}
+						} else if !c.sf(CSF_nostand) && c.ss.stateType == ST_C && c.cmd[0].Buffer.D < 0 {
+							if c.ss.no != 12 {
+								c.changeState(12, -1, -1, "")
+							}
+						} else if !c.sf(CSF_nowalk) && c.ss.stateType == ST_S &&
+							(c.cmd[0].Buffer.F > 0 || !(c.inguarddist && c.scf(SCF_guard)) &&
+								c.cmd[0].Buffer.B > 0) {
+							if c.ss.no != 20 {
+								c.changeState(20, -1, -1, "")
+							}
+						} else if !c.sf(CSF_nobrake) && c.ss.no == 20 &&
+							c.cmd[0].Buffer.B < 0 && c.cmd[0].Buffer.F < 0 {
+							c.changeState(0, -1, -1, "")
+						}
+						if c.inguarddist && c.scf(SCF_guard) && c.cmd[0].Buffer.B > 0 &&
+							!c.inGuardState() {
+							c.changeState(120, -1, -1, "")
+						}
+					}
+				}
+			} else {
+				switch c.ss.no {
+				case 11:
+					if !c.sf(CSF_nostand) {
+						c.changeState(12, -1, -1, "")
+					}
+				case 20:
+					if !c.sf(CSF_nobrake) && c.cmd[0].Buffer.U < 0 && c.cmd[0].Buffer.D < 0 &&
+						c.cmd[0].Buffer.B < 0 && c.cmd[0].Buffer.F < 0 {
+						c.changeState(0, -1, -1, "")
+					}
+				}
+			}
+		}
+		if c.ss.stateType != ST_A {
+			c.airJumpCount = 0
+		}
 	}
 	if sb, ok := c.gi().states[-10]; ok { // still minus 0
 		sb.run(c)
@@ -5794,7 +5796,6 @@ func (c *Char) update(cvmin, cvmax,
 				// So to explain because this is did confuse the future to me.
 				// Here we set up the extra frames the combo is gonna have.
 				// Once the combo becomes non-valid and becomes false this start to count down.
-				// This timer is related to the frame where a character has already recovered from a combo, but is still not allowed to act.
 				c.comboExtraFrameWindow = sys.comboExtraFrameWindow
 			} else {
 				if c.hittmp > 0 {
@@ -6593,6 +6594,11 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 					}
 				} else if getter.bindToId == c.id {
 					getter.setBindTime(0)
+				}
+				// This compensates for characters being able to act one frame sooner in Ikemen than in Mugen
+				if c.stCgi().ikemenver[0] == 0 && c.stCgi().ikemenver[1] == 0 {
+					ghv.hittime += 1
+					ghv.ctrltime += 1
 				}
 			} else if hitType == 1 {
 				if !getter.sf(CSF_nohitdamage) {


### PR DESCRIPTION
This fixes some of Mugen's longtime issues:
- Characters can now block or do basic actions in the same frame they return to an idle state
- If a character attacks while holding back, the first frame of the attack will no longer guard automatically because of a lingering guard flag
- Fixes #1069

To compensate for this change, legacy characters (without ikemenversion) now cause 1 extra frame of hittime on their opponents, thus keeping their frame data the same as before.
