### PR TITLE
feat: LifeBarVar trigger

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -601,6 +601,15 @@ const (
 	OC_ex_selfcommand
 	OC_ex_guardcount
 	OC_ex_gamefps
+	OC_ex_lifebarvar_info_author
+	OC_ex_lifebarvar_info_name
+	OC_ex_lifebarvar_round_ctrl_time
+	OC_ex_lifebarvar_round_over_hittime
+	OC_ex_lifebarvar_round_over_time
+	OC_ex_lifebarvar_round_over_waittime
+	OC_ex_lifebarvar_round_over_wintime
+	OC_ex_lifebarvar_round_slow_time
+	OC_ex_lifebarvar_round_start_waittime
 )
 const (
 	NumVar     = 60
@@ -2290,6 +2299,28 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushB(c.isHost())
 	case OC_ex_jugglepoints:
 		*sys.bcStack.Top() = c.jugglePoints(*sys.bcStack.Top())
+	case OC_ex_lifebarvar_info_author:
+		sys.bcStack.PushB(sys.lifebar.authorLow ==
+			sys.stringPool[sys.workingState.playerNo].List[*(*int32)(unsafe.Pointer(&be[*i]))])
+		*i += 4
+	case OC_ex_lifebarvar_info_name:
+		sys.bcStack.PushB(sys.lifebar.nameLow ==
+			sys.stringPool[sys.workingState.playerNo].List[*(*int32)(unsafe.Pointer(&be[*i]))])
+		*i += 4
+	case OC_ex_lifebarvar_round_ctrl_time:
+		sys.bcStack.PushI(sys.lifebar.ro.ctrl_time)
+	case OC_ex_lifebarvar_round_over_hittime:
+		sys.bcStack.PushI(sys.lifebar.ro.over_hittime)
+	case OC_ex_lifebarvar_round_over_time:
+		sys.bcStack.PushI(sys.lifebar.ro.over_time)
+	case OC_ex_lifebarvar_round_over_waittime:
+		sys.bcStack.PushI(sys.lifebar.ro.over_waittime)
+	case OC_ex_lifebarvar_round_over_wintime:
+		sys.bcStack.PushI(sys.lifebar.ro.over_wintime)
+	case OC_ex_lifebarvar_round_slow_time:
+		sys.bcStack.PushI(sys.lifebar.ro.slow_time)
+	case OC_ex_lifebarvar_round_start_waittime:
+		sys.bcStack.PushI(sys.lifebar.ro.start_waittime)
 	case OC_ex_localcoord_x:
 		sys.bcStack.PushF(sys.cgi[c.playerNo].localcoord[0])
 	case OC_ex_localcoord_y:

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -367,6 +367,7 @@ var triggerMap = map[string]int{
 	"ishost":             1,
 	"lastplayerid":       1,
 	"lerp":               1,
+	"lifebarvar":         1,
 	"localcoord":         1,
 	"localscale":         1,
 	"majorversion":       1,
@@ -2902,6 +2903,48 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		}
 	case "hitoverridden":
 		out.append(OC_ex_, OC_ex_hitoverridden)
+	case "lifebarvar":
+		if err := c.checkOpeningBracket(in); err != nil {
+			return bvNone(), err
+		}
+		lvname := c.token
+		c.token = c.tokenizer(in)
+		if err := c.checkClosingBracket(); err != nil {
+			return bvNone(), err
+		}
+		isStr := false
+		switch lvname {
+		case "info.author":
+			opc = OC_ex_lifebarvar_info_author
+			isStr = true
+		case "info.name":
+			opc = OC_ex_lifebarvar_info_name
+			isStr = true
+		case "round.ctrl.time":
+			opc = OC_ex_lifebarvar_round_ctrl_time
+		case "round.over.hittime":
+			opc = OC_ex_lifebarvar_round_over_hittime
+		case "round.over.time":
+			opc = OC_ex_lifebarvar_round_over_time
+		case "round.over.waittime":
+			opc = OC_ex_lifebarvar_round_over_waittime
+		case "round.over.wintime":
+			opc = OC_ex_lifebarvar_round_over_wintime
+		case "round.slow.time":
+			opc = OC_ex_lifebarvar_round_slow_time
+		case "round.start.waittime":
+			opc = OC_ex_lifebarvar_round_start_waittime
+		default:
+			return bvNone(), Error("Invalid data: " + lvname)
+		}
+		if isStr {
+			if err := nameSubEx(opc); err != nil {
+				return bvNone(), err
+			}
+		} else {
+			out.append(OC_ex_)
+			out.append(opc)
+		}
 	case "movehitvar":
 		if err := c.checkOpeningBracket(in); err != nil {
 			return bvNone(), err

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -2980,6 +2980,10 @@ func (mo *LifeBarMode) draw(layerno int16, f []*Fnt) {
 }
 
 type Lifebar struct {
+	name       string
+	nameLow    string
+	author     string
+	authorLow  string
 	at         AnimationTable
 	sff        *Sff
 	snd        *Snd
@@ -3088,6 +3092,10 @@ func loadLifebar(def string) (*Lifebar, error) {
 			if is.ReadBool("doubleres", &b) {
 				l.fnt_scale = 0.5
 			}
+			l.name, _, _ = is.getText("name")
+			l.nameLow = strings.ToLower(l.name)
+			l.author, _, _ = is.getText("author")
+			l.authorLow = strings.ToLower(l.author)
 		case "files":
 			if filesflg {
 				filesflg = false

--- a/src/script.go
+++ b/src/script.go
@@ -3396,6 +3396,31 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.debugWC.life))
 		return 1
 	})
+	luaRegister(l, "lifebarvar", func(*lua.LState) int {
+		switch strArg(l, 1) {
+		case "info.name":
+			l.Push(lua.LString(sys.lifebar.name))
+		case "info.author":
+			l.Push(lua.LString(sys.lifebar.author))
+		case "round.ctrl.time":
+			l.Push(lua.LNumber(sys.lifebar.ro.ctrl_time))
+		case "round.over.hittime":
+			l.Push(lua.LNumber(sys.lifebar.ro.over_hittime))
+		case "round.over.time":
+			l.Push(lua.LNumber(sys.lifebar.ro.over_time))
+		case "round.over.waittime":
+			l.Push(lua.LNumber(sys.lifebar.ro.over_waittime))
+		case "round.over.wintime":
+			l.Push(lua.LNumber(sys.lifebar.ro.over_wintime))
+		case "round.slow.time":
+			l.Push(lua.LNumber(sys.lifebar.ro.slow_time))
+		case "round.start.waittime":
+			l.Push(lua.LNumber(sys.lifebar.ro.start_waittime))
+		default:
+			l.Push(lua.LString(""))
+		}
+		return 1
+	})
 	luaRegister(l, "lifemax", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.lifeMax))
 		return 1

--- a/src/stage.go
+++ b/src/stage.go
@@ -823,8 +823,8 @@ func loadStage(def string, main bool) (*Stage, error) {
 				}
 			}
 		}
-		// If the MUGEN version is lower than 1.0, use camera pixel rounding (floor)
-		if s.mugenver[0] != 1 {
+		// If the MUGEN version is lower than 1.0, default to camera pixel rounding (floor)
+		if s.ikemenver[0] == 0 && s.ikemenver[1] == 0 && s.mugenver[0] != 1 {
 			s.stageprops.roundpos = true
 		}
 		if sec[0].LoadFile("attachedchar", []string{def, "", sys.motifDir, "data/"}, func(filename string) error {
@@ -1028,10 +1028,8 @@ func loadStage(def string, main bool) (*Stage, error) {
 		sec[0].readI32ForStage("color", &r, &g, &b)
 		r, g, b = Clamp(r, 0, 255), Clamp(g, 0, 255), Clamp(b, 0, 255)
 		// Disable color parameter specifically in Mugen 1.1 stages
-		if s.ikemenver[0] == 0 && s.ikemenver[1] == 0 {
-			if s.mugenver[0] == 1 && s.mugenver[1] == 1 {
-				r, g, b = 0, 0, 0
-			}
+		if s.ikemenver[0] == 0 && s.ikemenver[1] == 0 && s.mugenver[0] == 1 && s.mugenver[1] == 1 {
+			r, g, b = 0, 0, 0
 		}
 		s.sdw.color = uint32(r<<16 | g<<8 | b)
 		sec[0].ReadF32("yscale", &s.sdw.yscale)

--- a/src/system.go
+++ b/src/system.go
@@ -2977,13 +2977,14 @@ func (l *Loader) loadStage() bool {
 			def = sys.sel.sdefOverwrite
 		}
 		if sys.stage != nil && sys.stage.def == def && sys.stage.mainstage && !sys.stage.reload {
+			tstr = fmt.Sprintf("Cached stage loaded: %v", def)
 			return true
 		}
 		sys.stageList = make(map[int32]*Stage)
 		sys.stageLoop = false
 		sys.stageList[0], l.err = loadStage(def, true)
 		sys.stage = sys.stageList[0]
-		tstr = fmt.Sprintf("Stage loaded: %v", def)
+		tstr = fmt.Sprintf("New stage loaded: %v", def)
 	}
 	return l.err == nil
 }


### PR DESCRIPTION
- Returns information about the lifebars
- Format: LifeBarVar(parameter)
- Currently supported parameters: info.author, info.name, round.ctrl.time, round.over.hittime, round.over.time, round.over.waittime, round.over.wintime, round.slow.time, round.start.waittime
- Consequently, lifebars now read "name" and "author" parameters in their [Info] section

Fixes:
- Fixed a cached stage merely printing a "load time 0 seconds" message to the debug console
- BG element "roundpos" cannot default to 1 if the stage has ikemenversion. For consistency