### PR TITLE
feat: hit and guardsound channels constants

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -233,6 +233,8 @@ const (
 	OC_const_data_airjuggle
 	OC_const_data_sparkno
 	OC_const_data_guard_sparkno
+	OC_const_data_hitsound_channel
+	OC_const_data_guardsound_channel
 	OC_const_data_ko_echo
 	OC_const_data_intpersistindex
 	OC_const_data_floatpersistindex
@@ -1453,6 +1455,10 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(c.gi().data.sparkno)
 	case OC_const_data_guard_sparkno:
 		sys.bcStack.PushI(c.gi().data.guard.sparkno)
+	case OC_const_data_hitsound_channel:
+		sys.bcStack.PushI(c.gi().data.hitsound_channel)
+	case OC_const_data_guardsound_channel:
+		sys.bcStack.PushI(c.gi().data.guardsound_channel)
 	case OC_const_data_ko_echo:
 		sys.bcStack.PushI(c.gi().data.ko.echo)
 	case OC_const_data_intpersistindex:
@@ -4481,6 +4487,8 @@ func (sc hitDef) Run(c *Char, _ []int32) bool {
 	crun.hitdef.playerNo = sys.workingState.playerNo
 	crun.hitdef.sparkno = c.gi().data.sparkno
 	crun.hitdef.guard_sparkno = c.gi().data.guard.sparkno
+	crun.hitdef.hitsound_channel = c.gi().data.hitsound_channel
+	crun.hitdef.guardsound_channel = c.gi().data.guardsound_channel
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		if id == hitDef_redirectid {
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1473,6 +1473,10 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.append(OC_const_data_sparkno)
 		case "data.guard.sparkno":
 			out.append(OC_const_data_guard_sparkno)
+		case "data.hitsound.channel":
+			out.append(OC_const_data_hitsound_channel)
+		case "data.guardsound.channel":
+			out.append(OC_const_data_guardsound_channel)
 		case "data.ko.echo":
 			out.append(OC_const_data_ko_echo)
 		case "data.intpersistindex":

--- a/src/script.go
+++ b/src/script.go
@@ -2801,6 +2801,10 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.gi().data.sparkno)
 		case "data.guard.sparkno":
 			ln = lua.LNumber(c.gi().data.guard.sparkno)
+		case "data.hitsound.channel":
+			ln = lua.LNumber(c.gi().data.hitsound_channel)
+		case "data.guardsound.channel":
+			ln = lua.LNumber(c.gi().data.guardsound_channel)
 		case "data.ko.echo":
 			ln = lua.LNumber(c.gi().data.ko.echo)
 		case "data.intpersistindex":


### PR DESCRIPTION
- Allows setting the default channels for hitsounds, much like the constants for hitsparks
- Restored the ability to redirect the NoStandGuard, NoCrouchGuard and NoAirGuard flags