### PR TITLE
other: ModifySnd now allows -1 to modify all channels

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -8637,36 +8637,47 @@ func (sc modifySnd) Run(c *Char, _ []int32) bool {
 		return true
 	})
 	// Grab the correct sound channel now
-	snd = crun.soundChannels.Get(ch)
-	if snd != nil && snd.sfx != nil {
-		// If we didn't set the values, default them to current values.
-		if !freqMulSet {
-			fr = snd.sfx.freqmul
-		}
-		if !volumeSet {
-			vo = snd.sfx.volume
-		}
-		if !prioritySet {
-			pri = snd.sfx.priority
-		}
-		if !panSet {
-			p = snd.sfx.p
-			ls = snd.sfx.ls
-			x = snd.sfx.x
+	channelCount := 1
+	if ch < 0 {
+		channelCount = len(crun.soundChannels.channels)
+	}
+	for i := channelCount - 1; i >= 0; i-- {
+		if ch < 0 {
+			snd = &crun.soundChannels.channels[i]
+		} else {
+			snd = crun.soundChannels.Get(ch)
 		}
 
-		// Now set the values if they're different
-		if snd.sfx.freqmul != fr {
-			snd.SetFreqMul(fr)
-		}
-		if pri != snd.sfx.priority {
-			snd.SetPriority(pri)
-		}
-		if p != snd.sfx.p || ls != snd.sfx.ls || x != snd.sfx.x {
-			snd.SetPan(p*crun.facing, ls, x)
-		}
-		if vo != snd.sfx.volume {
-			snd.SetVolume(vo)
+		if snd != nil && snd.sfx != nil {
+			// If we didn't set the values, default them to current values.
+			if !freqMulSet {
+				fr = snd.sfx.freqmul
+			}
+			if !volumeSet {
+				vo = snd.sfx.volume
+			}
+			if !prioritySet {
+				pri = snd.sfx.priority
+			}
+			if !panSet {
+				p = snd.sfx.p
+				ls = snd.sfx.ls
+				x = snd.sfx.x
+			}
+
+			// Now set the values if they're different
+			if snd.sfx.freqmul != fr {
+				snd.SetFreqMul(fr)
+			}
+			if pri != snd.sfx.priority {
+				snd.SetPriority(pri)
+			}
+			if p != snd.sfx.p || ls != snd.sfx.ls || x != snd.sfx.x {
+				snd.SetPan(p*crun.facing, ls, x)
+			}
+			if vo != snd.sfx.volume {
+				snd.SetVolume(vo)
+			}
 		}
 	}
 	return false

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -4293,7 +4293,7 @@ func (c *Compiler) modifySnd(is IniSection, sc *StateControllerBase, _ int8) (St
 			return err
 		}
 		if err := c.paramValue(is, sc, "channel",
-			modifySnd_channel, VT_Int, 1, true); err != nil {
+			modifySnd_channel, VT_Int, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "pan",

--- a/src/sound.go
+++ b/src/sound.go
@@ -529,13 +529,15 @@ func (s *SoundChannel) SetChannel(channel int32) {
 }
 func (s *SoundChannel) SetFreqMul(freqmul float32) {
 	if s.ctrl != nil {
-		srcRate := s.sound.format.SampleRate
-		dstRate := beep.SampleRate(audioFrequency / freqmul)
-		if resampler, ok := s.ctrl.Streamer.(*beep.Resampler); ok {
-			speaker.Lock()
-			resampler.SetRatio(float64(srcRate) / float64(dstRate))
-			s.sfx.freqmul = freqmul
-			speaker.Unlock()
+		if s.sound != nil {
+			srcRate := s.sound.format.SampleRate
+			dstRate := beep.SampleRate(audioFrequency / freqmul)
+			if resampler, ok := s.ctrl.Streamer.(*beep.Resampler); ok {
+				speaker.Lock()
+				resampler.SetRatio(float64(srcRate) / float64(dstRate))
+				s.sfx.freqmul = freqmul
+				speaker.Unlock()
+			}
 		}
 	}
 }


### PR DESCRIPTION
`ModifySnd` now allows -1 to modify all sound channels of the entity. `channel` parameter is no longer required. Added nil checks for required safety.