### PR TITLE
feat: Explod RemoveOnChangeState parameter

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3491,6 +3491,7 @@ const (
 	explod_under
 	explod_shadow
 	explod_removeongethit
+	explod_removeonchangestate
 	explod_trans
 	explod_anim
 	explod_angle
@@ -3635,6 +3636,8 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 			}
 		case explod_removeongethit:
 			e.removeongethit = exp[0].evalB(c)
+		case explod_removeonchangestate:
+			e.removeonchangestate = exp[0].evalB(c)
 		case explod_trans:
 			e.alpha[0] = exp[0].evalI(c)
 			e.alpha[1] = exp[1].evalI(c)
@@ -3854,6 +3857,9 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 			case explod_removeongethit:
 				t := exp[0].evalB(c)
 				eachExpl(func(e *Explod) { e.removeongethit = t })
+			case explod_removeonchangestate:
+				t := exp[0].evalB(c)
+				eachExpl(func(e *Explod) { e.removeonchangestate = t })
 			case explod_trans:
 				s, d := exp[0].evalI(c), exp[1].evalI(c)
 				if len(exp) >= 3 {

--- a/src/char.go
+++ b/src/char.go
@@ -6718,9 +6718,7 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 				if getter.ghv.kill || !live {
 					getter.ghv.fatal = true
 					getter.ghv.fallf = true
-					// if getter.ghv.fall.animtype < RA_Back {
-					// getter.ghv.fall.animtype = RA_Back
-					// }
+					getter.ghv.animtype = getter.gethitAnimtype() // Update to fall anim type
 					if getter.kovelocity && !getter.sf(CSF_nokovelocity) {
 						if getter.ss.stateType == ST_A {
 							if getter.ghv.xvel < 0 {

--- a/src/char.go
+++ b/src/char.go
@@ -985,7 +985,8 @@ type Explod struct {
 	bindtime       int32
 	scale          [2]float32
 	time           int32
-	removeongethit bool
+	removeongethit      bool
+	removeonchangestate bool
 	removetime     int32
 	velocity       [2]float32
 	accel          [2]float32
@@ -1137,6 +1138,7 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 	if !e.ignorehitpause || e.removeongethit {
 		c = sys.playerID(e.playerId)
 	}
+	// Remove on get hit
 	if sys.tickNextFrame() &&
 		c != nil && e.removeongethit && c.sf(CSF_gethit) {
 		e.id, e.anim = IErr, nil
@@ -3390,6 +3392,14 @@ func (c *Char) changeStateEx(no int32, pn int, anim, ctrl int32, ffx string) {
 	}
 	if ctrl >= 0 {
 		c.setCtrl(ctrl != 0)
+	}
+	// Remove relevant explods
+	for i := range sys.explods[c.playerNo] {
+		e := sys.explods[c.playerNo]
+		if  e[i].playerId == c.id && e[i].removeonchangestate {
+			e[i].id = IErr
+			e[i].anim = nil
+		}
 	}
 	if c.stateChange1(no, pn) && sys.changeStateNest == 0 && c.minus == 0 {
 		for c.stchtmp && sys.changeStateNest < 2500 {

--- a/src/char.go
+++ b/src/char.go
@@ -4621,14 +4621,12 @@ func (c *Char) p2BodyDistX(oc *Char) BytecodeValue {
 	}
 }
 func (c *Char) hitVelSetX() {
-	if c.ss.moveType == MT_H {
-		c.setXV(c.ghv.xvel)
-	}
+	// Movetype H is not required in Mugen
+	c.setXV(c.ghv.xvel)
 }
 func (c *Char) hitVelSetY() {
-	if c.ss.moveType == MT_H {
-		c.setYV(c.ghv.yvel)
-	}
+	// Movetype H is not required in Mugen
+	c.setYV(c.ghv.yvel)
 }
 func (c *Char) getEdge(base float32, actually bool) float32 {
 	if !actually || c.stCgi().ver[0] != 1 {

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -685,6 +685,10 @@ func (c *Compiler) explodSub(is IniSection,
 		explod_removeongethit, VT_Bool, 1, false); err != nil {
 		return err
 	}
+	if err := c.paramValue(is, sc, "removeonchangestate",
+		explod_removeonchangestate, VT_Bool, 1, false); err != nil {
+		return err
+	}
 	if err := c.paramTrans(is, sc, "", explod_trans, false); err != nil {
 		return err
 	}


### PR DESCRIPTION
- Setting this parameter to 1 makes the Explod be removed if the character changes state
- Fix: If a character is KO'd, their get hit animation is now updated to "fall type"
- Fix: HitVelSet no longer requires the character to be in Movetype H to work (same as Mugen 1.1)