### PR TITLE
fix: Various window resizing-related fixes

### DIFF
--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -446,14 +446,20 @@ func (r *Renderer) EndFrame() {
 	gl.DrawArrays(gl.TRIANGLE_STRIP, 0, 4)
 	gl.DisableVertexAttribArray(uint32(loc))
 
-	// resize viewport and scale finished frame to window
-	gl.Viewport(x, y, resizedWidth, resizedHeight)
+	// rebind to prepare frame for blitting to window
 	if sys.multisampleAntialiasing {
 		gl.BindFramebuffer(gl.READ_FRAMEBUFFER, r.fbo_f)
 	} else {
 		gl.BindFramebuffer(gl.READ_FRAMEBUFFER, r.fbo)
 	}
 	gl.BindFramebuffer(gl.DRAW_FRAMEBUFFER, 0)
+
+	// clear the entire window's contents (prevents garbage data artifacts when resizing)
+	fullw, fullh := sys.window.GetSize()
+	gl.Viewport(0, 0, int32(fullw), int32(fullh))
+	gl.Clear(gl.COLOR_BUFFER_BIT)
+
+	// scale finished frame to window
 	gl.BlitFramebuffer(0, 0, sys.scrrect[2], sys.scrrect[3], x, y, x+resizedWidth, y+resizedHeight, gl.COLOR_BUFFER_BIT, gl.LINEAR)
 }
 

--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -449,9 +449,9 @@ func (r *Renderer) EndFrame() {
 	// resize viewport and scale finished frame to window
 	gl.Viewport(x, y, resizedWidth, resizedHeight)
 	if sys.multisampleAntialiasing {
-		gl.BindFramebuffer(gl.READ_FRAMEBUFFER, r.fbo_f_texture.handle)
+		gl.BindFramebuffer(gl.READ_FRAMEBUFFER, r.fbo_f)
 	} else {
-		gl.BindFramebuffer(gl.READ_FRAMEBUFFER, r.fbo_texture)
+		gl.BindFramebuffer(gl.READ_FRAMEBUFFER, r.fbo)
 	}
 	gl.BindFramebuffer(gl.DRAW_FRAMEBUFFER, 0)
 	gl.BlitFramebuffer(0, 0, sys.scrrect[2], sys.scrrect[3], x, y, x+resizedWidth, y+resizedHeight, gl.COLOR_BUFFER_BIT, gl.LINEAR)

--- a/src/system_glfw.go
+++ b/src/system_glfw.go
@@ -111,6 +111,10 @@ func (w *Window) GetScaledViewportSize() (int32, int32, int32, int32) {
 	var ratio float32
 	var x, y, resizedWidth, resizedHeight int32 = 0, 0, int32(winWidth), int32(winHeight)
 
+	if sys.fullscreen {
+		return 0, 0, int32(winWidth), int32(winHeight)
+	}
+
 	if ratioWidth < ratioHeight {
 		ratio = ratioWidth
 	} else {


### PR DESCRIPTION
Fixes a regression that caused Ikemen GO to crash when attempting to examine it via Renderdoc, and ~~suspected to also be the cause of~~ permanent black-screens on Intel Integrated graphics due to undefined behavior (binding a texture as if it were a framebuffer object) that Nvidia and AMD gloss over with their drivers.

I suggest merging this before merging my other PR (#1907) as this fixes a fairly severe regression (~~even if this isn't the fix for Intel~~, it at least fixes Renderdoc which is essential for graphics debugging) while the other adds a (albeit very minimal-code) feature.

UPDATE: I just got confirmation this fixes Intel integrated graphics having a black screen! Fixes #1901.