### PR TITLE
fix: button jamming, animation debugging, PrevMoveType

### DIFF
--- a/data/training.zss
+++ b/data/training.zss
@@ -158,15 +158,27 @@ ignoreHitPause if gameMode != "training" || isHelper || teamSide != 2 {
 			if map(_iksys_trainingDirection) = 1 && command != "holdback" {
 				if facing = 1 {
 					assertInput{flag: R}
+					for i = 1; numhelper; 1 {
+						assertInput{flag: R; redirectID: helperindex($i), ID}
+					}
 				} else {
 					assertInput{flag: L}
+					for i = 1; numhelper; 1 {
+						assertInput{flag: L; redirectID: helperindex($i), ID}
+					}
 				}
 			# if dummy should move backward and player is not trying to move dummy forward
 			} else if map(_iksys_trainingDirection) = -1 && command != "holdfwd" {
 				if facing = 1 {
 					assertInput{flag: L}
+					for i = 1; numhelper; 1 {
+						assertInput{flag: L; redirectID: helperindex($i), ID}
+					}
 				} else {
 					assertInput{flag: R}
+					for i = 1; numhelper; 1 {
+						assertInput{flag: R; redirectID: helperindex($i), ID}
+					}
 				}
 			}
 		} else {
@@ -175,13 +187,22 @@ ignoreHitPause if gameMode != "training" || isHelper || teamSide != 2 {
 			# Crouch
 			case 1:
 				assertInput{flag: D}
+				for i = 1; numhelper; 1 {
+					assertInput{flag: D; redirectID: helperindex($i), ID}
+				}
 			# Jump
 			case 2:
 				assertInput{flag: U}
+				for i = 1; numhelper; 1 {
+					assertInput{flag: U; redirectID: helperindex($i), ID}
+				}
 			# W Jump
 			case 3:
 				if vel y >= 0 {
 					assertInput{flag: U}
+					for i = 1; numhelper; 1 {
+						assertInput{flag: U; redirectID: helperindex($i), ID}
+					}
 				}
 			default:
 				# Do nothing
@@ -195,22 +216,49 @@ ignoreHitPause if gameMode != "training" || isHelper || teamSide != 2 {
 					switch map(_iksys_trainingButtonJam) {
 					case 1:
 						assertInput{flag: a}
+						for i = 1; numhelper; 1 {
+							assertInput{flag: a; redirectID: helperindex($i), ID}
+						}
 					case 2:
 						assertInput{flag: b}
+						for i = 1; numhelper; 1 {
+							assertInput{flag: b; redirectID: helperindex($i), ID}
+						}
 					case 3:
 						assertInput{flag: c}
+						for i = 1; numhelper; 1 {
+							assertInput{flag: c; redirectID: helperindex($i), ID}
+						}
 					case 4:
 						assertInput{flag: x}
+						for i = 1; numhelper; 1 {
+							assertInput{flag: x; redirectID: helperindex($i), ID}
+						}
 					case 5:
 						assertInput{flag: y}
+						for i = 1; numhelper; 1 {
+							assertInput{flag: y; redirectID: helperindex($i), ID}
+						}
 					case 6:
 						assertInput{flag: z}
+						for i = 1; numhelper; 1 {
+							assertInput{flag: z; redirectID: helperindex($i), ID}
+						}
 					case 7:
 						assertInput{flag: s}
+						for i = 1; numhelper; 1 {
+							assertInput{flag: s; redirectID: helperindex($i), ID}
+						}
 					case 8:
 						assertInput{flag: d}
+						for i = 1; numhelper; 1 {
+							assertInput{flag: d; redirectID: helperindex($i), ID}
+						}
 					case 9:
 						assertInput{flag: w}
+						for i = 1; numhelper; 1 {
+							assertInput{flag: w; redirectID: helperindex($i), ID}
+						}
 					default:
 						map(_iksys_trainingButtonJamDelay) := 0;
 					}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -9136,11 +9136,15 @@ func (sb *StateBytecode) init(c *Char) {
 		c.ss.changeStateType(sb.stateType)
 	}
 	if sb.moveType != MT_U {
-		c.ss.changeMoveType(sb.moveType)
+		if !c.ss.storeMoveType {
+			c.ss.prevMoveType = c.ss.moveType
+		}
+		c.ss.moveType = sb.moveType
 	}
 	if sb.physics != ST_U {
 		c.ss.physics = sb.physics
 	}
+	c.ss.storeMoveType = false
 	sys.workingState = sb
 	sb.stateDef.Run(c)
 }

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3875,7 +3875,7 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 			if ffx != "" && ffx != "s" {
 				e.ownpal = true
 			}
-			e.anim = crun.getAnim(exp[1].evalI(c), ffx, false)
+			e.anim = crun.getAnim(exp[1].evalI(c), ffx, true)
 		case explod_ownpal:
 			e.ownpal = exp[0].evalB(c)
 		case explod_remappal:
@@ -4360,7 +4360,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				})
 			case explod_anim:
 				if c.stCgi().ikemenver[0] > 0 || c.stCgi().ikemenver[1] > 0 {
-					anim := crun.getAnim(exp[1].evalI(c), string(*(*[]byte)(unsafe.Pointer(&exp[0]))), false)
+					anim := crun.getAnim(exp[1].evalI(c), string(*(*[]byte)(unsafe.Pointer(&exp[0]))), true)
 					eachExpl(func(e *Explod) { e.anim = anim })
 				}
 			case explod_animelem:
@@ -4490,7 +4490,7 @@ func (sc gameMakeAnim) Run(c *Char, _ []int32) bool {
 		case gameMakeAnim_under:
 			e.ontop = !exp[0].evalB(c)
 		case gameMakeAnim_anim:
-			e.anim = crun.getAnim(exp[1].evalI(c), string(*(*[]byte)(unsafe.Pointer(&exp[0]))), false)
+			e.anim = crun.getAnim(exp[1].evalI(c), string(*(*[]byte)(unsafe.Pointer(&exp[0]))), true)
 		}
 		return true
 	})
@@ -6229,7 +6229,7 @@ func (sc superPause) Run(c *Char, _ []int32) bool {
 	crun := c
 	var t, mt int32 = 30, 0
 	uh := true
-	sys.superanim, sys.superpmap.remap = crun.getAnim(100, "f", false), nil
+	sys.superanim, sys.superpmap.remap = crun.getAnim(100, "f", true), nil
 	sys.superpos, sys.superfacing = [...]float32{crun.pos[0] * crun.localscl, crun.pos[1] * crun.localscl}, crun.facing
 	sys.superpausebg, sys.superendcmdbuftime, sys.superdarken = true, 0, true
 	sys.superp2defmul = crun.gi().constants["super.targetdefencemul"]
@@ -6247,7 +6247,7 @@ func (sc superPause) Run(c *Char, _ []int32) bool {
 			sys.superdarken = exp[0].evalB(c)
 		case superPause_anim:
 			ffx := string(*(*[]byte)(unsafe.Pointer(&exp[0])))
-			if sys.superanim = crun.getAnim(exp[1].evalI(c), ffx, false); sys.superanim != nil {
+			if sys.superanim = crun.getAnim(exp[1].evalI(c), ffx, true); sys.superanim != nil {
 				if ffx != "" && ffx != "s" {
 					sys.superpmap.remap = nil
 				} else {
@@ -6280,7 +6280,7 @@ func (sc superPause) Run(c *Char, _ []int32) bool {
 		case superPause_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				sys.superanim, sys.superpmap.remap = crun.getAnim(30, "f", false), nil
+				sys.superanim, sys.superpmap.remap = crun.getAnim(30, "f", true), nil
 				sys.superpos, sys.superfacing = [...]float32{crun.pos[0] * crun.localscl, crun.pos[1] * crun.localscl}, crun.facing
 			} else {
 				return false

--- a/src/char.go
+++ b/src/char.go
@@ -2827,7 +2827,7 @@ func (c *Char) setJuggle(juggle int32) {
 	c.juggle = juggle
 }
 func (c *Char) changeAnimEx(animNo int32, playerNo int, ffx string, alt bool) {
-	if a := sys.chars[playerNo][0].getAnim(animNo, ffx, true); a != nil {
+	if a := sys.chars[playerNo][0].getAnim(animNo, ffx, false); a != nil {
 		c.anim = a
 		c.anim.remap = c.remapSpr
 		c.animPN = c.playerNo
@@ -3586,7 +3586,7 @@ func (c *Char) playSound(ffx string, lowpriority, loop bool, g, n, chNo, vol int
 	if s == nil {
 		if log {
 			if ffx != "" {
-				sys.appendToConsole(c.warn() + fmt.Sprintf("%v sound %v,%v doesn't exist", strings.ToUpper(ffx), g, n))
+				sys.appendToConsole(c.warn() + fmt.Sprintf("sound %v %v,%v doesn't exist", strings.ToUpper(ffx), g, n))
 			} else {
 				sys.appendToConsole(c.warn() + fmt.Sprintf("sound %v,%v doesn't exist", g, n))
 			}
@@ -4058,7 +4058,7 @@ func (c *Char) enemyExplodsRemove(en int) {
 	remove(&sys.topexplDrawlist[en], false)
 	remove(&sys.underexplDrawlist[en], true)
 }
-func (c *Char) getAnim(n int32, ffx string, log bool) (a *Animation) {
+func (c *Char) getAnim(n int32, ffx string, fx bool) (a *Animation) {
 	if n == -2 {
 		return &Animation{}
 	}
@@ -4073,9 +4073,15 @@ func (c *Char) getAnim(n int32, ffx string, log bool) (a *Animation) {
 		a = c.gi().anim.get(n)
 	}
 	if a == nil {
-		if log {
+		if fx {
 			if ffx != "" && ffx != "s" {
-				sys.appendToConsole(c.warn() + fmt.Sprintf("changed to invalid %v action %v", strings.ToUpper(ffx), n))
+				sys.appendToConsole(c.warn() + fmt.Sprintf("called invalid action %v %v", strings.ToUpper(ffx), n))
+			} else {
+				sys.appendToConsole(c.warn() + fmt.Sprintf("called invalid action %v", n))
+			}
+		} else {
+			if ffx != "" && ffx != "s" {
+				sys.appendToConsole(c.warn() + fmt.Sprintf("changed to invalid action %v %v", strings.ToUpper(ffx), n))
 			} else {
 				sys.appendToConsole(c.warn() + fmt.Sprintf("changed to invalid action %v", n))
 			}
@@ -5154,7 +5160,7 @@ func (c *Char) over() bool {
 }
 func (c *Char) makeDust(x, y float32) {
 	if e, i := c.newExplod(); e != nil {
-		e.anim = c.getAnim(120, "f", false)
+		e.anim = c.getAnim(120, "f", true)
 		if e.anim != nil {
 			e.anim.start_scale[0] *= c.localscl
 			e.anim.start_scale[1] *= c.localscl
@@ -7349,7 +7355,7 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 				off[1] += p1.hitdef.sparkxy[1] * c.localscl
 			}
 			if e, i := c.newExplod(); e != nil {
-				e.anim = c.getAnim(animNo, ffx, false)
+				e.anim = c.getAnim(animNo, ffx, true)
 				e.ontop = true
 				e.sprpriority = math.MinInt32
 				e.ownpal = true

--- a/src/char.go
+++ b/src/char.go
@@ -1618,6 +1618,7 @@ func (p *Projectile) update(playerNo int) {
 	}
 	if p.paused(playerNo) || p.hitpause > 0 || p.freezeflag {
 		p.setPos(p.pos)
+		// There's a minor issue here where a projectile will lag behind one frame relative to Mugen if created during a pause
 	} else {
 		if sys.tickFrame() {
 			p.newPos = [...]float32{p.pos[0] + p.velocity[0]*p.facing, p.pos[1] + p.velocity[1]}
@@ -1823,6 +1824,7 @@ type StateState struct {
 	prevStateType   StateType
 	moveType        MoveType
 	prevMoveType    MoveType
+	storeMoveType   bool
 	physics         StateType
 	ps              []int32
 	wakegawakaranai [MaxSimul*2 + MaxAttachedChar][]bool
@@ -6536,7 +6538,9 @@ func (c *Char) tick() {
 		}
 	}
 	if c.csf(CSF_gethit) && !c.hoKeepState {
-		c.ss.moveType = MT_H // Note that this change to MoveType breaks PrevMoveType
+		c.ss.changeMoveType(MT_H)
+		// This flag prevents the previous move type from being changed twice
+		c.ss.storeMoveType = true
 		if c.hitPauseTime > 0 {
 			c.ss.clearWw()
 		}


### PR DESCRIPTION
- Previously, hitting a character made PrevMoveType always return H, because movetype was changed to H twice in one frame. Adjusted the code so that the previous movetype information is now correctly kept
- Attempting to create explods or hit sparks with invalid animations will now also print an error to the clipboard
- Setting the training dummy to button jamming now also activates those inputs for any helpers the dummy has. Improves compatibility with some custom input systems