### PR TITLE
feat: ChangeState continue, fix animation offset

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3151,6 +3151,7 @@ const (
 	changeState_value byte = iota
 	changeState_ctrl
 	changeState_anim
+	changeState_continue
 	changeState_readplayerid
 	changeState_redirectid
 )
@@ -3159,7 +3160,7 @@ func (sc changeState) Run(c *Char, _ []int32) bool {
 	crun := c
 	var v, a, ctrl int32 = -1, -1, -1
 	ffx := ""
-	changeState := true
+	stop := true
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case changeState_value:
@@ -3171,16 +3172,18 @@ func (sc changeState) Run(c *Char, _ []int32) bool {
 			ffx = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
 		case changeState_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
-				changeState = rid.id == c.id
+				stop = false
 				crun = rid
 			} else {
 				return false
 			}
+		case changeState_continue:
+			stop = !exp[0].evalB(c)
 		}
 		return true
 	})
 	crun.changeState(v, a, ctrl, ffx)
-	return changeState
+	return stop
 }
 
 type selfState changeState
@@ -3189,7 +3192,7 @@ func (sc selfState) Run(c *Char, _ []int32) bool {
 	crun := c
 	var v, a, r, ctrl int32 = -1, -1, -1, -1
 	ffx := ""
-	changeState := true
+	stop := true
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case changeState_value:
@@ -3207,16 +3210,18 @@ func (sc selfState) Run(c *Char, _ []int32) bool {
 			}
 		case changeState_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
-				changeState = rid.id == c.id
+				stop = false
 				crun = rid
 			} else {
 				return false
 			}
+		case changeState_continue:
+			stop = !exp[0].evalB(c)
 		}
 		return true
 	})
 	crun.selfState(v, a, r, ctrl, ffx)
-	return changeState
+	return stop
 }
 
 type tagIn StateControllerBase

--- a/src/char.go
+++ b/src/char.go
@@ -6843,7 +6843,8 @@ func (c *Char) cueDraw() {
 		sdf := func() *SprData {
 			sd := &SprData{c.anim, c.getPalfx(), pos,
 				scl, c.alpha, c.sprPriority, Rotation{agl, 0, 0}, c.angleScale, false,
-				c.playerNo == sys.superplayer, c.gi().mugenver[0] != 1, c.facing, c.localscl / (320 / c.localcoord), 0, 0, [4]float32{0, 0, 0, 0}}
+				c.playerNo == sys.superplayer, c.gi().mugenver[0] != 1, c.facing, sys.chars[c.animPN][0].localcoord / c.localcoord, 0, 0, [4]float32{0, 0, 0, 0}}
+				// https://github.com/ikemen-engine/Ikemen-GO/issues/1459
 			if !c.csf(CSF_trans) {
 				sd.alpha[0] = -1
 			}

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -283,6 +283,10 @@ func (c *Compiler) changeStateSub(is IniSection,
 	}); err != nil {
 		return err
 	}
+	if err := c.paramValue(is, sc, "continue",
+		changeState_continue, VT_Bool, 1, false); err != nil {
+		return err
+	}
 	if err := c.paramValue(is, sc, "readplayerid",
 		changeState_readplayerid, VT_Int, 1, false); err != nil {
 		return err


### PR DESCRIPTION
ChangeState and SelfState:
- Setting Continue parameter to 1 will make the ChangeState not halt the execution of the current _negative_ state. Defaults to 0
- As seen in #1051
- Refactor: redirecting these state controllers to the player itself will have the same behavior as redirecting it towards others, i.e. it will also not stop the state (by default)

Fix:
- Fixed animation offset when state owner localcoord did not match animation owner localcoord
- Fixes #459
- Fixes #1459