### PR TITLE
fix: ModifyExplod timer params fixes and previous masking fixes refactor

### DIFF
--- a/src/anim.go
+++ b/src/anim.go
@@ -155,7 +155,6 @@ type Animation struct {
 	interpolate_blend_dstalpha float32
 	remap                      RemapPreset
 	start_scale                [2]float32
-	opaquepalette              bool
 }
 
 func newAnimation(sff *Sff, pal *PaletteList) *Animation {
@@ -718,10 +717,6 @@ func (a *Animation) Draw(window *[4]int32, x, y, xcs, ycs, xs, xbs, ys,
 		paltex = a.spr.CachePalette(pal)
 	}
 	mask := int32(a.mask)
-	//if !a.opaquepalette && a.spr.coldepth <= 8 && a.palettedata != nil && a.mask != -1 {
-	//	mask = -2
-		//if trans == -2 { mask = 0}
-	//}
 	rp := RenderParams{
 		a.spr.Tex, paltex, a.spr.Size,
 		x * sys.widthScale,
@@ -744,9 +739,6 @@ func (a *Animation) ShadowDraw(window *[4]int32, x, y, xscl, yscl, vscl, rxadd f
 	y += yscl * posLocalscl * vscl * v * (float32(a.frames[a.drawidx].Y) + a.interpolate_offset_y) * (1 / a.scale_x)
 
 	mask := int32(a.mask)
-	//if !a.opaquepalette && a.spr.coldepth <= 8 && a.palettedata != nil && a.mask != -1 {
-	//	mask = -2
-	//}
 	rp := RenderParams{
 		a.spr.Tex, nil, a.spr.Size,
 		AbsF(xscl*h) * float32(a.spr.Offset[0]) * sys.widthScale,

--- a/src/anim.go
+++ b/src/anim.go
@@ -159,14 +159,8 @@ type Animation struct {
 }
 
 func newAnimation(sff *Sff, pal *PaletteList) *Animation {
-	a := &Animation{sff: sff, palettedata: pal, mask: -1, srcAlpha: -1, newframe: true,
+	return &Animation{sff: sff, palettedata: pal, mask: -1, srcAlpha: -1, newframe: true,
 		remap: make(RemapPreset), start_scale: [...]float32{1, 1}}
-	if a.sff.header.Ver0 == 2 && a.sff.header.Ver2 == 1 {
-		a.opaquepalette = false
-	} else {
-		a.opaquepalette = true
-	}
-	return a
 }
 func ReadAnimation(sff *Sff, pal *PaletteList, lines []string, i *int) *Animation {
 	a := newAnimation(sff, pal)
@@ -562,11 +556,6 @@ func (a *Animation) UpdateSprite() {
 	}
 }
 func (a *Animation) Action() {
-	if a.sff != nil && (a.sff.header.Ver0 == 2 && a.sff.header.Ver2 == 1) {
-		a.opaquepalette = false
-	} else {
-		a.opaquepalette = true
-	}
 	if len(a.frames) == 0 {
 		a.loopend = true
 		return
@@ -729,10 +718,10 @@ func (a *Animation) Draw(window *[4]int32, x, y, xcs, ycs, xs, xbs, ys,
 		paltex = a.spr.CachePalette(pal)
 	}
 	mask := int32(a.mask)
-	if !a.opaquepalette && a.spr.coldepth <= 8 && a.palettedata != nil && a.mask != -1 {
-		mask = -2
+	//if !a.opaquepalette && a.spr.coldepth <= 8 && a.palettedata != nil && a.mask != -1 {
+	//	mask = -2
 		//if trans == -2 { mask = 0}
-	}
+	//}
 	rp := RenderParams{
 		a.spr.Tex, paltex, a.spr.Size,
 		x * sys.widthScale,
@@ -755,9 +744,9 @@ func (a *Animation) ShadowDraw(window *[4]int32, x, y, xscl, yscl, vscl, rxadd f
 	y += yscl * posLocalscl * vscl * v * (float32(a.frames[a.drawidx].Y) + a.interpolate_offset_y) * (1 / a.scale_x)
 
 	mask := int32(a.mask)
-	if !a.opaquepalette && a.spr.coldepth <= 8 && a.palettedata != nil && a.mask != -1 {
-		mask = -2
-	}
+	//if !a.opaquepalette && a.spr.coldepth <= 8 && a.palettedata != nil && a.mask != -1 {
+	//	mask = -2
+	//}
 	rp := RenderParams{
 		a.spr.Tex, nil, a.spr.Size,
 		AbsF(xscl*h) * float32(a.spr.Offset[0]) * sys.widthScale,
@@ -793,7 +782,13 @@ func (a *Animation) ShadowDraw(window *[4]int32, x, y, xscl, yscl, vscl, rxadd f
 	//}
 
 	if a.spr.coldepth <= 8 && (color != 0 || alpha > 0) {
-		if a.opaquepalette {
+		if (a.sff.header.Ver0 == 2 && a.sff.header.Ver2 == 1)  {
+			trans := a.alpha()
+			pal, paltex := a.pal(pfx, trans == -2)
+			if paltex == nil {
+				rp.paltex = a.spr.CachePalette(pal)
+			}
+		} else {
 			paltemp := a.spr.paltemp
 			if len(paltemp) == 0 {
 				if a.palettedata != nil {
@@ -803,12 +798,6 @@ func (a *Animation) ShadowDraw(window *[4]int32, x, y, xscl, yscl, vscl, rxadd f
 				}
 			}
 			rp.paltex = PaletteToTexture(paltemp[:])
-		} else {
-			trans := a.alpha()
-			pal, paltex := a.pal(pfx, trans == -2)
-			if paltex == nil {
-				rp.paltex = a.spr.CachePalette(pal)
-			}
 		}
 	}
 

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -4506,12 +4506,22 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				t := exp[0].evalI(c)
 				eachExpl(func(e *Explod) {
 					e.bindtime = t
+					//Bindtime fix(update bindtime according to current explod time)
+					if (crun.stWgi().ikemenver[0] > 0 || crun.stWgi().ikemenver[1] > 0) && t > 0 {
+						e.bindtime = e.time+t
+					}
 					e.setX(e.pos[0])
 					e.setY(e.pos[1])
 				})
 			case explod_removetime:
 				t := exp[0].evalI(c)
-				eachExpl(func(e *Explod) { e.removetime = t })
+				eachExpl(func(e *Explod) {
+					e.removetime = t
+					//Removetime fix(update removetime according to current explod time)
+					if (crun.stWgi().ikemenver[0] > 0 || crun.stWgi().ikemenver[1] > 0) && t > 0 {
+						e.removetime = e.time+t
+					}
+				})
 			case explod_supermove:
 				if exp[0].evalB(c) {
 					eachExpl(func(e *Explod) { e.supermovetime = -1 })
@@ -4520,10 +4530,22 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				}
 			case explod_supermovetime:
 				t := exp[0].evalI(c)
-				eachExpl(func(e *Explod) { e.supermovetime = t })
+				eachExpl(func(e *Explod) {
+					e.supermovetime = t
+					//Supermovetime fix(update supermovetime according to current explod time)
+					if (crun.stWgi().ikemenver[0] > 0 || crun.stWgi().ikemenver[1] > 0) && t > 0 {
+						e.supermovetime = e.time+t
+					}
+				})
 			case explod_pausemovetime:
 				t := exp[0].evalI(c)
-				eachExpl(func(e *Explod) { e.pausemovetime = t })
+				eachExpl(func(e *Explod) {
+					e.pausemovetime = t
+					//Pausemovetime fix(update pausemovetime according to current explod time)
+					if (crun.stWgi().ikemenver[0] > 0 || crun.stWgi().ikemenver[1] > 0) && t > 0 {
+						e.pausemovetime = e.time+t
+					}
+				})
 			case explod_sprpriority:
 				t := exp[0].evalI(c)
 				eachExpl(func(e *Explod) { e.sprpriority = t })
@@ -4645,7 +4667,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				if c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
 					interpolation := exp[0].evalB(c)
 					eachExpl(func(e *Explod) {
-						if e.interpolate != interpolation {
+						if e.interpolate != interpolation && e.interpolate_time[0] > 0 {
 							e.interpolate_animelem[0] = e.start_animelem
 							e.interpolate_animelem[1] = e.interpolate_animelem[2]
 							if e.ownpal {

--- a/src/char.go
+++ b/src/char.go
@@ -1401,9 +1401,6 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 
 func (e *Explod) Interpolate(act bool, scale *[2]float32, alpha *[2]int32, anglerot *[3]float32, fLength *float32) {
 	if sys.tickNextFrame() && act {
-		if e.interpolate_time[1] > 0 {
-			e.interpolate_time[1]--
-		}
 		t := float32(e.interpolate_time[1]) / float32(e.interpolate_time[0])
 		e.interpolate_fLength[0] = Lerp(e.interpolate_fLength[1], e.start_fLength, t)
 		if e.interpolate_animelem[1] >= 0 {
@@ -1423,6 +1420,9 @@ func (e *Explod) Interpolate(act bool, scale *[2]float32, alpha *[2]int32, angle
 				}
 			}
 			e.interpolate_angle[i] = Lerp(e.interpolate_angle[i+3], e.start_rot[i], t)
+		}
+		if e.interpolate_time[1] > 0 {
+			e.interpolate_time[1]--
 		}
 	}
 	for i := 0; i < 3; i++ {
@@ -2763,7 +2763,11 @@ func (c *Char) loadPalette() {
 					if _, err = io.ReadFull(f, rgb[:]); err != nil {
 						break
 					}
-					pl[i] = uint32(255)<<24 | uint32(rgb[2])<<16 | uint32(rgb[1])<<8 | uint32(rgb[0])
+					var alpha byte = 255
+					if i == 0 {
+						alpha = 0
+					}
+					pl[i] = uint32(alpha)<<24 | uint32(rgb[2])<<16 | uint32(rgb[1])<<8 | uint32(rgb[0])
 				}
 				chk(f.Close())
 				if err == nil {

--- a/src/font.go
+++ b/src/font.go
@@ -124,7 +124,11 @@ func loadFntV1(filename string) (*Fnt, error) {
 		if err := read(rgb[:]); err != nil {
 			return nil, err
 		}
-		spr.Pal[i] = uint32(rgb[2])<<16 | uint32(rgb[1])<<8 | uint32(rgb[0])
+		var alpha byte = 255
+		if i == 0 {
+			alpha = 0
+		}
+		spr.Pal[i] = uint32(alpha)<<24 | uint32(rgb[2])<<16 | uint32(rgb[1])<<8 | uint32(rgb[0])
 	}
 
 	px = spr.RlePcxDecode(px)

--- a/src/image.go
+++ b/src/image.go
@@ -130,6 +130,7 @@ func (pf *PalFX) getFxPal(pal []uint32, neg bool) []uint32 {
 		sub |= su << uint(i*8)
 	}
 	for i, c := range pal {
+		alpha := c & 0xff000000
 		if p.eInvertall {
 			c = ^c
 		}
@@ -145,7 +146,7 @@ func (pf *PalFX) getFxPal(pal []uint32, neg bool) []uint32 {
 		tmp = (tmp|uint32(-Btoi(tmp&0xff0000 != 0)<<8))&0xffff |
 			(((c>>16&0xff)+uint32(a[2]))*uint32(m[2])>>8)<<16
 		sys.workpal[i] = tmp | uint32(-Btoi(tmp&0xff000000 != 0)<<16) |
-			0xff000000
+			alpha
 	}
 	return sys.workpal
 }
@@ -835,7 +836,11 @@ func (s *Sprite) read(f *os.File, sh *SffHeader, offset int64, datasize uint32,
 			if err := read(rgb[:]); err != nil {
 				return err
 			}
-			pal[i] = uint32(255)<<24 | uint32(rgb[2])<<16 | uint32(rgb[1])<<8 | uint32(rgb[0])
+			var alpha byte = 255
+			if i == 0 {
+				alpha = 0
+			}
+			pal[i] = uint32(alpha)<<24 | uint32(rgb[2])<<16 | uint32(rgb[1])<<8 | uint32(rgb[0])
 		}
 	}
 	s.SetPxl(s.RlePcxDecode(px))
@@ -1261,7 +1266,11 @@ func loadSff(filename string, char bool) (*Sff, error) {
 						return nil, err
 					}
 					if s.header.Ver2 == 0 {
-						rgba[3] = 255
+						if i == 0 {
+							rgba[3] = 0
+						} else {
+							rgba[3] = 255
+						}
 					}
 					pal[i] = uint32(rgba[3])<<24 | uint32(rgba[2])<<16 | uint32(rgba[1])<<8 | uint32(rgba[0])
 				}
@@ -1457,7 +1466,11 @@ func preloadSff(filename string, char bool, preloadSpr map[[2]int16]bool) (*Sff,
 								return nil, nil, err
 							}
 							if h.Ver2 == 0 {
-								rgba[3] = 255
+								if i == 0 {
+									rgba[3] = 0
+								} else {
+									rgba[3] = 255
+								}
 							}
 							spriteList[i].Pal[j] = uint32(rgba[3])<<24 | uint32(rgba[2])<<16 | uint32(rgba[1])<<8 | uint32(rgba[0])
 						}

--- a/src/shaders/sprite.frag.glsl
+++ b/src/shaders/sprite.frag.glsl
@@ -46,12 +46,7 @@ void main(void) {
 			final_add *= c.a;
 			final_mul.rgb *= alpha;
 		} else {
-			// Colormap sprites use the old “buggy” Mugen way
-			if (int(255.25*c.r) == mask) {
-				final_mul = vec4(0.0);
-			} else {
-				c = texture2D(pal, vec2(c.r*0.9966, 0.5));
-			}
+			c = texture2D(pal, vec2(c.r*0.9966, 0.5));
 			if (mask == -1) {
 				c.a = 1.0;
 			}


### PR DESCRIPTION
- Now if ikemenversion > 0 ModifyExplod bindtime,removetime,supermovetime,pausemovetime will update according to current explod time. Mugen chars keeping old behaviour for compatability.

- Refactor of previous masking fixes.