### PR TITLE
feat: RescaleClsn and GuardCount

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5114,6 +5114,7 @@ const (
 	projectile_accel
 	projectile_projscale
 	projectile_projangle
+	projectile_projrescaleclsn
 	projectile_offset
 	projectile_projsprpriority
 	projectile_projstagebound
@@ -5139,6 +5140,7 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 	pt := PT_P1
 	var x, y float32 = 0, 0
 	op := false
+	rc := false
 	rp := [...]int32{-1, 0}
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		if p == nil {
@@ -5259,6 +5261,8 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 			if len(exp) > 1 {
 				rp[1] = exp[1].evalI(c)
 			}
+		case projectile_projrescaleclsn:
+			rc = exp[0].evalB(c)
 		// case projectile_platform:
 		// 	p.platform = exp[0].evalB(c)
 		// case projectile_platformwidth:
@@ -5305,7 +5309,7 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 	} else {
 		p.localscl = crun.localscl
 	}
-	crun.projInit(p, pt, x, y, op, rp[0], rp[1])
+	crun.projInit(p, pt, x, y, op, rp[0], rp[1], rc)
 	return false
 }
 
@@ -6378,6 +6382,7 @@ type angleDraw StateControllerBase
 const (
 	angleDraw_value byte = iota
 	angleDraw_scale
+	angleDraw_rescaleClsn
 	angleDraw_redirectid
 )
 
@@ -6393,6 +6398,12 @@ func (sc angleDraw) Run(c *Char, _ []int32) bool {
 			if len(exp) > 1 {
 				crun.angleScale[1] *= exp[1].evalF(c)
 				crun.angleScaleTrg[1] = crun.angleScale[1]
+			}
+		case angleDraw_rescaleClsn:
+			if exp[0].evalB(c) {
+				crun.clsnScale[0] *= crun.angleScale[0]
+				crun.clsnScale[1] *= crun.angleScale[1]
+				crun.angleRescaleClsn = true
 			}
 		case angleDraw_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -465,6 +465,7 @@ const (
 	OC_ex_gethitvar_guardpower
 	OC_ex_gethitvar_kill
 	OC_ex_gethitvar_priority
+	OC_ex_gethitvar_guardcount
 	OC_ex_ailevelf
 	OC_ex_animelemlength
 	OC_ex_animframe_alphadest
@@ -566,6 +567,7 @@ const (
 	OC_ex_movecontactframe
 	OC_ex_gethitframe
 	OC_ex_selfcommand
+	OC_ex_guardcount
 )
 const (
 	NumVar     = 60
@@ -1953,6 +1955,9 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(int32(c.ghv.groundtype))
 	case OC_ex_gethitvar_damage:
 		sys.bcStack.PushI(c.ghv.damage)
+
+	case OC_ex_gethitvar_guardcount:
+		sys.bcStack.PushI(c.ghv.guardcount)
 	case OC_ex_gethitvar_hitcount:
 		sys.bcStack.PushI(c.ghv.hitcount)
 	case OC_ex_gethitvar_fallcount:
@@ -2348,6 +2353,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 			sys.bcStack.PushB(ok)
 		}
 		*i += 4
+	case OC_ex_guardcount:
+		sys.bcStack.PushI(c.guardCount)
 	default:
 		sys.errLog.Printf("%v\n", be[*i-1])
 		c.panic()

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -230,6 +230,7 @@ var triggerMap = map[string]int{
 	"gametime":          1,
 	"gamewidth":         1,
 	"gethitvar":         1,
+	"guardcount":        1,
 	"helpername":        1,
 	"hitcount":          1,
 	"hitdefattr":        1,
@@ -1769,6 +1770,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				out.append(OC_ex_gethitvar_groundtype)
 			case "damage":
 				out.append(OC_ex_gethitvar_damage)
+			case "guardcount":
+				out.append(OC_ex_gethitvar_guardcount)
 			case "hitcount":
 				out.append(OC_ex_gethitvar_hitcount)
 			case "fallcount":
@@ -1859,6 +1862,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		if err := c.checkClosingBracket(); err != nil {
 			return bvNone(), err
 		}
+	case "guardcount":
+		out.append(OC_ex_, OC_ex_guardcount)
 	case "hitcount":
 		out.append(OC_hitcount)
 	case "hitdefattr":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1866,6 +1866,10 @@ func (c *Compiler) projectile(is IniSection, sc *StateControllerBase,
 			projectile_projangle, VT_Float, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "projrescaleclsn",
+			projectile_projrescaleclsn, VT_Bool, 1, false); err != nil {
+			return err
+		}
 
 		// hitdef部分
 		if err := c.hitDefSub(is, sc); err != nil {
@@ -2888,6 +2892,10 @@ func (c *Compiler) angleDraw(is IniSection, sc *StateControllerBase, _ int8) (St
 		}
 		if err := c.paramValue(is, sc, "scale",
 			angleDraw_scale, VT_Float, 2, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "rescaleclsn",
+			angleDraw_rescaleClsn, VT_Bool, 1, false); err != nil {
 			return err
 		}
 		return nil

--- a/src/script.go
+++ b/src/script.go
@@ -3172,6 +3172,8 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.ghv.groundtype)
 		case "damage":
 			ln = lua.LNumber(c.ghv.damage)
+		case "guardcount":
+			ln = lua.LNumber(c.ghv.guardcount)
 		case "hitcount":
 			ln = lua.LNumber(c.ghv.hitcount)
 		case "fallcount":
@@ -3258,6 +3260,10 @@ func triggerFunctions(l *lua.LState) {
 			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}
 		l.Push(ln)
+		return 1
+	})
+	luaRegister(l, "guardcount", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.guardCount))
 		return 1
 	})
 	luaRegister(l, "hitcount", func(*lua.LState) int {


### PR DESCRIPTION
Two parameters added for resizing the collision boxes when a character or projectile is resized:
- RescaleClsn in AngleDraw
- ProjRescaleClsn in Projectile
- Both are booleans

GuardCount and GetHitVar(GuardCount) triggers:
- Similar to HitCount, but they keep track of guarded hits