### PR TITLE
fix: Reload SFF when character is reloaded

### DIFF
--- a/src/script.go
+++ b/src/script.go
@@ -980,6 +980,9 @@ func systemScriptInit(l *lua.LState) {
 					// Match is restarting
 					for i, b := range sys.reloadCharSlot {
 						if b {
+							if s := sys.cgi[i].sff; s != nil {
+								removeSFFCache(s.filename)
+							}
 							sys.chars[i] = []*Char{}
 							b = false
 						}


### PR DESCRIPTION
SFF is not reloaded when shift F4 is pressed after SFF caching is implemented.
This commit fixes it.