### PR TITLE
fix: Reversaldef, refactor Clsn display

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -1757,10 +1757,10 @@ func (p *Projectile) cueDraw(oldVer bool, playerNo int) {
 		if frm := p.ani.drawFrame(); frm != nil {
 			xs := p.facing * p.clsnScale[0] * p.localscl
 			if clsn := frm.Clsn1(); len(clsn) > 0 {
-				sys.drawc1.Add(clsn, p.pos[0]*p.localscl, p.pos[1]*p.localscl, xs, p.clsnScale[1]*p.localscl)
+				sys.drawc1hit.Add(clsn, p.pos[0]*p.localscl, p.pos[1]*p.localscl, xs, p.clsnScale[1]*p.localscl)
 			}
 			if clsn := frm.Clsn2(); len(clsn) > 0 {
-				sys.drawc2.Add(clsn, p.pos[0]*p.localscl, p.pos[1]*p.localscl, xs, p.clsnScale[1]*p.localscl)
+				sys.drawc2hb.Add(clsn, p.pos[0]*p.localscl, p.pos[1]*p.localscl, xs, p.clsnScale[1]*p.localscl)
 			}
 		}
 	}
@@ -2011,7 +2011,7 @@ type Char struct {
 	inguarddist     bool
 	pushed          bool
 	hitdefContact   bool
-	atktmp          int8 // 1 hitdef active, 0 inactive, -1 other
+	atktmp          int8 // 1 hitdef can hit, 0 cannot hit, -1 other
 	hittmp          int8 // 0 idle, 1 being hit, 2 falling, -1 reversaldef
 	acttmp          int8 // 1 unpaused, 0 default, -1 hitpause, -2 pause
 	minus           int8 // current negative state
@@ -6860,11 +6860,17 @@ func (c *Char) cueDraw() {
 		xs := c.clsnScale[0] * (320 / sys.chars[c.animPN][0].localcoord) * c.facing
 		ys := c.clsnScale[1] * (320 / sys.chars[c.animPN][0].localcoord)
 		// Draw Clsn1
-		if clsn := c.curFrame.Clsn1(); len(clsn) > 0 && c.atktmp != 0 {
-			sys.drawc1.Add(clsn, x, y, xs, ys)
+		if clsn := c.curFrame.Clsn1(); len(clsn) > 0 {
+			if c.atktmp != 0 && c.hitdef.reversal_attr > 0 {
+				sys.drawc1rev.Add(clsn, xoff, yoff, xs, ys)
+			} else if c.atktmp != 0 && c.hitdef.attr > 0 {
+				sys.drawc1hit.Add(clsn, xoff, yoff, xs, ys)
+			} else {
+				sys.drawc1not.Add(clsn, xoff, yoff, xs, ys)
+			}
 		}
+		// Check invincibility to decide box colors
 		if clsn := c.curFrame.Clsn2(); len(clsn) > 0 {
-			// Check invincibility to decide box colors
 			hb, mtk := false, false
 			for _, h := range c.hitby {
 				if h.time != 0 {
@@ -6877,7 +6883,10 @@ func (c *Char) cueDraw() {
 				sys.drawc2mtk.Add(clsn, xoff, yoff, xs, ys)
 			} else if hb {
 				// Draw partially invincible Clsn2
-				sys.drawc2sp.Add(clsn, xoff, yoff, xs, ys)
+				sys.drawc2hb.Add(clsn, xoff, yoff, xs, ys)
+			} else if c.inguarddist && c.scf(SCF_guard) {
+				// Draw guarding Clsn2
+				sys.drawc2grd.Add(clsn, xoff, yoff, xs, ys)
 			} else {
 				// Draw regular Clsn2
 				sys.drawc2.Add(clsn, xoff, yoff, xs, ys)

--- a/src/system.go
+++ b/src/system.go
@@ -241,10 +241,13 @@ type System struct {
 	topSprites              DrawList
 	bottomSprites           DrawList
 	shadows                 ShadowList
-	drawc1                  ClsnRect
+	drawc1hit               ClsnRect
+	drawc1rev               ClsnRect
+	drawc1not               ClsnRect
 	drawc2                  ClsnRect
-	drawc2sp                ClsnRect
+	drawc2hb                ClsnRect
 	drawc2mtk               ClsnRect
+	drawc2grd               ClsnRect
 	drawwh                  ClsnRect
 	drawch                  ClsnRect
 	autoguard               [MaxSimul*2 + MaxAttachedChar]bool
@@ -1109,10 +1112,13 @@ func (s *System) action() {
 	s.topSprites = s.topSprites[:0]
 	s.bottomSprites = s.bottomSprites[:0]
 	s.shadows = s.shadows[:0]
-	s.drawc1 = s.drawc1[:0]
+	s.drawc1hit = s.drawc1hit[:0]
+	s.drawc1rev = s.drawc1rev[:0]
+	s.drawc1not = s.drawc1not[:0]
 	s.drawc2 = s.drawc2[:0]
-	s.drawc2sp = s.drawc2sp[:0]
+	s.drawc2hb = s.drawc2hb[:0]
 	s.drawc2mtk = s.drawc2mtk[:0]
+	s.drawc2grd = s.drawc2grd[:0]
 	s.drawwh = s.drawwh[:0]
 	s.drawch = s.drawch[:0]
 	s.clsnText = nil
@@ -1688,13 +1694,19 @@ func (s *System) drawTop() {
 	s.brightness = s.brightnessOld
 	if s.clsnDraw {
 		s.clsnSpr.Pal[0] = 0xff0000ff
-		s.drawc1.draw(0x3feff)
+		s.drawc1hit.draw(0x3feff)
+		s.clsnSpr.Pal[0] = 0xff0040c0
+		s.drawc1rev.draw(0x3feff)
+		s.clsnSpr.Pal[0] = 0xff000080
+		s.drawc1not.draw(0x3feff)
 		s.clsnSpr.Pal[0] = 0xffff0000
 		s.drawc2.draw(0x3feff)
-		s.clsnSpr.Pal[0] = 0xff00ff00
-		s.drawc2sp.draw(0x3feff)
-		s.clsnSpr.Pal[0] = 0xff002000
+		s.clsnSpr.Pal[0] = 0xff808000
+		s.drawc2hb.draw(0x3feff)
+		s.clsnSpr.Pal[0] = 0xff004000
 		s.drawc2mtk.draw(0x3feff)
+		s.clsnSpr.Pal[0] = 0xffc00040
+		s.drawc2grd.draw(0x3feff)
 		s.clsnSpr.Pal[0] = 0xff303030
 		s.drawwh.draw(0x3feff)
 		s.clsnSpr.Pal[0] = 0xffffffff


### PR DESCRIPTION
- Refined implementation of previous Reversaldef commit
- Fixes #1823 

Clsn display:
- Expanded collision box color coding during debug. It will now draw the following:
Inactive Clsn1 (faded red)
Guarding (purple)
Reversaldef (orange)
- Adjusted full and partial invincibility colors