### PR TITLE
feat: GetHitVar(power); Projectile and KO fixes

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -463,6 +463,7 @@ const (
 	OC_ex_gethitvar_score
 	OC_ex_gethitvar_hitdamage
 	OC_ex_gethitvar_guarddamage
+	OC_ex_gethitvar_power
 	OC_ex_gethitvar_hitpower
 	OC_ex_gethitvar_guardpower
 	OC_ex_gethitvar_kill
@@ -2038,6 +2039,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(c.ghv.hitdamage)
 	case OC_ex_gethitvar_guarddamage:
 		sys.bcStack.PushI(c.ghv.guarddamage)
+	case OC_ex_gethitvar_power:
+		sys.bcStack.PushI(c.ghv.power)
 	case OC_ex_gethitvar_hitpower:
 		sys.bcStack.PushI(c.ghv.hitpower)
 	case OC_ex_gethitvar_guardpower:

--- a/src/char.go
+++ b/src/char.go
@@ -6394,8 +6394,8 @@ func (c *Char) update(cvmin, cvmax,
 				}
 			}
 		}
-		if c.acttmp > 0 && c.ss.moveType != MT_H || c.roundState() == 2 &&
-			c.scf(SCF_ko) && c.scf(SCF_over) {
+		// https://github.com/ikemen-engine/Ikemen-GO/issues/1592
+		if c.acttmp > 0 && c.ss.moveType != MT_H || c.ss.no == 5150 {
 			c.exitTarget(true)
 		}
 		c.platformPosY = 0
@@ -6747,9 +6747,6 @@ func (c *Char) cueDraw() {
 		}
 	}
 	if sys.tickNextFrame() {
-		if c.roundState() == 4 {
-			c.exitTarget(false)
-		}
 		if sys.supertime < 0 && c.teamside != sys.superplayer&1 {
 			c.superDefenseMul *= sys.superp2defmul
 		}

--- a/src/char.go
+++ b/src/char.go
@@ -768,6 +768,7 @@ type GetHitVar struct {
 	score          float32
 	hitdamage      int32
 	guarddamage    int32
+	power          int32
 	hitpower       int32
 	guardpower     int32
 	hitredlife     int32
@@ -6217,6 +6218,7 @@ func (c *Char) actionRun() {
 		}
 		c.ghv.hitdamage = 0
 		c.ghv.guarddamage = 0
+		c.ghv.power = 0
 		c.ghv.hitpower = 0
 		c.ghv.guardpower = 0
 		if c.ghv.dizzypoints != 0 {
@@ -7020,6 +7022,7 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 				byf *= -1
 			}
 		}
+		// HitDef connects
 		if hitType > 0 {
 			if hitType == 1 {
 				if ch := getter.soundChannels.Get(0); ch != nil {
@@ -7036,10 +7039,17 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 				cmb := (getter.ss.moveType == MT_H || getter.csf(CSF_gethit)) &&
 					!ghv.guarded
 				// Save existing hit information
-				fall, hc, gc, fc, by, dmg := ghv.fallf, ghv.hitcount, ghv.guardcount, ghv.fallcount, ghv.hitBy, ghv.damage
+				dmg, hdmg, gdmg := ghv.damage, ghv.hitdamage, ghv.guarddamage
+				pwr, hpwr, gpwr := ghv.power, ghv.hitpower, ghv.guardpower
+				fall, hc, gc, fc, by := ghv.fallf, ghv.hitcount, ghv.guardcount, ghv.fallcount, ghv.hitBy
 				ghv.clear()
 				ghv.hitBy = by
 				ghv.damage = dmg
+				ghv.hitdamage = hdmg
+				ghv.guarddamage = gdmg
+				ghv.power = pwr
+				ghv.hitpower = hpwr
+				ghv.guardpower = gpwr
 				ghv.attr = hd.attr
 				ghv.hitid = hd.id
 				ghv.playerNo = hd.playerNo
@@ -7378,6 +7388,7 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 				c.powerAdd(hd.hitgetpower)
 				if getter.player {
 					getter.powerAdd(hd.hitgivepower)
+					getter.ghv.power += hd.hitgivepower
 				}
 				if getter.ss.moveType == MT_A {
 					c.counterHit = true
@@ -7414,6 +7425,7 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 				c.powerAdd(hd.guardgetpower)
 				if getter.player {
 					getter.powerAdd(hd.guardgivepower)
+					getter.ghv.power += hd.guardgivepower
 				}
 			}
 		}
@@ -7713,6 +7725,7 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 						dist >= -float32(c.hitdef.guard_dist[1]) {
 						getter.inguarddist = true
 					}
+					// ReversalDef connects
 					if getter.hitCheck(c) {
 						if ht := hit(c, &c.hitdef, [2]float32{}, 0, c.attackMul, 1); ht != 0 {
 							mvh := ht > 0 || c.hitdef.reversal_attr > 0
@@ -7766,6 +7779,7 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 									c.hitPauseTime = Max(1, c.hitdef.pausetime+
 										Btoi(c.gi().mugenver[0] == 1))
 								}
+								c.powerAdd(c.hitdef.hitgetpower)
 								c.uniqHitCount++
 							} else {
 								if mvh {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1850,6 +1850,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				out.append(OC_ex_gethitvar_hitdamage)
 			case "guarddamage":
 				out.append(OC_ex_gethitvar_guarddamage)
+			case "power":
+				out.append(OC_ex_gethitvar_power)
 			case "hitpower":
 				out.append(OC_ex_gethitvar_hitpower)
 			case "guardpower":

--- a/src/script.go
+++ b/src/script.go
@@ -3252,6 +3252,8 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.ghv.hitdamage)
 		case "guarddamage":
 			ln = lua.LNumber(c.ghv.guarddamage)
+		case "power":
+			ln = lua.LNumber(c.ghv.power)
 		case "hitpower":
 			ln = lua.LNumber(c.ghv.hitpower)
 		case "guardpower":


### PR DESCRIPTION
- Added GetHitVar(Power) trigger to return power received from last hit, regardless of getting hit or guarding
- Refactored Projectile code a bit to further improve backwards compatibility (Fixes #1512)

- Like Mugen, targets now exit target lists when they are specifically in state 5150, rather than RoundState 4 (Fixes #1592)