### PR TITLE
feat: TargetAdd state controller, fixes

### DIFF
--- a/data/common1.cns.zss
+++ b/data/common1.cns.zss
@@ -251,7 +251,7 @@ if animTime = -8 {
 }
 
 #-------------------------------------------------------------------------------
-[Function HiToLoAndLoToHi()]
+[Function IkSys_HiToLoAndLoToHi()]
 if command = "holddown" {
 	if stateType = S {
 		stateTypeSet{statetype: C; physics: C}
@@ -261,7 +261,7 @@ if command = "holddown" {
 }
 
 #-------------------------------------------------------------------------------
-[Function StopGuarding()]
+[Function IkSys_StopGuarding()]
 if command != "holdback" || !inGuardDist {
 	changeState{value: 140}
 }
@@ -270,7 +270,7 @@ if command != "holdback" || !inGuardDist {
 # GUARD (start)
 [StateDef 120; type: U; physics: U;]
 
-call HiToLoAndLoToHi();
+call IkSys_HiToLoAndLoToHi();
 if time = 0 {
 	changeAnim{value: 120 + (stateType = C) + (stateType = A) * 2}
 	if stateType = S {
@@ -284,7 +284,7 @@ if time = 0 {
 if animTime = 0 {
 	changeState{value: 130 + (stateType = C) + (stateType = A) * 2}
 }
-call StopGuarding();
+call IkSys_StopGuarding();
 
 #-------------------------------------------------------------------------------
 # Stand guard (guarding)
@@ -296,7 +296,7 @@ if anim != 130 {
 if command = "holddown" {
 	changeState{value: 131}
 }
-call StopGuarding();
+call IkSys_StopGuarding();
 
 #-------------------------------------------------------------------------------
 # Crouch guard (guarding)
@@ -308,10 +308,10 @@ if anim != 131 {
 if command != "holddown" {
 	changeState{value: 130}
 }
-call StopGuarding();
+call IkSys_StopGuarding();
 
 #-------------------------------------------------------------------------------
-[Function AirGuardLand()]
+[Function IkSys_AirGuardLand()]
 velAdd{y: const(movement.yAccel)}
 if sysVar(0) := (pos y >= 0 && vel y > 0) {
 	velSet{y: 0}
@@ -326,14 +326,14 @@ if sysVar(0) := (pos y >= 0 && vel y > 0) {
 if anim != 132 {
 	changeAnim{value: 132}
 }
-call AirGuardLand();
-call StopGuarding();
+call IkSys_AirGuardLand();
+call IkSys_StopGuarding();
 
 #-------------------------------------------------------------------------------
 # Guard (end)
 [StateDef 140; type: U; physics: U; ctrl: 1;]
 
-call HiToLoAndLoToHi();
+call IkSys_HiToLoAndLoToHi();
 if time = 0 {
 	changeAnim{value: 140 + (stateType = C) + (stateType = A) * 2}
 	if stateType = S {
@@ -346,15 +346,15 @@ if time = 0 {
 }
 
 #-------------------------------------------------------------------------------
-[Function GuardShaking(anim)]
+[Function IkSys_GuardShaking(anim)]
 changeAnim{value: $anim}
 if hitShakeOver {
 	changeState{value: 151 + 2 * (command = "holddown")}
 }
-call HiToLoAndLoToHi();
+call IkSys_HiToLoAndLoToHi();
 
 #-------------------------------------------------------------------------------
-[Function GuardKnockedBack(nextState)]
+[Function IkSys_GuardKnockedBack(nextState)]
 if time = 0 {
 	hitVelSet{x: 1}
 }
@@ -364,7 +364,7 @@ if time = getHitVar(slideTime) || hitOver {
 if time = getHitVar(ctrlTime) {
 	ctrlSet{value: 1}
 }
-call HiToLoAndLoToHi();
+call IkSys_HiToLoAndLoToHi();
 if hitOver {
 	changeState{value: $nextState; ctrl: 1}
 }
@@ -373,7 +373,7 @@ if hitOver {
 # Stand guard hit (shaking)
 [StateDef 150; type: S; movetype: H; physics: N; velset: 0, 0;]
 
-call GuardShaking(150);
+call IkSys_GuardShaking(150);
 if time = 0 {
 	forceFeedback{waveform: square; time: 3}
 }
@@ -382,13 +382,13 @@ if time = 0 {
 # Stand guard hit (knocked back)
 [StateDef 151; type: S; movetype: H; physics: S; anim: 150;]
 
-call GuardKnockedBack(130);
+call IkSys_GuardKnockedBack(130);
 
 #-------------------------------------------------------------------------------
 # Crouch guard hit (shaking)
 [StateDef 152; type: C; movetype: H; physics: N; velset: 0, 0;]
 
-call GuardShaking(151);
+call IkSys_GuardShaking(151);
 if time = 0 {
 	forceFeedback{waveform: square; time: 4}
 }
@@ -397,7 +397,7 @@ if time = 0 {
 # Crouch guard hit (knocked back)
 [StateDef 153; type: C; movetype: H; physics: C; anim: 151;]
 
-call GuardKnockedBack(131);
+call IkSys_GuardKnockedBack(131);
 
 #-------------------------------------------------------------------------------
 # Air guard hit (shaking)
@@ -421,7 +421,7 @@ if time = 0 {
 if time = getHitVar(ctrlTime) {
 	ctrlSet{value: 1}
 }
-call AirGuardLand();
+call IkSys_AirGuardLand();
 
 #-------------------------------------------------------------------------------
 # Lose (time over)
@@ -461,7 +461,7 @@ if time = 0 {
 }
 
 #-------------------------------------------------------------------------------
-[Function GetHitShaking(lAnim)]
+[Function IkSys_GetHitShaking(lAnim)]
 if time = 0 {
 	if getHitVar(animType) = [4, 5] &&
 		selfAnimExist(5051 + getHitVar(animType) - 4) {
@@ -476,7 +476,7 @@ if time = 0 {
 }
 
 #-------------------------------------------------------------------------------
-[Function GetHitKnockedBack(lAnim, nextState)]
+[Function IkSys_GetHitKnockedBack(lAnim, nextState)]
 if time = 0 {
 	hitVelSet{x: 1}
 }
@@ -496,7 +496,7 @@ if hitOver {
 # Stand get-hit (shaking)
 [StateDef 5000; type: S; movetype: H; physics: N; velset: 0, 0;]
 
-call GetHitShaking(ifElse(getHitVar(groundType) = 1, 5000, 5010));
+call IkSys_GetHitShaking(ifElse(getHitVar(groundType) = 1, 5000, 5010));
 if (time = 0 && (getHitVar(yVel) || getHitVar(fall))) || pos y != 0 {
 	stateTypeSet{statetype: A}
 }
@@ -515,13 +515,13 @@ if hitShakeOver {
 # Stand get-hit (knocked back)
 [StateDef 5001; type: S; movetype: H; physics: S;]
 
-call GetHitKnockedBack(5005 + (getHitVar(groundType) = 2) * 10, 0);
+call IkSys_GetHitKnockedBack(5005 + (getHitVar(groundType) = 2) * 10, 0);
 
 #-------------------------------------------------------------------------------
 # Crouch get-hit (shaking)
 [StateDef 5010; type: C; movetype: H; physics: N; velset: 0, 0;]
 
-call GetHitShaking(5020);
+call IkSys_GetHitShaking(5020);
 if (time = 0 && (getHitVar(yVel) || getHitVar(fall))) || pos y != 0 {
 	stateTypeSet{statetype: A}
 }
@@ -540,13 +540,13 @@ if anim = 5020 {
 # Crouch get-hit (knocked back)
 [StateDef 5011; type: C; movetype: H; physics: C;]
 
-call GetHitKnockedBack(5025, 11);
+call IkSys_GetHitKnockedBack(5025, 11);
 
 #-------------------------------------------------------------------------------
 # Air get-hit (shaking)
 [StateDef 5020; type: A; movetype: H; physics: N; velset: 0, 0;]
 
-call GetHitShaking(ifElse(getHitVar(airType) = 1, 5000, 5010));
+call IkSys_GetHitShaking(ifElse(getHitVar(airType) = 1, 5000, 5010));
 if hitShakeOver {
 	changeState{value: 5030}
 }
@@ -676,7 +676,7 @@ if vel y > 0 && pos y >= const(movement.air.gethit.trip.groundlevel) {
 }
 
 #-------------------------------------------------------------------------------
-[Function SelfAnimExistAddMod10(cond, base) ret]
+[Function IkSys_SelfAnimExistAddMod10(cond, base) ret]
 let ret = cond($cond && selfAnimExist($base + anim % 10),
 	$base + anim % 10, $base);
 
@@ -717,7 +717,7 @@ if hitOver {
 }
 
 #-------------------------------------------------------------------------------
-[Function HitGroundEffect(vely)]
+[Function IkSys_HitGroundEffect(vely)]
 if mugenVersion < 1.0 {
 	gameMakeAnim{
 		value: 60 + ($vely > 5) + ($vely > 14);
@@ -745,7 +745,7 @@ if time = 0 {
 	}
 	fallEnvShake{}
 	sysVar(1) := floor(vel y);
-	let a = call SelfAnimExistAddMod10(anim = [5051, 5059] ||
+	let a = call IkSys_SelfAnimExistAddMod10(anim = [5051, 5059] ||
 		anim = [5061, 5069], 5100);
 	changeAnim{value: $a}
 	posSet{y: 0}
@@ -755,7 +755,7 @@ if time = 0 {
 		changeState{value: 5110}
 	}
 } else if time = 1 {
-	call HitGroundEffect(sysVar(1));
+	call IkSys_HitGroundEffect(sysVar(1));
 } else if time = 3 {
 	hitFallDamage{}
 }
@@ -772,7 +772,7 @@ if time = 0 {
 [StateDef 5101; type: L; movetype: H; physics: N;]
 
 if time = 0 {
-	let a = call SelfAnimExistAddMod10(anim = [5101, 5109], 5160);
+	let a = call IkSys_SelfAnimExistAddMod10(anim = [5101, 5109], 5160);
 	changeAnim{value: $a}
 	hitFallVel{}
 	posSet{y: const(movement.down.bounce.offset.y)}
@@ -795,7 +795,7 @@ persistent(0) if selfAnimExist(5110 + anim % 10) && anim = [5081, 5089] {
 if time = 0 {
 	fallEnvShake{}
 	if anim != [5110, 5119] {
-		let a = call SelfAnimExistAddMod10(anim = [5161, 5169], 5170);
+		let a = call IkSys_SelfAnimExistAddMod10(anim = [5161, 5169], 5170);
 		changeAnim{value: $a}
 	}
 	hitFallDamage{}
@@ -804,7 +804,7 @@ if time = 0 {
 		sysVar(1) := floor(vel y);
 	}
 	if !sysVar(0) {
-		call HitGroundEffect(sysVar(1));
+		call IkSys_HitGroundEffect(sysVar(1));
 	}
 	velSet{y: 0}
 }
@@ -840,7 +840,7 @@ if time = 0 {
 [StateDef 5120; type: L; movetype: I; physics: N;]
 
 if time = 0 {
-	let a = call SelfAnimExistAddMod10(anim = [5111, 5119], 5120);
+	let a = call IkSys_SelfAnimExistAddMod10(anim = [5111, 5119], 5120);
 	changeAnim{value: $a}
 	velSet{x: 0}
 }
@@ -857,7 +857,7 @@ if animTime = 0 {
 [StateDef 5150; type: L; movetype: H; physics: N; sprpriority: -3; ctrl: 0;]
 
 if time = 0 {
-	let a = call SelfAnimExistAddMod10(anim = [5111, 5119] ||
+	let a = call IkSys_SelfAnimExistAddMod10(anim = [5111, 5119] ||
 		anim = [5171, 5179], 5140);
 	if selfAnimExist($a) {
 		changeAnim{value: $a}

--- a/data/dizzy.zss
+++ b/data/dizzy.zss
@@ -319,6 +319,7 @@ if !dizzy || time > 300 {
 #===============================================================================
 [StateDef const(StateDizzy); type: S; movetype: I; physics: S; anim: const(AnimDizzy); velset: 0, 0; ctrl: 0;]
 
+# This flag prevents the char from becoming dizzy more than once in the same combo
 map(_iksys_dizzyLimit) := 1;
 
 if time = 0 {
@@ -370,8 +371,8 @@ if !const(Default.Enable.Dizzy) || isHelper || teamSide = 0 {
 	map(_iksys_dizzyPointsTimer) := 0;
 	map(_iksys_dizzyLimit) := 0;
 } else if alive {
-	# Upon hit, set cooldown timer
-	if moveType = H || dizzy || stateNo = const(StateDownedGetHit_gettingUp) {
+	# Upon getting hit, set cooldown timer
+	if dizzy || moveType = H || stateNo = const(StateDownedGetHit_gettingUp) {
 		map(_iksys_dizzyPointsTimer) := 60;
 	# Otherwise decrease cooldown timer by 1 each frame
 	} else if map(_iksys_dizzyPointsTimer) > 0 {
@@ -387,11 +388,12 @@ if !const(Default.Enable.Dizzy) || isHelper || teamSide = 0 {
 	}
 
 	# Set dizzy flag
-	if !dizzy && dizzyPoints = 0 {
-		if getHitVar(damage) && getHitVar(dizzyPoints) <= 0 {
+	if !dizzy && dizzyPoints = 0 && !getHitVar(guarded) {
+		if getHitVar(frame) && getHitVar(dizzyPoints) <= 0 {
 			dizzyPointsSet{value: 1} # Similar to using kill = 0 in LifeAdd
 		} else if moveType = H && !inCustomState {
 			dizzySet{value: 1}
+			hitFallSet{value: 1}
 			getHitVarSet{fall.recover: 0}
 		}
 	}
@@ -436,7 +438,7 @@ if !const(Default.Enable.Dizzy) || isHelper || teamSide = 0 {
 
 	# Reset dizzy limit once character can act again
 	if map(_iksys_dizzyLimit) {
-		if (ctrl && time > 0) || moveType = A {
+		if ctrl || moveType = A {
 			map(_iksys_dizzyLimit) := 0;
 		}
 	}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -362,6 +362,9 @@ const (
 	OC_const_stagevar_camera_zoomout
 	OC_const_stagevar_camera_zoomin
 	OC_const_stagevar_camera_zoomindelay
+	OC_const_stagevar_camera_zoominspeed
+	OC_const_stagevar_camera_zoomoutspeed
+	OC_const_stagevar_camera_yscrollspeed
 	OC_const_stagevar_camera_ytension_enable
 	OC_const_stagevar_camera_autocenter
 	OC_const_stagevar_playerinfo_leftbound
@@ -1965,6 +1968,14 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(sys.stage.stageCamera.zoomout)
 	case OC_const_stagevar_camera_zoomin:
 		sys.bcStack.PushF(sys.stage.stageCamera.zoomin)
+	case OC_const_stagevar_camera_zoomindelay:
+		sys.bcStack.PushF(sys.stage.stageCamera.zoomindelay)
+	case OC_const_stagevar_camera_zoominspeed:
+		sys.bcStack.PushF(sys.stage.stageCamera.zoominspeed)
+	case OC_const_stagevar_camera_zoomoutspeed:
+		sys.bcStack.PushF(sys.stage.stageCamera.zoomoutspeed)
+	case OC_const_stagevar_camera_yscrollspeed:
+		sys.bcStack.PushF(sys.stage.stageCamera.yscrollspeed)
 	case OC_const_stagevar_camera_ytension_enable:
 		sys.bcStack.PushB(sys.stage.stageCamera.ytensionenable)
 	case OC_const_stagevar_playerinfo_leftbound:
@@ -9564,6 +9575,9 @@ const (
 	modifyStageVar_camera_zoomout
 	modifyStageVar_camera_zoomin
 	modifyStageVar_camera_zoomindelay
+	modifyStageVar_camera_zoominspeed
+	modifyStageVar_camera_zoomoutspeed
+	modifyStageVar_camera_yscrollspeed
 	modifyStageVar_camera_ytension_enable
 	modifyStageVar_camera_autocenter
 	modifyStageVar_playerinfo_leftbound
@@ -9623,8 +9637,14 @@ func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 			s.stageCamera.zoomin = exp[0].evalF(c)
 		case modifyStageVar_camera_zoomindelay:
 			s.stageCamera.zoomindelay = exp[0].evalF(c)
+		case modifyStageVar_camera_zoominspeed:
+			s.stageCamera.zoominspeed = exp[0].evalF(c)
+		case modifyStageVar_camera_zoomoutspeed:
+			s.stageCamera.zoomoutspeed = exp[0].evalF(c)
 		case modifyStageVar_camera_ytension_enable:
 			s.stageCamera.ytensionenable = exp[0].evalB(c)
+		case modifyStageVar_camera_yscrollspeed:
+			s.stageCamera.yscrollspeed = exp[0].evalF(c)
 		case modifyStageVar_playerinfo_leftbound:
 			s.leftbound = exp[0].evalF(c)
 		case modifyStageVar_playerinfo_rightbound:
@@ -9666,7 +9686,7 @@ func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 			s.reflection = Clamp(exp[0].evalI(c), 0, 255)
 		case modifyStageVar_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
-				//crun = rid
+				//crun = rid - RedirectID is useless when modifying a stage
 			} else {
 				return false
 			}
@@ -9675,7 +9695,7 @@ func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 	})
 	sys.stage.reload = true // Stage will have to be reloaded if it's re-selected
 	sys.cam.stageCamera = s.stageCamera
-	sys.cam.Reset()
+	sys.cam.Reset() // TODO: Resetting the camera makes the zoom jitter
 	return false
 }
 

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2426,6 +2426,12 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			opc = OC_const_stagevar_camera_zoomin
 		case "camera.zoomindelay":
 			opc = OC_const_stagevar_camera_zoomindelay
+		case "camera.zoominspeed":
+			opc = OC_const_stagevar_camera_zoominspeed
+		case "camera.zoomoutspeed":
+			opc = OC_const_stagevar_camera_zoomoutspeed
+		case "camera.yscrollspeed":
+			opc = OC_const_stagevar_camera_yscrollspeed
 		case "camera.ytension.enable":
 			opc = OC_const_stagevar_camera_ytension_enable
 		case "camera.autocenter":

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -173,6 +173,7 @@ func newCompiler() *Compiler {
 		"modifysnd":            c.modifySnd,
 		"modifybgm":            c.modifyBgm,
 		"groundleveloffset":    c.groundLevelOffset,
+		"targetadd":            c.targetAdd,
 	}
 	return c
 }

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -4847,6 +4847,18 @@ func (c *Compiler) modifyStageVar(is IniSection, sc *StateControllerBase, _ int8
 			modifyStageVar_camera_zoomindelay, VT_Int, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "camera.zoominspeed",
+			modifyStageVar_camera_zoominspeed, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "camera.zoomoutspeed",
+			modifyStageVar_camera_zoomoutspeed, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "camera.yscrollspeed",
+			modifyStageVar_camera_yscrollspeed, VT_Float, 1, false); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "camera.ytension.enable",
 			modifyStageVar_camera_ytension_enable, VT_Bool, 1, false); err != nil {
 			return err

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -5183,6 +5183,21 @@ func (c *Compiler) groundLevelOffset(is IniSection, sc *StateControllerBase, _ i
 	return *ret, err
 }
 
+func (c *Compiler) targetAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+	ret, err := (*targetAdd)(sc), c.stateSec(is, func() error {
+		if err := c.paramValue(is, sc, "redirectid",
+			targetAdd_redirectid, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "id",
+			targetAdd_id, VT_Int, 1, true); err != nil {
+			return err
+		}
+		return nil
+	})
+	return *ret, err
+}
+
 // It's just a Null... Has no effect whatsoever.
 func (c *Compiler) null(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	return nullStateController, nil

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -5175,7 +5175,7 @@ func (c *Compiler) groundLevelOffset(is IniSection, sc *StateControllerBase, _ i
 			return err
 		}
 		if err := c.paramValue(is, sc, "value",
-			groundLevelOffset_value, VT_Float, 1, false); err != nil {
+			groundLevelOffset_value, VT_Float, 1, true); err != nil {
 			return err
 		}
 		return nil

--- a/src/script.go
+++ b/src/script.go
@@ -4042,6 +4042,14 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LNumber(sys.stage.stageCamera.zoomout))
 		case "camera.zoomin":
 			l.Push(lua.LNumber(sys.stage.stageCamera.zoomin))
+		case "camera.zoomindelay":
+			l.Push(lua.LNumber(sys.stage.stageCamera.zoomindelay))
+		case "camera.zoominspeed":
+			l.Push(lua.LNumber(sys.stage.stageCamera.zoominspeed))
+		case "camera.zoomoutspeed":
+			l.Push(lua.LNumber(sys.stage.stageCamera.zoomoutspeed))
+		case "camera.yscrollspeed":
+			l.Push(lua.LNumber(sys.stage.stageCamera.yscrollspeed))
 		case "camera.ytension.enable":
 			l.Push(lua.LBool(sys.stage.stageCamera.ytensionenable))
 		case "playerinfo.leftbound":

--- a/src/script.go
+++ b/src/script.go
@@ -921,7 +921,7 @@ func systemScriptInit(l *lua.LState) {
 			}
 			winp := int32(0)
 			p := make([]*Char, len(sys.chars))
-			sys.debugRef = [2]int{}
+			sys.debugRef = [3]int{}
 			sys.roundsExisted = [2]int32{}
 			sys.matchWins = [2]int32{}
 
@@ -2556,35 +2556,17 @@ func systemScriptInit(l *lua.LState) {
 		if !sys.debugDraw {
 			sys.debugDraw = true
 		} else {
-			pn := sys.debugRef[0]
-			hn := sys.debugRef[1]
-			for i := hn + 1; i <= len(sys.chars[pn]); i++ {
-				hn = i
-				if hn >= len(sys.chars[pn]) {
-					pn += 1
-					hn = 0
-					break
-				}
-				if sys.chars[pn][hn] != nil && !sys.chars[pn][hn].csf(CSF_destroy) {
-					break
-				}
-			}
-			ok := false
-			for pn < len(sys.chars) {
-				if len(sys.chars[pn]) > 0 {
-					ok = true
-					break
-				}
-				pn += 1
-
-			}
-			if !ok {
-				pn = 0
-				hn = 0
+			idx := sys.debugRef[2] + 1
+			if idx >= len(sys.charList.runOrder) {
+				sys.debugRef[0] = 0
+				sys.debugRef[1] = 0
+				sys.debugRef[2] = 0
 				sys.debugDraw = false
+			} else {
+				sys.debugRef[0] = sys.charList.runOrder[idx].playerNo
+				sys.debugRef[1] = int(sys.charList.runOrder[idx].helperIndex)
+				sys.debugRef[2] = idx
 			}
-			sys.debugRef[0] = pn
-			sys.debugRef[1] = hn
 		}
 		return 0
 	})

--- a/src/system.go
+++ b/src/system.go
@@ -119,7 +119,7 @@ type System struct {
 	turnsRecoveryRate       float32
 	debugFont               *TextSprite
 	debugDraw               bool
-	debugRef                [2]int
+	debugRef                [3]int // player number, helper index, player index
 	soundMixer              *beep.Mixer
 	bgm                     Bgm
 	soundChannels           *SoundChannels


### PR DESCRIPTION
TargetAdd:
- Adds the enemy with the specified ID to the player's target list

Fixes:
- MoveHitVar(ID) will now register properly even if the enemy has a HitOverride
- Fixed chars entering the dizzy state when they blocked with low dizzy points

Other:
- Added ZoomInSpeed, ZoomOutSpeed and YScrollSpeed to StageVar and ModifyStageVar
- Pressing ctrl + D will now change to the next player index rather than the next helper of the current player. This is like Mugen and makes it easier to find a particular player after seeing its ID with Clsn display
- Added debug message when the player tries to change to a state number that is too high
- Added "IkSys" prefix to common1 functions as well