### PR TITLE
feat: ModifyChar changing character name

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -264,7 +264,7 @@ const (
 	OC_const_size_draw_offset_y
 	OC_const_size_z_width
 	OC_const_size_z_enable
-	OC_const_size_classicpushbox
+	OC_const_size_ignoreclsn2push
 	OC_const_velocity_walk_fwd_x
 	OC_const_velocity_walk_back_x
 	OC_const_velocity_walk_up_x
@@ -1600,8 +1600,8 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.size.z.width * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_z_enable:
 		sys.bcStack.PushB(c.size.z.enable)
-	case OC_const_size_classicpushbox:
-		sys.bcStack.PushI(c.size.classicpushbox)
+	case OC_const_size_ignoreclsn2push:
+		sys.bcStack.PushI(c.size.ignoreclsn2push)
 	case OC_const_velocity_walk_fwd_x:
 		sys.bcStack.PushF(c.gi().velocity.walk.fwd * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_walk_back_x:
@@ -8852,36 +8852,38 @@ const (
 
 func (sc modifyChar) Run(c *Char, _ []int32) bool {
 	crun := c
-	var lm, pm, dp, gp int32
-	var ts int
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case modifyChar_lifemax:
-			lm = exp[0].evalI(c)
+			lm := exp[0].evalI(c)
 			if lm < 1 {
 				lm = 1
 			}
 			crun.lifeMax = lm
+			crun.life = Clamp(crun.life, 0, crun.lifeMax)
 		case modifyChar_powermax:
-			pm = exp[0].evalI(c)
+			pm := exp[0].evalI(c)
 			if pm < 0 {
 				pm = 0
 			}
 			crun.powerMax = pm
+			crun.power = Clamp(crun.power, 0, crun.powerMax)
 		case modifyChar_dizzypointsmax:
-			dp = exp[0].evalI(c)
+			dp := exp[0].evalI(c)
 			if dp < 0 {
 				dp = 0
 			}
 			crun.dizzyPointsMax = dp
+			crun.dizzyPoints = Clamp(crun.dizzyPoints, 0, crun.dizzyPointsMax)
 		case modifyChar_guardpointsmax:
-			gp = exp[0].evalI(c)
+			gp := exp[0].evalI(c)
 			if gp < 0 {
 				gp = 0
 			}
 			crun.guardPointsMax = gp
+			crun.guardPoints = Clamp(crun.guardPoints, 0, crun.guardPointsMax)
 		case modifyChar_teamside:
-			ts = int(exp[0].evalI(c))
+			ts := int(exp[0].evalI(c))
 			if ts >= 0 && ts <= 2 {
 				ts -= 1 // Internally the teamside goes from -1 to 1
 				crun.teamside = ts

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -8847,6 +8847,8 @@ const (
 	modifyChar_dizzypointsmax
 	modifyChar_guardpointsmax
 	modifyChar_teamside
+	modifyChar_displayname
+	modifyChar_lifebarname
 	modifyChar_redirectid
 )
 
@@ -8888,6 +8890,12 @@ func (sc modifyChar) Run(c *Char, _ []int32) bool {
 				ts -= 1 // Internally the teamside goes from -1 to 1
 				crun.teamside = ts
 			}
+		case modifyChar_displayname:
+			dn := string(*(*[]byte)(unsafe.Pointer(&exp[0])))
+			sys.cgi[crun.playerNo].displayname = dn
+		case modifyChar_lifebarname:
+			ln := string(*(*[]byte)(unsafe.Pointer(&exp[0])))
+			sys.cgi[crun.playerNo].lifebarname = ln
 		case modifyChar_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1555,8 +1555,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.append(OC_const_size_z_width)
 		case "size.z.enable":
 			out.append(OC_const_size_z_enable)
-		case "size.classicpushbox":
-			out.append(OC_const_size_classicpushbox)
+		case "size.ignoreclsn2push":
+			out.append(OC_const_size_ignoreclsn2push)
 		case "velocity.walk.fwd.x":
 			out.append(OC_const_velocity_walk_fwd_x)
 		case "velocity.walk.back.x":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -4768,6 +4768,24 @@ func (c *Compiler) modifyChar(is IniSection, sc *StateControllerBase, _ int8) (S
 			modifyChar_teamside, VT_Int, 1, false); err != nil {
 			return err
 		}
+		if err := c.stateParam(is, "displayname", func(data string) error {
+			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
+				return Error("Not enclosed in \"")
+			}
+			sc.add(modifyChar_displayname, sc.beToExp(BytecodeExp(data[1:len(data)-1])))
+			return nil
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "lifebarname", func(data string) error {
+			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
+				return Error("Not enclosed in \"")
+			}
+			sc.add(modifyChar_lifebarname, sc.beToExp(BytecodeExp(data[1:len(data)-1])))
+			return nil
+		}); err != nil {
+			return err
+		}
 		return nil
 	})
 	return *ret, err

--- a/src/script.go
+++ b/src/script.go
@@ -2936,8 +2936,8 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.size.z.width)
 		case "size.z.enable":
 			ln = lua.LNumber(Btoi(c.size.z.enable))
-		case "size.classicpushbox":
-			ln = lua.LNumber(c.size.classicpushbox)
+		case "size.ignoreclsn2push":
+			ln = lua.LNumber(c.size.ignoreclsn2push)
 		case "velocity.walk.fwd.x":
 			ln = lua.LNumber(c.gi().velocity.walk.fwd)
 		case "velocity.walk.back.x":

--- a/src/system.go
+++ b/src/system.go
@@ -1718,19 +1718,27 @@ func (s *System) fight() (reload bool) {
 	}()
 	var oldStageVars Stage
 	oldStageVars.copyStageVars(s.stage)
-	var life, pow, gpow, spow, rlife [len(s.chars)]int32
+	var life, lifeMax, power, powerMax [len(s.chars)]int32
+	var guardPoints, guardPointsMax, dizzyPoints, dizzyPointsMax, redLife [len(s.chars)]int32
+	var teamside [len(s.chars)]int
 	var ivar [len(s.chars)][]int32
 	var fvar [len(s.chars)][]float32
 	var dialogue [len(s.chars)][]string
 	var mapArray [len(s.chars)]map[string]float32
 	var remapSpr [len(s.chars)]RemapPreset
 	// Anonymous function to assign initial character values
+	// ModifyChar parameters should ideally also be reset here
 	copyVar := func(pn int) {
 		life[pn] = s.chars[pn][0].life
-		pow[pn] = s.chars[pn][0].power
-		gpow[pn] = s.chars[pn][0].guardPoints
-		spow[pn] = s.chars[pn][0].dizzyPoints
-		rlife[pn] = s.chars[pn][0].redLife
+		lifeMax[pn] = s.chars[pn][0].lifeMax
+		power[pn] = s.chars[pn][0].power
+		powerMax[pn] = s.chars[pn][0].powerMax
+		guardPoints[pn] = s.chars[pn][0].guardPoints
+		guardPointsMax[pn] = s.chars[pn][0].guardPointsMax
+		dizzyPoints[pn] = s.chars[pn][0].dizzyPoints
+		dizzyPointsMax[pn] = s.chars[pn][0].dizzyPointsMax
+		redLife[pn] = s.chars[pn][0].redLife
+		teamside[pn] = s.chars[pn][0].teamside
 		if len(ivar[pn]) < len(s.chars[pn][0].ivar) {
 			ivar[pn] = make([]int32, len(s.chars[pn][0].ivar))
 		}
@@ -1931,10 +1939,15 @@ func (s *System) fight() (reload bool) {
 		for i, p := range s.chars {
 			if len(p) > 0 {
 				p[0].life = life[i]
-				p[0].power = pow[i]
-				p[0].guardPoints = gpow[i]
-				p[0].dizzyPoints = spow[i]
-				p[0].redLife = rlife[i]
+				p[0].lifeMax = lifeMax[i]
+				p[0].power = power[i]
+				p[0].powerMax = powerMax[i]
+				p[0].guardPoints = guardPoints[i]
+				p[0].guardPointsMax = guardPointsMax[i]
+				p[0].dizzyPoints = dizzyPoints[i]
+				p[0].dizzyPointsMax = dizzyPointsMax[i]
+				p[0].redLife = redLife[i]
+				p[0].teamside = teamside[i]
 				copy(p[0].ivar[:], ivar[i])
 				copy(p[0].fvar[:], fvar[i])
 				copy(p[0].dialogue[:], dialogue[i])


### PR DESCRIPTION
- ModifyChar can now also change the character's DisplayName and LifebarName. Should be used carefully as there's currently no way to save and restore an enemy char's original name
- Most ModifyChar parameters are now reset when using F4
- Adjusted AssertCommand so it works correctly during custom states
- ClassicPushbox constant renamed to IgnoreClsn2Push for better clarity