### PR TITLE
fix: projectile hitting after removetime expires

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -1438,8 +1438,11 @@ func (p *Projectile) update(playerNo int) {
 					p.velocity[0] *= -1
 				}
 				p.accel, p.velmul, p.anim = [2]float32{}, [...]float32{1, 1}, -1
-				if p.hits >= 0 {
-					p.hits = -1
+				// In Mugen, projectiles can hit even after their removetime expires
+				if c.stCgi().ikemenver[0] > 0 || c.stCgi().ikemenver[1] > 0 {
+					if p.hits >= 0 {
+						p.hits = -1
+					}
 				}
 			}
 		}


### PR DESCRIPTION
- In Mugen, projectiles can still hit after their removetime expires. Because the Ikemen behavior where they cannot hit makes more sense, the Mugen behavior was locked to characters without ikemenversion
- Fixes #1362