### PR TITLE
feat: KeepAspect (MUGEN 1.1 feature), Y-centering to window scaling

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -220,6 +220,7 @@ type configSettings struct {
 	InputButtonAssist          bool
 	InputSOCDResolution        int32
 	IP                         map[string]string
+	KeepAspect                 bool
 	LifeMul                    float32
 	ListenPort                 string
 	LoseSimul                  bool
@@ -369,6 +370,7 @@ func setupConfig() configSettings {
 	sys.gameWidth = tmp.GameWidth
 	sys.gameHeight = tmp.GameHeight
 	sys.gameSpeed = tmp.GameFramerate / float32(tmp.Framerate)
+	sys.keepAspect = tmp.KeepAspect
 	sys.helperMax = tmp.MaxHelper
 	sys.inputButtonAssist = tmp.InputButtonAssist
 	sys.inputSOCDresolution = Clamp(tmp.InputSOCDResolution, 0, 4)

--- a/src/resources/defaultConfig.json
+++ b/src/resources/defaultConfig.json
@@ -58,6 +58,7 @@
   "InputButtonAssist": true,
   "InputSOCDResolution": 2,
   "IP": {},
+  "KeepAspect": true,
   "LifeMul": 100,
   "ListenPort": "7500",
   "LoseSimul": true,

--- a/src/system.go
+++ b/src/system.go
@@ -38,6 +38,7 @@ var sys = System{
 	scrrect:           [...]int32{0, 0, 320, 240},
 	gameWidth:         320,
 	gameHeight:        240,
+	keepAspect:        true,
 	widthScale:        1,
 	heightScale:       1,
 	brightness:        256,
@@ -106,6 +107,7 @@ type System struct {
 	scrrect                 [4]int32
 	gameWidth, gameHeight   int32
 	widthScale, heightScale float32
+	keepAspect              bool
 	window                  *Window
 	gameEnd, frameSkip      bool
 	redrawWait              struct{ nextTime, lastDraw time.Time }

--- a/src/system_glfw.go
+++ b/src/system_glfw.go
@@ -109,7 +109,7 @@ func (w *Window) GetScaledViewportSize() (int32, int32, int32, int32) {
 	ratioWidth := float32(winWidth) / float32(sys.gameWidth)
 	ratioHeight := float32(winHeight) / float32(sys.gameHeight)
 	var ratio float32
-	var x, y int32 = 0, 0
+	var x, y, resizedWidth, resizedHeight int32 = 0, 0, int32(winWidth), int32(winHeight)
 
 	if ratioWidth < ratioHeight {
 		ratio = ratioWidth
@@ -117,12 +117,17 @@ func (w *Window) GetScaledViewportSize() (int32, int32, int32, int32) {
 		ratio = ratioHeight
 	}
 
-	resizedWidth := int32(float32(sys.gameWidth) * ratio)
-	resizedHeight := int32(float32(sys.gameHeight) * ratio)
+	if (sys.keepAspect) {
+		resizedWidth = int32(float32(sys.gameWidth)*ratio)
+		resizedHeight = int32(float32(sys.gameHeight)*ratio)
 
-	// calculate an X offset for the resized width to center it to the window
-	if resizedWidth < int32(winWidth) {
-		x = (int32(winWidth) - resizedWidth) / 2
+		// calculate offsets for the resized width to center it to the window
+		if (resizedWidth < int32(winWidth)) {
+			x = (int32(winWidth) - resizedWidth) / 2
+		}
+		if (resizedHeight < int32(winHeight)) {
+			y = (int32(winHeight) - resizedHeight) / 2
+		}
 	}
 
 	return x, y, resizedWidth, resizedHeight


### PR DESCRIPTION
https://github.com/ikemen-engine/Ikemen-GO/assets/22881403/fee3d533-aec7-42fb-9f36-127873ed1a36

[As per K4thos's request](https://github.com/ikemen-engine/Ikemen-GO/pull/1868#issuecomment-2205063570), this adds the `KeepAspect` setting from MUGEN 1.1. Defaults to "true", and when set to "false" it stretches the game to fill the entire window, whatever size it may be.

Quite a few people also considered the lack of Y centering when resizing the window to be a bug, so I've fixed that in this PR as well.