### PR TITLE
fix: lifebar combo updating

### DIFF
--- a/src/input.go
+++ b/src/input.go
@@ -1884,8 +1884,13 @@ func (cl *CommandList) Input(i int, facing int32, aiLevel float32, ib InputBits)
 		if ib > 0 {
 			U = ib&IB_PU != 0 || U
 			D = ib&IB_PD != 0 || D
-			L = ib&IB_PL != 0 || L
-			R = ib&IB_PR != 0 || R
+			if facing > 0 {
+				B = ib&IB_PL != 0 || B
+				F = ib&IB_PR != 0 || F
+			} else {
+				B = ib&IB_PR != 0 || B
+				F = ib&IB_PL != 0 || F
+			}
 			a = ib&IB_A != 0 || a
 			b = ib&IB_B != 0 || b
 			c = ib&IB_C != 0 || c

--- a/src/main.go
+++ b/src/main.go
@@ -186,7 +186,6 @@ type configSettings struct {
 	BarRedLife                 bool
 	BarStun                    bool
 	Borderless                 bool
-	ComboExtraFrameWindow      int32
 	CommonAir                  []string
 	CommonCmd                  []string
 	CommonConst                []string
@@ -337,7 +336,6 @@ func setupConfig() configSettings {
 	sys.cam.ZoomMax = tmp.ForceStageZoomin
 	sys.cam.ZoomMin = tmp.ForceStageZoomout
 	sys.cam.ZoomSpeed = 12 - tmp.ZoomSpeed
-	sys.comboExtraFrameWindow = tmp.ComboExtraFrameWindow
 	sys.commonAir = tmp.CommonAir
 	sys.commonCmd = tmp.CommonCmd
 	sys.commonConst = tmp.CommonConst

--- a/src/resources/defaultConfig.json
+++ b/src/resources/defaultConfig.json
@@ -9,7 +9,6 @@
   "BarRedLife": true,
   "BarStun": false,
   "Borderless": false,
-  "ComboExtraFrameWindow": 0,
   "CommonAir": [
     "data/common.air"
   ],

--- a/src/system.go
+++ b/src/system.go
@@ -74,7 +74,6 @@ var sys = System{
 	errLog:                log.New(NewLogWriter(), "", log.LstdFlags),
 	keyInput:              KeyUnknown,
 	wavChannels:           256,
-	comboExtraFrameWindow: 1,
 	fontShaderVer:         120,
 	//FLAC_FrameWait:          -1,
 	luaSpriteScale:       1,
@@ -166,7 +165,6 @@ type System struct {
 	workingState            *StateBytecode
 	specialFlag             GlobalSpecialFlag
 	afterImageMax           int32
-	comboExtraFrameWindow   int32
 	envShake                EnvShake
 	pause                   int32
 	pausetime               int32
@@ -972,6 +970,9 @@ func (s *System) charUpdate(cvmin, cvmax,
 			}
 		}
 	}
+	// Update lifebars before hit detection
+	// Allows a combo to still end if a character is hit in the same frame where it exits movetype H
+	s.lifebar.step()
 	if s.tickNextFrame() {
 		for i, pr := range s.projs {
 			for j, p := range pr {
@@ -1336,7 +1337,6 @@ func (s *System) action() {
 	} else {
 		s.charUpdate(&cvmin, &cvmax, &highest, &lowest, &leftest, &rightest)
 	}
-	s.lifebar.step()
 
 	// Set global First Attack flag if either team got it
 	if s.firstAttack[0] >= 0 || s.firstAttack[1] >= 0 {


### PR DESCRIPTION
- Lifebars now update immediately before character hit detection happens, for improved combo display accuracy
- Removed "fake combo" code as it became obsolete after the changes to character guarding and combo tracking. There is no longer a need to extend combos by 1 frame like Mugen
- Fixes #597 