### PR TITLE
feat: Camera Movement Revamp

### DIFF
--- a/src/bgdef.go
+++ b/src/bgdef.go
@@ -93,7 +93,7 @@ func loadBGDef(sff *Sff, def string, bgname string) (*BGDef, error) {
 			bglink = s.bg[len(s.bg)-1]
 		}
 		s.bg = append(s.bg, readBackGround(bgsec, bglink,
-			s.sff, s.at, 0, s.stageprops))
+			s.sff, s.at, s.stageprops))
 	}
 	bgcdef := *newBgCtrl()
 	i = 0

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1295,7 +1295,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 		case OC_camerapos_x:
 			sys.bcStack.PushF(sys.cam.Pos[0] / oc.localscl)
 		case OC_camerapos_y:
-			sys.bcStack.PushF((sys.cam.Pos[1] + sys.cam.aspectCorrection + sys.cam.zoomAnchorCorrection) / oc.localscl)
+			sys.bcStack.PushF((sys.cam.Pos[1] + sys.cam.aspectcorrection + sys.cam.zoomanchorcorrection) / oc.localscl)
 		case OC_camerazoom:
 			sys.bcStack.PushF(sys.cam.Scale)
 		case OC_canrecover:

--- a/src/camera.go
+++ b/src/camera.go
@@ -1,7 +1,5 @@
 package main
 
-import "math"
-
 type stageCamera struct {
 	startx               int32
 	boundleft            int32
@@ -22,7 +20,6 @@ type stageCamera struct {
 	localscl             float32
 	zoffset              int32
 	ztopscale            float32
-	drawOffsetY          float32
 	startzoom            float32
 	zoomin               float32
 	zoomout              float32
@@ -34,6 +31,7 @@ type stageCamera struct {
 	near                 float32
 	aspectCorrection     float32
 	zoomAnchorCorrection float32
+	yWithoutBound        float32
 }
 
 func newStageCamera() *stageCamera {
@@ -62,9 +60,7 @@ type Camera struct {
 	XMin, XMax                      float32
 	Scale, MinScale                 float32
 	boundL, boundR, boundH, boundLo float32
-	minYZoomDelta                   float32
 	zoff                            float32
-	screenZoff                      float32
 	halfWidth                       float32
 	FollowChar                      *Char
 }
@@ -73,12 +69,6 @@ func newCamera() *Camera {
 	return &Camera{View: Fighting_View, ZoomMin: 5.0 / 6, ZoomMax: 15.0 / 14, ZoomSpeed: 12}
 }
 func (c *Camera) Reset() {
-	c.minYZoomDelta = 1
-	for _, b := range sys.stage.bg {
-		if b.zoomdelta[1] < c.minYZoomDelta {
-			c.minYZoomDelta = b.zoomdelta[1]
-		}
-	}
 	c.ZoomEnable = c.ZoomActive && (c.stageCamera.zoomin != 1 || c.stageCamera.zoomout != 1)
 	c.boundL = float32(c.boundleft-c.startx)*c.localscl - ((1-c.zoomout)*100*c.zoomout)*(1/c.zoomout)*(1/c.zoomout)*1.6*(float32(sys.gameWidth)/320)
 	c.boundR = float32(c.boundright-c.startx)*c.localscl + ((1-c.zoomout)*100*c.zoomout)*(1/c.zoomout)*(1/c.zoomout)*1.6*(float32(sys.gameWidth)/320)
@@ -105,16 +95,13 @@ func (c *Camera) Reset() {
 	}
 	c.boundH = float32(c.boundhigh) * c.localscl
 	c.boundLo = float32(Max(c.boundhigh, c.boundlow)) * c.localscl
+	c.boundlow = Max(c.boundhigh, c.boundlow)
 
 	xminscl := float32(sys.gameWidth) / (float32(sys.gameWidth) - c.boundL +
 		c.boundR)
 	//yminscl := float32(sys.gameHeight) / (240 - MinF(0, c.boundH))
 	c.MinScale = MaxF(c.zoomout, MinF(c.zoomin, xminscl))
-	c.screenZoff = float32(c.zoffset-c.localcoord[1])*c.localscl + 240 - c.drawOffsetY
-	if c.boundhigh > 0 {
-		//c.boundH += float32(c.boundhigh) * c.localscl
-		c.screenZoff -= float32(c.boundhigh) * c.localscl
-	}
+	c.yWithoutBound = c.Pos[1]
 }
 func (c *Camera) Init() {
 	c.Reset()
@@ -151,16 +138,6 @@ func (c *Camera) XBound(scl, x float32) float32 {
 		c.boundL-c.halfWidth+c.halfWidth/scl,
 		c.boundR+c.halfWidth-c.halfWidth/scl)
 }
-func (c *Camera) YBound(scl, y float32) float32 {
-	if c.verticalfollow <= 0 {
-		return MaxF(0, c.boundLo)
-	} else {
-		bound := ClampF(y,
-			c.boundH*scl,
-			c.boundLo*scl)
-		return bound
-	}
-}
 func (c *Camera) BaseScale() float32 {
 	return c.ztopscale
 }
@@ -170,101 +147,140 @@ func (c *Camera) GroundLevel() float32 {
 func (c *Camera) ResetZoomdelay() {
 	c.zoomdelay = 0
 }
-func (c *Camera) action(x, y *float32, leftest, rightest, lowest, highest,
-	vmin, vmax float32, pause bool) (sclMul float32) {
-	switch c.View {
-	case Fighting_View:
-		tension := MaxF(0, c.halfWidth/c.Scale-float32(c.tension)*c.localscl)
-		tmp, vx := (leftest+rightest)/2, vmin+vmax
-		// Set base horizontal vel
-		vel := float32(3)
-		if sys.intro > sys.lifebar.ro.ctrl_time+1 {
-			vel = c.halfWidth
-		} else if pause {
-			vel = 2
-		}
-		vel *= 2 * c.tensionvel
-		// Apply base vel to average vel
-		if tmp < 0 {
-			vx -= vel
-		} else {
-			vx += vel
-		}
-		// Interpolate horizontal vel through GameSpeed/Turbo
-		if sys.debugPaused() {
-			vx = 0
-		} else {
-			vx *= MinF(1, sys.turbo)
-		}
-		// Make sure chars will stay behind tension limits if one of them isn't in a corner
-		if vx < 0 {
-			tmp = MaxF(leftest+tension, tmp)
-			if vx < tmp {
-				vx = MinF(0, tmp)
+func (c *Camera) action(x, y, scale float32, leftest, rightest, lowest, highest,
+	vr, vl float32, pause bool) (newX, newY, newScale float32) {
+	newX = x
+	newY = y
+	newScale = scale
+	if !sys.debugPaused() {
+		switch c.View {
+		case Fighting_View:
+			tension := MaxF(0, float32(c.tension)*c.localscl)
+			oldLeft, oldRight := x-c.halfWidth/scale, x+c.halfWidth/scale
+			targetLeft, targetRight := oldLeft, oldRight
+			maxRight := float32(c.boundright)*c.localscl + c.halfWidth/c.zoomout
+			minLeft := float32(c.boundleft)*c.localscl - c.halfWidth/c.zoomout
+			if leftest < oldLeft+tension {
+				targetLeft = MaxF(leftest-tension, minLeft)
+				targetRight = MaxF(oldRight-(oldLeft-targetLeft), MinF(rightest+tension, maxRight))
+			} else if rightest > oldRight-tension {
+				targetRight = MinF(rightest+tension, maxRight)
+				targetLeft = MinF(oldLeft-(oldRight-targetRight), MaxF(leftest-tension, minLeft))
 			}
-		} else {
-			tmp = MinF(rightest-tension, tmp)
-			if vx > tmp {
-				vx = MaxF(0, tmp)
+			if c.halfWidth*2/(targetRight-targetLeft) < c.zoomout {
+				x := (targetRight + targetLeft) / 2
+				targetLeft = x - c.halfWidth/c.zoomout
+				targetRight = x + c.halfWidth/c.zoomout
+				if leftest-targetLeft < float32(sys.stage.screenleft)*c.localscl {
+					diff := float32(sys.stage.screenleft)*c.localscl - (leftest - targetLeft)
+					targetLeft -= diff
+					targetRight -= diff
+				} else if targetRight-rightest < float32(sys.stage.screenright)*c.localscl {
+					diff := float32(sys.stage.screenright)*c.localscl - (targetRight - rightest)
+					targetLeft += diff
+					targetRight += diff
+				}
 			}
-		}
-		*x += vx
-		ftension, vfollow, ftensionlow := float32(c.floortension)*c.localscl-c.drawOffsetY, c.verticalfollow, -c.drawOffsetY
-		if c.ytensionenable {
-			heightValue := (240 / (float32(sys.gameWidth) / float32(c.localcoord[0])))
-			ftension = (heightValue/c.Scale - float32(c.tensionhigh) - float32(c.drawOffsetY) - (heightValue - float32(c.zoffset))) * c.localscl
-			vfollow = 1
-		}
-		if ftension < 0 {
-			ftension += 240*2 - float32(c.localcoord[1])*c.localscl - 240*c.Scale
-			if ftension < 0 {
-				ftension = 0
+			tmpScale := c.zoomin
+			if c.ytensionenable {
+				tmpScale = MinF(MaxF(float32(sys.gameHeight)/((lowest+float32(c.tensionlow)*c.localscl)-(highest-float32(c.tensionhigh)*c.localscl)), c.zoomout), c.zoomin)
 			}
-		}
-		if highest < -ftension {
-			*y = (highest + ftension + MaxF(0, lowest+ftensionlow)) * Pow(vfollow,
-				MinF(1, 1/Pow(c.Scale, 4)))
-		} else if lowest > -ftensionlow {
-			*y = (lowest + ftensionlow) * Pow(vfollow,
-				MinF(1, 1/Pow(c.Scale, 4)))
-		} else {
-			*y = c.Pos[1]
-		}
-		tmp = (rightest + sys.screenright) - (leftest - sys.screenleft) -
-			float32(sys.gameWidth-320)
-		if tmp < 0 {
-			tmp = 0
-		}
-		tmp = MaxF(220/c.Scale, float32(math.Sqrt(float64(Pow(tmp, 2)+
-			Pow(lowest+float32(c.tensionlow)*c.localscl+67-highest, 2)))))
-		sclMul = tmp * c.Scale / MaxF(c.Scale, (400-80*MaxF(1, c.Scale))*
-			Pow(2, c.ZoomSpeed-2))
-		if sclMul >= 3/Pow(2, c.ZoomSpeed) {
-			sclMul = MaxF(3.0/4, 67.0/64-sclMul*Pow(2, c.ZoomSpeed-6))
-		} else {
-			sclMul = MinF(4.0/3, Pow((Pow(2, c.ZoomSpeed)+3)/Pow(2, c.ZoomSpeed)-
-				sclMul, 64))
-		}
-		// Zoom delay
-		if c.ZoomDelayEnable && sclMul > 1 {
-			sclMul = (sclMul-1)*Pow(c.zoomdelay, 8) + 1
-			if tmp*sclMul > sys.xmax-sys.xmin {
-				sclMul = (sys.xmax - sys.xmin) / tmp
+			if c.halfWidth*2/(targetRight-targetLeft) < tmpScale {
+				diffLeft := MaxF(leftest-tension-targetLeft, 0)
+				if diffLeft < 0 {
+					diffLeft = 0
+				}
+				diffRight := MinF(rightest+tension-targetRight, 0)
+				if diffRight > 0 {
+					diffRight = 0
+				}
+				if c.halfWidth*2/((targetRight+diffRight)-(targetLeft+diffLeft)) > tmpScale {
+					tmp, tmp2 := diffLeft/(diffLeft-diffRight)*((targetRight+diffRight)-(targetLeft+diffLeft)-c.halfWidth*2/tmpScale), diffRight/(diffLeft-diffRight)*((targetRight+diffRight)-(targetLeft+diffLeft)-c.halfWidth*2/tmpScale)
+					diffLeft += tmp
+					diffRight += tmp2
+				}
+				targetLeft += diffLeft
+				targetRight += diffRight
 			}
-			if sys.tickNextFrame() {
-				c.zoomdelay = MinF(1, c.zoomdelay+1.0/32)
+			targetX := (targetLeft + targetRight) / 2
+			targetScale := c.halfWidth * 2 / (targetRight - targetLeft)
+
+			if !c.ytensionenable {
+				newY = c.yWithoutBound
+				//old*0.85+target* 0.15 if diff > 1
+				targetY := (highest + float32(c.floortension)*c.localscl) * c.verticalfollow
+				for i := 0; i < 3; i++ {
+					newY = newY*.85 + targetY*.15
+					if AbsF(targetY-newY) < 1 {
+						newY = targetY
+						break
+					}
+				}
+				c.yWithoutBound = newY
+			} else {
+				targetScale = MinF(MinF(MaxF(float32(sys.gameHeight)/((lowest+float32(c.tensionlow)*c.localscl)-(highest-float32(c.tensionhigh)*c.localscl)), c.zoomout), c.zoomin), targetScale)
+				targetX = MinF(MaxF(targetX, float32(c.boundleft)*c.localscl-c.halfWidth*(1/c.zoomout-1/targetScale)), float32(c.boundright)*c.localscl+c.halfWidth*(1/c.zoomout-1/targetScale))
+				targetLeft = targetX - c.halfWidth/targetScale
+				targetRight = targetX + c.halfWidth/targetScale
+
+				newY = c.yWithoutBound
+				targetY := c.GroundLevel()/targetScale + (highest - float32(c.tensionhigh)*c.localscl)
+				for i := 0; i < 3; i++ {
+					newY = newY*.85 + targetY*.15
+					if AbsF(targetY-newY) < 1 {
+						newY = targetY
+						break
+					}
+				}
+				c.yWithoutBound = newY
+
 			}
-		} else {
-			c.zoomdelay = 0
+
+			newLeft, newRight := oldLeft, oldRight
+
+			for i := 0; i < 3; i++ {
+				newLeft, newRight = newLeft+(targetLeft-newLeft)*0.05*sys.turbo*c.tensionvel, newRight+(targetRight-newRight)*0.05*sys.turbo*c.tensionvel
+				diffLeft := targetLeft - newLeft
+				diffRight := targetRight - newRight
+				if AbsF(diffLeft) <= 0.1*sys.turbo {
+					newLeft = targetLeft
+				} else if diffLeft > 0 {
+					newLeft += 0.1 * sys.turbo * c.tensionvel
+				} else {
+					newLeft -= 0.1 * sys.turbo * c.tensionvel
+				}
+				if newLeft-oldLeft > 0 && newLeft-oldLeft < vr {
+					newLeft = MinF(oldLeft+vr, targetLeft)
+				} else if newLeft-oldLeft < 0 && newLeft-oldLeft > vl {
+					newLeft = MaxF(oldLeft+vl, targetLeft)
+				}
+
+				if AbsF(diffRight) <= 0.1*sys.turbo*c.tensionvel {
+					newRight = targetRight
+				} else if diffRight > 0 {
+					newRight += 0.1 * sys.turbo * c.tensionvel
+				} else {
+					newRight -= 0.1 * sys.turbo * c.tensionvel
+				}
+				if newRight-oldRight > 0 && newRight-oldRight < vr {
+					newRight = MinF(oldRight+vr, targetRight)
+				} else if newRight-oldRight < 0 && newRight-oldRight > vl {
+					newRight = MaxF(oldRight+vl, targetRight)
+				}
+
+				newX = (newLeft + newRight) / 2
+			}
+			newScale = c.halfWidth * 2 / (newRight - newLeft)
+			newY = MinF(MaxF(newY, float32(c.boundhigh)*c.localscl*newScale), float32(c.boundlow)*c.localscl*newScale)
+		case Follow_View:
+			newX = c.FollowChar.pos[0]
+			newY = c.FollowChar.pos[1] * Pow(c.verticalfollow, MinF(1, 1/Pow(c.Scale, 4)))
+			newScale = 1
+		case Free_View:
+			newX = c.Pos[0]
+			newY = c.Pos[1]
+			newScale = 1
 		}
-	case Follow_View:
-		*x = c.FollowChar.pos[0]
-		*y = c.FollowChar.pos[1] * Pow(c.verticalfollow, MinF(1, 1/Pow(c.Scale, 4)))
-		sclMul = 1
-	case Free_View:
-		*x = c.Pos[0]
-		*y = c.Pos[1]
-		sclMul = 1
 	}
 	return
 }

--- a/src/camera.go
+++ b/src/camera.go
@@ -4,6 +4,7 @@ import "math"
 
 type stageCamera struct {
 	startx               int32
+	starty               int32
 	boundleft            int32
 	boundright           int32
 	boundhigh            int32
@@ -28,28 +29,29 @@ type stageCamera struct {
 	ytensionenable       bool
 	autocenter           bool
 	zoomanchor           bool
-	zoomInDelay          float32
-	zoomInDelayTime      float32
+	zoomindelay          float32
+	zoomindelaytime      float32
 	fov                  float32
 	yshift               float32
 	far                  float32
 	near                 float32
-	aspectCorrection     float32
-	zoomAnchorCorrection float32
-	yWithoutBound        float32
+	aspectcorrection     float32
+	zoomanchorcorrection float32
+	ywithoutbound        float32
 	highest              float32
 	lowest               float32
 	leftest              float32
 	rightest             float32
-	leftestVel           float32
-	rightestVel          float32
+	leftestvel           float32
+	rightestvel          float32
+	roundstart           bool
 }
 
 func newStageCamera() *stageCamera {
 	return &stageCamera{verticalfollow: 0.2, tensionvel: 1, tension: 50,
 		cuthigh: 0, cutlow: 0,
 		localcoord: [...]int32{320, 240}, localscl: float32(sys.gameWidth / 320),
-		ztopscale: 1, startzoom: 1, zoomin: 1, zoomout: 1, ytensionenable: false, fov: 40, yshift: 0, far: 10000, near: 0.1, zoomInDelay: 0}
+		ztopscale: 1, startzoom: 1, zoomin: 1, zoomout: 1, ytensionenable: false, fov: 40, yshift: 0, far: 10000, near: 0.1, zoomindelay: 0}
 }
 
 type CameraView int
@@ -86,20 +88,20 @@ func (c *Camera) Reset() {
 	c.halfWidth = float32(sys.gameWidth) / 2
 	c.XMin = c.boundL - c.halfWidth/c.BaseScale()
 	c.XMax = c.boundR + c.halfWidth/c.BaseScale()
-	c.aspectCorrection = 0
-	c.zoomAnchorCorrection = 0
+	c.aspectcorrection = 0
+	c.zoomanchorcorrection = 0
 	if float32(c.localcoord[1])*c.localscl-float32(sys.gameHeight) < 0 {
-		c.aspectCorrection = MinF(0, (float32(c.localcoord[1])*c.localscl-float32(sys.gameHeight))+MinF((float32(sys.gameHeight)-float32(c.localcoord[1])*c.localscl)/2, float32(c.overdrawlow)*c.localscl))
+		c.aspectcorrection = MinF(0, (float32(c.localcoord[1])*c.localscl-float32(sys.gameHeight))+MinF((float32(sys.gameHeight)-float32(c.localcoord[1])*c.localscl)/2, float32(c.overdrawlow)*c.localscl))
 	} else if float32(c.localcoord[1])*c.localscl-float32(sys.gameHeight) > 0 {
 		if c.cuthigh+c.cutlow <= 0 {
-			c.aspectCorrection = float32(Ceil(float32(c.localcoord[1])*c.localscl) - sys.gameHeight)
+			c.aspectcorrection = float32(Ceil(float32(c.localcoord[1])*c.localscl) - sys.gameHeight)
 		} else {
 			diff := Ceil(float32(c.localcoord[1])*c.localscl) - sys.gameHeight
 			tmp := Ceil(float32(c.cuthigh)*c.localscl) * diff / (Ceil(float32(c.cuthigh)*c.localscl) + Ceil(float32(c.cutlow)*c.localscl))
 			if diff-tmp <= c.cutlow {
-				c.aspectCorrection = float32(tmp)
+				c.aspectcorrection = float32(tmp)
 			} else {
-				c.aspectCorrection = float32(diff - Ceil(float32(c.cutlow)*c.localscl))
+				c.aspectcorrection = float32(diff - Ceil(float32(c.cutlow)*c.localscl))
 			}
 		}
 
@@ -107,31 +109,33 @@ func (c *Camera) Reset() {
 	c.boundH = float32(c.boundhigh) * c.localscl
 	c.boundLo = float32(Max(c.boundhigh, c.boundlow)) * c.localscl
 	c.boundlow = Max(c.boundhigh, c.boundlow)
-	c.zoomInDelayTime = c.zoomInDelay
 
 	xminscl := float32(sys.gameWidth) / (float32(sys.gameWidth) - c.boundL +
 		c.boundR)
 	//yminscl := float32(sys.gameHeight) / (240 - MinF(0, c.boundH))
 	c.MinScale = MaxF(c.zoomout, MinF(c.zoomin, xminscl))
-	c.yWithoutBound = c.Pos[1]
 }
 func (c *Camera) Init() {
 	c.Reset()
 	c.View = Fighting_View
+	c.roundstart = true
+	c.Scale = c.startzoom
+	c.Pos[0], c.Pos[1], c.ywithoutbound = float32(c.startx)*c.localscl, float32(c.starty)*c.localscl, float32(c.starty)*c.localscl
+	c.zoomindelaytime = c.zoomindelay
 }
 func (c *Camera) ResetTracking() {
 	c.leftest = c.Pos[0]
 	c.rightest = c.Pos[0]
 	c.highest = math.MaxFloat32
 	c.lowest = -math.MaxFloat32
-	c.leftestVel = 0
-	c.rightestVel = 0
+	c.leftestvel = 0
+	c.rightestvel = 0
 }
 func (c *Camera) Update(scl, x, y float32) {
 	c.Scale = c.BaseScale() * scl
 	c.zoff = float32(c.zoffset) * c.localscl
 	if sys.stage.stageCamera.zoomanchor {
-		c.zoomAnchorCorrection = c.zoff - (float32(sys.gameHeight) + c.aspectCorrection - (float32(sys.gameHeight)-c.zoff+c.aspectCorrection)*scl)
+		c.zoomanchorcorrection = c.zoff - (float32(sys.gameHeight) + c.aspectcorrection - (float32(sys.gameHeight)-c.zoff+c.aspectcorrection)*scl)
 	}
 	for i := 0; i < 2; i++ {
 		c.Offset[i] = sys.stage.bga.offset[i] * sys.stage.localscl * scl
@@ -162,7 +166,7 @@ func (c *Camera) BaseScale() float32 {
 	return c.ztopscale
 }
 func (c *Camera) GroundLevel() float32 {
-	return c.zoff - c.aspectCorrection - c.zoomAnchorCorrection
+	return c.zoff - c.aspectcorrection - c.zoomanchorcorrection
 }
 func (c *Camera) ResetZoomdelay() {
 	c.zoomdelay = 0
@@ -171,140 +175,157 @@ func (c *Camera) action(x, y, scale float32, pause bool) (newX, newY, newScale f
 	newX = x
 	newY = y
 	newScale = scale
-	if !sys.debugPaused() && c.highest != math.MaxFloat32 && c.lowest != -math.MaxFloat32 {
+	if !sys.debugPaused() {
 		switch c.View {
 		case Fighting_View:
-			tension := MaxF(0, float32(c.tension)*c.localscl)
-			oldLeft, oldRight := x-c.halfWidth/scale, x+c.halfWidth/scale
-			targetLeft, targetRight := oldLeft, oldRight
-			maxRight := float32(c.boundright)*c.localscl + c.halfWidth/c.zoomout
-			minLeft := float32(c.boundleft)*c.localscl - c.halfWidth/c.zoomout
-			if c.autocenter {
-				targetLeft = MinF(MaxF((c.leftest+c.rightest)/2-c.halfWidth/scale, minLeft), maxRight-2*c.halfWidth/scale)
-				targetRight = targetLeft + 2*c.halfWidth/scale
-			}
-
-			if c.leftest < targetLeft+tension {
-				diff := targetLeft - MaxF(c.leftest-tension, minLeft)
-				targetLeft = MaxF(c.leftest-tension, minLeft)
-				targetRight = MaxF(oldRight-diff, MinF(c.rightest+tension, maxRight))
-			} else if c.rightest > targetRight-tension {
-				diff := targetRight - MinF(c.rightest+tension, maxRight)
-				targetRight = MinF(c.rightest+tension, maxRight)
-				targetLeft = MinF(oldLeft-diff, MaxF(c.leftest-tension, minLeft))
-			}
-			if c.halfWidth*2/(targetRight-targetLeft) < c.zoomout {
-				x := (targetRight + targetLeft) / 2
-				targetLeft = x - c.halfWidth/c.zoomout
-				targetRight = x + c.halfWidth/c.zoomout
-				if c.leftest-targetLeft < float32(sys.stage.screenleft)*c.localscl {
-					diff := float32(sys.stage.screenleft)*c.localscl - (c.leftest - targetLeft)
-					targetLeft -= diff
-					targetRight -= diff
-				} else if targetRight-c.rightest < float32(sys.stage.screenright)*c.localscl {
-					diff := float32(sys.stage.screenright)*c.localscl - (targetRight - c.rightest)
-					targetLeft += diff
-					targetRight += diff
+			if c.highest != math.MaxFloat32 && c.lowest != -math.MaxFloat32 {
+				tension := MaxF(0, float32(c.tension)*c.localscl)
+				oldLeft, oldRight := x-c.halfWidth/scale, x+c.halfWidth/scale
+				targetLeft, targetRight := oldLeft, oldRight
+				maxRight := float32(c.boundright)*c.localscl + c.halfWidth/c.zoomout
+				minLeft := float32(c.boundleft)*c.localscl - c.halfWidth/c.zoomout
+				if c.autocenter {
+					targetLeft = MinF(MaxF((c.leftest+c.rightest)/2-c.halfWidth/scale, minLeft), maxRight-2*c.halfWidth/scale)
+					targetRight = targetLeft + 2*c.halfWidth/scale
 				}
-			}
-			maxScale := c.zoomin
-			if c.ytensionenable {
-				maxScale = MinF(MaxF(float32(sys.gameHeight)/((c.lowest+float32(c.tensionlow)*c.localscl)-(c.highest-float32(c.tensionhigh)*c.localscl)), c.zoomout), maxScale)
-			}
-			if c.halfWidth*2/(targetRight-targetLeft) < maxScale {
-				if c.zoomInDelayTime > 0 {
-					c.zoomInDelayTime -= 1
+
+				if c.leftest < targetLeft+tension {
+					diff := targetLeft - MaxF(c.leftest-tension, minLeft)
+					targetLeft = MaxF(c.leftest-tension, minLeft)
+					targetRight = MaxF(oldRight-diff, MinF(c.rightest+tension, maxRight))
+				} else if c.rightest > targetRight-tension {
+					diff := targetRight - MinF(c.rightest+tension, maxRight)
+					targetRight = MinF(c.rightest+tension, maxRight)
+					targetLeft = MinF(oldLeft-diff, MaxF(c.leftest-tension, minLeft))
+				}
+				if c.halfWidth*2/(targetRight-targetLeft) < c.zoomout {
+					x := (targetRight + targetLeft) / 2
+					targetLeft = x - c.halfWidth/c.zoomout
+					targetRight = x + c.halfWidth/c.zoomout
+					if c.leftest-targetLeft < float32(sys.stage.screenleft)*c.localscl {
+						diff := float32(sys.stage.screenleft)*c.localscl - (c.leftest - targetLeft)
+						targetLeft -= diff
+						targetRight -= diff
+					} else if targetRight-c.rightest < float32(sys.stage.screenright)*c.localscl {
+						diff := float32(sys.stage.screenright)*c.localscl - (targetRight - c.rightest)
+						targetLeft += diff
+						targetRight += diff
+					}
+				}
+				maxScale := c.zoomin
+				if c.ytensionenable {
+					maxScale = MinF(MaxF(float32(sys.gameHeight)/((c.lowest+float32(c.tensionlow)*c.localscl)-(c.highest-float32(c.tensionhigh)*c.localscl)), c.zoomout), maxScale)
+				}
+				if c.halfWidth*2/(targetRight-targetLeft) < maxScale {
+					if c.zoomindelaytime > 0 {
+						c.zoomindelaytime -= 1
+					} else {
+						diffLeft := MaxF(c.leftest-tension-targetLeft, 0)
+						if diffLeft < 0 {
+							diffLeft = 0
+						}
+						diffRight := MinF(c.rightest+tension-targetRight, 0)
+						if diffRight > 0 {
+							diffRight = 0
+						}
+						if c.halfWidth*2/((targetRight+diffRight)-(targetLeft+diffLeft)) > maxScale {
+							tmp, tmp2 := diffLeft/(diffLeft-diffRight)*((targetRight+diffRight)-(targetLeft+diffLeft)-c.halfWidth*2/maxScale), diffRight/(diffLeft-diffRight)*((targetRight+diffRight)-(targetLeft+diffLeft)-c.halfWidth*2/maxScale)
+							diffLeft += tmp
+							diffRight += tmp2
+						}
+						targetLeft += diffLeft
+						targetRight += diffRight
+					}
 				} else {
-					diffLeft := MaxF(c.leftest-tension-targetLeft, 0)
-					if diffLeft < 0 {
-						diffLeft = 0
-					}
-					diffRight := MinF(c.rightest+tension-targetRight, 0)
-					if diffRight > 0 {
-						diffRight = 0
-					}
-					if c.halfWidth*2/((targetRight+diffRight)-(targetLeft+diffLeft)) > maxScale {
-						tmp, tmp2 := diffLeft/(diffLeft-diffRight)*((targetRight+diffRight)-(targetLeft+diffLeft)-c.halfWidth*2/maxScale), diffRight/(diffLeft-diffRight)*((targetRight+diffRight)-(targetLeft+diffLeft)-c.halfWidth*2/maxScale)
-						diffLeft += tmp
-						diffRight += tmp2
-					}
-					targetLeft += diffLeft
-					targetRight += diffRight
+					c.zoomindelaytime = c.zoomindelay
 				}
-			} else {
-				c.zoomInDelayTime = c.zoomInDelay
-			}
 
-			targetX := (targetLeft + targetRight) / 2
-			targetScale := c.halfWidth * 2 / (targetRight - targetLeft)
+				targetX := (targetLeft + targetRight) / 2
+				targetScale := c.halfWidth * 2 / (targetRight - targetLeft)
 
-			if !c.ytensionenable {
-				newY = c.yWithoutBound
-				//old*0.85+target* 0.15 if diff > 1
-				targetY := (c.highest + float32(c.floortension)*c.localscl) * c.verticalfollow
-				for i := 0; i < 3; i++ {
-					newY = newY*.85 + targetY*.15
-					if AbsF(targetY-newY) < 1 {
+				if !c.ytensionenable {
+					newY = c.ywithoutbound
+					//old*0.85+target* 0.15 if diff > 1
+					targetY := (c.highest + float32(c.floortension)*c.localscl) * c.verticalfollow
+					if !c.roundstart {
+						for i := 0; i < 3; i++ {
+							newY = newY*.85 + targetY*.15
+							if AbsF(targetY-newY) < 1 {
+								newY = targetY
+								break
+							}
+						}
+					}
+					c.ywithoutbound = newY
+				} else {
+					targetScale = MinF(MinF(MaxF(float32(sys.gameHeight)/((c.lowest+float32(c.tensionlow)*c.localscl)-(c.highest-float32(c.tensionhigh)*c.localscl)), c.zoomout), c.zoomin), targetScale)
+					targetX = MinF(MaxF(targetX, float32(c.boundleft)*c.localscl-c.halfWidth*(1/c.zoomout-1/targetScale)), float32(c.boundright)*c.localscl+c.halfWidth*(1/c.zoomout-1/targetScale))
+					targetLeft = targetX - c.halfWidth/targetScale
+					targetRight = targetX + c.halfWidth/targetScale
+
+					newY = c.ywithoutbound
+					targetY := c.GroundLevel()/targetScale + (c.highest - float32(c.tensionhigh)*c.localscl)
+					if !c.roundstart {
+						for i := 0; i < 3; i++ {
+							newY = newY*.85 + targetY*.15
+							if AbsF(targetY-newY) < 1 {
+								newY = targetY
+								break
+							}
+						}
+					} else {
 						newY = targetY
-						break
 					}
+					c.ywithoutbound = newY
+
 				}
-				c.yWithoutBound = newY
+
+				newLeft, newRight := oldLeft, oldRight
+				if !c.roundstart {
+					for i := 0; i < 3; i++ {
+						newLeft, newRight = newLeft+(targetLeft-newLeft)*0.05*sys.turbo*c.tensionvel, newRight+(targetRight-newRight)*0.05*sys.turbo*c.tensionvel
+						diffLeft := targetLeft - newLeft
+						diffRight := targetRight - newRight
+						if AbsF(diffLeft) <= 0.1*sys.turbo {
+							newLeft = targetLeft
+						} else if diffLeft > 0 {
+							newLeft += 0.1 * sys.turbo * c.tensionvel
+						} else {
+							newLeft -= 0.1 * sys.turbo * c.tensionvel
+						}
+						if newLeft-oldLeft > 0 && newLeft-oldLeft < c.rightestvel {
+							newLeft = MinF(oldLeft+c.rightestvel, targetLeft)
+						} else if newLeft-oldLeft < 0 && newLeft-oldLeft > c.leftestvel {
+							newLeft = MaxF(oldLeft+c.leftestvel, targetLeft)
+						}
+
+						if AbsF(diffRight) <= 0.1*sys.turbo*c.tensionvel {
+							newRight = targetRight
+						} else if diffRight > 0 {
+							newRight += 0.1 * sys.turbo * c.tensionvel
+						} else {
+							newRight -= 0.1 * sys.turbo * c.tensionvel
+						}
+						if newRight-oldRight > 0 && newRight-oldRight < c.rightestvel {
+							newRight = MinF(oldRight+c.rightestvel, targetRight)
+						} else if newRight-oldRight < 0 && newRight-oldRight > c.leftestvel {
+							newRight = MaxF(oldRight+c.leftestvel, targetRight)
+						}
+
+						newX = (newLeft + newRight) / 2
+					}
+				} else {
+					newLeft, newRight = targetLeft, targetRight
+					newX = (newLeft + newRight) / 2
+				}
+				newScale = c.halfWidth * 2 / (newRight - newLeft)
+				newY = MinF(MaxF(newY, float32(c.boundhigh)*c.localscl*newScale), float32(c.boundlow)*c.localscl*newScale)
 			} else {
-				targetScale = MinF(MinF(MaxF(float32(sys.gameHeight)/((c.lowest+float32(c.tensionlow)*c.localscl)-(c.highest-float32(c.tensionhigh)*c.localscl)), c.zoomout), c.zoomin), targetScale)
-				targetX = MinF(MaxF(targetX, float32(c.boundleft)*c.localscl-c.halfWidth*(1/c.zoomout-1/targetScale)), float32(c.boundright)*c.localscl+c.halfWidth*(1/c.zoomout-1/targetScale))
-				targetLeft = targetX - c.halfWidth/targetScale
-				targetRight = targetX + c.halfWidth/targetScale
-
-				newY = c.yWithoutBound
-				targetY := c.GroundLevel()/targetScale + (c.highest - float32(c.tensionhigh)*c.localscl)
-				for i := 0; i < 3; i++ {
-					newY = newY*.85 + targetY*.15
-					if AbsF(targetY-newY) < 1 {
-						newY = targetY
-						break
-					}
-				}
-				c.yWithoutBound = newY
-
+				newScale = MinF(MaxF(newScale, c.zoomout), c.zoomin)
+				newX = MinF(MaxF(newX, float32(c.boundleft)*c.localscl*newScale), float32(c.boundright)*c.localscl*newScale)
+				newY = MinF(MaxF(newY, float32(c.boundhigh)*c.localscl*newScale), float32(c.boundlow)*c.localscl*newScale)
 			}
 
-			newLeft, newRight := oldLeft, oldRight
-
-			for i := 0; i < 3; i++ {
-				newLeft, newRight = newLeft+(targetLeft-newLeft)*0.05*sys.turbo*c.tensionvel, newRight+(targetRight-newRight)*0.05*sys.turbo*c.tensionvel
-				diffLeft := targetLeft - newLeft
-				diffRight := targetRight - newRight
-				if AbsF(diffLeft) <= 0.1*sys.turbo {
-					newLeft = targetLeft
-				} else if diffLeft > 0 {
-					newLeft += 0.1 * sys.turbo * c.tensionvel
-				} else {
-					newLeft -= 0.1 * sys.turbo * c.tensionvel
-				}
-				if newLeft-oldLeft > 0 && newLeft-oldLeft < c.rightestVel {
-					newLeft = MinF(oldLeft+c.rightestVel, targetLeft)
-				} else if newLeft-oldLeft < 0 && newLeft-oldLeft > c.leftestVel {
-					newLeft = MaxF(oldLeft+c.leftestVel, targetLeft)
-				}
-
-				if AbsF(diffRight) <= 0.1*sys.turbo*c.tensionvel {
-					newRight = targetRight
-				} else if diffRight > 0 {
-					newRight += 0.1 * sys.turbo * c.tensionvel
-				} else {
-					newRight -= 0.1 * sys.turbo * c.tensionvel
-				}
-				if newRight-oldRight > 0 && newRight-oldRight < c.rightestVel {
-					newRight = MinF(oldRight+c.rightestVel, targetRight)
-				} else if newRight-oldRight < 0 && newRight-oldRight > c.leftestVel {
-					newRight = MaxF(oldRight+c.leftestVel, targetRight)
-				}
-
-				newX = (newLeft + newRight) / 2
-			}
-			newScale = c.halfWidth * 2 / (newRight - newLeft)
-			newY = MinF(MaxF(newY, float32(c.boundhigh)*c.localscl*newScale), float32(c.boundlow)*c.localscl*newScale)
 		case Follow_View:
 			newX = c.FollowChar.pos[0]
 			newY = c.FollowChar.pos[1] * Pow(c.verticalfollow, MinF(1, 1/Pow(c.Scale, 4)))
@@ -312,8 +333,10 @@ func (c *Camera) action(x, y, scale float32, pause bool) (newX, newY, newScale f
 		case Free_View:
 			newX = c.Pos[0]
 			newY = c.Pos[1]
+			c.ywithoutbound = newY
 			newScale = 1
 		}
 	}
+	c.roundstart = false
 	return
 }

--- a/src/char.go
+++ b/src/char.go
@@ -4147,7 +4147,7 @@ func (c *Char) posReset() {
 		c.setZ(0)
 	} else {
 		c.facing = 1 - 2*float32(c.playerNo&1)
-		c.setX((float32(sys.stage.p[c.playerNo&1].startx-sys.cam.startx)*
+		c.setX((float32(sys.stage.p[c.playerNo&1].startx)*
 			sys.stage.localscl - c.facing*float32(c.playerNo>>1)*sys.stage.p1p3dist) / c.localscl)
 		c.setY(float32(sys.stage.p[c.playerNo&1].starty) * sys.stage.localscl / c.localscl)
 		c.setZ(float32(sys.stage.p[c.playerNo&1].startz))
@@ -5735,7 +5735,7 @@ func (c *Char) trackableByCamera() bool {
 }
 func (c *Char) xScreenBound() {
 	x := c.pos[0]
-	if c.trackableByCamera() && c.csf(CSF_screenbound) && !c.scf(SCF_standby) {
+	if !sys.cam.roundstart && c.trackableByCamera() && c.csf(CSF_screenbound) && !c.scf(SCF_standby) {
 		min, max := c.getEdge(c.edge[0], true), -c.getEdge(c.edge[1], true)
 		if c.facing > 0 {
 			min, max = -max, -min
@@ -6346,26 +6346,26 @@ func (c *Char) track() {
 		if c.facing > 0 {
 			min, max = -max, -min
 		}
-		if c.csf(CSF_screenbound) && !c.scf(SCF_standby) {
+		if !sys.cam.roundstart && c.csf(CSF_screenbound) && !c.scf(SCF_standby) {
 			c.drawPos[0] = ClampF(c.drawPos[0], min+sys.xmin/c.localscl, max+sys.xmax/c.localscl)
 		}
 		if c.csf(CSF_movecamera_x) && !c.scf(SCF_standby) {
 			if c.drawPos[0]*c.localscl-min*c.localscl < sys.cam.leftest {
-				sys.cam.leftest = MaxF(sys.xmin, MinF(c.drawPos[0]*c.localscl-min*c.localscl, sys.cam.leftest))
+				sys.cam.leftest = MinF(c.drawPos[0]*c.localscl-min*c.localscl, sys.cam.leftest)
 				if c.acttmp > 0 && !c.csf(CSF_posfreeze) &&
 					(c.bindTime == 0 || math.IsNaN(float64(c.bindPos[0]))) {
-					sys.cam.leftestVel = c.vel[0] * c.localscl * c.facing
+					sys.cam.leftestvel = c.vel[0] * c.localscl * c.facing
 				} else {
-					sys.cam.leftestVel = 0
+					sys.cam.leftestvel = 0
 				}
 			}
 			if c.drawPos[0]*c.localscl-max*c.localscl > sys.cam.rightest {
-				sys.cam.rightest = MinF(sys.xmax, MaxF(c.drawPos[0]*c.localscl-max*c.localscl, sys.cam.rightest))
+				sys.cam.rightest = MaxF(c.drawPos[0]*c.localscl-max*c.localscl, sys.cam.rightest)
 				if c.acttmp > 0 && !c.csf(CSF_posfreeze) &&
 					(c.bindTime == 0 || math.IsNaN(float64(c.bindPos[0]))) {
-					sys.cam.rightestVel = c.vel[0] * c.localscl * c.facing
+					sys.cam.rightestvel = c.vel[0] * c.localscl * c.facing
 				} else {
-					sys.cam.rightestVel = 0
+					sys.cam.rightestvel = 0
 				}
 			}
 		}

--- a/src/stage.go
+++ b/src/stage.go
@@ -424,11 +424,7 @@ func (bg backGround) draw(pos [2]float32, scl, bgscl, lclscl float32,
 	x *= bgscl
 	if isStage {
 		zoff := float32(sys.cam.zoffset) * lclscl
-		//if sys.cam.zoomanchor {
-		//	y = y*bgscl + ((float32(sys.gameHeight)/lclscl*float32(sys.gameHeight)/float32(sys.cam.localcoord[1])-shakeY/lclscl)/scly-float32(sys.gameHeight))/stgscl[1]
-		//} else {
 		y = y*bgscl + ((zoff-shakeY)/scly-zoff)/lclscl/stgscl[1]
-		//}
 		y -= sys.cam.aspectCorrection / (scly * lclscl * stgscl[1])
 		y -= sys.cam.zoomAnchorCorrection / (scly * lclscl * stgscl[1])
 	} else {
@@ -1090,33 +1086,7 @@ func loadStage(def string, main bool) (*Stage, error) {
 			s.stageCamera.zoffset += int32(b.start[1] * s.scale[1])
 		}
 	}
-	ratio1 := float32(s.stageCamera.localcoord[0]) / float32(s.stageCamera.localcoord[1])
-	ratio2 := float32(sys.gameWidth) / 240
-	if ratio1 > ratio2 {
-		s.stageCamera.drawOffsetY =
-			MinF(float32(s.stageCamera.localcoord[1])*s.localscl*0.5*
-				(ratio1/ratio2-1), float32(Max(0, s.stageCamera.overdrawlow)))
-	}
-	if !s.stageCamera.ytensionenable {
-		s.stageCamera.drawOffsetY += MinF(float32(s.stageCamera.boundlow), MaxF(0, float32(s.stageCamera.floortension)*s.stageCamera.verticalfollow)) * s.localscl
-	} else {
-		s.stageCamera.drawOffsetY += MinF(float32(s.stageCamera.boundlow),
-			MaxF(0, (-26+(240/(float32(sys.gameWidth)/float32(s.stageCamera.localcoord[0])))-float32(s.stageCamera.tensionhigh)))) * s.localscl
-	}
-	//TODO: test if it works reasonably close to mugen
-	if sys.gameWidth > s.stageCamera.localcoord[0]*3*320/(s.stageCamera.localcoord[1]*4) {
-		if s.stageCamera.cutlow == math.MinInt32 {
-			//if omitted, the engine attempts to guess a reasonable set of values
-			s.stageCamera.drawOffsetY -= float32(s.stageCamera.localcoord[1]-s.stageCamera.zoffset) / s.localscl //- float32(s.stageCamera.boundlow)*s.localscl
-		} else {
-			//number of pixels into the bottom of the screen that may be cut from drawing when the screen aspect is shorter than the stage aspect
-			if s.stageCamera.cutlow < s.stageCamera.boundlow || s.stageCamera.boundlow <= 0 {
-				s.stageCamera.drawOffsetY -= float32(s.stageCamera.cutlow) * s.localscl
-			} // else {
-			//	s.stageCamera.drawOffsetY -= float32(s.stageCamera.boundlow) * s.localscl
-			//}
-		}
-	}
+
 	s.mainstage = main
 	return s, nil
 }
@@ -1409,7 +1379,7 @@ func (s *Stage) draw(top bool, x, y, scl float32) {
 		if yofs < 0 {
 			tmp := (float32(s.stageCamera.boundhigh) - pos[1]) * scl2
 			if scl > 1 {
-				tmp += (sys.cam.screenZoff + float32(sys.gameHeight-240)) * (1/scl - 1)
+				tmp += (sys.cam.GroundLevel() + float32(sys.gameHeight-240)) * (1/scl - 1)
 			} else {
 				tmp += float32(sys.gameHeight) * (1/scl - 1)
 			}

--- a/src/stage.go
+++ b/src/stage.go
@@ -129,7 +129,6 @@ type backGround struct {
 	id                 int32
 	start              [2]float32
 	xofs               float32
-	camstartx          float32
 	delta              [2]float32
 	width              [2]int32
 	xscale             [2]float32
@@ -164,9 +163,8 @@ func newBackGround(sff *Sff) *backGround {
 		startrect: [...]int32{-32768, -32768, 65535, 65535}}
 }
 func readBackGround(is IniSection, link *backGround,
-	sff *Sff, at AnimationTable, camstartx float32, sProps StageProps) *backGround {
+	sff *Sff, at AnimationTable, sProps StageProps) *backGround {
 	bg := newBackGround(sff)
-	bg.camstartx = camstartx
 	typ := is["type"]
 	if len(typ) == 0 {
 		return bg
@@ -413,7 +411,7 @@ func (bg backGround) draw(pos [2]float32, scl, bgscl, lclscl float32,
 			pos[i] = float32(math.Floor(float64(pos[i])))
 		}
 	}
-	x := bg.start[0] + bg.xofs - (pos[0]/stgscl[0]+bg.camstartx)*bg.delta[0] +
+	x := bg.start[0] + bg.xofs - (pos[0]/stgscl[0])*bg.delta[0] +
 		bg.bga.offset[0]
 	// Hires breaks ydelta scrolling vel, so bgscl was commented from here.
 	yScrollPos := (pos[1] / scl / stgscl[1]) * bg.delta[1] // * bgscl
@@ -425,8 +423,8 @@ func (bg backGround) draw(pos [2]float32, scl, bgscl, lclscl float32,
 	if isStage {
 		zoff := float32(sys.cam.zoffset) * lclscl
 		y = y*bgscl + ((zoff-shakeY)/scly-zoff)/lclscl/stgscl[1]
-		y -= sys.cam.aspectCorrection / (scly * lclscl * stgscl[1])
-		y -= sys.cam.zoomAnchorCorrection / (scly * lclscl * stgscl[1])
+		y -= sys.cam.aspectcorrection / (scly * lclscl * stgscl[1])
+		y -= sys.cam.zoomanchorcorrection / (scly * lclscl * stgscl[1])
 	} else {
 		y = y*bgscl + ((float32(sys.gameHeight)-shakeY)/lclscl/scly-240)/stgscl[1]
 	}
@@ -444,7 +442,7 @@ func (bg backGround) draw(pos [2]float32, scl, bgscl, lclscl float32,
 				bgscl * lscl[i]
 		}
 	}
-	startrect0 := (float32(rect[0]) - (pos[0]+bg.camstartx)*bg.windowdelta[0] + (float32(sys.gameWidth)/2/sclx - float32(bg.notmaskwindow)*(float32(sys.gameWidth)/2)*(1/lscl[0]))) * sys.widthScale * wscl[0]
+	startrect0 := (float32(rect[0]) - (pos[0])*bg.windowdelta[0] + (float32(sys.gameWidth)/2/sclx - float32(bg.notmaskwindow)*(float32(sys.gameWidth)/2)*(1/lscl[0]))) * sys.widthScale * wscl[0]
 	if !isStage && wscl[0] == 1 {
 		startrect0 += float32(sys.gameWidth-320) / 2 * sys.widthScale
 	}
@@ -891,7 +889,7 @@ func loadStage(def string, main bool) (*Stage, error) {
 	s.stageCamera.localscl = s.localscl
 	if sec := defmap["camera"]; len(sec) > 0 {
 		sec[0].ReadI32("startx", &s.stageCamera.startx)
-		//sec[0].ReadI32("starty", &s.stageCamera.starty) //does nothing in mugen
+		sec[0].ReadI32("starty", &s.stageCamera.starty) //does nothing in mugen
 		sec[0].ReadI32("boundleft", &s.stageCamera.boundleft)
 		sec[0].ReadI32("boundright", &s.stageCamera.boundright)
 		sec[0].ReadI32("boundhigh", &s.stageCamera.boundhigh)
@@ -910,7 +908,7 @@ func loadStage(def string, main bool) (*Stage, error) {
 		sec[0].ReadF32("near", &s.stageCamera.near)
 		sec[0].ReadF32("far", &s.stageCamera.far)
 		sec[0].ReadBool("autocenter", &s.stageCamera.autocenter)
-		sec[0].ReadF32("zoomindelay", &s.stageCamera.zoomInDelay)
+		sec[0].ReadF32("zoomindelay", &s.stageCamera.zoomindelay)
 		if sys.cam.ZoomMax == 0 {
 			sec[0].ReadF32("zoomin", &s.stageCamera.zoomin)
 		} else {
@@ -1027,7 +1025,7 @@ func loadStage(def string, main bool) (*Stage, error) {
 			bglink = s.bg[len(s.bg)-1]
 		}
 		s.bg = append(s.bg, readBackGround(bgsec, bglink,
-			s.sff, s.at, float32(s.stageCamera.startx), s.stageprops))
+			s.sff, s.at, s.stageprops))
 	}
 	bgcdef := *newBgCtrl()
 	i = 0
@@ -2424,9 +2422,9 @@ func (s *Stage) drawModel(pos [2]float32, yofs float32, scl float32) {
 	var posMul float32 = float32(math.Tan(float64(drawFOV)/2)) * -s.model.offset[2] / (float32(sys.scrrect[3]) / 2)
 
 	var syo float32
-	aspectCorrection := (float32(sys.cam.zoffset)*float32(sys.gameHeight)/float32(sys.cam.localcoord[1]) - (float32(sys.cam.zoffset)*s.localscl - sys.cam.aspectCorrection))
+	aspectCorrection := (float32(sys.cam.zoffset)*float32(sys.gameHeight)/float32(sys.cam.localcoord[1]) - (float32(sys.cam.zoffset)*s.localscl - sys.cam.aspectcorrection))
 	syo = -(float32(s.stageCamera.zoffset) - float32(sys.cam.localcoord[1])/2) * (1 - scl) / scl * float32(sys.gameHeight) / float32(s.stageCamera.localcoord[1])
-	offset := []float32{(pos[0]*-posMul*s.localscl*sys.widthScale + s.model.offset[0]/scl), (((pos[1]*s.localscl+sys.cam.zoomAnchorCorrection+aspectCorrection)/scl+yofs/scl+syo)*posMul*sys.heightScale + s.model.offset[1]), s.model.offset[2] / scl}
+	offset := []float32{(pos[0]*-posMul*s.localscl*sys.widthScale + s.model.offset[0]/scl), (((pos[1]*s.localscl+sys.cam.zoomanchorcorrection+aspectCorrection)/scl+yofs/scl+syo)*posMul*sys.heightScale + s.model.offset[1]), s.model.offset[2] / scl}
 	rotation := []float32{s.model.rotation[0], s.model.rotation[1], s.model.rotation[2]}
 	scale := []float32{s.model.scale[0], s.model.scale[1], s.model.scale[2]}
 	proj := mgl.Translate3D(0, sys.cam.yshift*scl, 0)

--- a/src/stage.go
+++ b/src/stage.go
@@ -909,6 +909,8 @@ func loadStage(def string, main bool) (*Stage, error) {
 		sec[0].ReadF32("yshift", &s.stageCamera.yshift)
 		sec[0].ReadF32("near", &s.stageCamera.near)
 		sec[0].ReadF32("far", &s.stageCamera.far)
+		sec[0].ReadBool("autocenter", &s.stageCamera.autocenter)
+		sec[0].ReadF32("zoomindelay", &s.stageCamera.zoomInDelay)
 		if sys.cam.ZoomMax == 0 {
 			sec[0].ReadF32("zoomin", &s.stageCamera.zoomin)
 		} else {

--- a/src/system.go
+++ b/src/system.go
@@ -960,9 +960,8 @@ func (s *System) commandUpdate() {
 		}
 	}
 }
-func (s *System) charUpdate(cvl, cvr,
-	highest, lowest, leftest, rightest *float32) {
-	s.charList.update(cvl, cvr, highest, lowest, leftest, rightest)
+func (s *System) charUpdate() {
+	s.charList.update()
 	for i, pr := range s.projs {
 		for j, p := range pr {
 			if p.id >= 0 {
@@ -1012,13 +1011,7 @@ func (s *System) action() {
 	s.drawch = s.drawch[:0]
 	s.clsnText = nil
 	var x, y, scl float32 = s.cam.Pos[0], s.cam.Pos[1], s.cam.Scale / s.cam.BaseScale()
-	var cvr, cvl, highest, lowest, leftest, rightest float32 = 0, 0, 0, 0, 0, 0
-	leftest, rightest = x, x
-	if s.cam.ytensionenable {
-		if y < 0 {
-			lowest = y
-		}
-	}
+	s.cam.ResetTracking()
 
 	// Run lifebar
 	if s.lifebar.ro.act() {
@@ -1333,11 +1326,10 @@ func (s *System) action() {
 		if s.superanim != nil {
 			s.superanim.Action()
 		}
-		s.charList.action(x, &cvr, &cvl,
-			&highest, &lowest, &leftest, &rightest)
+		s.charList.action(x)
 		s.nomusic = s.gsf(GSF_nomusic) && !sys.postMatchFlg
 	} else {
-		s.charUpdate(&cvl, &cvr, &highest, &lowest, &leftest, &rightest)
+		s.charUpdate()
 	}
 
 	// Set global First Attack flag if either team got it
@@ -1346,7 +1338,7 @@ func (s *System) action() {
 	}
 
 	// Run camera
-	x, y, scl = s.cam.action(x, y, scl, leftest, rightest, lowest, highest, cvr, cvl, s.super > 0 || s.pause > 0)
+	x, y, scl = s.cam.action(x, y, scl, s.super > 0 || s.pause > 0)
 
 	//introSkip := false
 	if s.tickNextFrame() {

--- a/src/system.go
+++ b/src/system.go
@@ -831,7 +831,6 @@ func (s *System) nextRound() {
 		s.stage.reset()
 	}
 	s.cam.ResetZoomdelay()
-	s.cam.Update(1, 0, 0)
 	for i, p := range s.chars {
 		if len(p) > 0 {
 			s.nextCharId = Max(s.nextCharId, p[0].id+1)
@@ -1957,7 +1956,6 @@ func (s *System) fight() (reload bool) {
 		s.nextRound()
 		s.roundResetFlg, s.introSkipped = false, false
 		s.reloadFlg, s.reloadStageFlg, s.reloadLifebarFlg = false, false, false
-		s.cam.Update(s.cam.startzoom, 0, 0)
 	}
 	reset()
 


### PR DESCRIPTION
Rewrite the camera movement function to make it closer to Mugen 1.1.
Will break some stages that rely on Ikemen GO only camera behavior (e.g. setting a high tension value to make the camera always move to the center of the characters)

Feature port:
stage starty

New stage parameters:
autocenter: always try to move the camera to the center of leftest and rightest characters. Tension value is only used to calculate the camera zoom.
zoomindelay: Set the time delay of camera zoom in