### PR TITLE
feat: A new stage camera parameter: 'verticalfollowdelta'.

### DIFF
--- a/src/camera.go
+++ b/src/camera.go
@@ -30,8 +30,8 @@ type stageCamera struct {
 	ytensionenable       bool
 	autocenter           bool
 	zoomanchor           bool
-	boundhighdelta       float32
-	verticalfollowdelta  float32
+	boundhighzoomdelta      float32
+	verticalfollowzoomdelta float32
 	zoomindelay          float32
 	zoomindelaytime      float32
 	fov                  float32
@@ -59,7 +59,7 @@ func newStageCamera() *stageCamera {
 		ztopscale: 1, startzoom: 1, zoomin: 1, zoomout: 1, ytensionenable: false,
 		tensionhigh: 0, tensionlow: 0,
 		fov: 40, yshift: 0, far: 10000, near: 0.1,
-		zoomindelay: 0, boundhighdelta: 0, verticalfollowdelta: 0}
+		zoomindelay: 0, boundhighzoomdelta: 0, verticalfollowzoomdelta: 0}
 }
 
 type CameraView int
@@ -284,7 +284,7 @@ func (c *Camera) action(x, y, scale float32, pause bool) (newX, newY, newScale f
 				if !c.ytensionenable {
 					//newY = c.ywithoutbound
 					ywithoutbound := c.ywithoutbound
-					verticalfollow := MaxF(c.verticalfollow, 0.0) + (targetScale-c.zoomout)*MaxF(c.verticalfollowdelta, 0.0)
+					verticalfollow := MaxF(c.verticalfollow, 0.0) + (targetScale-c.zoomout)*MaxF(c.verticalfollowzoomdelta, 0.0)
 					targetY := (c.highest + float32(c.floortension)*c.localscl) * verticalfollow
 					if !c.roundstart {
 						for i := 0; i < 3; i++ {
@@ -376,9 +376,9 @@ func (c *Camera) action(x, y, scale float32, pause bool) (newX, newY, newScale f
 					newX = (newLeft + newRight) / 2
 				}
 				newScale = MinF(c.halfWidth*2/(newRight-newLeft), c.zoomin)
-				if c.boundhighdelta > 0 {
+				if c.boundhighzoomdelta > 0 {
 					topBound := float32(c.boundhigh)*c.localscl - c.GroundLevel()/c.zoomout
-					boundHigh := float32(c.boundhigh)*c.localscl + ((topBound+c.GroundLevel()/newScale)-float32(c.boundhigh)*c.localscl)/c.boundhighdelta
+					boundHigh := float32(c.boundhigh)*c.localscl + ((topBound+c.GroundLevel()/newScale)-float32(c.boundhigh)*c.localscl)/c.boundhighzoomdelta
 					newY = MinF(MaxF(newY, boundHigh), float32(c.boundlow)*c.localscl) * newScale
 				} else {
 					newY = MinF(MaxF(newY, float32(c.boundhigh)*c.localscl), float32(c.boundlow)*c.localscl) * newScale
@@ -386,9 +386,9 @@ func (c *Camera) action(x, y, scale float32, pause bool) (newX, newY, newScale f
 			} else {
 				newScale = MinF(MaxF(newScale, c.zoomout), c.zoomin)
 				newX = MinF(MaxF(newX, c.minLeft+c.halfWidth/newScale), c.maxRight-c.halfWidth/newScale)
-				if c.boundhighdelta > 0 {
+				if c.boundhighzoomdelta > 0 {
 					topBound := float32(c.boundhigh)*c.localscl - c.GroundLevel()/c.zoomout
-					boundHigh := float32(c.boundhigh)*c.localscl + ((topBound+c.GroundLevel()/newScale)-float32(c.boundhigh)*c.localscl)/c.boundhighdelta
+					boundHigh := float32(c.boundhigh)*c.localscl + ((topBound+c.GroundLevel()/newScale)-float32(c.boundhigh)*c.localscl)/c.boundhighzoomdelta
 					newY = MinF(MaxF(newY, boundHigh), float32(c.boundlow)*c.localscl) * newScale
 				} else {
 					newY = MinF(MaxF(newY, float32(c.boundhigh)*c.localscl), float32(c.boundlow)*c.localscl) * newScale

--- a/src/camera.go
+++ b/src/camera.go
@@ -31,6 +31,7 @@ type stageCamera struct {
 	autocenter           bool
 	zoomanchor           bool
 	boundhighdelta       float32
+	verticalfollowdelta  float32
 	zoomindelay          float32
 	zoomindelaytime      float32
 	fov                  float32
@@ -58,7 +59,7 @@ func newStageCamera() *stageCamera {
 		ztopscale: 1, startzoom: 1, zoomin: 1, zoomout: 1, ytensionenable: false,
 		tensionhigh: 0, tensionlow: 0,
 		fov: 40, yshift: 0, far: 10000, near: 0.1,
-		zoomindelay: 0, boundhighdelta: 0}
+		zoomindelay: 0, boundhighdelta: 0, verticalfollowdelta: 0}
 }
 
 type CameraView int
@@ -283,7 +284,8 @@ func (c *Camera) action(x, y, scale float32, pause bool) (newX, newY, newScale f
 				if !c.ytensionenable {
 					//newY = c.ywithoutbound
 					ywithoutbound := c.ywithoutbound
-					targetY := (c.highest + float32(c.floortension)*c.localscl) * c.verticalfollow
+					verticalfollow := MaxF(c.verticalfollow, 0.0) + (targetScale-c.zoomout)*MaxF(c.verticalfollowdelta, 0.0)
+					targetY := (c.highest + float32(c.floortension)*c.localscl) * verticalfollow
 					if !c.roundstart {
 						for i := 0; i < 3; i++ {
 							ywithoutbound = ywithoutbound*.85 + targetY*.15
@@ -295,10 +297,10 @@ func (c *Camera) action(x, y, scale float32, pause bool) (newX, newY, newScale f
 							} else {
 								if newY > ywithoutbound {
 									newY -= float32(sys.gameWidth) / 320 * 0.5
-									newY -= (newY - ywithoutbound) * c.verticalfollow / 10
+									newY -= (newY - ywithoutbound) * verticalfollow / 10
 								} else {
 									newY += float32(sys.gameWidth) / 320 * 0.5
-									newY += (ywithoutbound - newY) * c.verticalfollow / 10
+									newY += (ywithoutbound - newY) * verticalfollow / 10
 								}
 							}
 						}

--- a/src/stage.go
+++ b/src/stage.go
@@ -928,8 +928,8 @@ func loadStage(def string, main bool) (*Stage, error) {
 		sec[0].ReadF32("far", &s.stageCamera.far)
 		sec[0].ReadBool("autocenter", &s.stageCamera.autocenter)
 		sec[0].ReadF32("zoomindelay", &s.stageCamera.zoomindelay)
-		sec[0].ReadF32("boundhighdelta", &s.stageCamera.boundhighdelta)
-		sec[0].ReadF32("verticalfollowdelta", &s.stageCamera.verticalfollowdelta)
+		sec[0].ReadF32("boundhighzoomdelta", &s.stageCamera.boundhighzoomdelta)
+		sec[0].ReadF32("verticalfollowzoomdelta", &s.stageCamera.verticalfollowzoomdelta)
 		sec[0].ReadBool("lowestcap", &s.stageCamera.lowestcap)
 		if sys.cam.ZoomMax == 0 {
 			sec[0].ReadF32("zoomin", &s.stageCamera.zoomin)

--- a/src/stage.go
+++ b/src/stage.go
@@ -929,6 +929,7 @@ func loadStage(def string, main bool) (*Stage, error) {
 		sec[0].ReadBool("autocenter", &s.stageCamera.autocenter)
 		sec[0].ReadF32("zoomindelay", &s.stageCamera.zoomindelay)
 		sec[0].ReadF32("boundhighdelta", &s.stageCamera.boundhighdelta)
+		sec[0].ReadF32("verticalfollowdelta", &s.stageCamera.verticalfollowdelta)
 		sec[0].ReadBool("lowestcap", &s.stageCamera.lowestcap)
 		if sys.cam.ZoomMax == 0 {
 			sec[0].ReadF32("zoomin", &s.stageCamera.zoomin)


### PR DESCRIPTION
A positive float value - increses the `verticalfollow` when the camera zoom is above the minimum (`zoomout`); the default value is `0` (constant `verticalfollow`, matching Mugen 1.1 behaviour); a value of `1` increases the `verticalfollow` by the amount of the current zoom-in above the minimal zoom.

---

Also renamed the stage parameters scaling with zoom, as per @potsmugen's [suggestion](https://github.com/ikemen-engine/Ikemen-GO/discussions/1749#discussioncomment-9556422).