### PR TITLE
feat: unhardcoded minimum guard distance

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -250,10 +250,12 @@ const (
 	OC_const_size_height_air_top
 	OC_const_size_height_air_bottom
 	OC_const_size_height_down
-	OC_const_size_attack_dist
+	OC_const_size_attack_dist_front
+	OC_const_size_attack_dist_back
 	OC_const_size_attack_z_width_back
 	OC_const_size_attack_z_width_front
-	OC_const_size_proj_attack_dist
+	OC_const_size_proj_attack_dist_front
+	OC_const_size_proj_attack_dist_back
 	OC_const_size_proj_doscale
 	OC_const_size_head_pos_x
 	OC_const_size_head_pos_y
@@ -1578,14 +1580,18 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.size.height.air[1] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_height_down:
 		sys.bcStack.PushF(c.size.height.down * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_size_attack_dist:
-		sys.bcStack.PushF(c.size.attack.dist * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_size_attack_dist_front:
+		sys.bcStack.PushF(c.size.attack.dist.front * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_size_attack_dist_back:
+		sys.bcStack.PushF(c.size.attack.dist.back * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_attack_z_width_back:
 		sys.bcStack.PushF(c.size.attack.z.width[1] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_attack_z_width_front:
 		sys.bcStack.PushF(c.size.attack.z.width[0] * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_size_proj_attack_dist:
-		sys.bcStack.PushF(c.size.proj.attack.dist * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_size_proj_attack_dist_front:
+		sys.bcStack.PushF(c.size.proj.attack.dist.front * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_size_proj_attack_dist_back:
+		sys.bcStack.PushF(c.size.proj.attack.dist.back * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_proj_doscale:
 		sys.bcStack.PushI(c.size.proj.doscale)
 	case OC_const_size_head_pos_x:
@@ -4719,6 +4725,7 @@ const (
 	hitDef_ground_hittime
 	hitDef_guard_hittime
 	hitDef_guard_dist
+	hitDef_guard_dist_back
 	hitDef_pausetime
 	hitDef_guard_pausetime
 	hitDef_air_velocity
@@ -4938,7 +4945,9 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 	case hitDef_guard_hittime:
 		hd.guard_hittime = exp[0].evalI(c)
 	case hitDef_guard_dist:
-		hd.guard_dist = exp[0].evalI(c)
+		hd.guard_dist[0] = exp[0].evalI(c)
+	case hitDef_guard_dist_back:
+		hd.guard_dist[1] = exp[0].evalI(c)
 	case hitDef_pausetime:
 		hd.pausetime = exp[0].evalI(c)
 		hd.guard_pausetime = hd.pausetime
@@ -6672,6 +6681,7 @@ type attackDist StateControllerBase
 
 const (
 	attackDist_value byte = iota
+	attackDist_back
 	attackDist_redirectid
 )
 
@@ -6681,7 +6691,9 @@ func (sc attackDist) Run(c *Char, _ []int32) bool {
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case attackDist_value:
-			crun.attackDist = exp[0].evalF(c) * lclscround
+			crun.attackDist[0] = exp[0].evalF(c) * lclscround
+		case attackDist_back:
+			crun.attackDist[1] = exp[0].evalF(c) * lclscround
 		case attackDist_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1535,14 +1535,18 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.append(OC_const_size_height_air_bottom)
 		case "size.height.down":
 			out.append(OC_const_size_height_down)
-		case "size.attack.dist":
-			out.append(OC_const_size_attack_dist)
+		case "size.attack.dist", "size.attack.dist.front":
+			out.append(OC_const_size_attack_dist_front)
+		case "size.attack.dist.back":
+			out.append(OC_const_size_attack_dist_back)
 		case "size.attack.z.width.back":
 			out.append(OC_const_size_attack_z_width_back)
 		case "size.attack.z.width.front":
 			out.append(OC_const_size_attack_z_width_front)
-		case "size.proj.attack.dist":
-			out.append(OC_const_size_proj_attack_dist)
+		case "size.proj.attack.dist", "size.proj.attack.dist.front":
+			out.append(OC_const_size_proj_attack_dist_front)
+		case "size.proj.attack.dist.back":
+			out.append(OC_const_size_proj_attack_dist_back)
 		case "size.proj.doscale":
 			out.append(OC_const_size_proj_doscale)
 		case "size.head.pos.x":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1605,6 +1605,10 @@ func (c *Compiler) hitDefSub(is IniSection,
 		hitDef_guard_dist, VT_Int, 1, false); err != nil {
 		return err
 	}
+	if err := c.paramValue(is, sc, "guard.dist.back",
+		hitDef_guard_dist_back, VT_Int, 1, false); err != nil {
+		return err
+	}
 	if err := c.paramValue(is, sc, "pausetime",
 		hitDef_pausetime, VT_Int, 2, false); err != nil {
 		return err
@@ -3079,6 +3083,10 @@ func (c *Compiler) attackDist(is IniSection, sc *StateControllerBase, _ int8) (S
 		}
 		if err := c.paramValue(is, sc, "value",
 			attackDist_value, VT_Float, 1, true); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "back",
+			attackDist_back, VT_Float, 1, false); err != nil {
 			return err
 		}
 		return nil

--- a/src/script.go
+++ b/src/script.go
@@ -2898,7 +2898,7 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.size.air.back)
 		case "size.air.front":
 			ln = lua.LNumber(c.size.air.front)
-		case "size.height":
+		case "size.height", "size.height.stand":
 			ln = lua.LNumber(c.size.height.stand)
 		case "size.height.crouch":
 			ln = lua.LNumber(c.size.height.crouch)
@@ -2908,14 +2908,18 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.size.height.air[1])
 		case "size.height.down":
 			ln = lua.LNumber(c.size.height.down)
-		case "size.attack.dist":
-			ln = lua.LNumber(c.size.attack.dist)
+		case "size.attack.dist", "size.attack.dist.front":
+			ln = lua.LNumber(c.size.attack.dist.front)
+		case "size.attack.dist.back":
+			ln = lua.LNumber(c.size.attack.dist.back)
 		case "size.attack.z.width.back":
 			ln = lua.LNumber(c.size.attack.z.width[1])
 		case "size.attack.z.width.front":
 			ln = lua.LNumber(c.size.attack.z.width[0])
-		case "size.proj.attack.dist":
-			ln = lua.LNumber(c.size.proj.attack.dist)
+		case "size.proj.attack.dist", "size.proj.attack.dist.front":
+			ln = lua.LNumber(c.size.proj.attack.dist.front)
+		case "size.proj.attack.dist.back":
+			ln = lua.LNumber(c.size.proj.attack.dist.back)
 		case "size.proj.doscale":
 			ln = lua.LNumber(c.size.proj.doscale)
 		case "size.head.pos.x":


### PR DESCRIPTION
- In addition to maximum guard distance, chars can now also specify minimum guard distance instead of having it hardcoded to be 0
- In Hitdef/Projectile it is specified by the new "guard.dist.back" parameter
- In the AttackDist sctrl it can be specified with the new "back" parameter
- New char constants of "size.attack.dist.back" and "size.proj.attack.dist.back" added to control the default values
- These parameters all take positive values. Meaning for instance "guard.dist.back = 50" allows the enemy to guard up to 50 pixels behind the player