### PR TITLE
feat: Add bgmfreqmul feature to stage [Music], add ModifyBGM SCTRL

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -8680,6 +8680,68 @@ func (sc modifyBGCtrl) Run(c *Char, _ []int32) bool {
 	return false
 }
 
+type modifyBgm StateControllerBase
+
+const (
+	modifyBgm_volume = iota
+	modifyBgm_loopstart
+	modifyBgm_loopend
+	modifyBgm_position
+	modifyBgm_freqmul
+	modifyBgm_redirectid
+)
+
+func (sc modifyBgm) Run(c *Char, _ []int32) bool {
+	var volumeSet, loopStartSet, loopEndSet, posSet, freqSet = false, false, false, false, false
+	var volume, loopstart, loopend, position int = 100, 0, 0, 0
+	var freqmul float32 = 1.0
+	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
+		switch id {
+		case modifyBgm_volume:
+			volume = int(exp[0].evalI(c))
+			volumeSet = true
+		case modifyBgm_loopstart:
+			loopstart = int(exp[0].evalI(c))
+			loopStartSet = true
+		case modifyBgm_loopend:
+			loopend = int(exp[0].evalI(c))
+			loopEndSet = true
+		case modifyBgm_position:
+			position = int(exp[0].evalI(c))
+			posSet = true
+		case modifyBgm_freqmul:
+			freqmul = float32(exp[0].evalF(c))
+			freqSet = true
+		case modifyBgm_redirectid:
+			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
+
+			} else {
+				return false
+			}
+		}
+		return true
+	})
+	if sys.bgm.ctrl != nil {
+		// Set values that are different only
+		if volumeSet {
+			volumeScaled := int(float64(volume) / 100.0 * float64(sys.maxBgmVolume))
+			sys.bgm.bgmVolume = int(Min(int32(volumeScaled), int32(sys.maxBgmVolume)))
+			sys.bgm.UpdateVolume()
+		}
+		if posSet {
+			sys.bgm.Seek(position)
+		}
+		if (loopStartSet && sys.bgm.bgmLoopStart != loopstart) || (loopEndSet && sys.bgm.bgmLoopEnd != loopend) {
+			sys.bgm.SetLoopPoints(loopstart, loopend)
+		}
+		if freqSet && sys.bgm.freqmul != freqmul {
+			sys.bgm.SetFreqMul(freqmul)
+		}
+		return true
+	}
+	return false
+}
+
 type modifySnd StateControllerBase
 
 const (
@@ -8797,6 +8859,7 @@ const (
 	playBgm_loopstart
 	playBgm_loopend
 	playBgm_startposition
+	playBgm_freqmul
 	playBgm_redirectid
 )
 
@@ -8805,6 +8868,7 @@ func (sc playBgm) Run(c *Char, _ []int32) bool {
 	var b bool
 	var bgm string
 	var loop, volume, loopstart, loopend, startposition int = 1, 100, 0, 0, 0
+	var freqmul float32 = 1.0
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case playBgm_bgm:
@@ -8826,6 +8890,8 @@ func (sc playBgm) Run(c *Char, _ []int32) bool {
 			loopend = int(exp[0].evalI(c))
 		case playBgm_startposition:
 			startposition = int(exp[0].evalI(c))
+		case playBgm_freqmul:
+			freqmul = exp[0].evalF(c)
 		case playBgm_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -8836,7 +8902,7 @@ func (sc playBgm) Run(c *Char, _ []int32) bool {
 		return true
 	})
 	if b {
-		sys.bgm.Open(bgm, loop, volume, loopstart, loopend, startposition)
+		sys.bgm.Open(bgm, loop, volume, loopstart, loopend, startposition, freqmul)
 		sys.playBgmFlg = true
 	}
 	return false

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -171,6 +171,7 @@ func newCompiler() *Compiler {
 		"modifychar":           c.modifyChar,
 		"gethitvarset":         c.getHitVarSet,
 		"modifysnd":            c.modifySnd,
+		"modifybgm":            c.modifyBgm,
 	}
 	return c
 }

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -4328,6 +4328,36 @@ func (c *Compiler) modifySnd(is IniSection, sc *StateControllerBase, _ int8) (St
 	})
 	return *ret, err
 }
+func (c *Compiler) modifyBgm(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+	ret, err := (*modifyBgm)(sc), c.stateSec(is, func() error {
+		if err := c.paramValue(is, sc, "redirectid",
+			modifyBgm_redirectid, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "volume",
+			modifyBgm_volume, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "loopstart",
+			modifyBgm_loopstart, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "loopend",
+			modifyBgm_loopend, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "freqmul",
+			modifyBgm_freqmul, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "position",
+			modifyBgm_position, VT_Int, 1, false); err != nil {
+			return err
+		}
+		return nil
+	})
+	return *ret, err
+}
 func (c *Compiler) printToConsole(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*printToConsole)(sc), c.stateSec(is, func() error {
 		return c.displayToClipboardSub(is, sc)

--- a/src/script.go
+++ b/src/script.go
@@ -1106,7 +1106,7 @@ func systemScriptInit(l *lua.LState) {
 				l.Push(lua.LNumber(winp))
 				l.Push(tbl)
 				if sys.playBgmFlg {
-					sys.bgm.Open("", 1, 100, 0, 0, 0)
+					sys.bgm.Open("", 1, 100, 0, 0, 0, 1.0)
 					sys.playBgmFlg = false
 				}
 				sys.clearAllSound()
@@ -1604,6 +1604,7 @@ func systemScriptInit(l *lua.LState) {
 	})
 	luaRegister(l, "playBGM", func(l *lua.LState) int {
 		var loop, volume, loopstart, loopend, startposition int = 1, 100, 0, 0, 0
+		var freqmul float32 = 1.0
 		if l.GetTop() >= 2 {
 			loop = int(numArg(l, 2))
 		}
@@ -1619,7 +1620,10 @@ func systemScriptInit(l *lua.LState) {
 		if l.GetTop() >= 6 && numArg(l, 6) > 1 {
 			startposition = int(numArg(l, 6))
 		}
-		sys.bgm.Open(strArg(l, 1), loop, volume, loopstart, loopend, startposition)
+		if l.GetTop() >= 7 {
+			freqmul = ClampF(float32(numArg(l, 7)), 0.01, 5.0)
+		}
+		sys.bgm.Open(strArg(l, 1), loop, volume, loopstart, loopend, startposition, freqmul)
 		return 0
 	})
 	luaRegister(l, "playerBufReset", func(*lua.LState) int {
@@ -1818,6 +1822,30 @@ func systemScriptInit(l *lua.LState) {
 	luaRegister(l, "selectStart", func(l *lua.LState) int {
 		sys.sel.ClearSelected()
 		sys.loadStart()
+		return 0
+	})
+	luaRegister(l, "setBGMFreqMul", func(l *lua.LState) int {
+		freqmul := ClampF(float32(numArg(l, 1)), 0.01, 5.0)
+		sys.bgm.SetFreqMul(freqmul)
+		return 0
+	})
+	luaRegister(l, "setBGMLoopPoints", func(l *lua.LState) int {
+		var loopstart, loopend int = 0, 0
+		if l.GetTop() >= 1 {
+			loopstart = int(numArg(l, 1))
+		}
+		if l.GetTop() >= 2 && numArg(l, 2) > 1 {
+			loopend = int(numArg(l, 2))
+		}
+		sys.bgm.SetLoopPoints(loopstart, loopend)
+		return 0
+	})
+	luaRegister(l, "setBGMPosition", func(l *lua.LState) int {
+		var position int = 0
+		if numArg(l, 1) > 1 {
+			position = int(numArg(l, 1))
+		}
+		sys.bgm.Seek(position)
 		return 0
 	})
 	luaRegister(l, "sffNew", func(l *lua.LState) int {

--- a/src/stage.go
+++ b/src/stage.go
@@ -702,51 +702,53 @@ type stagePlayer struct {
 	startx, starty, startz int32
 }
 type Stage struct {
-	def             string
-	bgmusic         string
-	name            string
-	displayname     string
-	author          string
-	nameLow         string
-	displaynameLow  string
-	authorLow       string
-	attachedchardef []string
-	sff             *Sff
-	at              AnimationTable
-	bg              []*backGround
-	bgc             []bgCtrl
-	bgct            bgcTimeLine
-	bga             bgAction
-	sdw             stageShadow
-	p               [2]stagePlayer
-	leftbound       float32
-	rightbound      float32
-	screenleft      int32
-	screenright     int32
-	zoffsetlink     int32
-	reflection      int32
-	hires           bool
-	resetbg         bool
-	debugbg         bool
-	bgclearcolor    [3]int32
-	localscl        float32
-	scale           [2]float32
-	bgmvolume       int32
-	bgmloopstart    int32
-	bgmloopend      int32
-	bgmratiolife    int32
-	bgmtriggerlife  int32
-	bgmtriggeralt   int32
-	mainstage       bool
-	stageCamera     stageCamera
-	stageTime       int32
-	constants       map[string]float32
-	p1p3dist        float32
-	mugenver        [2]uint16
-	reload          bool
-	stageprops      StageProps
-	model           *Model
-	ikemenver       [3]uint16
+	def              string
+	bgmusic          string
+	name             string
+	displayname      string
+	author           string
+	nameLow          string
+	displaynameLow   string
+	authorLow        string
+	attachedchardef  []string
+	sff              *Sff
+	at               AnimationTable
+	bg               []*backGround
+	bgc              []bgCtrl
+	bgct             bgcTimeLine
+	bga              bgAction
+	sdw              stageShadow
+	p                [2]stagePlayer
+	leftbound        float32
+	rightbound       float32
+	screenleft       int32
+	screenright      int32
+	zoffsetlink      int32
+	reflection       int32
+	hires            bool
+	resetbg          bool
+	debugbg          bool
+	bgclearcolor     [3]int32
+	localscl         float32
+	scale            [2]float32
+	bgmvolume        int32
+	bgmloopstart     int32
+	bgmloopend       int32
+	bgmstartposition int32
+	bgmfreqmul       float32
+	bgmratiolife     int32
+	bgmtriggerlife   int32
+	bgmtriggeralt    int32
+	mainstage        bool
+	stageCamera      stageCamera
+	stageTime        int32
+	constants        map[string]float32
+	p1p3dist         float32
+	mugenver         [2]uint16
+	reload           bool
+	stageprops       StageProps
+	model            *Model
+	ikemenver        [3]uint16
 }
 
 func newStage(def string) *Stage {
@@ -949,6 +951,8 @@ func loadStage(def string, main bool) (*Stage, error) {
 		sec[0].ReadI32("bgmvolume", &s.bgmvolume)
 		sec[0].ReadI32("bgmloopstart", &s.bgmloopstart)
 		sec[0].ReadI32("bgmloopend", &s.bgmloopend)
+		sec[0].ReadI32("bgmstartposition", &s.bgmstartposition)
+		sec[0].ReadF32("bgmfreqmul", &s.bgmfreqmul)
 		sec[0].ReadI32("bgmratio.life", &s.bgmratiolife)
 		sec[0].ReadI32("bgmtrigger.life", &s.bgmtriggerlife)
 		sec[0].ReadI32("bgmtrigger.alt", &s.bgmtriggeralt)

--- a/src/system.go
+++ b/src/system.go
@@ -1959,7 +1959,7 @@ func (s *System) fight() (reload bool) {
 
 	//default bgm playback, used only in Quick VS or if externalized Lua implementaion is disabled
 	if s.round == 1 && (s.gameMode == "" || len(sys.commonLua) == 0) {
-		s.bgm.Open(s.stage.bgmusic, 1, int(s.stage.bgmvolume), int(s.stage.bgmloopstart), int(s.stage.bgmloopend), 0)
+		s.bgm.Open(s.stage.bgmusic, 1, int(s.stage.bgmvolume), int(s.stage.bgmloopstart), int(s.stage.bgmloopend), int(s.stage.bgmstartposition), s.stage.bgmfreqmul)
 	}
 
 	oldWins, oldDraws := s.wins, s.draws


### PR DESCRIPTION
This adds `bgmfreqmul` as a parameter to `[Music]` for stages (defaults to 1.0, no change in frequency for all stages) and the ability to modify the `freqmul`, `position`, `loopstart`, `loopend`, and `volume` parameters of the currently playing BGM with `ModifyBGM` SCTRL. Exposes `freqmul` to existing `PlayBGM` SCTRL. Existing Lua method changed to accommodate for new parameter, but does not affect existing scripts due to how Lua arguments work. New Lua methods `setBGMFreqMul`, `setBGMLoopPoints`, and `setBGMPosition` exposed to Lua so that equivalent functionality may be achieved that way as well.

Tested with two characters using the SCTRL at once, no problematic behavior witnessed (demo code below).

Limitations: If users want to modify only certain parameters at a time, they must code it in a manner similar to this:
```sh
    if roundState < 2 {
	map(_sndsys_ft) := fightTime;
    }
    let scaleFactor = 1 + cos(pi*(map(_sndsys_ft)-fightTime)/256);

ignorehitpause if fightTime-map(_sndsys_ft) > 0 && roundState = 2 && !IsHelper {
    # modifyBGM test
    if random%365 = [2,5] {
        modifyBgm { freqmul: 5.0*((random+1)/1000.0); position: randomrange(0,bgmLength); volume: 50 * $scaleFactor; }
    } else {
        modifyBgm { volume: 50 * $scaleFactor; }
    }
}
 ```
 
And not like this:
```sh
    if roundState < 2 {
	map(_sndsys_ft) := fightTime;
    }
    let scaleFactor = 1 + cos(pi*(map(_sndsys_ft)-fightTime)/256);

ignorehitpause if fightTime-map(_sndsys_ft) > 0 && roundState = 2 && !IsHelper {
    # modifyBGM test
    modifyBgm { volume: 50 * $scaleFactor; }
    if random%365 = [2,5] {
        modifyBgm { freqmul: 5.0*((random+1)/1000.0); position: randomrange(0,bgmLength); volume: 50 * $scaleFactor; }
    }
}
 ```