### PR TITLE
fix: some directional input fixes

### DIFF
--- a/src/compiler.go
+++ b/src/compiler.go
@@ -5574,25 +5574,25 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 				rm := func(name string, k, nk *CommandKey) {
 					switch strings.ToLower(is[name]) {
 					case "x":
-						*k, *nk = CK_x, CK_nx
+						*k, *nk = CK_x, CK_rx
 					case "y":
-						*k, *nk = CK_y, CK_ny
+						*k, *nk = CK_y, CK_ry
 					case "z":
-						*k, *nk = CK_z, CK_nz
+						*k, *nk = CK_z, CK_rz
 					case "a":
-						*k, *nk = CK_a, CK_na
+						*k, *nk = CK_a, CK_ra
 					case "b":
-						*k, *nk = CK_b, CK_nb
+						*k, *nk = CK_b, CK_rb
 					case "c":
-						*k, *nk = CK_c, CK_nc
+						*k, *nk = CK_c, CK_rc
 					case "s":
-						*k, *nk = CK_s, CK_ns
+						*k, *nk = CK_s, CK_rs
 					case "d":
-						*k, *nk = CK_d, CK_nd
+						*k, *nk = CK_d, CK_rd
 					case "w":
-						*k, *nk = CK_w, CK_nw
+						*k, *nk = CK_w, CK_rw
 					case "m":
-						*k, *nk = CK_m, CK_nm
+						*k, *nk = CK_m, CK_rm
 					}
 				}
 				rm("x", &ckr.x, &ckr.nx)

--- a/src/input.go
+++ b/src/input.go
@@ -1048,25 +1048,28 @@ func (ce *cmdElem) IsDirToButton(next cmdElem) bool {
 	if next.slash {
 		return false
 	}
-	btn := true
-	for _, k := range ce.key {
-		if k < CK_a {
-			btn = false
-			break
+	// This logic seems more complex in Mugen because of variable input delay
+	for i, k := range ce.key {
+		// Not if both elements share keys
+		for _, n := range next.key {
+			if k == n {
+				return false
+			}
+		}
+		// Not if first element includes buttons
+		if k >= CK_a {
+			return false
+		}
+		// Yes if release direction then not release direction
+		if (k >= CK_rB && k <= CK_rUF || k >= CK_rBs && k <= CK_rUFs) {
+			if (next.key[i] < CK_rB || next.key[i] > CK_rUF) && (next.key[i] < CK_rBs || next.key[i] > CK_rUFs) {
+				return true
+			}
 		}
 	}
-	if btn {
-		return false
-	}
-	if len(ce.key) != len(next.key) {
-		return true
-	}
-	for i, k := range ce.key {
-		// if "not release dir" and "not release dir sign"
-		if k != next.key[i] && ((k < CK_rB || k > CK_rUF) &&
-			(k < CK_rBs || k > CK_rUFs) ||
-			(next.key[i] < CK_rB || next.key[i] > CK_rUF) &&
-				(next.key[i] < CK_rBs || next.key[i] > CK_rUFs)) {
+	// Yes if second element includes buttons
+	for _, k := range next.key {
+		if k >= CK_a {
 			return true
 		}
 	}


### PR DESCRIPTION
- Changed the way the parser decides if it's acceptable to read two command elements in the same frame
- Previously if a command had two consecutive directions, they were treated as having ">". Fixed so that only consecutive identical directions do that
- Refactored the code a little to make it easier to understand
- Fixes #350
- Fixes #463