### PR TITLE
feat: Explods interpolation

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -1045,13 +1045,14 @@ type Explod struct {
 	pausemovetime       int32
 	anim                *Animation
 	animelem            int32
-	animelemlooped      bool
+	animfreeze      	bool
 	ontop               bool
 	under               bool
 	alpha               [2]int32
 	ownpal              bool
 	ignorehitpause      bool
 	rot                 Rotation
+	anglerot            [3]float32
 	projection          Projection
 	fLength             float32
 	oldPos              [2]float32
@@ -1062,6 +1063,20 @@ type Explod struct {
 	window              [4]float32
 	lockSpriteFacing    bool
 	localscl            float32
+	blendmode			int32
+ 	start_animelem 		int32
+	start_scale 		[2]float32
+ 	start_rot 			[3]float32
+	start_alpha 		[2]int32
+	start_fLength 		float32
+	interpolate  		bool	
+	interpolate_time   	[2]int32
+	interpolate_animelem [2]int32			
+	interpolate_scale   [4]float32
+	interpolate_alpha   [5]int32
+	interpolate_pos     [4]float32
+	interpolate_angle   [6]float32
+	interpolate_fLength [2]float32	
 }
 
 func (e *Explod) clear() {
@@ -1069,6 +1084,7 @@ func (e *Explod) clear() {
 		postype: PT_P1, space: Space_none, relativef: 1, facing: 1, vfacing: 1, localscl: 1,
 		projection: Projection_Orthographic,
 		window:     [4]float32{0, 0, 0, 0},
+		animelem:   1, blendmode: 0,	
 		alpha:      [...]int32{-1, 0}, playerId: -1, bindId: -2, ignorehitpause: true}
 }
 func (e *Explod) reset() {
@@ -1229,9 +1245,6 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 			return
 		}
 	}
-	if e.time == 0 || e.bindtime != 0 {
-		e.setAnimElem()
-	}
 	if e.bindtime != 0 && (e.space == Space_stage ||
 		(e.space == Space_screen && e.postype <= PT_P2)) {
 		if c := sys.playerID(e.bindId); c != nil {
@@ -1281,29 +1294,35 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 		pfx.remap = nil
 	}
 	alp := e.alpha
+	anglerot := e.anglerot
+	fLength := e.fLength
+	scale := e.scale
+	if e.interpolate {
+		e.Interpolate(&scale,&alp,&anglerot,&fLength)	
+	}
 	if alp[0] < 0 {
 		alp[0] = -1
 	}
-	rot := e.rot
 	if (e.facing*e.relativef < 0) != (e.vfacing < 0) {
-		rot.angle *= -1
-		rot.yangle *= -1
+		anglerot[0] *= -1
+		anglerot[2] *= -1
 	}
-
 	sdwalp := 255 - alp[1]
 	if sdwalp < 0 {
 		sdwalp = 256
 	}
-
-	fLength := e.fLength
 	if fLength <= 0 {
 		fLength = 2048
 	}
 	fLength = fLength * e.localscl
-	var epos = [2]float32{(e.pos[0] + e.offset[0] + off[0]) * e.localscl, (e.pos[1] + e.offset[1] + off[1]) * e.localscl}
+	rot := e.rot
+	rot.angle = anglerot[0]
+	rot.xangle = anglerot[1]
+	rot.yangle = anglerot[2]		
+	var epos = [2]float32{(e.pos[0] + e.offset[0] + off[0] + e.interpolate_pos[0]) * e.localscl, (e.pos[1] + e.offset[1] + off[1] + e.interpolate_pos[1]) * e.localscl}
 	var ewin = [4]float32{e.window[0] * e.localscl * facing, e.window[1] * e.localscl * e.vfacing, e.window[2] * e.localscl * facing, e.window[3] * e.localscl * e.vfacing}
-	sprs.add(&SprData{e.anim, pfx, epos, [...]float32{facing * e.scale[0] * e.localscl,
-		e.vfacing * e.scale[1] * e.localscl}, alp, e.sprpriority, rot, [...]float32{1, 1},
+	sprs.add(&SprData{e.anim, pfx, epos, [...]float32{(facing * scale[0]) * e.localscl,
+		(e.vfacing * scale[1]) * e.localscl}, alp, e.sprpriority, rot, [...]float32{1, 1},
 		e.space == Space_screen, playerNo == sys.superplayer, oldVer, facing, 1, int32(e.projection), fLength, ewin},
 		e.shadow[0]<<16|e.shadow[1]&0xff<<8|e.shadow[0]&0xff, sdwalp, 0, 0)
 	if sys.tickNextFrame() {
@@ -1340,7 +1359,8 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 			for i := range e.velocity {
 				e.velocity[i] += e.accel[i]
 			}
-			if e.animelemlooped {
+			eleminterpolate := e.interpolate && e.interpolate_time[1] > 0 && e.interpolate_animelem[1] >= 0
+			if e.animfreeze || eleminterpolate {
 				e.setAnimElem()
 			} else {
 				e.anim.Action()
@@ -1350,6 +1370,101 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 			e.setX(e.pos[0])
 			e.setY(e.pos[1])
 		}
+	}
+}
+
+func (e *Explod) Interpolate(scale *[2]float32, alpha *[2]int32, anglerot *[3]float32, fLength *float32) {
+	if sys.tickNextFrame() {
+
+		if e.interpolate_time[1] > 0 {
+			e.interpolate_time[1]--
+		}
+		t := float32(e.interpolate_time[1])/float32(e.interpolate_time[0])
+		e.interpolate_fLength[0] = Lerp(e.interpolate_fLength[1],e.start_fLength,t)
+		if e.interpolate_animelem[1] >= 0 {
+			elem := Ceil(Lerp(float32(e.interpolate_animelem[0]-1),float32(e.interpolate_animelem[1]),1-t))
+
+			if e.interpolate_animelem[0] > e.interpolate_animelem[1] {
+				elem = Ceil(Lerp(float32(e.interpolate_animelem[1]-1),float32(e.interpolate_animelem[0]),t))		
+			}
+			e.animelem = Clamp(elem,Min(e.interpolate_animelem[0],e.interpolate_animelem[1]),Max(e.interpolate_animelem[0],e.interpolate_animelem[1]))
+			//e.setAnimElem()
+		}		
+		for i := 0; i < 3; i++ {
+			if i < 2 {
+				e.interpolate_pos[i] = Lerp(e.interpolate_pos[i+2],0,t)
+				e.interpolate_scale[i] = Lerp(e.interpolate_scale[i+2],e.start_scale[i],t)//-e.start_scale[i]
+				if e.blendmode == 1 {
+					e.interpolate_alpha[i] = Clamp(int32(Lerp(float32(e.interpolate_alpha[i+2]),float32(e.start_alpha[i]),t)),0,255)
+				}
+			}
+			e.interpolate_angle[i] = Lerp(e.interpolate_angle[i+3],e.start_rot[i],t)
+		}
+	}
+	for i := 0; i < 3; i++ {
+		if i < 2 {
+			(*scale)[i] = e.interpolate_scale[i]*e.scale[i]
+			if e.blendmode == 1 {
+				(*alpha)[i] = int32(float32(e.interpolate_alpha[i])*( float32(e.alpha[i])/255 ) )					
+			}
+		}
+		(*anglerot)[i] = e.interpolate_angle[i]+e.anglerot[i]
+	}
+	*fLength = e.interpolate_fLength[0]+e.fLength
+}
+
+func (e *Explod) setStartParams(pfd *PalFXDef) {
+	e.start_animelem = e.animelem
+	e.start_fLength = e.fLength
+	for i := 0; i < 3; i++ {
+		if i < 2 {
+			e.start_scale[i] = e.scale[i]
+			e.start_alpha[i] = e.alpha[i]	
+		}
+		e.start_rot[i] = e.anglerot[i]
+	}		
+	if e.interpolate {
+		e.fLength = 0
+		for i := 0; i < 3; i++ {
+			if e.ownpal { 
+				pfd.mul[i] = 256
+				pfd.add[i] = 0	
+			}
+			if i < 2 {
+				e.scale[i] = 1
+				if e.blendmode == 1 { e.alpha[i] = 255 }
+			}
+			e.anglerot[i] = 0
+		}
+		if e.ownpal { 
+			pfd.color = 1
+			pfd.hue = 0	
+		}
+	}
+}
+
+func (e *Explod) resetInterpolation(pfd *PalFXDef) {
+	for i := 0; i < 3; i++ {
+		for j := 0; j < 2; j++ {
+			v := (i+(j*3))
+			pfd.iadd[v] = pfd.add[i]
+			pfd.imul[v] = pfd.mul[i]
+			e.interpolate_angle[v] = e.anglerot[i]		
+			if i < 2 {
+				v = (i+(j*2))
+				e.interpolate_pos[v] = 0
+				e.interpolate_scale[v] = e.scale[i]
+				e.interpolate_alpha[v] = e.alpha[i]	
+				if j == 0 {
+					pfd.icolor[i] = pfd.color
+					pfd.ihue[i] = pfd.hue
+				}
+			}					
+		}	
+	}
+	for i := 0; i < 2; i++ {
+		e.interpolate_animelem[i] = -1
+		e.interpolate_fLength[i] = e.fLength
 	}
 }
 

--- a/src/char.go
+++ b/src/char.go
@@ -1071,7 +1071,7 @@ type Explod struct {
 	start_fLength 		float32
 	interpolate  		bool	
 	interpolate_time   	[2]int32
-	interpolate_animelem [2]int32			
+	interpolate_animelem [3]int32			
 	interpolate_scale   [4]float32
 	interpolate_alpha   [5]int32
 	interpolate_pos     [4]float32
@@ -1298,7 +1298,7 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 	fLength := e.fLength
 	scale := e.scale
 	if e.interpolate {
-		e.Interpolate(&scale,&alp,&anglerot,&fLength)	
+		e.Interpolate(act,&scale,&alp,&anglerot,&fLength)	
 	}
 	if alp[0] < 0 {
 		alp[0] = -1
@@ -1373,9 +1373,8 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 	}
 }
 
-func (e *Explod) Interpolate(scale *[2]float32, alpha *[2]int32, anglerot *[3]float32, fLength *float32) {
-	if sys.tickNextFrame() {
-
+func (e *Explod) Interpolate(act bool,scale *[2]float32, alpha *[2]int32, anglerot *[3]float32, fLength *float32) {
+	if sys.tickNextFrame() && act {
 		if e.interpolate_time[1] > 0 {
 			e.interpolate_time[1]--
 		}
@@ -1388,7 +1387,6 @@ func (e *Explod) Interpolate(scale *[2]float32, alpha *[2]int32, anglerot *[3]fl
 				elem = Ceil(Lerp(float32(e.interpolate_animelem[1]-1),float32(e.interpolate_animelem[0]),t))		
 			}
 			e.animelem = Clamp(elem,Min(e.interpolate_animelem[0],e.interpolate_animelem[1]),Max(e.interpolate_animelem[0],e.interpolate_animelem[1]))
-			//e.setAnimElem()
 		}		
 		for i := 0; i < 3; i++ {
 			if i < 2 {
@@ -1447,15 +1445,17 @@ func (e *Explod) resetInterpolation(pfd *PalFXDef) {
 	for i := 0; i < 3; i++ {
 		for j := 0; j < 2; j++ {
 			v := (i+(j*3))
-			pfd.iadd[v] = pfd.add[i]
-			pfd.imul[v] = pfd.mul[i]
+			if e.ownpal {
+				pfd.iadd[v] = pfd.add[i]
+				pfd.imul[v] = pfd.mul[i]
+			}
 			e.interpolate_angle[v] = e.anglerot[i]		
 			if i < 2 {
 				v = (i+(j*2))
 				e.interpolate_pos[v] = 0
 				e.interpolate_scale[v] = e.scale[i]
 				e.interpolate_alpha[v] = e.alpha[i]	
-				if j == 0 {
+				if j == 0 && e.ownpal {
 					pfd.icolor[i] = pfd.color
 					pfd.ihue[i] = pfd.hue
 				}

--- a/src/common.go
+++ b/src/common.go
@@ -107,6 +107,16 @@ func AbsF(f float32) float32 {
 func Pow(x, y float32) float32 {
 	return float32(math.Pow(float64(x), float64(y)))
 }
+func Lerp(x, y, a float32) float32 {
+	//return float32(x + (y - x) * ClampF(a, 0, 1))
+	return float32((1 - a) * x + a * y)
+}
+func Ceil(x float32) int32 {
+	return int32(math.Ceil(float64(x)))
+}
+func Floor(x float32) int32 {
+	return int32(math.Floor(float64(x)))
+}
 func IsFinite(f float32) bool {
 	return math.Abs(float64(f)) <= math.MaxFloat64
 }

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -723,47 +723,47 @@ func (c *Compiler) explodSub(is IniSection,
 }
 func (c *Compiler) explodInterpolate(is IniSection,
 	sc *StateControllerBase) error {
-	if err := c.paramValue(is, sc, "interpolate.time",
+	if err := c.paramValue(is, sc, "interpolation.time",
 		explod_interpolate_time, VT_Int, 1, false); err != nil {
 		return err
 	}
-	if err := c.paramValue(is, sc, "interpolate.animelem",
+	if err := c.paramValue(is, sc, "interpolation.animelem",
 		explod_interpolate_animelem, VT_Int, 1, false); err != nil {
 		return err
 	}		
-	if err := c.paramValue(is, sc, "interpolate.scale",
+	if err := c.paramValue(is, sc, "interpolation.scale",
 		explod_interpolate_scale, VT_Float, 2, false); err != nil {
 		return err
 	}
-	if err := c.paramValue(is, sc, "interpolate.angle",
+	if err := c.paramValue(is, sc, "interpolation.angle",
 		explod_interpolate_angle, VT_Float, 3, false); err != nil {
 		return err
 	}
-	if err := c.paramValue(is, sc, "interpolate.alpha",
+	if err := c.paramValue(is, sc, "interpolation.alpha",
 		explod_interpolate_alpha, VT_Float, 2, false); err != nil {
 		return err
 	}
-	if err := c.paramValue(is, sc, "interpolate.offset",
+	if err := c.paramValue(is, sc, "interpolation.offset",
 		explod_interpolate_pos, VT_Float, 2, false); err != nil {
 		return err
 	}
-	if err := c.paramValue(is, sc, "interpolate.focallength",
+	if err := c.paramValue(is, sc, "interpolation.focallength",
 		explod_interpolate_focallength, VT_Float, 1, false); err != nil {
 		return err
 	}
-	if err := c.paramValue(is, sc, "interpolate.palfx.mul",
+	if err := c.paramValue(is, sc, "interpolation.palfx.mul",
 		explod_interpolate_pfx_mul, VT_Int, 3, false); err != nil {
 		return err
 	}
-	if err := c.paramValue(is, sc, "interpolate.palfx.add",
+	if err := c.paramValue(is, sc, "interpolation.palfx.add",
 		explod_interpolate_pfx_add, VT_Int, 3, false); err != nil {
 		return err
 	}
-	if err := c.paramValue(is, sc, "interpolate.palfx.color",
+	if err := c.paramValue(is, sc, "interpolation.palfx.color",
 		explod_interpolate_pfx_color, VT_Float, 1, false); err != nil {
 		return err
 	}
-	if err := c.paramValue(is, sc, "interpolate.palfx.hue",
+	if err := c.paramValue(is, sc, "interpolation.palfx.hue",
 		explod_interpolate_pfx_hue, VT_Float, 1, false); err != nil {
 		return err
 	}				
@@ -865,6 +865,10 @@ func (c *Compiler) modifyExplod(is IniSection, sc *StateControllerBase,
 			explod_focallength, VT_Float, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "interpolation",
+			explod_interpolation, VT_Bool, 1, false); err != nil {
+			return err
+		}		
 		if ihp == 0 {
 			sc.add(explod_ignorehitpause, sc.iToExp(0))
 		}

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -721,6 +721,54 @@ func (c *Compiler) explodSub(is IniSection,
 	}
 	return nil
 }
+func (c *Compiler) explodInterpolate(is IniSection,
+	sc *StateControllerBase) error {
+	if err := c.paramValue(is, sc, "interpolate.time",
+		explod_interpolate_time, VT_Int, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "interpolate.animelem",
+		explod_interpolate_animelem, VT_Int, 1, false); err != nil {
+		return err
+	}		
+	if err := c.paramValue(is, sc, "interpolate.scale",
+		explod_interpolate_scale, VT_Float, 2, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "interpolate.angle",
+		explod_interpolate_angle, VT_Float, 3, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "interpolate.alpha",
+		explod_interpolate_alpha, VT_Float, 2, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "interpolate.offset",
+		explod_interpolate_pos, VT_Float, 2, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "interpolate.focallength",
+		explod_interpolate_focallength, VT_Float, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "interpolate.palfx.mul",
+		explod_interpolate_pfx_mul, VT_Int, 3, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "interpolate.palfx.add",
+		explod_interpolate_pfx_add, VT_Int, 3, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "interpolate.palfx.color",
+		explod_interpolate_pfx_color, VT_Float, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "interpolate.palfx.hue",
+		explod_interpolate_pfx_hue, VT_Float, 1, false); err != nil {
+		return err
+	}				
+	return nil
+}
 func (c *Compiler) explod(is IniSection, sc *StateControllerBase,
 	ihp int8) (StateController, error) {
 	ret, err := (*explod)(sc), c.stateSec(is, func() error {
@@ -746,8 +794,8 @@ func (c *Compiler) explod(is IniSection, sc *StateControllerBase,
 			explod_animelem, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.paramValue(is, sc, "animelemlooped",
-			explod_animelemlooped, VT_Bool, 1, false); err != nil {
+		if err := c.paramValue(is, sc, "animfreeze",
+			explod_animfreeze, VT_Bool, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "angle",
@@ -766,6 +814,9 @@ func (c *Compiler) explod(is IniSection, sc *StateControllerBase,
 			explod_focallength, VT_Float, 1, false); err != nil {
 			return err
 		}
+		if err := c.explodInterpolate(is, sc); err != nil {
+			return err
+		}		
 		if ihp == 0 {
 			sc.add(explod_ignorehitpause, sc.iToExp(0))
 		}
@@ -794,8 +845,8 @@ func (c *Compiler) modifyExplod(is IniSection, sc *StateControllerBase,
 			explod_animelem, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.paramValue(is, sc, "animelemlooped",
-			explod_animelemlooped, VT_Bool, 1, false); err != nil {
+		if err := c.paramValue(is, sc, "animfreeze",
+			explod_animfreeze, VT_Bool, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "angle",

--- a/src/image.go
+++ b/src/image.go
@@ -37,6 +37,12 @@ type PalFXDef struct {
 	invertall   bool
 	invertblend int32
 	hue         float32
+	interpolate bool
+	iadd 		[6]int32
+	imul 		[6]int32
+	icolor 		[2]float32
+	ihue 		[2]float32
+	itime 		int32	
 }
 type PalFX struct {
 	PalFXDef
@@ -51,11 +57,17 @@ type PalFX struct {
 	eMul         [3]int32
 	eColor       float32
 	eHue         float32
+	eInterpolate bool
+	eiAdd 		 [3]int32
+	eiMul 		 [3]int32
+	eiColor 	 float32
+	eiHue 		 float32
+	eiTime 		 int32	
 }
 
 func newPalFX() *PalFX { return &PalFX{} }
 func (pf *PalFX) clear2(nt bool) {
-	pf.PalFXDef = PalFXDef{color: 1, mul: [...]int32{256, 256, 256}}
+	pf.PalFXDef = PalFXDef{color: 1, icolor: [...]float32{1,1}, mul: [...]int32{256, 256, 256}, imul: [...]int32{256, 256, 256, 256, 256, 256}}
 	pf.negType = nt
 	for i := 0; i < len(pf.sintime); i++ {
 		pf.sintime[i] = 0
@@ -205,13 +217,34 @@ func (pf *PalFX) sinHueshift(color *float32) {
 
 	}
 }
+func (pf *PalFX) interpolationUpdate() {
+	if pf.eiTime < pf.itime {
+		pf.eiTime++		
+	}
+	t := float32(pf.eiTime)/float32(pf.itime)
+	for i := 0; i < 3; i++ {
+		pf.eiMul[i] = int32(Lerp(float32(pf.imul[i+3]),float32(pf.imul[i]),t))
+		pf.eMul[i] = int32(float32(pf.eiMul[i])*float32(pf.mul[i])/256 )
+		pf.eiAdd[i] = int32(Lerp(float32(pf.iadd[i+3]),float32(pf.iadd[i]),t))
+		pf.eAdd[i] = pf.eiAdd[i]+pf.add[i]
+	}
+	pf.eiColor = Lerp(pf.icolor[1],pf.icolor[0],t)
+	pf.eColor = pf.eiColor*pf.color
+	pf.eiHue = Lerp(pf.ihue[1],pf.ihue[0],t)
+	pf.eHue = pf.eiHue+pf.hue
+}
 func (pf *PalFX) step() {
 	pf.enable = pf.time != 0
 	if pf.enable {
-		pf.eMul = pf.mul
-		pf.eAdd = pf.add
-		pf.eColor = pf.color
-		pf.eHue = pf.hue
+	pf.eInterpolate = pf.interpolate
+		if pf.eInterpolate { 
+			pf.interpolationUpdate()
+		} else {
+			pf.eMul = pf.mul
+			pf.eAdd = pf.add
+			pf.eColor = pf.color
+			pf.eHue = pf.hue
+		}
 		pf.eInvertall = pf.invertall
 		if pf.invertblend <= -2 && pf.eInvertall {
 			pf.eInvertblend = 3

--- a/src/render.go
+++ b/src/render.go
@@ -397,13 +397,10 @@ func renderWithBlending(render func(eq BlendEquation, src, dst BlendFunc, a floa
 			} else {
 				Blend = BlendAdd
 			}
-			if (invblend >= 2 || invblend <= -1) && acolor != nil && mcolor != nil && src < 255 {
+			if !isrgba && (invblend >= 2 || invblend <= -1) && acolor != nil && mcolor != nil && src < 255 {
 				//Summ of add components
 				gc := AbsF(acolor[0]) + AbsF(acolor[1]) + AbsF(acolor[2])
 				v3, ml, al := MaxF((gc*255)-float32(dst+src), 512)/128, (float32(src) / 255), (float32(src+dst) / 255)
-				if isrgba {
-					v3 = 1
-				}
 				rM, gM, bM := mcolor[0]*ml, mcolor[1]*ml, mcolor[2]*ml
 				(*mcolor)[0], (*mcolor)[1], (*mcolor)[2] = rM, gM, bM
 				render(Blend, blendSourceFactor, BlendOne, al*Pow(v3, 3))


### PR DESCRIPTION
Interpolation works just as the .air counterpart, interpolating linearly between 2 values.

The syntax is as follows:

Interpolation.<type>

Where <type> is one of: time, animElem, scale, alpha, angle, offset, focallenght

> Interpolation.Time is required for any of the parameters to work.

**time = duration (int)**
	Specifies the time period of the animation (if omitted, defaults to 0)
**animElem = elem_no (int)**
	Interpolation. the number of frames between AnimElem and Interpolation.AnimElem
	> if AnimElem is omitted, defaults to 1.
	> AnimFreeze will stop the animation from going further than Interpolation.AnimElem if
	Interpolation.Time exceeds RemoveTime.  
**alpha = alpha_source, alpha_dest (int, int)**
	Interpolation. between Alpha values and Interpolation.Alpha.
	> if Alpha is omitted, defaults to AS256D0. 
	> Sub and Add1 are not supported.
**angle = angle, xangle, yangle (float, float, float)**
	Interpolation. between Angle and Interpolation.Angle.
**offset = offset_x, offset_y (float, float)**
	Interpolation. between Pos and Interpolation.Offset.
**scale= scale_x, scale_y (float, float)**
	Interpolation. between scale and Interpolation.Scale.
**focalLenght = value(float)**
	Interpolation. between FocalLenght and Interpolation.FocalLenght.


Palfx is also compatible with the syntax:

Interpolation.PalFx.<type>

where <type> is one of: mul, add, hue, color

> PalFx.Time and OwnPal = 1 is required for any of the parameters to work.

**mul = mul_r, mul_g, mul_b (int, int, int)** 
	Interpolation. between PalFx.Mul values and Interpolation.PalFx.Mul.
	> If PalFx.Mul is omitted, defaults to 256, 256, 256.
**add = add_r, add_g, add_b (int, int, int)**
	Interpolation. between PalFx.Add values and Interpolation.PalFx.Add.
	> If PalFx.Add is omitted, defaults to 0, 0, 0.
**hue = value (int)**
	Interpolation. between PalFx.Hue value and Interpolation.PalFx.Hue.
	> If PalFx.Hue is omitted, defaults to 0.
**color = value (int)**
	Interpolation. between PalFx.Color value and Interpolation.PalFx.Color.
	> If PalFx.Color is omitted, defaults to 256.

These parameters can be used interchangeably.


Usage Examples:

Spinning object doing a full circle in a period of 60 ticks:
Angle = 0;
XAngle = 0;
YAngle = 0;
Interpolation.Time = 60;
Interpolation.Angle = 360, 0, 0;

Moving object from 0, 0 to 50, 0 in a period of 100 ticks:
Pos = 0, 0;
Interpolation.Time = 100;
Interpolation.OffSet = 50, 0;

Object fading out in 30 ticks:
Trans = AddAlpha;
Alpha = 256, 0;
Interpolation.Time = 30;
Interpolation.Alpha = 0, 256;

Object Changing from Blue to Red in 50 ticks:
PalFx.Time = 50;
PalFx.Mul = 0, 0, 256;
Interpolation.Time = 50;
Interpolation.PalFx.Mul = 256, 0, 0;

ModifyExplod:
**interpolation= value(bool)** 1-on, 0-off

Fix: Explods param called "Animelemlooped" was renamed to "Animfreeze"
