### PR TITLE
feat: HelperIndexExist, PlayerIndex, PlayerIndexExist, PlayerCount, NumPlayer triggers

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -213,6 +213,7 @@ const (
 	OC_enemy
 	OC_enemynear
 	OC_playerid
+	OC_playerindex	
 	OC_helperindex
 	OC_p2
 	OC_stateowner
@@ -516,6 +517,7 @@ const (
 	OC_ex_guardpoints
 	OC_ex_guardpointsmax
 	OC_ex_helpername
+	OC_ex_helperindexexist	
 	OC_ex_hitoverridden
 	OC_ex_incustomstate
 	OC_ex_indialogue
@@ -527,6 +529,7 @@ const (
 	OC_ex_maparray
 	OC_ex_max
 	OC_ex_min
+	OC_ex_numplayer
 	OC_ex_clamp
 	OC_ex_sign
 	OC_ex_atan2
@@ -540,6 +543,7 @@ const (
 	OC_ex_pausetime
 	OC_ex_physics
 	OC_ex_playerno
+	OC_ex_playerindexexist	
 	OC_ex_randomrange
 	OC_ex_ratiolevel
 	OC_ex_receiveddamage
@@ -560,6 +564,7 @@ const (
 	OC_ex_timeelapsed
 	OC_ex_timeremaining
 	OC_ex_timetotal
+	OC_ex_playercount	
 	OC_ex_pos_z
 	OC_ex_vel_z
 	OC_ex_prevanim
@@ -1112,6 +1117,13 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			i += int(*(*int32)(unsafe.Pointer(&be[i]))) + 4
 		case OC_playerid:
 			if c = sys.playerID(sys.bcStack.Pop().ToI()); c != nil {
+				i += 4
+				continue
+			}
+			sys.bcStack.Push(BytecodeSF())
+			i += int(*(*int32)(unsafe.Pointer(&be[i]))) + 4
+		case OC_playerindex:
+			if c = sys.playerIndex(sys.bcStack.Pop().ToI()); c != nil {
 				i += 4
 				continue
 			}
@@ -2235,6 +2247,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 			sys.stringPool[sys.workingState.playerNo].List[*(*int32)(
 				unsafe.Pointer(&be[*i]))])
 		*i += 4
+	case OC_ex_helperindexexist:
+		*sys.bcStack.Top() = c.helperByIndexExist(*sys.bcStack.Top())
 	case OC_ex_hitoverridden:
 		sys.bcStack.PushB(c.hoIdx >= 0)
 	case OC_ex_incustomstate:
@@ -2264,6 +2278,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_min:
 		v2 := sys.bcStack.Pop()
 		be.min(sys.bcStack.Top(), v2)
+	case OC_ex_numplayer:
+		sys.bcStack.PushI(c.numPlayer())	
 	case OC_ex_clamp:
 		v3 := sys.bcStack.Pop()
 		v2 := sys.bcStack.Pop()
@@ -2296,6 +2312,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		*i++
 	case OC_ex_playerno:
 		sys.bcStack.PushI(int32(c.playerNo) + 1)
+	case OC_ex_playerindexexist:
+		*sys.bcStack.Top() = sys.playerIndexExist(*sys.bcStack.Top())			
 	case OC_ex_randomrange:
 		v2 := sys.bcStack.Pop()
 		be.random(sys.bcStack.Top(), v2)
@@ -2338,6 +2356,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(timeRemaining())
 	case OC_ex_timetotal:
 		sys.bcStack.PushI(timeTotal())
+	case OC_ex_playercount:
+		sys.bcStack.PushI(sys.playercount())
 	case OC_ex_pos_z:
 		sys.bcStack.PushF(c.pos[2] * (c.localscl / oc.localscl))
 	case OC_ex_vel_z:

--- a/src/char.go
+++ b/src/char.go
@@ -2977,14 +2977,27 @@ func (c *Char) helper(id int32) *Char {
 	sys.appendToConsole(c.warn() + fmt.Sprintf("has no helper: %v", id))
 	return nil
 }
-func (c *Char) helperByIndex(id int32) *Char {
+func (c *Char) gethelperByIndex(id int32) *Char {
+	index := int32(id - 1)
+	if index < 0 { return sys.chars[c.playerNo][0] }
 	for j, h := range sys.chars[c.playerNo][1:] {
-		if (id - 1) == int32(j) {
+		if index == int32(j) {
 			return h
 		}
 	}
+	return nil
+}
+func (c *Char) helperByIndex(id int32) *Char {
+	h := c.gethelperByIndex(id)
+	if h != nil { return h }
 	sys.appendToConsole(c.warn() + fmt.Sprintf("has no helper with index: %v", id))
 	return nil
+}
+func (c *Char) helperByIndexExist( id BytecodeValue) BytecodeValue {
+	if id.IsSF() {
+		return BytecodeSF()
+	}
+	return BytecodeBool(c.gethelperByIndex(id.ToI()) != nil)
 }
 func (c *Char) target(id int32) *Char {
 	for _, tid := range c.targets {
@@ -3321,6 +3334,16 @@ func (c *Char) numEnemy() int32 {
 	}
 	for i := ^c.playerNo & 1; i < int(sys.numSimul[^c.playerNo&1]*2); i += 2 {
 		if len(sys.chars[i]) > 0 && !sys.chars[i][0].scf(SCF_standby) && !sys.chars[i][0].scf(SCF_disabled) {
+			n += 1
+		}
+	}
+	return n
+}
+func (c *Char) numPlayer() int32 {
+	n := int32(0)
+	for i := 0; i < len(sys.chars)-1; i++ {
+		//&& !sys.chars[i][0].scf(SCF_standby)
+		if len(sys.chars[i]) > 0 && !sys.chars[i][0].scf(SCF_disabled) {
 			n += 1
 		}
 	}
@@ -7955,6 +7978,14 @@ func (cl *CharList) get(id int32) *Char {
 		return nil
 	}
 	return cl.idMap[id]
+}
+func (cl *CharList) getIndex(id int32) *Char {
+	for j, p := range cl.runOrder {
+		if (id - 1) == int32(j) {
+			return p
+		}
+	}
+	return nil
 }
 func (cl *CharList) p2enemyDelete(c *Char) {
 	for _, e := range cl.runOrder {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -184,6 +184,7 @@ var triggerMap = map[string]int{
 	"enemy":       0,
 	"enemynear":   0,
 	"playerid":    0,
+	"playerindex": 0,
 	"p2":          0,
 	"stateowner":  0,
 	"helperindex": 0,
@@ -357,6 +358,7 @@ var triggerMap = map[string]int{
 	"guardbreak":         1,
 	"guardpoints":        1,
 	"guardpointsmax":     1,
+	"helperindexexist":   1,
 	"hitoverridden":      1,
 	"incustomstate":      1,
 	"indialogue":         1,
@@ -372,6 +374,7 @@ var triggerMap = map[string]int{
 	"movecontactframe":   1,
 	"movecountered":      1,
 	"mugenversion":       1,
+	"numplayer":          1,
 	"offset":             1,
 	"p5name":             1,
 	"p6name":             1,
@@ -380,6 +383,8 @@ var triggerMap = map[string]int{
 	"pausetime":          1,
 	"physics":            1,
 	"playerno":           1,
+	"playercount":        1,
+	"playerindexexist":   1,		
 	"prevanim":           1,
 	"prevmovetype":       1,
 	"prevstatetype":      1,
@@ -1186,7 +1191,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 	case "":
 		return bvNone(), Error("Nothing assigned")
 	case "root", "player", "parent", "helper", "target", "partner",
-		"enemy", "enemynear", "playerid", "p2", "stateowner", "helperindex":
+		"enemy", "enemynear", "playerid", "playerindex", "p2", "stateowner", "helperindex":
 		switch c.token {
 		case "parent":
 			opc = OC_parent
@@ -1216,6 +1221,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				opc = OC_enemynear
 			case "playerid":
 				opc = OC_playerid
+			case "playerindex":
+				opc = OC_playerindex			
 			case "helperindex":
 				opc = OC_helperindex
 			}
@@ -1240,6 +1247,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 					return bvNone(), Error("Missing '(' after player")
 				case OC_playerid:
 					return bvNone(), Error("Missing '(' after playerid")
+				case OC_playerindex:
+					return bvNone(), Error("Missing '(' after playerindex")					
 				case OC_helperindex:
 					return bvNone(), Error("Missing '(' after helperindex")
 				}
@@ -1901,6 +1910,11 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		}
 	case "guardcount":
 		out.append(OC_ex_, OC_ex_guardcount)
+	case "helperindexexist":
+		if _, err := c.oneArg(out, in, rd, true); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_ex_,OC_ex_helperindexexist)		
 	case "hitcount":
 		out.append(OC_hitcount)
 	case "hitdefattr":
@@ -3047,6 +3061,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_ex_, OC_ex_movecountered)
 	case "mugenversion":
 		out.append(OC_ex_, OC_ex_mugenversion)
+	case "numplayer":
+		out.append(OC_ex_, OC_ex_numplayer)			
 	case "pausetime":
 		out.append(OC_ex_, OC_ex_pausetime)
 	case "physics":
@@ -3073,7 +3089,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 	case "playerno":
-		out.append(OC_ex_, OC_ex_playerno)
+		out.append(OC_ex_, OC_ex_playerno)	
 	case "ratiolevel":
 		out.append(OC_ex_, OC_ex_ratiolevel)
 	case "receiveddamage":
@@ -3125,6 +3141,13 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_ex_, OC_ex_timeremaining)
 	case "timetotal":
 		out.append(OC_ex_, OC_ex_timetotal)
+	case "playercount":
+		out.append(OC_ex_, OC_ex_playercount)
+	case "playerindexexist":
+		if _, err := c.oneArg(out, in, rd, true); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_ex_, OC_ex_playerindexexist)	
 	case "drawpalno":
 		out.append(OC_ex_, OC_ex_drawpalno)
 	case "angle":

--- a/src/script.go
+++ b/src/script.go
@@ -4165,6 +4165,11 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.debugWC.guardPointsMax))
 		return 1
 	})
+	luaRegister(l, "helperindexexist", func(*lua.LState) int {
+		l.Push(lua.LBool(sys.debugWC.helperByIndexExist(
+	BytecodeInt(int32(numArg(l, 1)))).ToB()))
+		return 1
+	})	
 	luaRegister(l, "hitoverridden", func(*lua.LState) int {
 		l.Push(lua.LBool(sys.debugWC.hoIdx >= 0))
 		return 1
@@ -4343,6 +4348,10 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.debugWC.mugenVersion()))
 		return 1
 	})
+	luaRegister(l, "numplayer", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.numPlayer()))
+		return 1
+	})	
 	luaRegister(l, "offsetX", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.offsetTrg[0]))
 		return 1
@@ -4374,6 +4383,23 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.debugWC.playerNo + 1))
 		return 1
 	})
+	luaRegister(l, "playerindex", func(*lua.LState) int {
+		ret := false
+		if c := sys.playerIndex(int32(numArg(l, 1))); c != nil {
+			sys.debugWC, ret = c, true
+		}
+		l.Push(lua.LBool(ret))
+		return 1
+	})	
+	luaRegister(l, "playerindexexist", func(*lua.LState) int {
+		l.Push(lua.LBool(sys.playerIndexExist(
+			BytecodeInt(int32(numArg(l, 1)))).ToB()))
+		return 1
+	})
+	luaRegister(l, "playercount", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.playercount()))
+		return 1
+	})	
 	//randomrange (dedicated functionality already exists in Lua)
 	//rad (dedicated functionality already exists in Lua)
 	luaRegister(l, "ratiolevel", func(*lua.LState) int {

--- a/src/system.go
+++ b/src/system.go
@@ -625,6 +625,9 @@ func (s *System) anyButton() bool {
 func (s *System) playerID(id int32) *Char {
 	return s.charList.get(id)
 }
+func (s *System) playerIndex(id int32) *Char {
+	return s.charList.getIndex(id)
+}
 func (s *System) matchOver() bool {
 	return s.wins[0] >= s.matchWins[0] || s.wins[1] >= s.matchWins[1]
 }
@@ -633,6 +636,15 @@ func (s *System) playerIDExist(id BytecodeValue) BytecodeValue {
 		return BytecodeSF()
 	}
 	return BytecodeBool(s.playerID(id.ToI()) != nil)
+}
+func (s *System) playerIndexExist(id BytecodeValue) BytecodeValue {
+	if id.IsSF() {
+		return BytecodeSF()
+	}
+	return BytecodeBool(s.playerIndex(id.ToI()) != nil)
+}
+func (s *System) playercount() int32 {
+	return int32(len(s.charList.runOrder))
 }
 func (s *System) screenHeight() float32 {
 	return 240


### PR DESCRIPTION
HelperIndexExist:

- Returns 1 if a helper with the specified Index number exists, 0 otherwise. 

PlayerIndex:

- Redirects the trigger to the player entity by index.

PlayerIndexExist:

-  Returns 1 if a player with the specified Index number exists, 0 otherwise.

PlayerCount:

- Returns total players/helpers count  in scene.

NumPlayer:

- Returns main players count in scene (Attached char is ignored).