### PR TITLE
fix: Enable wireframe debug hotkey

### DIFF
--- a/external/script/global.lua
+++ b/external/script/global.lua
@@ -5,6 +5,7 @@
 addHotkey('c', true, false, false, true, false, 'toggleClsnDraw()')
 addHotkey('d', true, false, false, true, false, 'toggleDebugDraw()')
 addHotkey('d', false, false, true, true, false, 'toggleDebugDraw(true)')
+addHotkey('w', true, false, false, true, false, 'toggleWireframeDraw()')
 addHotkey('s', true, false, false, true, true, 'changeSpeed()')
 addHotkey('KP_PLUS', true, false, false, true, true, 'changeSpeed(1)')
 addHotkey('KP_MINUS', true, false, false, true, true, 'changeSpeed(-1)')


### PR DESCRIPTION
An oversight in my last commit resulted in me not actually adding the debug toggle hotkey to global.lua, which this PR fixes. My bad!