### PR TITLE
feat: WindowScaleMode (nearest/bilinear filter toggle)

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -221,6 +221,7 @@ type configSettings struct {
 	InputSOCDResolution        int32
 	IP                         map[string]string
 	KeepAspect                 bool
+	WindowScaleMode            bool
 	LifeMul                    float32
 	ListenPort                 string
 	LoseSimul                  bool
@@ -373,6 +374,7 @@ func setupConfig() configSettings {
 	sys.gameHeight = tmp.GameHeight
 	sys.gameSpeed = tmp.GameFramerate / float32(tmp.Framerate)
 	sys.keepAspect = tmp.KeepAspect
+	sys.windowScaleMode = tmp.WindowScaleMode
 	sys.helperMax = tmp.MaxHelper
 	sys.inputButtonAssist = tmp.InputButtonAssist
 	sys.inputSOCDresolution = Clamp(tmp.InputSOCDResolution, 0, 4)

--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -424,6 +424,13 @@ func (r *Renderer) EndFrame() {
 	x, y, resizedWidth, resizedHeight := sys.window.GetScaledViewportSize()
 	postShader := r.postShaderSelect[sys.postProcessingShader]
 
+	var scaleMode uint32 // GL enum
+	if (sys.windowScaleMode == true) {
+		scaleMode = gl.LINEAR
+	} else {
+		scaleMode = gl.NEAREST
+	}
+
 	gl.UseProgram(postShader.program)
 	gl.Disable(gl.BLEND)
 
@@ -437,11 +444,11 @@ func (r *Renderer) EndFrame() {
 	gl.Uniform2f(postShader.u["TextureSize"], float32(sys.scrrect[2]), float32(sys.scrrect[3]))
 
 	gl.BindBuffer(gl.ARRAY_BUFFER, r.postVertBuffer)
+	gl.Finish()
 
 	loc := r.modelShader.a["VertCoord"]
 	gl.EnableVertexAttribArray(uint32(loc))
 	gl.VertexAttribPointerWithOffset(uint32(loc), 2, gl.FLOAT, false, 0, 0)
-	gl.Finish()
 
 	gl.DrawArrays(gl.TRIANGLE_STRIP, 0, 4)
 	gl.DisableVertexAttribArray(uint32(loc))
@@ -454,7 +461,7 @@ func (r *Renderer) EndFrame() {
 		gl.BindFramebuffer(gl.READ_FRAMEBUFFER, r.fbo_texture)
 	}
 	gl.BindFramebuffer(gl.DRAW_FRAMEBUFFER, 0)
-	gl.BlitFramebuffer(0, 0, sys.scrrect[2], sys.scrrect[3], x, y, x+resizedWidth, y+resizedHeight, gl.COLOR_BUFFER_BIT, gl.LINEAR)
+	gl.BlitFramebuffer(0, 0, sys.scrrect[2], sys.scrrect[3], x, y, x+resizedWidth, y+resizedHeight, gl.COLOR_BUFFER_BIT, scaleMode)
 }
 
 func (r *Renderer) SetPipeline(eq BlendEquation, src, dst BlendFunc) {

--- a/src/resources/defaultConfig.json
+++ b/src/resources/defaultConfig.json
@@ -130,6 +130,7 @@
     "external/icons/IkemenCylia_96.png",
     "external/icons/IkemenCylia_48.png"
   ],
+  "WindowScaleMode": true,
   "WindowTitle": "Ikemen GO",
   "XinputTriggerSensitivity": 0,
   "ZoomActive": true,

--- a/src/system.go
+++ b/src/system.go
@@ -39,6 +39,7 @@ var sys = System{
 	gameWidth:         320,
 	gameHeight:        240,
 	keepAspect:        true,
+	windowScaleMode:   true,
 	widthScale:        1,
 	heightScale:       1,
 	brightness:        256,
@@ -109,6 +110,7 @@ type System struct {
 	gameWidth, gameHeight   int32
 	widthScale, heightScale float32
 	keepAspect              bool
+	windowScaleMode         bool
 	window                  *Window
 	gameEnd, frameSkip      bool
 	redrawWait              struct{ nextTime, lastDraw time.Time }


### PR DESCRIPTION
Requested by a few people and trivially easy to implement, so why not?
Defaults to `true`, bilinear filtering, while setting it to `false` uses nearest-neighbor.
![image](https://github.com/user-attachments/assets/e8091078-2b78-4850-8089-c119b753eb46)
![image](https://github.com/user-attachments/assets/e16fd04a-00ba-4a31-b8ff-1312b3df0d4d)
