### PR TITLE
fix: Hitdef priority, BindToRoot

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -7411,8 +7411,8 @@ func (sc bindToParent) Run(c *Char, _ []int32) bool {
 	}
 	crun.bindPos[0] = x
 	crun.bindPos[1] = y
-	crun.setBindTime(time)
 	crun.setBindToId(p)
+	crun.setBindTime(time)
 	return false
 }
 
@@ -7455,8 +7455,8 @@ func (sc bindToRoot) Run(c *Char, _ []int32) bool {
 	}
 	crun.bindPos[0] = x
 	crun.bindPos[1] = y
-	crun.setBindTime(time)
 	crun.setBindToId(r)
+	crun.setBindTime(time)
 	return false
 }
 

--- a/src/char.go
+++ b/src/char.go
@@ -500,6 +500,7 @@ const (
 	HT_Unknown HitType = -1
 )
 
+// Aiuchi = trading hits
 type AiuchiType int32
 
 const (
@@ -1982,7 +1983,8 @@ type Char struct {
 	mctime          int32
 	children        []*Char
 	targets         []int32
-	targetsOfHitdef []int32
+	hitdefTargets   []int32
+	hitdefTargetsBuffer []int32
 	enemynear       [2][]*Char
 	p2enemy         []*Char
 	pos             [3]float32
@@ -4376,7 +4378,7 @@ func (c *Char) projInit(p *Projectile, pt PosType, x, y float32,
 }
 func (c *Char) setHitdefDefault(hd *HitDef, proj bool) {
 	if !proj {
-		c.targetsOfHitdef = c.targetsOfHitdef[:0]
+		c.hitdefTargets = c.hitdefTargets[:0]
 	}
 	if hd.attr&^int32(ST_MASK) == 0 {
 		hd.attr = 0
@@ -5748,7 +5750,7 @@ func (c *Char) hasTarget(id int32) bool {
 	return false
 }
 func (c *Char) hasTargetOfHitdef(id int32) bool {
-	for _, tid := range c.targetsOfHitdef {
+	for _, tid := range c.hitdefTargets {
 		if tid == id {
 			return true
 		}
@@ -6014,9 +6016,8 @@ func (c *Char) attrCheck(h *HitDef, pid int32, st StateType) bool {
 	//}
 	return true
 }
-func (c *Char) hittable(h *HitDef, e *Char, st StateType,
-	// Check which character should win in case attacks connect in the same frame
-	countercheck func(*HitDef) bool) bool {
+// Check which character should win in case attacks connect in the same frame
+func (c *Char) loseHitTrade(h *HitDef, e *Char, st StateType, countercheck func(*HitDef) bool) bool {
 	if !c.attrCheck(h, e.id, st) {
 		return false
 	}
@@ -6050,8 +6051,7 @@ func (c *Char) hittable(h *HitDef, e *Char, st StateType,
 		default:
 			return true
 		}
-		//return !countercheck(&c.hitdef) || c.hasTargetOfHitdef(e.id) || c.hitdef.attr == 0 // https://github.com/ikemen-engine/Ikemen-GO/issues/1410
-		return !countercheck(&c.hitdef)
+		return !countercheck(&c.hitdef) || c.hasTargetOfHitdef(e.id) || c.hitdef.attr == 0
 	}
 	return true
 }
@@ -6654,6 +6654,12 @@ func (c *Char) tick() {
 		c.hitdef.attr = c.hitdef.attr&^int32(ST_MASK) | int32(c.ss.stateType)
 		c.hitdef.lhit = false
 	}
+	// Get Hitdef targets from the buffer. Using a buffer mitigates processing order errors
+	// https://github.com/ikemen-engine/Ikemen-GO/issues/1798
+	if len(c.hitdefTargetsBuffer) > 0 {
+		c.hitdefTargets = append(c.hitdefTargets, c.hitdefTargetsBuffer...)
+		c.hitdefTargetsBuffer = c.hitdefTargetsBuffer[:0]
+	}
 	if c.mctime < 0 {
 		c.mctime = 1
 		if c.mctype == MC_Hit {
@@ -7110,8 +7116,8 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 			}
 		}
 		if !proj {
-			c.targetsOfHitdef = append(c.targetsOfHitdef, getter.id)
-			c.mhv.uniqhit = int32(len(c.targetsOfHitdef))
+			c.hitdefTargetsBuffer = append(c.hitdefTargetsBuffer, getter.id)
+			c.mhv.uniqhit = int32(len(c.hitdefTargets))
 		}
 		ghvset := !getter.stchtmp || p2s || !getter.csf(CSF_gethit)
 		// This flag determines if juggle points will be subtracted further down
@@ -7791,7 +7797,7 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 					(c.asf(ASF_nojugglecheck) || getter.ghv.getJuggle(c.id, c.gi().data.airjuggle) >= p.hitdef.air_juggle) &&
 					(!ap_projhit || p.hitdef.attr&int32(AT_AP) == 0) &&
 					p.curmisstime <= 0 && p.hitpause <= 0 && p.hitdef.hitonce >= 0 &&
-					getter.hittable(&p.hitdef, c, ST_N, func(h *HitDef) bool { return false }) {
+					getter.loseHitTrade(&p.hitdef, c, ST_N, func(h *HitDef) bool { return false }) {
 					orghittmp := getter.hittmp
 					if getter.csf(CSF_gethit) {
 						getter.hittmp = int8(Btoi(getter.ghv.fallf)) + 1
@@ -7868,9 +7874,8 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 				}
 				if c.hitdef.hitonce >= 0 && !c.hasTargetOfHitdef(getter.id) &&
 					(c.hitdef.reversal_attr <= 0 || !getter.hasTargetOfHitdef(c.id)) &&
-					(getter.hittmp < 2 || c.asf(ASF_nojugglecheck) || !c.hasTarget(getter.id) ||
-						getter.ghv.getJuggle(c.id, c.gi().data.airjuggle) >= c.juggle) &&
-					getter.hittable(&c.hitdef, c, c.ss.stateType, func(h *HitDef) bool {
+					(getter.hittmp < 2 || c.asf(ASF_nojugglecheck) || !c.hasTarget(getter.id) || getter.ghv.getJuggle(c.id, c.gi().data.airjuggle) >= c.juggle) &&
+					getter.loseHitTrade(&c.hitdef, c, c.ss.stateType, func(h *HitDef) bool {
 						return (c.atktmp >= 0 || !getter.hasTarget(c.id)) &&
 							c.attrCheck(h, getter.id, getter.ss.stateType) &&
 							c.hitCheck(getter)
@@ -7922,7 +7927,7 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 									}
 									getter.ghv.fallf = getter.ghv.fallf || fall
 
-									getter.targetsOfHitdef = append(getter.targetsOfHitdef, c.id)
+									getter.hitdefTargetsBuffer = append(getter.hitdefTargetsBuffer, c.id)
 									if getter.hittmp == 0 {
 										getter.hittmp = -1
 									}


### PR DESCRIPTION
- Fixed a bug where essentially setting BindToRoot time to 0 would make triggers like P2Dist return the root's P2Dist rather than the helper's
- Fixed a very specific scenario where Hitdef priority would be checked twice when player A would HitOverride player B's Hitdef and then hit them back
- Fixes #1798 