### PR TITLE
feat: IntroState trigger

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -152,6 +152,7 @@ const (
 	OC_powermax
 	OC_canrecover
 	OC_roundstate
+	OC_introstate
 	OC_ishelper
 	OC_numhelper
 	OC_numexplod
@@ -1540,6 +1541,8 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushF(c.rightEdge() * (c.localscl / oc.localscl))
 		case OC_roundstate:
 			sys.bcStack.PushI(sys.roundState())
+		case OC_introstate:
+			sys.bcStack.PushI(sys.introState())
 		case OC_screenheight:
 			sys.bcStack.PushF(c.screenHeight())
 		case OC_screenpos_x:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -152,7 +152,6 @@ const (
 	OC_powermax
 	OC_canrecover
 	OC_roundstate
-	OC_introstate
 	OC_ishelper
 	OC_numhelper
 	OC_numexplod
@@ -669,6 +668,7 @@ const (
 	OC_ex2_palfxvar_all_hue
 	OC_ex2_palfxvar_all_invertall
 	OC_ex2_palfxvar_all_invertblend
+	OC_ex2_introstate
 )
 const (
 	NumVar     = 60
@@ -1541,8 +1541,6 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushF(c.rightEdge() * (c.localscl / oc.localscl))
 		case OC_roundstate:
 			sys.bcStack.PushI(sys.roundState())
-		case OC_introstate:
-			sys.bcStack.PushI(sys.introState())
 		case OC_screenheight:
 			sys.bcStack.PushF(c.screenHeight())
 		case OC_screenpos_x:
@@ -2730,6 +2728,8 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(sys.palfxvar(-1, 2))
 	case OC_ex2_palfxvar_all_invertblend:
 		sys.bcStack.PushI(sys.palfxvar(-2, 2))
+	case OC_ex2_introstate:
+		sys.bcStack.PushI(sys.introState())
 	default:
 		sys.errLog.Printf("%v\n", be[*i-1])
 		c.panic()

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -301,6 +301,7 @@ var triggerMap = map[string]int{
 	"roundno":           1,
 	"roundsexisted":     1,
 	"roundstate":        1,
+	"introstate":        1,
 	"screenpos":         1,
 	"screenheight":      1,
 	"screenwidth":       1,
@@ -2243,6 +2244,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_ex_, OC_ex_roundsexisted)
 	case "roundstate":
 		out.append(OC_roundstate)
+	case "introstate":
+		out.append(OC_introstate)
 	case "screenheight":
 		out.append(OC_screenheight)
 	case "screenpos":

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2245,7 +2245,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 	case "roundstate":
 		out.append(OC_roundstate)
 	case "introstate":
-		out.append(OC_introstate)
+		out.append(OC_ex2_, OC_ex2_introstate)
 	case "screenheight":
 		out.append(OC_screenheight)
 	case "screenpos":

--- a/src/script.go
+++ b/src/script.go
@@ -3880,6 +3880,10 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.roundState()))
 		return 1
 	})
+	luaRegister(l, "introstate", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.introState()))
+		return 1
+	})
 	luaRegister(l, "screenheight", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.screenHeight()))
 		return 1

--- a/src/system.go
+++ b/src/system.go
@@ -736,6 +736,32 @@ func (s *System) roundState() int32 {
 		return 3
 	}
 }
+func (s *System) introState() int32 {
+	switch {
+	// Implements discussion #1172
+	case sys.intro > sys.lifebar.ro.ctrl_time+1:
+		// roundstate = 0
+		return 1
+	case sys.intro > sys.lifebar.ro.ctrl_time:
+		// characters are doing their intros
+		return 2 
+	case sys.lifebar.ro.cur == 1 && sys.intro > 0:
+		// fight!
+		return 4
+	case sys.lifebar.ro.cur == 0:
+		// dialogueFlg doesn't work here :(
+		for _, p := range sys.chars {
+			if len(p) > 0 && len(p[0].dialogue) > 0 {
+				return 2
+			}
+		}
+		// round <n>
+		return 3
+	default:
+		// players have gained ctrl, or not applicable
+		return 0
+	}
+}
 func (s *System) roundWinTime() bool {
 	return s.wintime < 0
 }


### PR DESCRIPTION
This PR implements the IntroState trigger from #1172. It allows more precise detection of round states during the intro phase.
Here's a description of the return values for this new trigger:
- `0`: not applicable, or players have gained ctrl after "fight!"
- `1`: same as `RoundState = 0`
- `2`: at least one character is in an intro state, or dialogue is active
- `3`: "round \<n\>" has been called
- `4`: "fight!" has been called