### PR TITLE
fix: disabled repeating first attack score bonus

### DIFF
--- a/data/score.zss
+++ b/data/score.zss
@@ -45,9 +45,11 @@ if !const(Default.Enable.Score) || teamSide = 0 {
 	}
 } else ignoreHitPause if roundState >= 2 {
 	# score: first attack bonus
-	let ret = call FirstAttack();
-	if $ret {
-		scoreAdd{value: 1500}
+	if !isHelper {
+		let ret = call FirstAttack();
+		if $ret {
+			scoreAdd{value: 1500}
+		}
 	}
 	# score: counter bonus
 	let ret = call CounterHit();


### PR DESCRIPTION
- Since first attack was refactored to work based on player number instead of ID, every time a new helper was spawned the player would get another first attack bonus. As such first attack score code is now only run by the root characters