### PR TITLE
fix: ChangeAnim crash, multiple ReversalDefs

### DIFF
--- a/src/anim.go
+++ b/src/anim.go
@@ -398,18 +398,21 @@ func (a *Animation) drawFrame() *AnimFrame {
 }
 func (a *Animation) SetAnimElem(elem int32) {
 	a.current = Max(0, elem-1)
+	// If trying to set an element higher than the last one in the animation
 	if int(a.current) >= len(a.frames) {
-		if a.totaltime == -1 {
-			a.current = int32(len(a.frames)) - 1
-		} else {
-			a.current = a.loopstart +
-				(a.current-a.loopstart)%(int32(len(a.frames))-a.loopstart)
-		}
+		//if a.totaltime == -1 {
+		//	a.current = int32(len(a.frames)) - 1
+		//} else if int32(len(a.frames))-a.loopstart > 0 { // Prevent division by zero crash
+		//	a.current = a.loopstart +
+		//		(a.current-a.loopstart)%(int32(len(a.frames))-a.loopstart)
+		//}
+		// Mugen merely sets the element to 1
+		a.current = 0
 	}
 	a.drawidx, a.time, a.newframe = a.current, 0, true
 	a.UpdateSprite()
 	a.loopend = false
-	a.sumtime = 0 // AnimElemTime 内で使用
+	a.sumtime = 0 // AnimElemTime 内で使用 // "Used within AnimElemTime"
 	a.sumtime = -a.AnimElemTime(a.current + 1)
 }
 func (a *Animation) animSeek(elem int32) {

--- a/src/char.go
+++ b/src/char.go
@@ -2944,6 +2944,11 @@ func (c *Char) setAnimElem(e int32) {
 	if c.anim != nil {
 		c.anim.SetAnimElem(e)
 		c.curFrame = c.anim.CurrentFrame()
+		if int(e) < 0 {
+			sys.appendToConsole(c.warn() + fmt.Sprintf("changed to negative animelem"))
+		} else if int(e) > len(c.anim.frames) {
+			sys.appendToConsole(c.warn() + fmt.Sprintf("changed to invalid animelem %v within action %v", e, c.animNo))
+		}
 	}
 }
 func (c *Char) setCtrl(ctrl bool) {

--- a/src/system.go
+++ b/src/system.go
@@ -1070,7 +1070,7 @@ func (s *System) charUpdate() {
 				}
 			}
 		}
-		s.charList.getHit()
+		s.charList.hitDetection()
 		for i, pr := range s.projs {
 			for j, p := range pr {
 				if p.id != IErr {


### PR DESCRIPTION
- Fixed a division by zero crash that could happen with ChangeAnim with elem = animelemno(0)
- Previously, if ChangeAnim elem parameter was higher than the last element of the animation, Ikemen set the element to the last looping point. Adjusted so that the element is simply set to 1, like Mugen
- Added a couple error messages when using ChangeAnim incorrectly
- Reversaldefs are now always processed before Hitdefs. Fixes a clash system in some Mugen characters
- Fixed a scenario where two partner characters can Reversaldef the same enemy attack