### PR TITLE
fix: Force `bgmfreqmul` to 1 when not specified

### DIFF
--- a/src/stage.go
+++ b/src/stage.go
@@ -956,6 +956,7 @@ func loadStage(def string, main bool) (*Stage, error) {
 			sec[0].ReadI32("tensionhigh", &s.stageCamera.tensionhigh)
 		}
 	}
+    s.bgmfreqmul = 1 // fallback value to allow music to play on legacy stages without a bgmfreqmul parameter
 	if sec := defmap["music"]; len(sec) > 0 {
 		s.bgmusic = sec[0]["bgmusic"]
 		sec[0].ReadI32("bgmvolume", &s.bgmvolume)


### PR DESCRIPTION
Fixes a regression where stages launched via command line (`./Ikemen_GO kfm kfm -s stage0`) were unable to play music if they had no `bgmfreqmul` parameter in their DEF file. Since that's nearly every single stage out there right now, I figured this was worth a quick one-liner.