### PR TITLE
fix: landing, KO velocity and inputs, guard points

### DIFF
--- a/data/dizzy.zss
+++ b/data/dizzy.zss
@@ -367,17 +367,17 @@ ignoreHitPause if !const(Default.Enable.Dizzy) || isHelper || teamSide = 0 {
 	# Do nothing, global code disabled locally or executed by helper/stage
 } else ignoreHitPause if roundState = 0 {
 	dizzyPointsSet{value: dizzyPointsMax}
-	map(_iksys_dizzyPointsCounter) := 0;
+	map(_iksys_dizzyPointsTimer) := 0;
 	map(_iksys_dizzyLimit) := 0;
 
 } else ignoreHitPause if alive {
-	# Upon hit, set cooldown counter
+	# Upon hit, set cooldown timer
 	# Cooldown time could be a character constant
 	if moveType = H || dizzy || stateNo = const(StateDownedGetHit_gettingUp) {
-		map(_iksys_dizzyPointsCounter) := 60;
-	# Otherwise decrease cooldown counter by 1 each frame
-	} else if map(_iksys_dizzyPointsCounter) > 0 {
-		mapAdd{map: "_iksys_dizzyPointsCounter"; value: -1}
+		map(_iksys_dizzyPointsTimer) := 60;
+	# Otherwise decrease cooldown timer by 1 each frame
+	} else if map(_iksys_dizzyPointsTimer) > 0 {
+		mapAdd{map: "_iksys_dizzyPointsTimer"; value: -1}
 	}
 
 	# Freeze dizzy points if character was already dizzied once in the combo
@@ -429,7 +429,7 @@ ignoreHitPause if !const(Default.Enable.Dizzy) || isHelper || teamSide = 0 {
 	}
 
 	# Dizzy points recovery after cooldown ends
-	if !dizzy && dizzyPoints < dizzyPointsMax && map(_iksys_dizzyPointsCounter) = 0 {
+	if !dizzy && dizzyPoints < dizzyPointsMax && map(_iksys_dizzyPointsTimer) = 0 {
 		# Fixed value. Characters with a longer dizzy bar take longer to recover
 		# This property could use a character constant as well instead
 		dizzyPointsAdd{value: 5; absolute: 1}

--- a/data/functions.zss
+++ b/data/functions.zss
@@ -27,11 +27,11 @@ ignoreHitPause{
 [Function Technical() ret]
 ignoreHitPause{
 	let ret = 0;
-	if stateNo = [const(StateAirGetHit_fallRecoveryOnGround), const(StateAirGetHit_fallRecoveryInAir)]
+	if (stateNo = const(StateAirGetHit_fallRecoveryOnGround) || stateNo = const(StateAirGetHit_fallRecoveryInAir))
 		&& (map(_iksys_technicalFlag) = 0 || map(_iksys_technicalFlag) = gameTime) {
 		let ret = 1;
 		map(_iksys_technicalFlag) := gameTime;
-	} else if stateNo != [const(StateAirGetHit_fallRecoveryOnGround), const(StateAirGetHit_fallRecoveryInAir)] {
+	} else if moveType = H && stateNo != const(StateAirGetHit_fallRecoveryOnGround) && stateNo != const(StateAirGetHit_fallRecoveryInAir) {
 		map(_iksys_technicalFlag) := 0;
 	}
 }

--- a/data/guardbreak.zss
+++ b/data/guardbreak.zss
@@ -148,11 +148,13 @@ if !const(Default.Enable.GuardBreak) || isHelper || teamSide = 0 {
 	# Do nothing, global code disabled locally or executed by helper/stage
 } else if roundState = 0 {
 	guardPointsSet{value: guardPointsMax}
-	map(_iksys_guardPointsCounter) := 0;
+	map(_iksys_guardPointsTimer) := 0;
 } else if roundState = 2 && alive {
-	# Reset cooldown counter
+	# Manage cooldown timer
 	ignoreHitPause if moveType = H {
-		map(_iksys_guardPointsCounter) := 60;
+		map(_iksys_guardPointsTimer) := 60;
+	} else if map(_iksys_guardPointsTimer) > 0 {
+		mapAdd{map: "_iksys_guardPointsTimer"; value: -1}
 	}
 	# Upon block
 	ignoreHitPause if stateNo = const(StateStandGuardHit_shaking) || stateNo = const(StateCrouchGuardHit_shaking) || stateNo = const(StateAirGuardHit_shaking) {
@@ -160,13 +162,10 @@ if !const(Default.Enable.GuardBreak) || isHelper || teamSide = 0 {
 		if (gameTime % 5) = 0 && guardPoints <= min((0.5 * guardPointsMax), 333) {
 			palFx{time: 2; add: 200, 0, 0}
 		}
-		# Entering guard break state
-		ignoreHitPause if guardPoints = 0 && !guardBreak {
-			changeState{value: const(StateGuardBreakHit)}
+		# Enter guard break state
+		if !guardBreak && guardPoints = 0 {
+			selfState{value: const(StateGuardBreakHit)}
 		}
-	# Otherwise decrease cooldown counter by 1 each frame
-	} else if map(_iksys_guardPointsCounter) > 0 && getHitVar(isBound) = 0 && !standby {
-		mapAdd{map: "_iksys_guardPointsCounter"; value: -1}
 	}
 	# Reset guard points and remove guard break flag if player is no longer in one of guard break states
 	ignoreHitPause if guardBreak && stateNo != [const(StateGuardBreakHit), const(StateGuardBreakRecover)] {
@@ -174,8 +173,7 @@ if !const(Default.Enable.GuardBreak) || isHelper || teamSide = 0 {
 		guardBreakSet{value: 0}
 	}
 	# Guard points recovery
-	if !guardBreak && guardPoints < guardPointsMax && map(_iksys_guardPointsCounter) = 0 {
-		guardPointsAdd{value: round(float(guardPointsMax) / 25, 0); absolute: 1}
-		map(_iksys_guardPointsCounter) := 30;
+	ignoreHitPause if !guardBreak && guardPoints < guardPointsMax && map(_iksys_guardPointsTimer) <= 0 {
+		guardPointsAdd{value: 2; absolute: 1}
 	}
 }

--- a/src/system.go
+++ b/src/system.go
@@ -912,10 +912,7 @@ func (s *System) commandUpdate() {
 				(r.ss.no == 0 || r.ss.no == 11 || r.ss.no == 20 || r.ss.no == 52) {
 				r.turn()
 			}
-			if !r.sf(CSF_postroundinput) && r.scf(SCF_inputwait) {
-				r.setSF(CSF_noinput)
-			}
-			if r.inputOver() || r.sf(CSF_noinput) || (r.aiLevel() > 0 && !r.alive()) {
+			if r.inputOver() || r.sf(CSF_noinput) {
 				for j := range r.cmd {
 					r.cmd[j].BufReset()
 				}


### PR DESCRIPTION
- Landing from physics A is no longer a loop, thus preventing a game crash if the landing state is also set to physics A
- Extra hit velocity on KO is no longer applied to statetype L
- Adjusted the "input over" flag so that KO characters can now process inputs while the round is still ongoing
- Being KO by itself no longer prevents the character from performing basic actions
- Adjusted PostRoundInput flag to enable inputs in more instances such as KO
- Adjusted "Technical" message so it does not give duplicate messages for some characters
- Minor adjustments and bug fixes to how guard points are recovered
- Every character now recovers them at the same rate, regardless of their maximum guard points. Recovery also happens every frame, including hitpause
- Minor refactor: dizzy and guard break cooldown timers are now referred to as that instead of "counters", to avoid confusion with counter hits