### PR TITLE
feat: AnimFrame triggers

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -468,6 +468,18 @@ const (
 	OC_ex_gethitvar_priority
 	OC_ex_ailevelf
 	OC_ex_animelemlength
+	OC_ex_animframe_alphadest
+	OC_ex_animframe_angle
+	OC_ex_animframe_alphasource
+	OC_ex_animframe_group
+	OC_ex_animframe_hflip
+	OC_ex_animframe_image
+	OC_ex_animframe_time
+	OC_ex_animframe_vflip
+	OC_ex_animframe_xoffset
+	OC_ex_animframe_xscale
+	OC_ex_animframe_yoffset
+	OC_ex_animframe_yscale
 	OC_ex_animlength
 	OC_ex_attack
 	OC_ex_combocount
@@ -2031,6 +2043,84 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 			sys.bcStack.PushI(f.Time)
 		} else {
 			sys.bcStack.PushI(0)
+		}
+	case OC_ex_animframe_alphadest:
+		if f := c.anim.CurrentFrame(); f != nil {
+			sys.bcStack.PushI(int32(f.DstAlpha))
+		} else {
+			sys.bcStack.PushI(0)
+		}
+	case OC_ex_animframe_angle:
+		if f := c.anim.CurrentFrame(); f != nil {
+			if len(f.Ex) > 2 && len(f.Ex[2]) > 2 { // Anim.go code could be refactored so these are easier to read
+				sys.bcStack.PushF(f.Ex[2][2])
+			} else {
+				sys.bcStack.PushF(0)
+			}
+		}
+	case OC_ex_animframe_alphasource:
+		if f := c.anim.CurrentFrame(); f != nil {
+			sys.bcStack.PushI(int32(f.SrcAlpha))
+		} else {
+			sys.bcStack.PushI(0)
+		}
+	case OC_ex_animframe_group:
+		if f := c.anim.CurrentFrame(); f != nil {
+			sys.bcStack.PushI(int32(f.Group))
+		} else {
+			sys.bcStack.PushI(-1)
+		}
+	case OC_ex_animframe_hflip:
+		if f := c.anim.CurrentFrame(); f != nil {
+			sys.bcStack.PushB(f.H < 0)
+		} else {
+			sys.bcStack.PushI(0)
+		}
+	case OC_ex_animframe_image:
+		if f := c.anim.CurrentFrame(); f != nil {
+			sys.bcStack.PushI(int32(f.Number))
+		} else {
+			sys.bcStack.PushI(-1)
+		}
+	case OC_ex_animframe_time: // Same as AnimElemLength
+		if f := c.anim.CurrentFrame(); f != nil {
+			sys.bcStack.PushI(f.Time)
+		} else {
+			sys.bcStack.PushI(-1)
+		}
+	case OC_ex_animframe_vflip:
+		if f := c.anim.CurrentFrame(); f != nil {
+			sys.bcStack.PushB(f.V < 0)
+		} else {
+			sys.bcStack.PushI(0)
+		}
+	case OC_ex_animframe_xoffset:
+		if f := c.anim.CurrentFrame(); f != nil {
+			sys.bcStack.PushI(int32(-f.X))
+		} else {
+			sys.bcStack.PushI(0)
+		}
+	case OC_ex_animframe_xscale:
+		if f := c.anim.CurrentFrame(); f != nil {
+			if len(f.Ex) > 2 {
+				sys.bcStack.PushF(f.Ex[2][0])
+			} else {
+				sys.bcStack.PushF(0)
+			}
+		}
+	case OC_ex_animframe_yoffset:
+		if f := c.anim.CurrentFrame(); f != nil {
+			sys.bcStack.PushI(int32(-f.Y))
+		} else {
+			sys.bcStack.PushI(0)
+		}
+	case OC_ex_animframe_yscale:
+		if f := c.anim.CurrentFrame(); f != nil {
+			if len(f.Ex) > 2 && len(f.Ex[2]) > 1 {
+				sys.bcStack.PushF(f.Ex[2][1])
+			} else {
+				sys.bcStack.PushF(0)
+			}
 		}
 	case OC_ex_animlength:
 		sys.bcStack.PushI(c.anim.totaltime)

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2721,6 +2721,43 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_ex_, OC_ex_airjumpcount)
 	case "animelemlength":
 		out.append(OC_ex_, OC_ex_animelemlength)
+	case "animframe":
+		if err := c.checkOpeningBracket(in); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_ex_)
+		switch c.token {
+		case "alphadest":
+			out.append(OC_ex_animframe_alphadest)
+		case "angle":
+			out.append(OC_ex_animframe_angle)
+		case "alphasource":
+			out.append(OC_ex_animframe_alphasource)
+		case "group":
+			out.append(OC_ex_animframe_group)
+		case "hflip":
+			out.append(OC_ex_animframe_hflip)
+		case "image":
+			out.append(OC_ex_animframe_image)
+		case "time":
+			out.append(OC_ex_animframe_time)
+		case "vflip":
+			out.append(OC_ex_animframe_vflip)
+		case "xoffset":
+			out.append(OC_ex_animframe_xoffset)
+		case "xscale":
+			out.append(OC_ex_animframe_xscale)
+		case "yoffset":
+			out.append(OC_ex_animframe_yoffset)
+		case "yscale":
+			out.append(OC_ex_animframe_yscale)
+		default:
+			return bvNone(), Error("Invalid data: " + c.token)
+		}
+		c.token = c.tokenizer(in)
+		if err := c.checkClosingBracket(); err != nil {
+			return bvNone(), err
+		}
 	case "animlength":
 		out.append(OC_ex_, OC_ex_animlength)
 	case "attack":

--- a/src/script.go
+++ b/src/script.go
@@ -3924,6 +3924,108 @@ func triggerFunctions(l *lua.LState) {
 		}
 		return 1
 	})
+	luaRegister(l, "animframealphadest", func(*lua.LState) int {
+		if f := sys.debugWC.anim.CurrentFrame(); f != nil {
+			l.Push(lua.LNumber(f.DstAlpha))
+		} else {
+			l.Push(lua.LNumber(0))
+		}
+		return 1
+	})
+	luaRegister(l, "animframeangle", func(*lua.LState) int {
+		if f := sys.debugWC.anim.CurrentFrame(); f != nil {
+			if len(f.Ex) > 2 && len(f.Ex[2]) > 2 {
+				l.Push(lua.LNumber(f.Ex[2][2]))
+			} else {
+				l.Push(lua.LNumber(0))
+			}
+		}
+		return 1
+	})
+	luaRegister(l, "animframealphasource", func(*lua.LState) int {
+		if f := sys.debugWC.anim.CurrentFrame(); f != nil {
+			l.Push(lua.LNumber(f.SrcAlpha))
+		} else {
+			l.Push(lua.LNumber(0))
+		}
+		return 1
+	})
+	luaRegister(l, "animframegroup", func(*lua.LState) int {
+		if f := sys.debugWC.anim.CurrentFrame(); f != nil {
+			l.Push(lua.LNumber(f.Group))
+		} else {
+			l.Push(lua.LNumber(-1))
+		}
+		return 1
+	})
+	luaRegister(l, "animframehflip", func(*lua.LState) int {
+		if f := sys.debugWC.anim.CurrentFrame(); f != nil {
+			l.Push(lua.LBool(f.H < 0))
+		} else {
+			l.Push(lua.LBool(false))
+		}
+		return 1
+	})
+	luaRegister(l, "animframeimage", func(*lua.LState) int {
+		if f := sys.debugWC.anim.CurrentFrame(); f != nil {
+			l.Push(lua.LNumber(f.Number))
+		} else {
+			l.Push(lua.LNumber(-1))
+		}
+		return 1
+	})
+	luaRegister(l, "animframetime", func(*lua.LState) int { // Same as AnimElemLength
+		if f := sys.debugWC.anim.CurrentFrame(); f != nil {
+			l.Push(lua.LNumber(f.Time))
+		} else {
+			l.Push(lua.LNumber(-1))
+		}
+		return 1
+	})
+	luaRegister(l, "animframevflip", func(*lua.LState) int {
+		if f := sys.debugWC.anim.CurrentFrame(); f != nil {
+			l.Push(lua.LBool(f.V < 0))
+		} else {
+			l.Push(lua.LBool(false))
+		}
+		return 1
+	})
+	luaRegister(l, "animframexoffset", func(*lua.LState) int {
+		if f := sys.debugWC.anim.CurrentFrame(); f != nil {
+			l.Push(lua.LNumber(-f.X))
+		} else {
+			l.Push(lua.LNumber(0))
+		}
+		return 1
+	})
+	luaRegister(l, "animframexscale", func(*lua.LState) int {
+		if f := sys.debugWC.anim.CurrentFrame(); f != nil {
+			if len(f.Ex) > 2 {
+				l.Push(lua.LNumber(f.Ex[2][0]))
+			} else {
+				l.Push(lua.LNumber(0))
+			}
+		}
+		return 1
+	})
+	luaRegister(l, "animframeyoffset", func(*lua.LState) int {
+		if f := sys.debugWC.anim.CurrentFrame(); f != nil {
+			l.Push(lua.LNumber(-f.Y))
+		} else {
+			l.Push(lua.LNumber(0))
+		}
+		return 1
+	})
+	luaRegister(l, "animframeyscale", func(*lua.LState) int {
+		if f := sys.debugWC.anim.CurrentFrame(); f != nil {
+			if len(f.Ex) > 2 && len(f.Ex[2]) > 1 {
+				l.Push(lua.LNumber(f.Ex[2][0]))
+			} else {
+				l.Push(lua.LNumber(0))
+			}
+		}
+		return 1
+	})
 	luaRegister(l, "animlength", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.anim.totaltime))
 		return 1


### PR DESCRIPTION
- Returns information about the current animation frame that was previous unavailable, most notably the sprite number.
- Usage: AnimFrame(parameter)
- Parameters: AlphaDest, AlphaSource, Angle, Group, HFlip, Image, Time, VFlip, XOffset, XScale, YOffset, YScale (see AIR file documentation)
- AnimFrame(Time) is equivalent to AnimElemLength