### PR TITLE
feat: stage Ikemenversion and load time, several minor fixes

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -6026,8 +6026,8 @@ func (c *Char) actionPrepare() {
 			// In Mugen, characters can perform basic actions even if they are KO
 			if c.ctrl() && !c.inputOver() && (c.key >= 0 || c.helperIndex == 0) {
 				if !c.asf(ASF_nohardcodedkeys) {
-					// TODO disable jumps right after KO instead of after over.hittime
-					if !c.asf(ASF_nojump) && (!sys.roundEnd() || c.asf(ASF_postroundinput)) && c.ss.stateType == ST_S && c.cmd[0].Buffer.U > 0 {
+					if !c.asf(ASF_nojump) && c.ss.stateType == ST_S && c.cmd[0].Buffer.U > 0 &&
+						(!(sys.intro < 0 && sys.intro > -sys.lifebar.ro.over_waittime) || c.asf(ASF_postroundinput)) {
 						if c.ss.no != 40 {
 							c.changeState(40, -1, -1, "")
 						}

--- a/src/char.go
+++ b/src/char.go
@@ -7112,13 +7112,14 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 			var absredlife int32
 			if ghvset {
 				ghv := &getter.ghv
-				cmb := (getter.ss.moveType == MT_H || getter.csf(CSF_gethit)) &&
-					!ghv.guarded
-				// Save existing hit information
+				cmb := (getter.ss.moveType == MT_H || getter.csf(CSF_gethit)) && !ghv.guarded
+				// Save existing variables that should persist or stack
 				dmg, hdmg, gdmg := ghv.damage, ghv.hitdamage, ghv.guarddamage
 				pwr, hpwr, gpwr := ghv.power, ghv.hitpower, ghv.guardpower
+				dpnt, gpnt := ghv.dizzypoints, ghv.guardpoints
 				fall, hc, gc, fc, by := ghv.fallf, ghv.hitcount, ghv.guardcount, ghv.fallcount, ghv.hitBy
 				ghv.clear()
+				// Restore variables
 				ghv.hitBy = by
 				ghv.damage = dmg
 				ghv.hitdamage = hdmg
@@ -7126,6 +7127,9 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 				ghv.power = pwr
 				ghv.hitpower = hpwr
 				ghv.guardpower = gpwr
+				ghv.dizzypoints = dpnt
+				ghv.guardpoints = gpnt
+				// Update variables
 				ghv.attr = hd.attr
 				ghv.hitid = hd.id
 				ghv.playerNo = hd.playerNo

--- a/src/stage.go
+++ b/src/stage.go
@@ -958,6 +958,11 @@ func loadStage(def string, main bool) (*Stage, error) {
 				return err
 			}
 			*s.sff = *sff
+			// SFF v2.01 was not available before Mugen 1.1, therefore we assume that's the minimum correct version for the stage
+			if s.sff.header.Ver0 == 2 && s.sff.header.Ver2 == 1 {
+				s.mugenver[0] = 1
+				s.mugenver[1] = 1
+			}
 			return nil
 		}); err != nil {
 			return nil, err
@@ -972,6 +977,11 @@ func loadStage(def string, main bool) (*Stage, error) {
 			s.model.pfx = newPalFX()
 			s.model.pfx.clear()
 			s.model.pfx.time = -1
+			// 3D models were not available before Ikemen 1.0, therefore we assume that's the minimum correct version for the stage
+			if s.ikemenver[0] == 0 && s.ikemenver[1] == 0 {
+				s.ikemenver[0] = 1
+				s.ikemenver[1] = 0
+			}
 			return nil
 		}); err != nil {
 			return nil, err
@@ -1019,7 +1029,7 @@ func loadStage(def string, main bool) (*Stage, error) {
 		r, g, b = Clamp(r, 0, 255), Clamp(g, 0, 255), Clamp(b, 0, 255)
 		// Disable color parameter specifically in Mugen 1.1 stages
 		if s.ikemenver[0] == 0 && s.ikemenver[1] == 0 {
-			if (s.mugenver[0] == 1 && s.mugenver[1] == 1) || (s.sff.header.Ver0 == 2 && s.sff.header.Ver2 == 1) {
+			if s.mugenver[0] == 1 && s.mugenver[1] == 1 {
 				r, g, b = 0, 0, 0
 			}
 		}

--- a/src/system.go
+++ b/src/system.go
@@ -2943,6 +2943,23 @@ func (l *Loader) loadAttachedChar(pn int) int {
 
 func (l *Loader) loadStage() bool {
 	if sys.round == 1 {
+		var tstr string
+		tnow := time.Now()
+		defer func() {
+			sys.loadTime(tnow, tstr, false, true)
+			// Mugen compatibility mode indicator
+			if sys.stage.ikemenver[0] == 0 && sys.stage.ikemenver[1] == 0 {
+				if sys.stage.mugenver[0] == 1 && sys.stage.mugenver[1] == 1 {
+					sys.appendToConsole("Using Mugen 1.1 compatibility mode.")
+				} else if sys.stage.mugenver[0] == 1 && sys.stage.mugenver[1] == 0 {
+					sys.appendToConsole("Using Mugen 1.0 compatibility mode.")
+				} else if sys.stage.mugenver[0] != 1 {
+					sys.appendToConsole("Using WinMugen compatibility mode.")
+				} else {
+					sys.appendToConsole("Stage with unknown engine version.")
+				}
+			}
+		}()
 		var def string
 		if sys.sel.selectedStageNo == 0 {
 			randomstageno := Rand(0, int32(len(sys.sel.stagelist))-1)
@@ -2960,6 +2977,7 @@ func (l *Loader) loadStage() bool {
 		sys.stageLoop = false
 		sys.stageList[0], l.err = loadStage(def, true)
 		sys.stage = sys.stageList[0]
+		tstr = fmt.Sprintf("Stage loaded: %v", def)
 	}
 	return l.err == nil
 }


### PR DESCRIPTION
- The Ikemenversion parameter in stages is now actually read
- Currently it is only used to restore the shadow color parameter functionality, which was removed in Mugen 1.1

Also:
- As with characters, the stage's load time and compatibility mode are now also printed to the console
- If a stage uses a SFF v2.01, its Mugen version is automatically set to 1.1
- If a stage uses a 3D model, its Ikemen version defaults to 1.0

Fixes:
- Adjusted jump restrictions after KO to be more like Mugen
- Simultaneous hits now properly deal the total amount of dizzy and guard points that they should