### PR TITLE
feat: Added loop points to Play/ModifySnd, fix ModifyBGM, added GameOption and BGMVar triggers.

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -669,6 +669,17 @@ const (
 	OC_ex2_palfxvar_all_invertall
 	OC_ex2_palfxvar_all_invertblend
 	OC_ex2_introstate
+	OC_ex2_bgmvar_filename
+	OC_ex2_bgmvar_loopend
+	OC_ex2_bgmvar_loopstart
+	OC_ex2_bgmvar_startposition
+	OC_ex2_bgmvar_volume
+	OC_ex2_gameoption_sound_panningrange
+	OC_ex2_gameoption_sound_wavchannels
+	OC_ex2_gameoption_sound_mastervolume
+	OC_ex2_gameoption_sound_wavvolume
+	OC_ex2_gameoption_sound_bgmvolume
+	OC_ex2_gameoption_sound_maxvolume
 )
 const (
 	NumVar     = 60
@@ -2730,6 +2741,39 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(sys.palfxvar(-2, 2))
 	case OC_ex2_introstate:
 		sys.bcStack.PushI(sys.introState())
+	case OC_ex2_bgmvar_loopstart:
+		if sys.bgm.volctrl != nil {
+			if sl, ok := sys.bgm.volctrl.Streamer.(*StreamLooper); ok {
+				sys.bcStack.PushI(int32(sl.loopstart))
+			}
+		}
+	case OC_ex2_bgmvar_loopend:
+		if sys.bgm.volctrl != nil {
+			if sl, ok := sys.bgm.volctrl.Streamer.(*StreamLooper); ok {
+				sys.bcStack.PushI(int32(sl.loopend))
+			}
+		}
+	case OC_ex2_bgmvar_startposition:
+		sys.bcStack.PushI(int32(sys.bgm.startPos))
+	case OC_ex2_bgmvar_volume:
+		sys.bcStack.PushI(int32(sys.bgm.bgmVolume))
+	case OC_ex2_bgmvar_filename:
+		sys.bcStack.PushB(sys.bgm.filename ==
+			sys.stringPool[sys.workingState.playerNo].List[*(*int32)(
+				unsafe.Pointer(&be[*i]))])
+		*i += 4
+	case OC_ex2_gameoption_sound_bgmvolume:
+		sys.bcStack.PushI(int32(sys.bgmVolume))
+	case OC_ex2_gameoption_sound_mastervolume:
+		sys.bcStack.PushI(int32(sys.masterVolume))
+	case OC_ex2_gameoption_sound_maxvolume:
+		sys.bcStack.PushI(int32(sys.maxBgmVolume))
+	case OC_ex2_gameoption_sound_panningrange:
+		sys.bcStack.PushI(int32(sys.panningRange))
+	case OC_ex2_gameoption_sound_wavchannels:
+		sys.bcStack.PushI(int32(sys.wavChannels))
+	case OC_ex2_gameoption_sound_wavvolume:
+		sys.bcStack.PushI(int32(sys.wavVolume))
 	default:
 		sys.errLog.Printf("%v\n", be[*i-1])
 		c.panic()
@@ -3226,6 +3270,9 @@ const (
 	playSnd_loop
 	playSnd_redirectid
 	playSnd_priority
+	playSnd_loopstart
+	playSnd_loopend
+	playSnd_startposition
 )
 
 func (sc playSnd) Run(c *Char, _ []int32) bool {
@@ -3235,6 +3282,7 @@ func (sc playSnd) Run(c *Char, _ []int32) bool {
 	crun := c
 	f, lw, lp := "", false, false
 	var g, n, ch, vo, pri int32 = -1, 0, -1, 100, 0
+	var loopstart, loopend, startposition = 0, 0, 0
 	var p, fr float32 = 0, 1
 	x := &c.pos[0]
 	ls := c.localscl
@@ -3266,6 +3314,12 @@ func (sc playSnd) Run(c *Char, _ []int32) bool {
 			lp = exp[0].evalB(c)
 		case playSnd_priority:
 			pri = exp[0].evalI(c)
+		case playSnd_loopstart:
+			loopstart = int(exp[0].evalI64(c))
+		case playSnd_loopend:
+			loopend = int(exp[0].evalI64(c))
+		case playSnd_startposition:
+			startposition = int(exp[0].evalI64(c))
 		case playSnd_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -3277,7 +3331,7 @@ func (sc playSnd) Run(c *Char, _ []int32) bool {
 		}
 		return true
 	})
-	crun.playSound(f, lw, lp, g, n, ch, vo, p, fr, ls, x, true, pri)
+	crun.playSound(f, lw, lp, g, n, ch, vo, p, fr, ls, x, true, pri, loopstart, loopend, startposition)
 	return false
 }
 
@@ -6659,7 +6713,7 @@ func (sc superPause) Run(c *Char, _ []int32) bool {
 			vo := int32(100)
 			ffx := string(*(*[]byte)(unsafe.Pointer(&exp[0])))
 			crun.playSound(ffx, false, false, exp[1].evalI(c), n, -1,
-				vo, 0, 1, 1, nil, false, 0)
+				vo, 0, 1, 1, nil, false, 0, 0, 0, 0)
 		case superPause_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -8849,13 +8903,13 @@ func (sc modifyBgm) Run(c *Char, _ []int32) bool {
 			volume = int(exp[0].evalI(c))
 			volumeSet = true
 		case modifyBgm_loopstart:
-			loopstart = int(exp[0].evalI(c))
+			loopstart = int(exp[0].evalI64(c))
 			loopStartSet = true
 		case modifyBgm_loopend:
-			loopend = int(exp[0].evalI(c))
+			loopend = int(exp[0].evalI64(c))
 			loopEndSet = true
 		case modifyBgm_position:
-			position = int(exp[0].evalI(c))
+			position = int(exp[0].evalI64(c))
 			posSet = true
 		case modifyBgm_freqmul:
 			freqmul = float32(exp[0].evalF(c))
@@ -8879,8 +8933,10 @@ func (sc modifyBgm) Run(c *Char, _ []int32) bool {
 		if posSet {
 			sys.bgm.Seek(position)
 		}
-		if (loopStartSet && sys.bgm.bgmLoopStart != loopstart) || (loopEndSet && sys.bgm.bgmLoopEnd != loopend) {
-			sys.bgm.SetLoopPoints(loopstart, loopend)
+		if sl, ok := sys.bgm.volctrl.Streamer.(*StreamLooper); ok {
+			if (loopStartSet && sl.loopstart != loopstart) || (loopEndSet && sl.loopend != loopend) {
+				sys.bgm.SetLoopPoints(loopstart, loopend)
+			}
 		}
 		if freqSet && sys.bgm.freqmul != freqmul {
 			sys.bgm.SetFreqMul(freqmul)
@@ -8900,6 +8956,9 @@ const (
 	modifySnd_freqmul
 	modifySnd_redirectid
 	modifySnd_priority
+	modifySnd_loopstart
+	modifySnd_loopend
+	modifySnd_position
 )
 
 func (sc modifySnd) Run(c *Char, _ []int32) bool {
@@ -8910,7 +8969,8 @@ func (sc modifySnd) Run(c *Char, _ []int32) bool {
 	snd := crun.soundChannels.Get(-1)
 	var ch, pri int32 = -1, 0
 	var vo, fr float32 = 100, 1.0
-	freqMulSet, volumeSet, prioritySet, panSet := false, false, false, false
+	freqMulSet, volumeSet, prioritySet, panSet, loopStartSet, loopEndSet, posSet := false, false, false, false, false, false, false
+	var loopstart, loopend, position int = 0, 0, 0
 	var p float32 = 0
 	x := &c.pos[0]
 	ls := crun.localscl
@@ -8938,6 +8998,15 @@ func (sc modifySnd) Run(c *Char, _ []int32) bool {
 		case modifySnd_priority:
 			pri = exp[0].evalI(c)
 			prioritySet = true
+		case modifySnd_loopstart:
+			loopstart = int(exp[0].evalI64(c))
+			loopStartSet = true
+		case modifySnd_loopend:
+			loopend = int(exp[0].evalI64(c))
+			loopEndSet = true
+		case modifySnd_position:
+			position = int(exp[0].evalI64(c))
+			posSet = true
 		case modifySnd_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -8985,6 +9054,14 @@ func (sc modifySnd) Run(c *Char, _ []int32) bool {
 			}
 			if pri != snd.sfx.priority {
 				snd.SetPriority(pri)
+			}
+			if posSet {
+				snd.streamer.Seek(position)
+			}
+			if sl, ok := snd.sfx.streamer.(*StreamLooper); ok {
+				if (loopStartSet && sl.loopstart != loopstart) || (loopEndSet && sl.loopend != loopend) {
+					snd.SetLoopPoints(loopstart, loopend)
+				}
 			}
 			if p != snd.sfx.p || ls != snd.sfx.ls || x != snd.sfx.x {
 				snd.SetPan(p*crun.facing, ls, x)

--- a/src/char.go
+++ b/src/char.go
@@ -3706,7 +3706,7 @@ func (c *Char) winType(wt WinType) bool {
 	return c.win() && sys.winTrigger[c.playerNo&1] == wt
 }
 func (c *Char) playSound(ffx string, lowpriority, loop bool, g, n, chNo, vol int32,
-	p, freqmul, ls float32, x *float32, log bool, priority int32) {
+	p, freqmul, ls float32, x *float32, log bool, priority int32, loopstart, loopend, startposition int) {
 	if g < 0 {
 		return
 	}
@@ -3746,7 +3746,7 @@ func (c *Char) playSound(ffx string, lowpriority, loop bool, g, n, chNo, vol int
 		crun = c.root()
 	}
 	if ch := crun.soundChannels.New(chNo, lowpriority, priority); ch != nil {
-		ch.Play(s, loop, freqmul)
+		ch.Play(s, loop, freqmul, loopstart, loopend, startposition)
 		vol = Clamp(vol, -25600, 25600)
 		//if c.gi().mugenver[0] == 1 {
 		if ffx != "" {
@@ -5663,7 +5663,7 @@ func (c *Char) appendLifebarAction(text string, snd, spr [2]int32, anim, time in
 		return
 	}
 	if snd[0] != -1 {
-		sys.lifebar.snd.play(snd, 100, 0)
+		sys.lifebar.snd.play(snd, 100, 0, 0, 0, 0)
 	}
 	index := 0
 	if !top {
@@ -6667,7 +6667,7 @@ func (c *Char) update() {
 		} else {
 			if c.koEchoTime == 60 || c.koEchoTime == 120 {
 				vo := int32(100 * (240 - (c.koEchoTime + 60)) / 240)
-				c.playSound("", false, false, 11, 0, -1, vo, 0, 1, c.localscl, &c.pos[0], false, 0)
+				c.playSound("", false, false, 11, 0, -1, vo, 0, 1, c.localscl, &c.pos[0], false, 0, 0, 0, 0)
 			}
 			c.koEchoTime++
 		}
@@ -6832,7 +6832,7 @@ func (c *Char) tick() {
 			// KO sound
 			if !sys.gsf(GSF_nokosnd) && c.alive() {
 				vo := int32(100)
-				c.playSound("", false, false, 11, 0, -1, vo, 0, 1, c.localscl, &c.pos[0], false, 0)
+				c.playSound("", false, false, 11, 0, -1, vo, 0, 1, c.localscl, &c.pos[0], false, 0, 0, 0, 0)
 				if c.gi().data.ko.echo != 0 {
 					c.koEchoTime = 1
 				}
@@ -7617,7 +7617,7 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 			if hd.hitsound[0] >= 0 {
 				vo := int32(100)
 				c.playSound(hd.hitsound_ffx, false, false, hd.hitsound[0], hd.hitsound[1],
-					hd.hitsound_channel, vo, 0, 1, getter.localscl, &getter.pos[0], true, 0)
+					hd.hitsound_channel, vo, 0, 1, getter.localscl, &getter.pos[0], true, 0, 0, 0, 0)
 			}
 			if hitType > 0 {
 				c.powerAdd(hd.hitgetpower)
@@ -7654,7 +7654,7 @@ func (cl *CharList) clsn(getter *Char, proj bool) {
 			if hd.guardsound[0] >= 0 {
 				vo := int32(100)
 				c.playSound(hd.guardsound_ffx, false, false, hd.guardsound[0], hd.guardsound[1],
-					hd.guardsound_channel, vo, 0, 1, getter.localscl, &getter.pos[0], true, 0)
+					hd.guardsound_channel, vo, 0, 1, getter.localscl, &getter.pos[0], true, 0, 0, 0, 0)
 			}
 			if hitType > 0 {
 				c.powerAdd(hd.guardgetpower)

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -258,6 +258,18 @@ func (c *Compiler) playSnd(is IniSection, sc *StateControllerBase, _ int8) (Stat
 			playSnd_priority, VT_Int, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "loopstart",
+			playSnd_loopstart, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "loopend",
+			playSnd_loopend, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "startposition",
+			playSnd_startposition, VT_Int, 1, false); err != nil {
+			return err
+		}
 		return nil
 	})
 	return *ret, err
@@ -4322,6 +4334,18 @@ func (c *Compiler) modifySnd(is IniSection, sc *StateControllerBase, _ int8) (St
 		}
 		if err := c.paramValue(is, sc, "priority",
 			modifySnd_priority, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "loopstart",
+			modifySnd_loopstart, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "loopend",
+			modifySnd_loopend, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "position",
+			modifySnd_position, VT_Int, 1, false); err != nil {
 			return err
 		}
 		return nil

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -210,7 +210,7 @@ func readLbBgTextSnd(pre string, is IniSection,
 }
 func (bts *LbBgTextSnd) step(snd *Snd) {
 	if bts.cnt == bts.sndtime {
-		snd.play(bts.snd, 100, 0)
+		snd.play(bts.snd, 100, 0, 0, 0, 0)
 	}
 	if bts.cnt >= bts.time {
 		bts.bg.Action()
@@ -580,7 +580,7 @@ func (pb *PowerBar) step(ref int, pbr *PowerBar, snd *Snd) {
 	}
 	if level > pbr.prevLevel {
 		i := Min(8, level-1)
-		snd.play(pb.level_snd[i], 100, 0)
+		snd.play(pb.level_snd[i], 100, 0, 0, 0, 0)
 	}
 	pbr.prevLevel = level
 	var fv1 int32
@@ -2111,11 +2111,11 @@ func (ro *LifeBarRound) act() bool {
 				}
 				if ro.swt[0] == 0 {
 					if !sys.consecutiveRounds && sys.roundType[0] == RT_Final && ro.round_final.snd[0] != -1 {
-						ro.snd.play(ro.round_final.snd, 100, 0)
+						ro.snd.play(ro.round_final.snd, 100, 0, 0, 0, 0)
 					} else if int(roundNum) <= len(ro.round) && ro.round[roundNum-1].snd[0] != -1 {
-						ro.snd.play(ro.round[roundNum-1].snd, 100, 0)
+						ro.snd.play(ro.round[roundNum-1].snd, 100, 0, 0, 0, 0)
 					} else {
-						ro.snd.play(ro.round_default.snd, 100, 0)
+						ro.snd.play(ro.round_default.snd, 100, 0, 0, 0, 0)
 					}
 				}
 				ro.swt[0]--
@@ -2165,7 +2165,7 @@ func (ro *LifeBarRound) act() bool {
 				ro.wt[1]--
 			} else if !ro.introState[1] {
 				if ro.swt[1] == 0 {
-					ro.snd.play(ro.fight.snd, 100, 0)
+					ro.snd.play(ro.fight.snd, 100, 0, 0, 0, 0)
 				}
 				ro.swt[1]--
 				if ro.wt[1] <= 0 {
@@ -2196,7 +2196,7 @@ func (ro *LifeBarRound) act() bool {
 			}
 			f := func(ats *AnimTextSnd, t int, delay int32) {
 				if ro.swt[t]+delay == 0 {
-					ro.snd.play(ats.snd, 100, 0)
+					ro.snd.play(ats.snd, 100, 0, 0, 0, 0)
 					ro.swt[t]--
 				}
 				ro.swt[t]--

--- a/src/script.go
+++ b/src/script.go
@@ -3531,14 +3531,6 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LBool(sys.matchOver()))
 		return 1
 	})
-	luaRegister(l, "maxbgmvolume", func(*lua.LState) int {
-		if sys.bgm.streamer == nil {
-			l.Push(lua.LNumber(0))
-		} else {
-			l.Push(lua.LNumber(int32(sys.maxBgmVolume)))
-		}
-		return 1
-	})
 	luaRegister(l, "movecontact", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.moveContact()))
 		return 1

--- a/src/script.go
+++ b/src/script.go
@@ -497,6 +497,7 @@ func systemScriptInit(l *lua.LState) {
 		}
 		f, lw, lp := false, false, false
 		var g, n, ch, vo, priority int32 = -1, 0, -1, 100, 0
+		var loopstart, loopend, startposition int = 0, 0, 0
 		var p, fr float32 = 0, 1
 		x := &sys.chars[pn-1][0].pos[0]
 		ls := sys.chars[pn-1][0].localscl
@@ -530,11 +531,20 @@ func systemScriptInit(l *lua.LState) {
 		if l.GetTop() >= 11 {
 			priority = int32(numArg(l, 11))
 		}
+		if l.GetTop() >= 12 {
+			loopstart = int(numArg(l, 12))
+		}
+		if l.GetTop() >= 13 {
+			loopend = int(numArg(l, 13))
+		}
+		if l.GetTop() >= 14 {
+			startposition = int(numArg(l, 14))
+		}
 		preffix := ""
 		if f {
 			preffix = "f"
 		}
-		sys.chars[pn-1][0].playSound(preffix, lw, lp, g, n, ch, vo, p, fr, ls, x, false, priority)
+		sys.chars[pn-1][0].playSound(preffix, lw, lp, g, n, ch, vo, p, fr, ls, x, false, priority, loopstart, loopend, startposition)
 		return 0
 	})
 	luaRegister(l, "charSndStop", func(l *lua.LState) int {
@@ -2373,7 +2383,17 @@ func systemScriptInit(l *lua.LState) {
 		if l.GetTop() >= 5 {
 			pan = float32(numArg(l, 5))
 		}
-		s.play([...]int32{int32(numArg(l, 2)), int32(numArg(l, 3))}, volumescale, pan)
+		var loopstart, loopend, startposition int
+		if l.GetTop() >= 6 {
+			loopstart = int(numArg(l, 6))
+		}
+		if l.GetTop() >= 7 {
+			loopend = int(numArg(l, 7))
+		}
+		if l.GetTop() >= 8 {
+			startposition = int(numArg(l, 8))
+		}
+		s.play([...]int32{int32(numArg(l, 2)), int32(numArg(l, 3))}, volumescale, pan, loopstart, loopend, startposition)
 		return 0
 	})
 	luaRegister(l, "sndPlaying", func(*lua.LState) int {
@@ -2656,7 +2676,7 @@ func systemScriptInit(l *lua.LState) {
 		if !ok {
 			userDataError(l, 1, s)
 		}
-		sys.soundChannels.Play(s, 100, 0.0)
+		sys.soundChannels.Play(s, 100, 0.0, 0, 0, 0)
 		return 0
 	})
 }
@@ -2848,6 +2868,43 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LNumber(0))
 		} else {
 			l.Push(lua.LNumber(int32(sys.bgm.streamer.Position())))
+		}
+		return 1
+	})
+	luaRegister(l, "bgmvar", func(*lua.LState) int {
+
+		arg := strings.ToLower(strArg(l, 1))
+
+		// If the streamer is nil, return nil for strings
+		if arg == "filename" {
+			if sys.bgm.streamer == nil {
+				l.Push(lua.LNil)
+			} else {
+				l.Push(lua.LString(sys.bgm.filename))
+			}
+			// Return a number
+		} else {
+			ln := lua.LNumber(0)
+
+			if sys.bgm.streamer != nil {
+				switch arg {
+				case "length":
+					ln = lua.LNumber(int32(sys.bgm.streamer.Len()))
+				case "loopend":
+					if sl, ok := sys.bgm.volctrl.Streamer.(*StreamLooper); ok {
+						ln = lua.LNumber(sl.loopend)
+					}
+				case "loopstart":
+					if sl, ok := sys.bgm.volctrl.Streamer.(*StreamLooper); ok {
+						ln = lua.LNumber(sl.loopstart)
+					}
+				case "position":
+					ln = lua.LNumber(int32(sys.bgm.streamer.Position()))
+				case "startposition":
+					ln = lua.LNumber(int32(sys.bgm.startPos))
+				}
+			}
+			l.Push(ln)
 		}
 		return 1
 	})
@@ -3167,6 +3224,28 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.debugWC.gameHeight()))
 		return 1
 	})
+	luaRegister(l, "gameoption", func(*lua.LState) int {
+		arg := strings.ToLower(strArg(l, 1))
+		ln := lua.LNumber(0)
+
+		switch arg {
+		case "sound.panningrange":
+			ln = lua.LNumber(int32(sys.bgm.streamer.Len()))
+		case "sound.wavchannels":
+			ln = lua.LNumber(sys.wavChannels)
+		case "sound.mastervolume":
+			ln = lua.LNumber(sys.masterVolume)
+		case "sound.wavvolume":
+			ln = lua.LNumber(int32(sys.wavVolume))
+		case "sound.bgmvolume":
+			ln = lua.LNumber(int32(sys.bgmVolume))
+		case "sound.maxvolume":
+			ln = lua.LNumber(int32(sys.maxBgmVolume))
+		}
+
+		l.Push(ln)
+		return 1
+	})
 	luaRegister(l, "gametime", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.gameTime + sys.preFightTime))
 		return 1
@@ -3450,6 +3529,14 @@ func triggerFunctions(l *lua.LState) {
 	})
 	luaRegister(l, "matchover", func(*lua.LState) int {
 		l.Push(lua.LBool(sys.matchOver()))
+		return 1
+	})
+	luaRegister(l, "maxbgmvolume", func(*lua.LState) int {
+		if sys.bgm.streamer == nil {
+			l.Push(lua.LNumber(0))
+		} else {
+			l.Push(lua.LNumber(int32(sys.maxBgmVolume)))
+		}
 		return 1
 	})
 	luaRegister(l, "movecontact", func(*lua.LState) int {

--- a/src/sound.go
+++ b/src/sound.go
@@ -84,25 +84,24 @@ func (n *NormalizerLR) process(mul float64, sam *float64) float64 {
 }
 
 // ------------------------------------------------------------------
-// Bgm Loop Streamer
+// Loop Streamer
 
 // Based on Loop() from Beep package. It adds support for loop points.
-
-type bgmLooper struct {
+type StreamLooper struct {
 	s         beep.StreamSeeker
 	loopcount int
 	loopstart int
 	loopend   int
 }
 
-func BgmLooper(s beep.StreamSeeker, loopcount, loopstart, loopend int) beep.Streamer {
+func newStreamLooper(s beep.StreamSeeker, loopcount, loopstart, loopend int) beep.Streamer {
 	if loopstart < 0 || loopstart >= s.Len() {
 		loopstart = 0
 	}
 	if loopend <= loopstart {
 		loopend = s.Len()
 	}
-	return &bgmLooper{
+	return &StreamLooper{
 		s:         s,
 		loopcount: loopcount,
 		loopstart: loopstart,
@@ -110,7 +109,7 @@ func BgmLooper(s beep.StreamSeeker, loopcount, loopstart, loopend int) beep.Stre
 	}
 }
 
-func (b *bgmLooper) Stream(samples [][2]float64) (n int, ok bool) {
+func (b *StreamLooper) Stream(samples [][2]float64) (n int, ok bool) {
 	if b.loopcount == 0 || b.s.Err() != nil {
 		return 0, false
 	}
@@ -135,25 +134,36 @@ func (b *bgmLooper) Stream(samples [][2]float64) (n int, ok bool) {
 	return n, true
 }
 
-func (b *bgmLooper) Err() error {
+func (b *StreamLooper) Err() error {
 	return b.s.Err()
+}
+
+func (b *StreamLooper) Len() int {
+	return b.s.Len()
+}
+
+func (b *StreamLooper) Position() int {
+	return b.s.Position()
+}
+
+func (b *StreamLooper) Seek(p int) error {
+	return b.s.Seek(p)
 }
 
 // ------------------------------------------------------------------
 // Bgm
 
 type Bgm struct {
-	filename     string
-	bgmVolume    int
-	bgmLoopStart int
-	bgmLoopEnd   int
-	loop         int
-	streamer     beep.StreamSeekCloser
-	ctrl         *beep.Ctrl
-	volctrl      *effects.Volume
-	format       string
-	freqmul      float32
-	sampleRate   beep.SampleRate
+	filename   string
+	bgmVolume  int
+	loop       int
+	streamer   beep.StreamSeekCloser
+	ctrl       *beep.Ctrl
+	volctrl    *effects.Volume
+	format     string
+	freqmul    float32
+	sampleRate beep.SampleRate
+	startPos   int
 }
 
 func newBgm() *Bgm {
@@ -164,8 +174,6 @@ func (bgm *Bgm) Open(filename string, loop, bgmVolume, bgmLoopStart, bgmLoopEnd,
 	bgm.filename = filename
 	bgm.loop = loop
 	bgm.bgmVolume = bgmVolume
-	bgm.bgmLoopStart = bgmLoopStart
-	bgm.bgmLoopEnd = bgmLoopEnd
 	bgm.freqmul = freqmul
 	// Starve the current music streamer
 	if bgm.ctrl != nil {
@@ -218,8 +226,8 @@ func (bgm *Bgm) Open(filename string, loop, bgmVolume, bgmLoopStart, bgmLoopEnd,
 	if loop > 0 {
 		loopCount = -1
 	}
-	//streamer := beep.Loop(loopCount, bgm.streamer)
-	streamer := BgmLooper(bgm.streamer, loopCount, bgm.bgmLoopStart, bgm.bgmLoopEnd)
+	bgm.startPos = startPosition
+	streamer := newStreamLooper(bgm.streamer, loopCount, bgmLoopStart, bgmLoopEnd)
 	bgm.volctrl = &effects.Volume{Streamer: streamer, Base: 2, Volume: 0, Silent: true}
 	bgm.sampleRate = format.SampleRate
 	dstFreq := beep.SampleRate(audioFrequency / bgm.freqmul)
@@ -286,21 +294,23 @@ func (bgm *Bgm) SetFreqMul(freqmul float32) {
 
 func (bgm *Bgm) SetLoopPoints(bgmLoopStart int, bgmLoopEnd int) {
 	// Set both at once, why not
-	if bgm.bgmLoopStart != bgmLoopStart && bgm.bgmLoopEnd != bgmLoopEnd {
-		speaker.Lock()
-		bgm.bgmLoopStart = bgmLoopStart
-		bgm.bgmLoopEnd = bgmLoopEnd
-		speaker.Unlock()
-		// Set one at a time
-	} else {
-		if bgm.bgmLoopStart != bgmLoopStart {
+	if sl, ok := bgm.volctrl.Streamer.(*StreamLooper); ok {
+		if sl.loopstart != bgmLoopStart && sl.loopend != bgmLoopEnd {
 			speaker.Lock()
-			bgm.bgmLoopStart = bgmLoopStart
+			sl.loopstart = bgmLoopStart
+			sl.loopend = bgmLoopEnd
 			speaker.Unlock()
-		} else if bgm.bgmLoopEnd != bgmLoopEnd {
-			speaker.Lock()
-			bgm.bgmLoopEnd = bgmLoopEnd
-			speaker.Unlock()
+			// Set one at a time
+		} else {
+			if sl.loopstart != bgmLoopStart {
+				speaker.Lock()
+				sl.loopstart = bgmLoopStart
+				speaker.Unlock()
+			} else if sl.loopend != bgmLoopEnd {
+				speaker.Lock()
+				sl.loopend = bgmLoopEnd
+				speaker.Unlock()
+			}
 		}
 	}
 }
@@ -454,9 +464,9 @@ func LoadSndFiltered(filename string, keepItem func([2]int32) bool, max uint32) 
 func (s *Snd) Get(gn [2]int32) *Sound {
 	return s.table[gn]
 }
-func (s *Snd) play(gn [2]int32, volumescale int32, pan float32) bool {
+func (s *Snd) play(gn [2]int32, volumescale int32, pan float32, loopstart, loopend, startposition int) bool {
 	sound := s.Get(gn)
-	return sys.soundChannels.Play(sound, volumescale, pan)
+	return sys.soundChannels.Play(sound, volumescale, pan, loopstart, loopend, startposition)
 }
 func (s *Snd) stop(gn [2]int32) {
 	sound := s.Get(gn)
@@ -528,7 +538,7 @@ type SoundChannel struct {
 	sound    *Sound
 }
 
-func (s *SoundChannel) Play(sound *Sound, loop bool, freqmul float32) {
+func (s *SoundChannel) Play(sound *Sound, loop bool, freqmul float32, loopStart int, loopEnd int, startPosition int) {
 	if sound == nil {
 		return
 	}
@@ -538,12 +548,13 @@ func (s *SoundChannel) Play(sound *Sound, loop bool, freqmul float32) {
 	if loop {
 		loopCount = -1
 	}
-	looper := beep.Loop(loopCount, s.streamer)
+	looper := newStreamLooper(s.streamer, loopCount, loopStart, loopEnd)
 	s.sfx = &SoundEffect{streamer: looper, volume: 256, priority: 0, channel: -1, loop: int32(loopCount), freqmul: freqmul}
 	srcRate := s.sound.format.SampleRate
 	dstRate := beep.SampleRate(audioFrequency / s.sfx.freqmul)
 	resampler := beep.Resample(audioResampleQuality, srcRate, dstRate, s.sfx)
 	s.ctrl = &beep.Ctrl{Streamer: resampler}
+	s.streamer.Seek(startPosition)
 	sys.soundMixer.Add(s.ctrl)
 }
 func (s *SoundChannel) IsPlaying() bool {
@@ -588,6 +599,28 @@ func (s *SoundChannel) SetFreqMul(freqmul float32) {
 				speaker.Lock()
 				resampler.SetRatio(float64(srcRate) / float64(dstRate))
 				s.sfx.freqmul = freqmul
+				speaker.Unlock()
+			}
+		}
+	}
+}
+func (s *SoundChannel) SetLoopPoints(loopstart, loopend int) {
+	// Set both at once, why not
+	if sl, ok := s.sfx.streamer.(*StreamLooper); ok {
+		if sl.loopstart != loopstart && sl.loopend != loopend {
+			speaker.Lock()
+			sl.loopstart = loopstart
+			sl.loopend = loopend
+			speaker.Unlock()
+			// Set one at a time
+		} else {
+			if sl.loopstart != loopstart {
+				speaker.Lock()
+				sl.loopstart = loopstart
+				speaker.Unlock()
+			} else if sl.loopend != loopend {
+				speaker.Lock()
+				sl.loopend = loopend
 				speaker.Unlock()
 			}
 		}
@@ -661,7 +694,7 @@ func (s *SoundChannels) Get(ch int32) *SoundChannel {
 	}
 	return nil
 }
-func (s *SoundChannels) Play(sound *Sound, volumescale int32, pan float32) bool {
+func (s *SoundChannels) Play(sound *Sound, volumescale int32, pan float32, loopStart, loopEnd, startPosition int) bool {
 	if sound == nil {
 		return false
 	}
@@ -669,7 +702,7 @@ func (s *SoundChannels) Play(sound *Sound, volumescale int32, pan float32) bool 
 	if c == nil {
 		return false
 	}
-	c.Play(sound, false, 1.0)
+	c.Play(sound, false, 1.0, loopStart, loopEnd, startPosition)
 	c.SetVolume(float32(volumescale * 64 / 25))
 	c.SetPan(pan, 0, nil)
 	return true


### PR DESCRIPTION
* Added loop points and start position to PlaySnd (`loopstart`, `loopend`, and `startposition`)
* ModifySnd now has `position`, `loopstart`, and `loopend` parameters.
* Fixed BGM loop points not setting properly for ModifyBGM.
* Added `GameOption` (sound vars only for now) and `BGMVar` as triggers.

Example:
```sh
if map(_intro_snd) = 2 {
	if !map(_intro_time) {
		map(_intro_time) := GameTime+120;
	}
	modifySnd { volumescale: (map(_intro_time)-GameTime)/1.2; channel: 6; }
	if gameTime >= map(_intro_time) {
		stopSnd{channel: 6;}
		map(_intro_snd) := 3;
	}
}

# ModifySnd with loop points
if map(_intro_snd) = 1 {
	modifySnd { loopstart: 13797; loopend: 17576; channel: 6; }
	map(_intro_snd) := 2;
}

# PlaySnd with startposition
if roundState = 1 && !map(_intro_snd) {
	playSnd { loop: 1; value: S1000,0; startposition: 13797; channel: 6; }
	map(_intro_snd) := 1;
}


# PlaySnd with loop points
if roundState > 3 && winKO && !map(_IFESys_applause) {
	playSnd { loop: 1; loopstart: 7421; loopend: 32768; value: S10000,0; }
	map(_IFESys_applause) := 1;
}
# BGMVolume example
else if roundState = 3 {
	# Fade out.
	modifyBgm { volume: cond(BGMVar(Volume)-2 <= 0, 0, BGMVar(Volume)-2); }
}

# MaxBGMVolume example
if roundState < 3 {
	if map(_IFESys_applause) {
		map(_IFESys_applause) := 0;
		modifyBgm { volume: GameOption(Sound.MaxVolume); position: BGMVar(StartPosition); }
	}
}
```