### PR TITLE
refactor: StageBackEdgeDist and StageFrontEdgeDist

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -506,8 +506,8 @@ const (
 	OC_ex_scoretotal
 	OC_ex_selfstatenoexist
 	OC_ex_sprpriority
-	OC_ex_stagebackedge
-	OC_ex_stagefrontedge
+	OC_ex_stagebackedgedist
+	OC_ex_stagefrontedgedist
 	OC_ex_stagetime
 	OC_ex_standby
 	OC_ex_teamleader
@@ -2067,10 +2067,10 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		*sys.bcStack.Top() = c.selfStatenoExist(*sys.bcStack.Top())
 	case OC_ex_sprpriority:
 		sys.bcStack.PushI(c.sprPriority)
-	case OC_ex_stagebackedge:
-		sys.bcStack.PushF(c.stageBackEdge() * (c.localscl / oc.localscl))
-	case OC_ex_stagefrontedge:
-		sys.bcStack.PushF(c.stageFrontEdge() * (c.localscl / oc.localscl))
+	case OC_ex_stagebackedgedist:
+		sys.bcStack.PushF(c.stageBackEdgeDist() * (c.localscl / oc.localscl))
+	case OC_ex_stagefrontedgedist:
+		sys.bcStack.PushF(c.stageFrontEdgeDist() * (c.localscl / oc.localscl))
 	case OC_ex_stagetime:
 		sys.bcStack.PushI(sys.stage.stageTime)
 	case OC_ex_standby:

--- a/src/char.go
+++ b/src/char.go
@@ -3213,17 +3213,29 @@ func (c *Char) selfStatenoExist(stateno BytecodeValue) BytecodeValue {
 	_, ok := c.gi().states[stateno.ToI()]
 	return BytecodeBool(ok)
 }
-func (c *Char) stageFrontEdge() float32 {
-	if c.facing > 0 {
-		return sys.cam.XMax/c.localscl - c.pos[0]
-	}
-	return c.pos[0] - sys.cam.XMin/c.localscl
-}
-func (c *Char) stageBackEdge() float32 {
+func (c *Char) stageFrontEdgeDist() float32 {
+	side := float32(0)
 	if c.facing < 0 {
-		return sys.cam.XMax/c.localscl - c.pos[0]
+		side = sys.screenleft / c.localscl
+	} else {
+		side = sys.screenright / c.localscl
 	}
-	return c.pos[0] - sys.cam.XMin/c.localscl
+	if c.facing > 0 {
+		return sys.cam.XMax/c.localscl - side - c.pos[0]
+	}
+	return c.pos[0] - sys.cam.XMin/c.localscl - side
+}
+func (c *Char) stageBackEdgeDist() float32 {
+	side := float32(0)
+	if c.facing < 0 {
+		side = sys.screenleft / c.localscl
+	} else {
+		side = sys.screenright / c.localscl
+	}
+	if c.facing < 0 {
+		return sys.cam.XMax/c.localscl - side - c.pos[0]
+	}
+	return c.pos[0] - sys.cam.XMin/c.localscl - side
 }
 func (c *Char) teamLeader() int {
 	if c.teamside == -1 || sys.tmode[c.playerNo&1] == TM_Single || sys.tmode[c.playerNo&1] == TM_Turns {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -377,9 +377,9 @@ var triggerMap = map[string]int{
 	"scoretotal":       1,
 	"selfstatenoexist": 1,
 	"sprpriority":      1,
-	"stagebackedge":    1,
+	"stagebackedgedist":    1,
 	"stageconst":       1,
-	"stagefrontedge":   1,
+	"stagefrontedgedist":   1,
 	"stagetime":        1,
 	"standby":          1,
 	"teamleader":       1,
@@ -2833,8 +2833,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_ex_, OC_ex_selfstatenoexist)
 	case "sprpriority":
 		out.append(OC_ex_, OC_ex_sprpriority)
-	case "stagebackedge":
-		out.append(OC_ex_, OC_ex_stagebackedge)
+	case "stagebackedgedist", "stagebackedge": //Latter is deprecated
+		out.append(OC_ex_, OC_ex_stagebackedgedist)
 	case "stageconst":
 		if err := c.checkOpeningBracket(in); err != nil {
 			return bvNone(), err
@@ -2847,8 +2847,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), Error("Missing ')' before " + c.token)
 		}
 		*in = (*in)[1:]
-	case "stagefrontedge":
-		out.append(OC_ex_, OC_ex_stagefrontedge)
+	case "stagefrontedgedist", "stagefrontedge": //Latter is deprecated
+		out.append(OC_ex_, OC_ex_stagefrontedgedist)
 	case "stagetime":
 		out.append(OC_ex_, OC_ex_stagetime)
 	case "standby":

--- a/src/script.go
+++ b/src/script.go
@@ -4141,16 +4141,16 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.debugWC.sprPriority))
 		return 1
 	})
-	luaRegister(l, "stagebackedge", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.stageBackEdge()))
+	luaRegister(l, "stagebackedgedist", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.stageBackEdgeDist()))
 		return 1
 	})
 	luaRegister(l, "stageconst", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.stage.constants[strArg(l, 1)]))
 		return 1
 	})
-	luaRegister(l, "stagefrontedge", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.stageFrontEdge()))
+	luaRegister(l, "stagefrontedgedist", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.stageFrontEdgeDist()))
 		return 1
 	})
 	luaRegister(l, "stagetime", func(*lua.LState) int {


### PR DESCRIPTION
- Now return 0 when a character is at the respective end of the stage
- Added "dist" to the trigger names. The previous trigger names are still accepted but deprecated
- See #1151