### PR TITLE
feat: AssertSpecial AnimateHitpause, other fixes and refactoring

### DIFF
--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2893,6 +2893,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nopowerbardisplay))
 		case "autoguard":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_autoguard))
+		case "animatehitpause":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_animatehitpause))
 		case "animfreeze":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_animfreeze))
 		case "postroundinput":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -117,6 +117,8 @@ func (c *Compiler) assertSpecial(is IniSection, sc *StateControllerBase, _ int8)
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nopowerbardisplay)))
 			case "autoguard":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_autoguard)))
+			case "animatehitpause":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_animatehitpause)))
 			case "animfreeze":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_animfreeze)))
 			case "postroundinput":

--- a/src/script.go
+++ b/src/script.go
@@ -4191,6 +4191,8 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_nopowerbardisplay)))
 		case "autoguard":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_autoguard)))
+		case "animatehitpause":
+			l.Push(lua.LBool(sys.debugWC.asf(ASF_animatehitpause)))
 		case "animfreeze":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_animfreeze)))
 		case "postroundinput":

--- a/src/system.go
+++ b/src/system.go
@@ -1885,8 +1885,10 @@ func (s *System) fight() (reload bool) {
 				/* If round 1 or a new character in turns mode, initialize values */
 				if p[0].ocd().life != -1 {
 					p[0].life = Clamp(p[0].ocd().life, 0, p[0].lifeMax)
+					p[0].redLife = p[0].life
 				} else {
 					p[0].life = p[0].lifeMax
+					p[0].redLife = p[0].lifeMax
 				}
 				if s.round == 1 {
 					if s.maxPowerMode {
@@ -1920,7 +1922,6 @@ func (s *System) fight() (reload bool) {
 			} else {
 				p[0].dizzyPoints = p[0].dizzyPointsMax
 			}
-			p[0].redLife = p[0].lifeMax
 			copyVar(i)
 		}
 	}


### PR DESCRIPTION
- When asserted, this flag makes the character's animation advance normally during a hitpause

Fixes:
- Fixed AssertCommand loop sometimes breaking early
- Ported #1559 from the release build
- If two attacks hit in the same frame and one kills but the other doesn't, they will always kill (fixes a bug posted on Discord)
- Minor adjustments to KO behavior