### PR TITLE
feat: EnvShake trigger

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -521,6 +521,7 @@ const (
 	OC_ex_bgmlength
 	OC_ex_bgmposition
 	OC_ex_airjumpcount
+	OC_ex_envshake
 )
 const (
 	NumVar     = 60
@@ -2097,6 +2098,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		}
 	case OC_ex_airjumpcount:
 		sys.bcStack.PushI(c.airJumpCount)
+	case OC_ex_envshake:
+		sys.bcStack.PushF(float32(math.Abs(float64(sys.envShake.ampl / oc.localscl))))
 	default:
 		sys.errLog.Printf("%v\n", be[*i-1])
 		c.panic()

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3748,7 +3748,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				eachExpl(func(e *Explod) {
 					e.postype = pt
 					e.setPos(c)
-					e.relativef = 1 // In Mugen ModifyExplod updates facing by default
+					e.relativef = 1 // In Mugen facing is updated by default
 				})
 			case explod_space:
 				if c.stCgi().ikemenver[0] > 0 || c.stCgi().ikemenver[1] > 0 {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1966,7 +1966,7 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_fighttime:
 		sys.bcStack.PushI(sys.gameTime)
 	case OC_ex_firstattack:
-		sys.bcStack.PushB(sys.firstAttack[c.teamside] == c.id)
+		sys.bcStack.PushB(sys.firstAttack[c.teamside] == c.playerNo)
 	case OC_ex_framespercount:
 		sys.bcStack.PushI(sys.lifebar.ti.framespercount)
 	case OC_ex_float:
@@ -3748,6 +3748,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				eachExpl(func(e *Explod) {
 					e.postype = pt
 					e.setPos(c)
+					e.relativef = 1 // In Mugen ModifyExplod updates facing by default
 				})
 			case explod_space:
 				if c.stCgi().ikemenver[0] > 0 || c.stCgi().ikemenver[1] > 0 {
@@ -4508,6 +4509,8 @@ func (sc hitDef) Run(c *Char, _ []int32) bool {
 		return true
 	})
 	//winmugenでHitdefのattrが投げ属性で自分側pausetimeが1以上の時、毎フレーム実行されなくなる
+	//"In Winmugen, when the attr of Hitdef is set to 'Throw' and the pausetime
+	// on the attacker's side is greater than 1, it no longer executes every frame."
 	if crun.hitdef.attr&int32(AT_AT) != 0 && crun.moveContact() == 1 &&
 		c.gi().ver[0] != 1 && crun.hitdef.pausetime > 0 {
 		crun.hitdef.attr = 0

--- a/src/char.go
+++ b/src/char.go
@@ -5794,6 +5794,12 @@ func (c *Char) update(cvmin, cvmax,
 			}
 		}
 		if c.ss.moveType == MT_H {
+			// Set opposing team's First Attack flag
+			if c.teamside != -1 && sys.firstAttack[1-c.teamside] < 0 && sys.firstAttack[2] == 0 {
+				if c.ghv.guarded == false && c.ghv.playerNo >= 0 {
+					sys.firstAttack[1-c.teamside] = c.ghv.playerNo
+				}
+			}
 			if sys.super <= 0 && sys.pause <= 0 {
 				c.superMovetime, c.pauseMovetime = 0, 0
 			}
@@ -6801,10 +6807,6 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 				if getter.ss.moveType == MT_A {
 					c.counterHit = true
 				}
-				if c.teamside != -1 && sys.firstAttack[2] == 0 && sys.firstAttack[c.teamside] == 0 && ghvset &&
-					getter.hoIdx < 0 && getter.helperIndex == 0 {
-					sys.firstAttack[c.teamside] = c.id
-				}
 				if !math.IsNaN(float64(hd.score[0])) {
 					c.scoreAdd(hd.score[0])
 				}
@@ -7210,7 +7212,6 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 					}
 				}
 			}
-
 			if getter.teamside != c.teamside && getter.sf(CSF_playerpush) && !c.scf(SCF_standby) && !getter.scf(SCF_standby) &&
 				c.sf(CSF_playerpush) && (getter.ss.stateType == ST_A ||
 				getter.pos[1]*getter.localscl-c.pos[1]*c.localscl < getter.height()*c.localscl) &&

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -333,6 +333,7 @@ var triggerMap = map[string]int{
 	"dizzypoints":      1,
 	"dizzypointsmax":   1,
 	"drawpalno":        1,
+	"envshake":         1,
 	"fighttime":        1,
 	"firstattack":      1,
 	"float":            1,
@@ -2578,6 +2579,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_ex_, OC_ex_dizzypoints)
 	case "dizzypointsmax":
 		out.append(OC_ex_, OC_ex_dizzypointsmax)
+	case "envshake":
+		out.append(OC_ex_, OC_ex_envshake)
 	case "fighttime":
 		out.append(OC_ex_, OC_ex_fighttime)
 	case "firstattack":

--- a/src/script.go
+++ b/src/script.go
@@ -3839,7 +3839,7 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "firstattack", func(*lua.LState) int {
-		l.Push(lua.LBool(sys.firstAttack[sys.debugWC.teamside] == sys.debugWC.id))
+		l.Push(lua.LBool(sys.firstAttack[sys.debugWC.teamside] == sys.debugWC.playerNo))
 		return 1
 	})
 	luaRegister(l, "framespercount", func(l *lua.LState) int {

--- a/src/script.go
+++ b/src/script.go
@@ -3011,6 +3011,10 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LBool(sys.debugWC.drawgame()))
 		return 1
 	})
+	luaRegister(l, "envshake", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.envShake.ampl))
+		return 1
+	})
 	luaRegister(l, "facing", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.facing))
 		return 1

--- a/src/stage.go
+++ b/src/stage.go
@@ -46,6 +46,8 @@ func (es *EnvShake) next() {
 		es.time--
 		es.phase += es.freq
 		es.ampl *= es.mul
+	} else {
+		es.ampl = 0
 	}
 }
 func (es *EnvShake) getOffset() float32 {

--- a/src/stage.go
+++ b/src/stage.go
@@ -45,7 +45,10 @@ func (es *EnvShake) next() {
 	if es.time > 0 {
 		es.time--
 		es.phase += es.freq
-		es.ampl *= es.mul
+		if es.phase > math.Pi*2 {
+			es.ampl *= es.mul
+			es.phase -= math.Pi*2
+		}
 	} else {
 		es.ampl = 0
 	}

--- a/src/system.go
+++ b/src/system.go
@@ -338,7 +338,7 @@ type System struct {
 	matchData         *lua.LTable
 	consecutiveWins   [2]int32
 	consecutiveRounds bool
-	firstAttack       [3]int32
+	firstAttack       [3]int
 	teamLeader        [2]int
 	gameSpeed         float32
 	maxPowerMode      bool
@@ -768,7 +768,7 @@ func (s *System) playerClear(pn int, destroy bool) {
 func (s *System) nextRound() {
 	s.resetGblEffect()
 	s.lifebar.reset()
-	s.firstAttack = [3]int32{}
+	s.firstAttack = [3]int{-1, -1, 0}
 	s.finish = FT_NotYet
 	s.winTeam = -1
 	s.winType = [...]WinType{WT_N, WT_N}
@@ -1187,7 +1187,7 @@ func (s *System) action() {
 			}
 			// Check if player skipped win pose time
 			if s.roundWinTime() && (s.anyButton() && !s.sf(GSF_roundnotskip)) {
-				s.intro = Min(s.intro, -(s.lifebar.ro.over_waittime + s.lifebar.ro.over_time - s.lifebar.ro.fadeout_time))
+				s.intro = Min(s.intro, -(s.lifebar.ro.over_waittime+s.lifebar.ro.over_time-s.lifebar.ro.fadeout_time))
 				s.winskipped = true
 			}
 			rs4t := -s.lifebar.ro.over_waittime
@@ -1324,7 +1324,9 @@ func (s *System) action() {
 		s.charUpdate(&cvmin, &cvmax, &highest, &lowest, &leftest, &rightest)
 	}
 	s.lifebar.step()
-	if s.firstAttack[0] != 0 || s.firstAttack[1] != 0 {
+
+	// Set global First Attack flag if either team got it
+	if s.firstAttack[0] >= 0 || s.firstAttack[1] >= 0 {
 		s.firstAttack[2] = 1
 	}
 


### PR DESCRIPTION
- Returns the current (absolute) amplitude of the active EnvShake effect. Mostly useful for interactive stages
- The EnvShake mul parameter is now only applied after each cycle of the shaking effect. This makes it so that values lower than 0.9 don't stop the effect almost immediately
- Refactored first attack code: now works based on player number instead of ID. This allows characters to be flagged with first attack if any of their helpers hit the opponent, thus making the trigger easier to use. Now checked when a character or helper enters Movetype H rather than upon move contact, for improved compatibility with counter grabs (Geese type), super armor, etc
- Explod facing is now updated to 1 by default if PosType is modified (fixes #1252)