### PR TITLE
feat: InputTime trigger

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -523,6 +523,20 @@ const (
 	OC_ex_helperindexexist
 	OC_ex_helpername
 	OC_ex_hitoverridden
+	OC_ex_inputtime_B
+	OC_ex_inputtime_D
+	OC_ex_inputtime_F
+	OC_ex_inputtime_U
+	OC_ex_inputtime_a
+	OC_ex_inputtime_b
+	OC_ex_inputtime_c
+	OC_ex_inputtime_x
+	OC_ex_inputtime_y
+	OC_ex_inputtime_z
+	OC_ex_inputtime_s
+	OC_ex_inputtime_d
+	OC_ex_inputtime_w
+	OC_ex_inputtime_m
 	OC_ex_movehitvar_frame
 	OC_ex_movehitvar_cornerpush
 	OC_ex_movehitvar_id
@@ -2236,6 +2250,90 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(c.anim.totaltime)
 	case OC_ex_attack:
 		sys.bcStack.PushF(c.attackMul * 100)
+	case OC_ex_inputtime_B:
+		if c.keyctrl[0] && c.cmd != nil {
+			sys.bcStack.PushI(c.cmd[0].Buffer.Bb)
+		} else {
+			sys.bcStack.PushI(0)
+		}
+	case OC_ex_inputtime_D:
+		if c.keyctrl[0] && c.cmd != nil {
+			sys.bcStack.PushI(c.cmd[0].Buffer.Db)
+		} else {
+			sys.bcStack.PushI(0)
+		}
+	case OC_ex_inputtime_F:
+		if c.keyctrl[0] && c.cmd != nil {
+			sys.bcStack.PushI(c.cmd[0].Buffer.Fb)
+		} else {
+			sys.bcStack.PushI(0)
+		}
+	case OC_ex_inputtime_U:
+		if c.keyctrl[0] && c.cmd != nil {
+			sys.bcStack.PushI(c.cmd[0].Buffer.Ub)
+		} else {
+			sys.bcStack.PushI(0)
+		}
+	case OC_ex_inputtime_a:
+		if c.keyctrl[0] && c.cmd != nil {
+			sys.bcStack.PushI(c.cmd[0].Buffer.ab)
+		} else {
+			sys.bcStack.PushI(0)
+		}
+	case OC_ex_inputtime_b:
+		if c.keyctrl[0] && c.cmd != nil {
+			sys.bcStack.PushI(c.cmd[0].Buffer.bb)
+		} else {
+			sys.bcStack.PushI(0)
+		}
+	case OC_ex_inputtime_c:
+		if c.keyctrl[0] && c.cmd != nil {
+			sys.bcStack.PushI(c.cmd[0].Buffer.cb)
+		} else {
+			sys.bcStack.PushI(0)
+		}
+	case OC_ex_inputtime_x:
+		if c.keyctrl[0] && c.cmd != nil {
+			sys.bcStack.PushI(c.cmd[0].Buffer.xb)
+		} else {
+			sys.bcStack.PushI(0)
+		}
+	case OC_ex_inputtime_y:
+		if c.keyctrl[0] && c.cmd != nil {
+			sys.bcStack.PushI(c.cmd[0].Buffer.yb)
+		} else {
+			sys.bcStack.PushI(0)
+		}
+	case OC_ex_inputtime_z:
+		if c.keyctrl[0] && c.cmd != nil {
+			sys.bcStack.PushI(c.cmd[0].Buffer.zb)
+		} else {
+			sys.bcStack.PushI(0)
+		}
+	case OC_ex_inputtime_s:
+		if c.keyctrl[0] && c.cmd != nil {
+			sys.bcStack.PushI(c.cmd[0].Buffer.sb)
+		} else {
+			sys.bcStack.PushI(0)
+		}
+	case OC_ex_inputtime_d:
+		if c.keyctrl[0] && c.cmd != nil {
+			sys.bcStack.PushI(c.cmd[0].Buffer.db)
+		} else {
+			sys.bcStack.PushI(0)
+		}
+	case OC_ex_inputtime_w:
+		if c.keyctrl[0] && c.cmd != nil {
+			sys.bcStack.PushI(c.cmd[0].Buffer.wb)
+		} else {
+			sys.bcStack.PushI(0)
+		}
+	case OC_ex_inputtime_m:
+		if c.keyctrl[0] && c.cmd != nil {
+			sys.bcStack.PushI(c.cmd[0].Buffer.mb)
+		} else {
+			sys.bcStack.PushI(0)
+		}
 	case OC_ex_combocount:
 		sys.bcStack.PushI(c.comboCount())
 	case OC_ex_consecutivewins:

--- a/src/char.go
+++ b/src/char.go
@@ -1250,7 +1250,7 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 	}
 	// Remove on get hit
 	if sys.tickNextFrame() &&
-		c != nil && e.removeongethit && c.csf(CSF_gethit) {
+		c != nil && e.removeongethit && c.csf(CSF_gethit) && !c.inGuardState() {
 		e.id, e.anim = IErr, nil
 		return
 	}

--- a/src/char.go
+++ b/src/char.go
@@ -1687,7 +1687,7 @@ func (p *Projectile) clsn(playerNo int) {
 			}
 			clsn1 := pr.ani.CurrentFrame().Clsn2()
 			clsn2 := p.ani.CurrentFrame().Clsn2()
-			if sys.clsnHantei(clsn1, [...]float32{pr.clsnScale[0] * pr.localscl, pr.clsnScale[1] * pr.localscl},
+			if sys.clsnOverlap(clsn1, [...]float32{pr.clsnScale[0] * pr.localscl, pr.clsnScale[1] * pr.localscl},
 				[...]float32{pr.pos[0] * pr.localscl, pr.pos[1] * pr.localscl}, pr.facing,
 				clsn2, [...]float32{p.clsnScale[0] * p.localscl, p.clsnScale[1] * p.localscl},
 				[...]float32{p.pos[0] * p.localscl, p.pos[1] * p.localscl}, p.facing) {
@@ -5934,7 +5934,7 @@ func (c *Char) projClsnCheck(p *Projectile, gethit bool) bool {
 	} else {
 		clsn1, clsn2 = frm.Clsn2(), c.curFrame.Clsn1()
 	}
-	return sys.clsnHantei(clsn1, [...]float32{p.clsnScale[0] * p.localscl, p.clsnScale[1] * p.localscl},
+	return sys.clsnOverlap(clsn1, [...]float32{p.clsnScale[0] * p.localscl, p.clsnScale[1] * p.localscl},
 		[...]float32{p.pos[0] * p.localscl, p.pos[1] * p.localscl}, p.facing,
 		clsn2, [...]float32{c.clsnScale[0] * (320 / sys.chars[c.animPN][0].localcoord), c.clsnScale[1] * (320 / sys.chars[c.animPN][0].localcoord)},
 		[...]float32{c.pos[0]*c.localscl + c.offsetX()*c.localscl,
@@ -5967,10 +5967,10 @@ func (c *Char) clsnCheck(atk *Char, c1atk, c1slf bool) bool {
 	} else {
 		clsn2 = c.curFrame.Clsn2()
 	}
-	return sys.clsnHantei(clsn1, [...]float32{sys.chars[atk.animPN][0].clsnScale[0] * (320 / sys.chars[atk.animPN][0].localcoord), sys.chars[atk.animPN][0].clsnScale[1] * (320 / sys.chars[atk.animPN][0].localcoord)},
+	return sys.clsnOverlap(clsn1, [...]float32{atk.clsnScale[0]*(320/sys.chars[atk.animPN][0].localcoord), atk.clsnScale[1]*(320/sys.chars[atk.animPN][0].localcoord)},
 		[...]float32{atk.pos[0]*atk.localscl + atk.offsetX()*atk.localscl,
-			atk.pos[1]*atk.localscl + atk.offsetY()*atk.localscl},
-		atk.facing, clsn2, [...]float32{sys.chars[c.animPN][0].clsnScale[0] * (320 / sys.chars[c.animPN][0].localcoord), sys.chars[c.animPN][0].clsnScale[1] * (320 / sys.chars[c.animPN][0].localcoord)},
+			atk.pos[1]*atk.localscl + atk.offsetY()*atk.localscl}, atk.facing, 
+		clsn2, [...]float32{c.clsnScale[0]*(320/sys.chars[c.animPN][0].localcoord), c.clsnScale[1]*(320/sys.chars[c.animPN][0].localcoord)},
 		[...]float32{c.pos[0]*c.localscl + c.offsetX()*c.localscl,
 			c.pos[1]*c.localscl + c.offsetY()*c.localscl}, c.facing)
 }

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -365,6 +365,7 @@ var triggerMap = map[string]int{
 	"hitoverridden":      1,
 	"incustomstate":      1,
 	"indialogue":         1,
+	"inputtime":          1,
 	"isasserted":         1,
 	"ishost":             1,
 	"lastplayerid":       1,
@@ -821,17 +822,14 @@ func (c *Compiler) checkOpeningBracket(in *string) error {
 	return nil
 }
 
-/*
-TODO: Case sensitive maps
-
-	func (c *Compiler) checkOpeningBracketCS(in *string) error {
-		if c.tokenizerCS(in) != "(" {
-			return Error("Missing '(' after " + c.token)
-		}
-		c.token = c.tokenizerCS(in)
-		return nil
+func (c *Compiler) checkOpeningBracketCS(in *string) error {
+	if c.tokenizerCS(in) != "(" {
+		return Error("Missing '(' after " + c.token)
 	}
-*/
+	c.token = c.tokenizerCS(in)
+	return nil
+}
+
 func (c *Compiler) checkClosingBracket() error {
 	c.reverseOrder = true
 	if c.token != ")" {
@@ -2875,13 +2873,13 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		if err := c.checkOpeningBracket(in); err != nil {
 			return bvNone(), err
 		}
-		lvname := c.token
+		fsvname := c.token
 		c.token = c.tokenizer(in)
 		if err := c.checkClosingBracket(); err != nil {
 			return bvNone(), err
 		}
 		isStr := false
-		switch lvname {
+		switch fsvname {
 		case "info.author":
 			opc = OC_ex_fightscreenvar_info_author
 			isStr = true
@@ -2903,7 +2901,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "round.start.waittime":
 			opc = OC_ex_fightscreenvar_round_start_waittime
 		default:
-			return bvNone(), Error("Invalid data: " + lvname)
+			return bvNone(), Error("Invalid data: " + fsvname)
 		}
 		if isStr {
 			if err := nameSubEx(opc); err != nil {
@@ -2946,6 +2944,47 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		}
 	case "hitoverridden":
 		out.append(OC_ex_, OC_ex_hitoverridden)
+	case "inputtime":
+		if err := c.checkOpeningBracketCS(in); err != nil {
+			return bvNone(), err
+		}
+		key := c.token
+		c.token = c.tokenizer(in)
+		if err := c.checkClosingBracket(); err != nil {
+			return bvNone(), err
+		}
+		switch key {
+		case "B":
+			out.append(OC_ex_, OC_ex_inputtime_B)
+		case "D":
+			out.append(OC_ex_, OC_ex_inputtime_D)
+		case "F":
+			out.append(OC_ex_, OC_ex_inputtime_F)
+		case "U":
+			out.append(OC_ex_, OC_ex_inputtime_U)
+		case "a":
+			out.append(OC_ex_, OC_ex_inputtime_a)
+		case "b":
+			out.append(OC_ex_, OC_ex_inputtime_b)
+		case "c":
+			out.append(OC_ex_, OC_ex_inputtime_c)
+		case "x":
+			out.append(OC_ex_, OC_ex_inputtime_x)
+		case "y":
+			out.append(OC_ex_, OC_ex_inputtime_y)
+		case "z":
+			out.append(OC_ex_, OC_ex_inputtime_z)
+		case "s":
+			out.append(OC_ex_, OC_ex_inputtime_s)
+		case "d":
+			out.append(OC_ex_, OC_ex_inputtime_d)
+		case "w":
+			out.append(OC_ex_, OC_ex_inputtime_w)
+		case "m":
+			out.append(OC_ex_, OC_ex_inputtime_m)
+		default:
+			return bvNone(), Error("Invalid data: " + key)
+		}
 	case "movehitvar":
 		if err := c.checkOpeningBracket(in); err != nil {
 			return bvNone(), err

--- a/src/script.go
+++ b/src/script.go
@@ -4178,7 +4178,7 @@ func triggerFunctions(l *lua.LState) {
 		case "round.start.waittime":
 			l.Push(lua.LNumber(sys.lifebar.ro.start_waittime))
 		default:
-			l.Push(lua.LString(""))
+			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}
 		return 1
 	})
@@ -4237,6 +4237,69 @@ func triggerFunctions(l *lua.LState) {
 	})
 	luaRegister(l, "indialogue", func(*lua.LState) int {
 		l.Push(lua.LBool(sys.dialogueFlg))
+		return 1
+	})
+	luaRegister(l, "inputtime", func(*lua.LState) int {
+		switch strArg(l, 1) {
+		case "B":
+			if sys.debugWC.keyctrl[0] && sys.debugWC.cmd != nil {
+				l.Push(lua.LNumber(sys.debugWC.cmd[0].Buffer.Bb))
+			}
+		case "D":
+			if sys.debugWC.keyctrl[0] && sys.debugWC.cmd != nil {
+				l.Push(lua.LNumber(sys.debugWC.cmd[0].Buffer.Db))
+			}
+		case "F":
+			if sys.debugWC.keyctrl[0] && sys.debugWC.cmd != nil {
+				l.Push(lua.LNumber(sys.debugWC.cmd[0].Buffer.Fb))
+			}
+		case "U":
+			if sys.debugWC.keyctrl[0] && sys.debugWC.cmd != nil {
+				l.Push(lua.LNumber(sys.debugWC.cmd[0].Buffer.Ub))
+			}
+		case "a":
+			if sys.debugWC.keyctrl[0] && sys.debugWC.cmd != nil {
+				l.Push(lua.LNumber(sys.debugWC.cmd[0].Buffer.ab))
+			}
+		case "b":
+			if sys.debugWC.keyctrl[0] && sys.debugWC.cmd != nil {
+				l.Push(lua.LNumber(sys.debugWC.cmd[0].Buffer.bb))
+			}
+		case "c":
+			if sys.debugWC.keyctrl[0] && sys.debugWC.cmd != nil {
+				l.Push(lua.LNumber(sys.debugWC.cmd[0].Buffer.cb))
+			}
+		case "x":
+			if sys.debugWC.keyctrl[0] && sys.debugWC.cmd != nil {
+				l.Push(lua.LNumber(sys.debugWC.cmd[0].Buffer.xb))
+			}
+		case "y":
+			if sys.debugWC.keyctrl[0] && sys.debugWC.cmd != nil {
+				l.Push(lua.LNumber(sys.debugWC.cmd[0].Buffer.yb))
+			}
+		case "z":
+			if sys.debugWC.keyctrl[0] && sys.debugWC.cmd != nil {
+				l.Push(lua.LNumber(sys.debugWC.cmd[0].Buffer.zb))
+			}
+		case "s":
+			if sys.debugWC.keyctrl[0] && sys.debugWC.cmd != nil {
+				l.Push(lua.LNumber(sys.debugWC.cmd[0].Buffer.sb))
+			}
+		case "d":
+			if sys.debugWC.keyctrl[0] && sys.debugWC.cmd != nil {
+				l.Push(lua.LNumber(sys.debugWC.cmd[0].Buffer.db))
+			}
+		case "w":
+			if sys.debugWC.keyctrl[0] && sys.debugWC.cmd != nil {
+				l.Push(lua.LNumber(sys.debugWC.cmd[0].Buffer.wb))
+			}
+		case "m":
+			if sys.debugWC.keyctrl[0] && sys.debugWC.cmd != nil {
+				l.Push(lua.LNumber(sys.debugWC.cmd[0].Buffer.mb))
+			}
+		default:
+			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
+		}
 		return 1
 	})
 	luaRegister(l, "isasserted", func(*lua.LState) int {

--- a/src/system.go
+++ b/src/system.go
@@ -701,9 +701,8 @@ func (s *System) loadTime(start time.Time, str string, shell, console bool) {
 		s.appendToConsole(str)
 	}
 }
-func (s *System) clsnHantei(clsn1 []float32, scl1, pos1 [2]float32,
-	facing1 float32, clsn2 []float32, scl2, pos2 [2]float32,
-	facing2 float32) bool {
+func (s *System) clsnOverlap(clsn1 []float32, scl1, pos1 [2]float32, facing1 float32,
+	clsn2 []float32, scl2, pos2 [2]float32,	facing2 float32) bool {
 	if scl1[0] < 0 {
 		facing1 *= -1
 		scl1[0] *= -1


### PR DESCRIPTION
- Returns how many frames a certain button has been held or released
- Usage InputTime(button). If button has been held for 50 frames, the trigger will return 50. If it was released 30 frames ago, it will return -30. If it was just pressed, it returns 1, and so on
- Based on the idea behind the `buffer` trigger in #1051

Fixes:
- Explods with RemoveOnGethit are no longer removed when guarding
- Fixed bug where a helper's rescaled Clsn boxes acted as if they had the root's scale when running hit detection