### PR TITLE
feat: Add GameFPS trigger and display to debug.

### DIFF
--- a/external/script/global.lua
+++ b/external/script/global.lua
@@ -150,7 +150,7 @@ function boolToInt(bool)
 end
 
 function engineInfo()
-	return string.format('Frames: %d, VSync: %d; Speed: %d/%d%%', tickcount(), vsync(), gameLogicSpeed(), gamespeed())
+	return string.format('Frames: %d, VSync: %d; Speed: %d/%d%%; FPS: %.3f', tickcount(), vsync(), gameLogicSpeed(), gamespeed(), gamefps())
 end
 
 function playerInfo()

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -191,6 +191,7 @@ const (
 	OC_id
 	OC_playeridexist
 	OC_gametime
+	OC_gamefps
 	OC_numtarget
 	OC_numenemy
 	OC_numpartner
@@ -1350,6 +1351,8 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushI(int32(c.frontEdgeBodyDist() * (c.localscl / oc.localscl)))
 		case OC_frontedgedist:
 			sys.bcStack.PushI(int32(c.frontEdgeDist() * (c.localscl / oc.localscl)))
+		case OC_gamefps:
+			sys.bcStack.PushF(sys.gameFPS)
 		case OC_gameheight:
 			// Optional exception preventing GameHeight from being affected by stage zoom.
 			if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 0 &&

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -349,6 +349,7 @@ var triggerMap = map[string]int{
 	"firstattack":        1,
 	"float":              1,
 	"framespercount":     1,
+	"gamefps":            1,
 	"gamemode":           1,
 	"getplayerid":        1,
 	"groundangle":        1,
@@ -1756,6 +1757,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_frontedgebodydist)
 	case "frontedgedist":
 		out.append(OC_frontedgedist)
+	case "gamefps":
+		out.append(OC_gamefps)
 	case "gameheight":
 		out.append(OC_gameheight)
 	case "gametime":

--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -11,6 +11,7 @@ import (
 	"unsafe"
 
 	gl "github.com/go-gl/gl/v2.1/gl"
+	glfw "github.com/go-gl/glfw/v3.3/glfw"
 	"golang.org/x/mobile/exp/f32"
 )
 
@@ -280,6 +281,9 @@ func (r *Renderer) Init() {
 	chk(gl.Init())
 	sys.errLog.Printf("Using OpenGL %v (%v)", gl.GetString(gl.VERSION), gl.GetString(gl.RENDERER))
 
+	// Store current timestamp
+	sys.prevTimestamp = glfw.GetTime()
+
 	r.postShaderSelect = make([]*ShaderProgram, 1+len(sys.externalShaderList))
 
 	// Data buffers for rendering
@@ -400,6 +404,7 @@ func (r *Renderer) Close() {
 }
 
 func (r *Renderer) BeginFrame(clearColor bool) {
+	sys.absTickCountF++
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo)
 	gl.Viewport(0, 0, sys.scrrect[2], sys.scrrect[3])
 	if clearColor {

--- a/src/script.go
+++ b/src/script.go
@@ -3135,6 +3135,10 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.debugWC.fvarGet(int32(numArg(l, 1))).ToF()))
 		return 1
 	})
+	luaRegister(l, "gamefps", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.gameFPS))
+		return 1
+	})
 	luaRegister(l, "gameheight", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.gameHeight()))
 		return 1

--- a/src/system.go
+++ b/src/system.go
@@ -369,6 +369,11 @@ type System struct {
 	windowCentered    bool
 	loopBreak         bool
 	loopContinue      bool
+
+	// for avg. FPS calculations
+	gameFPS       float32
+	prevTimestamp float64
+	absTickCountF float32
 }
 
 // Initialize stuff, this is called after the config int at main.go
@@ -538,6 +543,7 @@ func (s *System) await(fps int) bool {
 		s.frameSkip = true
 	}
 	s.eventUpdate()
+
 	return !s.gameEnd
 }
 
@@ -927,7 +933,7 @@ func (s *System) addFrameTime(t float32) bool {
 	return true
 }
 func (s *System) resetFrameTime() {
-	s.tickCount, s.oldTickCount, s.tickCountF, s.lastTick = 0, -1, 0, 0
+	s.tickCount, s.oldTickCount, s.tickCountF, s.lastTick, s.absTickCountF = 0, -1, 0, 0, 0
 	s.nextAddTime, s.oldNextAddTime = 1, 1
 }
 func (s *System) commandUpdate() {

--- a/src/system_glfw.go
+++ b/src/system_glfw.go
@@ -81,6 +81,13 @@ func (s *System) newWindow(w, h int) (*Window, error) {
 
 func (w *Window) SwapBuffers() {
 	w.Window.SwapBuffers()
+	// Retrieve GL timestamp now
+	glNow := glfw.GetTime()
+	if glNow-sys.prevTimestamp >= 1 {
+		sys.gameFPS = sys.absTickCountF / float32(glNow-sys.prevTimestamp)
+		sys.absTickCountF = 0
+		sys.prevTimestamp = glNow
+	}
 }
 
 func (w *Window) SetIcon(icon []image.Image) {


### PR DESCRIPTION
This feature adds a `GameFPS` trigger for use in characters and Lua method `gamefps()` to retrieve the current rolling Game FPS. Frame counts are currently averaged over the duration of a second with no smoothing. GameFPS appears to dip when lag is introduced, whether by expensive resources such as 3D stages, or code designed to introduce lag (e.g. Inktrebuchet's lag maker). A separate counter was made so that the FPS is able to update even while paused.

The following ZSS snippet is capable of introducing lag as a test case (the more you press start, the more lag you introduce):
```
#-------------------------------------------------------------------------------
# Lag maker
# by Inktrebuchet
[Statedef 33333376;
type: A; movetype: I; physics: N; ctrl: 0; velset: 0, 0; anim: -2;]
displayToClipboard{text: "lag maker \n%d"; params: var(0)}

if Time <= 0 {
    var(0) := var(0)+1;
}

if var(0) < 2500 {
    changeState{value: stateNo}
}
else if Time > 0 {
    var(0) := 0;
    changeState{value: stateNo}
}

[StateDef -2]
# Lag maker code
ignoreHitPause {
    if command = "start" {
        helper {
            name: "lag maker";
            ID: 33333376;
            stateNo: 33333376;
            posType: p1;
            ownpal: 1;
            keyctrl: 0;
            size.Xscale: 1.0;
            size.Yscale: 1.0;
            superMoveTime: 2147483647;
            pauseMoveTime: 2147483647;
        }
    }
}
```

Trigger example for wiki:
```
trigger1 = Time = floor(1.5 * (GameFPS/60) * TicksPerSecond) ; triggers every 1.5 seconds regardless of
                                                             ; game speed or frame drops
```
The trigger I'll admit seems like a niche use case but I decided to expose it just in case someone finds it useful.

Tested on Raspberry Pi 4 32-bit, Raspberry Pi 5 64-bit, macOS ARM (using one of fantasma's special builds, have no profiling tools to compare info with due to OpenGL profiler not working with IKEMEN-Go on either macOS Intel or ARM), and Windows 64-bit. The frame counts vary from Raspberry Pi 4 to Raspberry Pi 5 (as expected of the current nightly without any batching) in addition to showing introduced lag FPS drops with the code above on all platforms, so I'm fairly confident in its accuracy now.

Windows testing comparisons on different profilers from @potsmugen and I (error margin between engine output and profiler output seems negligible/acceptable):
![image](https://github.com/ikemen-engine/Ikemen-GO/assets/20290325/570b086b-f395-4403-99cb-0bd850075fa2)
![image](https://github.com/ikemen-engine/Ikemen-GO/assets/20290325/7284d8b9-4594-4b2b-a509-f0b6f9690fab)
