### PR TITLE
feat: fightscreenvar(round.called)

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -632,6 +632,7 @@ const (
 	OC_ex_fightscreenvar_round_over_wintime
 	OC_ex_fightscreenvar_round_slow_time
 	OC_ex_fightscreenvar_round_start_waittime
+	OC_ex_fightscreenvar_round_called
 )
 const (
 	OC_ex2_index OpCode = iota
@@ -2428,6 +2429,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(sys.lifebar.ro.slow_time)
 	case OC_ex_fightscreenvar_round_start_waittime:
 		sys.bcStack.PushI(sys.lifebar.ro.start_waittime)
+	case OC_ex_fightscreenvar_round_called:
+		sys.bcStack.PushB((!sys.lifebar.ro.introState[0]) && sys.lifebar.ro.wt[0] < 0)
 	case OC_ex_fighttime:
 		sys.bcStack.PushI(sys.gameTime)
 	case OC_ex_firstattack:

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2996,6 +2996,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			opc = OC_ex_fightscreenvar_round_slow_time
 		case "round.start.waittime":
 			opc = OC_ex_fightscreenvar_round_start_waittime
+		case "round.called":
+			opc = OC_ex_fightscreenvar_round_called
 		default:
 			return bvNone(), Error("Invalid data: " + fsvname)
 		}

--- a/src/script.go
+++ b/src/script.go
@@ -4286,6 +4286,8 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LNumber(sys.lifebar.ro.slow_time))
 		case "round.start.waittime":
 			l.Push(lua.LNumber(sys.lifebar.ro.start_waittime))
+		case "round.called":
+			l.Push(lua.LBool((!sys.lifebar.ro.introState[0]) && sys.lifebar.ro.wt[0] < 0))
 		default:
 			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}


### PR DESCRIPTION
Returns 1 when the `round<n>` component is currently on screen. Returns 0 otherwise.

I needed to detect when "Round N" was being called and `IsAsserted(Intro)` couldn't reliably detect that; this PR adds a property to FightScreenVar that does exactly that.