### PR TITLE
feat: spark rotation directly from Hitdef

### DIFF
--- a/data/dizzy.zss
+++ b/data/dizzy.zss
@@ -389,9 +389,10 @@ ignoreHitPause if !const(Default.Enable.Dizzy) || isHelper || teamSide = 0 {
 	}
 
 	# Set dizzy flag
-	if dizzyPoints = 0 {
-		if !dizzy && moveType = H && !inCustomState &&
-			(getHitVar(attr) != [const(AttrStandingHyperAttack), const(AttrAerialHyperProjectile)] || getHitVar(dizzyPoints) < 0) {
+	if !dizzy && dizzyPoints = 0 {
+		if time = 0 && getHitVar(dizzyPoints) >= 0 {
+			dizzyPointsSet{value: 1} # Similar to using kill = 0 in LifeAdd
+		} else if moveType = H && !inCustomState {
 			dizzySet{value: 1}
 		}
 	}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -4145,7 +4145,9 @@ const (
 	hitDef_fall_recover
 	hitDef_fall_recovertime
 	hitDef_sparkno
+	hitDef_sparkangle
 	hitDef_guard_sparkno
+	hitDef_guard_sparkangle
 	hitDef_sparkxy
 	hitDef_down_hittime
 	hitDef_p1facing
@@ -4310,9 +4312,13 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 	case hitDef_sparkno:
 		hd.sparkno_ffx = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
 		hd.sparkno = exp[1].evalI(c)
+	case hitDef_sparkangle:
+		hd.sparkangle = exp[0].evalF(c)
 	case hitDef_guard_sparkno:
 		hd.guard_sparkno_ffx = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
 		hd.guard_sparkno = exp[1].evalI(c)
+	case hitDef_guard_sparkangle:
+		hd.guard_sparkangle = exp[0].evalF(c)
 	case hitDef_sparkxy:
 		hd.sparkxy[0] = exp[0].evalF(c)
 		if len(exp) > 1 {

--- a/src/char.go
+++ b/src/char.go
@@ -541,8 +541,10 @@ type HitDef struct {
 	guard_shaketime            int32
 	sparkno                    int32
 	sparkno_ffx                string
+	sparkangle                 float32
 	guard_sparkno              int32
 	guard_sparkno_ffx          string
+	guard_sparkangle           float32
 	sparkxy                    [2]float32
 	hitsound                   [2]int32
 	hitsound_channel           int32
@@ -629,8 +631,10 @@ func (hd *HitDef) clear() {
 		bothhittype:        AT_Hit,
 		sparkno:            -1,
 		sparkno_ffx:        "f",
+		sparkangle:         0,
 		guard_sparkno:      -1,
 		guard_sparkno_ffx:  "f",
+		guard_sparkangle:   0,
 		hitsound:           [...]int32{-1, 0},
 		hitsound_channel:   -1,
 		hitsound_ffx:       "f",
@@ -6687,7 +6691,7 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 				}
 			}
 		}
-		hitspark := func(p1, p2 *Char, animNo int32, ffx string) {
+		hitspark := func(p1, p2 *Char, animNo int32, ffx string, sparkangle float32) {
 			off := pos
 			if !proj {
 				off[0] = p2.pos[0]*p2.localscl - p1.pos[0]*p1.localscl
@@ -6725,15 +6729,16 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 					e.anim.start_scale[1] *= c.localscl
 				}
 				e.setPos(p1)
+				e.rot.angle = sparkangle
 				c.insertExplod(i)
 			}
 		}
 		if Abs(hitType) == 1 {
 			if hd.sparkno >= 0 {
 				if hd.reversal_attr > 0 {
-					hitspark(getter, c, hd.sparkno, hd.sparkno_ffx)
+					hitspark(getter, c, hd.sparkno, hd.sparkno_ffx, hd.sparkangle)
 				} else {
-					hitspark(c, getter, hd.sparkno, hd.sparkno_ffx)
+					hitspark(c, getter, hd.sparkno, hd.sparkno_ffx, hd.sparkangle)
 				}
 			}
 			if hd.hitsound[0] >= 0 {
@@ -6773,9 +6778,9 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 		} else {
 			if hd.guard_sparkno >= 0 {
 				if hd.reversal_attr > 0 {
-					hitspark(getter, c, hd.guard_sparkno, hd.guard_sparkno_ffx)
+					hitspark(getter, c, hd.guard_sparkno, hd.guard_sparkno_ffx, hd.guard_sparkangle)
 				} else {
-					hitspark(c, getter, hd.guard_sparkno, hd.guard_sparkno_ffx)
+					hitspark(c, getter, hd.guard_sparkno, hd.guard_sparkno_ffx, hd.guard_sparkangle)
 				}
 			}
 			if hd.guardsound[0] >= 0 {

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1362,9 +1362,17 @@ func (c *Compiler) hitDefSub(is IniSection,
 	}); err != nil {
 		return err
 	}
+	if err := c.paramValue(is, sc, "sparkangle",
+		hitDef_sparkangle, VT_Float, 1, false); err != nil {
+		return err
+	}
 	if err := c.stateParam(is, "guard.sparkno", func(data string) error {
 		return sprk(hitDef_guard_sparkno, data)
 	}); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "guard.sparkangle",
+		hitDef_guard_sparkangle, VT_Float, 1, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "sparkxy",


### PR DESCRIPTION
- Implemented two new Hitdef parameters: sparkangle and guard.sparkangle. These allow setting the hitspark rotation directly from a Hitdef
- If a character's dizzy points are 0 and they are hit by a move that cannot dizzy, the dizzy points will be set to 1. Similar to using kill = 0 in LifeAdd