### PR TITLE
fix: Improve window scaling behavior, fix broken shader scaling

### DIFF
--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -422,12 +422,8 @@ func (r *Renderer) EndFrame() {
 	}
 
 	x, y, resizedWidth, resizedHeight := sys.window.GetScaledViewportSize()
-	gl.Viewport(x, y, resizedWidth, resizedHeight)
-	gl.BindFramebuffer(gl.FRAMEBUFFER, 0)
-
 	postShader := r.postShaderSelect[sys.postProcessingShader]
 
-	gl.Clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT)
 	gl.UseProgram(postShader.program)
 	gl.Disable(gl.BLEND)
 
@@ -445,10 +441,20 @@ func (r *Renderer) EndFrame() {
 	loc := r.modelShader.a["VertCoord"]
 	gl.EnableVertexAttribArray(uint32(loc))
 	gl.VertexAttribPointerWithOffset(uint32(loc), 2, gl.FLOAT, false, 0, 0)
+	gl.MemoryBarrier(gl.ALL_BARRIER_BITS)
 
 	gl.DrawArrays(gl.TRIANGLE_STRIP, 0, 4)
-
 	gl.DisableVertexAttribArray(uint32(loc))
+
+	// resize viewport and scale finished frame to window
+	gl.Viewport(x, y, resizedWidth, resizedHeight)
+	if sys.multisampleAntialiasing {
+		gl.BindFramebuffer(gl.READ_FRAMEBUFFER, r.fbo_f_texture.handle)
+	} else {
+		gl.BindFramebuffer(gl.READ_FRAMEBUFFER, r.fbo_texture)
+	}
+	gl.BindFramebuffer(gl.DRAW_FRAMEBUFFER, 0)
+	gl.BlitFramebuffer(0, 0, sys.scrrect[2], sys.scrrect[3], x, y, x+resizedWidth, y+resizedHeight, gl.COLOR_BUFFER_BIT, gl.LINEAR)
 }
 
 func (r *Renderer) SetPipeline(eq BlendEquation, src, dst BlendFunc) {


### PR DESCRIPTION
This PR improves window resizing behavior by properly scaling the game's output instead of merely relying on viewport behavior on the GPU. Shaders should now work as expected across various window sizes, and we now scale bilinearly by default when resizing. This matches MUGEN 1.1/SDL's window behavior.

![image](https://github.com/user-attachments/assets/9edf4df9-9c8e-4712-bf0e-12203811906b)


See https://github.com/ikemen-engine/Ikemen-GO/discussions/1876 for more information.