### PR TITLE
feat: ModifyHidef, ModifyProjectile, plus others

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5897,6 +5897,63 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 	return false
 }
 
+type modifyHitDef hitDef
+
+const (
+	modifyHitDef_redirectid = iota + hitDef_last + 1
+)
+
+func (sc modifyHitDef) Run(c *Char, _ []int32) bool {
+	crun := c
+	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
+		switch id {
+		case modifyHitDef_redirectid:
+			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
+				crun = rid
+			} else {
+				return false
+			}
+		default:
+			if crun.hitdef.attr > 0 && crun.hitdef.reversal_attr == 0 {
+				hitDef(sc).runSub(c, &crun.hitdef, id, exp)
+			}
+		}
+		return true
+	})
+	return false
+}
+
+type modifyReversalDef hitDef
+
+const (
+	modifyReversalDef_reversal_attr = iota + hitDef_last + 1
+	modifyReversalDef_redirectid
+)
+
+func (sc modifyReversalDef) Run(c *Char, _ []int32) bool {
+	crun := c
+	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
+		switch id {
+		case modifyReversalDef_redirectid:
+			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
+				crun = rid
+			} else {
+				return false
+			}
+		case modifyReversalDef_reversal_attr:
+			if crun.hitdef.reversal_attr > 0 {
+				crun.hitdef.reversal_attr = exp[0].evalI(c)
+			}
+		default:
+			if crun.hitdef.reversal_attr > 0 {
+				hitDef(sc).runSub(c, &crun.hitdef, id, exp)
+			}
+		}
+		return true
+	})
+	return false
+}
+
 type width StateControllerBase
 
 const (

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5035,7 +5035,10 @@ func (sc gameMakeAnim) Run(c *Char, _ []int32) bool {
 				e.relativePos[1] += RandF(-rndy, rndy)
 			}
 		case gameMakeAnim_under:
-			e.ontop = !exp[0].evalB(c)
+			if exp[0].evalB(c) {
+				e.under = true
+				e.ontop = false
+			}
 		case gameMakeAnim_anim:
 			e.anim = crun.getAnim(exp[1].evalI(c), string(*(*[]byte)(unsafe.Pointer(&exp[0]))), true)
 		}

--- a/src/char.go
+++ b/src/char.go
@@ -4480,6 +4480,16 @@ func (c *Char) projInit(p *Projectile, pt PosType, x, y float32,
 		c.forceRemapPal(p.palfx, [...]int32{rpg, rpn})
 	}
 }
+
+func (c *Char) getProjs(id int32) (projs []*Projectile) {
+	for i, p := range sys.projs[c.playerNo] {
+		if id < 0 || p.id == id {
+			projs = append(projs, &sys.projs[c.playerNo][i])
+		}
+	}
+	return
+}
+
 func (c *Char) setHitdefDefault(hd *HitDef, proj bool) {
 	if !proj {
 		c.hitdefTargets = c.hitdefTargets[:0]

--- a/src/char.go
+++ b/src/char.go
@@ -2929,7 +2929,7 @@ func (c *Char) changeAnimEx(animNo int32, playerNo int, ffx string, alt bool) {
 		c.animPN = c.playerNo
 		c.prevAnimNo = c.animNo
 		c.animNo = animNo
-		// If player is in custom state and used ChangeAnim2
+		// If using ChangeAnim2, the animation is changed but the sff is kept
 		if alt {
 			c.animPN = playerNo
 			a.sff = sys.cgi[c.playerNo].sff
@@ -2966,12 +2966,12 @@ func (c *Char) changeAnim(animNo int32, playerNo int, ffx string) {
 	}
 	c.changeAnimEx(animNo, playerNo, ffx, false)
 }
-func (c *Char) changeAnim2(animNo int32, ffx string) {
+func (c *Char) changeAnim2(animNo int32, playerNo int, ffx string) {
 	if animNo < 0 && animNo != -2 {
 		sys.appendToConsole(c.warn() + fmt.Sprintf("attempted change to negative anim (different from -2)"))
 		animNo = 0
 	}
-	c.changeAnimEx(animNo, c.ss.sb.playerNo, ffx, true)
+	c.changeAnimEx(animNo, playerNo, ffx, true)
 }
 func (c *Char) setAnimElem(e int32) {
 	if c.anim != nil {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1886,8 +1886,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				out.append(OC_ex_gethitvar_slidetime)
 			case "ctrltime":
 				out.append(OC_ex_gethitvar_ctrltime)
-			case "recovertime":
-				out.append(OC_ex_gethitvar_recovertime)
+			case "recovertime", "down.recovertime": // Added second term for consistency
+				out.append(OC_ex_gethitvar_down_recovertime)
 			case "xoff":
 				out.append(OC_ex_gethitvar_xoff)
 			case "yoff":
@@ -1980,6 +1980,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				out.append(OC_ex_gethitvar_airguard_velocity_y)
 			case "frame":
 				out.append(OC_ex_gethitvar_frame)
+			case "down.recover":
+				out.append(OC_ex_gethitvar_down_recover)
 			default:
 				return bvNone(), Error("Invalid data: " + c.token)
 			}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -174,6 +174,8 @@ func newCompiler() *Compiler {
 		"modifybgm":            c.modifyBgm,
 		"groundleveloffset":    c.groundLevelOffset,
 		"targetadd":            c.targetAdd,
+		"modifyhitdef":         c.modifyHitDef,
+		"modifyreversaldef":    c.modifyReversalDef,
 	}
 	return c
 }

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -176,6 +176,7 @@ func newCompiler() *Compiler {
 		"targetadd":            c.targetAdd,
 		"modifyhitdef":         c.modifyHitDef,
 		"modifyreversaldef":    c.modifyReversalDef,
+		"modifyprojectile":     c.modifyProjectile,
 	}
 	return c
 }

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1339,8 +1339,7 @@ func (c *Compiler) afterImageTime(is IniSection, sc *StateControllerBase, _ int8
 	})
 	return *ret, err
 }
-func (c *Compiler) hitDefSub(is IniSection,
-	sc *StateControllerBase) error {
+func (c *Compiler) hitDefSub(is IniSection,	sc *StateControllerBase) error {
 	if err := c.stateParam(is, "attr", func(data string) error {
 		attr, err := c.attr(data, true)
 		if err != nil {
@@ -1925,6 +1924,7 @@ func (c *Compiler) hitDefSub(is IniSection,
 	}
 	return nil
 }
+
 func (c *Compiler) hitDef(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*hitDef)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -1935,6 +1935,18 @@ func (c *Compiler) hitDef(is IniSection, sc *StateControllerBase, _ int8) (State
 	})
 	return *ret, err
 }
+
+func (c *Compiler) modifyHitDef(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+	ret, err := (*modifyHitDef)(sc), c.stateSec(is, func() error {
+		if err := c.paramValue(is, sc, "redirectid",
+			modifyHitDef_redirectid, VT_Int, 1, false); err != nil {
+			return err
+		}
+		return c.hitDefSub(is, sc)
+	})
+	return *ret, err
+}
+
 func (c *Compiler) reversalDef(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*reversalDef)(sc), c.stateSec(is, func() error {
 		attr := int32(-1)
@@ -1953,180 +1965,6 @@ func (c *Compiler) reversalDef(is IniSection, sc *StateControllerBase, _ int8) (
 			return Error("reversal.attr parameter not specified")
 		}
 		sc.add(reversalDef_reversal_attr, sc.iToExp(attr))
-		return c.hitDefSub(is, sc)
-	})
-	return *ret, err
-}
-func (c *Compiler) projectile(is IniSection, sc *StateControllerBase,
-	ihp int8) (StateController, error) {
-	ret, err := (*projectile)(sc), c.stateSec(is, func() error {
-		if err := c.paramValue(is, sc, "redirectid",
-			projectile_redirectid, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramPostype(is, sc, projectile_postype); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "projid",
-			projectile_projid, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "projremove",
-			projectile_projremove, VT_Bool, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "projremovetime",
-			projectile_projremovetime, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "projshadow",
-			projectile_projshadow, VT_Int, 3, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "projmisstime",
-			projectile_projmisstime, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "projhits",
-			projectile_projhits, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "projpriority",
-			projectile_projpriority, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.stateParam(is, "projhitanim", func(data string) error {
-			prefix := c.getDataPrefix(&data, false)
-			return c.scAdd(sc, projectile_projhitanim, data, VT_Int, 1,
-				sc.beToExp(BytecodeExp(prefix))...)
-		}); err != nil {
-			return err
-		}
-		if err := c.stateParam(is, "projremanim", func(data string) error {
-			prefix := c.getDataPrefix(&data, false)
-			return c.scAdd(sc, projectile_projremanim, data, VT_Int, 1,
-				sc.beToExp(BytecodeExp(prefix))...)
-		}); err != nil {
-			return err
-		}
-		if err := c.stateParam(is, "projcancelanim", func(data string) error {
-			prefix := c.getDataPrefix(&data, false)
-			return c.scAdd(sc, projectile_projcancelanim, data, VT_Int, 1,
-				sc.beToExp(BytecodeExp(prefix))...)
-		}); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "velocity",
-			projectile_velocity, VT_Float, 2, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "velmul",
-			projectile_velmul, VT_Float, 2, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "remvelocity",
-			projectile_remvelocity, VT_Float, 2, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "accel",
-			projectile_accel, VT_Float, 2, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "projscale",
-			projectile_projscale, VT_Float, 2, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "projangle",
-			projectile_projangle, VT_Float, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "projrescaleclsn",
-			projectile_projrescaleclsn, VT_Bool, 1, false); err != nil {
-			return err
-		}
-
-		// HitDef section
-		if err := c.hitDefSub(is, sc); err != nil {
-			return err
-		}
-
-		if err := c.paramValue(is, sc, "offset",
-			projectile_offset, VT_Float, 2, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "projsprpriority",
-			projectile_projsprpriority, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "projstagebound",
-			projectile_projstagebound, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "projedgebound",
-			projectile_projedgebound, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "projheightbound",
-			projectile_projheightbound, VT_Int, 2, false); err != nil {
-			return err
-		}
-		if err := c.stateParam(is, "projanim", func(data string) error {
-			prefix := c.getDataPrefix(&data, false)
-			return c.scAdd(sc, projectile_projanim, data, VT_Int, 1,
-				sc.beToExp(BytecodeExp(prefix))...)
-		}); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "supermovetime",
-			projectile_supermovetime, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "pausemovetime",
-			projectile_pausemovetime, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "ownpal",
-			projectile_ownpal, VT_Bool, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "remappal",
-			projectile_remappal, VT_Int, 2, false); err != nil {
-			return err
-		}
-		if err := c.afterImageSub(is, sc, ihp, "afterimage."); err != nil {
-			return err
-		}
-		// if err := c.paramValue(is, sc, "platform",
-		// 	projectile_platform, VT_Bool, 1, false); err != nil {
-		// 	return err
-		// }
-		// if err := c.paramValue(is, sc, "platformwidth",
-		// 	projectile_platformwidth, VT_Float, 2, false); err != nil {
-		// 	return err
-		// }
-		// if err := c.paramValue(is, sc, "platformheight",
-		// 	projectile_platformheight, VT_Float, 2, false); err != nil {
-		// 	return err
-		// }
-		// if err := c.paramValue(is, sc, "platformangle",
-		// 	projectile_platformangle, VT_Float, 1, false); err != nil {
-		// 	return err
-		// }
-		// if err := c.paramValue(is, sc, "platformfence",
-		// 	projectile_platformfence, VT_Bool, 1, false); err != nil {
-		// 	return err
-		// }
-		return nil
-	})
-	return *ret, err
-}
-
-func (c *Compiler) modifyHitDef(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
-	ret, err := (*modifyHitDef)(sc), c.stateSec(is, func() error {
-		if err := c.paramValue(is, sc, "redirectid",
-			modifyHitDef_redirectid, VT_Int, 1, false); err != nil {
-			return err
-		}
 		return c.hitDefSub(is, sc)
 	})
 	return *ret, err
@@ -2150,6 +1988,177 @@ func (c *Compiler) modifyReversalDef(is IniSection, sc *StateControllerBase, _ i
 			sc.add(modifyReversalDef_reversal_attr, sc.iToExp(attr))
 		}
 		return c.hitDefSub(is, sc)
+	})
+	return *ret, err
+}
+
+func (c *Compiler) projectileSub(is IniSection,	sc *StateControllerBase, ihp int8) error {
+	if err := c.paramValue(is, sc, "redirectid",
+		projectile_redirectid, VT_Int, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramPostype(is, sc, projectile_postype); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "projid",
+		projectile_projid, VT_Int, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "projremove",
+		projectile_projremove, VT_Bool, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "projremovetime",
+		projectile_projremovetime, VT_Int, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "projshadow",
+		projectile_projshadow, VT_Int, 3, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "projmisstime",
+		projectile_projmisstime, VT_Int, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "projhits",
+		projectile_projhits, VT_Int, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "projpriority",
+		projectile_projpriority, VT_Int, 1, false); err != nil {
+		return err
+	}
+	if err := c.stateParam(is, "projhitanim", func(data string) error {
+		prefix := c.getDataPrefix(&data, false)
+		return c.scAdd(sc, projectile_projhitanim, data, VT_Int, 1,
+			sc.beToExp(BytecodeExp(prefix))...)
+	}); err != nil {
+		return err
+	}
+	if err := c.stateParam(is, "projremanim", func(data string) error {
+		prefix := c.getDataPrefix(&data, false)
+		return c.scAdd(sc, projectile_projremanim, data, VT_Int, 1,
+			sc.beToExp(BytecodeExp(prefix))...)
+	}); err != nil {
+		return err
+	}
+	if err := c.stateParam(is, "projcancelanim", func(data string) error {
+		prefix := c.getDataPrefix(&data, false)
+		return c.scAdd(sc, projectile_projcancelanim, data, VT_Int, 1,
+			sc.beToExp(BytecodeExp(prefix))...)
+	}); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "velocity",
+		projectile_velocity, VT_Float, 2, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "velmul",
+		projectile_velmul, VT_Float, 2, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "remvelocity",
+		projectile_remvelocity, VT_Float, 2, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "accel",
+		projectile_accel, VT_Float, 2, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "projscale",
+		projectile_projscale, VT_Float, 2, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "projangle",
+		projectile_projangle, VT_Float, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "projrescaleclsn",
+		projectile_projrescaleclsn, VT_Bool, 1, false); err != nil {
+		return err
+	}
+
+	// HitDef section
+	if err := c.hitDefSub(is, sc); err != nil {
+		return err
+	}
+
+	if err := c.paramValue(is, sc, "offset",
+		projectile_offset, VT_Float, 2, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "projsprpriority",
+		projectile_projsprpriority, VT_Int, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "projstagebound",
+		projectile_projstagebound, VT_Int, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "projedgebound",
+		projectile_projedgebound, VT_Int, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "projheightbound",
+		projectile_projheightbound, VT_Int, 2, false); err != nil {
+		return err
+	}
+	if err := c.stateParam(is, "projanim", func(data string) error {
+		prefix := c.getDataPrefix(&data, false)
+		return c.scAdd(sc, projectile_projanim, data, VT_Int, 1,
+			sc.beToExp(BytecodeExp(prefix))...)
+	}); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "supermovetime",
+		projectile_supermovetime, VT_Int, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "pausemovetime",
+		projectile_pausemovetime, VT_Int, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "ownpal",
+		projectile_ownpal, VT_Bool, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "remappal",
+		projectile_remappal, VT_Int, 2, false); err != nil {
+		return err
+	}
+	if err := c.afterImageSub(is, sc, ihp, "afterimage."); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Compiler) projectile(is IniSection, sc *StateControllerBase, ihp int8) (StateController, error) {
+	ret, err := (*projectile)(sc), c.stateSec(is, func() error {
+		if err := c.projectileSub(is, sc, ihp); err != nil {
+			return err
+		}
+		return nil
+	})
+	return *ret, err
+}
+
+func (c *Compiler) modifyProjectile(is IniSection, sc *StateControllerBase,
+	ihp int8) (StateController, error) {
+	ret, err := (*modifyProjectile)(sc), c.stateSec(is, func() error {
+		if err := c.paramValue(is, sc, "redirectid",
+			modifyProjectile_redirectid, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "id",
+			modifyProjectile_id, VT_Int, 1, false); err != nil {
+			return err
+		}
+
+		if err := c.projectileSub(is, sc, ihp); err != nil {
+			return err
+		}
+
+		return nil
 	})
 	return *ret, err
 }

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -13,13 +13,17 @@ import (
 
 func (c *Compiler) hitBySub(is IniSection, sc *StateControllerBase) error {
 	attr := int32(-1)
-	vnum := int32(1)
+	vnum := int32(-1)
 	var err error
-	if err = c.stateParam(is, "value", false, func(data string) error {
-		attr, err = c.attr(data, false)
-		return err
-	}); err != nil {
-		return err
+	// Old syntax uses valueX
+	if attr == -1 {
+		if err = c.stateParam(is, "value", false, func(data string) error {
+			vnum = 1
+			attr, err = c.attr(data, false)
+			return err
+		}); err != nil {
+			return err
+		}
 	}
 	if attr == -1 {
 		if err = c.stateParam(is, "value2", false, func(data string) error {
@@ -30,62 +34,24 @@ func (c *Compiler) hitBySub(is IniSection, sc *StateControllerBase) error {
 			return err
 		}
 	}
-	if attr == -1 {
-		if err = c.stateParam(is, "value3", false, func(data string) error {
-			vnum = 3
-			attr, err = c.attr(data, false)
-			return err
-		}); err != nil {
-			return err
-		}
-	}
-	if attr == -1 {
-		if err = c.stateParam(is, "value4", false, func(data string) error {
-			vnum = 4
-			attr, err = c.attr(data, false)
-			return err
-		}); err != nil {
+	// New syntax uses attr and slot
+	if err := c.stateParam(is, "attr", false, func(data string) error {
+		vnum = -1
+		attr, err = c.attr(data, false)
+		if err != nil {
 			return err
 		}
+		sc.add(hitBy_attr, sc.iToExp(attr))
+		return nil
+	}); err != nil {
+		return err
 	}
 	if attr == -1 {
-		if err = c.stateParam(is, "value5", false, func(data string) error {
-			vnum = 5
-			attr, err = c.attr(data, false)
-			return err
-		}); err != nil {
-			return err
-		}
+		return Error("Attributes not specified")
 	}
-	if attr == -1 {
-		if err = c.stateParam(is, "value6", false, func(data string) error {
-			vnum = 6
-			attr, err = c.attr(data, false)
-			return err
-		}); err != nil {
-			return err
-		}
-	}
-	if attr == -1 {
-		if err = c.stateParam(is, "value7", false, func(data string) error {
-			vnum = 7
-			attr, err = c.attr(data, false)
-			return err
-		}); err != nil {
-			return err
-		}
-	}
-	if attr == -1 {
-		if err = c.stateParam(is, "value8", false, func(data string) error {
-			vnum = 8
-			attr, err = c.attr(data, false)
-			return err
-		}); err != nil {
-			return err
-		}
-	}
-	if attr == -1 {
-		return Error("value parameter not specified")
+	if err := c.paramValue(is, sc, "slot",
+		hitBy_slot, VT_Int, 1, false); err != nil {
+		return err
 	}
 	if err := c.paramValue(is, sc, "time",
 		hitBy_time, VT_Int, 1, false); err != nil {
@@ -103,25 +69,14 @@ func (c *Compiler) hitBySub(is IniSection, sc *StateControllerBase) error {
 		hitBy_stack, VT_Bool, 1, false); err != nil {
 		return err
 	}
-	if vnum == 8 {
-		sc.add(hitBy_value8, sc.iToExp(attr))
-	} else if vnum == 7 {
-		sc.add(hitBy_value7, sc.iToExp(attr))
-	} else if vnum == 6 {
-		sc.add(hitBy_value6, sc.iToExp(attr))
-	} else if vnum == 5 {
-		sc.add(hitBy_value5, sc.iToExp(attr))
-	} else if vnum == 4 {
-		sc.add(hitBy_value4, sc.iToExp(attr))
-	} else if vnum == 3 {
-		sc.add(hitBy_value3, sc.iToExp(attr))
+	if vnum == 1 {
+		sc.add(hitBy_value, sc.iToExp(attr))
 	} else if vnum == 2 {
 		sc.add(hitBy_value2, sc.iToExp(attr))
-	} else {
-		sc.add(hitBy_value, sc.iToExp(attr))
 	}
 	return nil
 }
+
 func (c *Compiler) hitBy(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*hitBy)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1872,6 +1872,14 @@ func (c *Compiler) hitDefSub(is IniSection,	sc *StateControllerBase) error {
 	}); err != nil {
 		return err
 	}
+	if err := c.paramValue(is, sc, "down.recover",
+		hitDef_down_recover, VT_Bool, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "down.recovertime",
+		hitDef_down_recovertime, VT_Int, 1, false); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -5204,6 +5212,14 @@ func (c *Compiler) getHitVarSet(is IniSection, sc *StateControllerBase, _ int8) 
 		}
 		if err := c.paramValue(is, sc, "ctrltime",
 			getHitVarSet_ctrltime, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "down.recover",
+			getHitVarSet_down_recover, VT_Bool, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "down.recovertime",
+			getHitVarSet_down_recovertime, VT_Int, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "fall",

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -15,14 +15,14 @@ func (c *Compiler) hitBySub(is IniSection, sc *StateControllerBase) error {
 	attr := int32(-1)
 	vnum := int32(1)
 	var err error
-	if err = c.stateParam(is, "value", func(data string) error {
+	if err = c.stateParam(is, "value", false, func(data string) error {
 		attr, err = c.attr(data, false)
 		return err
 	}); err != nil {
 		return err
 	}
 	if attr == -1 {
-		if err = c.stateParam(is, "value2", func(data string) error {
+		if err = c.stateParam(is, "value2", false, func(data string) error {
 			vnum = 2
 			attr, err = c.attr(data, false)
 			return err
@@ -31,7 +31,7 @@ func (c *Compiler) hitBySub(is IniSection, sc *StateControllerBase) error {
 		}
 	}
 	if attr == -1 {
-		if err = c.stateParam(is, "value3", func(data string) error {
+		if err = c.stateParam(is, "value3", false, func(data string) error {
 			vnum = 3
 			attr, err = c.attr(data, false)
 			return err
@@ -40,7 +40,7 @@ func (c *Compiler) hitBySub(is IniSection, sc *StateControllerBase) error {
 		}
 	}
 	if attr == -1 {
-		if err = c.stateParam(is, "value4", func(data string) error {
+		if err = c.stateParam(is, "value4", false, func(data string) error {
 			vnum = 4
 			attr, err = c.attr(data, false)
 			return err
@@ -49,7 +49,7 @@ func (c *Compiler) hitBySub(is IniSection, sc *StateControllerBase) error {
 		}
 	}
 	if attr == -1 {
-		if err = c.stateParam(is, "value5", func(data string) error {
+		if err = c.stateParam(is, "value5", false, func(data string) error {
 			vnum = 5
 			attr, err = c.attr(data, false)
 			return err
@@ -58,7 +58,7 @@ func (c *Compiler) hitBySub(is IniSection, sc *StateControllerBase) error {
 		}
 	}
 	if attr == -1 {
-		if err = c.stateParam(is, "value6", func(data string) error {
+		if err = c.stateParam(is, "value6", false, func(data string) error {
 			vnum = 6
 			attr, err = c.attr(data, false)
 			return err
@@ -67,7 +67,7 @@ func (c *Compiler) hitBySub(is IniSection, sc *StateControllerBase) error {
 		}
 	}
 	if attr == -1 {
-		if err = c.stateParam(is, "value7", func(data string) error {
+		if err = c.stateParam(is, "value7", false, func(data string) error {
 			vnum = 7
 			attr, err = c.attr(data, false)
 			return err
@@ -76,7 +76,7 @@ func (c *Compiler) hitBySub(is IniSection, sc *StateControllerBase) error {
 		}
 	}
 	if attr == -1 {
-		if err = c.stateParam(is, "value8", func(data string) error {
+		if err = c.stateParam(is, "value8", false, func(data string) error {
 			vnum = 8
 			attr, err = c.attr(data, false)
 			return err
@@ -274,7 +274,7 @@ func (c *Compiler) assertSpecial(is IniSection, sc *StateControllerBase, _ int8)
 			return nil
 		}
 		f := false
-		if err := c.stateParam(is, "flag", func(data string) error {
+		if err := c.stateParam(is, "flag", false, func(data string) error {
 			f = true
 			return foo(data)
 		}); err != nil {
@@ -283,12 +283,12 @@ func (c *Compiler) assertSpecial(is IniSection, sc *StateControllerBase, _ int8)
 		if !f {
 			return Error("flag parameter not specified")
 		}
-		if err := c.stateParam(is, "flag2", func(data string) error {
+		if err := c.stateParam(is, "flag2", false, func(data string) error {
 			return foo(data)
 		}); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "flag3", func(data string) error {
+		if err := c.stateParam(is, "flag3", false, func(data string) error {
 			return foo(data)
 		}); err != nil {
 			return err
@@ -303,17 +303,12 @@ func (c *Compiler) playSnd(is IniSection, sc *StateControllerBase, _ int8) (Stat
 			playSnd_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
-		f := false
-		if err := c.stateParam(is, "value", func(data string) error {
-			f = true
+		if err := c.stateParam(is, "value", true, func(data string) error {
 			prefix := c.getDataPrefix(&data, false)
 			return c.scAdd(sc, playSnd_value, data, VT_Int, 2,
 				sc.beToExp(BytecodeExp(prefix))...)
 		}); err != nil {
 			return err
-		}
-		if !f {
-			return Error("value parameter not specified")
 		}
 		if err := c.paramValue(is, sc, "channel",
 			playSnd_channel, VT_Int, 1, false); err != nil {
@@ -393,7 +388,7 @@ func (c *Compiler) changeStateSub(is IniSection,
 		changeState_ctrl, VT_Int, 1, false); err != nil {
 		return err
 	}
-	if err := c.stateParam(is, "anim", func(data string) error {
+	if err := c.stateParam(is, "anim", false, func(data string) error {
 		prefix := c.getDataPrefix(&data, false)
 		return c.scAdd(sc, changeState_anim, data, VT_Int, 1,
 			sc.beToExp(BytecodeExp(prefix))...)
@@ -519,7 +514,7 @@ func (c *Compiler) changeAnimSub(is IniSection,
 		changeAnim_elem, VT_Int, 1, false); err != nil {
 		return err
 	}
-	if err := c.stateParam(is, "value", func(data string) error {
+	if err := c.stateParam(is, "value", true, func(data string) error {
 		prefix := c.getDataPrefix(&data, false)
 		return c.scAdd(sc, changeAnim_value, data, VT_Int, 1,
 			sc.beToExp(BytecodeExp(prefix))...)
@@ -546,7 +541,7 @@ func (c *Compiler) helper(is IniSection, sc *StateControllerBase, _ int8) (State
 			helper_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "helpertype", func(data string) error {
+		if err := c.stateParam(is, "helpertype", false, func(data string) error {
 			if len(data) == 0 {
 				return Error("Value not specified")
 			}
@@ -566,7 +561,7 @@ func (c *Compiler) helper(is IniSection, sc *StateControllerBase, _ int8) (State
 		}); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "name", func(data string) error {
+		if err := c.stateParam(is, "name", false, func(data string) error {
 			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
 				return Error("Not enclosed in \"")
 			}
@@ -642,7 +637,7 @@ func (c *Compiler) helper(is IniSection, sc *StateControllerBase, _ int8) (State
 			helper_stateno, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "keyctrl", func(data string) error {
+		if err := c.stateParam(is, "keyctrl", false, func(data string) error {
 			bes, err := c.exprs(data, VT_Int, 4)
 			if err != nil {
 				return err
@@ -751,7 +746,7 @@ func (c *Compiler) explodSub(is IniSection,
 		return err
 	}
 	found := false
-	if err := c.stateParam(is, "vel", func(data string) error {
+	if err := c.stateParam(is, "vel", false, func(data string) error {
 		found = true
 		return c.scAdd(sc, explod_velocity, data, VT_Float, 2)
 	}); err != nil {
@@ -808,7 +803,7 @@ func (c *Compiler) explodSub(is IniSection,
 		explod_bindid, VT_Int, 1, false); err != nil {
 		return err
 	}
-	if err := c.stateParam(is, "ontop", func(data string) error {
+	if err := c.stateParam(is, "ontop", false, func(data string) error {
 		if err := c.scAdd(sc, explod_ontop, data, VT_Bool, 1); err != nil {
 			return err
 		}
@@ -819,7 +814,7 @@ func (c *Compiler) explodSub(is IniSection,
 	}); err != nil {
 		return err
 	}
-	if err := c.stateParam(is, "under", func(data string) error {
+	if err := c.stateParam(is, "under", false, func(data string) error {
 		if err := c.scAdd(sc, explod_under, data, VT_Bool, 1); err != nil {
 			return err
 		}
@@ -906,7 +901,7 @@ func (c *Compiler) explod(is IniSection, sc *StateControllerBase,
 			explod_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "anim", func(data string) error {
+		if err := c.stateParam(is, "anim", false, func(data string) error {
 			prefix := c.getDataPrefix(&data, false)
 			return c.scAdd(sc, explod_anim, data, VT_Int, 1,
 				sc.beToExp(BytecodeExp(prefix))...)
@@ -964,7 +959,7 @@ func (c *Compiler) modifyExplod(is IniSection, sc *StateControllerBase,
 		if err := c.explodSub(is, sc); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "anim", func(data string) error {
+		if err := c.stateParam(is, "anim", false, func(data string) error {
 			prefix := c.getDataPrefix(&data, false)
 			return c.scAdd(sc, explod_anim, data, VT_Int, 1,
 				sc.beToExp(BytecodeExp(prefix))...)
@@ -1031,13 +1026,13 @@ func (c *Compiler) gameMakeAnim(is IniSection, sc *StateControllerBase, _ int8) 
 			return c.scAdd(sc, gameMakeAnim_anim, data, VT_Int, 1,
 				sc.beToExp(BytecodeExp(prefix))...)
 		}
-		if err := c.stateParam(is, "anim", func(data string) error {
+		if err := c.stateParam(is, "anim", false, func(data string) error {
 			return anim(data)
 		}); err != nil {
 			return err
 		}
 		if !b {
-			if err := c.stateParam(is, "value", func(data string) error {
+			if err := c.stateParam(is, "value", false, func(data string) error {
 				return anim(data)
 			}); err != nil {
 				return err
@@ -1127,7 +1122,7 @@ func (c *Compiler) palFXSub(is IniSection,
 		palFX_hue, VT_Float, 1, false); err != nil {
 		return err
 	}
-	if err := c.stateParam(is, prefix+"add", func(data string) error {
+	if err := c.stateParam(is, prefix+"add", false, func(data string) error {
 		bes, err := c.exprs(data, VT_Int, 3)
 		if err != nil {
 			return err
@@ -1140,7 +1135,7 @@ func (c *Compiler) palFXSub(is IniSection,
 	}); err != nil {
 		return err
 	}
-	if err := c.stateParam(is, prefix+"mul", func(data string) error {
+	if err := c.stateParam(is, prefix+"mul", false, func(data string) error {
 		bes, err := c.exprs(data, VT_Int, 3)
 		if err != nil {
 			return err
@@ -1153,7 +1148,7 @@ func (c *Compiler) palFXSub(is IniSection,
 	}); err != nil {
 		return err
 	}
-	if err := c.stateParam(is, prefix+"sinadd", func(data string) error {
+	if err := c.stateParam(is, prefix+"sinadd", false, func(data string) error {
 		bes, err := c.exprs(data, VT_Int, 4)
 		if err != nil {
 			return err
@@ -1166,7 +1161,7 @@ func (c *Compiler) palFXSub(is IniSection,
 	}); err != nil {
 		return err
 	}
-	if err := c.stateParam(is, prefix+"sinmul", func(data string) error {
+	if err := c.stateParam(is, prefix+"sinmul", false, func(data string) error {
 		bes, err := c.exprs(data, VT_Int, 4)
 		if err != nil {
 			return err
@@ -1179,7 +1174,7 @@ func (c *Compiler) palFXSub(is IniSection,
 	}); err != nil {
 		return err
 	}
-	if err := c.stateParam(is, prefix+"sincolor", func(data string) error {
+	if err := c.stateParam(is, prefix+"sincolor", false, func(data string) error {
 		bes, err := c.exprs(data, VT_Int, 2)
 		if err != nil {
 			return err
@@ -1192,7 +1187,7 @@ func (c *Compiler) palFXSub(is IniSection,
 	}); err != nil {
 		return err
 	}
-	if err := c.stateParam(is, prefix+"sinhue", func(data string) error {
+	if err := c.stateParam(is, prefix+"sinhue", false, func(data string) error {
 		bes, err := c.exprs(data, VT_Int, 2)
 		if err != nil {
 			return err
@@ -1318,14 +1313,14 @@ func (c *Compiler) afterImageTime(is IniSection, sc *StateControllerBase, _ int8
 			return err
 		}
 		b := false
-		if err := c.stateParam(is, "time", func(data string) error {
+		if err := c.stateParam(is, "time", false, func(data string) error {
 			b = true
 			return c.scAdd(sc, afterImageTime_time, data, VT_Int, 1)
 		}); err != nil {
 			return err
 		}
 		if !b {
-			if err := c.stateParam(is, "value", func(data string) error {
+			if err := c.stateParam(is, "value", false, func(data string) error {
 				b = true
 				return c.scAdd(sc, afterImageTime_time, data, VT_Int, 1)
 			}); err != nil {
@@ -1340,7 +1335,7 @@ func (c *Compiler) afterImageTime(is IniSection, sc *StateControllerBase, _ int8
 	return *ret, err
 }
 func (c *Compiler) hitDefSub(is IniSection,	sc *StateControllerBase) error {
-	if err := c.stateParam(is, "attr", func(data string) error {
+	if err := c.stateParam(is, "attr", false, func(data string) error {
 		attr, err := c.attr(data, true)
 		if err != nil {
 			return err
@@ -1377,12 +1372,12 @@ func (c *Compiler) hitDefSub(is IniSection,	sc *StateControllerBase) error {
 		sc.add(id, sc.iToExp(flg))
 		return nil
 	}
-	if err := c.stateParam(is, "guardflag", func(data string) error {
+	if err := c.stateParam(is, "guardflag", false, func(data string) error {
 		return hflg(hitDef_guardflag, data)
 	}); err != nil {
 		return err
 	}
-	if err := c.stateParam(is, "hitflag", func(data string) error {
+	if err := c.stateParam(is, "hitflag", false, func(data string) error {
 		return hflg(hitDef_hitflag, data)
 	}); err != nil {
 		return err
@@ -1407,12 +1402,12 @@ func (c *Compiler) hitDefSub(is IniSection,	sc *StateControllerBase) error {
 		sc.add(id, sc.iToExp(int32(ht)))
 		return nil
 	}
-	if err := c.stateParam(is, "ground.type", func(data string) error {
+	if err := c.stateParam(is, "ground.type", false, func(data string) error {
 		return htyp(hitDef_ground_type, data)
 	}); err != nil {
 		return err
 	}
-	if err := c.stateParam(is, "air.type", func(data string) error {
+	if err := c.stateParam(is, "air.type", false, func(data string) error {
 		return htyp(hitDef_air_type, data)
 	}); err != nil {
 		return err
@@ -1441,22 +1436,22 @@ func (c *Compiler) hitDefSub(is IniSection,	sc *StateControllerBase) error {
 		sc.add(id, sc.iToExp(int32(ra)))
 		return nil
 	}
-	if err := c.stateParam(is, "animtype", func(data string) error {
+	if err := c.stateParam(is, "animtype", false, func(data string) error {
 		return reac(hitDef_animtype, data)
 	}); err != nil {
 		return err
 	}
-	if err := c.stateParam(is, "air.animtype", func(data string) error {
+	if err := c.stateParam(is, "air.animtype", false, func(data string) error {
 		return reac(hitDef_air_animtype, data)
 	}); err != nil {
 		return err
 	}
-	if err := c.stateParam(is, "fall.animtype", func(data string) error {
+	if err := c.stateParam(is, "fall.animtype", false, func(data string) error {
 		return reac(hitDef_fall_animtype, data)
 	}); err != nil {
 		return err
 	}
-	if err := c.stateParam(is, "affectteam", func(data string) error {
+	if err := c.stateParam(is, "affectteam", false, func(data string) error {
 		if len(data) == 0 {
 			return Error("Value not specified")
 		}
@@ -1532,7 +1527,7 @@ func (c *Compiler) hitDefSub(is IniSection,	sc *StateControllerBase) error {
 		prefix := c.getDataPrefix(&data, true)
 		return c.scAdd(sc, id, data, VT_Int, 2, sc.beToExp(BytecodeExp(prefix))...)
 	}
-	if err := c.stateParam(is, "hitsound", func(data string) error {
+	if err := c.stateParam(is, "hitsound", false, func(data string) error {
 		return hsnd(hitDef_hitsound, data)
 	}); err != nil {
 		return err
@@ -1541,7 +1536,7 @@ func (c *Compiler) hitDefSub(is IniSection,	sc *StateControllerBase) error {
 		hitDef_hitsound_channel, VT_Int, 1, false); err != nil {
 		return err
 	}
-	if err := c.stateParam(is, "guardsound", func(data string) error {
+	if err := c.stateParam(is, "guardsound", false, func(data string) error {
 		return hsnd(hitDef_guardsound, data)
 	}); err != nil {
 		return err
@@ -1550,7 +1545,7 @@ func (c *Compiler) hitDefSub(is IniSection,	sc *StateControllerBase) error {
 		hitDef_guardsound_channel, VT_Int, 1, false); err != nil {
 		return err
 	}
-	if err := c.stateParam(is, "priority", func(data string) error {
+	if err := c.stateParam(is, "priority", false, func(data string) error {
 		be, err := c.argExpression(&data, VT_Int)
 		if err != nil {
 			return err
@@ -1587,7 +1582,7 @@ func (c *Compiler) hitDefSub(is IniSection,	sc *StateControllerBase) error {
 		return err
 	}
 	b := false
-	if err := c.stateParam(is, "p1sprpriority", func(data string) error {
+	if err := c.stateParam(is, "p1sprpriority", false, func(data string) error {
 		b = true
 		return c.scAdd(sc, hitDef_p1sprpriority, data, VT_Int, 1)
 	}); err != nil {
@@ -1640,7 +1635,7 @@ func (c *Compiler) hitDefSub(is IniSection,	sc *StateControllerBase) error {
 		return c.scAdd(sc, id, data, VT_Int, 1,
 			sc.beToExp(BytecodeExp(prefix))...)
 	}
-	if err := c.stateParam(is, "sparkno", func(data string) error {
+	if err := c.stateParam(is, "sparkno", false, func(data string) error {
 		return sprk(hitDef_sparkno, data)
 	}); err != nil {
 		return err
@@ -1649,7 +1644,7 @@ func (c *Compiler) hitDefSub(is IniSection,	sc *StateControllerBase) error {
 		hitDef_sparkangle, VT_Float, 1, false); err != nil {
 		return err
 	}
-	if err := c.stateParam(is, "guard.sparkno", func(data string) error {
+	if err := c.stateParam(is, "guard.sparkno", false, func(data string) error {
 		return sprk(hitDef_guard_sparkno, data)
 	}); err != nil {
 		return err
@@ -1766,7 +1761,7 @@ func (c *Compiler) hitDefSub(is IniSection,	sc *StateControllerBase) error {
 		hitDef_airguard_ctrltime, VT_Int, 1, false); err != nil {
 		return err
 	}
-	if err := c.stateParam(is, "ground.velocity", func(data string) error {
+	if err := c.stateParam(is, "ground.velocity", false, func(data string) error {
 		in := data
 		if c.token = c.tokenizer(&in); c.token == "n" {
 			if c.token = c.tokenizer(&in); len(c.token) > 0 && c.token != "," {
@@ -1878,7 +1873,7 @@ func (c *Compiler) hitDefSub(is IniSection,	sc *StateControllerBase) error {
 		hitDef_score, VT_Float, 2, false); err != nil {
 		return err
 	}
-	if err := c.stateParam(is, "p2clsncheck", func(data string) error {
+	if err := c.stateParam(is, "p2clsncheck", false, func(data string) error {
 		if len(data) == 0 {
 			return Error("Value not specified")
 		}
@@ -1900,7 +1895,7 @@ func (c *Compiler) hitDefSub(is IniSection,	sc *StateControllerBase) error {
 	}); err != nil {
 		return err
 	}
-	if err := c.stateParam(is, "p2clsnrequire", func(data string) error {
+	if err := c.stateParam(is, "p2clsnrequire", false, func(data string) error {
 		if len(data) == 0 {
 			return Error("Value not specified")
 		}
@@ -1955,7 +1950,7 @@ func (c *Compiler) reversalDef(is IniSection, sc *StateControllerBase, _ int8) (
 			reversalDef_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err = c.stateParam(is, "reversal.attr", func(data string) error {
+		if err = c.stateParam(is, "reversal.attr", false, func(data string) error {
 			attr, err = c.attr(data, false)
 			return err
 		}); err != nil {
@@ -1978,7 +1973,7 @@ func (c *Compiler) modifyReversalDef(is IniSection, sc *StateControllerBase, _ i
 			modifyReversalDef_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err = c.stateParam(is, "reversal.attr", func(data string) error {
+		if err = c.stateParam(is, "reversal.attr", false, func(data string) error {
 			attr, err = c.attr(data, false)
 			return err
 		}); err != nil {
@@ -2028,21 +2023,21 @@ func (c *Compiler) projectileSub(is IniSection,	sc *StateControllerBase, ihp int
 		projectile_projpriority, VT_Int, 1, false); err != nil {
 		return err
 	}
-	if err := c.stateParam(is, "projhitanim", func(data string) error {
+	if err := c.stateParam(is, "projhitanim", false, func(data string) error {
 		prefix := c.getDataPrefix(&data, false)
 		return c.scAdd(sc, projectile_projhitanim, data, VT_Int, 1,
 			sc.beToExp(BytecodeExp(prefix))...)
 	}); err != nil {
 		return err
 	}
-	if err := c.stateParam(is, "projremanim", func(data string) error {
+	if err := c.stateParam(is, "projremanim", false, func(data string) error {
 		prefix := c.getDataPrefix(&data, false)
 		return c.scAdd(sc, projectile_projremanim, data, VT_Int, 1,
 			sc.beToExp(BytecodeExp(prefix))...)
 	}); err != nil {
 		return err
 	}
-	if err := c.stateParam(is, "projcancelanim", func(data string) error {
+	if err := c.stateParam(is, "projcancelanim", false, func(data string) error {
 		prefix := c.getDataPrefix(&data, false)
 		return c.scAdd(sc, projectile_projcancelanim, data, VT_Int, 1,
 			sc.beToExp(BytecodeExp(prefix))...)
@@ -2103,7 +2098,7 @@ func (c *Compiler) projectileSub(is IniSection,	sc *StateControllerBase, ihp int
 		projectile_projheightbound, VT_Int, 2, false); err != nil {
 		return err
 	}
-	if err := c.stateParam(is, "projanim", func(data string) error {
+	if err := c.stateParam(is, "projanim", false, func(data string) error {
 		prefix := c.getDataPrefix(&data, false)
 		return c.scAdd(sc, projectile_projanim, data, VT_Int, 1,
 			sc.beToExp(BytecodeExp(prefix))...)
@@ -2170,7 +2165,7 @@ func (c *Compiler) width(is IniSection, sc *StateControllerBase, _ int8) (StateC
 			return err
 		}
 		b := false
-		if err := c.stateParam(is, "edge", func(data string) error {
+		if err := c.stateParam(is, "edge", false, func(data string) error {
 			b = true
 			if len(data) == 0 {
 				return nil
@@ -2179,7 +2174,7 @@ func (c *Compiler) width(is IniSection, sc *StateControllerBase, _ int8) (StateC
 		}); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "player", func(data string) error {
+		if err := c.stateParam(is, "player", false, func(data string) error {
 			b = true
 			if len(data) == 0 {
 				return nil
@@ -2213,7 +2208,7 @@ func (c *Compiler) varSetSub(is IniSection,
 	sc *StateControllerBase, rd OpCode, oc OpCode) error {
 	b, v, fv := false, false, false
 	var value string
-	if err := c.stateParam(is, "value", func(data string) error {
+	if err := c.stateParam(is, "value", false, func(data string) error {
 		b = true
 		value = data
 		return nil
@@ -2222,7 +2217,7 @@ func (c *Compiler) varSetSub(is IniSection,
 	}
 	if b {
 		var ve BytecodeExp
-		if err := c.stateParam(is, "v", func(data string) (err error) {
+		if err := c.stateParam(is, "v", false, func(data string) (err error) {
 			v = true
 			ve, err = c.fullExpression(&data, VT_Int)
 			return
@@ -2230,7 +2225,7 @@ func (c *Compiler) varSetSub(is IniSection,
 			return err
 		}
 		if !v {
-			if err := c.stateParam(is, "fv", func(data string) (err error) {
+			if err := c.stateParam(is, "fv", false, func(data string) (err error) {
 				fv = true
 				ve, err = c.fullExpression(&data, VT_Int)
 				return
@@ -2356,7 +2351,7 @@ func (c *Compiler) varSetSub(is IniSection,
 		sc.add(varSet_, sc.beToExp(ve))
 		return nil
 	}
-	if err := c.stateParam(is, "var", func(data string) error {
+	if err := c.stateParam(is, "var", false, func(data string) error {
 		if data[0] != 'v' {
 			return Error(data[:3] + "'v' is not lowercase")
 		}
@@ -2369,7 +2364,7 @@ func (c *Compiler) varSetSub(is IniSection,
 	if b {
 		return nil
 	}
-	if err := c.stateParam(is, "fvar", func(data string) error {
+	if err := c.stateParam(is, "fvar", false, func(data string) error {
 		if rd == OC_rdreset && data[0] != 'f' {
 			return Error(data[:4] + "'f' is not lowercase")
 		}
@@ -2382,7 +2377,7 @@ func (c *Compiler) varSetSub(is IniSection,
 	if b {
 		return nil
 	}
-	if err := c.stateParam(is, "sysvar", func(data string) error {
+	if err := c.stateParam(is, "sysvar", false, func(data string) error {
 		if data[3] != 'v' {
 			return Error(data[:6] + "'v' is not lowercase")
 		}
@@ -2396,7 +2391,7 @@ func (c *Compiler) varSetSub(is IniSection,
 	if b {
 		return nil
 	}
-	if err := c.stateParam(is, "sysfvar", func(data string) error {
+	if err := c.stateParam(is, "sysfvar", false, func(data string) error {
 		b = true
 		fv = true
 		sys = true
@@ -2534,7 +2529,7 @@ func (c *Compiler) bindToTarget(is IniSection, sc *StateControllerBase, _ int8) 
 			bindToTarget_time, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "pos", func(data string) error {
+		if err := c.stateParam(is, "pos", false, func(data string) error {
 			be, err := c.argExpression(&data, VT_Float)
 			if err != nil {
 				return err
@@ -2781,7 +2776,7 @@ func (c *Compiler) screenBound(is IniSection, sc *StateControllerBase, _ int8) (
 			return err
 		}
 		b := false
-		if err := c.stateParam(is, "value", func(data string) error {
+		if err := c.stateParam(is, "value", false, func(data string) error {
 			b = true
 			return c.scAdd(sc, screenBound_value, data, VT_Bool, 1)
 		}); err != nil {
@@ -2791,7 +2786,7 @@ func (c *Compiler) screenBound(is IniSection, sc *StateControllerBase, _ int8) (
 			sc.add(screenBound_value, sc.iToExp(0))
 		}
 		b = false
-		if err := c.stateParam(is, "movecamera", func(data string) error {
+		if err := c.stateParam(is, "movecamera", false, func(data string) error {
 			b = true
 			return c.scAdd(sc, screenBound_movecamera, data, VT_Bool, 2)
 		}); err != nil {
@@ -2800,7 +2795,7 @@ func (c *Compiler) screenBound(is IniSection, sc *StateControllerBase, _ int8) (
 		if !b {
 			sc.add(screenBound_movecamera, append(sc.iToExp(0), sc.iToExp(0)...))
 		}
-		if err := c.stateParam(is, "stagebound", func(data string) error {
+		if err := c.stateParam(is, "stagebound", false, func(data string) error {
 			return c.scAdd(sc, screenBound_stagebound, data, VT_Bool, 1)
 		}); err != nil {
 			return err
@@ -2816,7 +2811,7 @@ func (c *Compiler) posFreeze(is IniSection, sc *StateControllerBase, _ int8) (St
 			return err
 		}
 		b := false
-		if err := c.stateParam(is, "value", func(data string) error {
+		if err := c.stateParam(is, "value", false, func(data string) error {
 			b = true
 			return c.scAdd(sc, posFreeze_value, data, VT_Bool, 1)
 		}); err != nil {
@@ -2861,7 +2856,7 @@ func (c *Compiler) hitOverride(is IniSection, sc *StateControllerBase, _ int8) (
 			hitOverride_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "attr", func(data string) error {
+		if err := c.stateParam(is, "attr", false, func(data string) error {
 			attr, err := c.attr(data, false)
 			if err != nil {
 				return err
@@ -2947,7 +2942,7 @@ func (c *Compiler) superPause(is IniSection, sc *StateControllerBase, _ int8) (S
 			superPause_darken, VT_Bool, 1, false); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "anim", func(data string) error {
+		if err := c.stateParam(is, "anim", false, func(data string) error {
 			prefix := c.getDataPrefix(&data, true)
 			return c.scAdd(sc, superPause_anim, data, VT_Int, 1,
 				sc.beToExp(BytecodeExp(prefix))...)
@@ -2970,7 +2965,7 @@ func (c *Compiler) superPause(is IniSection, sc *StateControllerBase, _ int8) (S
 			superPause_unhittable, VT_Bool, 1, false); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "sound", func(data string) error {
+		if err := c.stateParam(is, "sound", false, func(data string) error {
 			prefix := c.getDataPrefix(&data, true)
 			return c.scAdd(sc, superPause_sound, data, VT_Int, 2,
 				sc.beToExp(BytecodeExp(prefix))...)
@@ -2997,15 +2992,10 @@ func (c *Compiler) playerPush(is IniSection, sc *StateControllerBase, _ int8) (S
 			playerPush_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
-		b := false
-		if err := c.stateParam(is, "value", func(data string) error {
-			b = true
+		if err := c.stateParam(is, "value", true, func(data string) error {
 			return c.scAdd(sc, playerPush_value, data, VT_Bool, 1)
 		}); err != nil {
 			return err
-		}
-		if !b {
-			sc.add(playerPush_value, sc.iToExp(1))
 		}
 		return nil
 	})
@@ -3038,20 +3028,20 @@ func (c *Compiler) stateTypeSet(is IniSection, sc *StateControllerBase, _ int8) 
 			return nil
 		}
 		b := false
-		if err := c.stateParam(is, "statetype", func(data string) error {
+		if err := c.stateParam(is, "statetype", false, func(data string) error {
 			b = true
 			return statetype(data)
 		}); err != nil {
 			return err
 		}
 		if !b {
-			if err := c.stateParam(is, "value", func(data string) error {
+			if err := c.stateParam(is, "value", false, func(data string) error {
 				return statetype(data)
 			}); err != nil {
 				return err
 			}
 		}
-		if err := c.stateParam(is, "movetype", func(data string) error {
+		if err := c.stateParam(is, "movetype", false, func(data string) error {
 			if len(data) == 0 {
 				return Error("Value not specified")
 			}
@@ -3071,7 +3061,7 @@ func (c *Compiler) stateTypeSet(is IniSection, sc *StateControllerBase, _ int8) 
 		}); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "physics", func(data string) error {
+		if err := c.stateParam(is, "physics", false, func(data string) error {
 			if len(data) == 0 {
 				return Error("Value not specified")
 			}
@@ -3163,7 +3153,7 @@ func (c *Compiler) angleMul(is IniSection, sc *StateControllerBase, _ int8) (Sta
 }
 func (c *Compiler) envColor(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*envColor)(sc), c.stateSec(is, func() error {
-		if err := c.stateParam(is, "value", func(data string) error {
+		if err := c.stateParam(is, "value", false, func(data string) error {
 			bes, err := c.exprs(data, VT_Int, 3)
 			if err != nil {
 				return err
@@ -3194,7 +3184,7 @@ func (c *Compiler) displayToClipboardSub(is IniSection,
 		displayToClipboard_redirectid, VT_Int, 1, false); err != nil {
 		return err
 	}
-	if err := c.stateParam(is, "params", func(data string) error {
+	if err := c.stateParam(is, "params", false, func(data string) error {
 		bes, err := c.exprs(data, VT_SFalse, 100000)
 		if err != nil {
 			return err
@@ -3205,7 +3195,7 @@ func (c *Compiler) displayToClipboardSub(is IniSection,
 		return err
 	}
 	b := false
-	if err := c.stateParam(is, "text", func(data string) error {
+	if err := c.stateParam(is, "text", false, func(data string) error {
 		b = true
 		_else := false
 		if len(data) >= 2 && data[0] == '"' {
@@ -3261,7 +3251,7 @@ func (c *Compiler) makeDust(is IniSection, sc *StateControllerBase, _ int8) (Sta
 			return err
 		}
 		b := false
-		if err := c.stateParam(is, "spacing", func(data string) error {
+		if err := c.stateParam(is, "spacing", false, func(data string) error {
 			b = true
 			return c.scAdd(sc, makeDust_spacing, data, VT_Int, 1)
 		}); err != nil {
@@ -3271,7 +3261,7 @@ func (c *Compiler) makeDust(is IniSection, sc *StateControllerBase, _ int8) (Sta
 			sc.add(makeDust_spacing, sc.iToExp(3))
 		}
 		b = false
-		if err := c.stateParam(is, "pos", func(data string) error {
+		if err := c.stateParam(is, "pos", false, func(data string) error {
 			b = true
 			return c.scAdd(sc, makeDust_pos, data, VT_Float, 2)
 		}); err != nil {
@@ -3336,7 +3326,7 @@ func (c *Compiler) defenceMulSet(is IniSection, sc *StateControllerBase, _ int8)
 			return err
 		}
 
-		if err := c.stateParam(is, "multype", func(data string) error {
+		if err := c.stateParam(is, "multype", false, func(data string) error {
 			var mulType = Atoi(strings.TrimSpace(data))
 
 			if mulType >= 0 && mulType <= 1 {
@@ -3400,7 +3390,7 @@ func (c *Compiler) hitFallSet(is IniSection, sc *StateControllerBase, _ int8) (S
 			return err
 		}
 		b := false
-		if err := c.stateParam(is, "value", func(data string) error {
+		if err := c.stateParam(is, "value", false, func(data string) error {
 			b = true
 			return c.scAdd(sc, hitFallSet_value, data, VT_Int, 1)
 		}); err != nil {
@@ -3432,14 +3422,14 @@ func (c *Compiler) varRangeSet(is IniSection, sc *StateControllerBase, _ int8) (
 			return err
 		}
 		last := false
-		if err := c.stateParam(is, "last", func(data string) error {
+		if err := c.stateParam(is, "last", false, func(data string) error {
 			last = true
 			return c.scAdd(sc, varRangeSet_last, data, VT_Int, 1)
 		}); err != nil {
 			return err
 		}
 		b := false
-		if err := c.stateParam(is, "value", func(data string) error {
+		if err := c.stateParam(is, "value", false, func(data string) error {
 			b = true
 			if !last {
 				sc.add(varRangeSet_last, sc.iToExp(int32(NumVar-1)))
@@ -3449,7 +3439,7 @@ func (c *Compiler) varRangeSet(is IniSection, sc *StateControllerBase, _ int8) (
 			return err
 		}
 		if !b {
-			if err := c.stateParam(is, "fvalue", func(data string) error {
+			if err := c.stateParam(is, "fvalue", false, func(data string) error {
 				b = true
 				if !last {
 					sc.add(varRangeSet_last, sc.iToExp(int32(NumFvar-1)))
@@ -3588,7 +3578,7 @@ func (c *Compiler) removeExplod(is IniSection, sc *StateControllerBase, _ int8) 
 			return err
 		}
 		b := false
-		if err := c.stateParam(is, "id", func(data string) error {
+		if err := c.stateParam(is, "id", false, func(data string) error {
 			b = true
 			return c.scAdd(sc, removeExplod_id, data, VT_Int, 1)
 		}); err != nil {
@@ -3612,7 +3602,7 @@ func (c *Compiler) explodBindTime(is IniSection, sc *StateControllerBase, _ int8
 			return err
 		}
 		b := false
-		if err := c.stateParam(is, "time", func(data string) error {
+		if err := c.stateParam(is, "time", false, func(data string) error {
 			b = true
 			return c.scAdd(sc, explodBindTime_time, data, VT_Int, 1)
 		}); err != nil {
@@ -3725,7 +3715,7 @@ func (c *Compiler) forceFeedback(is IniSection, sc *StateControllerBase, _ int8)
 			forceFeedback_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "waveform", func(data string) error {
+		if err := c.stateParam(is, "waveform", false, func(data string) error {
 			if len(data) == 0 {
 				return Error("Value not specified")
 			}
@@ -3812,7 +3802,7 @@ func (c *Compiler) assertInput(is IniSection, sc *StateControllerBase, _ int8) (
 			return nil
 		}
 		f := false
-		if err := c.stateParam(is, "flag", func(data string) error {
+		if err := c.stateParam(is, "flag", false, func(data string) error {
 			f = true
 			return foo(data)
 		}); err != nil {
@@ -3821,12 +3811,12 @@ func (c *Compiler) assertInput(is IniSection, sc *StateControllerBase, _ int8) (
 		if !f {
 			return Error("flag parameter not specified")
 		}
-		if err := c.stateParam(is, "flag2", func(data string) error {
+		if err := c.stateParam(is, "flag2", false, func(data string) error {
 			return foo(data)
 		}); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "flag3", func(data string) error {
+		if err := c.stateParam(is, "flag3", false, func(data string) error {
 			return foo(data)
 		}); err != nil {
 			return err
@@ -3862,7 +3852,7 @@ func (c *Compiler) dialogue(is IniSection, sc *StateControllerBase, _ int8) (Sta
 		}
 		sort.Ints(keys)
 		for _, key := range keys {
-			if err := c.stateParam(is, fmt.Sprintf("text%v", key), func(data string) error {
+			if err := c.stateParam(is, fmt.Sprintf("text%v", key), false, func(data string) error {
 				if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
 					return Error("Not enclosed in \"")
 				}
@@ -3961,7 +3951,7 @@ func (c *Compiler) hitScaleSet(is IniSection, sc *StateControllerBase, _ int8) (
 			return err
 		}
 		// Parse affects
-		if err := c.stateParam(is, "affects", func(data string) error {
+		if err := c.stateParam(is, "affects", false, func(data string) error {
 			// We do really need to add string support.
 			var arrayData []string
 			var err2 error
@@ -3998,7 +3988,7 @@ func (c *Compiler) hitScaleSet(is IniSection, sc *StateControllerBase, _ int8) (
 		}
 		// Parse reset, valid values are 0, 1 and 2.
 		// If the value is not valid throw a error.
-		if err := c.stateParam(is, "reset", func(data string) error {
+		if err := c.stateParam(is, "reset", false, func(data string) error {
 			var reset = Atoi(strings.TrimSpace(data))
 
 			if reset < 0 && reset > 2 {
@@ -4024,7 +4014,7 @@ func (c *Compiler) hitScaleSet(is IniSection, sc *StateControllerBase, _ int8) (
 			return err
 		}
 		// The only valid values of addType are "mulFirst" and "addFirst"
-		if err := c.stateParam(is, "addType", func(data string) error {
+		if err := c.stateParam(is, "addType", false, func(data string) error {
 			var push = 0
 			// Change sting to lowecase and remove quotes
 			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
@@ -4096,7 +4086,7 @@ func (c *Compiler) lifebarAction(is IniSection, sc *StateControllerBase, _ int8)
 			lifebarAction_snd, VT_Int, 2, false); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "text", func(data string) error {
+		if err := c.stateParam(is, "text", false, func(data string) error {
 			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
 				return Error("Not enclosed in \"")
 			}
@@ -4115,7 +4105,7 @@ func (c *Compiler) loadFile(is IniSection, sc *StateControllerBase, _ int8) (Sta
 			loadFile_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "path", func(data string) error {
+		if err := c.stateParam(is, "path", false, func(data string) error {
 			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
 				return Error("Not enclosed in \"")
 			}
@@ -4141,7 +4131,7 @@ func (c *Compiler) mapSetSub(is IniSection, sc *StateControllerBase) error {
 			mapSet_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "map", func(data string) error {
+		if err := c.stateParam(is, "map", true, func(data string) error {
 			mapParam = data
 			// CNS: See if map parameter is ini-style or if it's an assign
 			ia := strings.Index(mapParam, "=")
@@ -4177,7 +4167,7 @@ func (c *Compiler) mapSetSub(is IniSection, sc *StateControllerBase) error {
 				}
 			} else {
 				b := false
-				if err := c.stateParam(is, "value", func(data string) error {
+				if err := c.stateParam(is, "value", false, func(data string) error {
 					b = true
 					value = data
 					return nil
@@ -4294,7 +4284,7 @@ func (c *Compiler) matchRestart(is IniSection, sc *StateControllerBase, _ int8) 
 			matchRestart_reload, VT_Bool, MaxSimul*2+MaxAttachedChar, false); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "stagedef", func(data string) error {
+		if err := c.stateParam(is, "stagedef", false, func(data string) error {
 			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
 				return Error("Not enclosed in \"")
 			}
@@ -4303,7 +4293,7 @@ func (c *Compiler) matchRestart(is IniSection, sc *StateControllerBase, _ int8) 
 		}); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "p1def", func(data string) error {
+		if err := c.stateParam(is, "p1def", false, func(data string) error {
 			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
 				return Error("Not enclosed in \"")
 			}
@@ -4312,7 +4302,7 @@ func (c *Compiler) matchRestart(is IniSection, sc *StateControllerBase, _ int8) 
 		}); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "p2def", func(data string) error {
+		if err := c.stateParam(is, "p2def", false, func(data string) error {
 			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
 				return Error("Not enclosed in \"")
 			}
@@ -4321,7 +4311,7 @@ func (c *Compiler) matchRestart(is IniSection, sc *StateControllerBase, _ int8) 
 		}); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "p3def", func(data string) error {
+		if err := c.stateParam(is, "p3def", false, func(data string) error {
 			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
 				return Error("Not enclosed in \"")
 			}
@@ -4330,7 +4320,7 @@ func (c *Compiler) matchRestart(is IniSection, sc *StateControllerBase, _ int8) 
 		}); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "p4def", func(data string) error {
+		if err := c.stateParam(is, "p4def", false, func(data string) error {
 			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
 				return Error("Not enclosed in \"")
 			}
@@ -4339,7 +4329,7 @@ func (c *Compiler) matchRestart(is IniSection, sc *StateControllerBase, _ int8) 
 		}); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "p5def", func(data string) error {
+		if err := c.stateParam(is, "p5def", false, func(data string) error {
 			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
 				return Error("Not enclosed in \"")
 			}
@@ -4348,7 +4338,7 @@ func (c *Compiler) matchRestart(is IniSection, sc *StateControllerBase, _ int8) 
 		}); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "p6def", func(data string) error {
+		if err := c.stateParam(is, "p6def", false, func(data string) error {
 			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
 				return Error("Not enclosed in \"")
 			}
@@ -4357,7 +4347,7 @@ func (c *Compiler) matchRestart(is IniSection, sc *StateControllerBase, _ int8) 
 		}); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "p7def", func(data string) error {
+		if err := c.stateParam(is, "p7def", false, func(data string) error {
 			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
 				return Error("Not enclosed in \"")
 			}
@@ -4366,7 +4356,7 @@ func (c *Compiler) matchRestart(is IniSection, sc *StateControllerBase, _ int8) 
 		}); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "p8def", func(data string) error {
+		if err := c.stateParam(is, "p8def", false, func(data string) error {
 			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
 				return Error("Not enclosed in \"")
 			}
@@ -4385,7 +4375,7 @@ func (c *Compiler) playBgm(is IniSection, sc *StateControllerBase, _ int8) (Stat
 			playBgm_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "bgm", func(data string) error {
+		if err := c.stateParam(is, "bgm", false, func(data string) error {
 			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
 				return Error("Not enclosed in \"")
 			}
@@ -4636,7 +4626,7 @@ func (c *Compiler) remapSprite(is IniSection, sc *StateControllerBase, _ int8) (
 			remapSprite_reset, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "preset", func(data string) error {
+		if err := c.stateParam(is, "preset", false, func(data string) error {
 			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
 				return Error("Not enclosed in \"")
 			}
@@ -4687,7 +4677,7 @@ func (c *Compiler) saveFile(is IniSection, sc *StateControllerBase, _ int8) (Sta
 			saveFile_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "path", func(data string) error {
+		if err := c.stateParam(is, "path", false, func(data string) error {
 			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
 				return Error("Not enclosed in \"")
 			}
@@ -4815,7 +4805,7 @@ func (c *Compiler) text(is IniSection, sc *StateControllerBase, _ int8) (StateCo
 			text_layerno, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "params", func(data string) error {
+		if err := c.stateParam(is, "params", false, func(data string) error {
 			bes, err := c.exprs(data, VT_SFalse, 100000)
 			if err != nil {
 				return err
@@ -4825,7 +4815,7 @@ func (c *Compiler) text(is IniSection, sc *StateControllerBase, _ int8) (StateCo
 		}); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "text", func(data string) error {
+		if err := c.stateParam(is, "text", false, func(data string) error {
 			_else := false
 			if len(data) >= 2 && data[0] == '"' {
 				if i := strings.Index(data[1:], "\""); i >= 0 {
@@ -4844,7 +4834,7 @@ func (c *Compiler) text(is IniSection, sc *StateControllerBase, _ int8) (StateCo
 		}); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "font", func(data string) error {
+		if err := c.stateParam(is, "font", false, func(data string) error {
 			prefix := c.getDataPrefix(&data, false)
 			fflg := prefix == "f"
 			return c.scAdd(sc, text_font, data, VT_Int, 1,
@@ -4897,7 +4887,7 @@ func (c *Compiler) createPlatform(is IniSection, sc *StateControllerBase, _ int8
 		// Here we check if the string is enclosed in quotes.
 		// (Because CNS has no real string support)
 		if err = c.stateParam(
-			is, "name",
+			is, "name", false,
 			func(data string) error {
 				if data[0] != '"' || data[len(data)-1] != '"' {
 					return Error(`[name] value in [createPlatform] not enclosed in quotation marks.` +
@@ -5120,7 +5110,7 @@ func (c *Compiler) cameraCtrl(is IniSection, sc *StateControllerBase, _ int8) (S
 			cameraCtrl_followid, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "view", func(data string) error {
+		if err := c.stateParam(is, "view", false, func(data string) error {
 			if len(data) == 0 {
 				return nil
 			}
@@ -5188,7 +5178,7 @@ func (c *Compiler) modifyChar(is IniSection, sc *StateControllerBase, _ int8) (S
 			modifyChar_teamside, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "displayname", func(data string) error {
+		if err := c.stateParam(is, "displayname", false, func(data string) error {
 			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
 				return Error("Not enclosed in \"")
 			}
@@ -5197,7 +5187,7 @@ func (c *Compiler) modifyChar(is IniSection, sc *StateControllerBase, _ int8) (S
 		}); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "lifebarname", func(data string) error {
+		if err := c.stateParam(is, "lifebarname", false, func(data string) error {
 			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
 				return Error("Not enclosed in \"")
 			}
@@ -5217,19 +5207,14 @@ func (c *Compiler) assertCommand(is IniSection, sc *StateControllerBase, _ int8)
 			assertCommand_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
-		havename := false
-		if err := c.stateParam(is, "name", func(data string) error {
+		if err := c.stateParam(is, "name", true, func(data string) error {
 			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
 				return Error("Not enclosed in \"")
 			}
 			sc.add(assertCommand_name, sc.beToExp(BytecodeExp(data[1:len(data)-1])))
-			havename = true
 			return nil
 		}); err != nil {
 			return err
-		}
-		if !havename {
-			return Error("Command name not specified")
 		}
 		if err := c.paramValue(is, sc, "buffertime",
 			assertCommand_buffertime, VT_Int, 1, false); err != nil {

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -2120,6 +2120,40 @@ func (c *Compiler) projectile(is IniSection, sc *StateControllerBase,
 	})
 	return *ret, err
 }
+
+func (c *Compiler) modifyHitDef(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+	ret, err := (*modifyHitDef)(sc), c.stateSec(is, func() error {
+		if err := c.paramValue(is, sc, "redirectid",
+			modifyHitDef_redirectid, VT_Int, 1, false); err != nil {
+			return err
+		}
+		return c.hitDefSub(is, sc)
+	})
+	return *ret, err
+}
+
+func (c *Compiler) modifyReversalDef(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+	ret, err := (*modifyReversalDef)(sc), c.stateSec(is, func() error {
+		attr := int32(-1)
+		var err error
+		if err := c.paramValue(is, sc, "redirectid",
+			modifyReversalDef_redirectid, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err = c.stateParam(is, "reversal.attr", func(data string) error {
+			attr, err = c.attr(data, false)
+			return err
+		}); err != nil {
+			return err
+		}
+		if attr != -1 {
+			sc.add(modifyReversalDef_reversal_attr, sc.iToExp(attr))
+		}
+		return c.hitDefSub(is, sc)
+	})
+	return *ret, err
+}
+
 func (c *Compiler) width(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*width)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",

--- a/src/script.go
+++ b/src/script.go
@@ -3305,8 +3305,8 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.ghv.slidetime)
 		case "ctrltime":
 			ln = lua.LNumber(c.ghv.ctrltime)
-		case "recovertime":
-			ln = lua.LNumber(c.recoverTime)
+		case "recovertime", "down.recovertime": // Added second term for consistency
+			ln = lua.LNumber(c.ghv.down_recovertime)
 		case "xoff":
 			ln = lua.LNumber(c.ghv.xoff)
 		case "yoff":
@@ -3399,6 +3399,8 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.ghv.airguard_velocity[1])
 		case "frame":
 			ln = lua.LNumber(Btoi(c.ghv.frame))
+		case "down.recover":
+			ln = lua.LNumber(Btoi(c.ghv.down_recover))
 		default:
 			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}

--- a/src/system.go
+++ b/src/system.go
@@ -39,6 +39,7 @@ var sys = System{
 	gameWidth:         320,
 	gameHeight:        240,
 	keepAspect:        true,
+	windowScaleMode:   true,
 	widthScale:        1,
 	heightScale:       1,
 	brightness:        256,
@@ -109,6 +110,7 @@ type System struct {
 	gameWidth, gameHeight   int32
 	widthScale, heightScale float32
 	keepAspect              bool
+	windowScaleMode         bool
 	window                  *Window
 	gameEnd, frameSkip      bool
 	redrawWait              struct{ nextTime, lastDraw time.Time }
@@ -898,18 +900,7 @@ func (s *System) softenAllSound() {
 			}
 		}
 	}
-	for i := 0; i < int(s.soundChannels.count()); i++ {
-		// Temporarily store the volume so it can be recalled later.
-		if s.soundChannels.channels[i].sfx != nil && s.soundChannels.channels[i].ctrl != nil {
-			s.soundChannels.volResume[i] = s.soundChannels.channels[i].sfx.volume
-			s.soundChannels.channels[i].SetVolume(float32(s.pauseMasterVolume * 64 / 25))
-
-			// Pause if pause master volume is 0
-			if s.pauseMasterVolume == 0 {
-				s.soundChannels.channels[i].SetPaused(true)
-			}
-		}
-	}
+	// Don't pause motif sounds
 }
 func (s *System) restoreAllVolume() {
 	for _, p := range s.chars {
@@ -924,17 +915,6 @@ func (s *System) restoreAllVolume() {
 						c.soundChannels.channels[i].SetPaused(false)
 					}
 				}
-			}
-		}
-	}
-	for i := 0; i < int(s.soundChannels.count()); i++ {
-		// Restore the volume we had.
-		if s.soundChannels.channels[i].sfx != nil && s.soundChannels.channels[i].ctrl != nil {
-			s.soundChannels.channels[i].SetVolume(s.soundChannels.volResume[i])
-
-			// Unpause
-			if s.soundChannels.channels[i].ctrl.Paused {
-				s.soundChannels.channels[i].SetPaused(false)
 			}
 		}
 	}
@@ -1558,7 +1538,7 @@ func (s *System) action() {
 		if s.superanim != nil {
 			s.superanim.Action()
 		}
-		s.charList.action(x)
+		s.charList.action()
 		s.nomusic = s.gsf(GSF_nomusic) && !sys.postMatchFlg
 	} else {
 		s.charUpdate()

--- a/src/system.go
+++ b/src/system.go
@@ -1714,13 +1714,13 @@ func (s *System) draw(x, y, scl float32) {
 			}
 			s.stage.draw(false, bgx, bgy, scl)
 		}
-		s.bottomSprites.draw(x, y, scl*s.cam.BaseScale())
 		if !s.gsf(GSF_globalnoshadow) {
 			if s.stage.reflection > 0 {
 				s.shadows.drawReflection(x, y, scl*s.cam.BaseScale())
 			}
 			s.shadows.draw(x, y, scl*s.cam.BaseScale())
 		}
+		s.bottomSprites.draw(x, y, scl*s.cam.BaseScale())
 		//off := s.envShake.getOffset()
 		//yofs, yofs2 := float32(s.gameHeight), float32(0)
 		//if scl > 1 && s.cam.verticalfollow > 0 {
@@ -1950,7 +1950,7 @@ func (s *System) fight() (reload bool) {
 		s.wincnt.update()
 	}()
 	var oldStageVars Stage
-	oldStageVars.copyStageVars(s.stage)
+	oldStageVars.copyStageVars(s.stage)	// NOTE: This save and restore of stage variables makes ModifyStageVar not persist. Maybe that should not be the case?
 	var life, lifeMax, power, powerMax [len(s.chars)]int32
 	var guardPoints, guardPointsMax, dizzyPoints, dizzyPointsMax, redLife [len(s.chars)]int32
 	var teamside [len(s.chars)]int
@@ -2132,6 +2132,7 @@ func (s *System) fight() (reload bool) {
 						p[0].power = 0
 					}
 				}
+				p[0].power = Clamp(p[0].power, 0, p[0].powerMax) // Because of Turns mode
 				p[0].dialogue = []string{}
 				p[0].mapArray = make(map[string]float32)
 				for k, v := range p[0].mapDefault {


### PR DESCRIPTION
Features:
- ModifyHitdef, ModifyReversaldef and ModifyProjectile. Modifies any parameter of the active HitDef, ReversalDef or specified Projectiles. Same syntax as the original state controllers
- Using ChangeAnim2 with ReadPlayerID can now change a player into someone else's animations (without also changing the sprites like ChangeAnim does)
- HitBy now supports a syntax similar to HitOverride, with Attr and Slot instead of ValueX. This syntax is required to use the new features
- Hitdef Down.Recover parameter: bool that enables/disables the target's ability to use "fast recovery from liedown"
- Hitdef Down.RecoverTime parameter: int that determines how long the target should stay down after a hit. Defaults to their "liedown.time" constant

Fixes:
- Explod "under" parameter now works closer to Mugen, no longer drawing under shadows
- Fixed case where if the previous team member in Turns mode had more power than the current member could store, it'd show that power until it was updated by some action
- Improved implementation of previous run order refactor
- Fixed MoveCountered being true in all hits of a move if the first one countered
- Fixes #1910 
- Fixes #1915 
- Fixes #1920 

Refactor:
- Adjusted compiler so that more parameters can be easily flagged as mandatory. Example: ChangeAnim now requires "value" like Mugen