### PR TITLE
feat: GroundLevelOffset sctrl and GroundLevel trigger, fixes

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -680,6 +680,7 @@ const (
 	OC_ex2_gameoption_sound_wavvolume
 	OC_ex2_gameoption_sound_bgmvolume
 	OC_ex2_gameoption_sound_maxvolume
+	OC_ex2_groundlevel
 )
 const (
 	NumVar     = 60
@@ -1529,7 +1530,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 					bindVely = c.vel[1]
 				}
 			}
-			sys.bcStack.PushF((c.pos[1] + bindVely - c.platformPosY) * (c.localscl / oc.localscl))
+			sys.bcStack.PushF((c.pos[1] + bindVely - c.groundLevel - c.platformPosY) * (c.localscl / oc.localscl))
 		case OC_power:
 			sys.bcStack.PushI(c.getPower())
 		case OC_powermax:
@@ -2774,6 +2775,8 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(int32(sys.wavChannels))
 	case OC_ex2_gameoption_sound_wavvolume:
 		sys.bcStack.PushI(int32(sys.wavVolume))
+	case OC_ex2_groundlevel:
+		sys.bcStack.PushF(c.groundLevel)
 	default:
 		sys.errLog.Printf("%v\n", be[*i-1])
 		c.panic()
@@ -3926,7 +3929,7 @@ func (sc posSet) Run(c *Char, _ []int32) bool {
 				crun.bindPosAdd[0] = x
 			}
 		case posSet_y:
-			y := exp[0].evalF(c)*lclscround + crun.platformPosY
+			y := exp[0].evalF(c)*lclscround + crun.groundLevel + crun.platformPosY
 			crun.setY(y)
 			if crun.bindToId > 0 && !math.IsNaN(float64(crun.bindPos[1])) && sys.playerID(crun.bindToId) != nil {
 				crun.bindPosAdd[1] = y
@@ -9907,6 +9910,33 @@ func (sc getHitVarSet) Run(c *Char, _ []int32) bool {
 		case getHitVarSet_yvel:
 			crun.ghv.yvel = exp[0].evalF(c) * lclscround
 		case getHitVarSet_redirectid:
+			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
+				crun = rid
+				lclscround = c.localscl / crun.localscl
+			} else {
+				return false
+			}
+		}
+		return true
+	})
+	return false
+}
+
+type groundLevelOffset StateControllerBase
+
+const (
+	groundLevelOffset_value byte = iota
+	groundLevelOffset_redirectid
+)
+
+func (sc groundLevelOffset) Run(c *Char, _ []int32) bool {
+	crun := c
+	var lclscround float32 = 1.0
+	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
+		switch id {
+		case groundLevelOffset_value:
+			crun.groundLevel = exp[0].evalF(c) * lclscround
+		case groundLevelOffset_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
 				lclscround = c.localscl / crun.localscl

--- a/src/char.go
+++ b/src/char.go
@@ -2040,6 +2040,7 @@ type Char struct {
 	pauseBool       bool
 	downHitOffset   float32
 	koEchoTime      int32
+	groundLevel     float32
 }
 
 func newChar(n int, idx int32) (c *Char) {
@@ -6432,10 +6433,11 @@ func (c *Char) actionRun() {
 			// Land from aerial physics
 			// This was a loop before like Mugen, so setting state 52 to physics A caused a crash
 			if c.ss.physics == ST_A {
-				if c.vel[1] > 0 && (c.pos[1]-c.platformPosY) >= 0 && c.ss.no != 105 {
+				if c.vel[1] > 0 && (c.pos[1]-c.groundLevel-c.platformPosY) >= 0 && c.ss.no != 105 {
 					c.changeState(52, -1, -1, "")
 				}
 			}
+			c.groundLevel = 0 // Only after position is updated
 			c.setFacing(c.p1facing)
 			c.p1facing = 0
 			c.ss.time++

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -172,6 +172,7 @@ func newCompiler() *Compiler {
 		"gethitvarset":         c.getHitVarSet,
 		"modifysnd":            c.modifySnd,
 		"modifybgm":            c.modifyBgm,
+		"groundleveloffset":    c.groundLevelOffset,
 	}
 	return c
 }
@@ -1983,6 +1984,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		if err := c.checkClosingBracket(); err != nil {
 			return bvNone(), err
 		}
+	case "groundlevel":
+		out.append(OC_ex2_, OC_ex2_groundlevel)
 	case "guardcount":
 		out.append(OC_ex_, OC_ex_guardcount)
 	case "helperindexexist":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -5168,6 +5168,21 @@ func (c *Compiler) getHitVarSet(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
+func (c *Compiler) groundLevelOffset(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+	ret, err := (*groundLevelOffset)(sc), c.stateSec(is, func() error {
+		if err := c.paramValue(is, sc, "redirectid",
+			groundLevelOffset_redirectid, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "value",
+			groundLevelOffset_value, VT_Float, 1, false); err != nil {
+			return err
+		}
+		return nil
+	})
+	return *ret, err
+}
+
 // It's just a Null... Has no effect whatsoever.
 func (c *Compiler) null(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	return nullStateController, nil

--- a/src/script.go
+++ b/src/script.go
@@ -3417,6 +3417,10 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(ln)
 		return 1
 	})
+	luaRegister(l, "groundlevel", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.groundLevel))
+		return 1
+	})
 	luaRegister(l, "guardcount", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.guardCount))
 		return 1

--- a/src/system.go
+++ b/src/system.go
@@ -819,19 +819,19 @@ func (s *System) clsnOverlap(clsn1 []float32, scl1, pos1 [2]float32, facing1 flo
 		scl2[0] *= -1
 	}
 	for i1 := 0; i1+3 < len(clsn1); i1 += 4 {
-		l1, r1 := clsn1[i1], clsn1[i1+2]+1
+		l1, r1 := clsn1[i1], clsn1[i1+2]
 		if facing1 < 0 {
 			l1, r1 = -r1, -l1
 		}
 		for i2 := 0; i2+3 < len(clsn2); i2 += 4 {
-			l2, r2 := clsn2[i2], clsn2[i2+2]+1
+			l2, r2 := clsn2[i2], clsn2[i2+2]
 			if facing2 < 0 {
 				l2, r2 = -r2, -l2
 			}
-			if l1*scl1[0]+pos1[0] < r2*scl2[0]+pos2[0] &&
-				l2*scl2[0]+pos2[0] < r1*scl1[0]+pos1[0] &&
-				clsn1[i1+1]*scl1[1]+pos1[1] < (clsn2[i2+3]+1)*scl2[1]+pos2[1] &&
-				clsn2[i2+1]*scl2[1]+pos2[1] < (clsn1[i1+3]+1)*scl1[1]+pos1[1] {
+			if l1*scl1[0]+pos1[0] <= r2*scl2[0]+pos2[0] && // Left Clsn1 <= Right Clsn2
+				l2*scl2[0]+pos2[0] <= r1*scl1[0]+pos1[0] && // Left Clsn2 <= Right Clsn1
+				clsn1[i1+1]*scl1[1]+pos1[1] <= (clsn2[i2+3])*scl2[1]+pos2[1] && // Top Clsn1 <= Bottom Clsn2
+				clsn2[i2+1]*scl2[1]+pos2[1] <= (clsn1[i1+3])*scl1[1]+pos1[1] { // Top Clsn2 <= Bottom Clsn1
 				return true
 			}
 		}


### PR DESCRIPTION
- GroundLevelOffset changes the char's Y position reference point
- GroundLevel returns the current value that is set
- Fixed hit detection "off by 1" errors
- Fixes #1383
- Fixes #1384