### PR TITLE
feat: ForceCrouch, HitOverride KeepState, ModifyChar

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5812,6 +5812,7 @@ const (
 	hitOverride_stateno
 	hitOverride_time
 	hitOverride_forceair
+	hitOverride_keepstate
 	hitOverride_redirectid
 )
 
@@ -5819,6 +5820,7 @@ func (sc hitOverride) Run(c *Char, _ []int32) bool {
 	crun := c
 	var a, s, st, t int32 = 0, 0, -1, 1
 	f := false
+	ks := false
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case hitOverride_attr:
@@ -5837,6 +5839,10 @@ func (sc hitOverride) Run(c *Char, _ []int32) bool {
 			}
 		case hitOverride_forceair:
 			f = exp[0].evalB(c)
+		case hitOverride_keepstate:
+			if st == -1 { // StateNo disables KeepState
+				ks = exp[0].evalB(c)
+			}
 		case hitOverride_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -5846,12 +5852,11 @@ func (sc hitOverride) Run(c *Char, _ []int32) bool {
 		}
 		return true
 	})
-	if st < 0 {
+	if st < 0 && !ks {
 		t = 0
 	}
 	pn := crun.playerNo
-	crun.ho[s] = HitOverride{attr: a, stateno: st, time: t, forceair: f,
-		playerNo: pn}
+	crun.ho[s] = HitOverride{attr: a, stateno: st, time: t, forceair: f, keepState: ks, playerNo: pn}
 	return false
 }
 

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -8669,6 +8669,65 @@ func (sc height) Run(c *Char, _ []int32) bool {
 	return false
 }
 
+type modifyChar StateControllerBase
+
+const (
+	modifyChar_lifemax byte = iota
+	modifyChar_powermax
+	modifyChar_dizzypointsmax
+	modifyChar_guardpointsmax
+	modifyChar_teamside
+	modifyChar_redirectid
+)
+
+func (sc modifyChar) Run(c *Char, _ []int32) bool {
+	crun := c
+	var lm, pm, dp, gp int32
+	var ts int
+	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
+		switch id {
+		case modifyChar_lifemax:
+			lm = exp[0].evalI(c)
+			if lm < 1 {
+				lm = 1
+			}
+			crun.lifeMax = lm
+		case modifyChar_powermax:
+			pm = exp[0].evalI(c)
+			if pm < 0 {
+				pm = 0
+			}
+			crun.powerMax = pm
+		case modifyChar_dizzypointsmax:
+			dp = exp[0].evalI(c)
+			if dp < 0 {
+				dp = 0
+			}
+			crun.dizzyPointsMax = dp
+		case modifyChar_guardpointsmax:
+			gp = exp[0].evalI(c)
+			if gp < 0 {
+				gp = 0
+			}
+			crun.guardPointsMax = gp
+		case modifyChar_teamside:
+			ts = int(exp[0].evalI(c))
+			if ts >= 0 && ts <= 2 {
+				ts -= 1	// Internally the teamside goes from -1 to 1
+				crun.teamside = ts
+			}
+		case modifyChar_redirectid:
+			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
+				crun = rid
+			} else {
+				return false
+			}
+		}
+		return true
+	})
+	return false
+}
+
 // StateDef data struct
 type StateBytecode struct {
 	stateType StateType

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -4402,6 +4402,7 @@ const (
 	hitDef_p1sprpriority
 	hitDef_p2sprpriority
 	hitDef_forcestand
+	hitDef_forcecrouch
 	hitDef_forcenofall
 	hitDef_fall_damage
 	hitDef_fall_xvelocity
@@ -4561,6 +4562,8 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 		hd.p2sprpriority = exp[0].evalI(c)
 	case hitDef_forcestand:
 		hd.forcestand = Btoi(exp[0].evalB(c))
+	case hitDef_forcecrouch:
+		hd.forcecrouch = Btoi(exp[0].evalB(c))
 	case hitDef_forcenofall:
 		hd.forcenofall = exp[0].evalB(c)
 	case hitDef_fall_damage:

--- a/src/char.go
+++ b/src/char.go
@@ -6392,10 +6392,12 @@ func (c *Char) cueDraw() {
 	if sys.clsnDraw && c.curFrame != nil {
 		x, y := c.pos[0]*c.localscl+c.offsetX()*c.localscl, c.pos[1]*c.localscl+c.offsetY()*c.localscl
 		xs, ys := c.facing*c.clsnScale[0]*(320/sys.chars[c.animPN][0].localcoord), c.clsnScale[1]*(320/sys.chars[c.animPN][0].localcoord)
+		// Draw Clsn1
 		if clsn := c.curFrame.Clsn1(); len(clsn) > 0 && c.atktmp != 0 {
 			sys.drawc1.Add(clsn, x, y, xs, ys)
 		}
 		if clsn := c.curFrame.Clsn2(); len(clsn) > 0 {
+			// Check invincibility to decide box colors
 			hb, mtk := false, false
 			for _, h := range c.hitby {
 				if h.time != 0 {
@@ -6403,24 +6405,28 @@ func (c *Char) cueDraw() {
 					mtk = mtk || h.flag&int32(ST_SCA) == 0 || h.flag&int32(AT_ALL) == 0 || c.gi().unhittable > 0
 				}
 			}
+			// Draw fully invincible Clsn2
 			if mtk {
 				sys.drawc2mtk.Add(clsn, x, y, xs, ys)
+			// Draw partially invincible Clsn2
 			} else if hb {
 				sys.drawc2sp.Add(clsn, x, y, xs, ys)
+			// Draw regular Clsn2
 			} else {
 				sys.drawc2.Add(clsn, x, y, xs, ys)
 			}
 		}
-		// Pushbox
+		// Draw pushbox (width * height)
 		if c.sf(CSF_playerpush) {
 			sys.drawwh.Add([]float32{-c.width[1] * c.localscl, -c.height[0] * c.localscl, c.width[0] * c.localscl, c.height[1] * c.localscl},
 				c.pos[0]*c.localscl, c.pos[1]*c.localscl, c.facing, 1)
 		}
+		// Draw crosshair
+		sys.drawch.Add([]float32{-1, -1, 1, 1}, c.pos[0]*c.localscl, c.pos[1]*c.localscl, c.facing, 1)
 		//debug clsnText
-		x = (x-sys.cam.Pos[0])*sys.cam.Scale + ((320-float32(sys.gameWidth))/2 + 1)
-		y = (y-sys.cam.Pos[1])*sys.cam.Scale + sys.cam.GroundLevel() + c.defTHeight()*c.localscl + 240 - float32(sys.gameHeight)
-		x += -c.width[1]*c.localscl + float32(sys.gameWidth)/2 + c.width[0]*c.localscl/2
-		y += -c.defTHeight()*(320/c.localcoord) + float32(sys.gameHeight-240)
+		x = (x-sys.cam.Pos[0])*sys.cam.Scale + ((320-float32(sys.gameWidth))/2 + 1) + float32(sys.gameWidth)/2
+		y = (y-sys.cam.Pos[1])*sys.cam.Scale + sys.cam.GroundLevel()
+		y += float32(sys.debugFont.fnt.Size[1]) * sys.debugFont.yscl / sys.heightScale
 		sys.clsnText = append(sys.clsnText, ClsnText{x: x, y: y, text: fmt.Sprintf("%s, %d", c.name, c.id), r: 255, g: 255, b: 255})
 		for _, tid := range c.targets {
 			if t := sys.playerID(tid); t != nil {

--- a/src/char.go
+++ b/src/char.go
@@ -7528,7 +7528,7 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 			gbot := (getter.pos[1] + getter.height[1]) * getter.localscl
 			if getter.teamside != c.teamside && getter.sf(CSF_playerpush) &&
 				!c.scf(SCF_standby) && !getter.scf(SCF_standby) &&
-				c.sf(CSF_playerpush) && (cbot > gtop && ctop < gbot) && // Pushbox vertical overlap
+				c.sf(CSF_playerpush) && (cbot >= gtop && ctop <= gbot) && // Pushbox vertical overlap
 				// Z axis check
 				!(c.size.z.enable && getter.size.z.enable &&
 					((c.pos[2]-c.size.z.width)*c.localscl > (getter.pos[2]+getter.size.z.width)*getter.localscl ||

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -167,6 +167,7 @@ func newCompiler() *Compiler {
 		"modifystagevar":       c.modifyStageVar,
 		"camera":               c.cameraCtrl,
 		"height":               c.height,
+		"modifychar":           c.modifyChar,
 	}
 	return c
 }

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1400,6 +1400,10 @@ func (c *Compiler) hitDefSub(is IniSection,
 		hitDef_forcestand, VT_Bool, 1, false); err != nil {
 		return err
 	}
+	if err := c.paramValue(is, sc, "forcecrouch",
+		hitDef_forcecrouch, VT_Bool, 1, false); err != nil {
+		return err
+	}
 	if err := c.paramValue(is, sc, "forcenofall",
 		hitDef_forcenofall, VT_Bool, 1, false); err != nil {
 		return err

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -4711,6 +4711,37 @@ func (c *Compiler) height(is IniSection, sc *StateControllerBase, _ int8) (State
 	return *ret, err
 }
 
+func (c *Compiler) modifyChar(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+	ret, err := (*modifyChar)(sc), c.stateSec(is, func() error {
+		if err := c.paramValue(is, sc, "redirectid",
+			modifyChar_redirectid, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "lifemax",
+			modifyChar_lifemax, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "powermax",
+			modifyChar_powermax, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "dizzypointsmax",
+			modifyChar_dizzypointsmax, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "guardpointsmax",
+			modifyChar_guardpointsmax, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "teamside",
+			modifyChar_teamside, VT_Int, 1, false); err != nil {
+			return err
+		}
+		return nil
+	})
+	return *ret, err
+}
+
 // It's just a Null... Has no effect whatsoever.
 func (c *Compiler) null(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	return nullStateController, nil

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -2584,6 +2584,10 @@ func (c *Compiler) hitOverride(is IniSection, sc *StateControllerBase, _ int8) (
 			hitOverride_forceair, VT_Bool, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "keepstate",
+			hitOverride_keepstate, VT_Bool, 1, false); err != nil {
+			return err
+		}
 		return nil
 	})
 	return *ret, err

--- a/src/system.go
+++ b/src/system.go
@@ -248,6 +248,7 @@ type System struct {
 	drawc2sp                ClsnRect
 	drawc2mtk               ClsnRect
 	drawwh                  ClsnRect
+	drawch                  ClsnRect
 	autoguard               [MaxSimul*2 + MaxAttachedChar]bool
 	accel                   float32
 	clsnSpr                 Sprite
@@ -1007,6 +1008,7 @@ func (s *System) action() {
 	s.drawc2sp = s.drawc2sp[:0]
 	s.drawc2mtk = s.drawc2mtk[:0]
 	s.drawwh = s.drawwh[:0]
+	s.drawch = s.drawch[:0]
 	s.clsnText = nil
 	var x, y, scl float32 = s.cam.Pos[0], s.cam.Pos[1], s.cam.Scale / s.cam.BaseScale()
 	var cvmin, cvmax, highest, lowest, leftest, rightest float32 = 0, 0, 0, 0, 0, 0
@@ -1589,8 +1591,10 @@ func (s *System) drawTop() {
 		s.drawc2sp.draw(0x3feff)
 		s.clsnSpr.Pal[0] = 0xff002000
 		s.drawc2mtk.draw(0x3feff)
-		s.clsnSpr.Pal[0] = 0xff404040
+		s.clsnSpr.Pal[0] = 0xff303030
 		s.drawwh.draw(0x3feff)
+		s.clsnSpr.Pal[0] = 0xffffffff
+		s.drawch.draw(0x3feff)
 	}
 }
 func (s *System) drawDebug() {


### PR DESCRIPTION
feat: ModifyChar state controller
- Changes some parameters that are normally out of reach. Currently supported: lifemax, powermax, dizzypointsmax, guardpointsmax, teamside
- This state controller should be used carefully. It is mostly meant to assist in codes such as fireball reflection (changing teamside)

feat: HitOverride KeepState parameter
- Enabling this parameter makes the character override hits without changing states
- Should make super armor easier to implement

feat: ForceCrouch Hitdef parameter:
- Forces a standing opponent to crouch upon hit
- Similar to forcestand

refactor: draw center point of chars during debug
- Enabling Clsn view will now display each char's 0, 0 point as well

fix: Player pushing at exactly same position
- Fixes an old and very specific scenario in which a character with height 0 could not push the opponent when standing in the same Y position as them