### PR TITLE
feat: invincibility display, refactoring, fixes

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1468,7 +1468,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushB(c.hitDefAttr(*(*int32)(unsafe.Pointer(&be[i]))))
 			i += 4
 		case OC_hitfall:
-			sys.bcStack.PushB(c.ghv.fallf)
+			sys.bcStack.PushB(c.ghv.fallflag)
 		case OC_hitover:
 			sys.bcStack.PushB(c.hitOver())
 		case OC_hitpausetime:
@@ -2139,7 +2139,7 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_gethitvar_isbound:
 		sys.bcStack.PushB(c.isBound())
 	case OC_ex_gethitvar_fall:
-		sys.bcStack.PushB(c.ghv.fallf)
+		sys.bcStack.PushB(c.ghv.fallflag)
 	case OC_ex_gethitvar_fall_damage:
 		sys.bcStack.PushI(c.ghv.fall.damage)
 	case OC_ex_gethitvar_fall_xvel:
@@ -9883,7 +9883,7 @@ func (sc getHitVarSet) Run(c *Char, _ []int32) bool {
 		case getHitVarSet_ctrltime:
 			crun.ghv.ctrltime = exp[0].evalI(c)
 		case getHitVarSet_fall:
-			crun.ghv.fallf = exp[0].evalB(c)
+			crun.ghv.fallflag = exp[0].evalB(c)
 		case getHitVarSet_fall_damage:
 			crun.ghv.fall.damage = exp[0].evalI(c)
 		case getHitVarSet_fall_envshake_ampl:

--- a/src/char.go
+++ b/src/char.go
@@ -6018,7 +6018,7 @@ func (c *Char) dropTargets() {
 				if t.ss.moveType != MT_H && !t.stchtmp {
 					c.targets[i] = c.targets[len(c.targets)-1]
 					c.targets = c.targets[:len(c.targets)-1]
-					if t.ghv._type != 0 { // GitHub #1268
+					if t.ghv._type != 0 { // https://github.com/ikemen-engine/Ikemen-GO/issues/1268
 						t.ghv.hitid = -1
 					}
 				} else {
@@ -8187,31 +8187,30 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 									getter.mhv.playerNo = c.playerNo
 									getter.hitdef.hitonce = -1 // Neutralize Hitdef
 									getter.gi().unhittable = 1 // Reversaldef makes the target invincible for 1 frame (but not the attacker)
-									// TODO: This 1 frame does not show up on debug (due to Clsn display process order?)
 
-									fall, by := getter.ghv.fallf, getter.ghv.hitBy
+									// In Mugen, ReversalDef does not clear the enemy's GetHitVars
+									// fall, by := getter.ghv.fallf, getter.ghv.hitBy
+									// getter.ghv.clear()
+									// getter.ghv.hitBy = by
+									// getter.ghv.fall = c.hitdef.fall
 
-									getter.ghv.clear()
-									getter.ghv.hitBy = by
 									getter.ghv.attr = c.hitdef.attr
 									getter.ghv.hitid = c.hitdef.id
 									getter.ghv.playerNo = c.playerNo
 									getter.ghv.id = c.id
-									getter.ghv.fall = c.hitdef.fall
 									getter.fallTime = 0
 									getter.ghv.fall.xvelocity = c.hitdef.fall.xvelocity * (c.localscl / getter.localscl)
 									getter.ghv.fall.yvelocity = c.hitdef.fall.yvelocity * (c.localscl / getter.localscl)
+
 									if c.hitdef.forcenofall {
-										fall = false
+										getter.ghv.fallf = false
+									} else if !getter.ghv.fallf {
+										if getter.ss.stateType == ST_A {
+											getter.ghv.fallf = c.hitdef.air_fall
+										} else {
+											getter.ghv.fallf = c.hitdef.ground_fall
+										}
 									}
-									if getter.ss.stateType == ST_A {
-										getter.ghv.fallf = c.hitdef.air_fall
-									} else if getter.ss.stateType == ST_L {
-										getter.ghv.fallf = c.hitdef.ground_fall
-									} else {
-										getter.ghv.fallf = c.hitdef.ground_fall
-									}
-									getter.ghv.fallf = getter.ghv.fallf || fall
 
 									getter.hitdefTargetsBuffer = append(getter.hitdefTargetsBuffer, c.id)
 									if getter.hittmp == 0 {

--- a/src/script.go
+++ b/src/script.go
@@ -3324,7 +3324,7 @@ func triggerFunctions(l *lua.LState) {
 		case "isbound":
 			ln = lua.LNumber(Btoi(c.isBound()))
 		case "fall":
-			ln = lua.LNumber(Btoi(c.ghv.fallf))
+			ln = lua.LNumber(Btoi(c.ghv.fallflag))
 		case "fall.damage":
 			ln = lua.LNumber(c.ghv.fall.damage)
 		case "fall.xvel":
@@ -3465,7 +3465,7 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "hitfall", func(*lua.LState) int {
-		l.Push(lua.LBool(sys.debugWC.ghv.fallf))
+		l.Push(lua.LBool(sys.debugWC.ghv.fallflag))
 		return 1
 	})
 	luaRegister(l, "hitover", func(*lua.LState) int {

--- a/src/system.go
+++ b/src/system.go
@@ -1768,6 +1768,7 @@ func (s *System) drawTop() {
 		fade(rect, s.lifebar.ro.shutter_col, 255)
 	}
 	s.brightness = s.brightnessOld
+	// Draw Clsn boxes
 	if s.clsnDraw {
 		s.clsnSpr.Pal[0] = 0xff0000ff
 		s.drawc1hit.draw(0x3feff)
@@ -1791,7 +1792,7 @@ func (s *System) drawTop() {
 		s.drawch.draw(0x3feff)
 	}
 }
-func (s *System) drawDebug() {
+func (s *System) drawDebugText() {
 	put := func(x, y *float32, txt string) {
 		for txt != "" {
 			w, drawTxt := int32(0), ""
@@ -1812,7 +1813,7 @@ func (s *System) drawDebug() {
 		}
 	}
 	if s.debugDraw {
-		//Player Info
+		// Player Info on top of screen
 		x := (320-float32(s.gameWidth))/2 + 1
 		y := 240 - float32(s.gameHeight)
 		if s.statusLFunc != nil {
@@ -1831,13 +1832,15 @@ func (s *System) drawDebug() {
 				}
 			}
 		}
-		//Console
+		// Console
 		y = MaxF(y, 48+240-float32(s.gameHeight))
 		s.debugFont.SetColor(255, 255, 255)
 		for _, s := range s.consoleText {
 			put(&x, &y, s)
 		}
-		//Data
+		// Data
+		y = float32(s.gameHeight) - float32(s.debugFont.fnt.Size[1])*sys.debugFont.yscl/s.heightScale*
+			(float32(len(s.listLFunc))+float32(s.clipboardRows)) - 1*s.heightScale
 		pn := s.debugRef[0]
 		hn := s.debugRef[1]
 		if pn >= len(s.chars) || hn >= len(s.chars[pn]) {
@@ -1845,8 +1848,6 @@ func (s *System) drawDebug() {
 			s.debugRef[1] = 0
 		}
 		s.debugWC = s.chars[s.debugRef[0]][s.debugRef[1]]
-		y = float32(s.gameHeight) - float32(s.debugFont.fnt.Size[1])*sys.debugFont.yscl/s.heightScale*
-			(float32(len(s.listLFunc))+float32(s.clipboardRows)) - 1*s.heightScale
 		for i, f := range s.listLFunc {
 			if f != nil {
 				if i == 1 {
@@ -1872,21 +1873,22 @@ func (s *System) drawDebug() {
 				s.luaLState.SetTop(top)
 			}
 		}
-		//Clipboard
+		// Clipboard
 		s.debugFont.SetColor(255, 255, 255)
 		for _, s := range s.debugWC.clipboardText {
 			put(&x, &y, s)
 		}
 	}
-	//Clsn
-	if s.clsnDraw {
+	// Draw Clsn text
+	// Unlike Mugen, this is drawn separately from the Clsn boxes themselves, making debug more flexible
+	//if s.clsnDraw {
 		for _, t := range s.clsnText {
 			s.debugFont.SetColor(t.r, t.g, t.b)
 			s.debugFont.fnt.Print(t.text, t.x, t.y, s.debugFont.xscl/s.widthScale,
 				s.debugFont.yscl/s.heightScale, 0, 0, &s.scrrect,
 				s.debugFont.palfx, s.debugFont.frgba)
 		}
-	}
+	//}
 }
 
 // Starts and runs gameplay
@@ -2332,8 +2334,8 @@ func (s *System) fight() (reload bool) {
 			}
 		}
 		// Render debug elements
-		if !s.frameSkip {
-			s.drawDebug()
+		if !s.frameSkip && s.debugDraw {
+			s.drawDebugText()
 		}
 		// Break if finished
 		if fin && (!s.postMatchFlg || len(sys.commonLua) == 0) {

--- a/src/system.go
+++ b/src/system.go
@@ -1024,7 +1024,6 @@ func (s *System) nextRound() {
 				}
 			}
 			s.cgi[i].clearPCTime()
-			s.cgi[i].unhittable = 0
 		}
 	}
 	for _, p := range s.chars {


### PR DESCRIPTION
- Clsn display now shows which attributes the char is invulnerable to
- Adjusted the code so that width and height values internally create an actual collision box. This will allow expanding hit detection in the future
- Reversaldefs no longer clear the enemy's GetHitVars, like Mugen
- Fixes #1891 
- SuperPause Unhittable timers now belong to each individual player (root or helper), rather than being shared by the root and all helpers with the same player number
- Pressing Ctrl+C will now turn on Clsn boxes only. Pressing Ctrl+D will now turn on debug text and Clsn text only. Invincibility text will appear if both are enabled
- Fixed Explod bug when an explod is removed by RemoveOnChangeState and another explod is created in the same frame
- Fixes #1889 