### PR TITLE
fix: Trans sctrl during hitpause bug

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -5720,6 +5720,10 @@ func (c *Char) actionPrepare() {
 			c.angleScale = [...]float32{1, 1}
 			c.offset = [2]float32{}
 		}
+		//Trans reset during hitpause if ignorehitpause = 0 fix
+		if c.sf(CSF_trans) && c.hitPause() {
+			c.unsetSF(CSF_trans)
+		}
 	}
 	c.dropTargets()
 	if c.downHitOffset != 0 {

--- a/src/render.go
+++ b/src/render.go
@@ -360,14 +360,11 @@ func renderWithBlending(render func(eq BlendEquation, src, dst BlendFunc, a floa
 	//Add1(128,128)
 	case trans < 255:
 		Blend = BlendAdd
-		if (invblend >= 2 || invblend <= -1) && acolor != nil && mcolor != nil {
+		if !isrgba && (invblend >= 2 || invblend <= -1) && acolor != nil && mcolor != nil {
 			src, dst := trans&0xff, trans>>10&0xff
 			//Summ of add components
 			gc := AbsF(acolor[0]) + AbsF(acolor[1]) + AbsF(acolor[2])
 			v3, al := MaxF((gc*255)-float32(dst+src), 512)/128, (float32(src+dst) / 255)
-			if isrgba {
-				v3 = 1
-			}
 			rM, gM, bM := mcolor[0]*al, mcolor[1]*al, mcolor[2]*al
 			(*mcolor)[0], (*mcolor)[1], (*mcolor)[2] = rM, gM, bM
 			render(BlendAdd, BlendZero, BlendOneMinusSrcAlpha, al)


### PR DESCRIPTION
When trans sctrl active and if ignorehitpause = 0 sctrl in ikemen dont reset during hitpause
Examples 

Ikemen:

https://github.com/ikemen-engine/Ikemen-GO/assets/132805988/063d39ca-0122-4d11-be23-3816698f49d2

Mugen: 

https://github.com/ikemen-engine/Ikemen-GO/assets/132805988/cd2c168f-c061-4043-a358-f0ee0d1e1e75

Fix: rgba sprites palfx add param fix for 1.1 blending if summ of src and dest alpha = 256(e.g 128x128, 96x160 etc)
