### PR TITLE
fix: Fixes #1849 crash with short looping sounds.

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3284,8 +3284,8 @@ func (sc playSnd) Run(c *Char, _ []int32) bool {
 	}
 	crun := c
 	f, lw, lp, stopgh, stopcs := "", false, false, false, false
-	var g, n, ch, vo, pri int32 = -1, 0, -1, 100, 0
-	var loopstart, loopend, startposition, lc = 0, 0, 0, 0
+	var g, n, ch, vo, pri, lc int32 = -1, 0, -1, 100, 0, 0
+	var loopstart, loopend, startposition = 0, 0, 0
 	var p, fr float32 = 0, 1
 	x := &c.pos[0]
 	ls := c.localscl
@@ -3327,7 +3327,7 @@ func (sc playSnd) Run(c *Char, _ []int32) bool {
 		case playSnd_startposition:
 			startposition = int(exp[0].evalI64(c))
 		case playSnd_loopcount:
-			lc = int(exp[0].evalI(c))
+			lc = exp[0].evalI(c)
 		case playSnd_stopongethit:
 			stopgh = exp[0].evalB(c)
 		case playSnd_stoponchangestate:

--- a/src/char.go
+++ b/src/char.go
@@ -3705,7 +3705,7 @@ func (c *Char) winPerfect() bool {
 func (c *Char) winType(wt WinType) bool {
 	return c.win() && sys.winTrigger[c.playerNo&1] == wt
 }
-func (c *Char) playSound(ffx string, lowpriority bool, loopCount int, g, n, chNo, vol int32,
+func (c *Char) playSound(ffx string, lowpriority bool, loopCount int32, g, n, chNo, vol int32,
 	p, freqmul, ls float32, x *float32, log bool, priority int32, loopstart, loopend, startposition int, stopgh, stopcs bool) {
 	if g < 0 {
 		return

--- a/src/script.go
+++ b/src/script.go
@@ -496,8 +496,8 @@ func systemScriptInit(l *lua.LState) {
 			l.RaiseError("\nPlayer not found: %v\n", pn)
 		}
 		f, lw, lp, stopgh, stopcs := false, false, false, false, false
-		var g, n, ch, vo, priority int32 = -1, 0, -1, 100, 0
-		var loopstart, loopend, startposition, lc int = 0, 0, 0, 0
+		var g, n, ch, vo, priority, lc int32 = -1, 0, -1, 100, 0, 0
+		var loopstart, loopend, startposition int = 0, 0, 0
 		var p, fr float32 = 0, 1
 		x := &sys.chars[pn-1][0].pos[0]
 		ls := sys.chars[pn-1][0].localscl
@@ -541,7 +541,7 @@ func systemScriptInit(l *lua.LState) {
 			startposition = int(numArg(l, 14))
 		}
 		if l.GetTop() >= 15 {
-			lc = int(numArg(l, 15))
+			lc = int32(numArg(l, 15))
 		}
 		if l.GetTop() >= 15 { // StopOnGetHit
 			stopgh = boolArg(l, 16)

--- a/src/sound.go
+++ b/src/sound.go
@@ -115,7 +115,7 @@ func (b *StreamLooper) Stream(samples [][2]float64) (n int, ok bool) {
 	}
 	for len(samples) > 0 {
 		sn, sok := b.s.Stream(samples)
-		if !sok || b.s.Position() >= b.loopend {
+		if !sok || (b.s.Position() >= b.loopend && b.loopend < b.s.Len()) {
 			if b.loopcount > 0 {
 				b.loopcount--
 			}
@@ -540,7 +540,7 @@ type SoundChannel struct {
 	stopOnChangeState bool
 }
 
-func (s *SoundChannel) Play(sound *Sound, loop int, freqmul float32, loopStart, loopEnd, startPosition int) {
+func (s *SoundChannel) Play(sound *Sound, loop int32, freqmul float32, loopStart, loopEnd, startPosition int) {
 	if sound == nil {
 		return
 	}
@@ -550,7 +550,7 @@ func (s *SoundChannel) Play(sound *Sound, loop int, freqmul float32, loopStart, 
 	if loop < 0 {
 		loopCount = -1
 	} else {
-		loopCount = int(Max(int32(loop), 1))
+		loopCount = int(Max(loop, 1))
 	}
 	looper := newStreamLooper(s.streamer, loopCount, loopStart, loopEnd)
 	s.sfx = &SoundEffect{streamer: looper, volume: 256, priority: 0, channel: -1, loop: int32(loopCount), freqmul: freqmul}


### PR DESCRIPTION
Fixes #1849 crash with short looping sounds in playSnd due to new looper.

Refactor also clarifies the loopcount datatype.