### PR TITLE
fix: PalFx and Blending Fixes

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3483,11 +3483,12 @@ type allPalFX palFX
 
 func (sc allPalFX) Run(c *Char, _ []int32) bool {
 	sys.allPalFX.clear()
-	sys.allPalFX.invertblend = -1
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		palFX(sc).runSub(c, &sys.allPalFX.PalFXDef, id, exp)
+		//Forcing 1.1 kind behavior
+		sys.allPalFX.invertblend = Clamp(sys.allPalFX.invertblend,0,1)
 		return true
-	})
+	})	
 	return false
 }
 
@@ -3495,9 +3496,11 @@ type bgPalFX palFX
 
 func (sc bgPalFX) Run(c *Char, _ []int32) bool {
 	sys.bgPalFX.clear()
-	sys.bgPalFX.invertblend = -1
+	//Forcing 1.1 behavior
+	sys.bgPalFX.invertblend = -2
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		palFX(sc).runSub(c, &sys.bgPalFX.PalFXDef, id, exp)
+		sys.bgPalFX.invertblend = -2	
 		return true
 	})
 	return false

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3441,7 +3441,7 @@ func (sc palFX) runSub(c *Char, pfd *PalFXDef,
 	case palFX_invertall:
 		pfd.invertall = exp[0].evalB(c)
 	case palFX_invertblend:
-		pfd.invertblend = exp[0].evalI(c)
+		pfd.invertblend = Clamp(exp[0].evalI(c),-1,2)
 	default:
 		return false
 	}
@@ -3457,9 +3457,6 @@ func (sc palFX) Run(c *Char, _ []int32) bool {
 		pf = newPalFX()
 	}
 	pf.clear2(true)
-	if crun.stCgi().ver[0] == 1 && crun.stCgi().ver[1] == 1 {
-		pf.invertblend = -1
-	}
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		if id == palFX_redirectid {
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
@@ -3472,6 +3469,10 @@ func (sc palFX) Run(c *Char, _ []int32) bool {
 			} else {
 				return false
 			}
+		}
+		//Mugen 1.1 behavior if invertblend param is omitted(Only if char mugenversion = 1.1)
+		if crun.stCgi().ver[0] == 1 && crun.stCgi().ver[1] == 1 && crun.stCgi().ikemenver[0] <= 0 {
+			pf.invertblend = -2
 		}
 		sc.runSub(c, &pf.PalFXDef, id, exp)
 		return true
@@ -3500,7 +3501,7 @@ func (sc bgPalFX) Run(c *Char, _ []int32) bool {
 	sys.bgPalFX.invertblend = -2
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		palFX(sc).runSub(c, &sys.bgPalFX.PalFXDef, id, exp)
-		sys.bgPalFX.invertblend = -2	
+		sys.bgPalFX.invertblend = -3	
 		return true
 	})
 	return false
@@ -3723,7 +3724,10 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 		case explod_window:
 			e.window = [4]float32{exp[0].evalF(c) * lclscround, exp[1].evalF(c) * lclscround, exp[2].evalF(c) * lclscround, exp[3].evalF(c) * lclscround}
 		default:
-			palFX(sc).runSub(c, &e.palfxdef, id, exp)
+			if crun.stCgi().ver[0] == 1 && crun.stCgi().ver[1] == 1 && crun.stCgi().ikemenver[0] <= 0 {
+				e.palfxdef.invertblend = -2
+			}
+			palFX(sc).runSub(c, &e.palfxdef, id, exp)		
 		}
 		return true
 	})
@@ -4194,6 +4198,10 @@ func (sc afterImage) Run(c *Char, _ []int32) bool {
 		}
 		if !doOce {
 			crun.aimg.clear()
+			//Mugen 1.1 behavior if invertblend param is omitted(Only if char mugenversion = 1.1)
+			if crun.stCgi().ver[0] == 1 && crun.stCgi().ver[1] == 1 && crun.stCgi().ikemenver[0] <= 0 {
+				crun.aimg.palfx[0].invertblend = -2
+			}							
 			crun.aimg.time = 1
 			doOce = true
 		}
@@ -4630,6 +4638,10 @@ func (sc hitDef) Run(c *Char, _ []int32) bool {
 			} else {
 				return false
 			}
+		}
+		//Mugen 1.1 behavior if invertblend param is omitted(Only if char mugenversion = 1.1)
+		if crun.stCgi().ver[0] == 1 && crun.stCgi().ver[1] == 1 && crun.stCgi().ikemenver[0] <= 0 {
+			crun.hitdef.palfx.invertblend = -2
 		}
 		sc.runSub(c, &crun.hitdef, id, exp)
 		return true

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -574,12 +574,6 @@ func (bv BytecodeValue) ToI() int32 {
 	}
 	return int32(bv.v)
 }
-func (bv BytecodeValue) ToI2() int32 {
-	if bv.IsSF() {
-		return -1
-	}
-	return int32(bv.v)
-}
 func (bv BytecodeValue) ToI64() int64 {
 	if bv.IsSF() {
 		return 0
@@ -2134,9 +2128,6 @@ func (be BytecodeExp) evalF(c *Char) float32 {
 func (be BytecodeExp) evalI(c *Char) int32 {
 	return be.run(c).ToI()
 }
-func (be BytecodeExp) evalI2(c *Char) int32 {
-	return be.run(c).ToI2()
-}
 func (be BytecodeExp) evalI64(c *Char) int64 {
 	return be.run(c).ToI64()
 }
@@ -3463,26 +3454,25 @@ func (sc palFX) Run(c *Char, _ []int32) bool {
 	}
 	pf := crun.palfx
 	if pf == nil {
-		pf = newPalFX()	
+		pf = newPalFX()
 	}
 	pf.clear2(true)
 	if crun.stCgi().ver[0] == 1 && crun.stCgi().ver[1] == 1 {
 		pf.invertblend = -1
-	}			
+	}
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		if id == palFX_redirectid {
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
 				pf = crun.palfx
 				if pf == nil {
-					pf = newPalFX()	
-								
+					pf = newPalFX()
 				}
-				pf.clear2(true)		
+				pf.clear2(true)
 			} else {
 				return false
 			}
-		}	
+		}
 		sc.runSub(c, &pf.PalFXDef, id, exp)
 		return true
 	})

--- a/src/char.go
+++ b/src/char.go
@@ -860,7 +860,7 @@ func (ai *AfterImage) clear() {
 	if len(ai.palfx) > 0 {
 		ai.palfx[0].eColor = 1
 		ai.palfx[0].eInvertall = false
-		ai.palfx[0].eInvertblend = 0		
+		ai.palfx[0].eInvertblend = 0	
 		ai.palfx[0].eAdd = [...]int32{30, 30, 30}
 		ai.palfx[0].eMul = [...]int32{120, 120, 220}
 	}
@@ -888,7 +888,7 @@ func (ai *AfterImage) setPalInvertall(invertall bool) {
 }
 func (ai *AfterImage) setPalInvertblend(invertblend int32) {
 	if len(ai.palfx) > 0 {
-		ai.palfx[0].eInvertblend = invertblend
+		ai.palfx[0].invertblend = invertblend
 	}
 }
 func (ai *AfterImage) setPalBrightR(addr int32) {
@@ -923,10 +923,15 @@ func (ai *AfterImage) setPalContrastB(mulb int32) {
 }
 func (ai *AfterImage) setupPalFX() {
 	pb := ai.postbright
+	if ai.palfx[0].invertblend <= -2 && ai.palfx[0].eInvertall {
+		ai.palfx[0].eInvertblend = 3
+	} else {
+		ai.palfx[0].eInvertblend = ai.palfx[0].invertblend	 
+	}	
 	for i := 1; i < len(ai.palfx); i++ {
 		ai.palfx[i].eColor = ai.palfx[i-1].eColor
 		ai.palfx[i].eInvertall = ai.palfx[i-1].eInvertall
-		ai.palfx[i].eInvertblend = ai.palfx[i-1].eInvertblend		
+		ai.palfx[i].eInvertblend = ai.palfx[i-1].eInvertblend
 		for j := range pb {
 			ai.palfx[i].eAdd[j] = ai.palfx[i-1].eAdd[j] + ai.add[j] + pb[j]
 			ai.palfx[i].eMul[j] = int32(float32(ai.palfx[i-1].eMul[j]) * ai.mul[j])
@@ -3638,6 +3643,10 @@ func (c *Char) helperInit(h *Char, st int32, pt PosType, x, y float32,
 			h.mapArray[key] = value
 		}
 	}
+	//Mugen 1.1 behavior if invertblend param is omitted(Only if char mugenversion = 1.1)
+	if h.stCgi().ver[0] == 1 && c.stCgi().ver[1] == 1 && h.stCgi().ikemenver[0] <= 0 {
+		h.palfx.invertblend = -2
+	}		
 	h.changeStateEx(st, c.playerNo, 0, 1, "")
 	// Prepare newly created helper so it can be successfully run later via actionRun() in charList.action()
 	h.actionPrepare()
@@ -4752,6 +4761,10 @@ func (c *Char) getPalfx() *PalFX {
 		}
 	}
 	c.palfx = newPalFX()
+	//Mugen 1.1 behavior if invertblend param is omitted(Only if char mugenversion = 1.1)
+	if c.stCgi().ver[0] == 1 && c.stCgi().ver[1] == 1 && c.stCgi().ikemenver[0] <= 0 && c.palfx != nil {
+		c.palfx.PalFXDef.invertblend = -2
+	}	
 	return c.palfx
 }
 func (c *Char) getPalMap() []int {

--- a/src/char.go
+++ b/src/char.go
@@ -860,6 +860,7 @@ func (ai *AfterImage) clear() {
 	if len(ai.palfx) > 0 {
 		ai.palfx[0].eColor = 1
 		ai.palfx[0].eInvertall = false
+		ai.palfx[0].eInvertblend = 0		
 		ai.palfx[0].eAdd = [...]int32{30, 30, 30}
 		ai.palfx[0].eMul = [...]int32{120, 120, 220}
 	}
@@ -883,6 +884,11 @@ func (ai *AfterImage) setPalColor(color int32) {
 func (ai *AfterImage) setPalInvertall(invertall bool) {
 	if len(ai.palfx) > 0 {
 		ai.palfx[0].eInvertall = invertall
+	}
+}
+func (ai *AfterImage) setPalInvertblend(invertblend int32) {
+	if len(ai.palfx) > 0 {
+		ai.palfx[0].eInvertblend = invertblend
 	}
 }
 func (ai *AfterImage) setPalBrightR(addr int32) {
@@ -920,6 +926,7 @@ func (ai *AfterImage) setupPalFX() {
 	for i := 1; i < len(ai.palfx); i++ {
 		ai.palfx[i].eColor = ai.palfx[i-1].eColor
 		ai.palfx[i].eInvertall = ai.palfx[i-1].eInvertall
+		ai.palfx[i].eInvertblend = ai.palfx[i-1].eInvertblend		
 		for j := range pb {
 			ai.palfx[i].eAdd[j] = ai.palfx[i-1].eAdd[j] + ai.add[j] + pb[j]
 			ai.palfx[i].eMul[j] = int32(float32(ai.palfx[i-1].eMul[j]) * ai.mul[j])
@@ -2716,7 +2723,7 @@ func (c *Char) helper(id int32) *Char {
 }
 func (c *Char) helperByIndex(id int32) *Char {
 	for j, h := range sys.chars[c.playerNo][1:] {
-		if !h.sf(CSF_destroy) && ((id - 1) == int32(j)) {
+		if ((id - 1) == int32(j)) {
 			return h
 		}
 	}

--- a/src/common.go
+++ b/src/common.go
@@ -762,6 +762,7 @@ func (al *AnimLayout) ReadAnimPalfx(pre string, is IniSection) {
 		}
 	}
 	is.ReadBool(pre+"invertall", &al.palfx.invertall)
+	is.ReadI32(pre+"invertblend", &al.palfx.invertblend)
 	var n float32
 	if is.ReadF32(pre+"color", &n) {
 		al.palfx.color = n / 256

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -993,6 +993,10 @@ func (c *Compiler) palFXSub(is IniSection,
 		palFX_invertall, VT_Bool, 1, false); err != nil {
 		return err
 	}
+	if err := c.paramValue(is, sc, prefix+"invertblend",
+		palFX_invertblend, VT_Int, 1, false); err != nil {
+		return err
+	}		
 	return nil
 }
 func (c *Compiler) palFX(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
@@ -1049,6 +1053,10 @@ func (c *Compiler) afterImageSub(is IniSection,
 	}
 	if err := c.paramValue(is, sc, prefix+"palinvertall",
 		afterImage_palinvertall, VT_Bool, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, prefix+"palinvertblend",
+		afterImage_palinvertblend, VT_Int, 1, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, prefix+"palbright",
@@ -4137,6 +4145,10 @@ func (c *Compiler) modifyBGCtrl(is IniSection, sc *StateControllerBase, _ int8) 
 			modifyBGCtrl_invertall, VT_Int, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "invertblend",
+			modifyBGCtrl_invertblend, VT_Int, 1, false); err != nil {
+			return err
+		}		
 		if err := c.paramValue(is, sc, "color",
 			modifyBGCtrl_color, VT_Float, 1, false); err != nil {
 			return err

--- a/src/image.go
+++ b/src/image.go
@@ -127,7 +127,7 @@ func (pf *PalFX) getFxPal(pal []uint32, neg bool) []uint32 {
 	return sys.workpal
 }
 func (pf *PalFX) getFcPalFx(transNeg bool) (neg bool, grayscale float32,
-	add, mul [3]float32) {
+	add, mul [3]float32, invblend int32 ) {
 	p := pf.getSynFx()
 	if !p.enable {
 		neg = false
@@ -142,6 +142,7 @@ func (pf *PalFX) getFcPalFx(transNeg bool) (neg bool, grayscale float32,
 	}
 	neg = p.eInvertall
 	grayscale = 1 - p.eColor
+	invblend = p.eInvertblend
 	if !p.eNegType {
 		transNeg = false
 	}
@@ -233,6 +234,16 @@ func (pf *PalFX) synthesize(pfx PalFX) {
 	}
 	pf.eColor *= pfx.eColor
 	pf.eInvertall = pf.eInvertall != pfx.eInvertall
+
+	if pfx.invertblend == 2 && pf.invertblend == -1 {
+		pf.eInvertblend = 2
+	} else if pfx.invertblend == 2 && pf.invertblend == 2  {
+		pf.eInvertblend = -1
+	} else if pfx.invertblend == 1 && pf.invertblend == 0  {
+		pf.eInvertblend = 1
+	} else if pfx.invertblend == 1 && pf.invertblend == 1  {
+		pf.eInvertblend = 0
+	}
 }
 
 func (pf *PalFX) setColor(r, g, b int32) {

--- a/src/image.go
+++ b/src/image.go
@@ -60,7 +60,6 @@ func (pf *PalFX) clear2(nt bool) {
 	pf.sintime = 0
 	pf.sintime2 = 0
 	pf.sintime3 = 0
-	pf.invertblend = 0
 }
 func (pf *PalFX) clear() {
 	pf.clear2(false)
@@ -200,7 +199,7 @@ func (pf *PalFX) step() {
 		pf.eAdd = pf.add
 		pf.eColor = pf.color
 		pf.eInvertall = pf.invertall
-		if pf.invertblend <= -1 && pf.eInvertall {
+		if pf.invertblend <= -2 && pf.eInvertall {
 			pf.eInvertblend = 3
 		} else {
 			pf.eInvertblend = pf.invertblend		
@@ -237,32 +236,36 @@ func (pf *PalFX) synthesize(pfx PalFX,blending bool) {
 
 	if pfx.invertall {
 		//Char blend inverse
-		if pfx.eInvertblend == 1 {
-			if blending && pf.invertblend > -2 { pf.eInvertall = pf.invertall }
+		if pfx.invertblend == 1 {
+			if blending && pf.invertblend > -3 { pf.eInvertall = pf.invertall }
 			switch {
 			case pf.invertblend == 0:
 				pf.eInvertblend = 1
 			case pf.invertblend == 1:
 				pf.eInvertblend = 0
-			case pf.invertblend == -1:
+			case pf.invertblend == -2:
 				if pf.eInvertall {
 					pf.eInvertall = false
-					pf.eInvertblend = -1
+					pf.eInvertblend = -2
 				} else {
 					pf.eInvertblend = 3
 				}
 			case pf.invertblend == 2:
 				pf.eInvertall = pf.invertall
 				pf.eInvertblend = -1
+			case pf.invertblend == -1:
+				pf.eInvertall = pf.invertall
+				pf.eInvertblend = 2				
 			}
 		}
+
 		//Bg blend inverse
-		if pf.invertblend == -2 {
+		if pf.invertblend == -3 {
 			if pf.eInvertall {
 				pf.eInvertblend = 3
 			} else {
 				pf.eInvertall = false
-				pf.eInvertblend = -2
+				pf.eInvertblend = -3
 			}
 		}
 	}

--- a/src/image.go
+++ b/src/image.go
@@ -35,20 +35,22 @@ type PalFXDef struct {
 	cycletimeMul   int32
 	cycletimeColor int32
 	invertall      bool
+	invertblend    int32	
 }
 type PalFX struct {
 	PalFXDef
-	remap      []int
-	negType    bool
-	sintime    int32
-	sintime2   int32
-	sintime3   int32
-	enable     bool
-	eNegType   bool
-	eInvertall bool
-	eAdd       [3]int32
-	eMul       [3]int32
-	eColor     float32
+	remap      		[]int
+	negType    		bool
+	sintime    		int32
+	sintime2   		int32
+	sintime3   		int32
+	enable     		bool
+	eNegType   		bool
+	eInvertall 		bool
+	eInvertblend 	int32	
+	eAdd       		[3]int32
+	eMul       		[3]int32
+	eColor     		float32
 }
 
 func newPalFX() *PalFX { return &PalFX{} }
@@ -58,6 +60,7 @@ func (pf *PalFX) clear2(nt bool) {
 	pf.sintime = 0
 	pf.sintime2 = 0
 	pf.sintime3 = 0
+	pf.invertblend = 0
 }
 func (pf *PalFX) clear() {
 	pf.clear2(false)
@@ -196,6 +199,11 @@ func (pf *PalFX) step() {
 		pf.eAdd = pf.add
 		pf.eColor = pf.color
 		pf.eInvertall = pf.invertall
+		if pf.invertblend == -1 && pf.eInvertall {
+			pf.eInvertblend = 2
+		} else {
+			pf.eInvertblend = pf.invertblend		
+		}
 		pf.eNegType = pf.negType
 		pf.sinAdd(&pf.eAdd)
 		pf.sinMul(&pf.eMul)

--- a/src/render.go
+++ b/src/render.go
@@ -283,9 +283,9 @@ func RenderSprite(rp RenderParams) {
 		blending := false
 		if rp.trans == -2 || rp.trans == -1 || (rp.trans&0xff > 0 && rp.trans>>10&0xff >= 255) { blending = true }
 		neg, grayscale, padd, pmul, invblend = rp.pfx.getFcPalFx(rp.trans == -2,blending)
-		if rp.trans == -2 && invblend < 1 {
-			padd[0], padd[1], padd[2] = -padd[0], -padd[1], -padd[2]
-		}
+		//if rp.trans == -2 && invblend < 1 {
+			//padd[0], padd[1], padd[2] = -padd[0], -padd[1], -padd[2]
+		//}
 	}
 
 	proj := mgl.Ortho(0, float32(sys.scrrect[2]), 0, float32(sys.scrrect[3]), -65535, 65535)
@@ -347,13 +347,14 @@ func renderWithBlending(render func(eq BlendEquation, src, dst BlendFunc, a floa
 		if invblend == 3 && neg != nil { *neg = false }		
 		render(BlendI, BlendOne, BlendOne, 1)
 	case trans <= 0:
+	//Add1(128,128)
 	case trans < 255:
 		Blend = BlendAdd
 		if (invblend >= 2 || invblend <= -1) && acolor != nil && mcolor != nil {
 			src, dst := trans&0xff, trans>>10&0xff
 			//Summ of add components
 			gc := float32(math.Abs(float64(acolor[0]))+math.Abs(float64(acolor[1]))+math.Abs(float64(acolor[2])))
-			v3,al := float32(MaxF((gc*255)-float32(dst),255))/255, (float32(src+dst)/255)
+			v3,al := float32(MaxF((gc*255)-float32(dst),255))/128, (float32(src+dst)/255)
 			rM,gM,bM := mcolor[0]*al,mcolor[1]*al,mcolor[2]*al
 			(*mcolor)[0], (*mcolor)[1], (*mcolor)[2] = rM, gM, bM
 			render(BlendAdd, BlendZero, BlendOneMinusSrcAlpha, al)	

--- a/src/render.go
+++ b/src/render.go
@@ -380,7 +380,7 @@ func renderWithBlending(render func(eq BlendEquation, src, dst BlendFunc, a floa
 			} else {
 				Blend = BlendAdd
 			}
-			if (invblend >= 2 || invblend <= -1) && acolor != nil && mcolor != nil {
+			if (invblend >= 2 || invblend <= -1) && acolor != nil && mcolor != nil && src < 255 {
 				//Summ of add components
 				gc := float32(math.Abs(float64(acolor[0]))+math.Abs(float64(acolor[1]))+math.Abs(float64(acolor[2])))
 				v3,ml,al := float32(MaxF((gc*255)-float32(dst),255))/255,(float32(src)/255), (float32(src+dst)/255)

--- a/src/render.go
+++ b/src/render.go
@@ -348,9 +348,10 @@ func renderWithBlending(render func(eq BlendEquation, src, dst BlendFunc, a floa
 	case trans < 255:
 		if invblend >= 2 && neg != nil{ *neg = false }			
 		render(BlendAdd, blendSourceFactor, BlendOneMinusSrcAlpha, float32(trans)/255)
-	//No blend mode
+	//None
 	case trans < 512:
 		render(BlendAdd, blendSourceFactor, BlendOneMinusSrcAlpha, 1)
+	//AddAlpha 
 	default:
 		src, dst := trans&0xff, trans>>10&0xff
 		if dst < 255 {

--- a/src/render.go
+++ b/src/render.go
@@ -282,7 +282,7 @@ func RenderSprite(rp RenderParams) {
 	if rp.pfx != nil {
 		blending := false
 		if rp.trans == -2 || rp.trans == -1 || (rp.trans&0xff > 0 && rp.trans>>10&0xff >= 255) { blending = true }
-		neg, grayscale, padd, pmul, invblend = rp.pfx.getFcPalFx(rp.trans == -2,blending)
+		neg, grayscale, padd, pmul, invblend = rp.pfx.getFcPalFx(false,blending)
 		//if rp.trans == -2 && invblend < 1 {
 			//padd[0], padd[1], padd[2] = -padd[0], -padd[1], -padd[2]
 		//}
@@ -353,12 +353,12 @@ func renderWithBlending(render func(eq BlendEquation, src, dst BlendFunc, a floa
 		if (invblend >= 2 || invblend <= -1) && acolor != nil && mcolor != nil {
 			src, dst := trans&0xff, trans>>10&0xff
 			//Summ of add components
-			gc := float32(math.Abs(float64(acolor[0]))+math.Abs(float64(acolor[1]))+math.Abs(float64(acolor[2])))
-			v3,al := float32(MaxF((gc*255)-float32(dst),255))/128, (float32(src+dst)/255)
+			gc := AbsF(acolor[0])+AbsF(acolor[1])+AbsF(acolor[2])
+			v3,al := MaxF((gc*255)-float32(dst+src),512)/128, (float32(src+dst)/255)
 			rM,gM,bM := mcolor[0]*al,mcolor[1]*al,mcolor[2]*al
 			(*mcolor)[0], (*mcolor)[1], (*mcolor)[2] = rM, gM, bM
 			render(BlendAdd, BlendZero, BlendOneMinusSrcAlpha, al)	
-			render(Blend, blendSourceFactor, BlendOne, al*float32(math.Pow(float64(v3),4)))
+			render(Blend, blendSourceFactor, BlendOne, al*Pow(v3,4))
 		} else {
 			render(Blend, blendSourceFactor, BlendOneMinusSrcAlpha, float32(trans)/255)
 		}	
@@ -383,11 +383,11 @@ func renderWithBlending(render func(eq BlendEquation, src, dst BlendFunc, a floa
 			}
 			if (invblend >= 2 || invblend <= -1) && acolor != nil && mcolor != nil && src < 255 {
 				//Summ of add components
-				gc := float32(math.Abs(float64(acolor[0]))+math.Abs(float64(acolor[1]))+math.Abs(float64(acolor[2])))
-				v3,ml,al := float32(MaxF((gc*255)-float32(dst),255))/255,(float32(src)/255), (float32(src+dst)/255)
+				gc := AbsF(acolor[0])+AbsF(acolor[1])+AbsF(acolor[2])
+				v3,ml,al := MaxF((gc*255)-float32(dst+src),512)/128,(float32(src)/255), (float32(src+dst)/255)
 				rM,gM,bM := mcolor[0]*ml,mcolor[1]*ml,mcolor[2]*ml
 				(*mcolor)[0], (*mcolor)[1], (*mcolor)[2] = rM, gM, bM 
-				render(Blend, blendSourceFactor, BlendOne,al*float32(math.Pow(float64(v3),3)))
+				render(Blend, blendSourceFactor, BlendOne,al*Pow(v3,3))
 			} else {
 				render(Blend, blendSourceFactor, BlendOne, float32(src)/255)
 			}

--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -344,8 +344,6 @@ func (r *Renderer) SetPipeline(eq BlendEquation, src, dst BlendFunc) {
 }
 
 func (r *Renderer) ReleasePipeline() {
-	gl.BlendEquation(BlendEquationLUT[BlendAdd])
-	gl.BlendFunc(BlendFunctionLUT[BlendSrcAlpha], BlendFunctionLUT[BlendOne])
 	gl.DisableVertexAttribArray(r.spriteShader.aPos)
 	gl.DisableVertexAttribArray(r.spriteShader.aUv)
 	gl.Disable(gl.BLEND)

--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -344,6 +344,8 @@ func (r *Renderer) SetPipeline(eq BlendEquation, src, dst BlendFunc) {
 }
 
 func (r *Renderer) ReleasePipeline() {
+	gl.BlendEquation(BlendEquationLUT[BlendAdd])
+	gl.BlendFunc(BlendFunctionLUT[BlendSrcAlpha], BlendFunctionLUT[BlendOne])
 	gl.DisableVertexAttribArray(r.spriteShader.aPos)
 	gl.DisableVertexAttribArray(r.spriteShader.aUv)
 	gl.Disable(gl.BLEND)

--- a/src/script.go
+++ b/src/script.go
@@ -301,6 +301,8 @@ func systemScriptInit(l *lua.LState) {
 					}
 				case "invertall":
 					a.palfx.invertall = lua.LVAsNumber(value) == 1
+				case "invertblend":
+					a.palfx.invertblend = int32(lua.LVAsNumber(value))			
 				case "color":
 					a.palfx.color = float32(lua.LVAsNumber(value)) / 256
 				default:

--- a/src/shaders/sprite.frag.glsl
+++ b/src/shaders/sprite.frag.glsl
@@ -29,7 +29,7 @@ void main(void) {
 		vec4 final_mul = vec4(mult, alpha);
 		if (isRgba) {
 			// RGBA sprites use premultiplied alpha for transparency
-			neg_base *= alpha;
+			neg_base *= c.a;
 			final_add *= c.a;
 			final_mul.rgb *= alpha;
 		} else {

--- a/src/stage.go
+++ b/src/stage.go
@@ -351,6 +351,7 @@ func (bg *backGround) reset() {
 	bg.bga.sintime = bg.startsint
 	bg.bga.sinlooptime = bg.startsinlt
 	bg.palfx.time = -1
+	bg.palfx.invertblend = -2
 }
 func (bg backGround) draw(pos [2]float32, scl, bgscl, lclscl float32,
 	stgscl [2]float32, shakeY float32, isStage bool) {

--- a/src/stage.go
+++ b/src/stage.go
@@ -351,7 +351,7 @@ func (bg *backGround) reset() {
 	bg.bga.sintime = bg.startsint
 	bg.bga.sinlooptime = bg.startsinlt
 	bg.palfx.time = -1
-	bg.palfx.invertblend = -2
+	bg.palfx.invertblend = -3
 }
 func (bg backGround) draw(pos [2]float32, scl, bgscl, lclscl float32,
 	stgscl [2]float32, shakeY float32, isStage bool) {

--- a/src/stage.go
+++ b/src/stage.go
@@ -456,6 +456,7 @@ type bgCtrl struct {
 	sinmul       [4]int32
 	sincolor     [2]int32
 	invall       bool
+	invblend     int32	
 	color        float32
 	positionlink bool
 	idx          int
@@ -489,6 +490,7 @@ func (bgc *bgCtrl) read(is IniSection, idx int) {
 		bgc.sinmul = [4]int32{0, 0, 0, 0}
 		bgc.sincolor = [2]int32{0, 0}
 		bgc.invall = false
+		bgc.invblend = 0		
 		bgc.color = 1
 	case "posset":
 		bgc._type = BT_PosSet
@@ -549,6 +551,9 @@ func (bgc *bgCtrl) read(is IniSection, idx int) {
 		if is.ReadI32("invertall", &tmp) {
 			bgc.invall = tmp != 0
 		}
+		if is.ReadI32("invertblend", &bgc.invblend) {
+			bgc.invblend = bgc.invblend
+		}		
 		if is.ReadF32("color", &bgc.color) {
 			bgc.color = bgc.color / 256
 		}
@@ -1114,6 +1119,7 @@ func (s *Stage) runBgCtrl(bgc *bgCtrl) {
 			bgc.bg[i].palfx.sincolor = bgc.sincolor[0] / 256
 			bgc.bg[i].palfx.cycletimeColor = bgc.sincolor[1]
 			bgc.bg[i].palfx.invertall = bgc.invall
+			bgc.bg[i].palfx.invertblend = bgc.invblend			
 			bgc.bg[i].palfx.color = bgc.color
 		}
 	case BT_PosSet:
@@ -1251,8 +1257,9 @@ func (s *Stage) action() {
 			// b.palfx.synthesize(sys.bgPalFX)
 			b.palfx.eAdd = sys.bgPalFX.eAdd
 			b.palfx.eMul = sys.bgPalFX.eMul
-			b.palfx.eColor = sys.bgPalFX.eColor
+			b.palfx.eColor = sys.bgPalFX.eColor		
 			b.palfx.eInvertall = sys.bgPalFX.eInvertall
+			b.palfx.eInvertblend = sys.bgPalFX.eInvertblend				
 			b.palfx.eNegType = sys.bgPalFX.eNegType
 		}
 		if b.active && !paused {
@@ -1349,7 +1356,7 @@ func (s *Stage) reset() {
 }
 
 func (s *Stage) modifyBGCtrl(id int32, t, v [3]int32, x, y float32, src, dst [2]int32,
-	add, mul [3]int32, sinadd [4]int32, sinmul [4]int32, sincolor [2]int32, invall int32, color float32) {
+	add, mul [3]int32, sinadd [4]int32, sinmul [4]int32, sincolor [2]int32, invall int32, invblend int32, color float32) {
 	for i := range s.bgc {
 		if id == s.bgc[i].sctrlid {
 			if t[0] != IErr {
@@ -1423,10 +1430,12 @@ func (s *Stage) modifyBGCtrl(id int32, t, v [3]int32, x, y float32, src, dst [2]
 					}
 				}
 			}
-
 			if invall != IErr {
 				s.bgc[i].invall = invall != 0
 			}
+			if invblend != IErr {
+				s.bgc[i].invblend = invblend
+			}			
 			if !math.IsNaN(float64(color)) {
 				s.bgc[i].color = color / 256
 			}


### PR DESCRIPTION
1. **Fixes related to this issues: #1411 #1373 #1326 #989 #288 #508**

2.  **Fix: PalfFX mul values inverse bug if Trans sctrl blend = sub**

- **Feat:** Added new **invertblend** parameter for PalFx and AllPalFx (For BgPalFx mugen 1.1 behavior forced). It inverts current blend mode if enabled so **Sub** becomes **Add** and **Add** becomes **Sub**
- **For PalFx it accepts 4 values:**

- **0   = Disabled(mugen 1.0 blending behavior)**
- **1   = Enabled(mugen 1.0 blending behavior)**
- **-1  = Disabled(mugen 1.1 blending behavior)**
- **2    = Enabled(mugen 1.1 blending behavior)**

If character mugenversion is 1.1 and invertall = 1 and if invertblend param is ommited it inverts blend by default. For all other mugenversion invertblend = 0 if ommitted.

- **For AllPalFx it accepts 2 values:**

- **0   = Disabled**
- **1   = Enabled**

Defaults to 0 im ommited. If 1 it inverts blending on chars "layer"
