### PR TITLE
fix: make ModifyExplod updating more like MUGEN

### DIFF
--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -600,23 +600,14 @@ func (c *Compiler) explodSub(is IniSection,
 		explod_random, VT_Float, 2, false); err != nil {
 		return err
 	}
-	if err := c.paramSpace(is, sc, explod_space); err != nil {
-		return err
-	}
-	if err := c.paramPostype(is, sc, explod_postype); err != nil {
-		return err
-	}
-	if err := c.paramProjection(is, sc, explod_projection); err != nil {
-		return err
-	}
-	f := false
+	found := false
 	if err := c.stateParam(is, "vel", func(data string) error {
-		f = true
+		found = true
 		return c.scAdd(sc, explod_velocity, data, VT_Float, 2)
 	}); err != nil {
 		return err
 	}
-	if !f {
+	if !found {
 		if err := c.paramValue(is, sc, "velocity",
 			explod_velocity, VT_Float, 2, false); err != nil {
 			return err
@@ -624,6 +615,15 @@ func (c *Compiler) explodSub(is IniSection,
 	}
 	if err := c.paramValue(is, sc, "accel",
 		explod_accel, VT_Float, 2, false); err != nil {
+		return err
+	}
+	if err := c.paramSpace(is, sc, explod_space); err != nil {
+		return err
+	}
+	if err := c.paramPostype(is, sc, explod_postype); err != nil {
+		return err
+	}
+	if err := c.paramProjection(is, sc, explod_projection); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "scale",


### PR DESCRIPTION
- Facing bug (sprite indefinitely facing left after it gets to face left for the first time) was finally properly recreated for non-ikemen characters.
- Non-ikemen characters can't influence in facing, pos, vel and accel values when not declaring postype anymore. This was notorious when, for example, creating an explod, then modifying its pos through ModifyExplod, and after that, calling ModifyExplod again to change postype without modifying anything else. Explod would inherit a relative pos value from prevous ModifyExplod call, when it shouldn't be like that.

A basic limitation lift was applied to Ikemen chars, so they can modify things like pos, vel, accel or facing even when not declaring postype. More explod behavior rework will be done in the future for Ikemenver characters.