### PR TITLE
feat: CornerPush, Overridden and UniqHit triggers

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -522,10 +522,13 @@ const (
 	OC_ex_helpername
 	OC_ex_hitoverridden
 	OC_ex_movehitvar_contact
+	OC_ex_movehitvar_cornerpush
 	OC_ex_movehitvar_id
+	OC_ex_movehitvar_overridden
 	OC_ex_movehitvar_playerno
 	OC_ex_movehitvar_spark_x
 	OC_ex_movehitvar_spark_y
+	OC_ex_movehitvar_uniqhit
 	OC_ex_incustomstate
 	OC_ex_indialogue
 	OC_ex_isassertedchar
@@ -2430,15 +2433,20 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(c.guardCount)
 	case OC_ex_movehitvar_contact:
 		sys.bcStack.PushB(c.mhv.contact)
+	case OC_ex_movehitvar_cornerpush:
+		sys.bcStack.PushF(c.mhv.cornerpush)
 	case OC_ex_movehitvar_id:
 		sys.bcStack.PushI(c.mhv.id)
+	case OC_ex_movehitvar_overridden:
+		sys.bcStack.PushB(c.mhv.overridden)
 	case OC_ex_movehitvar_playerno:
 		sys.bcStack.PushI(int32(c.mhv.playerNo))
 	case OC_ex_movehitvar_spark_x:
 		sys.bcStack.PushF(c.mhv.sparkxy[0] * (c.localscl / oc.localscl))
 	case OC_ex_movehitvar_spark_y:
 		sys.bcStack.PushF(c.mhv.sparkxy[1] * (c.localscl / oc.localscl))
-
+	case OC_ex_movehitvar_uniqhit:
+		sys.bcStack.PushI(c.mhv.uniqhit)
 	default:
 		sys.errLog.Printf("%v\n", be[*i-1])
 		c.panic()
@@ -6355,7 +6363,7 @@ func (sc superPause) Run(c *Char, _ []int32) bool {
 		case superPause_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				sys.superanim, sys.superpmap.remap = crun.getAnim(30, "f", true), nil
+				sys.superanim, sys.superpmap.remap = crun.getAnim(100, "f", true), nil
 				sys.superpos, sys.superfacing = [...]float32{crun.pos[0] * crun.localscl, crun.pos[1] * crun.localscl}, crun.facing
 			} else {
 				return false
@@ -9277,7 +9285,7 @@ func (sc getHitVarSet) Run(c *Char, _ []int32) bool {
 		case getHitVarSet_slidetime:
 			crun.ghv.slidetime = exp[0].evalI(c)
 		case getHitVarSet_xvel:
-			crun.ghv.xvel = exp[0].evalF(c) * lclscround
+			crun.ghv.xvel = exp[0].evalF(c) * crun.facing * lclscround
 		case getHitVarSet_yaccel:
 			crun.ghv.yaccel = exp[0].evalF(c) * lclscround
 		case getHitVarSet_yvel:

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2900,16 +2900,22 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		}
 		out.append(OC_ex_)
 		switch c.token {
+		case "cornerpush":
+			out.append(OC_ex_movehitvar_cornerpush)
 		case "contact":
 			out.append(OC_ex_movehitvar_contact)
 		case "id":
 			out.append(OC_ex_movehitvar_id)
+		case "overridden":
+			out.append(OC_ex_movehitvar_overridden)
 		case "playerno":
 			out.append(OC_ex_movehitvar_playerno)
 		case "sparkx":
 			out.append(OC_ex_movehitvar_spark_x)
 		case "sparky":
 			out.append(OC_ex_movehitvar_spark_y)
+		case "uniqhit":
+			out.append(OC_ex_movehitvar_uniqhit)
 		default:
 			return bvNone(), Error("Invalid data: " + c.token)
 		}

--- a/src/script.go
+++ b/src/script.go
@@ -3438,14 +3438,20 @@ func triggerFunctions(l *lua.LState) {
 		switch strArg(l, 1) {
 		case "contact":
 			ln = lua.LNumber(Btoi(c.mhv.contact))
+		case "cornerpush":
+			ln = lua.LNumber(c.mhv.cornerpush)
 		case "id":
 			ln = lua.LNumber(c.mhv.id)
+		case "overridden":
+			ln = lua.LNumber(Btoi(c.mhv.overridden))
 		case "playerno":
 			ln = lua.LNumber(c.mhv.playerNo)
 		case "sparkx":
 			ln = lua.LNumber(c.mhv.sparkxy[0])
 		case "sparky":
 			ln = lua.LNumber(c.mhv.sparkxy[1])
+		case "uniqhit":
+			ln = lua.LNumber(c.mhv.uniqhit)
 		default:
 			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}


### PR DESCRIPTION
New triggers to use with MoveHitVar:
- CornerPush: returns cornerpush velocity offset
- Overridden: returns 1 if the last hit encountered a HitOverride
- UniqHit: returns the number of players the last hit connected with
- Some minor fixes