### PR TITLE
fix: Refine anim no. handling from #1448, PlayBGM SCTRL leaking to the character select screen

### DIFF
--- a/data/dizzy.zss
+++ b/data/dizzy.zss
@@ -76,7 +76,7 @@ playSnd{value: F7, ($vely > const240p(5)) + ($vely > const240p(14))}
 #===============================================================================
 # StateDizzyBirdsHelper [helper]
 #===============================================================================
-[StateDef const(StateDizzyBirdsHelper); type: A; physics: N; anim: -1; velset: 0, 0; ctrl: 0;]
+[StateDef const(StateDizzyBirdsHelper); type: A; physics: N; anim: -2; velset: 0, 0; ctrl: 0;]
 
 # Destroy helper
 # 32 ticks after conditions are met so that it may fade out the effects

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -2487,7 +2487,7 @@ func (sc stateDef) Run(c *Char) {
 				}
 			}
 		case stateDef_anim:
-			c.changeAnim(exp[1].evalI(c), string(*(*[]byte)(unsafe.Pointer(&exp[0]))))
+			c.changeAnimEx(exp[1].evalI(c), c.playerNo, string(*(*[]byte)(unsafe.Pointer(&exp[0]))), false)
 		case stateDef_ctrl:
 			//in mugen fatal blow ignores statedef ctrl
 			if !c.ghv.fatal {
@@ -2961,7 +2961,7 @@ func (sc changeAnim) Run(c *Char, _ []int32) bool {
 			if r != -1 {
 				pn = r
 			}
-			crun.changeAnimEx(exp[1].evalI(c), pn, string(*(*[]byte)(unsafe.Pointer(&exp[0]))), false)
+			crun.changeAnim(exp[1].evalI(c), pn, string(*(*[]byte)(unsafe.Pointer(&exp[0]))))
 			if setelem {
 				crun.setAnimElem(elem)
 			}

--- a/src/script.go
+++ b/src/script.go
@@ -425,7 +425,7 @@ func systemScriptInit(l *lua.LState) {
 				if ffx {
 					preffix = "f"
 				}
-				c[0].changeAnim(an, preffix)
+				c[0].changeAnim(an, c[0].playerNo, preffix)
 				if l.GetTop() >= 3 {
 					c[0].setAnimElem(int32(numArg(l, 3)))
 				}

--- a/src/script.go
+++ b/src/script.go
@@ -1089,7 +1089,7 @@ func systemScriptInit(l *lua.LState) {
 				l.Push(lua.LNumber(winp))
 				l.Push(tbl)
 				if sys.playBgmFlg {
-					sys.bgm = *newBgm()
+					sys.bgm.Open("", 1, 100, 0, 0, 0)
 					sys.playBgmFlg = false
 				}
 				sys.clearAllSound()


### PR DESCRIPTION
Anim No. negative values are now being handled like this:

- In ChangeAnim/ChangeAnim2 SCTRL: Any negative value (except for -2) is clamped to 0
- In ChangeState/SelfState SCTRL: Any negative value (except for -1 and -2) is clamped to 0
- In StateDef: Any negative value (except for -1 and -2) throws a warning message in the console

This is the best approach to mixing MUGEN 1.1 handling of negative values and Ikemen GO's -2 anim (which is a 'no-sprite' anim).