### PR TITLE
fix: type None and ChainID

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -415,6 +415,7 @@ const (
 	OC_ex_gethitvar_air_animtype
 	OC_ex_gethitvar_ground_animtype
 	OC_ex_gethitvar_fall_animtype
+	OC_ex_gethitvar_type
 	OC_ex_gethitvar_airtype
 	OC_ex_gethitvar_groundtype
 	OC_ex_gethitvar_damage
@@ -1858,6 +1859,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(int32(c.ghv.groundanimtype))
 	case OC_ex_gethitvar_fall_animtype:
 		sys.bcStack.PushI(int32(c.ghv.fall.animtype))
+	case OC_ex_gethitvar_type:
+		sys.bcStack.PushI(int32(c.ghv._type))
 	case OC_ex_gethitvar_airtype:
 		sys.bcStack.PushI(int32(c.ghv.airtype))
 	case OC_ex_gethitvar_groundtype:

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1711,8 +1711,6 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			bv.SetF(0)
 		case "yveladd":
 			bv.SetF(0)
-		case "type":
-			bv.SetI(0)
 		case "zoff":
 			bv.SetF(0)
 		case "fall.envshake.dir":
@@ -1728,6 +1726,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				out.append(OC_ex_gethitvar_ground_animtype)
 			case "fall.animtype":
 				out.append(OC_ex_gethitvar_fall_animtype)
+			case "type":
+				out.append(OC_ex_gethitvar_type)
 			case "airtype":
 				out.append(OC_ex_gethitvar_airtype)
 			case "groundtype":

--- a/src/script.go
+++ b/src/script.go
@@ -3111,8 +3111,6 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(0)
 		case "yveladd":
 			ln = lua.LNumber(0)
-		case "type":
-			ln = lua.LNumber(0)
 		case "zoff":
 			ln = lua.LNumber(0)
 		case "fall.envshake.dir":
@@ -3125,6 +3123,8 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.ghv.groundanimtype)
 		case "fall.animtype":
 			ln = lua.LNumber(c.ghv.fall.animtype)
+		case "type":
+			ln = lua.LNumber(c.ghv._type)
 		case "airtype":
 			ln = lua.LNumber(c.ghv.airtype)
 		case "groundtype":


### PR DESCRIPTION
- Added an exception to the code so that characters hit by a type = None attack are correctly assigned a ChainID
- Added new trigger for GetHitVar "type". Returns the value of either groundtype or airtype, depending on where the character was hit