### PR TITLE
feat: AssertSpecial CornerPriority, refactoring, fixes

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3253,10 +3253,11 @@ func (sc assertSpecial) Run(c *Char, _ []int32) bool {
 		case assertSpecial_flag_g:
 			sys.setGSF(GlobalSpecialFlag(exp[0].evalI(c)))
 		case assertSpecial_noko:
-			if c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
-				crun.setASF(AssertSpecialFlag(ASF_noko))
+			// NoKO affects all characters in Mugen, so legacy chars do so as well
+			if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
+				sys.setGSF(GlobalSpecialFlag(GSF_globalnoko))
 			} else {
-				sys.setGSF(GlobalSpecialFlag(GSF_noko))
+				crun.setASF(AssertSpecialFlag(ASF_noko))
 			}
 		case assertSpecial_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -3203,6 +3203,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		}
 		out.append(OC_ex_)
 		switch c.token {
+		// Mugen char flags
 		case "nostandguard":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nostandguard))
 		case "nocrouchguard":
@@ -3221,6 +3222,30 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noautoturn))
 		case "nowalk":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nowalk))
+		case "noko":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noko))
+		// Mugen global flags
+		case "globalnoshadow":
+			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_globalnoshadow))
+		case "intro":
+			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_intro))
+		case "roundnotover":
+			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_roundnotover))
+		case "nobardisplay":
+			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_nobardisplay))
+		case "nobg":
+			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_nobg))
+		case "nofg":
+			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_nofg))
+		case "nokoslow":
+			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_nokoslow))
+		case "nokosnd":
+			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_nokosnd))
+		case "nomusic":
+			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_nomusic))
+		case "timerfreeze":
+			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_timerfreeze))
+		// Ikemen char flags
 		case "nobrake":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nobrake))
 		case "nocrouch":
@@ -3267,8 +3292,6 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noredlifedamage))
 		case "nomakedust":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nomakedust))
-		case "noko":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noko))
 		case "noguardko":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noguardko))
 		case "nokovelocity":
@@ -3281,28 +3304,11 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_ignoreclsn2push))
 		case "immovable":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_immovable))
-		case "intro":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_intro))
-		case "roundnotover":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_roundnotover))
-		case "nomusic":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_nomusic))
-		case "nobardisplay":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_nobardisplay))
-		case "nobg":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_nobg))
-		case "nofg":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_nofg))
-		case "globalnoshadow":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_globalnoshadow))
-		case "timerfreeze":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_timerfreeze))
-		case "nokosnd":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_nokosnd))
-		case "nokoslow":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_nokoslow))
+		case "cornerpriority":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_cornerpriority))
+		// Ikemen global flags
 		case "globalnoko":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_noko))
+			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_globalnoko))
 		case "roundnotskip":
 			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_roundnotskip))
 		case "roundfreeze":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -71,24 +71,50 @@ func (c *Compiler) assertSpecial(is IniSection, sc *StateControllerBase, _ int8)
 		}
 		foo := func(data string) error {
 			switch strings.ToLower(data) {
-			case "nostandguard":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nostandguard)))
-			case "nocrouchguard":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nocrouchguard)))
-			case "noairguard":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_noairguard)))
-			case "noshadow":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_noshadow)))
+			// Mugen char flags
+			case "intro":
+				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_intro)))
 			case "invisible":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_invisible)))
-			case "unguardable":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_unguardable)))
-			case "nojugglecheck":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nojugglecheck)))
+			case "noairguard":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_noairguard)))
 			case "noautoturn":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_noautoturn)))
+			case "nocrouchguard":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nocrouchguard)))
+			case "nojugglecheck":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nojugglecheck)))
+			case "noshadow":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_noshadow)))
+			case "nostandguard":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nostandguard)))
 			case "nowalk":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nowalk)))
+			case "unguardable":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_unguardable)))
+			// Mugen global flags
+			case "globalnoshadow":
+				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_globalnoshadow)))
+			case "nobardisplay":
+				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_nobardisplay)))
+			case "nobg":
+				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_nobg)))
+			case "nofg":
+				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_nofg)))
+			case "noko":
+				sc.add(assertSpecial_noko, sc.i64ToExp(0))
+			case "nokoslow":
+				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_nokoslow)))
+			case "nokosnd":
+				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_nokosnd)))
+			case "nomusic":
+				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_nomusic)))
+
+			case "roundnotover":
+				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_roundnotover)))
+			case "timerfreeze":
+				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_timerfreeze)))
+			// Ikemen char flags
 			case "nobrake":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nobrake)))
 			case "nocrouch":
@@ -117,8 +143,6 @@ func (c *Compiler) assertSpecial(is IniSection, sc *StateControllerBase, _ int8)
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nopowerbardisplay)))
 			case "autoguard":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_autoguard)))
-			case "animatehitpause":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_animatehitpause)))
 			case "animfreeze":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_animfreeze)))
 			case "postroundinput":
@@ -147,34 +171,17 @@ func (c *Compiler) assertSpecial(is IniSection, sc *StateControllerBase, _ int8)
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_ignoreclsn2push)))
 			case "immovable":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_immovable)))
-			case "intro":
-				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_intro)))
-			case "roundnotover":
-				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_roundnotover)))
-			case "nomusic":
-				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_nomusic)))
-			case "nobardisplay":
-				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_nobardisplay)))
-			case "nobg":
-				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_nobg)))
-			case "nofg":
-				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_nofg)))
-			case "globalnoshadow":
-				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_globalnoshadow)))
-			case "timerfreeze":
-				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_timerfreeze)))
-			case "nokosnd":
-				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_nokosnd)))
-			case "nokoslow":
-				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_nokoslow)))
+			case "animatehitpause":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_animatehitpause)))
+			case "cornerpriority":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_cornerpriority)))
+			// Ikemen global flags
 			case "globalnoko":
-				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_noko)))
+				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_globalnoko)))
 			case "roundnotskip":
 				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_roundnotskip)))
 			case "roundfreeze":
 				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_roundfreeze)))
-			case "noko":
-				sc.add(assertSpecial_noko, sc.i64ToExp(0))
 			default:
 				return Error("Invalid value: " + data)
 			}

--- a/src/script.go
+++ b/src/script.go
@@ -921,7 +921,7 @@ func systemScriptInit(l *lua.LState) {
 			}
 			winp := int32(0)
 			p := make([]*Char, len(sys.chars))
-			sys.debugRef = [3]int{}
+			sys.debugRef = [2]int{}
 			sys.roundsExisted = [2]int32{}
 			sys.matchWins = [2]int32{}
 
@@ -2556,16 +2556,22 @@ func systemScriptInit(l *lua.LState) {
 		if !sys.debugDraw {
 			sys.debugDraw = true
 		} else {
-			idx := sys.debugRef[2] + 1
-			if idx >= len(sys.charList.runOrder) {
+			idx := 0
+			// Find index of current debug player
+			for i := 0; i < len(sys.charList.runOrder); i++ {
+				ro := sys.charList.runOrder[i]
+				if ro.playerNo == sys.debugRef[0] && ro.helperIndex == int32(sys.debugRef[1]) {
+					idx = i + 1 // Then check the next one
+					break
+				}
+			}
+			if idx == 0 || idx >= len(sys.charList.runOrder) {
 				sys.debugRef[0] = 0
 				sys.debugRef[1] = 0
-				sys.debugRef[2] = 0
 				sys.debugDraw = false
 			} else {
 				sys.debugRef[0] = sys.charList.runOrder[idx].playerNo
 				sys.debugRef[1] = int(sys.charList.runOrder[idx].helperIndex)
-				sys.debugRef[2] = idx
 			}
 		}
 		return 0
@@ -4519,7 +4525,7 @@ func triggerFunctions(l *lua.LState) {
 	})
 	luaRegister(l, "isasserted", func(*lua.LState) int {
 		switch strArg(l, 1) {
-		// CharSpecialFlag
+		// AssertSpecialFlag
 		case "nostandguard":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_nostandguard)))
 		case "nocrouchguard":
@@ -4566,8 +4572,6 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_nopowerbardisplay)))
 		case "autoguard":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_autoguard)))
-		case "animatehitpause":
-			l.Push(lua.LBool(sys.debugWC.asf(ASF_animatehitpause)))
 		case "animfreeze":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_animfreeze)))
 		case "postroundinput":
@@ -4598,6 +4602,10 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_ignoreclsn2push)))
 		case "immovable":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_immovable)))
+		case "animatehitpause":
+			l.Push(lua.LBool(sys.debugWC.asf(ASF_animatehitpause)))
+		case "cornerpriority":
+			l.Push(lua.LBool(sys.debugWC.asf(ASF_cornerpriority)))
 		// GlobalSpecialFlag
 		case "intro":
 			l.Push(lua.LBool(sys.gsf(GSF_intro)))
@@ -4620,7 +4628,7 @@ func triggerFunctions(l *lua.LState) {
 		case "nokoslow":
 			l.Push(lua.LBool(sys.gsf(GSF_nokoslow)))
 		case "globalnoko":
-			l.Push(lua.LBool(sys.gsf(GSF_noko)))
+			l.Push(lua.LBool(sys.gsf(GSF_globalnoko)))
 		case "roundnotskip":
 			l.Push(lua.LBool(sys.gsf(GSF_roundnotskip)))
 		case "roundfreeze":

--- a/src/system.go
+++ b/src/system.go
@@ -119,7 +119,7 @@ type System struct {
 	turnsRecoveryRate       float32
 	debugFont               *TextSprite
 	debugDraw               bool
-	debugRef                [3]int // player number, helper index, player index
+	debugRef                [2]int // player number, helper index
 	soundMixer              *beep.Mixer
 	bgm                     Bgm
 	soundChannels           *SoundChannels
@@ -1159,11 +1159,11 @@ func (s *System) charUpdate() {
 		for i, pr := range s.projs {
 			for j, p := range pr {
 				if p.id >= 0 {
-					s.projs[i][j].clsn(i)
+					s.projs[i][j].tradeDetection(i)
 				}
 			}
 		}
-		s.charList.hitDetection()
+		s.charList.collisionDetection()
 		for i, pr := range s.projs {
 			for j, p := range pr {
 				if p.id != IErr {
@@ -1434,7 +1434,7 @@ func (s *System) action() {
 					}
 					for _, p := range s.chars {
 						if len(p) > 0 {
-							//default life recovery, used only if externalized Lua implementaion is disabled
+							//default life recovery, used only if externalized Lua implementation is disabled
 							if len(sys.commonLua) == 0 && s.waitdown >= 0 && s.time > 0 && p[0].win() &&
 								p[0].alive() && !s.matchOver() &&
 								(s.tmode[0] == TM_Turns || s.tmode[1] == TM_Turns) {


### PR DESCRIPTION
- Asserting this flag makes the character have priority to push the enemy out of the corner
- The decision for which character should stay in the corner in case of a tie is now more consistent
- Fixes #1426
- Some refactoring. The player pushing code was segregated from the Hitdef code
- Improved implementation of previous debug commit (b22d40c)
- Fixed hit type "None" adding to the combo counter
- Fixes #1884 