### PR TITLE
feat: new stage camera parameter boundhighdelta

### DIFF
--- a/src/camera.go
+++ b/src/camera.go
@@ -115,6 +115,7 @@ func (c *Camera) Reset() {
 	c.boundH = float32(c.boundhigh) * c.localscl
 	c.boundLo = float32(Max(c.boundhigh, c.boundlow)) * c.localscl
 	c.boundlow = Max(c.boundhigh, c.boundlow)
+	c.tensionvel = MaxF(MinF(c.tensionvel, 20), 0)
 
 	xminscl := float32(sys.gameWidth) / (float32(sys.gameWidth) - c.boundL +
 		c.boundR)

--- a/src/camera.go
+++ b/src/camera.go
@@ -30,7 +30,7 @@ type stageCamera struct {
 	ytensionenable       bool
 	autocenter           bool
 	zoomanchor           bool
-	dynamicboundhigh     bool
+	boundhighdelta       float32
 	zoomindelay          float32
 	zoomindelaytime      float32
 	fov                  float32
@@ -55,7 +55,9 @@ func newStageCamera() *stageCamera {
 	return &stageCamera{verticalfollow: 0.2, tensionvel: 1, tension: 50,
 		cuthigh: 0, cutlow: 0,
 		localcoord: [...]int32{320, 240}, localscl: float32(sys.gameWidth / 320),
-		ztopscale: 1, startzoom: 1, zoomin: 1, zoomout: 1, ytensionenable: false, fov: 40, yshift: 0, far: 10000, near: 0.1, zoomindelay: 0}
+		ztopscale: 1, startzoom: 1, zoomin: 1, zoomout: 1, ytensionenable: false,
+		fov: 40, yshift: 0, far: 10000, near: 0.1,
+		zoomindelay: 0, boundhighdelta: 1}
 }
 
 type CameraView int
@@ -364,9 +366,9 @@ func (c *Camera) action(x, y, scale float32, pause bool) (newX, newY, newScale f
 					newX = (newLeft + newRight) / 2
 				}
 				newScale = MinF(c.halfWidth*2/(newRight-newLeft), c.zoomin)
-				if c.dynamicboundhigh {
+				if c.boundhighdelta > 0 {
 					topBound := float32(c.boundhigh)*c.localscl - c.GroundLevel()/c.zoomout
-					boundHigh := topBound + c.GroundLevel()/newScale
+					boundHigh := float32(c.boundhigh)*c.localscl + ((topBound+c.GroundLevel()/newScale)-float32(c.boundhigh)*c.localscl)/c.boundhighdelta
 					newY = MinF(MaxF(newY, boundHigh), float32(c.boundlow)*c.localscl) * newScale
 				} else {
 					newY = MinF(MaxF(newY, float32(c.boundhigh)*c.localscl), float32(c.boundlow)*c.localscl) * newScale
@@ -374,9 +376,9 @@ func (c *Camera) action(x, y, scale float32, pause bool) (newX, newY, newScale f
 			} else {
 				newScale = MinF(MaxF(newScale, c.zoomout), c.zoomin)
 				newX = MinF(MaxF(newX, c.minLeft+c.halfWidth/newScale), c.maxRight-c.halfWidth/newScale)
-				if c.dynamicboundhigh {
-					topBound := float32(c.boundhigh)*c.localscl + float32(sys.gameHeight)*sys.heightScale/2/c.zoomout
-					boundHigh := topBound - float32(sys.gameHeight)*sys.heightScale/2/newScale
+				if c.boundhighdelta > 0 {
+					topBound := float32(c.boundhigh)*c.localscl - c.GroundLevel()/c.zoomout
+					boundHigh := float32(c.boundhigh)*c.localscl + ((topBound+c.GroundLevel()/newScale)-float32(c.boundhigh)*c.localscl)/c.boundhighdelta
 					newY = MinF(MaxF(newY, boundHigh), float32(c.boundlow)*c.localscl) * newScale
 				} else {
 					newY = MinF(MaxF(newY, float32(c.boundhigh)*c.localscl), float32(c.boundlow)*c.localscl) * newScale

--- a/src/stage.go
+++ b/src/stage.go
@@ -925,7 +925,7 @@ func loadStage(def string, main bool) (*Stage, error) {
 		sec[0].ReadF32("far", &s.stageCamera.far)
 		sec[0].ReadBool("autocenter", &s.stageCamera.autocenter)
 		sec[0].ReadF32("zoomindelay", &s.stageCamera.zoomindelay)
-		sec[0].ReadBool("dynamicboundhigh", &s.stageCamera.dynamicboundhigh)
+		sec[0].ReadF32("boundhighdelta", &s.stageCamera.boundhighdelta)
 		sec[0].ReadBool("lowestcap", &s.stageCamera.lowestcap)
 		if sys.cam.ZoomMax == 0 {
 			sec[0].ReadF32("zoomin", &s.stageCamera.zoomin)


### PR DESCRIPTION
```dynamicboundhigh``` is replaced by ```boundhighdelta``` : changes the bound high when camera zoom is not at minimum.
Default value is 0 (constant bound high), values closer to 0 means greater difference;

The maximum and minimum of ```tensionvel``` is set to be 20 and 0 respectively