### PR TITLE
feat: GetHitVar saves unused Hitdef velocities

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -472,6 +472,15 @@ const (
 	OC_ex_gethitvar_priority
 	OC_ex_gethitvar_guardcount
 	OC_ex_gethitvar_facing
+	OC_ex_gethitvar_ground_velocity_x
+	OC_ex_gethitvar_ground_velocity_y
+	OC_ex_gethitvar_air_velocity_x
+	OC_ex_gethitvar_air_velocity_y
+	OC_ex_gethitvar_down_velocity_x
+	OC_ex_gethitvar_down_velocity_y
+	OC_ex_gethitvar_guard_velocity_x
+	OC_ex_gethitvar_airguard_velocity_x
+	OC_ex_gethitvar_airguard_velocity_y
 	OC_ex_ailevelf
 	OC_ex_animelemlength
 	OC_ex_animframe_alphadest
@@ -2060,6 +2069,24 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(c.ghv.priority)
 	case OC_ex_gethitvar_facing:
 		sys.bcStack.PushI(c.ghv.facing)
+	case OC_ex_gethitvar_ground_velocity_x:
+		sys.bcStack.PushF(c.ghv.ground_velocity[0] * (c.localscl / oc.localscl))
+	case OC_ex_gethitvar_ground_velocity_y:
+		sys.bcStack.PushF(c.ghv.ground_velocity[1] * (c.localscl / oc.localscl))
+	case OC_ex_gethitvar_air_velocity_x:
+		sys.bcStack.PushF(c.ghv.air_velocity[0] * (c.localscl / oc.localscl))
+	case OC_ex_gethitvar_air_velocity_y:
+		sys.bcStack.PushF(c.ghv.air_velocity[1] * (c.localscl / oc.localscl))
+	case OC_ex_gethitvar_down_velocity_x:
+		sys.bcStack.PushF(c.ghv.down_velocity[0] * (c.localscl / oc.localscl))
+	case OC_ex_gethitvar_down_velocity_y:
+		sys.bcStack.PushF(c.ghv.down_velocity[1] * (c.localscl / oc.localscl))
+	case OC_ex_gethitvar_guard_velocity_x:
+		sys.bcStack.PushF(c.ghv.guard_velocity * (c.localscl / oc.localscl))
+	case OC_ex_gethitvar_airguard_velocity_x:
+		sys.bcStack.PushF(c.ghv.airguard_velocity[0] * (c.localscl / oc.localscl))
+	case OC_ex_gethitvar_airguard_velocity_y:
+		sys.bcStack.PushF(c.ghv.airguard_velocity[1] * (c.localscl / oc.localscl))
 	case OC_ex_ailevelf:
 		if !c.asf(ASF_noailevel) {
 			sys.bcStack.PushF(c.aiLevel())

--- a/src/char.go
+++ b/src/char.go
@@ -772,6 +772,11 @@ type GetHitVar struct {
 	kill           bool
 	priority       int32
 	facing         int32
+	ground_velocity   [2]float32
+	air_velocity      [2]float32
+	down_velocity     [2]float32
+	guard_velocity    float32
+	airguard_velocity [2]float32
 }
 
 func (ghv *GetHitVar) clear() {
@@ -7172,6 +7177,16 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 						ghv.hittime += 1
 					}
 				}
+				// Save velocities regardless of statetype
+				ghv.ground_velocity[0] = hd.ground_velocity[0] * (c.localscl / getter.localscl)
+				ghv.ground_velocity[1] = hd.ground_velocity[1] * (c.localscl / getter.localscl)
+				ghv.air_velocity[0] = hd.air_velocity[0] * (c.localscl / getter.localscl)
+				ghv.air_velocity[1] = hd.air_velocity[1] * (c.localscl / getter.localscl)
+				ghv.down_velocity[0] = hd.down_velocity[0] * (c.localscl / getter.localscl)
+				ghv.down_velocity[1] = hd.down_velocity[1] * (c.localscl / getter.localscl)
+				ghv.guard_velocity = hd.guard_velocity * (c.localscl / getter.localscl)
+				ghv.airguard_velocity[0] = hd.airguard_velocity[0] * (c.localscl / getter.localscl)
+				ghv.airguard_velocity[1] = hd.airguard_velocity[1] * (c.localscl / getter.localscl)
 				ghv.airanimtype = hd.air_animtype
 				ghv.groundanimtype = hd.animtype
 				ghv.animtype = getter.gethitAnimtype() // This must be placed after ghv.yvel

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1873,6 +1873,24 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				out.append(OC_ex_gethitvar_priority)
 			case "facing":
 				out.append(OC_ex_gethitvar_facing)
+			case "ground.velocity.x":
+				out.append(OC_ex_gethitvar_ground_velocity_x)
+			case "ground.velocity.y":
+				out.append(OC_ex_gethitvar_ground_velocity_y)
+			case "air.velocity.x":
+				out.append(OC_ex_gethitvar_air_velocity_x)
+			case "air.velocity.y":
+				out.append(OC_ex_gethitvar_air_velocity_y)
+			case "down.velocity.x":
+				out.append(OC_ex_gethitvar_down_velocity_x)
+			case "down.velocity.y":
+				out.append(OC_ex_gethitvar_down_velocity_y)
+			case "guard.velocity.x":
+				out.append(OC_ex_gethitvar_guard_velocity_x)
+			case "airguard.velocity.x":
+				out.append(OC_ex_gethitvar_airguard_velocity_x)
+			case "airguard.velocity.y":
+				out.append(OC_ex_gethitvar_airguard_velocity_y)
 			default:
 				return bvNone(), Error("Invalid data: " + c.token)
 			}

--- a/src/script.go
+++ b/src/script.go
@@ -3267,6 +3267,24 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.ghv.priority)
 		case "facing":
 			ln = lua.LNumber(c.ghv.facing)
+		case "ground.velocity.x":
+			ln = lua.LNumber(c.ghv.ground_velocity[0])
+		case "ground.velocity.y":
+			ln = lua.LNumber(c.ghv.ground_velocity[1])
+		case "air.velocity.x":
+			ln = lua.LNumber(c.ghv.air_velocity[0])
+		case "air.velocity.y":
+			ln = lua.LNumber(c.ghv.air_velocity[1])
+		case "down.velocity.x":
+			ln = lua.LNumber(c.ghv.down_velocity[0])
+		case "down.velocity.y":
+			ln = lua.LNumber(c.ghv.down_velocity[1])
+		case "guard.velocity.x":
+			ln = lua.LNumber(c.ghv.guard_velocity)
+		case "airguard.velocity.x":
+			ln = lua.LNumber(c.ghv.airguard_velocity[0])
+		case "airguard.velocity.y":
+			ln = lua.LNumber(c.ghv.airguard_velocity[1])
 		default:
 			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}


### PR DESCRIPTION
- GetHitVar trigger can now return hit velocities regardless of the statetype the character was hit from
- Available:
GetHitVar(ground.velocity.x)
GetHitVar(ground.velocity.y)
GetHitVar(air.velocity.x)
GetHitVar(air.velocity.y)
GetHitVar(down.velocity.x)
GetHitVar(down.velocity.y)
GetHitVar(guard.velocity.x)
GetHitVar(airguard.velocity.x)
GetHitVar(airguard.velocity.y)