### PR TITLE
feat: JugglePoints trigger

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -493,6 +493,7 @@ const (
 	OC_ex_isassertedchar
 	OC_ex_isassertedglobal
 	OC_ex_ishost
+	OC_ex_jugglepoints
 	OC_ex_localscale
 	OC_ex_maparray
 	OC_ex_max
@@ -2091,6 +2092,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		*i += 4
 	case OC_ex_ishost:
 		sys.bcStack.PushB(c.isHost())
+	case OC_ex_jugglepoints:
+		*sys.bcStack.Top() = c.jugglePoints(*sys.bcStack.Top())
 	case OC_ex_localscale:
 		sys.bcStack.PushF(c.localscl)
 	case OC_ex_majorversion:

--- a/src/char.go
+++ b/src/char.go
@@ -3052,6 +3052,23 @@ func (c *Char) isHelper(hid BytecodeValue) BytecodeValue {
 func (c *Char) isHost() bool {
 	return sys.netInput != nil && sys.netInput.host
 }
+func (c *Char) jugglePoints(hid BytecodeValue) BytecodeValue {
+	if hid.IsSF() {
+		return BytecodeSF()
+	}
+	tid := hid.ToI()
+	max := c.gi().data.airjuggle
+	jp := max // If no target is found it returns the char's maximum juggle points
+	for _, ct := range c.targets {
+		if ct >= 0 {
+			t := sys.playerID(ct)
+			if t != nil && t.id == tid {
+				jp = t.ghv.getJuggle(c.id, max)
+			}
+		}
+	}
+	return BytecodeInt(jp)
+}
 func (c *Char) leftEdge() float32 {
 	return sys.cam.ScreenPos[0] / c.localscl
 }
@@ -4133,8 +4150,8 @@ func (c *Char) setHitdefDefault(hd *HitDef, proj bool) {
 	if hd.air_type == HT_Unknown {
 		hd.air_type = hd.ground_type
 	}
-	ifierrset(&hd.forcestand, Btoi(hd.ground_velocity[1] != 0))
-	ifierrset(&hd.forcecrouch, Btoi(hd.ground_velocity[1] != 0))
+	ifierrset(&hd.forcestand, Btoi(hd.ground_velocity[1] != 0)) // Having a Y velocity causes ForceStand
+	ifierrset(&hd.forcecrouch, 0)
 	if hd.attr&int32(ST_A) != 0 {
 		ifnanset(&hd.ground_cornerpush_veloff, 0)
 	} else {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2902,6 +2902,11 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		}
 	case "ishost":
 		out.append(OC_ex_, OC_ex_ishost)
+	case "jugglepoints":
+		if _, err := c.oneArg(out, in, rd, true); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_ex_, OC_ex_jugglepoints)
 	case "lastplayerid":
 		out.append(OC_ex_, OC_ex_lastplayerid)
 	case "localscale":

--- a/src/script.go
+++ b/src/script.go
@@ -4112,6 +4112,14 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LBool(sys.debugWC.isHost()))
 		return 1
 	})
+	luaRegister(l, "jugglepoints", func(*lua.LState) int {
+		id := int32(-1)
+		if l.GetTop() >= 1 {
+			id = int32(numArg(l, 1))
+		}
+		l.Push(lua.LNumber(sys.debugWC.jugglePoints(BytecodeInt(id)).ToI()))
+		return 1
+	})
 	luaRegister(l, "lastplayerid", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.nextCharId - 1))
 		return 1


### PR DESCRIPTION
- Returns the remaining juggle points between the character and the specified player ID
- Usage: JugglePoints(Player_ID)
- Example: if JugglePoints(EnemyNear, ID) < 10