### PR TITLE
feat: common FX localcoord, plus fixes

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1330,7 +1330,8 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			} else {
 				cmdName := sys.stringPool[sys.workingState.playerNo].List[*(*int32)(unsafe.Pointer(&be[i]))]
 				pno := sys.workingState.playerNo
-				if cmdName == "recovery" || oc.stCgi().ikemenver[0] > 0 || oc.stCgi().ikemenver[1] > 0 {
+				// Engine version is checked in state owner rather than working state
+				if cmdName == "recovery" || oc.stOgi().ikemenver[0] > 0 || oc.stOgi().ikemenver[1] > 0 {
 					// Command is checked by name, rather than by command list order (MUGEN 1.1)
 					pno = c.playerNo
 				}
@@ -1351,7 +1352,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushI(int32(c.frontEdgeDist() * (c.localscl / oc.localscl)))
 		case OC_gameheight:
 			// Optional exception preventing GameHeight from being affected by stage zoom.
-			if c.stCgi().mugenver[0] == 1 && c.stCgi().mugenver[1] == 0 &&
+			if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 0 &&
 				c.gi().constants["default.legacygamedistancespec"] == 1 {
 				sys.bcStack.PushF(c.screenHeight())
 			} else {
@@ -1369,7 +1370,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushI(sys.gameTime + pfTime)
 		case OC_gamewidth:
 			// Optional exception preventing GameWidth from being affected by stage zoom.
-			if c.stCgi().mugenver[0] == 1 && c.stCgi().mugenver[1] == 0 &&
+			if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 0 &&
 				c.gi().constants["default.legacygamedistancespec"] == 1 {
 				sys.bcStack.PushF(c.screenWidth())
 			} else {
@@ -1433,7 +1434,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushI(c.palno())
 		case OC_pos_x:
 			var bindVelx float32
-			if c.bindToId > 0 && !math.IsNaN(float64(c.bindPos[0])) && c.stCgi().ikemenver[0] == 0 && c.stCgi().ikemenver[1] == 0 {
+			if c.bindToId > 0 && !math.IsNaN(float64(c.bindPos[0])) && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
 				if sys.playerID(c.bindToId) != nil {
 					bindVelx = c.vel[0]
 				}
@@ -1441,7 +1442,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushF(((c.pos[0]+bindVelx)*(c.localscl/oc.localscl) - sys.cam.Pos[0]/oc.localscl))
 		case OC_pos_y:
 			var bindVely float32
-			if c.bindToId > 0 && !math.IsNaN(float64(c.bindPos[1])) && c.stCgi().ikemenver[0] == 0 && c.stCgi().ikemenver[1] == 0 {
+			if c.bindToId > 0 && !math.IsNaN(float64(c.bindPos[1])) && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
 				if sys.playerID(c.bindToId) != nil {
 					bindVely = c.vel[1]
 				}
@@ -2924,7 +2925,7 @@ func (sc assertSpecial) Run(c *Char, _ []int32) bool {
 		case assertSpecial_flag_g:
 			sys.setGSF(GlobalSpecialFlag(exp[0].evalI(c)))
 		case assertSpecial_noko:
-			if c.stCgi().ikemenver[0] > 0 || c.stCgi().ikemenver[1] > 0 {
+			if c.stWgi().ikemenver[0] > 0 || c.stWgi().ikemenver[1] > 0 {
 				crun.setASF(AssertSpecialFlag(ASF_noko))
 			} else {
 				sys.setGSF(GlobalSpecialFlag(GSF_noko))
@@ -3838,7 +3839,7 @@ func (sc palFX) Run(c *Char, _ []int32) bool {
 			}
 			pf.clear2(true)
 			//Mugen 1.1 behavior if invertblend param is omitted (Only if char mugenversion = 1.1)
-			if crun.stCgi().mugenver[0] == 1 && crun.stCgi().mugenver[1] == 1 && crun.stCgi().ikemenver[0] <= 0 && crun.stCgi().ikemenver[1] <= 0 {
+			if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 && c.stWgi().ikemenver[0] <= 0 && c.stWgi().ikemenver[1] <= 0 {
 				pf.invertblend = -2
 			}
 			doOnce = true
@@ -3960,7 +3961,7 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 				e.id = 0
 			}
 			// Mugenversion 1.1 chars default postype to "None"
-			if crun.stCgi().mugenver[0] == 1 && crun.stCgi().mugenver[1] == 1 {
+			if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 {
 				e.postype = PT_None
 			}
 		}
@@ -4092,14 +4093,14 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 				}
 			}
 		case explod_animelem:
-			if c.stCgi().ikemenver[0] > 0 || c.stCgi().ikemenver[1] > 0 {
+			if c.stWgi().ikemenver[0] > 0 || c.stWgi().ikemenver[1] > 0 {
 				animelem := exp[0].evalI(c)
 				e.animelem = animelem
 				e.anim.Action()
 				e.setAnimElem()
 			}
 		case explod_animfreeze:
-			if c.stCgi().ikemenver[0] > 0 || c.stCgi().ikemenver[1] > 0 {
+			if c.stWgi().ikemenver[0] > 0 || c.stWgi().ikemenver[1] > 0 {
 				e.animfreeze = exp[0].evalB(c)
 			}
 		case explod_angle:
@@ -4123,12 +4124,12 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 		case explod_window:
 			e.window = [4]float32{exp[0].evalF(c) * lclscround, exp[1].evalF(c) * lclscround, exp[2].evalF(c) * lclscround, exp[3].evalF(c) * lclscround}
 		default:
-			if crun.stCgi().mugenver[0] == 1 && crun.stCgi().mugenver[1] == 1 && crun.stCgi().ikemenver[0] <= 0 && crun.stCgi().ikemenver[1] <= 0 {
+			if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 && c.stWgi().ikemenver[0] <= 0 && c.stWgi().ikemenver[1] <= 0 {
 				e.palfxdef.invertblend = -2
 			}
 			palFX(sc).runSub(c, &e.palfxdef, id, exp)
 
-			if crun.stCgi().ikemenver[0] > 0 || crun.stCgi().ikemenver[1] > 0 {
+			if c.stWgi().ikemenver[0] > 0 || c.stWgi().ikemenver[1] > 0 {
 				explod(sc).setInterpolation(c, e, id, exp, &e.palfxdef)
 			}
 
@@ -4273,7 +4274,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				if exp[0].evalI(c) < 0 {
 					f = -1
 				}
-				if (c.stCgi().ikemenver[0] > 0 || c.stCgi().ikemenver[1] > 0) && !ptexists {
+				if (c.stWgi().ikemenver[0] > 0 || c.stWgi().ikemenver[1] > 0) && !ptexists {
 					eachExpl(func(e *Explod) {
 						e.relativef = f
 					})
@@ -4282,19 +4283,19 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				if exp[0].evalI(c) < 0 {
 					vf = -1
 				}
-				if (c.stCgi().ikemenver[0] > 0 || c.stCgi().ikemenver[1] > 0) && !ptexists {
+				if (c.stWgi().ikemenver[0] > 0 || c.stWgi().ikemenver[1] > 0) && !ptexists {
 					eachExpl(func(e *Explod) {
 						e.vfacing = vf
 					})
 				}
 			case explod_pos:
 				pos[0] = exp[0].evalF(c) * lclscround
-				if (c.stCgi().ikemenver[0] > 0 || c.stCgi().ikemenver[1] > 0) && !ptexists {
+				if (c.stWgi().ikemenver[0] > 0 || c.stWgi().ikemenver[1] > 0) && !ptexists {
 					eachExpl(func(e *Explod) { e.relativePos[0] = pos[0] })
 				}
 				if len(exp) > 1 {
 					pos[1] = exp[1].evalF(c) * lclscround
-					if (c.stCgi().ikemenver[0] > 0 || c.stCgi().ikemenver[1] > 0) && !ptexists {
+					if (c.stWgi().ikemenver[0] > 0 || c.stWgi().ikemenver[1] > 0) && !ptexists {
 						eachExpl(func(e *Explod) { e.relativePos[1] = pos[1] })
 					}
 				}
@@ -4302,42 +4303,42 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				rndx := (exp[0].evalF(c) / 2) * lclscround
 				rndx = RandF(-rndx, rndx)
 				pos[0] += rndx
-				if (c.stCgi().ikemenver[0] > 0 || c.stCgi().ikemenver[1] > 0) && !ptexists {
+				if (c.stWgi().ikemenver[0] > 0 || c.stWgi().ikemenver[1] > 0) && !ptexists {
 					eachExpl(func(e *Explod) { e.relativePos[0] += rndx })
 				}
 				if len(exp) > 1 {
 					rndy := (exp[1].evalF(c) / 2) * lclscround
 					rndy = RandF(-rndy, rndy)
 					pos[1] += rndy
-					if (c.stCgi().ikemenver[0] > 0 || c.stCgi().ikemenver[1] > 0) && !ptexists {
+					if (c.stWgi().ikemenver[0] > 0 || c.stWgi().ikemenver[1] > 0) && !ptexists {
 						eachExpl(func(e *Explod) { e.relativePos[1] += rndy })
 					}
 				}
 			case explod_velocity:
 				vel[0] = exp[0].evalF(c) * lclscround
-				if (c.stCgi().ikemenver[0] > 0 || c.stCgi().ikemenver[1] > 0) && !ptexists {
+				if (c.stWgi().ikemenver[0] > 0 || c.stWgi().ikemenver[1] > 0) && !ptexists {
 					eachExpl(func(e *Explod) { e.velocity[0] = vel[0] })
 				}
 				if len(exp) > 1 {
 					vel[1] = exp[1].evalF(c) * lclscround
-					if (c.stCgi().ikemenver[0] > 0 || c.stCgi().ikemenver[1] > 0) && !ptexists {
+					if (c.stWgi().ikemenver[0] > 0 || c.stWgi().ikemenver[1] > 0) && !ptexists {
 						eachExpl(func(e *Explod) { e.velocity[1] = vel[1] })
 					}
 				}
 			case explod_accel:
 				accel[0] = exp[0].evalF(c) * lclscround
-				if (c.stCgi().ikemenver[0] > 0 || c.stCgi().ikemenver[1] > 0) && !ptexists {
+				if (c.stWgi().ikemenver[0] > 0 || c.stWgi().ikemenver[1] > 0) && !ptexists {
 					eachExpl(func(e *Explod) { e.accel[0] = accel[0] })
 				}
 				if len(exp) > 1 {
 					accel[1] = exp[1].evalF(c) * lclscround
-					if (c.stCgi().ikemenver[0] > 0 || c.stCgi().ikemenver[1] > 0) && !ptexists {
+					if (c.stWgi().ikemenver[0] > 0 || c.stWgi().ikemenver[1] > 0) && !ptexists {
 						eachExpl(func(e *Explod) { e.accel[1] = accel[1] })
 					}
 				}
 			case explod_space:
 				sp = Space(exp[0].evalI(c))
-				if (c.stCgi().ikemenver[0] > 0 || c.stCgi().ikemenver[1] > 0) && !ptexists {
+				if (c.stWgi().ikemenver[0] > 0 || c.stWgi().ikemenver[1] > 0) && !ptexists {
 					eachExpl(func(e *Explod) { e.space = sp })
 				}
 			case explod_postype:
@@ -4454,12 +4455,12 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 					e.blendmode = int32(blendmode)
 				})
 			case explod_anim:
-				if c.stCgi().ikemenver[0] > 0 || c.stCgi().ikemenver[1] > 0 {
+				if c.stWgi().ikemenver[0] > 0 || c.stWgi().ikemenver[1] > 0 {
 					anim := crun.getAnim(exp[1].evalI(c), string(*(*[]byte)(unsafe.Pointer(&exp[0]))), true)
 					eachExpl(func(e *Explod) { e.anim = anim })
 				}
 			case explod_animelem:
-				if c.stCgi().ikemenver[0] > 0 || c.stCgi().ikemenver[1] > 0 {
+				if c.stWgi().ikemenver[0] > 0 || c.stWgi().ikemenver[1] > 0 {
 					animelem := exp[0].evalI(c)
 					eachExpl(func(e *Explod) {
 						e.interpolate_animelem[1] = -1
@@ -4469,7 +4470,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 					})
 				}
 			case explod_animfreeze:
-				if c.stCgi().ikemenver[0] > 0 || c.stCgi().ikemenver[1] > 0 {
+				if c.stWgi().ikemenver[0] > 0 || c.stWgi().ikemenver[1] > 0 {
 					animfreeze := exp[0].evalB(c)
 					eachExpl(func(e *Explod) { e.animfreeze = animfreeze })
 				}
@@ -4491,7 +4492,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 					e.window = [4]float32{exp[0].evalF(c) * lclscround, exp[1].evalF(c) * lclscround, exp[2].evalF(c) * lclscround, exp[3].evalF(c) * lclscround}
 				})
 			case explod_ignorehitpause:
-				if c.stCgi().ikemenver[0] > 0 || c.stCgi().ikemenver[1] > 0 {
+				if c.stWgi().ikemenver[0] > 0 || c.stWgi().ikemenver[1] > 0 {
 					ihp := exp[0].evalB(c)
 					eachExpl(func(e *Explod) { e.ignorehitpause = ihp })
 				}
@@ -4502,7 +4503,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				}
 				eachExpl(func(e *Explod) { e.setBind(bId) })
 			case explod_interpolation:
-				if c.stCgi().ikemenver[0] > 0 || c.stCgi().ikemenver[1] > 0 {
+				if c.stWgi().ikemenver[0] > 0 || c.stWgi().ikemenver[1] > 0 {
 					interpolation := exp[0].evalB(c)
 					eachExpl(func(e *Explod) {
 						if e.interpolate != interpolation {
@@ -4711,7 +4712,7 @@ func (sc afterImage) Run(c *Char, _ []int32) bool {
 		if !doOnce {
 			crun.aimg.clear()
 			//Mugen 1.1 behavior if invertblend param is omitted(Only if char mugenversion = 1.1)
-			if crun.stCgi().mugenver[0] == 1 && crun.stCgi().mugenver[1] == 1 && crun.stCgi().ikemenver[0] <= 0 && crun.stCgi().ikemenver[1] <= 0 {
+			if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 && c.stWgi().ikemenver[0] <= 0 && c.stWgi().ikemenver[1] <= 0 {
 				crun.aimg.palfx[0].invertblend = -2
 			}
 			crun.aimg.time = 1
@@ -5158,7 +5159,7 @@ func (sc hitDef) Run(c *Char, _ []int32) bool {
 			}
 		}
 		//Mugen 1.1 behavior if invertblend param is omitted(Only if char mugenversion = 1.1)
-		if crun.stCgi().mugenver[0] == 1 && crun.stCgi().mugenver[1] == 1 && crun.stCgi().ikemenver[0] <= 0 && crun.stCgi().ikemenver[1] <= 0 {
+		if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 && c.stWgi().ikemenver[0] <= 0 && c.stWgi().ikemenver[1] <= 0 {
 			crun.hitdef.palfx.invertblend = -2
 		}
 		sc.runSub(c, &crun.hitdef, id, exp)
@@ -5977,7 +5978,7 @@ func (sc lifeAdd) Run(c *Char, _ []int32) bool {
 		case lifeAdd_value:
 			v := exp[0].evalI(c)
 			// Mugen forces absolute parameter when healing characters
-			if v > 0 && c.stCgi().ikemenver[0] == 0 && c.stCgi().ikemenver[1] == 0 {
+			if v > 0 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
 				a = true
 			}
 			crun.lifeAdd(float64(v), k, a)
@@ -6840,24 +6841,17 @@ const (
 )
 
 func (sc defenceMulSet) Run(c *Char, _ []int32) bool {
-	// For redirectID.
 	crun := c
-
-	// Default values.
 	var val float32 = 1
-	var onHit bool = true
+	var onHit bool = false
+	var mulType int32 = 1
 
-	// 0 mimics Mugen behaviour (Default for not Ikemen chars)
-	// 1 is the new Ikemen behaviour.
-	var mulType int32 = 0
-
-	// Ikemen chars default behaviour.
-	if c.stCgi().ikemenver[0] > 0 || c.stCgi().ikemenver[1] > 0 {
-		onHit = false
-		mulType = 1
+	// Change default behavior for Mugen chars
+	if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
+		onHit = true
+		mulType = 0
 	}
 
-	// Parse values
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case defenceMulSet_value:
@@ -6876,12 +6870,13 @@ func (sc defenceMulSet) Run(c *Char, _ []int32) bool {
 		return true
 	})
 
-	// Apply "value".
-	if mulType == 0 {
-		crun.customDefense = 1.0 / val
-	} else {
+	// Apply "value" according to "mulType"
+	if mulType != 0 {
 		crun.customDefense = val
+	} else {
+		crun.customDefense = 1.0 / val
 	}
+
 	// Apply "onHit"
 	crun.defenseMulDelay = onHit
 
@@ -8711,7 +8706,7 @@ func (sc targetRedLifeAdd) Run(c *Char, _ []int32) bool {
 			}
 			v := exp[0].evalI(c)
 			// Mugen forces absolute parameter when healing characters
-			if v > 0 && c.stCgi().ikemenver[0] == 0 && c.stCgi().ikemenver[1] == 0 {
+			if v > 0 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
 				a = true
 			}
 			crun.targetRedLifeAdd(tar, exp[0].evalI(c), a)
@@ -8826,7 +8821,7 @@ func (sc text) Run(c *Char, _ []int32) bool {
 				if fflg {
 					ts.SetLocalcoord(float32(sys.lifebarLocalcoord[0]), float32(sys.lifebarLocalcoord[1]))
 				} else {
-					//ts.SetLocalcoord(crun.stCgi().localcoord[0], crun.stCgi().localcoord[1])
+					//ts.SetLocalcoord(c.stOgi().localcoord[0], c.stOgi().localcoord[1])
 				}
 			} else {
 				fnt = -1

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -4139,11 +4139,11 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 	if e == nil {
 		return false
 	}
-	if c.minus == -2 || c.minus == -4 { //TODO: isn't this supposed to check crun instead of c?
-		e.localscl = (320 / crun.localcoord)
-	} else {
-		e.localscl = crun.localscl
-	}
+	// In this scenario the explod scale is constant in Mugen
+	//if c.minus == -2 || c.minus == -4 {
+	//	e.localscl = (320 / crun.localcoord)
+	//} else {
+	e.localscl = crun.localscl
 	e.setStartParams(&e.palfxdef)
 	e.setPos(crun)
 	crun.insertExplodEx(i, rp)

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -484,7 +484,7 @@ const (
 	OC_ex_gethitvar_guard_velocity_x
 	OC_ex_gethitvar_airguard_velocity_x
 	OC_ex_gethitvar_airguard_velocity_y
-	OC_ex_gethitvar_contact
+	OC_ex_gethitvar_frame
 	OC_ex_ailevelf
 	OC_ex_animelemlength
 	OC_ex_animframe_alphadest
@@ -523,7 +523,7 @@ const (
 	OC_ex_helperindexexist
 	OC_ex_helpername
 	OC_ex_hitoverridden
-	OC_ex_movehitvar_contact
+	OC_ex_movehitvar_frame
 	OC_ex_movehitvar_cornerpush
 	OC_ex_movehitvar_id
 	OC_ex_movehitvar_overridden
@@ -2116,8 +2116,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.ghv.airguard_velocity[0] * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_airguard_velocity_y:
 		sys.bcStack.PushF(c.ghv.airguard_velocity[1] * (c.localscl / oc.localscl))
-	case OC_ex_gethitvar_contact:
-		sys.bcStack.PushB(c.ghv.contact)
+	case OC_ex_gethitvar_frame:
+		sys.bcStack.PushB(c.ghv.frame)
 	case OC_ex_ailevelf:
 		if !c.asf(ASF_noailevel) {
 			sys.bcStack.PushF(c.aiLevel())
@@ -2444,8 +2444,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		*i += 4
 	case OC_ex_guardcount:
 		sys.bcStack.PushI(c.guardCount)
-	case OC_ex_movehitvar_contact:
-		sys.bcStack.PushB(c.mhv.contact)
+	case OC_ex_movehitvar_frame:
+		sys.bcStack.PushB(c.mhv.frame)
 	case OC_ex_movehitvar_cornerpush:
 		sys.bcStack.PushF(c.mhv.cornerpush)
 	case OC_ex_movehitvar_id:

--- a/src/char.go
+++ b/src/char.go
@@ -777,7 +777,7 @@ type GetHitVar struct {
 	down_velocity     [2]float32
 	guard_velocity    float32
 	airguard_velocity [2]float32
-	contact           bool
+	frame             bool
 }
 
 func (ghv *GetHitVar) clear() {
@@ -847,8 +847,8 @@ func (ho *HitOverride) clear() {
 }
 
 type MoveHitVar struct {
-	contact    bool
 	cornerpush float32
+	frame      bool
 	id         int32
 	overridden bool
 	playerNo   int
@@ -6383,8 +6383,8 @@ func (c *Char) actionRun() {
 				c.ghv.hittime--
 			}
 		}
-		c.ghv.contact = false
-		c.mhv.contact = false
+		c.ghv.frame = false
+		c.mhv.frame = false
 		if c.helperIndex == 0 && c.gi().pctime >= 0 {
 			c.gi().pctime++
 		}
@@ -7361,7 +7361,7 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 				getter.stchtmp = false
 			}
 			getter.setCSF(CSF_gethit)
-			getter.ghv.contact = true
+			getter.ghv.frame = true
 			// If any hit in the current frame will KO the enemy, the others will not prevent it
 			if getter.ghv.damage >= getter.life {
 				getter.ghv.kill = true
@@ -7745,7 +7745,7 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 					sys.cgi[i].pctime = 0
 					sys.cgi[i].pcid = p.id
 					getter.hitdefContact = true
-					getter.mhv.contact = true
+					getter.mhv.frame = true
 					continue
 				}
 				if !(getter.stchtmp && (getter.csf(CSF_gethit) || getter.acttmp > 0)) &&
@@ -7858,7 +7858,7 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 									getter.mctype = MC_Reversed
 									getter.mctime = -1
 									getter.hitdefContact = true
-									getter.mhv.contact = true
+									getter.mhv.frame = true
 
 									fall, by := getter.ghv.fallf, getter.ghv.hitBy
 
@@ -7913,7 +7913,7 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 								c.hitdef.hitonce = -1
 							}
 							c.hitdefContact = true
-							c.mhv.contact = true
+							c.mhv.frame = true
 						}
 					}
 				}

--- a/src/char.go
+++ b/src/char.go
@@ -7685,12 +7685,19 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 					continue
 				}
 				dist := (getter.pos[0]*getter.localscl - (p.pos[0])*p.localscl) * p.facing
-				// Default guard distance
-				if !p.platform &&
-					p.hitdef.guard_dist[0] < 0 &&
-					dist <= float32(c.size.proj.attack.dist.front)*c.localscl &&
-					dist >= -float32(c.size.proj.attack.dist.back)*c.localscl {
-					getter.inguarddist = true
+				// Projectile guard distance
+				if !p.platform && p.hitdef.attr > 0 {// https://github.com/ikemen-engine/Ikemen-GO/issues/1445
+					if p.hitdef.guard_dist[0] < 0 {
+						if dist <= float32(c.size.proj.attack.dist.front)*c.localscl &&
+							dist >= -float32(c.size.proj.attack.dist.back)*c.localscl {
+							getter.inguarddist = true
+						}
+					} else {
+						if dist <= float32(p.hitdef.guard_dist[0]) &&
+							dist >= -float32(p.hitdef.guard_dist[1]) {
+							getter.inguarddist = true
+						}
+					}
 				}
 				if p.platform {
 					//Platformの足場上空判定
@@ -7750,11 +7757,6 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 					orghittmp := getter.hittmp
 					if getter.csf(CSF_gethit) {
 						getter.hittmp = int8(Btoi(getter.ghv.fallf)) + 1
-					}
-					// Guard distance
-					dist := -getter.distX(c, getter) * c.facing
-					if dist <= float32(p.hitdef.guard_dist[0]) && dist >= -float32(p.hitdef.guard_dist[1]) {
-						getter.inguarddist = true
 					}
 					if getter.projClsnCheck(p, true) {
 						hits := p.hits

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1900,8 +1900,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				out.append(OC_ex_gethitvar_airguard_velocity_x)
 			case "airguard.velocity.y":
 				out.append(OC_ex_gethitvar_airguard_velocity_y)
-			case "contact":
-				out.append(OC_ex_gethitvar_contact)
+			case "frame":
+				out.append(OC_ex_gethitvar_frame)
 			default:
 				return bvNone(), Error("Invalid data: " + c.token)
 			}
@@ -2907,8 +2907,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		switch c.token {
 		case "cornerpush":
 			out.append(OC_ex_movehitvar_cornerpush)
-		case "contact":
-			out.append(OC_ex_movehitvar_contact)
+		case "frame":
+			out.append(OC_ex_movehitvar_frame)
 		case "id":
 			out.append(OC_ex_movehitvar_id)
 		case "overridden":

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -60,10 +60,11 @@ type FightFx struct {
 	fsff     *Sff
 	fsnd     *Snd
 	fx_scale float32
+	localcoord [2]float32
 }
 
 func newFightFx() *FightFx {
-	return &FightFx{fsff: &Sff{}, fx_scale: 1.0}
+	return &FightFx{fsff: &Sff{}, fx_scale: 1.0, localcoord: [...]float32{320, 240}}
 }
 
 func loadFightFx(def string) error {
@@ -93,6 +94,14 @@ func loadFightFx(def string) error {
 					return Error(fmt.Sprintf("%v prefix is reserved for the system and cannot be used", strings.ToUpper(prefix)))
 				}
 				is.ReadF32("fx.scale", &ffx.fx_scale)
+				// Read localcoord
+				// Merely used for automatic fx.scale adjustment
+				// If localcoord is not available, we use the old method for scaling
+				if is.ReadF32("localcoord", &ffx.localcoord[0], &ffx.localcoord[1]) {
+					ffx.fx_scale *= float32(320 / ffx.localcoord[0])
+				} else {
+					ffx.fx_scale *= sys.lifebarScale
+				}
 			}
 		case "files":
 			// Read files section
@@ -133,8 +142,7 @@ func loadFightFx(def string) error {
 	}
 	// Set fx scale to anims
 	for _, a := range ffx.fat {
-		a.start_scale = [...]float32{sys.lifebarScale * ffx.fx_scale,
-			sys.lifebarScale * ffx.fx_scale}
+		a.start_scale = [...]float32{ffx.fx_scale, ffx.fx_scale}
 	}
 	if sys.ffx[prefix] == nil {
 		sys.ffxRegexp += "|^(" + prefix + ")"

--- a/src/script.go
+++ b/src/script.go
@@ -3281,8 +3281,8 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.ghv.airguard_velocity[0])
 		case "airguard.velocity.y":
 			ln = lua.LNumber(c.ghv.airguard_velocity[1])
-		case "contact":
-			ln = lua.LNumber(Btoi(c.ghv.contact))
+		case "frame":
+			ln = lua.LNumber(Btoi(c.ghv.frame))
 		default:
 			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}
@@ -3436,10 +3436,10 @@ func triggerFunctions(l *lua.LState) {
 		c := sys.debugWC
 		var ln lua.LNumber
 		switch strArg(l, 1) {
-		case "contact":
-			ln = lua.LNumber(Btoi(c.mhv.contact))
 		case "cornerpush":
 			ln = lua.LNumber(c.mhv.cornerpush)
+		case "frame":
+			ln = lua.LNumber(Btoi(c.mhv.frame))
 		case "id":
 			ln = lua.LNumber(c.mhv.id)
 		case "overridden":


### PR DESCRIPTION
Feat:
- Localcoord can now be used in common FX [Info] group to facilitate scale conversions between different lifebars

Fixes:
- Previously, when a character was in a custom state but executing code from their own states (-2 etc), their engine version was being checked in the state owner. This made for instance DefenceMulSet completely change its behavior when a char with ikemenversion threw one without it. Adjusted so that engine version is always checked in the character that runs the code
- Adjusted how explod scale is decided in custom states to be more like Mugen
- If a projectile has no attack attribute, it won't trigger "InGuardDist" in the enemy
- Fixed projectiles not properly accounting for their guard.dist
- Fixes #1445 

Refactor:
- New GetHitVar(Frame) and MoveHitVar(Frame) triggers renamed