### PR TITLE
fix: lying down get hit behavior

### DIFF
--- a/data/dizzy.zss
+++ b/data/dizzy.zss
@@ -432,7 +432,7 @@ ignoreHitPause if !const(Default.Enable.Dizzy) || isHelper || teamSide = 0 {
 	if !dizzy && dizzyPoints < dizzyPointsMax && map(_iksys_dizzyPointsCounter) = 0 {
 		# Fixed value. Characters with a longer dizzy bar take longer to recover
 		# This property could use a character constant as well instead
-		dizzyPointsAdd{value: 5}
+		dizzyPointsAdd{value: 5; absolute: 1}
 	}
 
 	# Reset dizzy limit

--- a/data/guardbreak.zss
+++ b/data/guardbreak.zss
@@ -175,7 +175,7 @@ if !const(Default.Enable.GuardBreak) || isHelper || teamSide = 0 {
 	}
 	# Guard points recovery
 	if !guardBreak && guardPoints < guardPointsMax && map(_iksys_guardPointsCounter) = 0 {
-		guardPointsAdd{value: round(float(guardPointsMax) / 25, 0)}
+		guardPointsAdd{value: round(float(guardPointsMax) / 25, 0); absolute: 1}
 		map(_iksys_guardPointsCounter) := 30;
 	}
 }


### PR DESCRIPTION
A few changes to make it behave more like Mugen:
- The fall defence bonus now stacks every time the character hits the ground
- Lie down recovery time only counts down in state 5110
- Hitting a character that's in state 5101 with a sweep now correctly sends them to state 5070
- The limit on hitting a character off the ground now depends on how much recovery time the char has left rather than how many times they have been bounced
- The value of PrevStateno when the character is hit into a custom state is more accurate to Mugen

Also:
- Dizzy and guard points recovery is no longer affected by defense multipliers