### PR TITLE
perf: lock/unlock the speaker only if the music is going to be paused/unpaused, reduce resampling quality

### DIFF
--- a/src/sound.go
+++ b/src/sound.go
@@ -238,12 +238,12 @@ func loadSoundFont(filename string) (*midi.SoundFont, error) {
 	return soundfont, nil
 }
 
-func (bgm *Bgm) SetPaused(paused bool) {
-	if bgm.ctrl == nil {
+func (bgm *Bgm) SetPaused(pause bool) {
+	if bgm.ctrl == nil || bgm.ctrl.Paused == pause {
 		return
 	}
 	speaker.Lock()
-	bgm.ctrl.Paused = paused
+	bgm.ctrl.Paused = pause
 	speaker.Unlock()
 }
 

--- a/src/sound.go
+++ b/src/sound.go
@@ -21,7 +21,7 @@ const (
 	audioOutLen          = 2048
 	audioFrequency       = 48000
 	audioPrecision       = 4
-	audioResampleQuality = 3
+	audioResampleQuality = 1
 	audioSoundFont       = "sound/soundfont.sf2" // default path for MIDI soundfont
 )
 


### PR DESCRIPTION
From my perception, reducing resampling quality doesn't noticeably affect the sound quality while improving overall game performance by a lot when sounds have to be processed.