### PR TITLE
feat: SelfCommand trigger reimplementation

### DIFF
--- a/src/compiler.go
+++ b/src/compiler.go
@@ -390,6 +390,7 @@ var triggerMap = map[string]int{
 	"round":              1,
 	"roundtype":          1,
 	"scale":              1,
+	"selfcommand"         1,
 	"sign":               1,
 	"score":              1,
 	"scoretotal":         1,
@@ -1452,7 +1453,12 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_camerazoom)
 	case "canrecover":
 		out.append(OC_canrecover)
-	case "command":
+	case "command", "selfcommand":
+		opc := OC_command
+		if c.token == "selfcommand" {
+			out.append(OC_ex_)
+			opc = OC_ex_selfcommand
+		}
 		if err := eqne(func() error {
 			if err := text(); err != nil {
 				return err
@@ -1461,8 +1467,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			if !ok {
 				return Error("Command doesn't exist: " + c.token)
 			}
-			i := sys.stringPool[c.playerNo].Add(c.token)
-			out.appendI32Op(OC_command, int32(i))
+			out.appendI32Op(opc, int32(sys.stringPool[c.playerNo].Add(c.token)))
 			return nil
 		}); err != nil {
 			return bvNone(), err


### PR DESCRIPTION
This PR attempts to rework current `Command` trigger behavior by reimplenting an old idea from #789: `Selfcommand` trigger.

So, right now, Command trigger has two different behaviors depending on Ikemenversion flag.

- If Ikemenversion is 0, then commands are checked by name on the targeted player command list. So, for example, if we do `enemy,command = "block"` and the enemy's command for block is `$F, a`, and the enemy does `$F, a`, it will eval to 1.
- If Ikemenversion is distinct from 0, then commands are first checked by name on the targeted player command list, and if that returns false, then they're checked by name on the state owner command list.

This implementation is flawed, because, if we want to just check if someone else performe a command from our own command list, we won't be able to if the other player performs a command of its own by the same name.

This situation necessitates a return to the previous separation between checking commands from the targeted player's command list and the state owner's command list through different triggers, so that's why `selfcommand` as a reimplementation is proposed to solve this issue.

Following this, some additional rework has been done to `command` trigger to improve its backwards compatibility with MUGEN 1.1 behavior. In MUGEN 1.1, commands are checked by command position in the command list, as opposed to by name. The only exception to this rule is "recovery" command, which is always checked by name, no matter which player we're targeting.

So, for example, if P1 has a "blocking" command positioned 5th on its own command list, when attempting to check that on P2 through `enemy,command = "blocking"`, it will check whatever command P2 has on the 5th position of its own command list. So, if P2 has "movefwd" in that position and it's performing it, then it will return 1.

Of course, this is also kind of a flawed implementation due to its impracticity, that's why I also added an exception through Ikemenversion flag where, if it's > 0, commands will be checked by name on the targeted player rather than by position on the list. `Selfcommand` will always check commands by name, no matter Ikemenversion value.