### PR TITLE
refactor: Use gl.Finish to end frame

### DIFF
--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -441,7 +441,7 @@ func (r *Renderer) EndFrame() {
 	loc := r.modelShader.a["VertCoord"]
 	gl.EnableVertexAttribArray(uint32(loc))
 	gl.VertexAttribPointerWithOffset(uint32(loc), 2, gl.FLOAT, false, 0, 0)
-	gl.MemoryBarrier(gl.ALL_BARRIER_BITS)
+	gl.Finish()
 
 	gl.DrawArrays(gl.TRIANGLE_STRIP, 0, 4)
 	gl.DisableVertexAttribArray(uint32(loc))


### PR DESCRIPTION
Fixes a crash on MacOS when launching Ikemen GO.
Thanks to @Jesuszilla for confirming this for me!