### PR TITLE
fix: Fixed mistake in getting palette array

### DIFF
--- a/src/image.go
+++ b/src/image.go
@@ -659,7 +659,7 @@ func (s *Sprite) shareCopy(src *Sprite) {
 	//s.PalTex = src.PalTex
 }
 func (s *Sprite) GetPal(pl *PaletteList) []uint32 {
-	if s.Pal != nil || s.coldepth > 8 {
+	if len(s.Pal) > 0 || s.coldepth > 8 {
 		return s.Pal
 	}
 	return pl.Get(int(s.palidx)) //pl.palettes[pl.paletteMap[int(s.palidx)]]

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -1108,7 +1108,6 @@ func (fa *LifeBarFace) draw(layerno int16, ref int, far *LifeBarFace) {
 		if far.face.PalTex != nil {
 			far.face.PalTex = far.face.GetPalTex(&sys.cgi[ref].palettedata.palList)
 		} else {
-			far.face.Pal = nil
 			far.face.Pal = far.face.GetPal(&sys.cgi[ref].palettedata.palList)
 		}
 		if far.palshare {


### PR DESCRIPTION
Fixed a possible return of an array 0 when retrieving a sprite palette array.
I think fixed #1455, but cannot be sure as I have not been able to reproduce the problem.