### PR TITLE
feat: optionally easier inputs

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -217,6 +217,8 @@ type configSettings struct {
 	GameWidth                  int32
 	GameHeight                 int32
 	GameFramerate              float32
+	InputButtonAssist          bool
+	InputSOCDResolution        int32
 	IP                         map[string]string
 	LifeMul                    float32
 	ListenPort                 string
@@ -359,6 +361,8 @@ func setupConfig() configSettings {
 	sys.gameHeight = tmp.GameHeight
 	sys.gameSpeed = tmp.GameFramerate / float32(tmp.Framerate)
 	sys.helperMax = tmp.MaxHelper
+	sys.inputButtonAssist = tmp.InputButtonAssist
+	sys.inputSOCDresolution = Clamp(tmp.InputSOCDResolution, 0, 4)
 	sys.lifeMul = tmp.LifeMul / 100
 	sys.lifeShare = [...]bool{tmp.TeamLifeShare, tmp.TeamLifeShare}
 	sys.listenPort = tmp.ListenPort

--- a/src/resources/defaultConfig.json
+++ b/src/resources/defaultConfig.json
@@ -56,6 +56,8 @@
   "GameWidth": 640,
   "GameHeight": 480,
   "GameFramerate": 60,
+  "InputButtonAssist": true,
+  "InputSOCDResolution": 1,
   "IP": {},
   "LifeMul": 100,
   "ListenPort": "7500",

--- a/src/system.go
+++ b/src/system.go
@@ -292,7 +292,10 @@ type System struct {
 	fullscreenWidth       int32
 	fullscreenHeight      int32
 
+	// Input variables
 	controllerStickSensitivity float32
+	inputButtonAssist          bool
+	inputSOCDresolution        int32
 	xinputTriggerSensitivity   float32
 
 	// Localcoord sceenpack


### PR DESCRIPTION
Added two new settings to config.json:
InputButtonAssist:
- If set to true (default), button inputs will wait one additional frame before registering, so that inputs with 2 or 3 button combinations are easier to perform. Note that this setting adds 1 frame of input lag

InputSOCDResolution:
- Allows setting how simultaneous opposing cardinal directions should be resolved. It accepts 5 values
- 0 > No resolution > Allows pressing both directions at the same time. Mugen behavior
- 1 > Last input priority > Only the last direction is registered. This is currently default
- 2 > Absolute priority > F has priority over B. U has priority over D
- 3 > First direction priority > Only the first direction is registered
- 4 > Deny either direction > Previous Ikemen behavior

For the time being, these options only work in local play. During netplay, button assist is off and SOCD resolution uses type 2.

Also a fix:
- If a command is completed successfully, the buffer for every command with the same name is now reset.
- Fixes #1474