### PR TITLE
fix: corrupted sounds freezing the game, ignorehitpause not affecting "else" statement in ZSS

### DIFF
--- a/src/compiler.go
+++ b/src/compiler.go
@@ -4652,7 +4652,7 @@ func (c *Compiler) subBlock(line *string, root bool,
 		c.scan(line)
 		var err error
 		if bl.elseBlock, err = c.subBlock(line, root,
-			sbc, numVars, inheritIhp, nestedInLoop); err != nil {
+			sbc, numVars, inheritIhp || bl.ctrlsIgnorehitpause, nestedInLoop); err != nil {
 			return nil, err
 		}
 		if bl.elseBlock.ignorehitpause >= -1 {

--- a/src/sound.go
+++ b/src/sound.go
@@ -285,6 +285,18 @@ func readSound(f *os.File, size uint32) (*Sound, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Check if the file can be fully played
+	var samples [512][2]float64
+	for {
+		sn, _ := s.Stream(samples[:])
+		if sn == 0 {
+			// If sound wasn't able to be fully played, we disable it to avoid engine freezing
+			if s.Position() < s.Len() {
+				return nil, nil
+			}
+			break;
+		}
+	}
 	return &Sound{wavData, fmt, s.Len()}, nil
 }
 

--- a/src/sound.go
+++ b/src/sound.go
@@ -384,6 +384,10 @@ func LoadSndFiltered(filename string, keepItem func([2]int32) bool, max uint32) 
 						return nil, err
 					}
 				} else {
+					// Sound is corrupted and can't be played, so we export a warning message to the console
+					if tmp == nil {
+						sys.appendToConsole(fmt.Sprintf("WARNING: %v sound %v,%v is corrupted and can't be played, so it was disabled", filename, num[0], num[1]))
+					}
 					s.table[num] = tmp
 					if max > 0 {
 						break


### PR DESCRIPTION
Corrupted sounds are now just disabled when they can't be played due to data corruption. The engine exports a warning message at file load if a sound can't be played.

Fixes #1286 
Fixes #1325