### PR TITLE
refactor: Moved GameFPS to where rest of ext. triggers live

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -191,7 +191,6 @@ const (
 	OC_id
 	OC_playeridexist
 	OC_gametime
-	OC_gamefps
 	OC_numtarget
 	OC_numenemy
 	OC_numpartner
@@ -601,6 +600,7 @@ const (
 	OC_ex_alpha_d
 	OC_ex_selfcommand
 	OC_ex_guardcount
+	OC_ex_gamefps
 )
 const (
 	NumVar     = 60
@@ -1351,8 +1351,6 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushI(int32(c.frontEdgeBodyDist() * (c.localscl / oc.localscl)))
 		case OC_frontedgedist:
 			sys.bcStack.PushI(int32(c.frontEdgeDist() * (c.localscl / oc.localscl)))
-		case OC_gamefps:
-			sys.bcStack.PushF(sys.gameFPS)
 		case OC_gameheight:
 			// Optional exception preventing GameHeight from being affected by stage zoom.
 			if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 0 &&
@@ -2249,6 +2247,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(sys.lifebar.ti.framespercount)
 	case OC_ex_float:
 		*sys.bcStack.Top() = BytecodeFloat(sys.bcStack.Top().ToF())
+	case OC_ex_gamefps:
+		sys.bcStack.PushF(sys.gameFPS)
 	case OC_ex_gamemode:
 		sys.bcStack.PushB(strings.ToLower(sys.gameMode) ==
 			sys.stringPool[sys.workingState.playerNo].List[*(*int32)(

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1757,8 +1757,6 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_frontedgebodydist)
 	case "frontedgedist":
 		out.append(OC_frontedgedist)
-	case "gamefps":
-		out.append(OC_gamefps)
 	case "gameheight":
 		out.append(OC_gameheight)
 	case "gametime":
@@ -2877,6 +2875,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_ex_, OC_ex_firstattack)
 	case "framespercount":
 		out.append(OC_ex_, OC_ex_framespercount)
+	case "gamefps":
+		out.append(OC_ex_, OC_ex_gamefps)
 	case "gamemode":
 		if err := nameSubEx(OC_ex_gamemode); err != nil {
 			return bvNone(), err

--- a/src/script.go
+++ b/src/script.go
@@ -3135,10 +3135,6 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.debugWC.fvarGet(int32(numArg(l, 1))).ToF()))
 		return 1
 	})
-	luaRegister(l, "gamefps", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.gameFPS))
-		return 1
-	})
 	luaRegister(l, "gameheight", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.gameHeight()))
 		return 1
@@ -4171,6 +4167,10 @@ func triggerFunctions(l *lua.LState) {
 	})
 	luaRegister(l, "framespercount", func(l *lua.LState) int {
 		l.Push(lua.LNumber(sys.lifebar.ti.framespercount))
+		return 1
+	})
+	luaRegister(l, "gamefps", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.gameFPS))
 		return 1
 	})
 	luaRegister(l, "gamemode", func(*lua.LState) int {


### PR DESCRIPTION
Moved the logic of the gameFPS trigger to where it rightfully belongs since it's an extended trigger (sorry, new to the repo). No differences in functionality from previous PR.