### PR TITLE
refactor: version checks, minor changes

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -769,7 +769,7 @@ func (BytecodeExp) pow(v1 *BytecodeValue, v2 BytecodeValue, pn int) {
 		var i, bit, tmp int32 = 1, 0, i1
 		for ; bit <= hb; bit++ {
 			var shift uint
-			if bit == hb || sys.cgi[pn].ver[0] == 1 {
+			if bit == hb || sys.cgi[pn].mugenver[0] == 1 {
 				shift = uint(bit)
 			} else {
 				shift = uint((hb - 1) - bit)
@@ -1305,7 +1305,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushI(int32(c.frontEdgeDist() * (c.localscl / oc.localscl)))
 		case OC_gameheight:
 			// Optional exception preventing GameHeight from being affected by stage zoom.
-			if c.stCgi().ver[0] == 1 && c.stCgi().ver[1] == 0 &&
+			if c.stCgi().mugenver[0] == 1 && c.stCgi().mugenver[1] == 0 &&
 				c.gi().constants["default.legacygamedistancespec"] == 1 {
 				sys.bcStack.PushF(c.screenHeight())
 			} else {
@@ -1323,7 +1323,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushI(sys.gameTime + pfTime)
 		case OC_gamewidth:
 			// Optional exception preventing GameWidth from being affected by stage zoom.
-			if c.stCgi().ver[0] == 1 && c.stCgi().ver[1] == 0 &&
+			if c.stCgi().mugenver[0] == 1 && c.stCgi().mugenver[1] == 0 &&
 				c.gi().constants["default.legacygamedistancespec"] == 1 {
 				sys.bcStack.PushF(c.screenWidth())
 			} else {
@@ -2187,7 +2187,7 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_localscale:
 		sys.bcStack.PushF(c.localscl)
 	case OC_ex_majorversion:
-		sys.bcStack.PushB(c.gi().ver[0] == 1)
+		sys.bcStack.PushB(c.gi().mugenver[0] == 1)
 	case OC_ex_maparray:
 		sys.bcStack.PushF(c.mapArray[sys.stringPool[sys.workingState.playerNo].List[*(*int32)(unsafe.Pointer(&be[*i]))]])
 		*i += 4
@@ -3699,7 +3699,7 @@ func (sc palFX) Run(c *Char, _ []int32) bool {
 			}
 		}
 		//Mugen 1.1 behavior if invertblend param is omitted(Only if char mugenversion = 1.1)
-		if crun.stCgi().ver[0] == 1 && crun.stCgi().ver[1] == 1 && crun.stCgi().ikemenver[0] <= 0 && crun.stCgi().ikemenver[1] <= 0 {
+		if crun.stCgi().mugenver[0] == 1 && crun.stCgi().mugenver[1] == 1 && crun.stCgi().ikemenver[0] <= 0 && crun.stCgi().ikemenver[1] <= 0 {
 			pf.invertblend = -2
 		}
 		sc.runSub(c, &pf.PalFXDef, id, exp)
@@ -3807,7 +3807,7 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 				e.id = 0
 			}
 			// Mugenversion 1.1 chars default postype to "None"
-			if crun.stCgi().ver[0] == 1 && crun.stCgi().ver[1] == 1 {
+			if crun.stCgi().mugenver[0] == 1 && crun.stCgi().mugenver[1] == 1 {
 				e.postype = PT_None
 			}
 		}
@@ -3952,7 +3952,7 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 		case explod_window:
 			e.window = [4]float32{exp[0].evalF(c) * lclscround, exp[1].evalF(c) * lclscround, exp[2].evalF(c) * lclscround, exp[3].evalF(c) * lclscround}
 		default:
-			if crun.stCgi().ver[0] == 1 && crun.stCgi().ver[1] == 1 && crun.stCgi().ikemenver[0] <= 0 && crun.stCgi().ikemenver[1] <= 0 {
+			if crun.stCgi().mugenver[0] == 1 && crun.stCgi().mugenver[1] == 1 && crun.stCgi().ikemenver[0] <= 0 && crun.stCgi().ikemenver[1] <= 0 {
 				e.palfxdef.invertblend = -2
 			}
 			palFX(sc).runSub(c, &e.palfxdef, id, exp)
@@ -4430,7 +4430,7 @@ func (sc afterImage) Run(c *Char, _ []int32) bool {
 		if !doOce {
 			crun.aimg.clear()
 			//Mugen 1.1 behavior if invertblend param is omitted(Only if char mugenversion = 1.1)
-			if crun.stCgi().ver[0] == 1 && crun.stCgi().ver[1] == 1 && crun.stCgi().ikemenver[0] <= 0 && crun.stCgi().ikemenver[1] <= 0 {
+			if crun.stCgi().mugenver[0] == 1 && crun.stCgi().mugenver[1] == 1 && crun.stCgi().ikemenver[0] <= 0 && crun.stCgi().ikemenver[1] <= 0 {
 				crun.aimg.palfx[0].invertblend = -2
 			}
 			crun.aimg.time = 1
@@ -4874,7 +4874,7 @@ func (sc hitDef) Run(c *Char, _ []int32) bool {
 			}
 		}
 		//Mugen 1.1 behavior if invertblend param is omitted(Only if char mugenversion = 1.1)
-		if crun.stCgi().ver[0] == 1 && crun.stCgi().ver[1] == 1 && crun.stCgi().ikemenver[0] <= 0 && crun.stCgi().ikemenver[1] <= 0 {
+		if crun.stCgi().mugenver[0] == 1 && crun.stCgi().mugenver[1] == 1 && crun.stCgi().ikemenver[0] <= 0 && crun.stCgi().ikemenver[1] <= 0 {
 			crun.hitdef.palfx.invertblend = -2
 		}
 		sc.runSub(c, &crun.hitdef, id, exp)
@@ -4884,7 +4884,7 @@ func (sc hitDef) Run(c *Char, _ []int32) bool {
 	//"In Winmugen, when the attr of Hitdef is set to 'Throw' and the pausetime
 	// on the attacker's side is greater than 1, it no longer executes every frame."
 	if crun.hitdef.attr&int32(AT_AT) != 0 && crun.moveContact() == 1 &&
-		c.gi().ver[0] != 1 && crun.hitdef.pausetime > 0 {
+		c.gi().mugenver[0] != 1 && crun.hitdef.pausetime > 0 {
 		crun.hitdef.attr = 0
 		return false
 	}
@@ -5194,10 +5194,11 @@ const (
 
 func (sc sprPriority) Run(c *Char, _ []int32) bool {
 	crun := c
+	v := int32(0) // Mugen uses 0 if no value is set at all
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case sprPriority_value:
-			crun.setSprPriority(exp[0].evalI(c))
+			v = exp[0].evalI(c)
 		case sprPriority_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -5207,6 +5208,7 @@ func (sc sprPriority) Run(c *Char, _ []int32) bool {
 		}
 		return true
 	})
+	crun.setSprPriority(v)
 	return false
 }
 
@@ -6244,10 +6246,11 @@ const (
 
 func (sc angleSet) Run(c *Char, _ []int32) bool {
 	crun := c
+	v := float32(0) // Mugen uses 0 if no value is set at all
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case angleSet_value:
-			crun.angleSet(exp[0].evalF(c))
+			v = exp[0].evalF(c)
 		case angleSet_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -6257,6 +6260,7 @@ func (sc angleSet) Run(c *Char, _ []int32) bool {
 		}
 		return true
 	})
+	crun.angleSet(v)
 	return false
 }
 
@@ -6294,10 +6298,11 @@ const (
 
 func (sc angleMul) Run(c *Char, _ []int32) bool {
 	crun := c
+	v := float32(0) // Mugen uses 0 if no value is set at all
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case angleMul_value:
-			crun.angleSet(crun.angle * exp[0].evalF(c))
+			v = exp[0].evalF(c)
 		case angleMul_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -6307,6 +6312,7 @@ func (sc angleMul) Run(c *Char, _ []int32) bool {
 		}
 		return true
 	})
+	crun.angleSet(crun.angle * v)
 	return false
 }
 
@@ -8688,7 +8694,7 @@ func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 		case modifyStageVar_playerinfo_rightbound:
 			s.rightbound = exp[0].evalF(c)
 		case modifyStageVar_scaling_topscale:
-			if s.ver[0] == 0 { //mugen 1.0+ removed support for topscale
+			if s.mugenver[0] != 1 { //mugen 1.0+ removed support for topscale
 				s.stageCamera.ztopscale = exp[0].evalF(c)
 			}
 		case modifyStageVar_bound_screenleft:
@@ -8707,7 +8713,7 @@ func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 			s.sdw.intensity = Clamp(exp[0].evalI(c), 0, 255)
 		case modifyStageVar_shadow_color:
 			// mugen 1.1 removed support for color
-			if (s.ver[0] != 1 || s.ver[1] != 1) && (s.sff.header.Ver0 != 2 || s.sff.header.Ver2 != 1) {
+			if (s.mugenver[0] != 1 || s.mugenver[1] != 1) && (s.sff.header.Ver0 != 2 || s.sff.header.Ver2 != 1) {
 				r := Clamp(exp[0].evalI(c), 0, 255)
 				g := Clamp(exp[1].evalI(c), 0, 255)
 				b := Clamp(exp[2].evalI(c), 0, 255)

--- a/src/char.go
+++ b/src/char.go
@@ -1156,7 +1156,7 @@ func (e *Explod) setPos(c *Char) {
 		} else {
 			// explod の postype = front はキャラの向きで pos が反転しない
 			// "The postype "front" of "explod" does not invert the pos based on the character's orientation"
-			//if e.postype == PT_Front && c.gi().ver[0] != 1 {
+			//if e.postype == PT_Front && c.gi().mugenver[0] != 1 {
 			// 旧バージョンだと front は キャラの向きが facing に反映されない
 			// 1.1でも反映されてない模様
 			// "In the previous version, "front" does not reflect the character's orientation in facing."
@@ -1619,7 +1619,7 @@ func (p *Projectile) cueDraw(oldVer bool, playerNo int) {
 		sd := &SprData{p.ani, p.palfx, [...]float32{p.pos[0] * p.localscl, p.pos[1] * p.localscl},
 			[...]float32{p.facing * p.scale[0] * p.localscl, p.scale[1] * p.localscl}, [2]int32{-1},
 			p.sprpriority, Rotation{p.facing * p.angle, 0, 0}, [...]float32{1, 1}, false, playerNo == sys.superplayer,
-			sys.cgi[playerNo].ver[0] != 1, p.facing, 1, 0, 0, [4]float32{0, 0, 0, 0}}
+			sys.cgi[playerNo].mugenver[0] != 1, p.facing, 1, 0, 0, [4]float32{0, 0, 0, 0}}
 		p.aimg.recAndCue(sd, sys.tickNextFrame() && notpause, false)
 		sys.sprites.add(sd,
 			p.shadow[0]<<16|p.shadow[1]&255<<8|p.shadow[2]&255, 256, 0, 0)
@@ -1658,7 +1658,7 @@ type CharGlobalInfo struct {
 	pal              [MaxPalNo]string
 	palExist         [MaxPalNo]bool
 	palSelectable    [MaxPalNo]bool
-	ver              [2]uint16
+	mugenver         [2]uint16
 	data             CharData
 	velocity         CharVelocity
 	movement         CharMovement
@@ -2908,7 +2908,7 @@ func (c *Char) p2() *Char {
 	return p2
 }
 func (c *Char) aiLevel() float32 {
-	if c.helperIndex != 0 && c.gi().ver[0] == 1 {
+	if c.helperIndex != 0 && c.gi().mugenver[0] == 1 {
 		return 0
 	}
 	return sys.com[c.playerNo]
@@ -3216,7 +3216,7 @@ func (c *Char) numTarget(hid BytecodeValue) BytecodeValue {
 	return BytecodeInt(n)
 }
 func (c *Char) palno() int32 {
-	if c.helperIndex != 0 && c.gi().ver[0] != 1 {
+	if c.helperIndex != 0 && c.gi().mugenver[0] != 1 {
 		return 1
 	}
 	return c.gi().palno
@@ -3447,7 +3447,7 @@ func (c *Char) playSound(ffx string, lowpriority, loop bool, g, n, chNo, vol int
 	if ch := crun.soundChannels.New(chNo, lowpriority, priority); ch != nil {
 		ch.Play(s, loop, freqmul)
 		vol = Clamp(vol, -25600, 25600)
-		//if c.gi().ver[0] == 1 {
+		//if c.gi().mugenver[0] == 1 {
 		if ffx != "" {
 			ch.SetVolume(float32(vol * 64 / 25))
 		} else {
@@ -3759,7 +3759,7 @@ func (c *Char) helperInit(h *Char, st int32, pt PosType, x, y float32,
 		}
 	}
 	//Mugen 1.1 behavior if invertblend param is omitted(Only if char mugenversion = 1.1)
-	if h.stCgi().ver[0] == 1 && c.stCgi().ver[1] == 1 && h.stCgi().ikemenver[0] <= 0 && h.stCgi().ikemenver[1] <= 0 {
+	if h.stCgi().mugenver[0] == 1 && h.stCgi().mugenver[1] == 1 && h.stCgi().ikemenver[0] <= 0 && h.stCgi().ikemenver[1] <= 0 {
 		h.palfx.invertblend = -2
 	}
 	h.changeStateEx(st, c.playerNo, 0, 1, "")
@@ -3770,7 +3770,7 @@ func (c *Char) newExplod() (*Explod, int) {
 	explinit := func(expl *Explod) *Explod {
 		expl.clear()
 		expl.id, expl.playerId, expl.palfx, expl.palfxdef = -1, c.id, c.getPalfx(), PalFXDef{color: 1, hue: 0, mul: [...]int32{256, 256, 256}}
-		if c.stCgi().ver[0] == 1 && c.stCgi().ver[1] == 1 && c.stCgi().ikemenver[0] == 0 && c.stCgi().ikemenver[1] == 0 {
+		if c.stCgi().mugenver[0] == 1 && c.stCgi().mugenver[1] == 1 && c.stCgi().ikemenver[0] == 0 && c.stCgi().ikemenver[1] == 0 {
 			expl.projection = Projection_Perspective
 		} else {
 			expl.projection = Projection_Orthographic
@@ -4816,7 +4816,7 @@ func (c *Char) rdDistX(rd *Char, oc *Char) BytecodeValue {
 	}
 	dist := c.facing * c.distX(rd, oc)
 	if c.stCgi().ikemenver[0] == 0 && c.stCgi().ikemenver[1] == 0 {
-		if c.stCgi().ver[0] != 1 {
+		if c.stCgi().mugenver[0] != 1 {
 			// 旧バージョンでは小数点切り捨て
 			// "Before Mugen 1.0, rounding down to the nearest whole number was performed."
 			dist = float32(int32(dist))
@@ -4830,7 +4830,7 @@ func (c *Char) rdDistY(rd *Char, oc *Char) BytecodeValue {
 	}
 	dist := c.distY(rd, oc)
 	if c.stCgi().ikemenver[0] == 0 && c.stCgi().ikemenver[1] == 0 {
-		if c.stCgi().ver[0] != 1 {
+		if c.stCgi().mugenver[0] != 1 {
 			// "Before Mugen 1.0, rounding down to the nearest whole number was performed."
 			dist = float32(int32(dist))
 		}
@@ -4842,7 +4842,7 @@ func (c *Char) p2BodyDistX(oc *Char) BytecodeValue {
 		return BytecodeSF()
 	} else {
 		dist := c.facing * c.bodyDistX(p2, oc)
-		if c.stCgi().ver[0] != 1 {
+		if c.stCgi().mugenver[0] != 1 {
 			dist = float32(int32(dist)) //旧バージョンでは小数点切り捨て / "In the old version, decimal truncation was used."
 		}
 		return BytecodeFloat(dist)
@@ -4866,7 +4866,7 @@ func (c *Char) hitVelSetY() {
 	c.setYV(c.ghv.yvel)
 }
 func (c *Char) getEdge(base float32, actually bool) float32 {
-	if !actually || c.stCgi().ver[0] != 1 {
+	if !actually || c.stCgi().mugenver[0] != 1 {
 		switch c.ss.stateType {
 		case ST_A:
 			return base + 1
@@ -4960,7 +4960,7 @@ func (c *Char) getPalfx() *PalFX {
 	}
 	c.palfx = newPalFX()
 	//Mugen 1.1 behavior if invertblend param is omitted(Only if char mugenversion = 1.1)
-	if c.stCgi().ver[0] == 1 && c.stCgi().ver[1] == 1 && c.stCgi().ikemenver[0] <= 0 && c.stCgi().ikemenver[1] <= 0 && c.palfx != nil {
+	if c.stCgi().mugenver[0] == 1 && c.stCgi().mugenver[1] == 1 && c.stCgi().ikemenver[0] <= 0 && c.stCgi().ikemenver[1] <= 0 && c.palfx != nil {
 		c.palfx.PalFXDef.invertblend = -2
 	}
 	return c.palfx
@@ -5882,7 +5882,7 @@ func (c *Char) actionPrepare() {
 			}
 		}
 		c.unsetASF(ASF_noautoturn)
-		if c.gi().ver[0] == 1 {
+		if c.gi().mugenver[0] == 1 {
 			// The following flags are only reset later in the code
 			flagtemp := (c.assertFlag&ASF_nostandguard | c.assertFlag&ASF_nocrouchguard | c.assertFlag&ASF_noairguard)
 			c.unsetCSF(CSF_angledraw | CSF_offset)
@@ -6517,7 +6517,7 @@ func (c *Char) cueDraw() {
 		sdf := func() *SprData {
 			sd := &SprData{c.anim, c.getPalfx(), pos,
 				scl, c.alpha, c.sprPriority, Rotation{agl, 0, 0}, c.angleScale, false,
-				c.playerNo == sys.superplayer, c.gi().ver[0] != 1, c.facing, c.localscl / (320 / c.localcoord), 0, 0, [4]float32{0, 0, 0, 0}}
+				c.playerNo == sys.superplayer, c.gi().mugenver[0] != 1, c.facing, c.localscl / (320 / c.localcoord), 0, 0, [4]float32{0, 0, 0, 0}}
 			if !c.csf(CSF_trans) {
 				sd.alpha[0] = -1
 			}
@@ -6527,7 +6527,7 @@ func (c *Char) cueDraw() {
 		//	c.aimg.recAfterImg(sdf(), c.hitPause())
 		//}
 
-		//if c.gi().ver[0] != 1 && c.csf(CSF_angledraw) && !c.csf(CSF_trans) {
+		//if c.gi().mugenver[0] != 1 && c.csf(CSF_angledraw) && !c.csf(CSF_trans) {
 		//	c.setCSF(CSF_trans)
 		//	c.alpha = [...]int32{255, 0}
 		//}
@@ -7269,7 +7269,7 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 		var xmi, xma float32
 		xmi += sys.xmin + 2
 		xma += sys.xmax - 2
-		if c.stCgi().ver[0] != 1 {
+		if c.stCgi().mugenver[0] != 1 {
 			xmi += 2
 			xma -= 2
 		}
@@ -7550,13 +7550,13 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 									}
 									if !getter.csf(CSF_gethit) {
 										getter.hitPauseTime = Max(1, c.hitdef.shaketime+
-											Btoi(c.gi().ver[0] == 1))
+											Btoi(c.gi().mugenver[0] == 1))
 									}
 								}
 								if !c.csf(CSF_gethit) && (getter.ss.stateType == ST_A && c.hitdef.air_type != HT_None ||
 									getter.ss.stateType != ST_A && c.hitdef.ground_type != HT_None) {
 									c.hitPauseTime = Max(1, c.hitdef.pausetime+
-										Btoi(c.gi().ver[0] == 1))
+										Btoi(c.gi().mugenver[0] == 1))
 								}
 								c.uniqHitCount++
 							} else {
@@ -7565,7 +7565,7 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 								}
 								if !c.csf(CSF_gethit) {
 									c.hitPauseTime = Max(1, c.hitdef.guard_pausetime+
-										Btoi(c.gi().ver[0] == 1))
+										Btoi(c.gi().mugenver[0] == 1))
 								}
 							}
 							if c.hitdef.hitonce > 0 {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -701,7 +701,7 @@ func (c *Compiler) attr(text string, hitdef bool) (int32, error) {
 		case "h", "a":
 			flg |= int32(AT_HA | AT_HT | AT_HP)
 		default:
-			if sys.ignoreMostErrors && sys.cgi[c.playerNo].ver[0] == 1 {
+			if sys.ignoreMostErrors && sys.cgi[c.playerNo].mugenver[0] == 1 {
 				//if hitdef {
 				//	flg = hitdefflg
 				//}
@@ -1861,7 +1861,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			}
 			return nil
 		}
-		// if sys.cgi[c.playerNo].ver[0] == 1 {
+		// if sys.cgi[c.playerNo].mugenver[0] == 1 {
 		// if err := eqne(hda); err != nil {
 		// return bvNone(), err
 		// }
@@ -3970,7 +3970,7 @@ func (c *Compiler) paramTrans(is IniSection, sc *StateControllerBase,
 		}
 		var exp []BytecodeExp
 		b := false
-		if !afterImage || sys.cgi[c.playerNo].ver[0] == 1 {
+		if !afterImage || sys.cgi[c.playerNo].mugenver[0] == 1 {
 			if err := c.stateParam(is, prefix+"alpha", func(data string) error {
 				b = true
 				bes, err := c.exprs(data, VT_Int, 2)
@@ -4001,7 +4001,7 @@ func (c *Compiler) paramTrans(is IniSection, sc *StateControllerBase,
 				}
 				if len(bes) > 1 {
 					exp[1] = bes[1]
-					if tt != TT_alpha && tt != TT_add1 && !(tt == TT_add && sys.cgi[c.playerNo].ver[0] == 1) {
+					if tt != TT_alpha && tt != TT_add1 && !(tt == TT_add && sys.cgi[c.playerNo].mugenver[0] == 1) {
 						exp[1].append(OC_pop)
 					}
 				}
@@ -4011,7 +4011,7 @@ func (c *Compiler) paramTrans(is IniSection, sc *StateControllerBase,
 						exp[1].appendValue(BytecodeInt(255))
 					}
 				case TT_add:
-					if sys.cgi[c.playerNo].ver[0] == 1 {
+					if sys.cgi[c.playerNo].mugenver[0] == 1 {
 						if len(bes) <= 1 {
 							exp[1].appendValue(BytecodeInt(255))
 						}
@@ -5549,14 +5549,14 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 				info = false
 				var ok bool
 				var str string
-				sys.cgi[pn].ver = [2]uint16{}
+				sys.cgi[pn].mugenver = [2]uint16{}
 				if str, ok = is["mugenversion"]; ok {
 					for i, s := range SplitAndTrim(str, ".") {
-						if i >= len(sys.cgi[pn].ver) {
+						if i >= len(sys.cgi[pn].mugenver) {
 							break
 						}
 						if v, err := strconv.ParseUint(s, 10, 16); err == nil {
-							sys.cgi[pn].ver[i] = uint16(v)
+							sys.cgi[pn].mugenver[i] = uint16(v)
 						} else {
 							break
 						}
@@ -5574,6 +5574,11 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 							break
 						}
 					}
+				}
+				// Ikemen characters adopt Mugen 1.1 version as a safeguard
+				if sys.cgi[pn].ikemenver[0] != 0 || sys.cgi[pn].ikemenver[1] != 0 {
+					sys.cgi[pn].mugenver[0] = 1
+					sys.cgi[pn].mugenver[1] = 1
 				}
 			}
 		case "files":

--- a/src/script.go
+++ b/src/script.go
@@ -4256,7 +4256,7 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "majorversion", func(*lua.LState) int {
-		l.Push(lua.LBool(sys.debugWC.gi().ver[0] == 1))
+		l.Push(lua.LBool(sys.debugWC.gi().mugenver[0] == 1))
 		return 1
 	})
 	luaRegister(l, "map", func(*lua.LState) int {

--- a/src/stage.go
+++ b/src/stage.go
@@ -724,7 +724,7 @@ type Stage struct {
 	stageTime       int32
 	constants       map[string]float32
 	p1p3dist        float32
-	ver             [2]uint16
+	mugenver        [2]uint16
 	reload          bool
 	stageprops      StageProps
 }
@@ -777,21 +777,21 @@ func loadStage(def string, main bool) (*Stage, error) {
 		s.nameLow = strings.ToLower(s.name)
 		s.displaynameLow = strings.ToLower(s.displayname)
 		s.authorLow = strings.ToLower(s.author)
-		s.ver = [2]uint16{}
+		s.mugenver = [2]uint16{}
 		if str, ok := sec[0]["mugenversion"]; ok {
 			for k, v := range SplitAndTrim(str, ".") {
-				if k >= len(s.ver) {
+				if k >= len(s.mugenver) {
 					break
 				}
 				if v, err := strconv.ParseUint(v, 10, 16); err == nil {
-					s.ver[k] = uint16(v)
+					s.mugenver[k] = uint16(v)
 				} else {
 					break
 				}
 			}
 		}
 		// If the MUGEN version is lower than 1.0, use camera pixel rounding (floor)
-		if s.ver[0] == 0 {
+		if s.mugenver[0] != 1 {
 			s.stageprops.roundpos = true
 		}
 		if sec[0].LoadFile("attachedchar", []string{def, "", sys.motifDir, "data/"}, func(filename string) error {
@@ -838,7 +838,7 @@ func loadStage(def string, main bool) (*Stage, error) {
 		sec[0].ReadF32("p1p3dist", &s.p1p3dist)
 	}
 	if sec := defmap["scaling"]; len(sec) > 0 {
-		if s.ver[0] == 0 { //mugen 1.0+ removed support for topscale
+		if s.mugenver[0] != 1 { //mugen 1.0+ removed support for topscale
 			sec[0].ReadF32("topscale", &s.stageCamera.ztopscale)
 		}
 	}
@@ -935,7 +935,7 @@ func loadStage(def string, main bool) (*Stage, error) {
 		}
 		var r, g, b int32
 		// mugen 1.1 removed support for color
-		if (s.ver[0] != 1 || s.ver[1] != 1) && (s.sff.header.Ver0 != 2 || s.sff.header.Ver2 != 1) && sec[0].readI32ForStage("color", &r, &g, &b) {
+		if (s.mugenver[0] != 1 || s.mugenver[1] != 1) && (s.sff.header.Ver0 != 2 || s.sff.header.Ver2 != 1) && sec[0].readI32ForStage("color", &r, &g, &b) {
 			r, g, b = Clamp(r, 0, 255), Clamp(g, 0, 255), Clamp(b, 0, 255)
 		}
 		s.sdw.color = uint32(r<<16 | g<<8 | b)

--- a/src/system.go
+++ b/src/system.go
@@ -929,7 +929,7 @@ func (s *System) commandUpdate() {
 					c.helperIndex > 0 && &c.cmd[0] != &r.cmd[0]) &&
 					c.cmd[0].Input(c.key, int32(c.facing), sys.com[i], c.inputFlag) {
 					hp := c.hitPause() && c.gi().constants["input.pauseonhitpause"] != 0
-					buftime := Btoi(hp && c.gi().ver[0] != 1)
+					buftime := Btoi(hp && c.gi().mugenver[0] != 1)
 					if s.super > 0 {
 						if !act && s.super <= s.superendcmdbuftime {
 							hp = true
@@ -1408,7 +1408,7 @@ func (s *System) action() {
 	if s.superanim != nil {
 		s.topSprites.add(&SprData{s.superanim, &s.superpmap, s.superpos,
 			[...]float32{s.superfacing, 1}, [2]int32{-1}, 5, Rotation{}, [2]float32{},
-			false, true, s.cgi[s.superplayer].ver[0] != 1, 1, 1, 0, 0, [4]float32{0, 0, 0, 0}}, 0, 0, 0, 0)
+			false, true, s.cgi[s.superplayer].mugenver[0] != 1, 1, 1, 0, 0, [4]float32{0, 0, 0, 0}}, 0, 0, 0, 0)
 		if s.superanim.loopend {
 			s.superanim = nil
 		}
@@ -1416,7 +1416,7 @@ func (s *System) action() {
 	for i, pr := range s.projs {
 		for j, p := range pr {
 			if p.id >= 0 {
-				s.projs[i][j].cueDraw(s.cgi[i].ver[0] != 1, i)
+				s.projs[i][j].cueDraw(s.cgi[i].mugenver[0] != 1, i)
 			}
 		}
 	}
@@ -1425,7 +1425,7 @@ func (s *System) action() {
 		for i, el := range *edl {
 			for j := len(el) - 1; j >= 0; j-- {
 				if el[j] >= 0 {
-					s.explods[i][el[j]].update(s.cgi[i].ver[0] != 1, i)
+					s.explods[i][el[j]].update(s.cgi[i].mugenver[0] != 1, i)
 					if s.explods[i][el[j]].id == IErr {
 						if drop {
 							el = append(el[:j], el[j+1:]...)
@@ -2757,13 +2757,15 @@ func (l *Loader) loadChar(pn int) int {
 	defer func() {
 		sys.loadTime(tnow, tstr, false, true)
 		// Mugen compatibility mode indicator
-		if sys.cgi[pn].ikemenver[0] == 0 && sys.cgi[pn].ikemenver[0] == 0 {
-			if sys.cgi[pn].ver[0] == 1 && sys.cgi[pn].ikemenver[0] == 1 {
+		if sys.cgi[pn].ikemenver[0] == 0 && sys.cgi[pn].ikemenver[1] == 0 {
+			if sys.cgi[pn].mugenver[0] == 1 && sys.cgi[pn].mugenver[1] == 1 {
 				sys.appendToConsole("Using Mugen 1.1 compatibility mode.")
-			} else if sys.cgi[pn].ver[0] == 1 && sys.cgi[pn].ikemenver[0] == 0 {
+			} else if sys.cgi[pn].mugenver[0] == 1 && sys.cgi[pn].mugenver[1] == 0 {
 				sys.appendToConsole("Using Mugen 1.0 compatibility mode.")
-			} else if sys.cgi[pn].ver[0] != 1 {
+			} else if sys.cgi[pn].mugenver[0] != 1 {
 				sys.appendToConsole("Using WinMugen compatibility mode.")
+			} else {
+				sys.appendToConsole("Character with unknown engine version.")
 			}
 		}
 	}()


### PR DESCRIPTION
- If no value is specified for SprPriority, AngleSet or AngleMul, the sctrl is run with value set to 0 like Mugen
- Compatibility message now also outputs an "unknown" message if the version format is not recognized
- All Mugen version checks in the source code are now labelled as such rather than simply "version"
- Standardized Mugen version checks a little
- Ikemen characters now automatically set Mugen version to 1.1 internally, since that is the intended behavior for most things. This is a patch as version checks should be refactored in the future to skip Mugen version if Ikemen version exists