### PR TITLE
refactor: Replace Filesystem Calls - WIP for Buildable for Wasm

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"encoding/gob"
 	"math"
-	"os"
 	"path/filepath"
 	"strings"
 	"unsafe"
@@ -7955,7 +7954,7 @@ func (sc loadFile) Run(c *Char, _ []int32) bool {
 		return true
 	})
 	if path != "" {
-		decodeFile, err := os.Open(filepath.Dir(c.gi().def) + "/" + path)
+		decodeFile, err := ikemenFs.Open(filepath.Dir(c.gi().def) + "/" + path)
 		if err != nil {
 			defer decodeFile.Close()
 			return false
@@ -8279,7 +8278,7 @@ func (sc saveFile) Run(c *Char, _ []int32) bool {
 		return true
 	})
 	if path != "" {
-		encodeFile, err := os.Create(filepath.Dir(c.gi().def) + "/" + path)
+		encodeFile, err := ikemenFs.Create(filepath.Dir(c.gi().def) + "/" + path)
 		if err != nil {
 			panic(err)
 		}

--- a/src/char.go
+++ b/src/char.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"os"
 	"strings"
+
+	"github.com/ikemen-engine/Ikemen-GO/src/filesystem"
 )
 
 const MaxPalNo = 12
@@ -2708,10 +2709,10 @@ func (c *Char) loadPalette() {
 		tmp := 0
 		for i := 0; i < MaxPalNo; i++ {
 			pl := gi.palettedata.palList.Get(i)
-			var f *os.File
+			var f filesystem.IFile
 			var err error
 			if LoadFile(&gi.pal[i], []string{gi.def, "", sys.motifDir, "data/"}, func(file string) error {
-				f, err = os.Open(file)
+				f, err = ikemenFs.Open(file)
 				return err
 			}) == nil {
 				for i := 255; i >= 0; i-- {

--- a/src/common.go
+++ b/src/common.go
@@ -268,7 +268,7 @@ func FileExist(filename string) string {
 			pattern += string(r)
 		}
 	}
-	if m, _ := filepath.Glob(pattern); len(m) > 0 {
+	if m, _ := ikemenFs.Glob(pattern); len(m) > 0 {
 		return m[0]
 	}
 	return ""

--- a/src/common.go
+++ b/src/common.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"math"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -240,7 +239,7 @@ func I32ToU16(i32 int32) uint16 {
 	return uint16(i32)
 }
 func LoadText(filename string) (string, error) {
-	bytes, err := os.ReadFile(filename)
+	bytes, err := ikemenFs.ReadFile(filename)
 	if err != nil {
 		return "", err
 	}
@@ -252,7 +251,7 @@ func LoadText(filename string) (string, error) {
 }
 
 func FileExist(filename string) string {
-	if info, err := os.Stat(filename); !os.IsNotExist(err) {
+	if info, err := ikemenFs.Stat(filename); !ikemenFs.IsNotExist(err) {
 		if info == nil || info.IsDir() {
 			return ""
 		}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"math"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -4279,7 +4278,7 @@ func (c *Compiler) stateCompile(states map[int32]StateBytecode,
 		var err error
 		// If this is a zss file
 		if zss {
-			b, err := os.ReadFile(filename)
+			b, err := ikemenFs.ReadFile(filename)
 			if err != nil {
 				return err
 			}
@@ -4294,7 +4293,7 @@ func (c *Compiler) stateCompile(states map[int32]StateBytecode,
 		// If filename doesn't exist, see if a zss file exists
 		fnz += ".zss"
 		if err := LoadFile(&fnz, dirs, func(filename string) error {
-			b, err := os.ReadFile(filename)
+			b, err := ikemenFs.ReadFile(filename)
 			if err != nil {
 				return err
 			}

--- a/src/filesystem/file_common.go
+++ b/src/filesystem/file_common.go
@@ -1,0 +1,39 @@
+package filesystem
+
+import (
+	"time"
+)
+
+type IFile interface {
+	Readdirnames(n int) (names []string, err error)
+	Seek(offset int64, whence int) (ret int64, err error)
+	Write(p []byte) (n int, err error)
+	Read(b []byte) (n int, err error)
+	Close() error
+}
+
+type IFileInfo interface {
+	IsDir() bool
+	ModTime() time.Time
+	Mode() IFileMode
+	Name() string
+	Size() int64
+}
+
+type IFileMode uint32
+
+type WalkFn func(path string, info IFileInfo, err error) error
+
+type AbstractFileSystem interface {
+	Mkdir(name string, perm IFileMode) error
+	Create(name string) (IFile, error)
+	Open(name string) (IFile, error)
+	ReadFile(name string) ([]byte, error)
+	WriteFile(name string, data []byte, perm IFileMode) error
+	Stat(name string) (IFileInfo, error)
+	IsNotExist(err error) bool
+
+	ReadDir(path string) ([]string, error)
+	Walk(root string, fn WalkFn) error
+	Glob(pattern string) (matches []string, err error)
+}

--- a/src/filesystem/file_native.go
+++ b/src/filesystem/file_native.go
@@ -1,0 +1,99 @@
+//go:build !js
+// +build !js
+
+package filesystem
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+func NewFileSystem() AbstractFileSystem {
+	return &NativeFS{}
+}
+
+type NativeFS struct{}
+
+func (osFileSystem *NativeFS) Mkdir(name string, perm IFileMode) error {
+	return os.Mkdir(name, fs.FileMode(perm))
+}
+func (osFileSystem *NativeFS) Create(name string) (IFile, error) {
+	return os.Create(name)
+}
+func (osFileSystem *NativeFS) Open(name string) (IFile, error) {
+	return os.Open(name)
+}
+func (osFileSystem *NativeFS) ReadFile(name string) ([]byte, error) {
+	return os.ReadFile(name)
+}
+func (osFileSystem *NativeFS) WriteFile(name string, data []byte, perm IFileMode) error {
+	return os.WriteFile(name, data, fs.FileMode(perm))
+}
+func (osFileSystem *NativeFS) Stat(name string) (IFileInfo, error) {
+	stat, error := os.Stat(name)
+	if error != nil {
+		return nil, error
+	}
+	return NewFileInfoWrapper(stat), nil
+}
+func (osFileSystem *NativeFS) IsNotExist(err error) bool {
+	return os.IsNotExist(err)
+}
+
+func (osFileSystem *NativeFS) ReadDir(path string) ([]string, error) {
+	entries, error := os.ReadDir(path)
+	if error != nil {
+		return nil, error
+	}
+	entryLen := len(entries)
+	children := make([]string, entryLen)
+	for i := 0; i < entryLen; i++ {
+		children[i] = entries[i].Name()
+	}
+	return children, nil
+}
+
+func (osFileSystem *NativeFS) Walk(root string, wallkFn WalkFn) error {
+	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		return wallkFn(path, NewFileInfoWrapper(info), err)
+	})
+}
+func (osFileSystem *NativeFS) Glob(pattern string) (matches []string, err error) {
+	return filepath.Glob(pattern)
+}
+
+/*
+=======================================================
+FileInfoWrapper
+- to handle the IFileMode incompatabilities between abstraction and os.FileInfo
+=======================================================
+*/
+type FileInfoWrapper struct {
+	FileInfo os.FileInfo
+}
+
+func NewFileInfoWrapper(fi os.FileInfo) *FileInfoWrapper {
+	return &FileInfoWrapper{FileInfo: fi}
+}
+
+func (fiw *FileInfoWrapper) IsDir() bool {
+	return fiw.FileInfo.IsDir()
+}
+
+func (fiw *FileInfoWrapper) ModTime() time.Time {
+	return fiw.FileInfo.ModTime()
+}
+
+func (fiw *FileInfoWrapper) Mode() IFileMode {
+	return IFileMode(fiw.FileInfo.Mode())
+}
+
+func (fiw *FileInfoWrapper) Name() string {
+	return fiw.FileInfo.Name()
+}
+
+func (fiw *FileInfoWrapper) Size() int64 {
+	return fiw.FileInfo.Size()
+}

--- a/src/filesystem/file_wasm.go
+++ b/src/filesystem/file_wasm.go
@@ -1,0 +1,519 @@
+//go:build js
+// +build js
+
+package filesystem
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall/js"
+	"time"
+)
+
+var ErrorNotExist = errors.New("Path doesn't exist")
+var ErrorAlreadyExist = errors.New("Path Already Exists")
+var ErrorIsFile = errors.New("Path is File, Can't use as Directory")
+var ErrorIsDir = errors.New("Path is Directory, Can't use as File")
+var ErrorSeekToFar = errors.New("Cannot Seek that far")
+var ErrorIsClosed = errors.New("File Is Closed")
+
+// const ErrorNotExist = 1
+// const ErrorAlreadyExist = 2
+// const ErrorIsFile = 3
+// const ErrorIsDir = 4
+
+func NewFileSystem() AbstractFileSystem {
+	fmt.Println("About to build BrowserFS")
+
+	jsVar := js.Global().Get("IKEMEN_GO_BROWSER_FS")
+	fs := &BrowserFS{jsVar: jsVar}
+
+	fmt.Println("built BrowserFS")
+	return fs
+}
+
+type BrowserFS struct {
+	jsVar js.Value
+}
+
+func (fs *BrowserFS) Exists(name string) bool {
+	return fs.jsVar.Get("existsSync").Invoke(name).Bool()
+}
+
+func (fs *BrowserFS) Mkdir(name string, perm IFileMode) error {
+	if fs.Exists(name) {
+		return ErrorAlreadyExist
+	}
+
+	fs.jsVar.Get("mkdirSync").Invoke(name, perm)
+
+	return nil
+}
+
+func (fs *BrowserFS) Create(name string) (IFile, error) {
+	fs.jsVar.Get("writeFileSync").Invoke(name, "")
+	return makeNewFile(fs.jsVar, name), nil
+}
+
+func (fs *BrowserFS) Open(name string) (IFile, error) {
+	stat, statErr := fs.Stat(name)
+	if statErr != nil {
+		return nil, statErr
+	}
+	if stat.IsDir() {
+		return wrapFolder(fs.jsVar, name), nil
+	}
+	buffer := fs.jsVar.Get("readFileSync").Invoke(name, nil)
+	return wrapBufferAsFile(fs.jsVar, name, buffer), nil
+}
+
+func (fs *BrowserFS) ReadFile(path string) ([]byte, error) {
+	buffer := fs.jsVar.Get("readFileSync").Invoke(path, nil)
+	return jsValueToByteArray(buffer), nil
+}
+
+func (fs *BrowserFS) WriteFile(name string, data []byte, perm IFileMode) error {
+	fs.jsVar.Get("writeFileSync").Invoke(name, data)
+	return nil
+}
+
+func (fs *BrowserFS) Stat(path string) (IFileInfo, error) {
+	if !fs.Exists(path) {
+		return nil, ErrorNotExist
+	}
+	fmt.Println(("about to statSync"))
+	statVar := fs.jsVar.Get("statSync").Invoke(path)
+	fmt.Println(("statSync Successful"))
+	stat := new(BrowserFsFileInfo)
+	stat.path = path
+	stat.js = statVar
+
+	js.Global().Get("console").Call("log", stat.js)
+	fmt.Println(("testing stat fns now!"))
+
+	stat.IsDir()
+
+	fmt.Println(("statSync isDir Successful"))
+	stat.ModTime()
+	fmt.Println(("statSync ModTime Successful"))
+	stat.Mode()
+	fmt.Println(("statSync Mode Successful"))
+	stat.Name()
+	fmt.Println(("statSync Name Successful"))
+	stat.Size()
+	fmt.Println(("statSync Size Successful"))
+
+	return stat, nil
+}
+
+func (fs *BrowserFS) IsNotExist(err error) bool {
+	return errors.Is(err, ErrorNotExist)
+}
+
+const Separator string = "/"
+
+func (fs *BrowserFS) ReadDir(path string) ([]string, error) {
+	fmt.Println("reading dir " + path)
+	statValue, statErr := fs.Stat(path)
+	if statErr != nil {
+		fmt.Println("failed stat")
+		return nil, statErr
+	}
+	if !statValue.IsDir() {
+		fmt.Println("file is not dir")
+		return nil, ErrorIsFile
+	}
+	fmt.Println("file is dir")
+	dirArray := fs.jsVar.Get("readdirSync").Invoke(path)
+	fmt.Println("read dir success")
+
+	dirLen := dirArray.Get("length").Int()
+	fmt.Println("got length: " + strconv.Itoa(dirLen))
+
+	children := make([]string, dirLen)
+	for i := 0; i < dirLen; i++ {
+		key := strconv.Itoa(i)
+		children[i] = dirArray.Get(key).String()
+	}
+	return children, nil
+}
+
+func (fs *BrowserFS) Walk(root string, fn WalkFn) error {
+	return fs.WalkRecursive(root, fn)
+}
+
+func (fs *BrowserFS) WalkLoop(root string, fn WalkFn) error {
+	var decendents [][]string
+	var activeChildren = []string{root}
+	for true {
+		if len(activeChildren) == 0 {
+			if len(decendents) == 0 {
+				return nil
+			}
+			activeChildren, decendents = decendents[len(activeChildren)-1], decendents[:len(activeChildren)-1]
+			activeChildren = activeChildren[1:]
+		}
+		child := activeChildren[0]
+
+		fullPath := ""
+		for i := 0; i < len(decendents); i++ {
+			fullPath = fullPath + decendents[i][0] + Separator
+		}
+		fullPath = fullPath + child
+
+		stat, statErr := fs.Stat(fullPath)
+		if statErr != nil {
+			return statErr
+		}
+		error := fn(fullPath, stat, nil)
+		if error != nil {
+			return error
+		}
+
+		if stat.IsDir() {
+			decendents = append(decendents, activeChildren)
+			newChildren, readDirError := fs.ReadDir(fullPath)
+			if readDirError != nil {
+				return readDirError
+			}
+			activeChildren = newChildren
+		} else {
+			activeChildren = activeChildren[1:]
+		}
+	}
+
+	return nil
+}
+
+func (fs *BrowserFS) WalkRecursive(root string, fn WalkFn) error {
+	dirArray := fs.jsVar.Get("readdirSync").Invoke(root)
+	len := dirArray.Get("length").Int()
+	for i := 0; i < len; i++ {
+		key := strconv.Itoa(i)
+		fullPath := root + Separator + dirArray.Get(key).String()
+		stat, statError := fs.Stat(fullPath)
+		if statError != nil {
+			return statError
+		}
+		error := fn(fullPath, stat, nil)
+		if error != nil {
+			return error
+		}
+		if !stat.IsDir() {
+			continue
+		}
+		error = fs.WalkRecursive(fullPath, fn)
+		if error != nil {
+			return error
+		}
+	}
+	return nil
+}
+
+/*
+==================================================
+
+Browser File
+
+==================================================
+*/
+
+type BrowserFsFile struct {
+	jsVar    js.Value
+	isDir    bool
+	path     string
+	content  []byte
+	offset   uint64
+	isClosed bool
+}
+
+func makeNewFile(jsVar js.Value, path string) *BrowserFsFile {
+	file := new(BrowserFsFile)
+	file.jsVar = jsVar
+	file.isDir = false
+	file.content = make([]byte, 0, 0)
+	file.path = path
+	file.offset = 0
+	file.isClosed = false
+	return file
+}
+
+func wrapFolder(jsVar js.Value, path string) *BrowserFsFile {
+	dir := new(BrowserFsFile)
+	// https://www.reddit.com/r/golang/comments/bxcxxe/make_byte_array_as_empty/
+	dir.jsVar = jsVar
+	dir.isDir = true
+	dir.content = make([]byte, 0, 0)
+	dir.path = path
+	dir.offset = 0
+	dir.isClosed = false
+	return dir
+}
+
+func wrapBufferAsFile(jsVar js.Value, path string, buffer js.Value) *BrowserFsFile {
+	file := new(BrowserFsFile)
+	file.jsVar = jsVar
+	file.isDir = false
+	file.content = jsValueToByteArray(buffer)
+	file.path = path
+	file.offset = 0
+	file.isClosed = false
+	return file
+}
+
+func jsValueToByteArray(buffer js.Value) []byte {
+	destination := make([]byte, 0, 0)
+	js.CopyBytesToGo(destination, buffer)
+	return destination
+	// https://github.com/gopherjs/gopherjs/issues/165#issuecomment-71513058
+	// return js.Global.Get("Uint8Array").New(buffer).Interface().([]byte)
+}
+
+func (file *BrowserFsFile) Seek(offset int64, whence int) (ret int64, err error) {
+	if file.isClosed {
+		return 0, ErrorIsClosed
+	}
+	if file.isDir {
+		return 0, ErrorIsDir
+	}
+
+	var newOffset int64
+	switch whence {
+	case io.SeekStart:
+		newOffset = offset
+	case io.SeekCurrent:
+		newOffset = int64(file.offset) + offset
+	case io.SeekEnd:
+		newOffset = int64(len(file.content)) + offset
+	default:
+		return 0, errors.New("invalid whence")
+	}
+
+	if newOffset < 0 {
+		return 0, errors.New("negative result offset")
+	}
+
+	file.offset = uint64(newOffset)
+	return newOffset, nil
+}
+
+func (f *BrowserFsFile) Write(p []byte) (n int, err error) {
+	if f.isClosed {
+		return 0, ErrorIsClosed
+	}
+	if f.isDir {
+		return 0, ErrorIsDir
+	}
+
+	// Check if the offset is beyond the current content size
+	if f.offset > uint64(len(f.content)) {
+		// If so, extend the content slice with zeroes until the offset
+		padding := make([]byte, f.offset-uint64(len(f.content)))
+		f.content = append(f.content, padding...)
+	}
+
+	// Append the data to the content slice
+	f.content = append(f.content, p...)
+	n = len(p)
+
+	// Update the offset
+	f.offset += uint64(n)
+
+	return n, nil
+}
+
+func (file *BrowserFsFile) Read(b []byte) (n int, err error) {
+	if file.isClosed {
+		return 0, ErrorIsClosed
+	}
+	if file.isDir {
+		return 0, ErrorIsDir
+	}
+
+	if file.offset >= uint64(len(file.content)) {
+		return 0, io.EOF // End of file
+	}
+
+	n = copy(b, file.content[file.offset:])
+	file.offset += uint64(n)
+	return n, nil
+}
+
+func (file *BrowserFsFile) Close() error {
+	if file.isClosed {
+		return ErrorIsClosed
+	}
+	file.isClosed = true
+	return nil
+}
+
+func (file *BrowserFsFile) Readdirnames(n int) (names []string, err error) {
+	if !file.isDir {
+		return nil, ErrorIsFile
+	}
+	dirArray := file.jsVar.Get("readdirSync").Invoke(file.path)
+	len := dirArray.Get("length").Int()
+
+	if n <= 0 || n > len {
+		n = len
+	}
+	children := make([]string, n)
+	for i := 0; i < n; i++ {
+		key := strconv.Itoa(i)
+		children[i] = dirArray.Get(key).String()
+	}
+	return children, nil
+}
+
+/*
+
+==================================================
+
+Browser File Info
+
+==================================================
+
+*/
+
+type BrowserFsFileInfo struct {
+	path string
+	js   js.Value
+}
+
+func (info *BrowserFsFileInfo) IsDir() bool {
+	return info.js.Call("isDirectory").Bool()
+}
+func (info *BrowserFsFileInfo) ModTime() time.Time {
+	modTimestamp := info.js.Get("mtime").Call("getTime").Int()
+	return time.Unix(int64(modTimestamp), 0)
+}
+
+func (info *BrowserFsFileInfo) Mode() IFileMode {
+	intValue := info.js.Get("mode").Int()
+	return IFileMode(intValue)
+}
+
+func (info *BrowserFsFileInfo) Name() string {
+	return info.path
+}
+
+func (info *BrowserFsFileInfo) Size() int64 {
+	return int64(info.js.Get("size").Int())
+}
+
+/*
+
+==================================================
+
+This is all related to Glob
+
+==================================================
+
+*/
+
+var ErrBadPattern = errors.New("syntax error in pattern")
+
+func (fs *BrowserFS) Glob(pattern string) (matches []string, err error) {
+	return fs.globWithLimit(pattern, 0)
+}
+
+func (fs *BrowserFS) globWithLimit(pattern string, depth int) (matches []string, err error) {
+	// This limit is used prevent stack exhaustion issues. See CVE-2022-30632.
+	const pathSeparatorsLimit = 10000
+	if depth == pathSeparatorsLimit {
+		return nil, ErrBadPattern
+	}
+
+	// Check pattern is well-formed.
+	if _, err := filepath.Match(pattern, ""); err != nil {
+		return nil, err
+	}
+	if !hasMeta(pattern) {
+		if _, err = fs.Stat(pattern); err != nil {
+			return nil, nil
+		}
+		return []string{pattern}, nil
+	}
+
+	dir, file := filepath.Split(pattern)
+	volumeLen := 0
+	dir = cleanGlobPath(dir)
+
+	if !hasMeta(dir[volumeLen:]) {
+		return fs.glob(dir, file, nil)
+	}
+
+	// Prevent infinite recursion. See issue 15879.
+	if dir == pattern {
+		return nil, ErrBadPattern
+	}
+
+	var m []string
+	m, err = fs.globWithLimit(dir, depth+1)
+	if err != nil {
+		return
+	}
+	for _, d := range m {
+		matches, err = fs.glob(d, file, matches)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// glob searches for files matching pattern in the directory dir
+// and appends them to matches. If the directory cannot be
+// opened, it returns the existing matches. New matches are
+// added in lexicographical order.
+func (fs *BrowserFS) glob(dir, pattern string, matches []string) (m []string, e error) {
+	m = matches
+	fi, err := fs.Stat(dir)
+	if err != nil {
+		return // ignore I/O error
+	}
+	if !fi.IsDir() {
+		return // ignore I/O error
+	}
+	d, err := fs.Open(dir)
+	if err != nil {
+		return // ignore I/O error
+	}
+	defer d.Close()
+
+	names, _ := d.Readdirnames(-1)
+	sort.Strings(names)
+
+	for _, n := range names {
+		matched, err := filepath.Match(pattern, n)
+		if err != nil {
+			return m, err
+		}
+		if matched {
+			m = append(m, filepath.Join(dir, n))
+		}
+	}
+	return
+}
+
+func cleanGlobPath(path string) string {
+	switch path {
+	case "":
+		return "."
+	case string(Separator):
+		// do nothing to the path
+		return path
+	default:
+		return path[0 : len(path)-1] // chop off trailing separator
+	}
+}
+
+func hasMeta(path string) bool {
+	magicChars := `*?[`
+	return strings.ContainsAny(path, magicChars)
+}

--- a/src/font.go
+++ b/src/font.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/binary"
 	"math"
-	"os"
 	"regexp"
 	"strings"
 )
@@ -56,7 +55,7 @@ func loadFntV1(filename string) (*Fnt, error) {
 	f := newFnt()
 	f.images[0] = make(map[rune]*FntCharImage)
 
-	fp, err := os.Open(filename)
+	fp, err := ikemenFs.Open(filename)
 
 	if err != nil {
 		return nil, Error("File not found")

--- a/src/image.go
+++ b/src/image.go
@@ -8,9 +8,10 @@ import (
 	"image/png"
 	"io"
 	"math"
-	"os"
 	"runtime"
 	"unsafe"
+
+	"github.com/ikemen-engine/Ikemen-GO/src/filesystem"
 )
 
 type TransType int32
@@ -524,7 +525,7 @@ func newSprite() *Sprite {
 /*
 	func loadFromSff(filename string, g, n int16) (*Sprite, error) {
 		s := newSprite()
-		f, err := os.Open(filename)
+		f, err := ikemenFs.Open(filename)
 		if err != nil {
 			return nil, err
 		}
@@ -716,7 +717,7 @@ func (s *Sprite) readHeader(r io.Reader, ofs, size *uint32,
 	}
 	return nil
 }
-func (s *Sprite) readPcxHeader(f *os.File, offset int64) error {
+func (s *Sprite) readPcxHeader(f filesystem.IFile, offset int64) error {
 	f.Seek(offset, 0)
 	read := func(x interface{}) error {
 		return binary.Read(f, binary.LittleEndian, x)
@@ -786,7 +787,7 @@ func (s *Sprite) RlePcxDecode(rle []byte) (p []byte) {
 	s.rle = 0
 	return
 }
-func (s *Sprite) read(f *os.File, sh *SffHeader, offset int64, datasize uint32,
+func (s *Sprite) read(f filesystem.IFile, sh *SffHeader, offset int64, datasize uint32,
 	nextSubheader uint32, prev *Sprite, pl *PaletteList, c00 bool) error {
 	if int64(nextSubheader) > offset {
 		// 最後以外datasizeを無視 / Ignore datasize except last
@@ -1036,7 +1037,7 @@ func (s *Sprite) Lz5Decode(rle []byte) (p []byte) {
 	}
 	return
 }
-func (s *Sprite) readV2(f *os.File, offset int64, datasize uint32) error {
+func (s *Sprite) readV2(f filesystem.IFile, offset int64, datasize uint32) error {
 	var px []byte
 	var isRaw bool = false
 
@@ -1212,7 +1213,7 @@ func loadSff(filename string, char bool) (*Sff, error) {
 	}
 	s := newSff()
 	s.filename = filename
-	f, err := os.Open(filename)
+	f, err := ikemenFs.Open(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -1352,7 +1353,7 @@ func loadSff(filename string, char bool) (*Sff, error) {
 }
 func preloadSff(filename string, char bool, preloadSpr map[[2]int16]bool) (*Sff, []int32, error) {
 	sff := newSff()
-	f, err := os.Open(filename)
+	f, err := ikemenFs.Open(filename)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1537,8 +1538,8 @@ func captureScreen() {
 	}
 	for i := sys.captureNum; i < 999; i++ {
 		filename := fmt.Sprintf("%sikemen%03d.png", sys.screenshotFolder, i)
-		if _, err := os.Stat(filename); os.IsNotExist(err) {
-			file, _ := os.Create(filename)
+		if _, err := ikemenFs.Stat(filename); ikemenFs.IsNotExist(err) {
+			file, _ := ikemenFs.Create(filename)
 			defer file.Close()
 			png.Encode(file, img)
 			sys.captureNum = i

--- a/src/input.go
+++ b/src/input.go
@@ -3,9 +3,10 @@ package main
 import (
 	"encoding/binary"
 	"net"
-	"os"
 	"strings"
 	"time"
+
+	"github.com/ikemen-engine/Ikemen-GO/src/filesystem"
 )
 
 var ModAlt = NewModifierKey(false, true, false)
@@ -846,7 +847,7 @@ type NetInput struct {
 	time         int32
 	stoppedcnt   int32
 	delay        int32
-	rep          *os.File
+	rep          filesystem.IFile
 	host         bool
 	preFightTime int32
 }
@@ -1132,14 +1133,14 @@ func (ni *NetInput) Update() bool {
 }
 
 type FileInput struct {
-	f      *os.File
+	f      filesystem.IFile
 	ib     [MaxSimul*2 + MaxAttachedChar]InputBits
 	pfTime int32
 }
 
 func OpenFileInput(filename string) *FileInput {
 	fi := &FileInput{}
-	fi.f, _ = os.Open(filename)
+	fi.f, _ = ikemenFs.Open(filename)
 	return fi
 }
 

--- a/src/script.go
+++ b/src/script.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"os"
-	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/ikemen-engine/Ikemen-GO/src/filesystem"
 	lua "github.com/yuin/gopher-lua"
 )
 
@@ -1347,7 +1346,7 @@ func systemScriptInit(l *lua.LState) {
 	})
 	luaRegister(l, "getDirectoryFiles", func(*lua.LState) int {
 		dir := l.NewTable()
-		filepath.Walk(strArg(l, 1), func(path string, info os.FileInfo, err error) error {
+		ikemenFs.Walk(strArg(l, 1), func(path string, info filesystem.IFileInfo, err error) error {
 			dir.Append(lua.LString(path))
 			return nil
 		})
@@ -1704,7 +1703,7 @@ func systemScriptInit(l *lua.LState) {
 	})
 	luaRegister(l, "replayRecord", func(*lua.LState) int {
 		if sys.netInput != nil {
-			sys.netInput.rep, _ = os.Create(strArg(l, 1))
+			sys.netInput.rep, _ = ikemenFs.Create(strArg(l, 1))
 		}
 		return 0
 	})

--- a/src/sound.go
+++ b/src/sound.go
@@ -5,8 +5,8 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
-	"os"
 
+	"github.com/ikemen-engine/Ikemen-GO/src/filesystem"
 	"github.com/ikemen-engine/beep"
 	"github.com/ikemen-engine/beep/effects"
 
@@ -175,7 +175,7 @@ func (bgm *Bgm) Open(filename string, loop, bgmVolume, bgmLoopStart, bgmLoopEnd,
 		return
 	}
 
-	f, err := os.Open(bgm.filename)
+	f, err := ikemenFs.Open(bgm.filename)
 	if err != nil {
 		sys.bgm = *newBgm()
 		sys.errLog.Printf("Failed to open bgm: %v", err)
@@ -226,7 +226,7 @@ func (bgm *Bgm) Open(filename string, loop, bgmVolume, bgmLoopStart, bgmLoopEnd,
 }
 
 func loadSoundFont(filename string) (*midi.SoundFont, error) {
-	f, err := os.Open(filename)
+	f, err := ikemenFs.Open(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -272,7 +272,7 @@ type Sound struct {
 	length  int
 }
 
-func readSound(f *os.File, size uint32) (*Sound, error) {
+func readSound(f filesystem.IFile, size uint32) (*Sound, error) {
 	if size < 128 {
 		return nil, fmt.Errorf("wav size is too small")
 	}
@@ -326,7 +326,7 @@ func LoadSnd(filename string) (*Snd, error) {
 // If max > 0, the function returns immediately when a matching entry is found. It also gives up after "max" non-matching entries.
 func LoadSndFiltered(filename string, keepItem func([2]int32) bool, max uint32) (*Snd, error) {
 	s := newSnd()
-	f, err := os.Open(filename)
+	f, err := ikemenFs.Open(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/src/stage.go
+++ b/src/stage.go
@@ -10,7 +10,6 @@ import (
 	"image/draw"
 	_ "image/jpeg"
 	"math"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -1740,7 +1739,7 @@ func loadglTFStage(filepath string) (*Model, error) {
 				}
 			} else {
 				if err := LoadFile(&img.URI, []string{filepath, "", sys.motifDir, "data/"}, func(filename string) error {
-					data, err := os.ReadFile(filename)
+					data, err := ikemenFs.ReadFile(filename)
 					if err != nil {
 						return err
 					}

--- a/src/system.go
+++ b/src/system.go
@@ -401,14 +401,14 @@ func (s *System) init(w, h int32) *lua.LState {
 			s.externalShaderNames[i] = splitDir[len(splitDir)-1]
 
 			// Load vert shaders.
-			content, err := os.ReadFile(shaderLocation + ".vert")
+			content, err := ikemenFs.ReadFile(shaderLocation + ".vert")
 			if err != nil {
 				chk(err)
 			}
 			s.externalShaders[0][i] = string(content) + "\x00"
 
 			// Load frag shaders.
-			content, err = os.ReadFile(shaderLocation + ".frag")
+			content, err = ikemenFs.ReadFile(shaderLocation + ".frag")
 			if err != nil {
 				chk(err)
 			}
@@ -444,7 +444,7 @@ func (s *System) init(w, h int32) *lua.LState {
 		s.windowMainIcon = make([]image.Image, len(s.windowMainIconLocation))
 		// And then we load them.
 		for i, iconLocation := range s.windowMainIconLocation {
-			f[i], err = os.Open(iconLocation)
+			f[i], err = ikemenFs.Open(iconLocation)
 			if err != nil {
 				var dErr = "Icon file can not be found.\nPanic: " + err.Error()
 				ShowErrorDialog(dErr)
@@ -2169,7 +2169,7 @@ type wincntMap map[string][]int32
 
 func (wm *wincntMap) init() {
 	if sys.autolevel {
-		b, err := os.ReadFile(sys.wincntFileName)
+		b, err := ikemenFs.ReadFile(sys.wincntFileName)
 		if err != nil {
 			return
 		}
@@ -2238,7 +2238,7 @@ func (wm *wincntMap) update() {
 			}
 			str += "\r\n"
 		}
-		f, err := os.Create(sys.wincntFileName)
+		f, err := ikemenFs.Create(sys.wincntFileName)
 		if err == nil {
 			f.Write([]byte(str))
 			chk(f.Close())


### PR DESCRIPTION
Replaced most places where the os filsystem with an abstraction that can be replaced depending on compile target (complete wasm compatibility being the eventual goal).

I Ignored
- Windows only - https://github.com/ikemen-engine/Ikemen-GO/blob/develop/src/stdout_windows.go

Note, It successfully built for Linux, not sure about other environments.
