### PR TITLE
fix: RemapPal and Hitdef priority

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -5528,12 +5528,12 @@ func (c *Char) attrCheck(h *HitDef, pid int32, st StateType) bool {
 	return true
 }
 func (c *Char) hittable(h *HitDef, e *Char, st StateType,
+	// Check which character should win in case attacks connect in the same frame
 	countercheck func(*HitDef) bool) bool {
 	if !c.attrCheck(h, e.id, st) {
 		return false
 	}
-	if c.atktmp != 0 && (c.hitdef.attr > 0 && c.ss.stateType != ST_L ||
-		c.hitdef.reversal_attr > 0) {
+	if c.atktmp != 0 && (c.hitdef.attr > 0 && c.ss.stateType != ST_L || c.hitdef.reversal_attr > 0) {
 		switch {
 		case c.hitdef.reversal_attr > 0:
 			if h.reversal_attr > 0 {
@@ -5563,7 +5563,8 @@ func (c *Char) hittable(h *HitDef, e *Char, st StateType,
 		default:
 			return true
 		}
-		return !countercheck(&c.hitdef) || c.hasTargetOfHitdef(e.id) || c.hitdef.attr == 0
+		//return !countercheck(&c.hitdef) || c.hasTargetOfHitdef(e.id) || c.hitdef.attr == 0 // https://github.com/ikemen-engine/Ikemen-GO/issues/1410
+		return !countercheck(&c.hitdef)
 	}
 	return true
 }

--- a/src/char.go
+++ b/src/char.go
@@ -4841,9 +4841,14 @@ func (c *Char) hitFallSet(f int32, xv, yv float32) {
 	}
 }
 func (c *Char) remapPal(pfx *PalFX, src [2]int32, dst [2]int32) {
-	if dst[0] == -1 {
+	//Clear all remaps
+	if src[0] == -1 && dst[0] == -1 {
 		pfx.remap = nil
 		return
+	}
+	//Reset specified source
+	if dst[0] == -1 {
+		dst = src
 	}
 	if src[0] == -1 {
 		c.forceRemapPal(pfx, dst)


### PR DESCRIPTION
- Setting destination to -1 makes it take the same values as source
- Setting both destination and source to -1 clears all remaps
- Fixes #1382

- Reverted one line of code in the Hitdef priority check
- Fixes #1410 