### PR TITLE
fix: BG yDelta scrolling speed, camera getting stuck in non-4:3 ratios

### DIFF
--- a/src/camera.go
+++ b/src/camera.go
@@ -75,15 +75,14 @@ func (c *Camera) Reset() {
 	c.XMin = c.boundL - c.halfWidth/c.BaseScale()
 	c.XMax = c.boundR + c.halfWidth/c.BaseScale()
 	c.ExtraBoundH = ((1 - c.zoomout) * 100) * (1 / c.zoomout) * 2.1 * (float32(sys.gameHeight) / 240)
-	c.boundH = MinF(0, float32(c.boundhigh-c.localcoord[1])*c.localscl+float32(sys.gameHeight)-c.drawOffsetY) - c.ExtraBoundH
-	c.boundLo = MaxF(0, float32(c.boundlow)*c.localscl-c.drawOffsetY)
-
+	c.boundH = MinF(0, float32(c.boundhigh-c.localcoord[1])*c.localscl+float32(sys.gameHeight)-c.drawOffsetY)
+	c.boundLo = MaxF(0, float32(c.boundlow)*c.localscl)//-c.drawOffsetY)
 	//if c.boundlow < 0 {
 	//	c.boundLo += float32(c.boundlow) * c.localscl
 	//}
 	xminscl := float32(sys.gameWidth) / (float32(sys.gameWidth) - c.boundL +
 		c.boundR)
-	yminscl := float32(sys.gameHeight) / (240 - MinF(0, c.boundH))
+	yminscl := float32(sys.gameHeight) / (240 - MinF(0, c.boundH-c.ExtraBoundH))
 	c.MinScale = MaxF(c.zoomout, MinF(c.zoomin, MaxF(xminscl, yminscl)))
 	c.screenZoff = float32(c.zoffset-c.localcoord[1])*c.localscl + 240 - c.drawOffsetY
 	if c.boundhigh > 0 {
@@ -127,6 +126,10 @@ func (c *Camera) YBound(scl, y float32) float32 {
 	if c.verticalfollow <= 0 {
 		return 0
 	} else {
+		var extraBoundH float32
+		if c.zoomout < 1 {
+			extraBoundH = c.ExtraBoundH * ((1/scl)-1)/((1/c.zoomout)-1)
+		}
 		tmp := MaxF(0, 240-c.screenZoff)
 		c.CameraZoomYBound = 0
 		if !c.zoomanchor {
@@ -134,7 +137,7 @@ func (c *Camera) YBound(scl, y float32) float32 {
 			c.CameraZoomYBound = ((tmp / (scl)) - tmp) - c.drawOffsetY*(1-scl)*1.21
 		}
 		bound := ClampF(y,
-			MinF(tmp*(1/scl-1), c.boundH-c.CameraZoomYBound-240+MaxF(float32(sys.gameHeight)/scl, tmp+c.screenZoff/scl)),
+			MinF(tmp*(1/scl-1), c.boundH-extraBoundH-240+MaxF(float32(sys.gameHeight)/scl, tmp+c.screenZoff/scl)),
 			c.boundLo)
 		return bound + c.CameraZoomYBound
 	}

--- a/src/stage.go
+++ b/src/stage.go
@@ -402,8 +402,9 @@ func (bg backGround) draw(pos [2]float32, scl, bgscl, lclscl float32,
 	x := bg.start[0] + bg.xofs - (pos[0]/stgscl[0]+bg.camstartx)*bg.delta[0] +
 		bg.bga.offset[0]
 	zoomybound := sys.cam.CameraZoomYBound * float32(Btoi(isStage))
-	yScrollPos := ((pos[1] - (zoomybound / lclscl)) / stgscl[1]) * bg.delta[1] * bgscl
-	yScrollPos += ((zoomybound / lclscl) / stgscl[1]) * Pow(bg.zoomdelta[1], 1.4) / bgscl
+	// Hires breaks ydelta scrolling vel, so bgscl was commented from here.
+	yScrollPos := ((pos[1] - (zoomybound / lclscl)) / stgscl[1]) * bg.delta[1] // * bgscl
+	yScrollPos += ((zoomybound / lclscl) / stgscl[1]) * Pow(bg.zoomdelta[1], 1.4) // / bgscl
 	y := bg.start[1] - yScrollPos + bg.bga.offset[1]
 	ys2 := bg.scaledelta[1] * (pos[1] - zoomybound) * bg.delta[1] * bgscl
 	ys := ((100-(pos[1]-zoomybound)*bg.yscaledelta)*bgscl/bg.yscalestart)*bg.scalestart[1] + ys2
@@ -1280,11 +1281,17 @@ func (s *Stage) draw(top bool, x, y, scl float32) {
 	}
 	yofs, pos := sys.envShake.getOffset(), [...]float32{x, y}
 	scl2 := s.localscl * scl
-	if pos[1] <= float32(s.stageCamera.boundlow) && pos[1] < float32(s.stageCamera.boundhigh)-sys.cam.ExtraBoundH {
-		yofs += (pos[1]-float32(s.stageCamera.boundhigh))*scl2 +
-			sys.cam.ExtraBoundH*scl
-		pos[1] = float32(s.stageCamera.boundhigh) - sys.cam.ExtraBoundH/s.localscl
-	}
+	// This code makes the background scroll faster when surpassing boundhigh with the camera pushed down
+	// through floortension and boundlow. MUGEN 1.1 doesn't look like it does this, so it was commented.
+	// var extraBoundH float32
+	// if sys.cam.zoomout < 1 {
+		// extraBoundH = sys.cam.ExtraBoundH * ((1/scl)-1)/((1/sys.cam.zoomout)-1)
+	// }
+	// if pos[1] <= float32(s.stageCamera.boundlow) && pos[1] < float32(s.stageCamera.boundhigh)-extraBoundH {
+		// yofs += (pos[1]-float32(s.stageCamera.boundhigh))*scl2 +
+			// extraBoundH*scl
+		// pos[1] = float32(s.stageCamera.boundhigh) - extraBoundH/s.localscl
+	// }
 	if s.stageCamera.verticalfollow > 0 {
 		if yofs < 0 {
 			tmp := (float32(s.stageCamera.boundhigh) - pos[1]) * scl2


### PR DESCRIPTION
Camera was getting stuck in a case where floortension was defined and the game had an aspect ratio different from 4:3. The game would try to compensate by modifying drawOffsetY, and this would affect camera BoundLo value. With floortension being defined, the camera would be pushed down by drawOffsetY, potentially creating this stuck effect. Stage initial Y position might be misaligned, though, though it might just be differences in aspect ratio. And tensionhigh/tensionlow behavior needs to be investigated further, since this change might directly affect it.

Also, a bg miscalculation was commented out, since it provoked behavior different from MUGEN 1.1

Thanks to @NeatUnsou for input regarding how to fix ydelta.

Fixes #1319 