### PR TITLE
feat: PalFxVar, Index, RunOrder triggers

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -221,6 +221,7 @@ const (
 	OC_const_
 	OC_st_
 	OC_ex_
+	OC_ex2_
 )
 const (
 	OC_const_data_life OpCode = iota
@@ -631,6 +632,42 @@ const (
 	OC_ex_fightscreenvar_round_over_wintime
 	OC_ex_fightscreenvar_round_slow_time
 	OC_ex_fightscreenvar_round_start_waittime
+)
+const (
+	OC_ex2_index OpCode = iota
+	OC_ex2_runorder
+	OC_ex2_palfxvar_time
+	OC_ex2_palfxvar_addr
+	OC_ex2_palfxvar_addg
+	OC_ex2_palfxvar_addb
+	OC_ex2_palfxvar_mulr
+	OC_ex2_palfxvar_mulg
+	OC_ex2_palfxvar_mulb
+	OC_ex2_palfxvar_color
+	OC_ex2_palfxvar_hue
+	OC_ex2_palfxvar_invertall
+	OC_ex2_palfxvar_invertblend
+	OC_ex2_palfxvar_bg_time
+	OC_ex2_palfxvar_bg_addr
+	OC_ex2_palfxvar_bg_addg
+	OC_ex2_palfxvar_bg_addb
+	OC_ex2_palfxvar_bg_mulr
+	OC_ex2_palfxvar_bg_mulg
+	OC_ex2_palfxvar_bg_mulb
+	OC_ex2_palfxvar_bg_color
+	OC_ex2_palfxvar_bg_hue
+	OC_ex2_palfxvar_bg_invertall
+	OC_ex2_palfxvar_all_time
+	OC_ex2_palfxvar_all_addr
+	OC_ex2_palfxvar_all_addg
+	OC_ex2_palfxvar_all_addb
+	OC_ex2_palfxvar_all_mulr
+	OC_ex2_palfxvar_all_mulg
+	OC_ex2_palfxvar_all_mulb
+	OC_ex2_palfxvar_all_color
+	OC_ex2_palfxvar_all_hue
+	OC_ex2_palfxvar_all_invertall
+	OC_ex2_palfxvar_all_invertblend
 )
 const (
 	NumVar     = 60
@@ -1543,6 +1580,8 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			be.run_const(c, &i, oc)
 		case OC_ex_:
 			be.run_ex(c, &i, oc)
+		case OC_ex2_:
+			be.run_ex2(c, &i, oc)
 		case OC_var:
 			*sys.bcStack.Top() = c.varGet(sys.bcStack.Top().ToI())
 		case OC_sysvar:
@@ -2613,6 +2652,82 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.mhv.sparkxy[1] * (c.localscl / oc.localscl))
 	case OC_ex_movehitvar_uniqhit:
 		sys.bcStack.PushI(c.mhv.uniqhit)
+	default:
+		sys.errLog.Printf("%v\n", be[*i-1])
+		c.panic()
+	}
+}
+func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
+	(*i)++
+	switch be[*i-1] {
+	case OC_ex2_index:
+		sys.bcStack.PushI(c.index)
+	case OC_ex2_runorder:
+		sys.bcStack.PushI(c.runorder)
+	case OC_ex2_palfxvar_time:
+		sys.bcStack.PushI(c.palfxvar(0))
+	case OC_ex2_palfxvar_addr:
+		sys.bcStack.PushI(c.palfxvar(1))
+	case OC_ex2_palfxvar_addg:
+		sys.bcStack.PushI(c.palfxvar(2))
+	case OC_ex2_palfxvar_addb:
+		sys.bcStack.PushI(c.palfxvar(3))
+	case OC_ex2_palfxvar_mulr:
+		sys.bcStack.PushI(c.palfxvar(4))
+	case OC_ex2_palfxvar_mulg:
+		sys.bcStack.PushI(c.palfxvar(5))
+	case OC_ex2_palfxvar_mulb:
+		sys.bcStack.PushI(c.palfxvar(6))
+	case OC_ex2_palfxvar_color:
+		sys.bcStack.PushF(c.palfxvar2(1))
+	case OC_ex2_palfxvar_hue:
+		sys.bcStack.PushF(c.palfxvar2(2))
+	case OC_ex2_palfxvar_invertall:
+		sys.bcStack.PushI(c.palfxvar(-1))
+	case OC_ex2_palfxvar_invertblend:
+		sys.bcStack.PushI(c.palfxvar(-2))
+	case OC_ex2_palfxvar_bg_time:
+		sys.bcStack.PushI(sys.palfxvar(0,1))
+	case OC_ex2_palfxvar_bg_addr:
+		sys.bcStack.PushI(sys.palfxvar(1,1))
+	case OC_ex2_palfxvar_bg_addg:
+		sys.bcStack.PushI(sys.palfxvar(2,1))
+	case OC_ex2_palfxvar_bg_addb:
+		sys.bcStack.PushI(sys.palfxvar(3,1))
+	case OC_ex2_palfxvar_bg_mulr:
+		sys.bcStack.PushI(sys.palfxvar(4,1))
+	case OC_ex2_palfxvar_bg_mulg:
+		sys.bcStack.PushI(sys.palfxvar(5,1))
+	case OC_ex2_palfxvar_bg_mulb:
+		sys.bcStack.PushI(sys.palfxvar(6,1))
+	case OC_ex2_palfxvar_bg_color:
+		sys.bcStack.PushF(sys.palfxvar2(1,1))
+	case OC_ex2_palfxvar_bg_hue:
+		sys.bcStack.PushF(sys.palfxvar2(2,1))
+	case OC_ex2_palfxvar_bg_invertall:
+		sys.bcStack.PushI(sys.palfxvar(-1,1))
+	case OC_ex2_palfxvar_all_time:
+		sys.bcStack.PushI(sys.palfxvar(0,2))
+	case OC_ex2_palfxvar_all_addr:
+		sys.bcStack.PushI(sys.palfxvar(1,2))
+	case OC_ex2_palfxvar_all_addg:
+		sys.bcStack.PushI(sys.palfxvar(2,2))
+	case OC_ex2_palfxvar_all_addb:
+		sys.bcStack.PushI(sys.palfxvar(3,2))
+	case OC_ex2_palfxvar_all_mulr:
+		sys.bcStack.PushI(sys.palfxvar(4,2))
+	case OC_ex2_palfxvar_all_mulg:
+		sys.bcStack.PushI(sys.palfxvar(5,2))
+	case OC_ex2_palfxvar_all_mulb:
+		sys.bcStack.PushI(sys.palfxvar(6,2))
+	case OC_ex2_palfxvar_all_color:
+		sys.bcStack.PushF(sys.palfxvar2(1,2))
+	case OC_ex2_palfxvar_all_hue:
+		sys.bcStack.PushF(sys.palfxvar2(2,2))
+	case OC_ex2_palfxvar_all_invertall:
+		sys.bcStack.PushI(sys.palfxvar(-1,2))
+	case OC_ex2_palfxvar_all_invertblend:
+		sys.bcStack.PushI(sys.palfxvar(-2,2))
 	default:
 		sys.errLog.Printf("%v\n", be[*i-1])
 		c.panic()

--- a/src/char.go
+++ b/src/char.go
@@ -1946,6 +1946,8 @@ type Char struct {
 	ss              StateState
 	key             int
 	id              int32
+	index           int32
+	runorder        int32
 	helperId        int32
 	helperIndex     int32
 	parentIndex     int32
@@ -2105,6 +2107,8 @@ func (c *Char) clear1() {
 	c.defenseMulDelay = false
 	c.key = -1
 	c.id = -1
+	c.index = -1
+	c.runorder = -1
 	c.helperId = 0
 	c.helperIndex = -1
 	c.parentIndex = IErr
@@ -3470,6 +3474,50 @@ func (c *Char) palno() int32 {
 		return 1
 	}
 	return c.gi().palno
+}
+func (c *Char) palfxvar(x int32) int32 {
+	n := int32(0)
+	if x >= 4 { n = 256 }
+	if c.palfx != nil && c.palfx.enable {
+		switch x {
+		case -2:
+			n = c.palfx.eInvertblend
+		case -1:
+			n = Btoi(c.palfx.eInvertall)
+		case 0:
+			n = c.palfx.time
+		case 1:
+			n = c.palfx.eAdd[0]
+		case 2:
+			n = c.palfx.eAdd[1]
+		case 3:
+			n = c.palfx.eAdd[2]
+		case 4:
+			n = c.palfx.eMul[0]
+		case 5:
+			n = c.palfx.eMul[1]
+		case 6:
+			n = c.palfx.eMul[2]
+		default:
+			n = 0
+		}
+	}
+	return n
+}
+func (c *Char) palfxvar2(x int32) float32 {
+	n := float32(1)
+	if x > 1 { n = 0 }
+	if c.palfx != nil && c.palfx.enable {
+		switch x {
+		case 1:
+			n = c.palfx.eColor
+		case 2:
+			n = c.palfx.eHue
+		default:
+			n = 0
+		}
+	}
+	return n*256
 }
 func (c *Char) pauseTime() int32 {
 	var p int32
@@ -6907,6 +6955,7 @@ func (cl *CharList) clear() {
 }
 func (cl *CharList) add(c *Char) {
 	// Append to run order
+	c.index = int32(len(cl.runOrder))+1
 	cl.runOrder = append(cl.runOrder, c)
 	// If any entries in the draw order are empty, use that one
 	i := 0
@@ -6927,6 +6976,7 @@ func (cl *CharList) replace(dc *Char, pn int, idx int32) bool {
 	// Replace run order
 	for i, c := range cl.runOrder {
 		if c.playerNo == pn && c.helperIndex == idx {
+			c.index = int32(i)+1
 			cl.runOrder[i] = dc
 			ok = true
 			break
@@ -6970,30 +7020,35 @@ func (cl *CharList) action(x float32) {
 	// Run actions for attacking players and helpers
 	for i := 0; i < len(cl.runOrder); i++ {
 		if cl.runOrder[i].ss.moveType == MT_A {
+			cl.runOrder[i].runorder = 1
 			cl.runOrder[i].actionRun()
 		}
 	}
 	// Run actions for idle players
 	for i := 0; i < len(cl.runOrder); i++ {
 		if cl.runOrder[i].helperIndex == 0 && cl.runOrder[i].ss.moveType == MT_I {
+			cl.runOrder[i].runorder = 2
 			cl.runOrder[i].actionRun()
 		}
 	}
 	// Run actions for remaining players
 	for i := 0; i < len(cl.runOrder); i++ {
 		if cl.runOrder[i].helperIndex == 0 {
+			cl.runOrder[i].runorder = 3
 			cl.runOrder[i].actionRun()
 		}
 	}
 	// Run actions for idle helpers
 	for i := 0; i < len(cl.runOrder); i++ {
 		if cl.runOrder[i].helperIndex != 0 && cl.runOrder[i].ss.moveType == MT_I {
+			cl.runOrder[i].runorder = 4
 			cl.runOrder[i].actionRun()
 		}
 	}
 	// Run actions for remaining helpers
 	for i := 0; i < len(cl.runOrder); i++ {
 		if cl.runOrder[i].helperIndex != 0 {
+			cl.runOrder[i].runorder = 5
 			cl.runOrder[i].actionRun()
 		}
 	}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -247,6 +247,7 @@ var triggerMap = map[string]int{
 	"inguarddist":       1,
 	"ishelper":          1,
 	"ishometeam":        1,
+	"index":             1,
 	"leftedge":          1,
 	"life":              1,
 	"lifemax":           1,
@@ -383,6 +384,7 @@ var triggerMap = map[string]int{
 	"mugenversion":       1,
 	"numplayer":          1,
 	"offset":             1,
+	"palfxvar":           1,
 	"p5name":             1,
 	"p6name":             1,
 	"p7name":             1,
@@ -1981,6 +1983,10 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_ishelper)
 	case "ishometeam":
 		out.append(OC_ex_, OC_ex_ishometeam)
+	case "index":
+		out.append(OC_ex2_, OC_ex2_index)
+	case "runorder":
+		out.append(OC_ex2_, OC_ex2_runorder)
 	case "leftedge":
 		out.append(OC_leftedge)
 	case "life", "p2life":
@@ -2038,6 +2044,83 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			}
 			return nil
 		}); err != nil {
+			return bvNone(), err
+		}
+	case "palfxvar":
+		if err := c.checkOpeningBracket(in); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_ex2_)
+		switch c.token {
+		case "time":
+			out.append(OC_ex2_palfxvar_time)
+		case "add.r":
+			out.append(OC_ex2_palfxvar_addr)
+		case "add.g":
+			out.append(OC_ex2_palfxvar_addg)
+		case "add.b":
+			out.append(OC_ex2_palfxvar_addb)
+		case "mul.r":
+			out.append(OC_ex2_palfxvar_mulr)
+		case "mul.g":
+			out.append(OC_ex2_palfxvar_mulg)
+		case "mul.b":
+			out.append(OC_ex2_palfxvar_mulb)
+		case "color":
+			out.append(OC_ex2_palfxvar_color)
+		case "hue":
+			out.append(OC_ex2_palfxvar_hue)
+		case "invertall":
+			out.append(OC_ex2_palfxvar_invertall)
+		case "invertblend":
+			out.append(OC_ex2_palfxvar_invertblend)
+		case "bg.time":
+			out.append(OC_ex2_palfxvar_bg_time)
+		case "bg.add.r":
+			out.append(OC_ex2_palfxvar_bg_addr)
+		case "bg.add.g":
+			out.append(OC_ex2_palfxvar_bg_addg)
+		case "bg.add.b":
+			out.append(OC_ex2_palfxvar_bg_addb)
+		case "bg.mul.r":
+			out.append(OC_ex2_palfxvar_bg_mulr)
+		case "bg.mul.g":
+			out.append(OC_ex2_palfxvar_bg_mulg)
+		case "bg.mul.b":
+			out.append(OC_ex2_palfxvar_bg_mulb)
+		case "bg.color":
+			out.append(OC_ex2_palfxvar_bg_color)
+		case "bg.hue":
+			out.append(OC_ex2_palfxvar_bg_hue)
+		case "bg.invertall":
+			out.append(OC_ex2_palfxvar_bg_invertall)
+		case "all.time":
+			out.append(OC_ex2_palfxvar_all_time)
+		case "all.add.r":
+			out.append(OC_ex2_palfxvar_all_addr)
+		case "all.add.g":
+			out.append(OC_ex2_palfxvar_all_addg)
+		case "all.add.b":
+			out.append(OC_ex2_palfxvar_all_addb)
+		case "all.mul.r":
+			out.append(OC_ex2_palfxvar_all_mulr)
+		case "all.mul.g":
+			out.append(OC_ex2_palfxvar_all_mulg)
+		case "all.mul.b":
+			out.append(OC_ex2_palfxvar_all_mulb)
+		case "all.color":
+			out.append(OC_ex2_palfxvar_all_color)
+		case "all.hue":
+			out.append(OC_ex2_palfxvar_all_hue)
+		case "all.invertall":
+			out.append(OC_ex2_palfxvar_all_invertall)
+		case "all.invertblend":
+			out.append(OC_ex2_palfxvar_all_invertblend)
+		default:
+			return bvNone(), Error("Invalid data: " + c.token)
+		}
+		c.token = c.tokenizer(in)
+		if err := c.checkClosingBracket(); err != nil {
 			return bvNone(), err
 		}
 	case "name", "p1name", "p2name", "p3name", "p4name", "p5name", "p6name", "p7name", "p8name":

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -247,7 +247,6 @@ var triggerMap = map[string]int{
 	"inguarddist":       1,
 	"ishelper":          1,
 	"ishometeam":        1,
-	"index":             1,
 	"leftedge":          1,
 	"life":              1,
 	"lifemax":           1,
@@ -384,7 +383,6 @@ var triggerMap = map[string]int{
 	"mugenversion":       1,
 	"numplayer":          1,
 	"offset":             1,
-	"palfxvar":           1,
 	"p5name":             1,
 	"p6name":             1,
 	"p7name":             1,
@@ -425,6 +423,10 @@ var triggerMap = map[string]int{
 	"timetotal":          1,
 	"winhyper":           1,
 	"winspecial":         1,
+	// expanded triggers 2
+	"index":              1,
+	"palfxvar":           1,
+	"runorder":           1,
 }
 
 func (c *Compiler) tokenizer(in *string) string {

--- a/src/script.go
+++ b/src/script.go
@@ -3416,6 +3416,10 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LBool(sys.debugWC.teamside == sys.home))
 		return 1
 	})
+	luaRegister(l, "index", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.index))
+		return 1
+	})
 	luaRegister(l, "leftedge", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.leftEdge()))
 		return 1
@@ -3566,6 +3570,79 @@ func triggerFunctions(l *lua.LState) {
 			id = int32(numArg(l, 1))
 		}
 		l.Push(lua.LNumber(sys.debugWC.numTarget(BytecodeInt(id)).ToI()))
+		return 1
+	})
+	luaRegister(l, "palfxvar", func(*lua.LState) int {
+		var ln lua.LNumber
+		switch strArg(l, 1) {
+		case "time":
+			ln = lua.LNumber(sys.debugWC.palfxvar(0))
+		case "add.r":
+			ln = lua.LNumber(sys.debugWC.palfxvar(1))
+		case "add.g":
+			ln = lua.LNumber(sys.debugWC.palfxvar(2))
+		case "add.b":
+			ln = lua.LNumber(sys.debugWC.palfxvar(3))
+		case "mul.r":
+			ln = lua.LNumber(sys.debugWC.palfxvar(4))
+		case "mul.g":
+			ln = lua.LNumber(sys.debugWC.palfxvar(5))
+		case "mul.b":
+			ln = lua.LNumber(sys.debugWC.palfxvar(6))
+		case "color":
+			ln = lua.LNumber(sys.debugWC.palfxvar2(1))
+		case "hue":
+			ln = lua.LNumber(sys.debugWC.palfxvar2(2))
+		case "invertall":
+			ln = lua.LNumber(sys.debugWC.palfxvar(-1))
+		case "invertblend":
+			ln = lua.LNumber(sys.debugWC.palfxvar(-2))
+		case "bg.time":
+			ln = lua.LNumber(sys.palfxvar(0,1))
+		case "bg.add.r":
+			ln = lua.LNumber(sys.palfxvar(1,1))
+		case "bg.add.g":
+			ln = lua.LNumber(sys.palfxvar(2,1))
+		case "bg.add.b":
+			ln = lua.LNumber(sys.palfxvar(3,1))
+		case "bg.mul.r":
+			ln = lua.LNumber(sys.palfxvar(4,1))
+		case "bg.mul.g":
+			ln = lua.LNumber(sys.palfxvar(5,1))
+		case "bg.mul.b":
+			ln = lua.LNumber(sys.palfxvar(6,1))
+		case "bg.color":
+			ln = lua.LNumber(sys.palfxvar2(1,1))
+		case "bg.hue":
+			ln = lua.LNumber(sys.palfxvar2(2,1))
+		case "bg.invertall":
+			ln = lua.LNumber(sys.palfxvar(-1,1))
+		case "all.time":
+			ln = lua.LNumber(sys.palfxvar(0,2))
+		case "all.add.r":
+			ln = lua.LNumber(sys.palfxvar(1,2))
+		case "all.add.g":
+			ln = lua.LNumber(sys.palfxvar(2,2))
+		case "all.add.b":
+			ln = lua.LNumber(sys.palfxvar(3,2))
+		case "all.mul.r":
+			ln = lua.LNumber(sys.palfxvar(4,2))
+		case "all.mul.g":
+			ln = lua.LNumber(sys.palfxvar(5,2))
+		case "all.mul.b":
+			ln = lua.LNumber(sys.palfxvar(6,2))
+		case "all.color":
+			ln = lua.LNumber(sys.palfxvar2(1,2))
+		case "all.hue":
+			ln = lua.LNumber(sys.palfxvar2(2,2))
+		case "all.invertall":
+			ln = lua.LNumber(sys.palfxvar(-1,2))
+		case "all.invertblend":
+			ln = lua.LNumber(sys.palfxvar(-2,2))
+		default:
+			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
+		}
+		l.Push(ln)
 		return 1
 	})
 	//p1name and other variants can be checked via name
@@ -3729,6 +3806,10 @@ func triggerFunctions(l *lua.LState) {
 	luaRegister(l, "projhittime", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.projHitTime(
 			BytecodeInt(int32(numArg(l, 1)))).ToI()))
+		return 1
+	})
+	luaRegister(l, "runorder", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.runorder))
 		return 1
 	})
 	//random (dedicated functionality already exists in Lua)

--- a/src/system.go
+++ b/src/system.go
@@ -652,6 +652,59 @@ func (s *System) playerIndexExist(id BytecodeValue) BytecodeValue {
 func (s *System) playercount() int32 {
 	return int32(len(s.charList.runOrder))
 }
+
+func (s *System) palfxvar(x int32,y int32) int32 {
+	n := int32(0)
+	if x >= 4 { n = 256 }
+	pfx := s.bgPalFX
+	if y == 2 {
+		pfx = s.allPalFX
+	}
+	if pfx.enable {
+		switch x {
+		case -2:
+			n = pfx.eInvertblend
+		case -1:
+			n = Btoi(pfx.eInvertall)
+		case 0:
+			n = pfx.time
+		case 1:
+			n = pfx.eAdd[0]
+		case 2:
+			n = pfx.eAdd[1]
+		case 3:
+			n = pfx.eAdd[2]
+		case 4:
+			n = pfx.eMul[0]
+		case 5:
+			n = pfx.eMul[1]
+		case 6:
+			n = pfx.eMul[2]
+		default:
+			n = 0
+		}
+	}
+	return n
+}
+func (s *System) palfxvar2(x int32,y int32) float32 {
+	n := float32(1)
+	if x > 1 { n = 0 }
+	pfx := s.bgPalFX
+	if y == 2 {
+		pfx = s.allPalFX
+	}
+	if pfx.enable {
+		switch x {
+		case 1:
+			n = pfx.eColor
+		case 2:
+			n = pfx.eHue
+		default:
+			n = 0
+		}
+	}
+	return n*256
+}
 func (s *System) screenHeight() float32 {
 	return 240
 }


### PR DESCRIPTION
This PR adds 3 new triggers:

- **PalFxVar(param name).** Returns the values of **PalFx/BGPalFx/AllPalFx** parameters.
Its accepts following values:
>add.r, add.g, add.b (int,int,int)
>mul.r, mul.g, mul.b (int,int,int)
>color, hue (float,float) 
>invertall, invertblend (int,int)

With **bg** or **all** prefix its will returns **BGPalFx** or **AllPalFx** sctrl values instead.

Examples:

>trigger1 = PalFxVar(add.r) >= 128
>trigger1 = PalFxVar(bg.add.r) <= 56
>trigger1 = PalFxVar(all.add.r) <= 250

**- Index.** Returns player/helper index value, works in pair with PlayerIndex and PlayerIndexExist

**- RunOrder.** Returns the value of player/helper run order 

