### PR TITLE
fix: OS X systems not being able to compile GLSL shaders

### DIFF
--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -7,6 +7,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"runtime"
+	"strings"
 
 	gl "github.com/fyne-io/gl-js"
 	"golang.org/x/mobile/exp/f32"
@@ -77,6 +78,10 @@ func (s *ShaderProgram) RegisterTextures(names ...string) {
 
 func compileShader(shaderType gl.Enum, src string) (shader gl.Shader) {
 	shader = gl.CreateShader(shaderType)
+	// Might be necessary for the WebGL build
+	if strings.Contains(gl.GetString(gl.VERSION), "ES") {
+		src = "#version 100\nprecision highp float;\n"
+	}
 	gl.ShaderSource(shader, src)
 	gl.CompileShader(shader)
 	ok := gl.GetShaderi(shader, gl.COMPILE_STATUS)

--- a/src/shaders/ident.frag.glsl
+++ b/src/shaders/ident.frag.glsl
@@ -1,10 +1,7 @@
-#version 400
-precision highp float;
-
 uniform sampler2D Texture;
 
-in vec2 texcoord;
+varying vec2 texcoord;
 
 void main(void) {
-	gl_FragColor = texture(Texture, texcoord);
+	gl_FragColor = texture2D(Texture, texcoord);
 }

--- a/src/shaders/ident.vert.glsl
+++ b/src/shaders/ident.vert.glsl
@@ -1,10 +1,8 @@
-#version 400
-precision highp float;
+attribute vec2 VertCoord;
 
 uniform vec2 TextureSize;
 
-in vec2 VertCoord;
-out vec2 texcoord;
+varying vec2 texcoord;
 
 void main()
 {

--- a/src/shaders/sprite.frag.glsl
+++ b/src/shaders/sprite.frag.glsl
@@ -1,6 +1,3 @@
-#version 400
-precision highp float;
-
 uniform sampler2D tex;
 uniform sampler2D pal;
 
@@ -11,7 +8,7 @@ uniform float alpha, gray;
 uniform int mask;
 uniform bool isFlat, isRgba, isTrapez, neg;
 
-in vec2 texcoord;
+varying vec2 texcoord;
 
 void main(void) {
 	if (isFlat) {
@@ -26,7 +23,7 @@ void main(void) {
 			uv.x = (gl_FragCoord.x - bounds[0]) / (bounds[1] - bounds[0]);
 		}
 
-		vec4 c = texture(tex, uv);
+		vec4 c = texture2D(tex, uv);
 		vec3 neg_base = vec3(1.0);
 		vec3 final_add = add;
 		vec4 final_mul = vec4(mult, alpha);
@@ -40,7 +37,7 @@ void main(void) {
 			if (int(255.25*c.r) == mask) {
 				final_mul = vec4(0.0);
 			} else {
-				c = texture(pal, vec2(c.r*0.9966, 0.5));
+				c = texture2D(pal, vec2(c.r*0.9966, 0.5));
 			}
 		}
 

--- a/src/shaders/sprite.vert.glsl
+++ b/src/shaders/sprite.vert.glsl
@@ -1,11 +1,8 @@
-#version 400
-precision highp float;
-
 uniform mat4 modelview, projection;
 
-in vec2 position;
-in vec2 uv;
-out vec2 texcoord;
+attribute vec2 position;
+attribute vec2 uv;
+varying vec2 texcoord;
 
 void main(void) {
 	texcoord = uv;


### PR DESCRIPTION
See: https://github.com/ikemen-engine/Ikemen-GO/issues/1062#issuecomment-1640705487

An additional check was added for possible WebGL builds. I can't test it because I don't know to create a WASM build.

Fixes #728, #1062