### PR TITLE
feat: sound StopOnGetHit and StopOnChangeState, lifebar over.hittime, plus fixes

### DIFF
--- a/src/common.go
+++ b/src/common.go
@@ -204,6 +204,18 @@ func Atof(str string) float64 {
 	}
 	return f
 }
+
+// Prevent overflow errors when converting float64 to int32
+func F64toI32(f float64) int32 {
+    if f >= float64(math.MaxInt32) {
+        return math.MaxInt32
+    }
+    if f <= float64(math.MinInt32) {
+        return math.MinInt32
+    }
+    return int32(f)
+}
+
 func readDigit(d string) (int32, bool) {
 	if len(d) == 0 || (len(d) >= 2 && d[0] == '0') {
 		return 0, false

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -274,6 +274,14 @@ func (c *Compiler) playSnd(is IniSection, sc *StateControllerBase, _ int8) (Stat
 			playSnd_loopcount, VT_Int, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "stopongethit",
+			playSnd_stopongethit, VT_Bool, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "stoponchangestate",
+			playSnd_stoponchangestate, VT_Bool, 1, false); err != nil {
+			return err
+		}
 		return nil
 	})
 	return *ret, err
@@ -4358,6 +4366,14 @@ func (c *Compiler) modifySnd(is IniSection, sc *StateControllerBase, _ int8) (St
 		}
 		if err := c.paramValue(is, sc, "loopcount",
 			modifySnd_loopcount, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "stopongethit",
+			modifySnd_stopongethit, VT_Bool, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "stoponchangestate",
+			modifySnd_stoponchangestate, VT_Bool, 1, false); err != nil {
 			return err
 		}
 		return nil

--- a/src/script.go
+++ b/src/script.go
@@ -495,7 +495,7 @@ func systemScriptInit(l *lua.LState) {
 		if pn < 1 || pn > len(sys.chars) || len(sys.chars[pn-1]) == 0 {
 			l.RaiseError("\nPlayer not found: %v\n", pn)
 		}
-		f, lw, lp := false, false, false
+		f, lw, lp, stopgh, stopcs := false, false, false, false, false
 		var g, n, ch, vo, priority int32 = -1, 0, -1, 100, 0
 		var loopstart, loopend, startposition, lc int = 0, 0, 0, 0
 		var p, fr float32 = 0, 1
@@ -543,6 +543,12 @@ func systemScriptInit(l *lua.LState) {
 		if l.GetTop() >= 15 {
 			lc = int(numArg(l, 15))
 		}
+		if l.GetTop() >= 15 { // StopOnGetHit
+			stopgh = boolArg(l, 16)
+		}
+		if l.GetTop() >= 16 { // StopOnChangeState
+			stopcs = boolArg(l, 17)
+		}
 		preffix := ""
 		if f {
 			preffix = "f"
@@ -551,14 +557,14 @@ func systemScriptInit(l *lua.LState) {
 		// If the loopcount is 0, then read the loop parameter
 		if lc == 0 {
 			if lp {
-				sys.chars[pn-1][0].playSound(preffix, lw, -1, g, n, ch, vo, p, fr, ls, x, false, priority, loopstart, loopend, startposition)
+				sys.chars[pn-1][0].playSound(preffix, lw, -1, g, n, ch, vo, p, fr, ls, x, false, priority, loopstart, loopend, startposition, stopgh, stopcs)
 			} else {
-				sys.chars[pn-1][0].playSound(preffix, lw, 0, g, n, ch, vo, p, fr, ls, x, false, priority, loopstart, loopend, startposition)
+				sys.chars[pn-1][0].playSound(preffix, lw, 0, g, n, ch, vo, p, fr, ls, x, false, priority, loopstart, loopend, startposition, stopgh, stopcs)
 			}
 
 			// Otherwise, read the loopcount parameter directly
 		} else {
-			sys.chars[pn-1][0].playSound(preffix, lw, lc, g, n, ch, vo, p, fr, ls, x, false, priority, loopstart, loopend, startposition)
+			sys.chars[pn-1][0].playSound(preffix, lw, lc, g, n, ch, vo, p, fr, ls, x, false, priority, loopstart, loopend, startposition, stopgh, stopcs)
 		}
 		return 0
 	})

--- a/src/sound.go
+++ b/src/sound.go
@@ -536,6 +536,8 @@ type SoundChannel struct {
 	sfx      *SoundEffect
 	ctrl     *beep.Ctrl
 	sound    *Sound
+	stopOnGetHit      bool
+	stopOnChangeState bool
 }
 
 func (s *SoundChannel) Play(sound *Sound, loop int, freqmul float32, loopStart, loopEnd, startPosition int) {

--- a/src/system.go
+++ b/src/system.go
@@ -248,6 +248,7 @@ type System struct {
 	drawc2hb                ClsnRect
 	drawc2mtk               ClsnRect
 	drawc2grd               ClsnRect
+	drawc2stb               ClsnRect
 	drawwh                  ClsnRect
 	drawch                  ClsnRect
 	autoguard               [MaxSimul*2 + MaxAttachedChar]bool
@@ -1145,6 +1146,7 @@ func (s *System) action() {
 	s.drawc2hb = s.drawc2hb[:0]
 	s.drawc2mtk = s.drawc2mtk[:0]
 	s.drawc2grd = s.drawc2grd[:0]
+	s.drawc2stb = s.drawc2stb[:0]
 	s.drawwh = s.drawwh[:0]
 	s.drawch = s.drawch[:0]
 	s.clsnText = nil
@@ -1733,6 +1735,8 @@ func (s *System) drawTop() {
 		s.drawc2mtk.draw(0x3feff)
 		s.clsnSpr.Pal[0] = 0xffc00040
 		s.drawc2grd.draw(0x3feff)
+		s.clsnSpr.Pal[0] = 0xff404040
+		s.drawc2stb.draw(0x3feff)
 		s.clsnSpr.Pal[0] = 0xff303030
 		s.drawwh.draw(0x3feff)
 		s.clsnSpr.Pal[0] = 0xffffffff


### PR DESCRIPTION
- New parameters for PlaySnd and ModifySnd:
    - StopOnGetHit will make the sound be interrupted if the char gets hit. Defaults to 1 if channel is 0
    - StopOnChangeState will stop the sound when the char changes states
- Adjusted damage, dizzy, power and such calculations to prevent most overflow errors
- Implemented missing lifebar over.hittime behavior. On round end, characters can still damage each other while that timer is active
- If a Mugen character attacks a char with 0 life and kill = 0, the attack will actually heal 1 point
- Standby chars will have their collision boxes greyed out during debug
- Fixes #971
- Fixes #1200
- Fixes #1829