### PR TITLE
feat: Resizable window, scale game to fit window

### DIFF
--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -421,6 +421,8 @@ func (r *Renderer) EndFrame() {
 		gl.BlitFramebuffer(0, 0, sys.scrrect[2], sys.scrrect[3], 0, 0, sys.scrrect[2], sys.scrrect[3], gl.COLOR_BUFFER_BIT, gl.LINEAR)
 	}
 
+	x, y, resizedWidth, resizedHeight := sys.window.GetScaledViewportSize()
+	gl.Viewport(x, y, resizedWidth, resizedHeight)
 	gl.BindFramebuffer(gl.FRAMEBUFFER, 0)
 
 	postShader := r.postShaderSelect[sys.postProcessingShader]

--- a/src/system_glfw.go
+++ b/src/system_glfw.go
@@ -35,7 +35,7 @@ func (s *System) newWindow(w, h int) (*Window, error) {
 	_, forceWindowed := sys.cmdFlags["-windowed"]
 	fullscreen := s.fullscreen && !forceWindowed
 
-	glfw.WindowHint(glfw.Resizable, glfw.False)
+	glfw.WindowHint(glfw.Resizable, glfw.True)
 	glfw.WindowHint(glfw.ContextVersionMajor, 2)
 	glfw.WindowHint(glfw.ContextVersionMinor, 1)
 
@@ -100,6 +100,32 @@ func (w *Window) SetSwapInterval(interval int) {
 
 func (w *Window) GetSize() (int, int) {
 	return w.Window.GetSize()
+}
+
+func (w *Window) GetScaledViewportSize() (int32, int32, int32, int32) {
+	// calculates a position and size for the viewport to fill the window while centered (see render_gl.go)
+	// returns x, y, width, height respectively
+	winWidth, winHeight := w.GetSize()
+	ratioWidth := float32(winWidth) / float32(sys.gameWidth)
+	ratioHeight := float32(winHeight) / float32(sys.gameHeight)
+	var ratio float32
+	var x, y int32 = 0, 0
+
+	if ratioWidth < ratioHeight {
+	    ratio = ratioWidth
+	} else {
+	    ratio = ratioHeight
+	}
+
+	resizedWidth := int32(float32(sys.gameWidth)*ratio)
+	resizedHeight := int32(float32(sys.gameHeight)*ratio)
+
+	// calculate an X offset for the resized width to center it to the window
+	if (resizedWidth < int32(winWidth)) {
+	    x = (int32(winWidth) - resizedWidth) / 2
+	}
+
+	return x, y, resizedWidth, resizedHeight
 }
 
 func (w *Window) GetClipboardString() string {


### PR DESCRIPTION
https://github.com/ikemen-engine/Ikemen-GO/assets/22881403/40b5c982-a8e3-41ab-9de2-8dd14d898375

This change re-enables the ability to resize the game window and allows Ikemen GO to scale the game's viewport to fit the window by using a new function, GetScaledViewportSize().

`GetScaledViewportSize()` is a basic algorithim that just scales the GameWidth/GameHeight to the size of the window while maintaing aspect ratio, and then applies this to the viewport with a `gl.Viewport` command. Sadly the result doesn't apply any filter when scaling, so you get nearest-neighbor scaled pixels, but it's at least better than no resizing the window at all IMO.

Window size is not saved, and GameWidth/GameHeight still determine the starting size of the game's resolution and window size.

I hope to give this more flexibility in the future, such as allowing the end-user to toggle the aspect ratio correction and maybe integer scaling as well.