### PR TITLE
feat: HelperType Projectile, hit detection and HitBy expansion

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3178,23 +3178,60 @@ type hitBy StateControllerBase
 const (
 	hitBy_value byte = iota
 	hitBy_value2
+	hitBy_value3
+	hitBy_value4
+	hitBy_value5
+	hitBy_value6
+	hitBy_value7
+	hitBy_value8
 	hitBy_time
+	hitBy_playerno
+	hitBy_playerid
+	hitBy_stack
 	hitBy_redirectid
 )
 
 func (sc hitBy) Run(c *Char, _ []int32) bool {
 	time := int32(1)
+	pno := int(-1)
+	pid := int32(-1)
+	st := false
 	crun := c
+	set := func(idx int, exp []BytecodeExp, time int32, pno int, pid int32, st bool) {
+		crun.hitby[idx].not = false
+		crun.hitby[idx].time = time
+		crun.hitby[idx].flag = exp[0].evalI(c)
+		crun.hitby[idx].playerno = pno - 1
+		crun.hitby[idx].playerid = pid
+		crun.hitby[idx].stack = st
+	}
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case hitBy_time:
 			time = exp[0].evalI(c)
+		case hitBy_playerno:
+			pno = int(exp[0].evalI(c))
+		case hitBy_playerid:
+			pid = exp[0].evalI(c)
+		case hitBy_stack:
+			st = exp[0].evalB(c)
+		// This redundancy is because all values can be set simultaneously in Mugen
 		case hitBy_value:
-			crun.hitby[0].time = time
-			crun.hitby[0].flag = exp[0].evalI(c)
+			set(0, exp, time, pno, pid, st)
 		case hitBy_value2:
-			crun.hitby[1].time = time
-			crun.hitby[1].flag = exp[0].evalI(c)
+			set(1, exp, time, pno, pid, st)
+		case hitBy_value3:
+			set(2, exp, time, pno, pid, st)
+		case hitBy_value4:
+			set(3, exp, time, pno, pid, st)
+		case hitBy_value5:
+			set(4, exp, time, pno, pid, st)
+		case hitBy_value6:
+			set(5, exp, time, pno, pid, st)
+		case hitBy_value7:
+			set(6, exp, time, pno, pid, st)
+		case hitBy_value8:
+			set(7, exp, time, pno, pid, st)
 		case hitBy_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -3211,18 +3248,43 @@ type notHitBy hitBy
 
 func (sc notHitBy) Run(c *Char, _ []int32) bool {
 	time := int32(1)
+	pno := int(-1)
+	pid := int32(-1)
+	st := false
 	crun := c
+	set := func(idx int, exp []BytecodeExp, time int32, pno int, pid int32, st bool) {
+		crun.hitby[idx].not = true
+		crun.hitby[idx].time = time
+		crun.hitby[idx].flag = ^exp[0].evalI(c) // Opposite
+		crun.hitby[idx].playerno = pno - 1
+		crun.hitby[idx].playerid = pid
+	}
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case hitBy_time:
 			time = exp[0].evalI(c)
+		case hitBy_playerno:
+			pno = int(exp[0].evalI(c))
+		case hitBy_playerid:
+			pid = exp[0].evalI(c)
+		case hitBy_stack:
+			st = exp[0].evalB(c)
 		case hitBy_value:
-			crun.hitby[0].time = time
-			crun.hitby[0].flag = ^exp[0].evalI(c)
+			set(0, exp, time, pno, pid, st)
 		case hitBy_value2:
-			crun.hitby[1].time = time
-			crun.hitby[1].flag = ^exp[0].evalI(c)
-
+			set(1, exp, time, pno, pid, st)
+		case hitBy_value3:
+			set(2, exp, time, pno, pid, st)
+		case hitBy_value4:
+			set(3, exp, time, pno, pid, st)
+		case hitBy_value5:
+			set(4, exp, time, pno, pid, st)
+		case hitBy_value6:
+			set(5, exp, time, pno, pid, st)
+		case hitBy_value7:
+			set(6, exp, time, pno, pid, st)
+		case hitBy_value8:
+			set(7, exp, time, pno, pid, st)
 		case hitBy_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -9995,7 +10057,7 @@ func (sc groundLevelOffset) Run(c *Char, _ []int32) bool {
 type targetAdd StateControllerBase
 
 const (
-	targetAdd_id byte = iota
+	targetAdd_playerid byte = iota
 	targetAdd_redirectid
 )
 
@@ -10004,7 +10066,7 @@ func (sc targetAdd) Run(c *Char, _ []int32) bool {
 	var pid int32
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
-		case targetAdd_id:
+		case targetAdd_playerid:
 			pid = exp[0].evalI(c)
 		case targetAdd_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3787,7 +3787,13 @@ func (sc helper) Run(c *Char, _ []int32) bool {
 		}
 		switch id {
 		case helper_helpertype:
-			h.player = exp[0].evalB(c)
+			ht := exp[0].evalI(c)
+			switch ht {
+			case 1:
+				h.player = true
+			case 2:
+				h.hprojectile = true
+			}
 		case helper_name:
 			h.name = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
 		case helper_postype:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5239,6 +5239,8 @@ const (
 	hitDef_guardpoints
 	hitDef_redlife
 	hitDef_score
+	hitDef_p2clsncheck
+	hitDef_p2clsnrequire
 	hitDef_last = iota + afterImage_last + 1 - 1
 	hitDef_redirectid
 )
@@ -5514,6 +5516,20 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 		hd.score[0] = exp[0].evalF(c)
 		if len(exp) > 1 {
 			hd.score[1] = exp[1].evalF(c)
+		}
+	case hitDef_p2clsncheck:
+		v := exp[0].evalI(c)
+		if v == 0 || v == 1 || v == 2 || v == 3 {
+			hd.p2clsncheck = v
+		} else {
+			hd.p2clsncheck = -1
+		}
+	case hitDef_p2clsnrequire:
+		v := exp[0].evalI(c)
+		if v == 1 || v == 2 || v == 3 {
+			hd.p2clsnrequire = v
+		} else {
+			hd.p2clsnrequire = 0
 		}
 	default:
 		if !palFX(sc).runSub(c, &hd.palfx, id, exp) {

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -12,7 +12,8 @@ import (
 // This file contains the parsing code for the function in ZSS and CNS, also called State Controllers.
 
 func (c *Compiler) hitBySub(is IniSection, sc *StateControllerBase) error {
-	attr, two := int32(-1), false
+	attr := int32(-1)
+	vnum := int32(1)
 	var err error
 	if err = c.stateParam(is, "value", func(data string) error {
 		attr, err = c.attr(data, false)
@@ -22,7 +23,61 @@ func (c *Compiler) hitBySub(is IniSection, sc *StateControllerBase) error {
 	}
 	if attr == -1 {
 		if err = c.stateParam(is, "value2", func(data string) error {
-			two = true
+			vnum = 2
+			attr, err = c.attr(data, false)
+			return err
+		}); err != nil {
+			return err
+		}
+	}
+	if attr == -1 {
+		if err = c.stateParam(is, "value3", func(data string) error {
+			vnum = 3
+			attr, err = c.attr(data, false)
+			return err
+		}); err != nil {
+			return err
+		}
+	}
+	if attr == -1 {
+		if err = c.stateParam(is, "value4", func(data string) error {
+			vnum = 4
+			attr, err = c.attr(data, false)
+			return err
+		}); err != nil {
+			return err
+		}
+	}
+	if attr == -1 {
+		if err = c.stateParam(is, "value5", func(data string) error {
+			vnum = 5
+			attr, err = c.attr(data, false)
+			return err
+		}); err != nil {
+			return err
+		}
+	}
+	if attr == -1 {
+		if err = c.stateParam(is, "value6", func(data string) error {
+			vnum = 6
+			attr, err = c.attr(data, false)
+			return err
+		}); err != nil {
+			return err
+		}
+	}
+	if attr == -1 {
+		if err = c.stateParam(is, "value7", func(data string) error {
+			vnum = 7
+			attr, err = c.attr(data, false)
+			return err
+		}); err != nil {
+			return err
+		}
+	}
+	if attr == -1 {
+		if err = c.stateParam(is, "value8", func(data string) error {
+			vnum = 8
 			attr, err = c.attr(data, false)
 			return err
 		}); err != nil {
@@ -36,7 +91,31 @@ func (c *Compiler) hitBySub(is IniSection, sc *StateControllerBase) error {
 		hitBy_time, VT_Int, 1, false); err != nil {
 		return err
 	}
-	if two {
+	if err := c.paramValue(is, sc, "playerno",
+		hitBy_playerno, VT_Int, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "playerid",
+		hitBy_playerid, VT_Int, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "stack",
+		hitBy_stack, VT_Bool, 1, false); err != nil {
+		return err
+	}
+	if vnum == 8 {
+		sc.add(hitBy_value8, sc.iToExp(attr))
+	} else if vnum == 7 {
+		sc.add(hitBy_value7, sc.iToExp(attr))
+	} else if vnum == 6 {
+		sc.add(hitBy_value6, sc.iToExp(attr))
+	} else if vnum == 5 {
+		sc.add(hitBy_value5, sc.iToExp(attr))
+	} else if vnum == 4 {
+		sc.add(hitBy_value4, sc.iToExp(attr))
+	} else if vnum == 3 {
+		sc.add(hitBy_value3, sc.iToExp(attr))
+	} else if vnum == 2 {
 		sc.add(hitBy_value2, sc.iToExp(attr))
 	} else {
 		sc.add(hitBy_value, sc.iToExp(attr))
@@ -5254,8 +5333,8 @@ func (c *Compiler) targetAdd(is IniSection, sc *StateControllerBase, _ int8) (St
 			targetAdd_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.paramValue(is, sc, "id",
-			targetAdd_id, VT_Int, 1, true); err != nil {
+		if err := c.paramValue(is, sc, "playerid",
+			targetAdd_playerid, VT_Int, 1, true); err != nil {
 			return err
 		}
 		return nil

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1793,6 +1793,50 @@ func (c *Compiler) hitDefSub(is IniSection,
 		hitDef_score, VT_Float, 2, false); err != nil {
 		return err
 	}
+	if err := c.stateParam(is, "p2clsncheck", func(data string) error {
+		if len(data) == 0 {
+			return Error("Value not specified")
+		}
+		var box int32
+		switch strings.ToLower(data) {
+		case "none":
+			box = 0
+		case "clsn1":
+			box = 1
+		case "clsn2":
+			box = 2
+		case "size":
+			box = 3
+		default:
+			return Error("Invalid value: " + data)
+		}
+		sc.add(hitDef_p2clsncheck, sc.iToExp(box))
+		return nil
+	}); err != nil {
+		return err
+	}
+	if err := c.stateParam(is, "p2clsnrequire", func(data string) error {
+		if len(data) == 0 {
+			return Error("Value not specified")
+		}
+		var box int32
+		switch strings.ToLower(data) {
+		case "none":
+			box = 0
+		case "clsn1":
+			box = 1
+		case "clsn2":
+			box = 2
+		case "size":
+			box = 3
+		default:
+			return Error("Invalid value: " + data)
+		}
+		sc.add(hitDef_p2clsnrequire, sc.iToExp(box))
+		return nil
+	}); err != nil {
+		return err
+	}
 	return nil
 }
 func (c *Compiler) hitDef(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -464,16 +464,18 @@ func (c *Compiler) helper(is IniSection, sc *StateControllerBase, _ int8) (State
 			if len(data) == 0 {
 				return Error("Value not specified")
 			}
+			var ht int32
 			switch strings.ToLower(data) {
 			case "normal":
-				// Default, valid value
+				ht = 0
 			case "player":
-				sc.add(helper_helpertype, sc.iToExp(1))
+				ht = 1
 			case "projectile":
-				// Valid but unused in Mugen. Same as normal type
+				ht = 2
 			default:
 				return Error("Invalid value: " + data)
 			}
+			sc.add(helper_helpertype, sc.iToExp(ht))
 			return nil
 		}); err != nil {
 			return err

--- a/src/system.go
+++ b/src/system.go
@@ -829,6 +829,9 @@ func (s *System) loadTime(start time.Time, str string, shell, console bool) {
 }
 func (s *System) clsnOverlap(clsn1 []float32, scl1, pos1 [2]float32, facing1 float32,
 	clsn2 []float32, scl2, pos2 [2]float32, facing2 float32) bool {
+	if clsn1 == nil || clsn2 == nil {
+		return false
+	}
 	if scl1[0] < 0 {
 		facing1 *= -1
 		scl1[0] *= -1


### PR DESCRIPTION
HelperType Projectile:
- Helpers can now use Projectile in the HelperType parameter
- Currently this makes collisions with other projectiles (standard or helpers of this type) be checked with Clsn2 boxes

Expanded hit detection:
- Hitdef, Projectile and Reversaldef receive two new parameters: P2ClsnCheck and P2ClsnRequire
- P2ClsnCheck: the hit will be checked against this type of collision box in the enemy
- P2ClsnRequire: The hit will only happen if the enemy has any box of this type (no need for overlap)
- Valid parameters: clsn1, clsn2, size and none

Expanded (Not)HitBy:
- New parameters for HitBy and NotHitBy
- PlayerNo filters hits by player number
- PlayerID filters hits by player ID
- Stack makes each invincibility slot be cumulative
- Value3 through Value 8 add more invincibility slots

Minor refactor:
- TargetAdd parameter changed from "ID" to "PlayerID"