### PR TITLE
fix: Stage boundhigh, boundlow, overdrawlow, cuthigh, cutlow, groundlevel

### DIFF
--- a/src/anim.go
+++ b/src/anim.go
@@ -893,7 +893,7 @@ func (dl DrawList) draw(x, y, scl float32) {
 		} else {
 			p = [...]float32{sys.cam.Offset[0]/cs - (x - s.pos[0]),
 				(sys.cam.GroundLevel()+sys.cam.Offset[1]-sys.envShake.getOffset())/cs -
-					(y - s.pos[1])}
+					(y/cs - s.pos[1])}
 		}
 		if s.window[0] != 0 || s.window[1] != 0 || s.window[2] != 0 || s.window[3] != 0 {
 			w := s.window
@@ -988,18 +988,18 @@ func (sl ShadowList) draw(x, y, scl float32) {
 			var window [4]int32
 
 			window[0] = int32((sys.cam.Offset[0] - ((x - s.pos[0] - xshearoff) * scl) + w[0]*scl + float32(sys.gameWidth)/2) * sys.widthScale)
-			window[1] = int32((sys.cam.GroundLevel() + sys.cam.Offset[1] - sys.envShake.getOffset() - (y+s.pos[1]*sys.stage.sdw.yscale-s.offsetY)*scl + w[1]*sys.stage.sdw.yscale*scl) * sys.heightScale)
+			window[1] = int32((sys.cam.GroundLevel() + sys.cam.Offset[1] - sys.envShake.getOffset() - y - (s.pos[1]*sys.stage.sdw.yscale-s.offsetY)*scl + w[1]*sys.stage.sdw.yscale*scl) * sys.heightScale)
 			window[2] = int32(scl * (w[2] - w[0]) * sys.widthScale)
 			window[3] = int32(scl * (w[3] - w[1]) * sys.heightScale * sys.stage.sdw.yscale)
 			s.anim.ShadowDraw(&window, sys.cam.Offset[0]-(x-s.pos[0]-xshearoff)*scl,
-				sys.cam.GroundLevel()+sys.cam.Offset[1]-sys.envShake.getOffset()-
-					(y+s.pos[1]*sys.stage.sdw.yscale-s.offsetY)*scl,
+				sys.cam.GroundLevel()+sys.cam.Offset[1]-sys.envShake.getOffset()-y-
+					(s.pos[1]*sys.stage.sdw.yscale-s.offsetY)*scl,
 				scl*s.scl[0], scl*-s.scl[1], sys.stage.sdw.yscale, xshear, s.rot,
 				&sys.bgPalFX, s.oldVer, uint32(color), intensity, s.facing, s.posLocalscl, s.projection, s.fLength)
 		} else {
 			s.anim.ShadowDraw(&sys.scrrect, sys.cam.Offset[0]-(x-s.pos[0]-xshearoff)*scl,
-				sys.cam.GroundLevel()+sys.cam.Offset[1]-sys.envShake.getOffset()-
-					(y+s.pos[1]*sys.stage.sdw.yscale-s.offsetY)*scl,
+				sys.cam.GroundLevel()+sys.cam.Offset[1]-sys.envShake.getOffset()-y-
+					(s.pos[1]*sys.stage.sdw.yscale-s.offsetY)*scl,
 				scl*s.scl[0], scl*-s.scl[1], sys.stage.sdw.yscale, xshear, s.rot,
 				&sys.bgPalFX, s.oldVer, uint32(color), intensity, s.facing, s.posLocalscl, s.projection, s.fLength)
 		}
@@ -1035,18 +1035,18 @@ func (sl ShadowList) drawReflection(x, y, scl float32) {
 			}
 			var window [4]int32
 			window[0] = int32((scl*(sys.cam.Offset[0]/scl-(x-s.pos[0])+float32(w[0])) + float32(sys.gameWidth)/2) * sys.widthScale)
-			window[1] = int32(scl * ((sys.cam.GroundLevel()+sys.cam.Offset[1]-sys.envShake.getOffset())/scl - (y + s.pos[1] - s.offsetY) + float32(w[1])) * sys.heightScale)
+			window[1] = int32(scl * ((sys.cam.GroundLevel()+sys.cam.Offset[1]-sys.envShake.getOffset()-y)/scl - (s.pos[1] - s.offsetY) + float32(w[1])) * sys.heightScale)
 			window[2] = int32(scl * (w[2] - w[0]) * sys.widthScale)
 			window[3] = int32(scl * (w[3] - w[1]) * sys.heightScale)
 
 			s.anim.Draw(&window, sys.cam.Offset[0]/scl-(x-s.pos[0]),
-				(sys.cam.GroundLevel()+sys.cam.Offset[1]-sys.envShake.getOffset())/scl-
-					(y+s.pos[1]-s.offsetY), scl, scl, s.scl[0], s.scl[0], -s.scl[1], 0,
+				(sys.cam.GroundLevel()+sys.cam.Offset[1]-sys.envShake.getOffset())/scl-y-
+					(s.pos[1]-s.offsetY), scl, scl, s.scl[0], s.scl[0], -s.scl[1], 0,
 				s.rot, float32(sys.gameWidth)/2, s.fx, s.oldVer, s.facing, true, s.posLocalscl, s.projection, s.fLength)
 		} else {
 			s.anim.Draw(&sys.scrrect, sys.cam.Offset[0]/scl-(x-s.pos[0]),
-				(sys.cam.GroundLevel()+sys.cam.Offset[1]-sys.envShake.getOffset())/scl-
-					(y+s.pos[1]-s.offsetY), scl, scl, s.scl[0], s.scl[0], -s.scl[1], 0,
+				(sys.cam.GroundLevel()+sys.cam.Offset[1]-sys.envShake.getOffset())/scl-y-
+					(s.pos[1]-s.offsetY), scl, scl, s.scl[0], s.scl[0], -s.scl[1], 0,
 				s.rot, float32(sys.gameWidth)/2, s.fx, s.oldVer, s.facing, true, s.posLocalscl, s.projection, s.fLength)
 		}
 

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1286,7 +1286,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 		case OC_camerapos_x:
 			sys.bcStack.PushF(sys.cam.Pos[0] / oc.localscl)
 		case OC_camerapos_y:
-			sys.bcStack.PushF(sys.cam.Pos[1] / oc.localscl)
+			sys.bcStack.PushF((sys.cam.Pos[1] + sys.cam.aspectCorrection + sys.cam.zoomAnchorCorrection) / oc.localscl)
 		case OC_camerazoom:
 			sys.bcStack.PushF(sys.cam.Scale)
 		case OC_canrecover:

--- a/src/camera.go
+++ b/src/camera.go
@@ -86,7 +86,7 @@ func (c *Camera) Reset() {
 	c.XMax = c.boundR + c.halfWidth/c.BaseScale()
 	c.ExtraBoundH = ((1 - c.zoomout) * 100) * (1 / c.zoomout) * 2.1 * (float32(sys.gameHeight) / 240)
 	c.boundH = MinF(0, float32(c.boundhigh-c.localcoord[1])*c.localscl+float32(sys.gameHeight)-c.drawOffsetY) - c.ExtraBoundH*c.minYZoomDelta
-	c.boundLo = float32(c.boundlow) * c.localscl
+	c.boundLo = float32(Max(c.boundhigh, c.boundlow)) * c.localscl
 	//if c.boundlow < 0 {
 	//	c.boundLo += float32(c.boundlow) * c.localscl
 	//}

--- a/src/camera.go
+++ b/src/camera.go
@@ -3,35 +3,37 @@ package main
 import "math"
 
 type stageCamera struct {
-	startx         int32
-	boundleft      int32
-	boundright     int32
-	boundhigh      int32
-	boundlow       int32
-	verticalfollow float32
-	floortension   int32
-	tensionhigh    int32
-	tensionlow     int32
-	tension        int32
-	tensionvel     float32
-	overdrawhigh   int32 //TODO: not implemented
-	overdrawlow    int32
-	cuthigh        int32
-	cutlow         int32
-	localcoord     [2]int32
-	localscl       float32
-	zoffset        int32
-	ztopscale      float32
-	drawOffsetY    float32
-	startzoom      float32
-	zoomin         float32
-	zoomout        float32
-	ytensionenable bool
-	zoomanchor     bool
-	fov            float32
-	yshift         float32
-	far            float32
-	near           float32
+	startx               int32
+	boundleft            int32
+	boundright           int32
+	boundhigh            int32
+	boundlow             int32
+	verticalfollow       float32
+	floortension         int32
+	tensionhigh          int32
+	tensionlow           int32
+	tension              int32
+	tensionvel           float32
+	overdrawhigh         int32 //TODO: not implemented
+	overdrawlow          int32
+	cuthigh              int32
+	cutlow               int32
+	localcoord           [2]int32
+	localscl             float32
+	zoffset              int32
+	ztopscale            float32
+	drawOffsetY          float32
+	startzoom            float32
+	zoomin               float32
+	zoomout              float32
+	ytensionenable       bool
+	zoomanchor           bool
+	fov                  float32
+	yshift               float32
+	far                  float32
+	near                 float32
+	aspectCorrection     float32
+	zoomAnchorCorrection float32
 }
 
 func newStageCamera() *stageCamera {
@@ -60,7 +62,6 @@ type Camera struct {
 	XMin, XMax                      float32
 	Scale, MinScale                 float32
 	boundL, boundR, boundH, boundLo float32
-	ExtraBoundH                     float32
 	minYZoomDelta                   float32
 	zoff                            float32
 	screenZoff                      float32
@@ -84,19 +85,34 @@ func (c *Camera) Reset() {
 	c.halfWidth = float32(sys.gameWidth) / 2
 	c.XMin = c.boundL - c.halfWidth/c.BaseScale()
 	c.XMax = c.boundR + c.halfWidth/c.BaseScale()
-	c.ExtraBoundH = ((1 - c.zoomout) * 100) * (1 / c.zoomout) * 2.1 * (float32(sys.gameHeight) / 240)
-	c.boundH = MinF(0, float32(c.boundhigh-c.localcoord[1])*c.localscl+float32(sys.gameHeight)-c.drawOffsetY) - c.ExtraBoundH*c.minYZoomDelta
+	c.aspectCorrection = 0
+	c.zoomAnchorCorrection = 0
+	if float32(c.localcoord[1])*c.localscl-float32(sys.gameHeight) < 0 {
+		c.aspectCorrection = MinF(0, (float32(c.localcoord[1])*c.localscl-float32(sys.gameHeight))+MinF((float32(sys.gameHeight)-float32(c.localcoord[1])*c.localscl)/2, float32(c.overdrawlow)*c.localscl))
+	} else if float32(c.localcoord[1])*c.localscl-float32(sys.gameHeight) > 0 {
+		if c.cuthigh+c.cutlow <= 0 {
+			c.aspectCorrection = float32(Ceil(float32(c.localcoord[1])*c.localscl) - sys.gameHeight)
+		} else {
+			diff := Ceil(float32(c.localcoord[1])*c.localscl) - sys.gameHeight
+			tmp := Ceil(float32(c.cuthigh)*c.localscl) * diff / (Ceil(float32(c.cuthigh)*c.localscl) + Ceil(float32(c.cutlow)*c.localscl))
+			if diff-tmp <= c.cutlow {
+				c.aspectCorrection = float32(tmp)
+			} else {
+				c.aspectCorrection = float32(diff - Ceil(float32(c.cutlow)*c.localscl))
+			}
+		}
+
+	}
+	c.boundH = float32(c.boundhigh) * c.localscl
 	c.boundLo = float32(Max(c.boundhigh, c.boundlow)) * c.localscl
-	//if c.boundlow < 0 {
-	//	c.boundLo += float32(c.boundlow) * c.localscl
-	//}
+
 	xminscl := float32(sys.gameWidth) / (float32(sys.gameWidth) - c.boundL +
 		c.boundR)
-	yminscl := float32(sys.gameHeight) / (240 - MinF(0, c.boundH))
-	c.MinScale = MaxF(c.zoomout, MinF(c.zoomin, MaxF(xminscl, yminscl)))
+	//yminscl := float32(sys.gameHeight) / (240 - MinF(0, c.boundH))
+	c.MinScale = MaxF(c.zoomout, MinF(c.zoomin, xminscl))
 	c.screenZoff = float32(c.zoffset-c.localcoord[1])*c.localscl + 240 - c.drawOffsetY
 	if c.boundhigh > 0 {
-		c.boundH += float32(c.boundhigh) * c.localscl
+		//c.boundH += float32(c.boundhigh) * c.localscl
 		c.screenZoff -= float32(c.boundhigh) * c.localscl
 	}
 }
@@ -106,7 +122,10 @@ func (c *Camera) Init() {
 }
 func (c *Camera) Update(scl, x, y float32) {
 	c.Scale = c.BaseScale() * scl
-	c.zoff = (c.screenZoff-240)*scl + float32(sys.gameHeight)
+	c.zoff = float32(c.zoffset) * c.localscl
+	if sys.stage.stageCamera.zoomanchor {
+		c.zoomAnchorCorrection = c.zoff - (float32(sys.gameHeight) + c.aspectCorrection - (float32(sys.gameHeight)-c.zoff+c.aspectCorrection)*scl)
+	}
 	for i := 0; i < 2; i++ {
 		c.Offset[i] = sys.stage.bga.offset[i] * sys.stage.localscl * scl
 	}
@@ -134,15 +153,10 @@ func (c *Camera) XBound(scl, x float32) float32 {
 }
 func (c *Camera) YBound(scl, y float32) float32 {
 	if c.verticalfollow <= 0 {
-		return MaxF(0, c.boundLo*scl)
+		return MaxF(0, c.boundLo)
 	} else {
-		var extraBoundH float32
-		if c.zoomout < 1 {
-			extraBoundH = (c.ExtraBoundH * (1 - c.minYZoomDelta) * ((1 / scl) - 1) / ((1 / c.zoomout) - 1))
-		}
-		tmp := MaxF(0, 240-c.screenZoff)
 		bound := ClampF(y,
-			MinF(tmp*(1/scl-1), c.boundH-extraBoundH-240+MaxF(float32(sys.gameHeight)/scl, tmp+c.screenZoff/scl)),
+			c.boundH*scl,
 			c.boundLo*scl)
 		return bound
 	}
@@ -151,11 +165,7 @@ func (c *Camera) BaseScale() float32 {
 	return c.ztopscale
 }
 func (c *Camera) GroundLevel() float32 {
-	//return c.zoff
-	if sys.stage.stageCamera.zoomanchor {
-		return (float32(sys.gameHeight) - (float32(sys.gameHeight)-float32(c.zoffset)*float32(sys.gameHeight)/float32(c.localcoord[1]))*c.Scale)
-	}
-	return float32(c.zoffset) / float32(c.localcoord[1]) * float32(sys.gameHeight)
+	return c.zoff - c.aspectCorrection - c.zoomAnchorCorrection
 }
 func (c *Camera) ResetZoomdelay() {
 	c.zoomdelay = 0

--- a/src/camera.go
+++ b/src/camera.go
@@ -86,7 +86,7 @@ func (c *Camera) Reset() {
 	c.XMax = c.boundR + c.halfWidth/c.BaseScale()
 	c.ExtraBoundH = ((1 - c.zoomout) * 100) * (1 / c.zoomout) * 2.1 * (float32(sys.gameHeight) / 240)
 	c.boundH = MinF(0, float32(c.boundhigh-c.localcoord[1])*c.localscl+float32(sys.gameHeight)-c.drawOffsetY) - c.ExtraBoundH*c.minYZoomDelta
-	c.boundLo = MaxF(0, float32(c.boundlow)*c.localscl) //-c.drawOffsetY)
+	c.boundLo = float32(c.boundlow) * c.localscl
 	//if c.boundlow < 0 {
 	//	c.boundLo += float32(c.boundlow) * c.localscl
 	//}
@@ -134,7 +134,7 @@ func (c *Camera) XBound(scl, x float32) float32 {
 }
 func (c *Camera) YBound(scl, y float32) float32 {
 	if c.verticalfollow <= 0 {
-		return 0
+		return MaxF(0, c.boundLo*scl)
 	} else {
 		var extraBoundH float32
 		if c.zoomout < 1 {
@@ -143,7 +143,7 @@ func (c *Camera) YBound(scl, y float32) float32 {
 		tmp := MaxF(0, 240-c.screenZoff)
 		bound := ClampF(y,
 			MinF(tmp*(1/scl-1), c.boundH-extraBoundH-240+MaxF(float32(sys.gameHeight)/scl, tmp+c.screenZoff/scl)),
-			c.boundLo)
+			c.boundLo*scl)
 		return bound
 	}
 }

--- a/src/stage.go
+++ b/src/stage.go
@@ -416,7 +416,7 @@ func (bg backGround) draw(pos [2]float32, scl, bgscl, lclscl float32,
 	x := bg.start[0] + bg.xofs - (pos[0]/stgscl[0]+bg.camstartx)*bg.delta[0] +
 		bg.bga.offset[0]
 	// Hires breaks ydelta scrolling vel, so bgscl was commented from here.
-	yScrollPos := (pos[1] / stgscl[1]) * bg.delta[1] // * bgscl
+	yScrollPos := (pos[1] / scl / stgscl[1]) * bg.delta[1] // * bgscl
 	y := bg.start[1] - yScrollPos + bg.bga.offset[1]
 	ys2 := bg.scaledelta[1] * pos[1] * bg.delta[1] * bgscl
 	ys := ((100-(pos[1])*bg.yscaledelta)*bgscl/bg.yscalestart)*bg.scalestart[1] + ys2
@@ -2459,7 +2459,7 @@ func (s *Stage) drawModel(pos [2]float32, yofs float32, scl float32) {
 	} else {
 		syo = -(float32(sys.gameHeight) / 2) * (1 - scl) / scl
 	}
-	offset := []float32{(pos[0]*-posMul*s.localscl*sys.widthScale + s.model.offset[0]/scl), ((pos[1]*s.localscl+yofs/scl+syo)*posMul*sys.heightScale + s.model.offset[1]), s.model.offset[2] / scl}
+	offset := []float32{(pos[0]*-posMul*s.localscl*sys.widthScale + s.model.offset[0]/scl), ((pos[1]/scl*s.localscl+yofs/scl+syo)*posMul*sys.heightScale + s.model.offset[1]), s.model.offset[2] / scl}
 	rotation := []float32{s.model.rotation[0], s.model.rotation[1], s.model.rotation[2]}
 	scale := []float32{s.model.scale[0], s.model.scale[1], s.model.scale[2]}
 	proj := mgl.Translate3D(0, sys.cam.yshift*scl, 0)


### PR DESCRIPTION
Rework the stage bound codes to replicate Mugen 1.1 behavior.