### PR TITLE
feat: EnvShakeVar trigger

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -521,7 +521,9 @@ const (
 	OC_ex_bgmlength
 	OC_ex_bgmposition
 	OC_ex_airjumpcount
-	OC_ex_envshake
+	OC_ex_envshakevar_time
+	OC_ex_envshakevar_freq
+	OC_ex_envshakevar_ampl
 )
 const (
 	NumVar     = 60
@@ -2098,7 +2100,11 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		}
 	case OC_ex_airjumpcount:
 		sys.bcStack.PushI(c.airJumpCount)
-	case OC_ex_envshake:
+	case OC_ex_envshakevar_time:
+		sys.bcStack.PushI(sys.envShake.time)
+	case OC_ex_envshakevar_freq:
+		sys.bcStack.PushF(sys.envShake.freq/float32(math.Pi)*180)
+	case OC_ex_envshakevar_ampl:
 		sys.bcStack.PushF(float32(math.Abs(float64(sys.envShake.ampl / oc.localscl))))
 	default:
 		sys.errLog.Printf("%v\n", be[*i-1])

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -333,7 +333,7 @@ var triggerMap = map[string]int{
 	"dizzypoints":      1,
 	"dizzypointsmax":   1,
 	"drawpalno":        1,
-	"envshake":         1,
+	"envshakevar":      1,
 	"fighttime":        1,
 	"firstattack":      1,
 	"float":            1,
@@ -2579,8 +2579,25 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_ex_, OC_ex_dizzypoints)
 	case "dizzypointsmax":
 		out.append(OC_ex_, OC_ex_dizzypointsmax)
-	case "envshake":
-		out.append(OC_ex_, OC_ex_envshake)
+	case "envshakevar":
+		if err := c.checkOpeningBracket(in); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_ex_)
+		switch c.token {
+		case "time":
+			out.append(OC_ex_envshakevar_time)
+		case "freq":
+			out.append(OC_ex_envshakevar_freq)
+		case "ampl":
+			out.append(OC_ex_envshakevar_ampl)
+		default:
+			return bvNone(), Error("Invalid data: " + c.token)
+		}
+		c.token = c.tokenizer(in)
+		if err := c.checkClosingBracket(); err != nil {
+			return bvNone(), err
+		}
 	case "fighttime":
 		out.append(OC_ex_, OC_ex_fighttime)
 	case "firstattack":

--- a/src/script.go
+++ b/src/script.go
@@ -3011,8 +3011,19 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LBool(sys.debugWC.drawgame()))
 		return 1
 	})
-	luaRegister(l, "envshake", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.envShake.ampl))
+	luaRegister(l, "envshakevar", func(*lua.LState) int {
+		var ln lua.LNumber
+		switch strArg(l, 1) {
+		case "time":
+			ln = lua.LNumber(sys.envShake.time)
+		case "freq":
+			ln = lua.LNumber(sys.envShake.freq/float32(math.Pi)*180)
+		case "ampl":
+			ln = lua.LNumber(sys.envShake.ampl)
+		default:
+			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
+		}
+		l.Push(ln)
 		return 1
 	})
 	luaRegister(l, "facing", func(*lua.LState) int {


### PR DESCRIPTION
- Replaces previous EnvShake trigger
- Allows checking the (remaining) time, frequency and amplitude of the current EnvShake
- Used as EnvShakeVar(time), EnvShakeVar(freq) or EnvShakeVar(ampl)