### PR TITLE
feat: Add ModifySnd SCTRL

### DIFF
--- a/src/compiler.go
+++ b/src/compiler.go
@@ -170,6 +170,7 @@ func newCompiler() *Compiler {
 		"height":               c.height,
 		"modifychar":           c.modifyChar,
 		"gethitvarset":         c.getHitVarSet,
+		"modifysnd":            c.modifySnd,
 	}
 	return c
 }

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -4286,6 +4286,44 @@ func (c *Compiler) modifyBGCtrl(is IniSection, sc *StateControllerBase, _ int8) 
 	})
 	return *ret, err
 }
+func (c *Compiler) modifySnd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+	ret, err := (*modifySnd)(sc), c.stateSec(is, func() error {
+		if err := c.paramValue(is, sc, "redirectid",
+			modifySnd_redirectid, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "channel",
+			modifySnd_channel, VT_Int, 1, true); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "pan",
+			modifySnd_pan, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "abspan",
+			modifySnd_abspan, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "volume",
+			modifySnd_volume, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "volumescale",
+			modifySnd_volumescale, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "freqmul",
+			modifySnd_freqmul, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "priority",
+			modifySnd_priority, VT_Int, 1, false); err != nil {
+			return err
+		}
+		return nil
+	})
+	return *ret, err
+}
 func (c *Compiler) printToConsole(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*printToConsole)(sc), c.stateSec(is, func() error {
 		return c.displayToClipboardSub(is, sc)

--- a/src/sound.go
+++ b/src/sound.go
@@ -535,6 +535,7 @@ func (s *SoundChannel) SetFreqMul(freqmul float32) {
 		if resampler, ok := s.ctrl.Streamer.(*beep.Resampler); ok {
 			speaker.Lock()
 			resampler.SetRatio(float64(srcRate) / float64(dstRate))
+			s.sfx.freqmul = freqmul
 			s.SetChannel(ch)
 			speaker.Unlock()
 		}

--- a/src/sound.go
+++ b/src/sound.go
@@ -435,6 +435,7 @@ type SoundEffect struct {
 	priority int32
 	channel  int32
 	loop     int32
+	freqmul  float32
 }
 
 func (s *SoundEffect) Stream(samples [][2]float64) (n int, ok bool) {
@@ -524,6 +525,19 @@ func (s *SoundChannel) SetPriority(priority int32) {
 func (s *SoundChannel) SetChannel(channel int32) {
 	if s.ctrl != nil {
 		s.sfx.channel = channel
+	}
+}
+func (s *SoundChannel) SetFreqMul(freqmul float32) {
+	if s.ctrl != nil {
+		ch := s.sfx.channel
+		srcRate := s.sound.format.SampleRate
+		dstRate := beep.SampleRate(audioFrequency / freqmul)
+		if resampler, ok := s.ctrl.Streamer.(*beep.Resampler); ok {
+			speaker.Lock()
+			resampler.SetRatio(float64(srcRate) / float64(dstRate))
+			s.SetChannel(ch)
+			speaker.Unlock()
+		}
 	}
 }
 

--- a/src/sound.go
+++ b/src/sound.go
@@ -487,9 +487,9 @@ func (s *SoundChannel) Play(sound *Sound, loop bool, freqmul float32) {
 		loopCount = -1
 	}
 	looper := beep.Loop(loopCount, s.streamer)
-	s.sfx = &SoundEffect{streamer: looper, volume: 256, priority: 0, channel: -1, loop: int32(loopCount)}
+	s.sfx = &SoundEffect{streamer: looper, volume: 256, priority: 0, channel: -1, loop: int32(loopCount), freqmul: freqmul}
 	srcRate := s.sound.format.SampleRate
-	dstRate := beep.SampleRate(audioFrequency / freqmul)
+	dstRate := beep.SampleRate(audioFrequency / s.sfx.freqmul)
 	resampler := beep.Resample(audioResampleQuality, srcRate, dstRate, s.sfx)
 	s.ctrl = &beep.Ctrl{Streamer: resampler}
 	sys.soundMixer.Add(s.ctrl)

--- a/src/sound.go
+++ b/src/sound.go
@@ -529,14 +529,12 @@ func (s *SoundChannel) SetChannel(channel int32) {
 }
 func (s *SoundChannel) SetFreqMul(freqmul float32) {
 	if s.ctrl != nil {
-		ch := s.sfx.channel
 		srcRate := s.sound.format.SampleRate
 		dstRate := beep.SampleRate(audioFrequency / freqmul)
 		if resampler, ok := s.ctrl.Streamer.(*beep.Resampler); ok {
 			speaker.Lock()
 			resampler.SetRatio(float64(srcRate) / float64(dstRate))
 			s.sfx.freqmul = freqmul
-			s.SetChannel(ch)
 			speaker.Unlock()
 		}
 	}


### PR DESCRIPTION
This adds a `ModifySND` state controller to the engine which can modify the following parameters of currently playing sounds: `volume`, `volumescale`, `freqmul`, `pan`, `abspan`, and `priority`. It cannot set `loop` (if you need your sound to loop, set it in `PlaySnd` initially). `channel` is a required parameter, and this SCTRL only modifies the properties of currently playing sounds (use `PlaySnd` if you want to play a different sound on the same channel).

Usage (ZSS):
```sh
modifySnd {
    channel: int;
    volume: int;
    volumescale: int;
    pan: float;
    abspan: float;
    priority: int;
    redirectID: int;
}
```

Usage (CNS):
```sh
[State -2, ModifySnd]
type = ModifySnd
channel = int
volume = int
volumescale = int
pan = float
abspan = float
priority = int
redirectID = int
```

[Video demo (YouTube)](https://www.youtube.com/watch?v=tCn3fRPX8Iw)

Example code:
```sh
[StateDef -3]
if roundState < 2 {
	map(_sndsys_ft) := fightTime;
}
let scaleFactor = 1 + cos(pi*(map(_sndsys_ft)-fightTime)/256);
displayToClipboard {text: "sf: %f; ft = %d"; params: $scaleFactor, fightTime-floor(map(_sndsys_ft))}
ignorehitpause if fightTime-map(_sndsys_ft) > 0 && roundState = 2 && !IsHelper {
	if !map(_snd_channel_6_playing) {
		playSnd {redirectId: player(2), ID; value: 11,0; volumescale: 100; channel: 6; loop: 1;}
		map(_snd_channel_6_playing) := 1;
	}
	else {
		if fightTime-map(_sndsys_ft) > 420 {
			modifySnd{redirectId: player(2), ID; channel: 6; volumescale: 50*$scaleFactor; freqmul: $scaleFactor;}
		}
		else {
			modifySnd {redirectId: player(2), ID; channel: 6; volumescale: 50*$scaleFactor;}
		}
	}
}
```

Feature from testing appears to be stable now, but could still be problematic if multiple calls to modify the `freqmul` parameter on the same channel are made on the same frame due to having to lock the speaker to prevent race conditions in the streaming (see `SetFreqMul` in `sound.go`). All values set are absolute, but if a parameter is not specified, then it will not be changed from the currently playing sound.

The volume behavior should be correctly replicated based on how I followed the path of these same parameters from `PlaySnd` to get to its ultimate destination but please let me know if any changes should be made.