### PR TITLE
fix: crash when not declaring anim/sprite files on char, move "no-sprite" anim from -2 to -1

### DIFF
--- a/data/dizzy.zss
+++ b/data/dizzy.zss
@@ -76,7 +76,7 @@ playSnd{value: F7, ($vely > const240p(5)) + ($vely > const240p(14))}
 #===============================================================================
 # StateDizzyBirdsHelper [helper]
 #===============================================================================
-[StateDef const(StateDizzyBirdsHelper); type: A; physics: N; anim: -2; velset: 0, 0; ctrl: 0;]
+[StateDef const(StateDizzyBirdsHelper); type: A; physics: N; anim: -1; velset: 0, 0; ctrl: 0;]
 
 # Destroy helper
 # 32 ticks after conditions are met so that it may fade out the effects

--- a/src/char.go
+++ b/src/char.go
@@ -2638,7 +2638,6 @@ func (c *Char) setJuggle(juggle int32) {
 	c.juggle = juggle
 }
 func (c *Char) changeAnimEx(animNo int32, playerNo int, ffx string, alt bool) {
-	animNo = Max(0, animNo) // Avoid anim no. to get below 0, set it to 0 in that case (Like MUGEN 1.1)
 	if a := sys.chars[playerNo][0].getAnim(animNo, ffx, true); a != nil {
 		c.anim = a
 		c.anim.remap = c.remapSpr
@@ -3809,11 +3808,15 @@ func (c *Char) enemyExplodsRemove(en int) {
 	remove(&sys.underexplDrawlist[en], true)
 }
 func (c *Char) getAnim(n int32, ffx string, log bool) (a *Animation) {
-	if n == -2 {
+	if n == -1 {
 		return &Animation{}
 	}
-	if n < 0 {
-		return nil
+	if n < -1 {
+		// MUGEN 1.1 exports a warning message when attempting to change anim to a negative value, then sets
+		// the character animation to "0". Ikemen GO uses "-1" as a no-sprite/invisible anim, so we make
+		// an exception here
+		sys.appendToConsole(c.warn() + fmt.Sprintf("attempted change to negative anim (below -1)"))
+		n = 0
 	}
 	if ffx != "" && ffx != "s" {
 		if sys.ffx[ffx] != nil && sys.ffx[ffx].fat != nil {

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -1036,7 +1036,7 @@ func readLifeBarFace(pre string, is IniSection,
 }
 func (fa *LifeBarFace) step(ref int, far *LifeBarFace) {
 	group, number := int16(fa.face_spr[0]), int16(fa.face_spr[1])
-	if sys.chars[ref][0] != nil {
+	if sys.chars[ref][0] != nil && sys.chars[ref][0].anim != nil {
 		if mg, ok := sys.chars[ref][0].anim.remap[group]; ok {
 			if mn, ok := mg[number]; ok {
 				group, number = mn[0], mn[1]

--- a/src/system.go
+++ b/src/system.go
@@ -2519,22 +2519,30 @@ func (s *Select) addChar(def string) {
 	if fp = FileExist(fp); len(fp) == 0 {
 		fp = sprite
 	}
-	LoadFile(&fp, []string{def, "", "data/"}, func(file string) error {
-		var selPal []int32
-		var err error
-		sc.sff, selPal, err = preloadSff(file, true, listSpr)
-		if err != nil {
-			panic(fmt.Errorf("failed to load %v: %v\nerror preloading %v", file, err, def))
-		}
+	if len(fp) > 0 {
+		LoadFile(&fp, []string{def, "", "data/"}, func(file string) error {
+			var selPal []int32
+			var err error
+			sc.sff, selPal, err = preloadSff(file, true, listSpr)
+			if err != nil {
+				panic(fmt.Errorf("failed to load %v: %v\nerror preloading %v", file, err, def))
+			}
+			sc.anims.updateSff(sc.sff)
+			for k := range s.charSpritePreload {
+				sc.anims.addSprite(sc.sff, k[0], k[1])
+			}
+			if len(sc.pal) == 0 {
+				sc.pal = selPal
+			}
+			return nil
+		})
+	} else {
+		sc.sff = newSff()
 		sc.anims.updateSff(sc.sff)
 		for k := range s.charSpritePreload {
 			sc.anims.addSprite(sc.sff, k[0], k[1])
 		}
-		if len(sc.pal) == 0 {
-			sc.pal = selPal
-		}
-		return nil
-	})
+	}
 	//read movelist
 	if len(movelist) > 0 {
 		LoadFile(&movelist, []string{def, "", "data/"}, func(file string) error {


### PR DESCRIPTION
Also, negative anim handling was improved to fix some dizzy system issues.

BREAKING CHANGE:
"No-sprite" anim used to be "-2", but now it's "-1".