### PR TITLE
fix: sys.changeStateNest loop off-by-one error, added unique - state case

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -3735,7 +3735,7 @@ func (c *Char) turn() {
 	}
 }
 func (c *Char) stateChange1(no int32, pn int) bool {
-	if sys.changeStateNest >= 2500 {
+	if sys.changeStateNest > 2500 {
 		sys.appendToConsole(c.warn() + fmt.Sprintf("state machine stuck in loop (stopped after 2500 loops): %v -> %v -> %v", c.ss.prevno, c.ss.no, no))
 		sys.errLog.Printf("2500 loops: %v, %v -> %v -> %v\n",
 			c.name, c.ss.prevno, c.ss.no, no)
@@ -3777,7 +3777,13 @@ func (c *Char) stateChange1(no int32, pn int) bool {
 		c.localscl = newLs
 	}
 	var ok bool
-	if c.ss.sb, ok = sys.cgi[pn].states[no]; !ok {
+	// Check if user is trying to change to a negative state.
+	if no < 0 {
+		sys.appendToConsole(c.warn() + "attempted to change to negative state")
+		sys.errLog.Printf("Attempted to change to negative state: P%v:%v\n", pn+1, no)
+	}
+	// Always attempt to change to the state we set to.
+	if c.ss.sb, ok = sys.cgi[pn].states[c.ss.no]; !ok {
 		sys.appendToConsole(c.warn() + fmt.Sprintf("changed to invalid state %v (from state %v)", no, c.ss.prevno))
 		sys.errLog.Printf("Invalid state: P%v:%v\n", pn+1, no)
 		c.ss.sb = *newStateBytecode(pn)


### PR DESCRIPTION
Currently, this code causes the "state stopped after 2500" loops warning in IKEMEN-Go when this same snippet does not cause the same message to pop up and crash MUGEN:
```ini
[Statedef 33333376]
type = A
movetype = I
physics = N
ctrl = 0
velset = 0, 0
anim = 9741                   ; blank animation

[State n1, 0]
type = DisplayToClipboard
trigger1 =  1
text = "lag maker \n%d"
params = var(0)

[State n1, 1]
type = VarAdd
trigger1 = !time
var(0) = 1

[State n1, 2]
type = ChangeState
trigger1 = var(0) <= 2500
value = stateno

[State n1, 3]
type = ChangeState
trigger1 = time
trigger1 = var(0) := 0
value = stateno

[Statedef -2]
[state -2, lag maker]
type = helper
;trigger1 = !numhelper(33333376)
trigger1 = command="start"
name = "lag maker"
ID = 33333376
stateno = 33333376
postype = p1
ownpal = 1
keyctrl = 0
size.xscale = 1.0
size.yscale = 1.0
supermovetime = 2147483647
pausemovetime = 2147483647
ignorehitpause = 1
```

This fixes that off-by-one error as well as implements proper (MUGEN) behavior for when a user attempts to change to a negative state (engine warning, default to state 0). Invalid state behavior unaffected.