### PR TITLE
feat: AssertCommand sctrl, MugenVersion trigger

### DIFF
--- a/data/common1.cns.zss
+++ b/data/common1.cns.zss
@@ -718,19 +718,19 @@ if hitOver {
 
 #-------------------------------------------------------------------------------
 [Function HitGroundEffect(vely)]
-if majorVersion = 1 {
+if mugenVersion < 1.0 {
+	gameMakeAnim{
+		value: 60 + ($vely > 5) + ($vely > 14);
+		pos: 0, 0;
+		under: $vely <= 14;
+	}
+} else {
 	explod{
 		anim: F(60 + ($vely > const240p(5)) + ($vely > const240p(14)));
 		postype: none; #p1
 		pos: pos x + cameraPos x, 0; #0, 0
 		facing: facing;
 		sprpriority: ifElse($vely <= const240p(14), -10, 10);
-	}
-} else {
-	gameMakeAnim{
-		value: 60 + ($vely > 5) + ($vely > 14);
-		pos: 0, 0;
-		under: $vely <= 14;
 	}
 }
 playSnd{value: F7, ($vely > const240p(5)) + ($vely > const240p(14))}
@@ -740,7 +740,7 @@ playSnd{value: F7, ($vely > const240p(5)) + ($vely > const240p(14))}
 [StateDef 5100; type: L; movetype: H; physics: N;]
 
 if time = 0 {
-	if majorVersion != 1 && getHitVar(fall.yVel) = 0 && vel x > 1 {
+	if mugenVersion < 1.0 && getHitVar(fall.yVel) = 0 && vel x > 1 {
 		velSet{x: 1}
 	}
 	fallEnvShake{}
@@ -904,7 +904,7 @@ if time = 0 {
 	}
 	posSet{y: 0}
 	palFx{time: 3; add: 128, 128, 128}
-	if majorVersion = 1 {
+	if mugenVersion >= 1.0 {
 		explod{
 			anim: F60;
 			postype: none;
@@ -914,7 +914,7 @@ if time = 0 {
 			sprpriority: -10
 		}
 	}
-} else if time = 1 && majorVersion != 1 {
+} else if time = 1 && mugenVersion < 1.0 {
 	gameMakeAnim{value: 60; pos: 0, 0; under: 1}
 }
 notHitBy{value: SCA; time: 1}
@@ -931,7 +931,7 @@ if time = 0 {
 	}
 	notHitBy{value: SCA; time: 15}
 } else if time < 4 {
-	if majorVersion = 1 {
+	if mugenVersion >= 1.0 {
 		posFreeze{}
 	}
 } else {
@@ -944,7 +944,7 @@ if time = 0 {
 			x: const(velocity.air.gethit.airrecover.add.x);
 			y: const(velocity.air.gethit.airrecover.add.y);
 		}
-		if majorVersion != 1 {
+		if mugenVersion < 1.0 {
 			if vel y > 0 {
 				velMul{y: .5}
 			}

--- a/data/training.zss
+++ b/data/training.zss
@@ -80,13 +80,30 @@ ignoreHitPause if gameMode != "training" || isHelper || teamSide != 2 {
 		if map(_iksys_trainingFallRecovery) {
 			if stateNo != [const(StateAirGetHit_fallRecoveryOnGroundStillFalling), const(StateAirGetHit_fallRecoveryInAir)] {
 				if moveType = H && stateType = A && hitFall && !getHitVar(isbound) && (pos y || vel y) {
-					if (map(_iksys_trainingFallRecovery) = 1 && pos y >= const(movement.air.gethit.groundrecover.ground.threshold)) # Ground recovery
-					|| (map(_iksys_trainingFallRecovery) = 2 && pos y < const(movement.air.gethit.groundrecover.ground.threshold)) # Air recovery
-					|| (map(_iksys_trainingFallRecovery) = 3 && random < 100) { # Random recovery
-						if gametime % 2 {
-							assertInput{flag: x; flag2: y; flag3: z} # Ideally one would specifically force the character's "recovery" command
+					# Ground recovery. Attempt only if common1 conditions are met
+					if vel y > 0 && pos y >= const(movement.air.gethit.groundrecover.ground.threshold) {
+						if map(_iksys_trainingFallRecovery) = 1 { 
+							let rcv = 1;
+						}
+					# Air recovery. Attempt only if conditions for ground recovery are not met
+					} else if map(_iksys_trainingFallRecovery) = 2 {
+						let rcv = 1;
+					}
+					# Random recovery. Attempt regardless of conditions
+					if map(_iksys_trainingFallRecovery) = 3 && random < 100 {
+						let rcv = 1;
+					}
+					if $rcv {
+						# WinMugen characters assert inputs because asserting commands directly may trigger their AI activation codes
+						if mugenVersion < 1.0 {
+							if gametime % 2 {
+								assertInput{flag: x; flag2: y; flag3: z}
+							} else {
+								assertInput{flag: a; flag2: b; flag3: c}
+							}
 						} else {
-							assertInput{flag: a; flag2: b; flag3: c}
+							assertCommand{name: "recovery"; buffertime: 2}
+							# Buffered 2 frames because asserting a command instead of inputting it has 1 frame of lag in custom fall recovery systems
 						}
 						# Random direction
 						if map(_iksys_trainingFallRecovery) = 3 {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -519,6 +519,7 @@ const (
 	OC_ex_lerp
 	OC_ex_memberno
 	OC_ex_movecountered
+	OC_ex_mugenversion
 	OC_ex_pausetime
 	OC_ex_physics
 	OC_ex_playerno
@@ -2220,6 +2221,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(int32(c.memberNo) + 1)
 	case OC_ex_movecountered:
 		sys.bcStack.PushI(c.moveCountered())
+	case OC_ex_mugenversion:
+		sys.bcStack.PushF(c.mugenVersion())
 	case OC_ex_pausetime:
 		sys.bcStack.PushI(c.pauseTime())
 	case OC_ex_physics:
@@ -7277,6 +7280,37 @@ func (sc forceFeedback) Run(c *Char, _ []int32) bool {
 		return true
 	})*/
 	//TODO: not implemented
+	return false
+}
+
+type assertCommand StateControllerBase
+
+const (
+	assertCommand_name byte = iota
+	assertCommand_buffertime
+	assertCommand_redirectid
+)
+
+func (sc assertCommand) Run(c *Char, _ []int32) bool {
+	crun := c
+	n := ""
+	bt := int32(1)
+	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
+		switch id {
+		case assertCommand_name:
+			n = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
+		case assertCommand_buffertime:
+			bt = exp[0].evalI(c)
+		case assertCommand_redirectid:
+			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
+				crun = rid
+			} else {
+				return false
+			}
+		}
+		return true
+	})
+	crun.assertCommand(n, bt)
 	return false
 }
 

--- a/src/char.go
+++ b/src/char.go
@@ -2994,6 +2994,11 @@ func (c *Char) commandByName(name string) bool {
 	i, ok := c.cmd[c.playerNo].Names[name]
 	return ok && c.command(c.playerNo, i)
 }
+func (c *Char) assertCommand(name string, time int32) {
+	if !c.cmd[c.playerNo].Assert(name, time) {
+		sys.appendToConsole(c.warn() + fmt.Sprintf("attempted to assert an invalid command"))
+	}
+}
 func (c *Char) constp(coordinate, value float32) BytecodeValue {
 	return BytecodeFloat(c.stCgi().localcoord[0] / coordinate * value)
 }
@@ -3123,6 +3128,19 @@ func (c *Char) moveReversed() int32 {
 		return Abs(c.mctime)
 	}
 	return 0
+}
+func (c *Char) mugenVersion() float32 {
+	if c.stCgi().ikemenver[0] != 0 || c.stCgi().ikemenver[1] != 0 {
+		return 1.1
+	} else if c.stCgi().mugenver[0] == 1 && c.stCgi().mugenver[1] == 1 {
+		return 1.1
+	} else if c.stCgi().mugenver[0] == 1 && c.stCgi().mugenver[1] == 0 {
+		return 1.0
+	} else if c.stCgi().mugenver[0] != 1 {
+		return 0.5 // Arbitrary value
+	} else {
+		return 0
+	}
 }
 func (c *Char) numEnemy() int32 {
 	var n int32

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -130,6 +130,7 @@ func newCompiler() *Compiler {
 		"zoom":                 c.zoom,
 		"forcefeedback":        c.forceFeedback,
 		"null":                 c.null,
+		"assertcommand":        c.assertCommand,
 		"assertinput":          c.assertInput,
 		"dialogue":             c.dialogue,
 		"dizzypointsadd":       c.dizzyPointsAdd,
@@ -365,6 +366,7 @@ var triggerMap = map[string]int{
 	"memberno":           1,
 	"min":                1,
 	"movecountered":      1,
+	"mugenversion":       1,
 	"offset":             1,
 	"p5name":             1,
 	"p6name":             1,
@@ -2984,6 +2986,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_ex_, OC_ex_memberno)
 	case "movecountered":
 		out.append(OC_ex_, OC_ex_movecountered)
+	case "mugenversion":
+		out.append(OC_ex_, OC_ex_mugenversion)
 	case "pausetime":
 		out.append(OC_ex_, OC_ex_pausetime)
 	case "physics":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -4773,6 +4773,30 @@ func (c *Compiler) modifyChar(is IniSection, sc *StateControllerBase, _ int8) (S
 	return *ret, err
 }
 
+func (c *Compiler) assertCommand(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+	ret, err := (*assertCommand)(sc), c.stateSec(is, func() error {
+		if err := c.paramValue(is, sc, "redirectid",
+			assertCommand_redirectid, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "name", func(data string) error {
+			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
+				return Error("Not enclosed in \"")
+			}
+			sc.add(assertCommand_name, sc.beToExp(BytecodeExp(data[1:len(data)-1])))
+			return nil
+		}); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "buffertime",
+			assertCommand_buffertime, VT_Int, 1, false); err != nil {
+			return err
+		}
+		return nil
+	})
+	return *ret, err
+}
+
 // It's just a Null... Has no effect whatsoever.
 func (c *Compiler) null(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	return nullStateController, nil

--- a/src/input.go
+++ b/src/input.go
@@ -1909,6 +1909,20 @@ func (cl *CommandList) Input(i int, facing int32, aiLevel float32, ib InputBits)
 	return step
 }
 
+// Assert commands with a given name for a given time
+func (cl *CommandList) Assert(name string, time int32) bool {
+	has := false
+	for i := range cl.Commands {
+		for j := range cl.Commands[i] {
+			if cl.Commands[i][j].name == name {
+				cl.Commands[i][j].curbuftime = time
+				has = true
+			}
+		}
+	}
+	return has
+}
+
 // Reset commands with a given name
 func (cl *CommandList) ClearName(name string) {
 	for i := range cl.Commands {

--- a/src/script.go
+++ b/src/script.go
@@ -4278,6 +4278,10 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.debugWC.moveCountered()))
 		return 1
 	})
+	luaRegister(l, "mugenversion", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.mugenVersion()))
+		return 1
+	})
 	luaRegister(l, "offsetX", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.offsetTrg[0]))
 		return 1


### PR DESCRIPTION
AssertCommand:
- Sets the buffer time of all commands with the specified name to the specified amount of time
- Parameters: name and buffertime
- Example: assertCommand{name: "QCF_x"; buffertime: 10}
- Revised training.zss to make use of it

MugenVersion:
- Returns the character's Mugen version as a float
- Currently returns 0.5 for WinMugen characters, but checking if version is < 1.0 is better advised
- Returns 1.1 for characters with Ikemen version, regardless of what's specified in the def file
- MugenVersion >= 1.0 is equivalent to MajorVersion trigger