### PR TITLE
docs: Update README.md for build-docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ On MacOS or Linux, double-click on `Ikemen_GO.command`
 These instructions are for those interested in developing the Ikemen_GO engine. Instructions on contributing with custom stages, fonts, characters and other resources can be found in the community forum.
 
 ### Building on Windows
-Check the instructions [here](https://github.com/ikemen-engine/Ikemen-GO/wiki/Building-on-Windows)
+Check the instructions [here](https://github.com/ikemen-engine/Ikemen-GO/wiki/Building,-Installing-and-Distributing#building-on-windows )
 
 ### Building on Mac
-Check the instructions [here](https://github.com/ikemen-engine/Ikemen-GO/wiki/Building-on-MacOS)
+Check the instructions [here](https://github.com/ikemen-engine/Ikemen-GO/wiki/Building,-Installing-and-Distributing#building-on-macos)
 
 ### Building on Linux
-Check the instructions [here](https://github.com/ikemen-engine/Ikemen-GO/wiki/Building-on-Linux)
+Check the instructions [here](https://github.com/ikemen-engine/Ikemen-GO/wiki/Building,-Installing-and-Distributing#building-on-linux)
 
 ### Debugging
 Download the [Mugen dependencies](https://github.com/ikemen-engine/Ikemen_GO-Elecbyte-Screenpack) and unpack them into the Ikemen-GO source directory.


### PR DESCRIPTION
Building on Windows, Mac, and Linux were pointing to incorrect location, this pr fixes it.