### PR TITLE
fix: commands during custom states, TicksPerSecond

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1339,14 +1339,16 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 				sys.bcStack.PushB(false)
 			} else {
 				cmdName := sys.stringPool[sys.workingState.playerNo].List[*(*int32)(unsafe.Pointer(&be[i]))]
-				pno := sys.workingState.playerNo
-				// Engine version is checked in state owner rather than working state
-				if cmdName == "recovery" || oc.stOgi().ikemenver[0] != 0 || oc.stOgi().ikemenver[1] != 0 {
-					// Command is checked by name, rather than by command list order (MUGEN 1.1)
-					pno = c.playerNo
+				redir := c.playerNo
+				pno := c.playerNo
+				// For a Mugen character, the command position is checked in the redirecting char
+				// Recovery command is an exception in that its position is always checked in the final char
+				if cmdName != "recovery" && oc.stWgi().ikemenver[0] == 0 && oc.stWgi().ikemenver[1] == 0 {
+					redir = oc.ss.sb.playerNo
+					pno = c.ss.sb.playerNo
 				}
-				cmd, ok := c.cmd[pno].Names[cmdName]
-				ok = ok && c.command(c.playerNo, cmd)
+				cmdPos, ok := c.cmd[redir].Names[cmdName]
+				ok = ok && c.command(pno, cmdPos)
 				sys.bcStack.PushB(ok)
 			}
 			i += 4

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1997,7 +1997,7 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_ishometeam:
 		sys.bcStack.PushB(c.teamside == sys.home)
 	case OC_ex_tickspersecond:
-		sys.bcStack.PushI(int32(FPS))
+		sys.bcStack.PushI(int32(float32(FPS) * sys.gameSpeed * sys.accel))
 	case OC_ex_const240p:
 		*sys.bcStack.Top() = c.constp(320, sys.bcStack.Top().ToF())
 	case OC_ex_const480p:

--- a/src/char.go
+++ b/src/char.go
@@ -6141,9 +6141,6 @@ func (c *Char) actionPrepare() {
 				c.setSCF(SCF_over)
 			}
 			c.specialFlag = 0
-			// The following AssertSpecial flags are only reset later in the code
-			flagtemp := (c.assertFlag&ASF_nostandguard | c.assertFlag&ASF_nocrouchguard | c.assertFlag&ASF_noairguard)
-			c.assertFlag = flagtemp
 			c.inputFlag = 0
 			c.setCSF(CSF_stagebound)
 			if c.player {
@@ -6178,24 +6175,19 @@ func (c *Char) actionPrepare() {
 				c.pauseMovetime--
 			}
 		}
-		c.unsetASF(ASF_noautoturn)
+		// This flag is special in that it must always reset regardless of hitpause
 		c.unsetASF(ASF_animatehitpause)
 		// Reset hitbox scale
 		// This used to be only in changeAnimEx(), but because it can now be dynamically changed it was also placed here
 		c.clsnScale = [...]float32{sys.chars[c.animPN][0].size.xscale, sys.chars[c.animPN][0].size.yscale}
 		c.angleRescaleClsn = false
-		// In WinMugen these flags persist during hitpause
-		if c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 || c.stWgi().mugenver[0] == 1 {
-			c.unsetCSF(CSF_angledraw | CSF_offset)
-			// The following AssertSpecial flags are only reset later in the code
-			flagtemp := (c.assertFlag&ASF_nostandguard | c.assertFlag&ASF_nocrouchguard | c.assertFlag&ASF_noairguard)
-			c.assertFlag = flagtemp
+		// In WinMugen all of these flags persisted during hitpause
+		if !c.hitPause() || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 || c.stWgi().mugenver[0] == 1 {
+			c.unsetCSF(CSF_angledraw | CSF_offset | CSF_trans)
 			c.angleScale = [...]float32{1, 1}
 			c.offset = [2]float32{}
-		}
-		//Trans reset during hitpause if ignorehitpause = 0 fix
-		if c.csf(CSF_trans) && c.hitPause() {
-			c.unsetCSF(CSF_trans)
+			// Reset all AssertSpecial flags except the following, which are reset elsewhere in the code
+			c.assertFlag = (c.assertFlag&ASF_nostandguard | c.assertFlag&ASF_nocrouchguard | c.assertFlag&ASF_noairguard)
 		}
 	}
 	c.dropTargets()


### PR DESCRIPTION
- Fixed commands being checked in the wrong command list while the char is in a custom state, in the case of Mugen characters
- Rephrased the code a little so that Ikemen version is the rule instead of the exception
- Fixes #1655
- TicksPerSecond now correctly changes according to the game speed. Contrary to Mugen, it will also be affected by debug speed, as that seemed more useful than not

Refactor:
- Removed some redundancy from the AssertSpecial code
- Trans flag will not reset during hitpause for a Winmugen char