### PR TITLE
feat: new Height constants, ClassicPushbox option

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -245,7 +245,11 @@ const (
 	OC_const_size_ground_front
 	OC_const_size_air_back
 	OC_const_size_air_front
-	OC_const_size_height
+	OC_const_size_height_stand
+	OC_const_size_height_crouch
+	OC_const_size_height_air_top
+	OC_const_size_height_air_bottom
+	OC_const_size_height_down
 	OC_const_size_attack_dist
 	OC_const_size_attack_z_width_back
 	OC_const_size_attack_z_width_front
@@ -260,6 +264,7 @@ const (
 	OC_const_size_draw_offset_y
 	OC_const_size_z_width
 	OC_const_size_z_enable
+	OC_const_size_classicpushbox
 	OC_const_velocity_walk_fwd_x
 	OC_const_velocity_walk_back_x
 	OC_const_velocity_walk_up_x
@@ -1543,8 +1548,16 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.size.air.back * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_air_front:
 		sys.bcStack.PushF(c.size.air.front * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_size_height:
-		sys.bcStack.PushF(c.size.height * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_size_height_stand:
+		sys.bcStack.PushF(c.size.height.stand * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_size_height_crouch:
+		sys.bcStack.PushF(c.size.height.crouch * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_size_height_air_top:
+		sys.bcStack.PushF(c.size.height.air[0] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_size_height_air_bottom:
+		sys.bcStack.PushF(c.size.height.air[1] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_size_height_down:
+		sys.bcStack.PushF(c.size.height.down * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_attack_dist:
 		sys.bcStack.PushF(c.size.attack.dist * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_attack_z_width_back:
@@ -1573,6 +1586,8 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.size.z.width * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_z_enable:
 		sys.bcStack.PushB(c.size.z.enable)
+	case OC_const_size_classicpushbox:
+		sys.bcStack.PushI(c.size.classicpushbox)
 	case OC_const_velocity_walk_fwd_x:
 		sys.bcStack.PushF(c.gi().velocity.walk.fwd * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_walk_back_x:
@@ -3117,7 +3132,10 @@ const (
 	helper_size_ground_front
 	helper_size_air_back
 	helper_size_air_front
-	helper_size_height
+	helper_size_height_stand
+	helper_size_height_crouch
+	helper_size_height_air
+	helper_size_height_down
 	helper_size_proj_doscale
 	helper_size_head_pos
 	helper_size_mid_pos
@@ -3187,8 +3205,17 @@ func (sc helper) Run(c *Char, _ []int32) bool {
 			h.size.air.back = exp[0].evalF(c)
 		case helper_size_air_front:
 			h.size.air.front = exp[0].evalF(c)
-		case helper_size_height:
-			h.size.height = exp[0].evalF(c)
+		case helper_size_height_stand:
+			h.size.height.stand = exp[0].evalF(c)
+		case helper_size_height_crouch:
+			h.size.height.crouch = exp[0].evalF(c)
+		case helper_size_height_air:
+			h.size.height.air[0] = exp[0].evalF(c)
+			if len(exp) > 1 {
+				h.size.height.air[1] = exp[1].evalF(c)
+			}
+		case helper_size_height_down:
+			h.size.height.down = exp[0].evalF(c)
 		case helper_size_proj_doscale:
 			h.size.proj.doscale = exp[0].evalI(c)
 		case helper_size_head_pos:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -386,6 +386,7 @@ const (
 	OC_ex_p2dist_x OpCode = iota
 	OC_ex_p2dist_y
 	OC_ex_p2bodydist_x
+	OC_ex_p2bodydist_y
 	OC_ex_parentdist_x
 	OC_ex_parentdist_y
 	OC_ex_rootdist_x
@@ -1857,6 +1858,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.Push(c.rdDistY(c.p2(), oc))
 	case OC_ex_p2bodydist_x:
 		sys.bcStack.Push(c.p2BodyDistX(oc))
+	case OC_ex_p2bodydist_y:
+		sys.bcStack.Push(c.p2BodyDistY(oc))
 	case OC_ex_parentdist_x:
 		sys.bcStack.Push(c.rdDistX(c.parent(), oc))
 	case OC_ex_parentdist_y:

--- a/src/char.go
+++ b/src/char.go
@@ -7480,8 +7480,13 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 				gxmin += sys.xmin / getter.localscl
 				gxmax += sys.xmax / getter.localscl
 
-				if gl < cr && cl < gr &&
-					getter.clsnCheck(c, false, false) {
+				// If both chars are Ikemen, only the pushbox is checked
+				push := true
+				if (c.stCgi().ikemenver[0] == 0 && c.stCgi().ikemenver[1] == 0) || (getter.stCgi().ikemenver[0] == 0 && getter.stCgi().ikemenver[1] == 0) {
+					push = getter.clsnCheck(c, false, false)
+				}
+
+				if gl < cr && cl < gr && push {
 					getter.pushed, c.pushed = true, true
 					tmp := getter.distX(c, getter)
 					if tmp == 0 {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2353,7 +2353,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "x":
 			out.append(OC_ex_, OC_ex_p2bodydist_x)
 		case "y":
-			out.append(OC_ex_, OC_ex_p2dist_y)
+			out.append(OC_ex_, OC_ex_p2bodydist_y)
 		case "z":
 			bv = BytecodeFloat(0)
 		default:

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1514,8 +1514,16 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.append(OC_const_size_air_back)
 		case "size.air.front":
 			out.append(OC_const_size_air_front)
-		case "size.height":
-			out.append(OC_const_size_height)
+		case "size.height", "size.height.stand": // Latter is also accepted for consistency's sake
+			out.append(OC_const_size_height_stand)
+		case "size.height.crouch":
+			out.append(OC_const_size_height_crouch)
+		case "size.height.air.top":
+			out.append(OC_const_size_height_air_top)
+		case "size.height.air.bottom":
+			out.append(OC_const_size_height_air_bottom)
+		case "size.height.down":
+			out.append(OC_const_size_height_down)
 		case "size.attack.dist":
 			out.append(OC_const_size_attack_dist)
 		case "size.attack.z.width.back":
@@ -1544,6 +1552,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.append(OC_const_size_z_width)
 		case "size.z.enable":
 			out.append(OC_const_size_z_enable)
+		case "size.classicpushbox":
+			out.append(OC_const_size_classicpushbox)
 		case "velocity.walk.fwd.x":
 			out.append(OC_const_velocity_walk_fwd_x)
 		case "velocity.walk.back.x":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -475,7 +475,19 @@ func (c *Compiler) helper(is IniSection, sc *StateControllerBase, _ int8) (State
 			return err
 		}
 		if err := c.paramValue(is, sc, "size.height",
-			helper_size_height, VT_Int, 1, false); err != nil {
+			helper_size_height_stand, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "size.height.crouch",
+			helper_size_height_crouch, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "size.height.air",
+			helper_size_height_air, VT_Int, 2, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "size.height.down",
+			helper_size_height_down, VT_Int, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "size.proj.doscale",

--- a/src/input.go
+++ b/src/input.go
@@ -320,27 +320,35 @@ func (cl *CommandBuffer) SocdResolution(U, D, B, F bool) (bool, bool, bool, bool
 	} else {
 		// Check first direction held between U and D
 		if U || D {
+			if !U {
+				cl.SocdFirst[0] = false
+			}
+			if !D {
+				cl.SocdFirst[1] = false
+			}
 			if !cl.SocdFirst[0] && !cl.SocdFirst[1] {
 				if D {
-					cl.SocdFirst[0] = false
 					cl.SocdFirst[1] = true
 				} else {
 					cl.SocdFirst[0] = true
-					cl.SocdFirst[1] = false
 				}
 			}
 		} else {
 			cl.SocdFirst[0] = false
 			cl.SocdFirst[1] = false
 		}
-		// Check first direction held between B and F
+		// Check first direction held between U and D
 		if B || F {
+			if !B {
+				cl.SocdFirst[2] = false
+			}
+			if !F {
+				cl.SocdFirst[3] = false
+			}
 			if !cl.SocdFirst[2] && !cl.SocdFirst[3] {
 				if B {
 					cl.SocdFirst[2] = true
-					cl.SocdFirst[3] = false
 				} else {
-					cl.SocdFirst[2] = false
 					cl.SocdFirst[3] = true
 				}
 			}
@@ -382,7 +390,7 @@ func (cl *CommandBuffer) SocdResolution(U, D, B, F bool) (bool, bool, bool, bool
 					cl.SocdAllow[3] = false
 				}
 			// Type 4 - Deny either direction (neutral)
-			case 4:
+			default:
 				cl.SocdAllow[2] = false
 				cl.SocdAllow[3] = false
 			}
@@ -424,7 +432,7 @@ func (cl *CommandBuffer) SocdResolution(U, D, B, F bool) (bool, bool, bool, bool
 					cl.SocdAllow[1] = true
 				}
 			// Type 4 - Deny either direction (neutral)
-			case 4:
+			default:
 				cl.SocdAllow[0] = false
 				cl.SocdAllow[1] = false
 			}
@@ -1797,7 +1805,7 @@ func (c *Command) Step(cbuf *CommandBuffer, ai, hitpause bool, buftime int32) {
 	c.Clear(false)
 	if c.completeflag {
 		// Update buffer only if it's lower. Mugen doesn't do this but it seems like the right thing to do
-		c.curbuftime = Max(c.buftime, c.buftime+buftime)
+		c.curbuftime = Max(c.curbuftime, c.buftime+buftime)
 	}
 }
 

--- a/src/script.go
+++ b/src/script.go
@@ -2875,7 +2875,15 @@ func triggerFunctions(l *lua.LState) {
 		case "size.air.front":
 			ln = lua.LNumber(c.size.air.front)
 		case "size.height":
-			ln = lua.LNumber(c.size.height)
+			ln = lua.LNumber(c.size.height.stand)
+		case "size.height.crouch":
+			ln = lua.LNumber(c.size.height.crouch)
+		case "size.height.air.top":
+			ln = lua.LNumber(c.size.height.air[0])
+		case "size.height.air.bottom":
+			ln = lua.LNumber(c.size.height.air[1])
+		case "size.height.down":
+			ln = lua.LNumber(c.size.height.down)
 		case "size.attack.dist":
 			ln = lua.LNumber(c.size.attack.dist)
 		case "size.attack.z.width.back":
@@ -2904,6 +2912,8 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.size.z.width)
 		case "size.z.enable":
 			ln = lua.LNumber(Btoi(c.size.z.enable))
+		case "size.classicpushbox":
+			ln = lua.LNumber(c.size.classicpushbox)
 		case "velocity.walk.fwd.x":
 			ln = lua.LNumber(c.gi().velocity.walk.fwd)
 		case "velocity.walk.back.x":

--- a/src/script.go
+++ b/src/script.go
@@ -3447,7 +3447,7 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "p2bodydistY", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.rdDistY(sys.debugWC.p2(), sys.debugWC).ToI()))
+		l.Push(lua.LNumber(sys.debugWC.p2BodyDistY(sys.debugWC).ToI()))
 		return 1
 	})
 	luaRegister(l, "p2distX", func(*lua.LState) int {


### PR DESCRIPTION
- Added new Height constants that determine the vertical size of the char's "pushbox" in different state types
- Added a new ClassicPushbox constant that enables traditional fighting game push checking (uses pushbox only, ignoring Clsn2)
- Refactored P2BodyDist Y so that if the char has ikemenversion it returns the distance between the characters' push boxes instead of just doing the same as P2Dist Y
- Some small fixes to previous commits
- Some fixes to projectiles
- Fixes #1489
- Fixes #1490