### PR TITLE
feat: Lua start.f_selectReset hook entry point

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -415,6 +415,7 @@ main.font_def = {}
 -- * start.f_continue: start.lua 'f_continue' function (pre layerno=1)
 -- * start.f_hiscore: start.lua 'f_hiscore' function (pre layerno=1)
 -- * start.f_challenger: start.lua 'f_challenger' function (pre layerno=1)
+-- * start.f_selectReset: start.lua 'f_selectReset' function (before returning)
 -- More entry points may be added in future - let us know if your external
 -- module needs to hook code in place where it's not allowed yet.
 

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -1599,6 +1599,7 @@ function start.f_selectReset(hardReset)
 	end
 	t_recordText = start.f_getRecordText()
 	menu.movelistChar = 1
+	hook.run("start.f_selectReset")
 end
 
 function start.f_selectChallenger()


### PR DESCRIPTION
Adds `start.f_selectReset` as an entry point in the Lua hook system, which handles the resetting of several variables when selecting a menu item and other events.