### PR TITLE
feat: MoveContactFrame, GetHitFrame triggers

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -563,6 +563,8 @@ const (
 	OC_ex_offset_y
 	OC_ex_alpha_s
 	OC_ex_alpha_d
+	OC_ex_movecontactframe
+	OC_ex_gethitframe
 )
 const (
 	NumVar     = 60
@@ -2332,6 +2334,10 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(c.alphaTrg[0])
 	case OC_ex_alpha_d:
 		sys.bcStack.PushI(c.alphaTrg[1])
+	case OC_ex_movecontactframe:
+		sys.bcStack.PushB(c.moveContactFrame)
+	case OC_ex_gethitframe:
+		sys.bcStack.PushB(c.getHitFrame)
 	default:
 		sys.errLog.Printf("%v\n", be[*i-1])
 		c.panic()

--- a/src/char.go
+++ b/src/char.go
@@ -1990,6 +1990,8 @@ type Char struct {
 	pauseBool       bool
 	downHitOffset   float32
 	koEchoTime      int32
+	moveContactFrame bool
+	getHitFrame     bool
 }
 
 func newChar(n int, idx int32) (c *Char) {
@@ -6253,6 +6255,8 @@ func (c *Char) actionRun() {
 			c.gi().pctime++
 		}
 		c.gi().projidcount = 0
+		c.moveContactFrame = false
+		c.getHitFrame = false
 	}
 	c.xScreenBound()
 	if !c.pauseBool {
@@ -7189,6 +7193,7 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 				getter.stchtmp = false
 			}
 			getter.setCSF(CSF_gethit)
+			getter.getHitFrame = true
 			live := getter.life > 0
 			getter.ghv.kill = hd.kill
 			if hitType == 2 {
@@ -7551,6 +7556,7 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 					sys.cgi[i].pctime = 0
 					sys.cgi[i].pcid = p.id
 					getter.hitdefContact = true
+					getter.moveContactFrame = true
 					continue
 				}
 				if !(getter.stchtmp && (getter.csf(CSF_gethit) || getter.acttmp > 0)) &&
@@ -7661,6 +7667,7 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 									getter.mctype = MC_Reversed
 									getter.mctime = -1
 									getter.hitdefContact = true
+									getter.moveContactFrame = true
 
 									fall, by := getter.ghv.fallf, getter.ghv.hitBy
 
@@ -7715,6 +7722,7 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 								c.hitdef.hitonce = -1
 							}
 							c.hitdefContact = true
+							c.moveContactFrame = true
 						}
 					}
 				}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -348,6 +348,7 @@ var triggerMap = map[string]int{
 	"float":              1,
 	"framespercount":     1,
 	"gamemode":           1,
+	"gethitframe":        1,
 	"getplayerid":        1,
 	"groundangle":        1,
 	"guardbreak":         1,
@@ -365,6 +366,7 @@ var triggerMap = map[string]int{
 	"max":                1,
 	"memberno":           1,
 	"min":                1,
+	"movecontactframe":   1,
 	"movecountered":      1,
 	"mugenversion":       1,
 	"offset":             1,
@@ -1728,6 +1730,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_gametime)
 	case "gamewidth":
 		out.append(OC_gamewidth)
+	case "gethitframe":
+		out.append(OC_ex_, OC_ex_gethitframe)
 	case "gethitvar":
 		if err := c.checkOpeningBracket(in); err != nil {
 			return bvNone(), err
@@ -1933,6 +1937,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_ex_, OC_ex_matchover)
 	case "movecontact":
 		out.append(OC_movecontact)
+	case "movecontactframe":
+		out.append(OC_ex_, OC_ex_movecontactframe)
 	case "moveguarded":
 		out.append(OC_moveguarded)
 	case "movehit":

--- a/src/script.go
+++ b/src/script.go
@@ -3140,6 +3140,10 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.debugWC.gameWidth()))
 		return 1
 	})
+	luaRegister(l, "gethitframe", func(*lua.LState) int {
+		l.Push(lua.LBool(sys.debugWC.getHitFrame))
+		return 1
+	})
 	luaRegister(l, "gethitvar", func(*lua.LState) int {
 		c := sys.debugWC
 		var ln lua.LNumber
@@ -3381,6 +3385,10 @@ func triggerFunctions(l *lua.LState) {
 	})
 	luaRegister(l, "movecontact", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.moveContact()))
+		return 1
+	})
+	luaRegister(l, "movecontactframe", func(*lua.LState) int {
+		l.Push(lua.LBool(sys.debugWC.moveContactFrame))
 		return 1
 	})
 	luaRegister(l, "moveguarded", func(*lua.LState) int {


### PR DESCRIPTION
- MoveContactFrame returns true only during the frame where a Hitdef/Reversaldef connects
- GetHitFrame returns true only during the frame where the character gets hit
- These are meant to facilitate codes that should only trigger the instant an attack connects