### PR TITLE
fix: TargetBind, juggling

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -601,15 +601,15 @@ const (
 	OC_ex_selfcommand
 	OC_ex_guardcount
 	OC_ex_gamefps
-	OC_ex_lifebarvar_info_author
-	OC_ex_lifebarvar_info_name
-	OC_ex_lifebarvar_round_ctrl_time
-	OC_ex_lifebarvar_round_over_hittime
-	OC_ex_lifebarvar_round_over_time
-	OC_ex_lifebarvar_round_over_waittime
-	OC_ex_lifebarvar_round_over_wintime
-	OC_ex_lifebarvar_round_slow_time
-	OC_ex_lifebarvar_round_start_waittime
+	OC_ex_fightscreenvar_info_author
+	OC_ex_fightscreenvar_info_name
+	OC_ex_fightscreenvar_round_ctrl_time
+	OC_ex_fightscreenvar_round_over_hittime
+	OC_ex_fightscreenvar_round_over_time
+	OC_ex_fightscreenvar_round_over_waittime
+	OC_ex_fightscreenvar_round_over_wintime
+	OC_ex_fightscreenvar_round_slow_time
+	OC_ex_fightscreenvar_round_start_waittime
 )
 const (
 	NumVar     = 60
@@ -2248,6 +2248,28 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(c.dizzyPointsMax)
 	case OC_ex_drawpalno:
 		sys.bcStack.PushI(c.gi().drawpalno)
+	case OC_ex_fightscreenvar_info_author:
+		sys.bcStack.PushB(sys.lifebar.authorLow ==
+			sys.stringPool[sys.workingState.playerNo].List[*(*int32)(unsafe.Pointer(&be[*i]))])
+		*i += 4
+	case OC_ex_fightscreenvar_info_name:
+		sys.bcStack.PushB(sys.lifebar.nameLow ==
+			sys.stringPool[sys.workingState.playerNo].List[*(*int32)(unsafe.Pointer(&be[*i]))])
+		*i += 4
+	case OC_ex_fightscreenvar_round_ctrl_time:
+		sys.bcStack.PushI(sys.lifebar.ro.ctrl_time)
+	case OC_ex_fightscreenvar_round_over_hittime:
+		sys.bcStack.PushI(sys.lifebar.ro.over_hittime)
+	case OC_ex_fightscreenvar_round_over_time:
+		sys.bcStack.PushI(sys.lifebar.ro.over_time)
+	case OC_ex_fightscreenvar_round_over_waittime:
+		sys.bcStack.PushI(sys.lifebar.ro.over_waittime)
+	case OC_ex_fightscreenvar_round_over_wintime:
+		sys.bcStack.PushI(sys.lifebar.ro.over_wintime)
+	case OC_ex_fightscreenvar_round_slow_time:
+		sys.bcStack.PushI(sys.lifebar.ro.slow_time)
+	case OC_ex_fightscreenvar_round_start_waittime:
+		sys.bcStack.PushI(sys.lifebar.ro.start_waittime)
 	case OC_ex_fighttime:
 		sys.bcStack.PushI(sys.gameTime)
 	case OC_ex_firstattack:
@@ -2299,28 +2321,6 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushB(c.isHost())
 	case OC_ex_jugglepoints:
 		*sys.bcStack.Top() = c.jugglePoints(*sys.bcStack.Top())
-	case OC_ex_lifebarvar_info_author:
-		sys.bcStack.PushB(sys.lifebar.authorLow ==
-			sys.stringPool[sys.workingState.playerNo].List[*(*int32)(unsafe.Pointer(&be[*i]))])
-		*i += 4
-	case OC_ex_lifebarvar_info_name:
-		sys.bcStack.PushB(sys.lifebar.nameLow ==
-			sys.stringPool[sys.workingState.playerNo].List[*(*int32)(unsafe.Pointer(&be[*i]))])
-		*i += 4
-	case OC_ex_lifebarvar_round_ctrl_time:
-		sys.bcStack.PushI(sys.lifebar.ro.ctrl_time)
-	case OC_ex_lifebarvar_round_over_hittime:
-		sys.bcStack.PushI(sys.lifebar.ro.over_hittime)
-	case OC_ex_lifebarvar_round_over_time:
-		sys.bcStack.PushI(sys.lifebar.ro.over_time)
-	case OC_ex_lifebarvar_round_over_waittime:
-		sys.bcStack.PushI(sys.lifebar.ro.over_waittime)
-	case OC_ex_lifebarvar_round_over_wintime:
-		sys.bcStack.PushI(sys.lifebar.ro.over_wintime)
-	case OC_ex_lifebarvar_round_slow_time:
-		sys.bcStack.PushI(sys.lifebar.ro.slow_time)
-	case OC_ex_lifebarvar_round_start_waittime:
-		sys.bcStack.PushI(sys.lifebar.ro.start_waittime)
 	case OC_ex_localcoord_x:
 		sys.bcStack.PushF(sys.cgi[c.playerNo].localcoord[0])
 	case OC_ex_localcoord_y:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5987,7 +5987,7 @@ func (sc targetDrop) Run(c *Char, _ []int32) bool {
 	if len(tar) == 0 {
 		return false
 	}
-	crun.targetDrop(eid, ko)
+	crun.targetDrop(eid, -1, ko)
 	return false
 }
 

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -345,6 +345,7 @@ var triggerMap = map[string]int{
 	"dizzypointsmax":     1,
 	"drawpalno":          1,
 	"envshakevar":        1,
+	"fightscreenvar":     1,
 	"fighttime":          1,
 	"firstattack":        1,
 	"float":              1,
@@ -367,7 +368,6 @@ var triggerMap = map[string]int{
 	"ishost":             1,
 	"lastplayerid":       1,
 	"lerp":               1,
-	"lifebarvar":         1,
 	"localcoord":         1,
 	"localscale":         1,
 	"majorversion":       1,
@@ -2870,6 +2870,48 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		if err := c.checkClosingBracket(); err != nil {
 			return bvNone(), err
 		}
+	case "fightscreenvar":
+		if err := c.checkOpeningBracket(in); err != nil {
+			return bvNone(), err
+		}
+		lvname := c.token
+		c.token = c.tokenizer(in)
+		if err := c.checkClosingBracket(); err != nil {
+			return bvNone(), err
+		}
+		isStr := false
+		switch lvname {
+		case "info.author":
+			opc = OC_ex_fightscreenvar_info_author
+			isStr = true
+		case "info.name":
+			opc = OC_ex_fightscreenvar_info_name
+			isStr = true
+		case "round.ctrl.time":
+			opc = OC_ex_fightscreenvar_round_ctrl_time
+		case "round.over.hittime":
+			opc = OC_ex_fightscreenvar_round_over_hittime
+		case "round.over.time":
+			opc = OC_ex_fightscreenvar_round_over_time
+		case "round.over.waittime":
+			opc = OC_ex_fightscreenvar_round_over_waittime
+		case "round.over.wintime":
+			opc = OC_ex_fightscreenvar_round_over_wintime
+		case "round.slow.time":
+			opc = OC_ex_fightscreenvar_round_slow_time
+		case "round.start.waittime":
+			opc = OC_ex_fightscreenvar_round_start_waittime
+		default:
+			return bvNone(), Error("Invalid data: " + lvname)
+		}
+		if isStr {
+			if err := nameSubEx(opc); err != nil {
+				return bvNone(), err
+			}
+		} else {
+			out.append(OC_ex_)
+			out.append(opc)
+		}
 	case "fighttime":
 		out.append(OC_ex_, OC_ex_fighttime)
 	case "firstattack":
@@ -2903,48 +2945,6 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		}
 	case "hitoverridden":
 		out.append(OC_ex_, OC_ex_hitoverridden)
-	case "lifebarvar":
-		if err := c.checkOpeningBracket(in); err != nil {
-			return bvNone(), err
-		}
-		lvname := c.token
-		c.token = c.tokenizer(in)
-		if err := c.checkClosingBracket(); err != nil {
-			return bvNone(), err
-		}
-		isStr := false
-		switch lvname {
-		case "info.author":
-			opc = OC_ex_lifebarvar_info_author
-			isStr = true
-		case "info.name":
-			opc = OC_ex_lifebarvar_info_name
-			isStr = true
-		case "round.ctrl.time":
-			opc = OC_ex_lifebarvar_round_ctrl_time
-		case "round.over.hittime":
-			opc = OC_ex_lifebarvar_round_over_hittime
-		case "round.over.time":
-			opc = OC_ex_lifebarvar_round_over_time
-		case "round.over.waittime":
-			opc = OC_ex_lifebarvar_round_over_waittime
-		case "round.over.wintime":
-			opc = OC_ex_lifebarvar_round_over_wintime
-		case "round.slow.time":
-			opc = OC_ex_lifebarvar_round_slow_time
-		case "round.start.waittime":
-			opc = OC_ex_lifebarvar_round_start_waittime
-		default:
-			return bvNone(), Error("Invalid data: " + lvname)
-		}
-		if isStr {
-			if err := nameSubEx(opc); err != nil {
-				return bvNone(), err
-			}
-		} else {
-			out.append(OC_ex_)
-			out.append(opc)
-		}
 	case "movehitvar":
 		if err := c.checkOpeningBracket(in); err != nil {
 			return bvNone(), err

--- a/src/script.go
+++ b/src/script.go
@@ -3396,31 +3396,6 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.debugWC.life))
 		return 1
 	})
-	luaRegister(l, "lifebarvar", func(*lua.LState) int {
-		switch strArg(l, 1) {
-		case "info.name":
-			l.Push(lua.LString(sys.lifebar.name))
-		case "info.author":
-			l.Push(lua.LString(sys.lifebar.author))
-		case "round.ctrl.time":
-			l.Push(lua.LNumber(sys.lifebar.ro.ctrl_time))
-		case "round.over.hittime":
-			l.Push(lua.LNumber(sys.lifebar.ro.over_hittime))
-		case "round.over.time":
-			l.Push(lua.LNumber(sys.lifebar.ro.over_time))
-		case "round.over.waittime":
-			l.Push(lua.LNumber(sys.lifebar.ro.over_waittime))
-		case "round.over.wintime":
-			l.Push(lua.LNumber(sys.lifebar.ro.over_wintime))
-		case "round.slow.time":
-			l.Push(lua.LNumber(sys.lifebar.ro.slow_time))
-		case "round.start.waittime":
-			l.Push(lua.LNumber(sys.lifebar.ro.start_waittime))
-		default:
-			l.Push(lua.LString(""))
-		}
-		return 1
-	})
 	luaRegister(l, "lifemax", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.lifeMax))
 		return 1
@@ -4180,6 +4155,31 @@ func triggerFunctions(l *lua.LState) {
 	})
 	luaRegister(l, "dizzypointsmax", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.dizzyPointsMax))
+		return 1
+	})
+	luaRegister(l, "fightscreenvar", func(*lua.LState) int {
+		switch strArg(l, 1) {
+		case "info.name":
+			l.Push(lua.LString(sys.lifebar.name))
+		case "info.author":
+			l.Push(lua.LString(sys.lifebar.author))
+		case "round.ctrl.time":
+			l.Push(lua.LNumber(sys.lifebar.ro.ctrl_time))
+		case "round.over.hittime":
+			l.Push(lua.LNumber(sys.lifebar.ro.over_hittime))
+		case "round.over.time":
+			l.Push(lua.LNumber(sys.lifebar.ro.over_time))
+		case "round.over.waittime":
+			l.Push(lua.LNumber(sys.lifebar.ro.over_waittime))
+		case "round.over.wintime":
+			l.Push(lua.LNumber(sys.lifebar.ro.over_wintime))
+		case "round.slow.time":
+			l.Push(lua.LNumber(sys.lifebar.ro.slow_time))
+		case "round.start.waittime":
+			l.Push(lua.LNumber(sys.lifebar.ro.start_waittime))
+		default:
+			l.Push(lua.LString(""))
+		}
 		return 1
 	})
 	luaRegister(l, "fighttime", func(*lua.LState) int {


### PR DESCRIPTION
- Fixed binding position not being updated when the char changes to a state with a different localcoord
- Fixed moves with fall = 0 never subtracting juggle points
- Fixed "hitonce" moves dropping all targets and thus losing their juggle point information
- Fixes #1746
- Fixes some infinite combos

Refactor:
- LifebarVar renamed FightScreenVar. Fight screen was the seemingly official name of the features fight.def controls. Lifebars are only one of its features and "lifebar" itself is more of a colloquial term