### PR TITLE
feat: new stage camera parameter lowestcap and dynamicboundhigh

### DIFF
--- a/src/stage.go
+++ b/src/stage.go
@@ -923,6 +923,8 @@ func loadStage(def string, main bool) (*Stage, error) {
 		sec[0].ReadF32("far", &s.stageCamera.far)
 		sec[0].ReadBool("autocenter", &s.stageCamera.autocenter)
 		sec[0].ReadF32("zoomindelay", &s.stageCamera.zoomindelay)
+		sec[0].ReadBool("dynamicboundhigh", &s.stageCamera.dynamicboundhigh)
+		sec[0].ReadBool("lowestcap", &s.stageCamera.lowestcap)
 		if sys.cam.ZoomMax == 0 {
 			sec[0].ReadF32("zoomin", &s.stageCamera.zoomin)
 		} else {


### PR DESCRIPTION
Bring back the old ikemen go behavior
```
lowestcap: Set to 1 to cap the lowest player position in camera movement calculation when ytension is enabled
dynamicboundhigh: Set to 1 to change bound high when camera zoom is changed.
```
#1749 