### PR TITLE
refactor: Corner Push, others

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -264,7 +264,6 @@ const (
 	OC_const_size_draw_offset_y
 	OC_const_size_z_width
 	OC_const_size_z_enable
-	OC_const_size_ignoreclsn2push
 	OC_const_velocity_walk_fwd_x
 	OC_const_velocity_walk_back_x
 	OC_const_velocity_walk_up_x
@@ -1600,8 +1599,6 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.size.z.width * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_z_enable:
 		sys.bcStack.PushB(c.size.z.enable)
-	case OC_const_size_ignoreclsn2push:
-		sys.bcStack.PushI(c.size.ignoreclsn2push)
 	case OC_const_velocity_walk_fwd_x:
 		sys.bcStack.PushF(c.gi().velocity.walk.fwd * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_walk_back_x:

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1555,8 +1555,6 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.append(OC_const_size_z_width)
 		case "size.z.enable":
 			out.append(OC_const_size_z_enable)
-		case "size.ignoreclsn2push":
-			out.append(OC_const_size_ignoreclsn2push)
 		case "velocity.walk.fwd.x":
 			out.append(OC_const_velocity_walk_fwd_x)
 		case "velocity.walk.back.x":
@@ -2906,6 +2904,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noailevel))
 		case "nointroreset":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nointroreset))
+		case "ignoreclsn2push":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_ignoreclsn2push))
 		case "immovable":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_immovable))
 		case "intro":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -141,6 +141,8 @@ func (c *Compiler) assertSpecial(is IniSection, sc *StateControllerBase, _ int8)
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_noailevel)))
 			case "nointroreset":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nointroreset)))
+			case "ignoreclsn2push":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_ignoreclsn2push)))
 			case "immovable":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_immovable)))
 			case "intro":

--- a/src/script.go
+++ b/src/script.go
@@ -2936,8 +2936,6 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.size.z.width)
 		case "size.z.enable":
 			ln = lua.LNumber(Btoi(c.size.z.enable))
-		case "size.ignoreclsn2push":
-			ln = lua.LNumber(c.size.ignoreclsn2push)
 		case "velocity.walk.fwd.x":
 			ln = lua.LNumber(c.gi().velocity.walk.fwd)
 		case "velocity.walk.back.x":
@@ -4195,6 +4193,8 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_noailevel)))
 		case "nointroreset":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_nointroreset)))
+		case "ignoreclsn2push":
+			l.Push(lua.LBool(sys.debugWC.asf(ASF_ignoreclsn2push)))
 		case "immovable":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_immovable)))
 		// GlobalSpecialFlag


### PR DESCRIPTION
Refactored Corner Push:
- Instead of only being checked at the moment a hit connects, the velocity offset is now saved and will only be applied when the target reaches the corner. This means hitting an opponent that's a bit away from the corner can still inflict corner push on the player, unlike Mugen. This change should in theory not break any Mugen characters, so it skips backwards compatibility checks
- If the character has IkemenVersion, corner push friction will depend on what the target is doing (standing, crouching, etc) like regular hits, instead of using a magic number
- With these changes, Ikemen's corner push is still not perfect but should be better than Mugen's

Other:
- For better compatibility, AssertCommand now enables the command in every list the character has, rather than only its own and the state owner's
- Guarding an attack with insufficient life to survive the guard damage will now count as if the attack were not guarded at all, as in Mugen and most games (fixes #1553)
- The "ignoreclsn2push" constant is now an AssertSpecial flag instead, for more flexibility