### PR TITLE
feat: new Math triggers (Clamp, Sign, Atan2, Rad, Deg, Lerp) and char triggers (Angle, Scale, OffSet, Alpha)

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -216,13 +216,6 @@ const (
 	OC_helperindex
 	OC_p2
 	OC_stateowner
-	OC_angle
-	OC_scale_x
-	OC_scale_y
-	OC_offset_x
-	OC_offset_y
-	OC_alpha_s
-	OC_alpha_d	
 	OC_rdreset
 	OC_const_
 	OC_st_
@@ -539,6 +532,13 @@ const (
 	OC_ex_envshakevar_time
 	OC_ex_envshakevar_freq
 	OC_ex_envshakevar_ampl
+	OC_ex_angle
+	OC_ex_scale_x
+	OC_ex_scale_y
+	OC_ex_offset_x
+	OC_ex_offset_y
+	OC_ex_alpha_s
+	OC_ex_alpha_d
 )
 const (
 	NumVar     = 60
@@ -1452,20 +1452,6 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 		case OC_localvar:
 			sys.bcStack.Push(sys.bcVar[uint8(be[i])])
 			i++
-		case OC_angle:
-			sys.bcStack.PushF(c.angleTrg)
-		case OC_scale_x:			
-			sys.bcStack.PushF(c.angleScaleTrg[0])
-		case OC_scale_y:
-			sys.bcStack.PushF(c.angleScaleTrg[1])			
-		case OC_offset_x:
-			sys.bcStack.PushF(c.offsetTrg[0])
-		case OC_offset_y:
-			sys.bcStack.PushF(c.offsetTrg[1])
-		case OC_alpha_s:
-			sys.bcStack.PushI(c.alphaTrg[0])
-		case OC_alpha_d:
-			sys.bcStack.PushI(c.alphaTrg[1])
 		}		
 		c = oc
 	}
@@ -2197,6 +2183,20 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(sys.envShake.freq / float32(math.Pi) * 180)
 	case OC_ex_envshakevar_ampl:
 		sys.bcStack.PushF(float32(math.Abs(float64(sys.envShake.ampl / oc.localscl))))
+	case OC_ex_angle:
+		sys.bcStack.PushF(c.angleTrg)
+	case OC_ex_scale_x:			
+		sys.bcStack.PushF(c.angleScaleTrg[0])
+	case OC_ex_scale_y:
+		sys.bcStack.PushF(c.angleScaleTrg[1])			
+	case OC_ex_offset_x:
+		sys.bcStack.PushF(c.offsetTrg[0])
+	case OC_ex_offset_y:
+		sys.bcStack.PushF(c.offsetTrg[1])
+	case OC_ex_alpha_s:
+		sys.bcStack.PushI(c.alphaTrg[0])
+	case OC_ex_alpha_d:
+		sys.bcStack.PushI(c.alphaTrg[1])		
 	default:
 		sys.errLog.Printf("%v\n", be[*i-1])
 		c.panic()

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -965,7 +965,7 @@ func (BytecodeExp) lerp(v1 *BytecodeValue, v2 BytecodeValue, v3 BytecodeValue) {
 	if v3.v <= 0 {
 		amount = 0
 	} else if v3.v >= 1 {
-		amount = 0
+		amount = 1
 	}
 	v1.SetF(float32(v1.v+(v2.v-v1.v)*amount))
 }

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6926,32 +6926,27 @@ const (
 	offset_y
 	offset_redirectid
 )
-
 func (sc offset) Run(c *Char, _ []int32) bool {
 	crun := c
-	var lclscround float32 = 1.0
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case offset_x:
-			crun.offset[0] = exp[0].evalF(c) * lclscround
+			crun.offset[0] = exp[0].evalF(c) * c.localscl
 			crun.offsetTrg[0] = crun.offset[0]
 		case offset_y:
-			crun.offset[1] = exp[0].evalF(c) * lclscround
+			crun.offset[1] = exp[0].evalF(c) * c.localscl
 			crun.offsetTrg[1] = crun.offset[1]
 		case offset_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				lclscround = c.localscl / crun.localscl
 			} else {
 				return false
 			}
 		}
 		return true
 	})
-	crun.setSF(CSF_offset)	
 	return false
 }
-
 type victoryQuote StateControllerBase
 
 const (

--- a/src/char.go
+++ b/src/char.go
@@ -72,6 +72,7 @@ const (
 	CSF_posfreeze
 	CSF_playerpush
 	CSF_angledraw
+	CSF_offset
 	CSF_destroy
 	CSF_frontedge
 	CSF_backedge
@@ -1691,8 +1692,11 @@ type CharSystemVar struct {
 	bindFacing       float32
 	hitPauseTime     int32
 	angle            float32
+	angleTrg         float32	
 	angleScale       [2]float32
+	angleScaleTrg    [2]float32
 	alpha            [2]int32
+	alphaTrg         [2]int32	
 	recoverTime      int32
 	systemFlag       SystemCharFlag
 	specialFlag      CharSpecialFlag
@@ -1773,6 +1777,7 @@ type Char struct {
 	cpucmd                int32
 	attackDist            float32
 	offset                [2]float32
+	offsetTrg             [2]float32	
 	stchtmp               bool
 	inguarddist           bool
 	pushed                bool
@@ -1930,7 +1935,7 @@ func (c *Char) clear2() {
 	c.sysVarRangeSet(0, int32(NumSysVar)-1, 0)
 	c.sysFvarRangeSet(0, int32(NumSysFvar)-1, 0)
 	c.CharSystemVar = CharSystemVar{bindToId: -1,
-		angleScale: [...]float32{1, 1}, alpha: [...]int32{255, 0},
+		angleScale: [...]float32{1, 1}, angleScaleTrg: [...]float32{1, 1}, alphaTrg: [...]int32{255, 0}, alpha: [...]int32{255, 0},
 		width:           [...]float32{c.defFW(), c.defBW()},
 		attackMul:       float32(c.gi().data.attack) * c.ocd().attackRatio / 100,
 		fallDefenseMul:  1,
@@ -4724,6 +4729,7 @@ func (c *Char) hitPause() bool {
 }
 func (c *Char) angleSet(a float32) {
 	c.angle = a
+	c.angleTrg = c.angle
 }
 func (c *Char) inputOver() bool {
 	return !c.alive() || sys.time == 0 || sys.intro <= -sys.lifebar.ro.over_time
@@ -5617,7 +5623,7 @@ func (c *Char) actionPrepare() {
 		if c.gi().ver[0] == 1 {
 			// The following flags are only reset later in the code
 			flagtemp := (c.specialFlag&CSF_nostandguard | c.specialFlag&CSF_nocrouchguard | c.specialFlag&CSF_noairguard)
-			c.unsetSF(CSF_assertspecial | CSF_angledraw)
+			c.unsetSF(CSF_assertspecial | CSF_angledraw | CSF_offset)
 			c.setSF(flagtemp)
 			c.angleScale = [...]float32{1, 1}
 			c.offset = [2]float32{}
@@ -5805,6 +5811,17 @@ func (c *Char) update(cvmin, cvmax,
 		if c.sf(CSF_destroy) {
 			c.destroy()
 			return
+		}
+		if !c.sf(CSF_offset) {
+			c.offsetTrg = [2]float32{}
+		}
+		if !c.sf(CSF_angledraw) {
+			c.angleTrg = 0
+			c.angleScaleTrg = [...]float32{1, 1}
+		}
+		if !c.sf(CSF_trans) {
+			c.alphaTrg[0] = 255
+			c.alphaTrg[1] = 0			
 		}
 		if !c.pause() && !c.isBound() {
 			c.bind()

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2998,16 +2998,15 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_ex_, OC_ex_timetotal)
 	case "drawpalno":
 		out.append(OC_ex_, OC_ex_drawpalno)
-
 	case "angle":
-		out.append(OC_angle)
+		out.append(OC_ex_, OC_ex_angle)
 	case "scale":
 		c.token = c.tokenizer(in)
 		switch c.token {
 		case "x":
-			out.append(OC_scale_x)
+			out.append(OC_ex_, OC_ex_scale_x)
 		case "y":
-			out.append(OC_scale_y)
+			out.append(OC_ex_, OC_ex_scale_y)
 		default:
 			return bvNone(), Error("Invalid data: " + c.token)
 		}
@@ -3015,9 +3014,9 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		c.token = c.tokenizer(in)
 		switch c.token {
 		case "x":
-			out.append(OC_offset_x)
+			out.append(OC_ex_, OC_ex_offset_x)
 		case "y":
-			out.append(OC_offset_y)
+			out.append(OC_ex_, OC_ex_offset_y)
 		default:
 			return bvNone(), Error("Invalid data: " + c.token)
 		}		
@@ -3025,9 +3024,9 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		c.token = c.tokenizer(in)
 		switch c.token {
 		case "source":
-			out.append(OC_alpha_s)
+			out.append(OC_ex_, OC_ex_alpha_s)
 		case "dest":
-			out.append(OC_alpha_d)
+			out.append(OC_ex_, OC_ex_alpha_d)
 		default:
 			return bvNone(), Error("Invalid data: " + c.token)
 		}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -353,6 +353,12 @@ var triggerMap = map[string]int{
 	"majorversion":     1,
 	"map":              1,
 	"max":              1,
+	"clamp":       		1,
+	"sign":       		1,
+	"atan2":       		1,
+	"rad":       		1,
+	"deg":       		1,
+	"lerp":       		1,	
 	"memberno":         1,
 	"min":              1,
 	"movecountered":    1,
@@ -389,6 +395,11 @@ var triggerMap = map[string]int{
 	"timetotal":        1,
 	"winhyper":         1,
 	"winspecial":       1,
+	"angle":       		1,
+	"scale":       		1,
+	"offset":       	1,
+	"alphas":       	1,
+	"alphad":       	1,
 }
 
 func (c *Compiler) tokenizer(in *string) string {
@@ -2560,6 +2571,129 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.round(&bv1, bv2)
 			bv = bv1
 		}
+	case "clamp":
+		if err := c.checkOpeningBracket(in); err != nil {
+			return bvNone(), err
+		}
+		if bv1, err = c.expBoolOr(&be1, in); err != nil {
+			return bvNone(), err
+		}
+		if c.token != "," {
+			return bvNone(), Error("Missing ','")
+		}
+		c.token = c.tokenizer(in)
+		if bv2, err = c.expBoolOr(&be2, in); err != nil {
+			return bvNone(), err
+		}
+		if c.token != "," {
+			return bvNone(), Error("Missing ','")
+		}
+		c.token = c.tokenizer(in)
+		if bv3, err = c.expBoolOr(&be3, in); err != nil {
+			return bvNone(), err
+		}
+		if err := c.checkClosingBracket(); err != nil {
+			return bvNone(), err
+		}
+		if bv1.IsNone() || bv2.IsNone() || bv3.IsNone(){
+			if rd {
+				out.append(OC_rdreset)
+			}
+			out.append(be1...)
+			out.appendValue(bv1)
+			out.append(be2...)
+			out.appendValue(bv2)
+			out.append(be3...)
+			out.appendValue(bv3)
+			out.append(OC_ex_, OC_ex_clamp)
+		} else {
+			out.clamp(&bv1,bv2, bv3)
+			bv = bv1
+		}
+	case "atan2":
+		if err := c.checkOpeningBracket(in); err != nil {
+			return bvNone(), err
+		}
+		if bv1, err = c.expBoolOr(&be1, in); err != nil {
+			return bvNone(), err
+		}
+		if c.token != "," {
+			return bvNone(), Error("Missing ','")
+		}
+		c.token = c.tokenizer(in)
+		if bv2, err = c.expBoolOr(&be2, in); err != nil {
+			return bvNone(), err
+		}
+		if err := c.checkClosingBracket(); err != nil {
+			return bvNone(), err
+		}
+		if bv1.IsNone() || bv2.IsNone() {
+			if rd {
+				out.append(OC_rdreset)
+			}
+			out.append(be1...)
+			out.appendValue(bv1)
+			out.append(be2...)
+			out.appendValue(bv2)		
+			out.append(OC_ex_, OC_ex_atan2)
+		} else {
+			out.atan2(&bv1,bv2)
+			bv = bv1
+		}
+	case "sign":
+		if _, err := c.oneArg(out, in, rd, true); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_ex_, OC_ex_sign)
+	case "rad":
+		if _, err := c.oneArg(out, in, rd, true); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_ex_, OC_ex_rad)
+	case "deg":
+		if _, err := c.oneArg(out, in, rd, true); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_ex_, OC_ex_deg)
+	case "lerp":
+		if err := c.checkOpeningBracket(in); err != nil {
+			return bvNone(), err
+		}
+		if bv1, err = c.expBoolOr(&be1, in); err != nil {
+			return bvNone(), err
+		}
+		if c.token != "," {
+			return bvNone(), Error("Missing ','")
+		}
+		c.token = c.tokenizer(in)
+		if bv2, err = c.expBoolOr(&be2, in); err != nil {
+			return bvNone(), err
+		}
+		if c.token != "," {
+			return bvNone(), Error("Missing ','")
+		}
+		c.token = c.tokenizer(in)
+		if bv3, err = c.expBoolOr(&be3, in); err != nil {
+			return bvNone(), err
+		}
+		if err := c.checkClosingBracket(); err != nil {
+			return bvNone(), err
+		}
+		if bv1.IsNone() || bv2.IsNone() || bv3.IsNone(){
+			if rd {
+				out.append(OC_rdreset)
+			}
+			out.append(be1...)
+			out.appendValue(bv1)
+			out.append(be2...)
+			out.appendValue(bv2)
+			out.append(be3...)
+			out.appendValue(bv3)
+			out.append(OC_ex_, OC_ex_lerp)
+		} else {
+			out.lerp(&bv1,bv2, bv3)
+			bv = bv1
+		}		
 	case "ailevelf":
 		out.append(OC_ex_, OC_ex_ailevelf)
 	case "airjumpcount":
@@ -2863,6 +2997,39 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_ex_, OC_ex_timetotal)
 	case "drawpalno":
 		out.append(OC_ex_, OC_ex_drawpalno)
+
+	case "angle":
+		out.append(OC_angle)
+	case "scale":
+		c.token = c.tokenizer(in)
+		switch c.token {
+		case "x":
+			out.append(OC_scale_x)
+		case "y":
+			out.append(OC_scale_y)
+		default:
+			return bvNone(), Error("Invalid data: " + c.token)
+		}
+	case "offset":
+		c.token = c.tokenizer(in)
+		switch c.token {
+		case "x":
+			out.append(OC_offset_x)
+		case "y":
+			out.append(OC_offset_y)
+		default:
+			return bvNone(), Error("Invalid data: " + c.token)
+		}		
+	case "alpha":
+		c.token = c.tokenizer(in)
+		switch c.token {
+		case "source":
+			out.append(OC_alpha_s)
+		case "dest":
+			out.append(OC_alpha_d)
+		default:
+			return bvNone(), Error("Invalid data: " + c.token)
+		}
 	case "=", "!=", ">", ">=", "<", "<=", "&", "&&", "^", "^^", "|", "||",
 		"+", "*", "**", "/", "%":
 		if !sys.ignoreMostErrors || len(c.previousOperator) > 0 {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -398,8 +398,7 @@ var triggerMap = map[string]int{
 	"angle":       		1,
 	"scale":       		1,
 	"offset":       	1,
-	"alphas":       	1,
-	"alphad":       	1,
+	"alpha":       		1,
 }
 
 func (c *Compiler) tokenizer(in *string) string {

--- a/src/script.go
+++ b/src/script.go
@@ -4305,4 +4305,32 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(winp))
 		return 1
 	})
+	luaRegister(l, "angle", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.angleTrg))
+		return 1
+	})	
+	luaRegister(l, "scaleX", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.angleScaleTrg[0]))
+		return 1
+	})
+	luaRegister(l, "scaleY", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.angleScaleTrg[1]))
+		return 1
+	})
+	luaRegister(l, "offsetX", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.offsetTrg[0]))
+		return 1
+	})
+	luaRegister(l, "offsetY", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.offsetTrg[1]))
+		return 1
+	})
+	luaRegister(l, "alphaSource", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.alphaTrg[0]))
+		return 1
+	})
+	luaRegister(l, "offsetDest", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.alphaTrg[1]))
+		return 1
+	})
 }

--- a/src/script.go
+++ b/src/script.go
@@ -3855,6 +3855,18 @@ func triggerFunctions(l *lua.LState) {
 
 	// new triggers
 	//atan2 (dedicated functionality already exists in Lua)	
+	luaRegister(l, "angle", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.angleTrg))
+		return 1
+	})
+	luaRegister(l, "alphaSource", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.alphaTrg[0]))
+		return 1
+	})
+	luaRegister(l, "alphaDest", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.alphaTrg[1]))
+		return 1
+	})
 	luaRegister(l, "animelemlength", func(*lua.LState) int {
 		if f := sys.debugWC.anim.CurrentFrame(); f != nil {
 			l.Push(lua.LNumber(f.Time))
@@ -3879,6 +3891,12 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.consecutiveWins[sys.debugWC.teamside]))
 		return 1
 	})
+	luaRegister(l, "clamp", func(*lua.LState) int {
+		v1, v2, v3, retv := float32(numArg(l,1)),float32(numArg(l,2)),float32(numArg(l,3)), float32(0)
+		retv = MaxF(v2, MinF(v1, v3))
+		l.Push(lua.LNumber(retv))
+		return 1
+	})	
 	//deg (dedicated functionality already exists in Lua)		
 	luaRegister(l, "defence", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.finalDefense * 100))
@@ -4066,6 +4084,12 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.debugWC.localscl))
 		return 1
 	})
+	luaRegister(l, "lerp", func(*lua.LState) int {
+		a,b,amount, retv := float32(numArg(l,1)),float32(numArg(l,2)),float32(numArg(l,3)), float32(0)
+		retv = float32(a + (b - a) * MaxF(0, MinF(amount, 1)))
+		l.Push(lua.LNumber(retv))
+		return 1
+	})	
 	luaRegister(l, "majorversion", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.gi().ver[0]))
 		return 1
@@ -4082,6 +4106,14 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.debugWC.moveCountered()))
 		return 1
 	})
+	luaRegister(l, "offsetX", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.offsetTrg[0]))
+		return 1
+	})
+	luaRegister(l, "offsetY", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.offsetTrg[1]))
+		return 1
+	})	
 	luaRegister(l, "pausetime", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.pauseTime()))
 		return 1
@@ -4127,6 +4159,14 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.debugWC.roundType()))
 		return 1
 	})
+	luaRegister(l, "scaleX", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.angleScaleTrg[0]))
+		return 1
+	})
+	luaRegister(l, "scaleY", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.angleScaleTrg[1]))
+		return 1
+	})	
 	luaRegister(l, "score", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.score()))
 		return 1
@@ -4164,6 +4204,19 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LBool(sys.debugWC.scf(SCF_standby)))
 		return 1
 	})
+	luaRegister(l, "sign", func(*lua.LState) int {
+		v, retv := float32(numArg(l,1)), int32(0)
+		if v < 0 {
+			v = -1	
+		} else if v > 0 {
+			v = 1
+		} else {
+			v = 0
+		}
+		retv = int32(v)
+		l.Push(lua.LNumber(retv))
+		return 1
+	})	
 	luaRegister(l, "teamleader", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.teamLeader()))
 		return 1
@@ -4184,60 +4237,7 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(timeTotal()))
 		return 1
 	})
-	luaRegister(l, "angle", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.angleTrg))
-		return 1
-	})	
-	luaRegister(l, "scaleX", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.angleScaleTrg[0]))
-		return 1
-	})
-	luaRegister(l, "scaleY", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.angleScaleTrg[1]))
-		return 1
-	})
-	luaRegister(l, "offsetX", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.offsetTrg[0]))
-		return 1
-	})
-	luaRegister(l, "offsetY", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.offsetTrg[1]))
-		return 1
-	})
-	luaRegister(l, "alphaSource", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.alphaTrg[0]))
-		return 1
-	})
-	luaRegister(l, "alphaDest", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.alphaTrg[1]))
-		return 1
-	})
-	luaRegister(l, "lerp", func(*lua.LState) int {
-		a,b,amount, retv := float32(numArg(l,1)),float32(numArg(l,2)),float32(numArg(l,3)), float32(0)
-		retv = float32(a + (b - a) * MaxF(0, MinF(amount, 1)))
-		l.Push(lua.LNumber(retv))
-		return 1
-	})
-	luaRegister(l, "sign", func(*lua.LState) int {
-		v, retv := float32(numArg(l,1)), int32(0)
-		if v < 0 {
-			v = -1	
-		} else if v > 0 {
-			v = 1
-		} else {
-			v = 0
-		}
-		retv = int32(v)
-		l.Push(lua.LNumber(retv))
-		return 1
-	})	
-	luaRegister(l, "clamp", func(*lua.LState) int {
-		v1, v2, v3, retv := float32(numArg(l,1)),float32(numArg(l,2)),float32(numArg(l,3)), float32(0)
-		retv = MaxF(v2, MinF(v1, v3))
-		l.Push(lua.LNumber(retv))
-		return 1
-	})
-	
+
 	// lua/debug only triggers
 	luaRegister(l, "animelemcount", func(*lua.LState) int {
 		l.Push(lua.LNumber(len(sys.debugWC.anim.frames)))

--- a/src/script.go
+++ b/src/script.go
@@ -3854,6 +3854,7 @@ func triggerFunctions(l *lua.LState) {
 	})
 
 	// new triggers
+	//atan2 (dedicated functionality already exists in Lua)	
 	luaRegister(l, "animelemlength", func(*lua.LState) int {
 		if f := sys.debugWC.anim.CurrentFrame(); f != nil {
 			l.Push(lua.LNumber(f.Time))
@@ -3878,6 +3879,7 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.consecutiveWins[sys.debugWC.teamside]))
 		return 1
 	})
+	//deg (dedicated functionality already exists in Lua)		
 	luaRegister(l, "defence", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.finalDefense * 100))
 		return 1
@@ -4104,6 +4106,7 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	//randomrange (dedicated functionality already exists in Lua)
+	//rad (dedicated functionality already exists in Lua)		
 	luaRegister(l, "ratiolevel", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.ocd().ratioLevel))
 		return 1
@@ -4181,7 +4184,60 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(timeTotal()))
 		return 1
 	})
-
+	luaRegister(l, "angle", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.angleTrg))
+		return 1
+	})	
+	luaRegister(l, "scaleX", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.angleScaleTrg[0]))
+		return 1
+	})
+	luaRegister(l, "scaleY", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.angleScaleTrg[1]))
+		return 1
+	})
+	luaRegister(l, "offsetX", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.offsetTrg[0]))
+		return 1
+	})
+	luaRegister(l, "offsetY", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.offsetTrg[1]))
+		return 1
+	})
+	luaRegister(l, "alphaSource", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.alphaTrg[0]))
+		return 1
+	})
+	luaRegister(l, "alphaDest", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.alphaTrg[1]))
+		return 1
+	})
+	luaRegister(l, "lerp", func(*lua.LState) int {
+		a,b,amount, retv := float32(numArg(l,1)),float32(numArg(l,2)),float32(numArg(l,3)), float32(0)
+		retv = float32(a + (b - a) * MaxF(0, MinF(amount, 1)))
+		l.Push(lua.LNumber(retv))
+		return 1
+	})
+	luaRegister(l, "sign", func(*lua.LState) int {
+		v, retv := float32(numArg(l,1)), int32(0)
+		if v < 0 {
+			v = -1	
+		} else if v > 0 {
+			v = 1
+		} else {
+			v = 0
+		}
+		retv = int32(v)
+		l.Push(lua.LNumber(retv))
+		return 1
+	})	
+	luaRegister(l, "clamp", func(*lua.LState) int {
+		v1, v2, v3, retv := float32(numArg(l,1)),float32(numArg(l,2)),float32(numArg(l,3)), float32(0)
+		retv = MaxF(v2, MinF(v1, v3))
+		l.Push(lua.LNumber(retv))
+		return 1
+	})
+	
 	// lua/debug only triggers
 	luaRegister(l, "animelemcount", func(*lua.LState) int {
 		l.Push(lua.LNumber(len(sys.debugWC.anim.frames)))
@@ -4303,34 +4359,6 @@ func triggerFunctions(l *lua.LState) {
 			}
 		}
 		l.Push(lua.LNumber(winp))
-		return 1
-	})
-	luaRegister(l, "angle", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.angleTrg))
-		return 1
-	})	
-	luaRegister(l, "scaleX", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.angleScaleTrg[0]))
-		return 1
-	})
-	luaRegister(l, "scaleY", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.angleScaleTrg[1]))
-		return 1
-	})
-	luaRegister(l, "offsetX", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.offsetTrg[0]))
-		return 1
-	})
-	luaRegister(l, "offsetY", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.offsetTrg[1]))
-		return 1
-	})
-	luaRegister(l, "alphaSource", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.alphaTrg[0]))
-		return 1
-	})
-	luaRegister(l, "offsetDest", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.alphaTrg[1]))
 		return 1
 	})
 }

--- a/src/shaders/sprite.frag.glsl
+++ b/src/shaders/sprite.frag.glsl
@@ -32,7 +32,7 @@ void main(void) {
 		vec4 final_mul = vec4(mult, alpha);
 		if (isRgba) {
 			// RGBA sprites use premultiplied alpha for transparency
-			neg_base *= alpha;
+			neg_base *= c.a;
 			final_add *= c.a;
 			final_mul.rgb *= alpha;
 		} else {


### PR DESCRIPTION
- **fix: Rgba sprites mask inverse when palfx invertall = 1.**
Before fix:
![ikemen001](https://github.com/ikemen-engine/Ikemen-GO/assets/132805988/00119d52-b200-45fb-8c86-7e6ecc994268)
After fix:
![ikemen002](https://github.com/ikemen-engine/Ikemen-GO/assets/132805988/338d417f-ef9a-47f9-bbd9-56b6f76bcd0d)
[Char link](https://mega.nz/file/Hk5wmYrR#Ohmj1O49TANZbcwdfwoAN6dlPH-EA6ul0um4H78yFYM)

New Math triggers:

- Clamp(x,min,max) (float)
Return a value clamped to an inclusive range of two specified numbers

- Sign(value) (int)
Returns the sign of a real number. If value < 0 return -1. If value 0 return 0. if value > 0 return 1.

- Atan2(x,y) (float)
Returns the arc tangent of the two numbers x and y.

- Rad(value) (float)
Converts degress to radians.

- Deg(value) (float)
Converts radians to degress.

- Lerp(a,b,amount) (float)
Linear interpolation between two values.

New Char triggers:

- Angle (float)
Gets the value of the player's angle.
Example: "trigger1 = angle < 90" 
- Scale (float) (Arguments  x, y) 
Gets the value of the player's scale.
Example: "trigger1 = scale x< 2 || scale y > 2" 
- OffSet (float) (Arguments  x, y) 
Gets the value of the player's offset.
Example: "trigger1 = offset x > 20 || offset y > 15" 
- Alpha (int)  (Arguments  source, dest) 
Gets the value of the player's alpha.
Example: "trigger1 = alpha source > 128 || alpha dest < 64" 