### PR TITLE
feat: InputTime params L/R

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -527,6 +527,8 @@ const (
 	OC_ex_inputtime_D
 	OC_ex_inputtime_F
 	OC_ex_inputtime_U
+	OC_ex_inputtime_L
+	OC_ex_inputtime_R
 	OC_ex_inputtime_a
 	OC_ex_inputtime_b
 	OC_ex_inputtime_c
@@ -2271,6 +2273,18 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_inputtime_U:
 		if c.keyctrl[0] && c.cmd != nil {
 			sys.bcStack.PushI(c.cmd[0].Buffer.Ub)
+		} else {
+			sys.bcStack.PushI(0)
+		}
+	case OC_ex_inputtime_L:
+		if c.keyctrl[0] && c.cmd != nil {
+			sys.bcStack.PushI(c.cmd[0].Buffer.Lb)
+		} else {
+			sys.bcStack.PushI(0)
+		}
+	case OC_ex_inputtime_R:
+		if c.keyctrl[0] && c.cmd != nil {
+			sys.bcStack.PushI(c.cmd[0].Buffer.Rb)
 		} else {
 			sys.bcStack.PushI(0)
 		}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2963,6 +2963,10 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.append(OC_ex_, OC_ex_inputtime_F)
 		case "U":
 			out.append(OC_ex_, OC_ex_inputtime_U)
+		case "L":
+			out.append(OC_ex_, OC_ex_inputtime_L)
+		case "R":
+			out.append(OC_ex_, OC_ex_inputtime_R)
 		case "a":
 			out.append(OC_ex_, OC_ex_inputtime_a)
 		case "b":

--- a/src/script.go
+++ b/src/script.go
@@ -4285,6 +4285,14 @@ func triggerFunctions(l *lua.LState) {
 			if sys.debugWC.keyctrl[0] && sys.debugWC.cmd != nil {
 				l.Push(lua.LNumber(sys.debugWC.cmd[0].Buffer.Ub))
 			}
+		case "L":
+			if sys.debugWC.keyctrl[0] && sys.debugWC.cmd != nil {
+				l.Push(lua.LNumber(sys.debugWC.cmd[0].Buffer.Lb))
+			}
+		case "R":
+			if sys.debugWC.keyctrl[0] && sys.debugWC.cmd != nil {
+				l.Push(lua.LNumber(sys.debugWC.cmd[0].Buffer.Rb))
+			}
 		case "a":
 			if sys.debugWC.keyctrl[0] && sys.debugWC.cmd != nil {
 				l.Push(lua.LNumber(sys.debugWC.cmd[0].Buffer.ab))


### PR DESCRIPTION
- Adds two new parameters to the InputTime trigger: absolute Left and Right inputs, which do not change depending on facing.
- InputTime is currently the only way of accessing these absolute directions, since the normal Back/Forward inputs are sufficient in the majority of cases—those who would need Left and Right are going to be using InputTime for what they need anyway.
