### PR TITLE
feat: GetHitVarSet state controller, some fixes

### DIFF
--- a/data/dizzy.zss
+++ b/data/dizzy.zss
@@ -363,14 +363,13 @@ if !dizzy || time > 300 {
 #===============================================================================
 [StateDef -2]
 
-ignoreHitPause if !const(Default.Enable.Dizzy) || isHelper || teamSide = 0 {
+if !const(Default.Enable.Dizzy) || isHelper || teamSide = 0 {
 	# Do nothing, global code disabled locally or executed by helper/stage
-} else ignoreHitPause if roundState = 0 {
+} else if roundState = 0 {
 	dizzyPointsSet{value: dizzyPointsMax}
 	map(_iksys_dizzyPointsTimer) := 0;
 	map(_iksys_dizzyLimit) := 0;
-
-} else ignoreHitPause if alive {
+} else if alive {
 	# Upon hit, set cooldown timer
 	if moveType = H || dizzy || stateNo = const(StateDownedGetHit_gettingUp) {
 		map(_iksys_dizzyPointsTimer) := 60;
@@ -440,5 +439,12 @@ ignoreHitPause if !const(Default.Enable.Dizzy) || isHelper || teamSide = 0 {
 		if (ctrl && time > 0) || moveType = A {
 			map(_iksys_dizzyLimit) := 0;
 		}
+	}
+
+# Reset status if char is KO
+} else {
+	dizzySet{value: 0}
+	if dizzyPoints < 1 {
+		dizzyPointsSet{value: 1}
 	}
 }

--- a/data/dizzy.zss
+++ b/data/dizzy.zss
@@ -393,6 +393,7 @@ ignoreHitPause if !const(Default.Enable.Dizzy) || isHelper || teamSide = 0 {
 			dizzyPointsSet{value: 1} # Similar to using kill = 0 in LifeAdd
 		} else if moveType = H && !inCustomState {
 			dizzySet{value: 1}
+			getHitVarSet{fall.recover: 0}
 		}
 	}
 

--- a/data/guardbreak.zss
+++ b/data/guardbreak.zss
@@ -151,13 +151,13 @@ if !const(Default.Enable.GuardBreak) || isHelper || teamSide = 0 {
 	map(_iksys_guardPointsTimer) := 0;
 } else if roundState = 2 && alive {
 	# Manage cooldown timer
-	ignoreHitPause if moveType = H {
+	if moveType = H {
 		map(_iksys_guardPointsTimer) := 60;
 	} else if map(_iksys_guardPointsTimer) > 0 {
 		mapAdd{map: "_iksys_guardPointsTimer"; value: -1}
 	}
 	# Upon block
-	ignoreHitPause if stateNo = const(StateStandGuardHit_shaking) || stateNo = const(StateCrouchGuardHit_shaking) || stateNo = const(StateAirGuardHit_shaking) {
+	if stateNo = const(StateStandGuardHit_shaking) || stateNo = const(StateCrouchGuardHit_shaking) || stateNo = const(StateAirGuardHit_shaking) {
 		# Coloring if guard points left are under 333 or 50% for characters with a small guard bar
 		if (gameTime % 5) = 0 && guardPoints <= min((0.5 * guardPointsMax), 333) {
 			palFx{time: 2; add: 200, 0, 0}
@@ -168,12 +168,18 @@ if !const(Default.Enable.GuardBreak) || isHelper || teamSide = 0 {
 		}
 	}
 	# Reset guard points and remove guard break flag if player is no longer in one of guard break states
-	ignoreHitPause if guardBreak && stateNo != [const(StateGuardBreakHit), const(StateGuardBreakRecover)] {
+	if guardBreak && stateNo != [const(StateGuardBreakHit), const(StateGuardBreakRecover)] {
 		guardPointsSet{value: guardPointsMax}
 		guardBreakSet{value: 0}
 	}
 	# Guard points recovery
-	ignoreHitPause if !guardBreak && guardPoints < guardPointsMax && map(_iksys_guardPointsTimer) <= 0 {
+	if !guardBreak && guardPoints < guardPointsMax && map(_iksys_guardPointsTimer) <= 0 {
 		guardPointsAdd{value: 2; absolute: 1}
+	}
+# Reset status if char is KO
+} else {
+	guardBreakSet{value: 0}
+	if guardPoints < 1 {
+		guardPointsSet{value: 1}
 	}
 }

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -9146,6 +9146,118 @@ func (sc modifyChar) Run(c *Char, _ []int32) bool {
 	return false
 }
 
+type getHitVarSet StateControllerBase
+
+const (
+	getHitVarSet_airtype byte = iota
+	getHitVarSet_animtype
+	getHitVarSet_attr
+	getHitVarSet_chainid
+	getHitVarSet_ctrltime
+	getHitVarSet_fall
+	getHitVarSet_fall_damage
+	getHitVarSet_fall_envshake_ampl
+	getHitVarSet_fall_envshake_freq
+	getHitVarSet_fall_envshake_mul
+	getHitVarSet_fall_envshake_phase
+	getHitVarSet_fall_envshake_time
+	getHitVarSet_fall_kill
+	getHitVarSet_fall_recover
+	getHitVarSet_fall_recovertime
+	getHitVarSet_fall_xvel
+	getHitVarSet_fall_yvel
+	getHitVarSet_fallcount
+	getHitVarSet_ground_animtype
+	getHitVarSet_groundtype
+	getHitVarSet_guarded
+	getHitVarSet_hitshaketime
+	getHitVarSet_hittime
+	getHitVarSet_id
+	getHitVarSet_playerno
+	getHitVarSet_recovertime
+	getHitVarSet_slidetime
+	getHitVarSet_xvel
+	getHitVarSet_yaccel
+	getHitVarSet_yvel
+	getHitVarSet_redirectid
+)
+
+func (sc getHitVarSet) Run(c *Char, _ []int32) bool {
+	crun := c
+	var lclscround float32 = 1.0
+	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
+		switch id {
+		case getHitVarSet_airtype:
+			crun.ghv.airtype = HitType(exp[0].evalI(c))
+		case getHitVarSet_animtype:
+			crun.ghv.animtype = Reaction(exp[0].evalI(c))
+		case getHitVarSet_attr:
+			crun.ghv.attr = exp[0].evalI(c)
+		case getHitVarSet_chainid:
+			crun.ghv.hitid = exp[0].evalI(c)
+		case getHitVarSet_ctrltime:
+			crun.ghv.ctrltime = exp[0].evalI(c)
+		case getHitVarSet_fall:
+			crun.ghv.fallf = exp[0].evalB(c)
+		case getHitVarSet_fall_damage:
+			crun.ghv.fall.damage = exp[0].evalI(c)
+		case getHitVarSet_fall_envshake_ampl:
+			crun.ghv.fall.envshake_ampl = exp[0].evalI(c)*lclscround
+		case getHitVarSet_fall_envshake_freq:
+			crun.ghv.fall.envshake_freq = exp[0].evalF(c)
+		case getHitVarSet_fall_envshake_mul:
+			crun.ghv.fall.envshake_mul = exp[0].evalF(c)
+		case getHitVarSet_fall_envshake_phase:
+			crun.ghv.fall.envshake_phase = exp[0].evalF(c)
+		case getHitVarSet_fall_envshake_time:
+			crun.ghv.fall.envshake_time = exp[0].evalI(c)
+		case getHitVarSet_fall_kill:
+			crun.ghv.fall.kill = exp[0].evalB(c)
+		case getHitVarSet_fall_recover:
+			crun.ghv.fall.recover = exp[0].evalB(c)
+		case getHitVarSet_fall_recovertime:
+			crun.ghv.fall.recovertime = exp[0].evalI(c)
+		case getHitVarSet_fall_xvel:
+			crun.ghv.fall.xvelocity = exp[0].evalF(c)*lclscround
+		case getHitVarSet_fall_yvel:
+			crun.ghv.fall.yvelocity = exp[0].evalF(c)*lclscround
+		case getHitVarSet_fallcount:
+			crun.ghv.fallcount = exp[0].evalI(c)
+		case getHitVarSet_groundtype:
+			crun.ghv.groundtype = HitType(exp[0].evalI(c))
+		case getHitVarSet_guarded:
+			crun.ghv.guarded = exp[0].evalB(c)
+		case getHitVarSet_hittime:
+			crun.ghv.hittime = exp[0].evalI(c)
+		case getHitVarSet_hitshaketime:
+			crun.ghv.hitshaketime = exp[0].evalI(c)
+		case getHitVarSet_id:
+			crun.ghv.id = exp[0].evalI(c)
+		case getHitVarSet_playerno:
+			crun.ghv.playerNo = int(exp[0].evalI(c))
+		case getHitVarSet_recovertime:
+			crun.recoverTime = exp[0].evalI(c)
+		case getHitVarSet_slidetime:
+			crun.ghv.slidetime = exp[0].evalI(c)
+		case getHitVarSet_xvel:
+			crun.ghv.xvel = exp[0].evalF(c)*lclscround
+		case getHitVarSet_yaccel:
+			crun.ghv.yaccel = exp[0].evalF(c)*lclscround
+		case getHitVarSet_yvel:
+			crun.ghv.yvel = exp[0].evalF(c)*lclscround
+		case getHitVarSet_redirectid:
+			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
+				crun = rid
+				lclscround = c.localscl / crun.localscl
+			} else {
+				return false
+			}
+		}
+		return true
+	})
+	return false
+}
+
 // StateDef data struct
 type StateBytecode struct {
 	stateType StateType

--- a/src/char.go
+++ b/src/char.go
@@ -7762,6 +7762,7 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 									c.mctime = -1
 								}
 								if c.hitdef.reversal_attr > 0 {
+									c.powerAdd(c.hitdef.hitgetpower)
 									getter.hitdef.hitflag = 0
 									getter.mctype = MC_Reversed
 									getter.mctime = -1
@@ -7806,7 +7807,6 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 									c.hitPauseTime = Max(1, c.hitdef.pausetime+
 										Btoi(c.gi().mugenver[0] == 1))
 								}
-								c.powerAdd(c.hitdef.hitgetpower)
 								c.uniqHitCount++
 							} else {
 								if mvh {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -169,6 +169,7 @@ func newCompiler() *Compiler {
 		"camera":               c.cameraCtrl,
 		"height":               c.height,
 		"modifychar":           c.modifyChar,
+		"gethitvarset":         c.getHitVarSet,
 	}
 	return c
 }

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -429,10 +429,13 @@ func (c *Compiler) helper(is IniSection, sc *StateControllerBase, _ int8) (State
 			if len(data) == 0 {
 				return Error("Value not specified")
 			}
-			switch strings.ToLower(data)[0] {
-			case 'n':
-			case 'p':
+			switch strings.ToLower(data) {
+			case "normal":
+				// Default, valid value
+			case "player":
 				sc.add(helper_helpertype, sc.iToExp(1))
+			case "projectile":
+				// Valid but unused in Mugen. Same as normal type
 			default:
 				return Error("Invalid value: " + data)
 			}

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -4890,6 +4890,133 @@ func (c *Compiler) assertCommand(is IniSection, sc *StateControllerBase, _ int8)
 	return *ret, err
 }
 
+func (c *Compiler) getHitVarSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+	ret, err := (*getHitVarSet)(sc), c.stateSec(is, func() error {
+		if err := c.paramValue(is, sc, "redirectid",
+			getHitVarSet_redirectid, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "airtype",
+			getHitVarSet_airtype, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "animtype",
+			getHitVarSet_animtype, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "attr",
+			getHitVarSet_attr, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "chainid",
+			getHitVarSet_chainid, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "ctrltime",
+			getHitVarSet_ctrltime, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "fall",
+			getHitVarSet_fall, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "fall.damage",
+			getHitVarSet_fall_damage, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "fall.envshake.ampl",
+			getHitVarSet_fall_envshake_ampl, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "fall.envshake.freq",
+			getHitVarSet_fall_envshake_freq, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "fall.envshake.mul",
+			getHitVarSet_fall_envshake_mul, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "fall.envshake.phase",
+			getHitVarSet_fall_envshake_phase, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "fall.envshake.time",
+			getHitVarSet_fall_envshake_time, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "fall.kill",
+			getHitVarSet_fall_kill, VT_Bool, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "fall.recover",
+			getHitVarSet_fall_recover, VT_Bool, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "fall.recovertime",
+			getHitVarSet_fall_recovertime, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "fall.xvel",
+			getHitVarSet_fall_xvel, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "fall.yvel",
+			getHitVarSet_fall_yvel, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "fallcount",
+			getHitVarSet_fallcount, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "groundtype",
+			getHitVarSet_groundtype, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "guarded",
+			getHitVarSet_guarded, VT_Bool, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "hitshaketime",
+			getHitVarSet_hitshaketime, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "hittime",
+			getHitVarSet_hittime, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "id",
+			getHitVarSet_id, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "playerno",
+			getHitVarSet_playerno, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "recovertime",
+			getHitVarSet_recovertime, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "slidetime",
+			getHitVarSet_slidetime, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "xvel",
+			getHitVarSet_xvel, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "yaccel",
+			getHitVarSet_yaccel, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "yvel",
+			getHitVarSet_yvel, VT_Float, 1, false); err != nil {
+			return err
+		}
+		return nil
+	})
+	return *ret, err
+}
+
 // It's just a Null... Has no effect whatsoever.
 func (c *Compiler) null(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	return nullStateController, nil


### PR DESCRIPTION
GetHitVarSet:
- Allows changing a player's GetHitVar without hitting them
- Supported parameters: airtype, animtype, attr, chainid, ctrltime, fall, fall.damage, fall.envshake.ampl, fall.envshake.freq, fall.envshake.mul, fall.envshake.phase, fall.envshake.time, fall.kill, fall.recover, fall.recovertime, fall.xvel, fall.yvel, fallcount, groundtype, guarded, hitshaketime, hittime, ID, playerno, recovertime, slidetime, xvel, yaccel, yvel

Fixes:
- Fixed a regression in a previous commit that caused meter gained by "getpower" to be doubled
- Made helper type parameter parsing more strict. This prevents eventual "helpertype = projectile" (valid but useless in Mugen)  helpers from being evaluated as player type
- If a char is KO'd with 0 dizzy/guard points, they are now set to 1. This should prevent the respective bars from showing empty warnings