### PR TITLE
feat: new Math triggers (Clamp, Sign, Atan2, Rad, Deg, Lerp) and char triggers (Angle, Scale, OffSet, Alpha)

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -490,6 +490,12 @@ const (
 	OC_ex_maparray
 	OC_ex_max
 	OC_ex_min
+	OC_ex_clamp
+	OC_ex_sign
+	OC_ex_atan2
+	OC_ex_rad
+	OC_ex_deg
+	OC_ex_lerp	
 	OC_ex_memberno
 	OC_ex_movecountered
 	OC_ex_pausetime
@@ -526,6 +532,13 @@ const (
 	OC_ex_envshakevar_time
 	OC_ex_envshakevar_freq
 	OC_ex_envshakevar_ampl
+	OC_ex_angle
+	OC_ex_scale_x
+	OC_ex_scale_y
+	OC_ex_offset_x
+	OC_ex_offset_y
+	OC_ex_alpha_s
+	OC_ex_alpha_d	
 )
 const (
 	NumVar     = 60
@@ -926,6 +939,42 @@ func (BytecodeExp) random(v1 *BytecodeValue, v2 BytecodeValue) {
 func (BytecodeExp) round(v1 *BytecodeValue, v2 BytecodeValue) {
 	shift := math.Pow(10, v2.v)
 	v1.SetF(float32(math.Floor((v1.v*shift)+0.5) / shift))
+}
+func (BytecodeExp) clamp(v1 *BytecodeValue, v2 BytecodeValue, v3 BytecodeValue) {
+	if v1.v <= v2.v {
+		v1.SetF(float32(v2.v))
+	} else if v1.v >= v3.v {
+		v1.SetF(float32(v3.v))
+	} else {
+		v1.SetF(float32(v1.v))		
+	}
+}
+func (BytecodeExp) atan2(v1 *BytecodeValue, v2 BytecodeValue) {
+	v1.SetF(float32(math.Atan2(v1.v,v2.v)))
+}
+func (BytecodeExp) sign(v1 *BytecodeValue) {
+	if v1.v < 0 {
+		v1.SetI(int32(-1))
+	} else if v1.v > 0 {
+		v1.SetI(int32(1))
+	} else {
+		v1.SetI(int32(0))	
+	}
+}
+func (BytecodeExp) rad(v1 *BytecodeValue) {
+	v1.SetF(float32(v1.v*math.Pi/180))
+}
+func (BytecodeExp) deg(v1 *BytecodeValue) {
+	v1.SetF(float32(v1.v*180/math.Pi))
+}
+func (BytecodeExp) lerp(v1 *BytecodeValue, v2 BytecodeValue, v3 BytecodeValue) {
+	amount := v3.v
+	if v3.v <= 0 {
+		amount = 0
+	} else if v3.v >= 1 {
+		amount = 1
+	}
+	v1.SetF(float32(v1.v+(v2.v-v1.v)*amount))
 }
 func (be BytecodeExp) run(c *Char) BytecodeValue {
 	oc := c
@@ -2032,6 +2081,23 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_min:
 		v2 := sys.bcStack.Pop()
 		be.min(sys.bcStack.Top(), v2)
+	case OC_ex_clamp:
+		v3 := sys.bcStack.Pop()
+		v2 := sys.bcStack.Pop()
+		be.clamp(sys.bcStack.Top(), v2,v3)
+	case OC_ex_atan2:
+		v2 := sys.bcStack.Pop()
+		be.atan2(sys.bcStack.Top(),v2)
+	case OC_ex_sign:
+		be.sign(sys.bcStack.Top())
+	case OC_ex_rad:	
+		be.rad(sys.bcStack.Top())	
+	case OC_ex_deg:
+		be.deg(sys.bcStack.Top())
+	case OC_ex_lerp:
+		v3 := sys.bcStack.Pop()
+		v2 := sys.bcStack.Pop()
+		be.lerp(sys.bcStack.Top(), v2,v3)
 	case OC_ex_memberno:
 		sys.bcStack.PushI(int32(c.memberNo) + 1)
 	case OC_ex_movecountered:
@@ -2117,6 +2183,20 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(sys.envShake.freq / float32(math.Pi) * 180)
 	case OC_ex_envshakevar_ampl:
 		sys.bcStack.PushF(float32(math.Abs(float64(sys.envShake.ampl / oc.localscl))))
+	case OC_ex_angle:
+		sys.bcStack.PushF(c.angleTrg)
+	case OC_ex_scale_x:			
+		sys.bcStack.PushF(c.angleScaleTrg[0])
+	case OC_ex_scale_y:
+		sys.bcStack.PushF(c.angleScaleTrg[1])			
+	case OC_ex_offset_x:
+		sys.bcStack.PushF(c.offsetTrg[0])
+	case OC_ex_offset_y:
+		sys.bcStack.PushF(c.offsetTrg[1])
+	case OC_ex_alpha_s:
+		sys.bcStack.PushI(c.alphaTrg[0])
+	case OC_ex_alpha_d:
+		sys.bcStack.PushI(c.alphaTrg[1])		
 	default:
 		sys.errLog.Printf("%v\n", be[*i-1])
 		c.panic()
@@ -5882,6 +5962,8 @@ func (sc trans) Run(c *Char, _ []int32) bool {
 					crun.alpha[0] = 0
 				}
 			}
+			crun.alphaTrg[0] = crun.alpha[0]
+			crun.alphaTrg[1] = crun.alpha[1]			
 		case trans_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -5972,8 +6054,10 @@ func (sc angleDraw) Run(c *Char, _ []int32) bool {
 			crun.angleSet(exp[0].evalF(c))
 		case angleDraw_scale:
 			crun.angleScale[0] *= exp[0].evalF(c)
+			crun.angleScaleTrg[0] = crun.angleScale[0]
 			if len(exp) > 1 {
 				crun.angleScale[1] *= exp[1].evalF(c)
+				crun.angleScaleTrg[1] = crun.angleScale[1]
 			}
 		case angleDraw_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
@@ -6875,8 +6959,10 @@ func (sc offset) Run(c *Char, _ []int32) bool {
 		switch id {
 		case offset_x:
 			crun.offset[0] = exp[0].evalF(c) * c.localscl
+			crun.offsetTrg[0] = crun.offset[0]
 		case offset_y:
 			crun.offset[1] = exp[0].evalF(c) * c.localscl
+			crun.offsetTrg[1] = crun.offset[1]
 		case offset_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -325,10 +325,15 @@ var triggerMap = map[string]int{
 	"animelemlength":     1,
 	"animlength":         1,
 	"attack":             1,
+	"alpha":              1,
+  	"angle":              1,
+  	"atan2": 			  1,	
 	"bgmlength":          1,
 	"bgmposition":        1,
+	"clamp":              1,
 	"combocount":         1,
 	"consecutivewins":    1,
+	"deg": 				  1,
 	"defence":            1,
 	"dizzy":              1,
 	"dizzypoints":        1,
@@ -349,6 +354,7 @@ var triggerMap = map[string]int{
 	"incustomstate":      1,
 	"indialogue":         1,
 	"isasserted":         1,
+	"lerp": 			  1,
 	"localscale":         1,
 	"majorversion":       1,
 	"map":                1,
@@ -356,6 +362,7 @@ var triggerMap = map[string]int{
 	"memberno":           1,
 	"min":                1,
 	"movecountered":      1,
+	"offset": 			  1,
 	"p5name":             1,
 	"p6name":             1,
 	"p7name":             1,
@@ -365,6 +372,7 @@ var triggerMap = map[string]int{
 	"playerno":           1,
 	"prevanim":           1,
 	"prevmovetype":       1,
+	"rad": 				  1,
 	"ratiolevel":         1,
 	"randomrange":        1,
 	"receivedhits":       1,
@@ -373,6 +381,8 @@ var triggerMap = map[string]int{
 	"reversaldefattr":    1,
 	"round":              1,
 	"roundtype":          1,
+	"scale": 			  1,
+	"sign": 			  1,
 	"score":              1,
 	"scoretotal":         1,
 	"selfstatenoexist":   1,
@@ -2562,6 +2572,129 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.round(&bv1, bv2)
 			bv = bv1
 		}
+	case "clamp":
+		if err := c.checkOpeningBracket(in); err != nil {
+			return bvNone(), err
+		}
+		if bv1, err = c.expBoolOr(&be1, in); err != nil {
+			return bvNone(), err
+		}
+		if c.token != "," {
+			return bvNone(), Error("Missing ','")
+		}
+		c.token = c.tokenizer(in)
+		if bv2, err = c.expBoolOr(&be2, in); err != nil {
+			return bvNone(), err
+		}
+		if c.token != "," {
+			return bvNone(), Error("Missing ','")
+		}
+		c.token = c.tokenizer(in)
+		if bv3, err = c.expBoolOr(&be3, in); err != nil {
+			return bvNone(), err
+		}
+		if err := c.checkClosingBracket(); err != nil {
+			return bvNone(), err
+		}
+		if bv1.IsNone() || bv2.IsNone() || bv3.IsNone(){
+			if rd {
+				out.append(OC_rdreset)
+			}
+			out.append(be1...)
+			out.appendValue(bv1)
+			out.append(be2...)
+			out.appendValue(bv2)
+			out.append(be3...)
+			out.appendValue(bv3)
+			out.append(OC_ex_, OC_ex_clamp)
+		} else {
+			out.clamp(&bv1,bv2, bv3)
+			bv = bv1
+		}
+	case "atan2":
+		if err := c.checkOpeningBracket(in); err != nil {
+			return bvNone(), err
+		}
+		if bv1, err = c.expBoolOr(&be1, in); err != nil {
+			return bvNone(), err
+		}
+		if c.token != "," {
+			return bvNone(), Error("Missing ','")
+		}
+		c.token = c.tokenizer(in)
+		if bv2, err = c.expBoolOr(&be2, in); err != nil {
+			return bvNone(), err
+		}
+		if err := c.checkClosingBracket(); err != nil {
+			return bvNone(), err
+		}
+		if bv1.IsNone() || bv2.IsNone() {
+			if rd {
+				out.append(OC_rdreset)
+			}
+			out.append(be1...)
+			out.appendValue(bv1)
+			out.append(be2...)
+			out.appendValue(bv2)		
+			out.append(OC_ex_, OC_ex_atan2)
+		} else {
+			out.atan2(&bv1,bv2)
+			bv = bv1
+		}
+	case "sign":
+		if _, err := c.oneArg(out, in, rd, true); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_ex_, OC_ex_sign)
+	case "rad":
+		if _, err := c.oneArg(out, in, rd, true); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_ex_, OC_ex_rad)
+	case "deg":
+		if _, err := c.oneArg(out, in, rd, true); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_ex_, OC_ex_deg)
+	case "lerp":
+		if err := c.checkOpeningBracket(in); err != nil {
+			return bvNone(), err
+		}
+		if bv1, err = c.expBoolOr(&be1, in); err != nil {
+			return bvNone(), err
+		}
+		if c.token != "," {
+			return bvNone(), Error("Missing ','")
+		}
+		c.token = c.tokenizer(in)
+		if bv2, err = c.expBoolOr(&be2, in); err != nil {
+			return bvNone(), err
+		}
+		if c.token != "," {
+			return bvNone(), Error("Missing ','")
+		}
+		c.token = c.tokenizer(in)
+		if bv3, err = c.expBoolOr(&be3, in); err != nil {
+			return bvNone(), err
+		}
+		if err := c.checkClosingBracket(); err != nil {
+			return bvNone(), err
+		}
+		if bv1.IsNone() || bv2.IsNone() || bv3.IsNone(){
+			if rd {
+				out.append(OC_rdreset)
+			}
+			out.append(be1...)
+			out.appendValue(bv1)
+			out.append(be2...)
+			out.appendValue(bv2)
+			out.append(be3...)
+			out.appendValue(bv3)
+			out.append(OC_ex_, OC_ex_lerp)
+		} else {
+			out.lerp(&bv1,bv2, bv3)
+			bv = bv1
+		}		
 	case "ailevelf":
 		out.append(OC_ex_, OC_ex_ailevelf)
 	case "airjumpcount":
@@ -2865,6 +2998,38 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_ex_, OC_ex_timetotal)
 	case "drawpalno":
 		out.append(OC_ex_, OC_ex_drawpalno)
+	case "angle":
+		out.append(OC_ex_, OC_ex_angle)
+	case "scale":
+		c.token = c.tokenizer(in)
+		switch c.token {
+		case "x":
+			out.append(OC_ex_, OC_ex_scale_x)
+		case "y":
+			out.append(OC_ex_, OC_ex_scale_y)
+		default:
+			return bvNone(), Error("Invalid data: " + c.token)
+		}
+	case "offset":
+		c.token = c.tokenizer(in)
+		switch c.token {
+		case "x":
+			out.append(OC_ex_, OC_ex_offset_x)
+		case "y":
+			out.append(OC_ex_, OC_ex_offset_y)
+		default:
+			return bvNone(), Error("Invalid data: " + c.token)
+		}		
+	case "alpha":
+		c.token = c.tokenizer(in)
+		switch c.token {
+		case "source":
+			out.append(OC_ex_, OC_ex_alpha_s)
+		case "dest":
+			out.append(OC_ex_, OC_ex_alpha_d)
+		default:
+			return bvNone(), Error("Invalid data: " + c.token)
+		}		
 	case "=", "!=", ">", ">=", "<", "<=", "&", "&&", "^", "^^", "|", "||",
 		"+", "*", "**", "/", "%":
 		if !sys.ignoreMostErrors || len(c.previousOperator) > 0 {

--- a/src/script.go
+++ b/src/script.go
@@ -3859,6 +3859,19 @@ func triggerFunctions(l *lua.LState) {
 	})
 
 	// new triggers
+	//atan2 (dedicated functionality already exists in Lua)	
+	luaRegister(l, "angle", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.angleTrg))
+		return 1
+	})
+	luaRegister(l, "alphaSource", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.alphaTrg[0]))
+		return 1
+	})
+	luaRegister(l, "alphaDest", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.alphaTrg[1]))
+		return 1
+	})	
 	luaRegister(l, "animelemlength", func(*lua.LState) int {
 		if f := sys.debugWC.anim.CurrentFrame(); f != nil {
 			l.Push(lua.LNumber(f.Time))
@@ -3875,6 +3888,12 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.debugWC.attackMul * 100))
 		return 1
 	})
+	luaRegister(l, "clamp", func(*lua.LState) int {
+		v1, v2, v3, retv := float32(numArg(l,1)),float32(numArg(l,2)),float32(numArg(l,3)), float32(0)
+		retv = MaxF(v2, MinF(v1, v3))
+		l.Push(lua.LNumber(retv))
+		return 1
+	})	
 	luaRegister(l, "combocount", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.comboCount()))
 		return 1
@@ -3883,6 +3902,7 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.consecutiveWins[sys.debugWC.teamside]))
 		return 1
 	})
+	//deg (dedicated functionality already exists in Lua)	
 	luaRegister(l, "defence", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.finalDefense * 100))
 		return 1
@@ -4065,6 +4085,12 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LBool(sys.debugWC.isHost()))
 		return 1
 	})
+	luaRegister(l, "lerp", func(*lua.LState) int {
+		a,b,amount, retv := float32(numArg(l,1)),float32(numArg(l,2)),float32(numArg(l,3)), float32(0)
+		retv = float32(a + (b - a) * MaxF(0, MinF(amount, 1)))
+		l.Push(lua.LNumber(retv))
+		return 1
+	})	
 	luaRegister(l, "localscale", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.localscl))
 		return 1
@@ -4085,6 +4111,14 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.debugWC.moveCountered()))
 		return 1
 	})
+	luaRegister(l, "offsetX", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.offsetTrg[0]))
+		return 1
+	})
+	luaRegister(l, "offsetY", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.offsetTrg[1]))
+		return 1
+	})	
 	luaRegister(l, "pausetime", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.pauseTime()))
 		return 1
@@ -4109,6 +4143,7 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	//randomrange (dedicated functionality already exists in Lua)
+	//rad (dedicated functionality already exists in Lua)	
 	luaRegister(l, "ratiolevel", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.ocd().ratioLevel))
 		return 1
@@ -4129,6 +4164,27 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.debugWC.roundType()))
 		return 1
 	})
+	luaRegister(l, "scaleX", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.angleScaleTrg[0]))
+		return 1
+	})
+	luaRegister(l, "scaleY", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.angleScaleTrg[1]))
+		return 1
+	})
+	luaRegister(l, "sign", func(*lua.LState) int {
+		v, retv := float32(numArg(l,1)), int32(0)
+		if v < 0 {
+			v = -1	
+		} else if v > 0 {
+			v = 1
+		} else {
+			v = 0
+		}
+		retv = int32(v)
+		l.Push(lua.LNumber(retv))
+		return 1
+	})	
 	luaRegister(l, "score", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.score()))
 		return 1


### PR DESCRIPTION
New Math triggers:

- Clamp(x,min,max) (float)
Return a value clamped to an inclusive range of two specified numbers

- Sign(value) (int)
Returns the sign of a real number. If value < 0 return -1. If value 0 return 0. if value > 0 return 1.

- Atan2(x,y) (float)
Returns the arc tangent of the two numbers x and y.

- Rad(value) (float)
Converts degress to radians.

- Deg(value) (float)
Converts radians to degress.

- Lerp(a,b,amount) (float)
Linear interpolation between two values.

New Char triggers:

- Angle (float)
Gets the value of the player's angle.
Example: "trigger1 = angle < 90" 
- Scale (float) (Arguments  x, y) 
Gets the value of the player's scale.
Example: "trigger1 = scale x< 2 || scale y > 2" 
- OffSet (float) (Arguments  x, y) 
Gets the value of the player's offset.
Example: "trigger1 = offset x > 20 || offset y > 15" 
- Alpha (int)  (Arguments  source, dest) 
Gets the value of the player's alpha.
Example: "trigger1 = alpha source > 128 || alpha dest < 64" 