### PR TITLE
feat: Add `-width` and `-height` command line arguments

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -112,7 +112,7 @@ func processCommandLine() {
 		sys.cmdFlags = make(map[string]string)
 		key := ""
 		player := 1
-		r1, _ := regexp.Compile("^-[h%?]")
+		r1, _ := regexp.Compile("^-[h%?]$")
 		r2, _ := regexp.Compile("^-")
 		// Loop through arguments
 		for _, a := range os.Args[1:] {
@@ -124,6 +124,8 @@ func processCommandLine() {
 -r <path>               Loads motif <path>. eg. -r motifdir or -r motifdir/system.def
 -lifebar <path>         Loads lifebar <path>. eg. -lifebar data/fight.def
 -storyboard <path>      Loads storyboard <path>. eg. -storyboard chars/kfm/intro.def
+-width <num>            Overrides game window width
+-height <num>           Overrides game window height
 
 Quick VS Options:
 -p<n> <playername>      Loads player n, eg. -p3 kfm
@@ -320,6 +322,16 @@ func setupConfig() configSettings {
 	// Save config file, indent with two spaces to match calls to json.encode() in the Lua code
 	cfg, _ := json.MarshalIndent(tmp, "", "  ")
 	chk(os.WriteFile(cfgPath, cfg, 0644))
+
+	// If given width/height arguments, override config's width/height here
+	if _, wok := sys.cmdFlags["-width"]; wok {
+		var w, _ = strconv.ParseInt(sys.cmdFlags["-width"], 10, 32)
+		tmp.GameWidth = int32(w)
+	}
+	if _, hok := sys.cmdFlags["-height"]; hok {
+		var h, _ = strconv.ParseInt(sys.cmdFlags["-height"], 10, 32)
+		tmp.GameHeight = int32(h)
+	}
 
 	// Set each config property to the system object
 	sys.afterImageMax = tmp.MaxAfterImage


### PR DESCRIPTION
This PR adds two new command line arguments called `-width` and `-height`, both of which take numerical values. When given, these arguments override the game resolution as specified by `config.json`. This is pretty useful if, say, you want to quickly test a stage in a bunch of different common resolutions back-to-back.

![Demo of the -width and -height arguments. Note that these screenpack artifacts are NOT a byproduct of this command line argument; they appear identical when these resolutions are set via config.json as well.](https://github.com/ikemen-engine/Ikemen-GO/assets/22881403/3ee116e1-3b8d-4335-88bc-82daabdc66df)

The way I did this was by just modifying the value at runtime in `setupConfig()`. I'm not entirely sure if that's is the best place to put this override, but it seemed to produce expected behavior so that's why I left it there.

As a side effect, this PR also changes how Ikemen handles the `-h` parameter; it will now *only* return help information if given *specifically* `-h` or `-?`; prior to this PR it would accept any argument beginning with `-h` due to the RegEx not checking for the EOL.