### PR TITLE
fix: Fix inconsistent sound frame step behavior when BGM==err

### DIFF
--- a/src/sound.go
+++ b/src/sound.go
@@ -189,7 +189,7 @@ func (bgm *Bgm) Open(filename string, loop, bgmVolume, bgmLoopStart, bgmLoopEnd,
 
 	f, err := os.Open(bgm.filename)
 	if err != nil {
-		sys.bgm = *newBgm()
+		// sys.bgm = *newBgm() // removing this gets pause step playsnd to work correctly 100% of the time
 		sys.errLog.Printf("Failed to open bgm: %v", err)
 		return
 	}


### PR DESCRIPTION
Seems to fix a bug where framestepping causes no sound to play only when the BGM was errored out. Appeared to be that we were setting it to a blank BGM in that instance which seems unnecessary now.