### PR TITLE
feat: Wireframe toggle for 3D stages

### DIFF
--- a/src/script.go
+++ b/src/script.go
@@ -2520,6 +2520,13 @@ func systemScriptInit(l *lua.LState) {
 		}
 		return 0
 	})
+	luaRegister(l, "toggleWireframeDraw", func(*lua.LState) int {
+		if !sys.allowDebugMode {
+			return 0
+		}
+		sys.wireframeDraw = !sys.wireframeDraw
+		return 0
+	})
 	luaRegister(l, "toggleDialogueBars", func(*lua.LState) int {
 		if l.GetTop() >= 1 {
 			sys.dialogueBarsFlg = boolArg(l, 1)

--- a/src/stage.go
+++ b/src/stage.go
@@ -2057,6 +2057,10 @@ func drawNode(mdl *Model, n *Node, proj, modelview mgl.Mat4, drawBlended bool) {
 		} else {
 			gfx.SetModelUniformI("textured", 0)
 		}
+		mode := p.mode
+		if sys.wireframeDraw {
+		    mode = 1 // Set mesh render mode to "lines"
+		}
 		gfx.SetModelUniformFv("add", padd[:])
 		gfx.SetModelUniformFv("mult", []float32{pmul[0] * float32(sys.brightness) / 256, pmul[1] * float32(sys.brightness) / 256, pmul[2] * float32(sys.brightness) / 256})
 		gfx.SetModelUniformI("neg", int(Btoi(neg)))
@@ -2065,7 +2069,7 @@ func drawNode(mdl *Model, n *Node, proj, modelview mgl.Mat4, drawBlended bool) {
 		gfx.SetModelUniformI("enableAlpha", int(Btoi(mat.alphaMode == AlphaModeBlend)))
 		gfx.SetModelUniformF("alphaThreshold", mat.alphaCutoff)
 		gfx.SetModelUniformFv("baseColorFactor", color[:])
-		gfx.RenderElements(p.mode, int(p.numIndices), int(p.elementBufferOffset))
+		gfx.RenderElements(mode, int(p.numIndices), int(p.elementBufferOffset))
 
 		gfx.ReleaseModelPipeline()
 

--- a/src/system.go
+++ b/src/system.go
@@ -189,6 +189,7 @@ type System struct {
 	stageList               map[int32]*Stage
 	stageLoop               bool
 	stageLoopNo             int
+	wireframeDraw           bool
 	helperMax               int32
 	nextCharId              int32
 	wincnt                  wincntMap


### PR DESCRIPTION
Adds the debug hotkey **Ctrl+W** to toggle wireframe display in 3D stages. Fairly self-explanatory.

https://github.com/ikemen-engine/Ikemen-GO/assets/22881403/a3bbaae4-e327-4472-8b7a-4fe6e0c7813d

