### PR TITLE
refactor: dizzy, guard, red life points

### DIFF
--- a/data/common.const
+++ b/data/common.const
@@ -1,3 +1,7 @@
+; Common Constants
+; The constants defined in this file will be loaded by every character
+; Characters can override them by defining them in their own constants files
+
 [Constants]
 
 ; Negative state global code toggle
@@ -15,13 +19,13 @@ Input.PauseOnHitPause = 1           ; 1 makes inputs to be retained during hit p
 ; Rules
 Default.Attack.LifeToPowerMul = 0.7 ; multiplier for power the attacker gets when an attack successfully hits (overridden by getpower HitDef option)
 Default.GetHit.LifeToPowerMul = 0.6 ; multiplier for power the receiver gets when an attack successfully hits (overridden by givepower HitDef option)
-Super.TargetDefenceMul = 1.5        ; multiplier for how much damage a super does when you combo into it (ignored if SuperPause p2defmul option is set)
-Default.LifeToGuardPointsMul = -1.5 ; multiplier for guard points the receiver gets when a normal/special attack is blocked (overridden by guardpoints HitDef option)
-Super.LifeToGuardPointsMul = -0.33  ; multiplier for guard points the receiver gets when a super attack is blocked (overridden by guardpoints HitDef option)
-Default.LifeToDizzyPointsMul = -1.8 ; multiplier for dizzy points the receiver gets when a normal/special attack successfully hits (overridden by dizzypoints HitDef option)
-Super.LifeToDizzyPointsMul = 0      ; multiplier for dizzy points the receiver gets when a super attack successfully hits (overridden by dizzypoints HitDef option)
-Default.LifeToRedLifeMul = 0.25     ; multiplier for red life the receiver gets when a normal/special attack successfully hits (overridden by redlife HitDef option)
-Super.LifeToRedLifeMul = 0.25       ; multiplier for red life the receiver gets when a super attack successfully hits (overridden by redlife HitDef option)
+Super.TargetDefenceMul = 1.5        ; multiplier for how much a SuperPause increases the opponent's defence during combos (ignored if SuperPause p2defmul option is set)
+Default.LifeToGuardPointsMul = 1.5  ; multiplier for guard points the receiver loses when a normal/special attack is blocked (overridden by guardpoints HitDef option)
+Super.LifeToGuardPointsMul = 0.33   ; multiplier for guard points the receiver loses when a super attack is blocked (overridden by guardpoints HitDef option)
+Default.LifeToDizzyPointsMul = 1.8  ; multiplier for dizzy points the receiver loses when a normal/special attack successfully hits (overridden by dizzypoints HitDef option)
+Super.LifeToDizzyPointsMul = 0      ; multiplier for dizzy points the receiver loses when a super attack successfully hits (overridden by dizzypoints HitDef option)
+Default.LifeToRedLifeMul = 0.75     ; multiplier for red life the receiver loses when a normal/special attack successfully hits (overridden by redlife HitDef option)
+Super.LifeToRedLifeMul = 0.75       ; multiplier for red life the receiver loses when a super attack successfully hits (overridden by redlife HitDef option)
 
 ; tag.zss options
 TagInTime = 20                 ; tag-in total switch time

--- a/data/tag.zss
+++ b/data/tag.zss
@@ -144,6 +144,11 @@ posSet{
 	y: player(teamLeader),pos y - player(teamLeader),screenPos y - const240p(160);
 }
 
+# Red Life regeneration
+if life < redLife && (time % const(TagRedLifeRegenFrames)) = 0 { # every 30 frames (0.5s) by default
+	lifeAdd{value: min(redLife - life, ceil(lifeMax * const(TagRedLifeRegenPercent))); absolute: 1} # 0.5% lifeMax by default
+}
+
 #===============================================================================
 # StateTagJumpingIn
 #===============================================================================
@@ -325,11 +330,5 @@ if !const(Default.Enable.Tag) || isHelper || teamSide = 0 {
 			tagOut{}
 			tagIn{stateno: playerId($partnerId),const(StateTagJumpingIn); redirectid: $partnerId}
 		}
-	}
-	# Red Life regeneration
-	if standby && redLife > 0 && (time % const(TagRedLifeRegenFrames)) = 0 { # every 30 frames (0.5s) by default
-		let regenVal = min(redLife, ceil(lifeMax * const(TagRedLifeRegenPercent))); # 0.5% lifeMax by default
-		lifeAdd{value: $regenVal; absolute: 1}
-		redLifeAdd{value: -$regenVal; absolute: 1}
 	}
 }

--- a/data/training.zss
+++ b/data/training.zss
@@ -12,13 +12,14 @@
 #===============================================================================
 [Function TrainingRecovery(pn)]
 if player($pn),ctrl = 0 && player($pn),stateNo >= player($pn),const(StateRunForward) {
-	mapSet{map: "_iksys_trainingDummyCounter"; value: 0; redirectid: player($pn),id}
-} else if player($pn),map(_iksys_trainingDummyCounter) >= 60 {
+	mapSet{map: "_iksys_trainingDummyTimer"; value: 0; redirectid: player($pn),id}
+} else if player($pn),map(_iksys_trainingDummyTimer) >= 60 {
 	lifeSet{value: player($pn),lifeMax; redirectid: player($pn),id}
 	powerSet{value: player($pn),powerMax; redirectid: player($pn),id}
-	mapSet{map: "_iksys_trainingDummyCounter"; value: 0; redirectid: player($pn),id}
+	redLifeSet{value: player($pn),lifeMax; redirectid: player($pn),id}
+	mapSet{map: "_iksys_trainingDummyTimer"; value: 0; redirectid: player($pn),id}
 } else {
-	mapAdd{map: "_iksys_trainingDummyCounter"; value: 1; redirectid: player($pn),id}
+	mapAdd{map: "_iksys_trainingDummyTimer"; value: 1; redirectid: player($pn),id}
 }
 
 #===============================================================================
@@ -30,13 +31,13 @@ if gameMode != "training" || isHelper || teamSide != 2 {
 	# Do nothing, not training more or statedef executed by helper or not P2
 } else if roundState = 0 {
 	# Round start reset
-	powerSet{value: powerMax}
 	powerSet{value: player(1),powerMax; redirectid: player(1),id}
-	map(_iksys_trainingDummyCounter) := 0;
+	powerSet{value: player(2),powerMax; redirectid: player(2),id}
+	map(_iksys_trainingDummyTimer) := 0;
 	map(_iksys_trainingDirection) := 0;
 	map(_iksys_trainingAirJumpNum) := 0;
 } else if roundState = 2 {
-	ignoreHitPause{
+	ignoreHitPause {
 		assertSpecial{flag: globalNoKo}
 	}
 	# Life and Power recovery

--- a/external/script/global.lua
+++ b/external/script/global.lua
@@ -94,7 +94,7 @@ function full(p)
 		setPower(powermax())
 		setGuardPoints(guardpointsmax())
 		setDizzyPoints(dizzypointsmax())
-		setRedLife(0)
+		setRedLife(lifemax())
 		removeDizzy()
 		playerid(oldid)
 	end

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -311,7 +311,7 @@ func readHealthBar(pre string, is IniSection,
 func (hb *HealthBar) step(ref int, hbr *HealthBar) {
 	var life float32 = float32(sys.chars[ref][0].life) / float32(sys.chars[ref][0].lifeMax)
 	//redlife := (float32(sys.chars[ref][0].life) + float32(sys.chars[ref][0].redLife)) / float32(sys.chars[ref][0].lifeMax)
-	var redVal int32 = sys.chars[ref][0].redLife
+	var redVal int32 = sys.chars[ref][0].redLife - sys.chars[ref][0].life
 	var getHit bool = (sys.chars[ref][0].fakeReceivedHits != 0 || sys.chars[ref][0].ss.moveType == MT_H) && !sys.chars[ref][0].scf(SCF_over)
 
 	if hbr.toplife > life {
@@ -400,8 +400,8 @@ func (hb *HealthBar) bgDraw(layerno int16) {
 }
 func (hb *HealthBar) draw(layerno int16, ref int, hbr *HealthBar, f []*Fnt) {
 	life := float32(sys.chars[ref][0].life) / float32(sys.chars[ref][0].lifeMax)
-	redlife := (float32(sys.chars[ref][0].life) + float32(sys.chars[ref][0].redLife)) / float32(sys.chars[ref][0].lifeMax)
-	redval := sys.chars[ref][0].redLife
+	redlife := float32(sys.chars[ref][0].redLife) / float32(sys.chars[ref][0].lifeMax)
+	redval := sys.chars[ref][0].redLife - sys.chars[ref][0].life
 	var MidPos = (float32(sys.gameWidth-320) / 2)
 	width := func(life float32) (r [4]int32) {
 		r = sys.scrrect

--- a/src/system.go
+++ b/src/system.go
@@ -1889,7 +1889,7 @@ func (s *System) fight() (reload bool) {
 			} else {
 				p[0].dizzyPoints = p[0].dizzyPointsMax
 			}
-			p[0].redLife = 0
+			p[0].redLife = p[0].lifeMax
 			copyVar(i)
 		}
 	}


### PR DESCRIPTION
- Dizzy and guard points damage now works closer to regular life damage. Use positive values in a Hitdef to deal damage to the opponent and negative values to heal them
- Red life now works more like commercial games: it mirrors life rather than being appended to it. Meaning red life starts at LifeMax and decreases when the character gets hit
- During tag, partners now recover life only while they are in the waiting state, rather than the whole time they are standing by
- See #918