### PR TITLE
feat: Localization/Language Functionality

### DIFF
--- a/data/system.base.def
+++ b/data/system.base.def
@@ -76,10 +76,9 @@
 	; https://github.com/ikemen-engine/Ikemen-GO/wiki/Miscellaneous-info#external-modules
 	module = ""
 
-[Languages]
-	languages = en, ja
+[Languages] ; Ikemen feature, use to declare languages to show in the options menu.
+	languages = en
 	en = "English"
-	ja = "Japanese"
 	
 ;[ja.Files]
 	; Not used by default in Ikemen

--- a/data/system.base.def
+++ b/data/system.base.def
@@ -81,7 +81,7 @@
 	en = "English"
 	
 ;[ja.Files]
-	; Not used by default in Ikemen
+	
 
 [Music]
 	title.bgm = ""

--- a/data/system.base.def
+++ b/data/system.base.def
@@ -76,8 +76,13 @@
 	; https://github.com/ikemen-engine/Ikemen-GO/wiki/Miscellaneous-info#external-modules
 	module = ""
 
+[Languages]
+	languages = en, ja
+	en = "English"
+	ja = "Japanese"
+	
 ;[ja.Files]
-	; Not used in Ikemen
+	; Not used by default in Ikemen
 
 [Music]
 	title.bgm = ""
@@ -1565,6 +1570,7 @@
 	; https://github.com/ikemen-engine/Ikemen-GO/wiki/Screenpack-features#submenus
 	; If custom menu is not declared, following menu is loaded by default:
 	menu.itemname.menugame = "Game Settings"
+	menu.itemname.menugame.language = "Language"
 	menu.itemname.menugame.difficulty = "Difficulty Level"
 	menu.itemname.menugame.roundtime = "Time Limit"
 	menu.itemname.menugame.lifemul = "Life"

--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -2006,15 +2006,48 @@ local content = main.f_fileRead(motif.files.select)
 local csCell = 0
 content = content:gsub('([^\r\n;]*)%s*;[^\r\n]*', '%1')
 content = content:gsub('\n%s*\n', '\n')
+
+lanChars = false
+lanStages = false
+lanOptions = false
+lanStory = false
+for line in content:gmatch('[^\r\n]+') do
+	local lineCase = line:lower()
+	if lineCase:match('^%s*%[%s*' .. config.Language .. '.characters' .. '%s*%]') then
+		lanChars = true
+	elseif lineCase:match('^%s*%[%s*' .. config.Language .. '.extrastages' .. '%s*%]') then
+		lanStages = true
+	elseif lineCase:match('^%s*%[%s*' .. config.Language .. '.options' .. '%s*%]') then
+		lanOptions = true
+	elseif lineCase:match('^%s*%[%s*' .. config.Language .. '.storymode' .. '%s*%]') then
+		lanStory = true
+	end
+end
+
+
 for line in content:gmatch('[^\r\n]+') do
 --for line in io.lines("data/select.def") do
 	local lineCase = line:lower()
 	if lineCase:match('^%s*%[%s*characters%s*%]') then
 		row = 0
 		section = 1
+	elseif lineCase:match('^%s*%[%s*' .. config.Language .. '.characters' .. '%s*%]') then
+		if lanChars then
+			row = 0
+			section = 1
+		else 
+			section = -1
+		end
 	elseif lineCase:match('^%s*%[%s*extrastages%s*%]') then
 		row = 0
 		section = 2
+	elseif lineCase:match('^%s*%[%s*' .. config.Language .. '.extrastages' .. '%s*%]') then
+		if lanStages then
+			row = 0
+			section = 2
+		else 
+			section = -1
+		end
 	elseif lineCase:match('^%s*%[%s*options%s*%]') then
 		main.t_selOptions = {
 			arcadestart = {wins = 0, offset = 0},
@@ -2028,9 +2061,33 @@ for line in content:gmatch('[^\r\n]+') do
 		}
 		row = 0
 		section = 3
+	elseif lineCase:match('^%s*%[%s*' .. config.Language .. '.options' .. '%s*%]') then
+		if lanOptions then
+			main.t_selOptions = {
+				arcadestart = {wins = 0, offset = 0},
+				arcadeend = {wins = 0, offset = 0},
+				teamstart = {wins = 0, offset = 0},
+				teamend = {wins = 0, offset = 0},
+				survivalstart = {wins = 0, offset = 0},
+				survivalend = {wins = 0, offset = 0},
+				ratiostart = {wins = 0, offset = 0},
+				ratioend = {wins = 0, offset = 0},
+			}
+			row = 0
+			section = 3
+		else
+			section = -1
+		end
 	elseif lineCase:match('^%s*%[%s*storymode%s*%]') then
 		row = 0
 		section = 4
+	elseif lineCase:match('^%s*%[%s*' .. config.Language .. '.storymode' .. '%s*%]') then
+		if lanStory then
+			row = 0
+			section = 4
+		else
+			section = -1
+		end
 	elseif lineCase:match('^%s*%[%w+%]$') then
 		section = -1
 	elseif section == 1 then --[Characters]

--- a/external/script/motif.lua
+++ b/external/script/motif.lua
@@ -93,6 +93,11 @@ local motif =
 		hiscore_bgm_loopstart = 0, --Ikemen feature
 		hiscore_bgm_loopend = 0, --Ikemen feature
 	},
+	languages =
+	{
+		languages = {"en"},
+		en = "English",
+	},
 	title_info =
 	{
 		fadein_time = 10,
@@ -1942,6 +1947,7 @@ end
 
 function motif.setBaseOptionInfo()
 	motif.option_info.menu_itemname_menugame = "Game Settings"
+	motif.option_info.menu_itemname_menugame_language = "Language"
 	motif.option_info.menu_itemname_menugame_difficulty = "Difficulty Level"
 	motif.option_info.menu_itemname_menugame_roundtime = "Time Limit"
 	motif.option_info.menu_itemname_menugame_lifemul = "Life"
@@ -2066,6 +2072,7 @@ function motif.setBaseOptionInfo()
 	end
 	main.t_sort.option_info.menu = {
 		"menugame",
+		"menugame_language",
 		"menugame_difficulty",
 		"menugame_roundtime",
 		"menugame_lifemul",
@@ -2288,6 +2295,9 @@ for line in main.motifData:gmatch('([^\n]*)\n?') do
 		line = line:match('%[(.-)%s*%]%s*$') --match text between []
 		line = line:gsub('[%. ]', '_') --change . and space to _
 		group = tostring(line:lower())
+		if string.sub(group, 1, 3) == config.Language .. "_" then
+			group = string.sub(group, 4, -1)
+		end
 		if group:match('infobox_text$') then
 			t[group] = ''
 		elseif group:match('^begin_action_[0-9]+$') then --matched anim
@@ -2361,13 +2371,15 @@ for line in main.motifData:gmatch('([^\n]*)\n?') do
 							if subt == 'teammenu' then
 								prefix = 'p' .. i .. '_'
 							end
-							for _, v in ipairs({'_bg_', '_bg_active_'}) do
-								local bg = param:gsub('_itemname_', v)
-								def_pos[prefix .. bg .. '_anim'] = -1
-								def_pos[prefix .. bg .. '_spr'] = {-1, 0}
-								def_pos[prefix .. bg .. '_offset'] = {0, 0}
-								def_pos[prefix .. bg .. '_facing'] = 1
-								def_pos[prefix .. bg .. '_scale'] = {1.0, 1.0}
+							if prefix == not nil then 
+								for _, v in ipairs({'_bg_', '_bg_active_'}) do
+									local bg = param:gsub('_itemname_', v)
+									def_pos[prefix .. bg .. '_anim'] = -1
+									def_pos[prefix .. bg .. '_spr'] = {-1, 0}
+									def_pos[prefix .. bg .. '_offset'] = {0, 0}
+									def_pos[prefix .. bg .. '_facing'] = 1
+									def_pos[prefix .. bg .. '_scale'] = {1.0, 1.0}
+								end
 							end
 						end
 					end

--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -150,6 +150,7 @@ options.t_itemname = {
 			config.GameHeight = 480
 			config.GameFramerate = 60
 			--config.IP = {}
+			config.Language = "en"
 			config.LifeMul = 100
 			config.ListenPort = "7500"
 			config.LoseSimul = true
@@ -269,6 +270,45 @@ options.t_itemname = {
 			config.RoundTime = config.RoundTime - 1
 			t.items[item].vardisplay = options.f_definedDisplay(config.RoundTime, {[-1] = motif.option_info.menu_valuename_none}, config.RoundTime)
 			options.modified = true
+		end
+		return true
+	end,
+	--Language Setting
+	['language'] = function(t, item, cursorPosY, moveTxt)
+		if main.f_input(main.t_players, {'$F'}) then
+			languageCounter = 0
+			for x, c in ipairs(motif.languages.languages) do
+				if c == config.Language then
+					currentLanguage = x
+				end
+				languageCounter = languageCounter + 1
+			end
+			if languageCounter == currentLanguage then
+				config.Language = motif.languages.languages[1]
+			else
+				config.Language = motif.languages.languages[currentLanguage + 1]
+			end
+			options.modified = true
+			options.needReload = true
+			loadstring("sfs = " .. "motif.languages." .. config.Language)()
+			t.items[item].vardisplay = sfs or config.Language
+		elseif main.f_input(main.t_players, {'$B'}) then
+			languageCounter = 0
+			for x, c in ipairs(motif.languages.languages) do
+				if c == config.Language then
+					currentLanguage = x
+				end
+				languageCounter = languageCounter + 1
+			end
+			if currentLanguage == 1 then
+				config.Language = motif.languages.languages[languageCounter]
+			else
+				config.Language = motif.languages.languages[currentLanguage - 1]
+			end
+			options.modified = true
+			options.needReload = true
+			loadstring("sfs = " .. "motif.languages." .. config.Language)()
+			t.items[item].vardisplay = sfs or config.Language
 		end
 		return true
 	end,
@@ -1312,6 +1352,10 @@ options.t_vardisplay = {
 	end,
 	['helpermax'] = function()
 		return config.MaxHelper
+	end,
+	['language'] = function()
+		loadstring("sfs = " .. "motif.languages." .. config.Language)()
+		return sfs or config.Language
 	end,
 	['lifemul'] = function()
 		return config.LifeMul .. '%'

--- a/src/main.go
+++ b/src/main.go
@@ -222,6 +222,7 @@ type configSettings struct {
 	IP                         map[string]string
 	KeepAspect                 bool
 	WindowScaleMode            bool
+	Language 				   string
 	LifeMul                    float32
 	ListenPort                 string
 	LoseSimul                  bool
@@ -378,6 +379,7 @@ func setupConfig() configSettings {
 	sys.helperMax = tmp.MaxHelper
 	sys.inputButtonAssist = tmp.InputButtonAssist
 	sys.inputSOCDresolution = Clamp(tmp.InputSOCDResolution, 0, 4)
+	sys.language = tmp.Language
 	sys.lifeMul = tmp.LifeMul / 100
 	sys.lifeShare = [...]bool{tmp.TeamLifeShare, tmp.TeamLifeShare}
 	sys.listenPort = tmp.ListenPort

--- a/src/resources/defaultConfig.json
+++ b/src/resources/defaultConfig.json
@@ -59,6 +59,7 @@
   "InputSOCDResolution": 2,
   "IP": {},
   "KeepAspect": true,
+  "Language": "en",
   "LifeMul": 100,
   "ListenPort": "7500",
   "LoseSimul": true,

--- a/src/stage.go
+++ b/src/stage.go
@@ -790,7 +790,17 @@ func loadStage(def string, main bool) (*Stage, error) {
 			defmap[name] = append(defmap[name], is)
 		}
 	}
-	if sec := defmap["info"]; len(sec) > 0 {
+	var sec []IniSection
+	sectionExists := false
+	
+	if sec = defmap[fmt.Sprintf("%v.info", sys.language)]; len(sec) > 0 {
+		sectionExists = true
+	} else {
+		if sec = defmap["info"]; len(sec) > 0 {
+			sectionExists = true
+		}
+	}
+	if sectionExists {
 		var ok bool
 		s.name, ok, _ = sec[0].getText("name")
 		if !ok {
@@ -861,12 +871,28 @@ func loadStage(def string, main bool) (*Stage, error) {
 			sec[0].ReadBool("roundloop", &sys.stageLoop)
 		}
 	}
-	if sec := defmap["constants"]; len(sec) > 0 {
+	if sec = defmap[fmt.Sprintf("%v.constants", sys.language)]; len(sec) > 0 {
+		sectionExists = true
+	} else {
+		if sec = defmap["constants"]; len(sec) > 0 {
+			sectionExists = true
+		}
+	}
+	if sectionExists {
+		sectionExists = false
 		for key, value := range sec[0] {
 			s.constants[key] = float32(Atof(value))
 		}
 	}
-	if sec := defmap["playerinfo"]; len(sec) > 0 {
+	if sec = defmap[fmt.Sprintf("%v.playerinfo", sys.language)]; len(sec) > 0 {
+		sectionExists = true
+	} else {
+		if sec = defmap["playerinfo"]; len(sec) > 0 {
+			sectionExists = true
+		}
+	}
+	if sectionExists {
+		sectionExists = false
 		sec[0].ReadI32("p1startx", &s.p[0].startx)
 		sec[0].ReadI32("p1starty", &s.p[0].starty)
 		sec[0].ReadI32("p1startz", &s.p[0].startz)
@@ -877,16 +903,40 @@ func loadStage(def string, main bool) (*Stage, error) {
 		sec[0].ReadF32("rightbound", &s.rightbound)
 		sec[0].ReadF32("p1p3dist", &s.p1p3dist)
 	}
-	if sec := defmap["scaling"]; len(sec) > 0 {
+	if sec = defmap[fmt.Sprintf("%v.scaling", sys.language)]; len(sec) > 0 {
+		sectionExists = true
+	} else {
+		if sec = defmap["scaling"]; len(sec) > 0 {
+			sectionExists = true
+		}
+	}
+	if sectionExists {
+		sectionExists = false
 		if s.mugenver[0] != 1 { // mugen 1.0+ removed support for topscale
 			sec[0].ReadF32("topscale", &s.stageCamera.ztopscale)
 		}
 	}
-	if sec := defmap["bound"]; len(sec) > 0 {
+	if sec = defmap[fmt.Sprintf("%v.bound", sys.language)]; len(sec) > 0 {
+		sectionExists = true
+	} else {
+		if sec = defmap["bound"]; len(sec) > 0 {
+			sectionExists = true
+		}
+	}
+	if sectionExists {
+		sectionExists = false
 		sec[0].ReadI32("screenleft", &s.screenleft)
 		sec[0].ReadI32("screenright", &s.screenright)
 	}
-	if sec := defmap["stageinfo"]; len(sec) > 0 {
+	if sec = defmap[fmt.Sprintf("%v.stageinfo", sys.language)]; len(sec) > 0 {
+		sectionExists = true
+	} else {
+		if sec = defmap["stageinfo"]; len(sec) > 0 {
+			sectionExists = true
+		}
+	}
+	if sectionExists {
+		sectionExists = false
 		sec[0].ReadI32("zoffset", &s.stageCamera.zoffset)
 		sec[0].ReadI32("zoffsetlink", &s.zoffsetlink)
 		sec[0].ReadBool("hires", &s.hires)
@@ -957,7 +1007,15 @@ func loadStage(def string, main bool) (*Stage, error) {
 		}
 	}
 	s.bgmfreqmul = 1 // fallback value to allow music to play on legacy stages without a bgmfreqmul parameter
-	if sec := defmap["music"]; len(sec) > 0 {
+	if sec = defmap[fmt.Sprintf("%v.msuic", sys.language)]; len(sec) > 0 {
+		sectionExists = true
+	} else {
+		if sec = defmap["music"]; len(sec) > 0 {
+			sectionExists = true
+		}
+	}
+	if sectionExists {
+		sectionExists = false
 		s.bgmusic = sec[0]["bgmusic"]
 		sec[0].ReadI32("bgmvolume", &s.bgmvolume)
 		sec[0].ReadI32("bgmloopstart", &s.bgmloopstart)
@@ -968,7 +1026,15 @@ func loadStage(def string, main bool) (*Stage, error) {
 		sec[0].ReadI32("bgmtrigger.life", &s.bgmtriggerlife)
 		sec[0].ReadI32("bgmtrigger.alt", &s.bgmtriggeralt)
 	}
-	if sec := defmap["bgdef"]; len(sec) > 0 {
+	if sec = defmap[fmt.Sprintf("%v.bgdef", sys.language)]; len(sec) > 0 {
+		sectionExists = true
+	} else {
+		if sec = defmap["bgdef"]; len(sec) > 0 {
+			sectionExists = true
+		}
+	}
+	if sectionExists {
+		sectionExists = false
 		if sec[0].LoadFile("spr", []string{def, "", sys.motifDir, "data/"}, func(filename string) error {
 			sff, err := loadSff(filename, false)
 			if err != nil {
@@ -1007,7 +1073,15 @@ func loadStage(def string, main bool) (*Stage, error) {
 		sec[0].readI32ForStage("bgclearcolor", &s.bgclearcolor[0], &s.bgclearcolor[1], &s.bgclearcolor[2])
 		sec[0].ReadBool("roundpos", &s.stageprops.roundpos)
 	}
-	if sec := defmap["model"]; len(sec) > 0 && s.model != nil {
+	if sec = defmap[fmt.Sprintf("%v.model", sys.language)]; len(sec) > 0 {
+		sectionExists = true
+	} else {
+		if sec = defmap["model"]; len(sec) > 0 {
+			sectionExists = true
+		}
+	}
+	if sectionExists {
+		sectionExists = false
 		if str, ok := sec[0]["offset"]; ok {
 			for k, v := range SplitAndTrim(str, ",") {
 				if k >= len(s.model.offset) {
@@ -1036,7 +1110,15 @@ func loadStage(def string, main bool) (*Stage, error) {
 		}
 	}
 	reflect := true
-	if sec := defmap["shadow"]; len(sec) > 0 {
+	if sec = defmap[fmt.Sprintf("%v.shadow", sys.language)]; len(sec) > 0 {
+		sectionExists = true
+	} else {
+		if sec = defmap["shadow"]; len(sec) > 0 {
+			sectionExists = true
+		}
+	}
+	if sectionExists {
+		sectionExists = false
 		var tmp int32
 		if sec[0].ReadI32("intensity", &tmp) {
 			s.sdw.intensity = Clamp(tmp, 0, 255)
@@ -1055,7 +1137,15 @@ func loadStage(def string, main bool) (*Stage, error) {
 		sec[0].ReadF32("xshear", &s.sdw.xshear)
 	}
 	if reflect {
-		if sec := defmap["reflection"]; len(sec) > 0 {
+		if sec = defmap[fmt.Sprintf("%v.constants", sys.language)]; len(sec) > 0 {
+			sectionExists = true
+		} else {
+			if sec = defmap["constants"]; len(sec) > 0 {
+				sectionExists = true
+			}
+		}
+		if sectionExists {
+			sectionExists = false
 			var tmp int32
 			if sec[0].ReadI32("intensity", &tmp) {
 				s.reflection = Clamp(tmp, 0, 255)

--- a/src/stage.go
+++ b/src/stage.go
@@ -801,6 +801,7 @@ func loadStage(def string, main bool) (*Stage, error) {
 		}
 	}
 	if sectionExists {
+		sectionExists = false
 		var ok bool
 		s.name, ok, _ = sec[0].getText("name")
 		if !ok {

--- a/src/stage.go
+++ b/src/stage.go
@@ -1008,7 +1008,7 @@ func loadStage(def string, main bool) (*Stage, error) {
 		}
 	}
 	s.bgmfreqmul = 1 // fallback value to allow music to play on legacy stages without a bgmfreqmul parameter
-	if sec = defmap[fmt.Sprintf("%v.msuic", sys.language)]; len(sec) > 0 {
+	if sec = defmap[fmt.Sprintf("%v.music", sys.language)]; len(sec) > 0 {
 		sectionExists = true
 	} else {
 		if sec = defmap["music"]; len(sec) > 0 {

--- a/src/system.go
+++ b/src/system.go
@@ -2919,6 +2919,7 @@ func (s *Select) AddStage(def string) error {
 				}); err != nil {
 					return nil
 				}
+			}
 		case "music":
 			if music {
 				music = false


### PR DESCRIPTION
Implements Mugen's system of handling language features while also adding a language option to the settings, useful for full games to make changing languages more clear instead of modifying the configuration settings, as was required with Mugen. 

The default settings currently only have English, while Japanese technically would already show a difference in the engine through KFM's victory quotes; The current font does not support Japanese characters and would need a lot of additional characters to show the quote without changing the font.

Adding a language code(en, ja, es, etc.) before a section in system.def, a character's .def, or a stage.def will load that version of the section only if that language code matches what is set in the config. There is also a new section in the system.def for languages, where it is specified what languages are supported by the screenpack, and provides strings for those language codes to be used in the options menu. The intent is a scalable solution to adding languages to screenpacks. This section itself can also be adapted based on language, meaning different strings can be shown based on what language is currently being used.

Changed files include, system.base.def to reflect new and changed sections, defaultConfig.json to set the language to en by default, main and system.go to support the new config option, as well as char.go and stage.go to support individual characters/stages. There are also changes to options.lua, motif.lua and main.lua to reflect the new options setting and support variations to the screenpack sections.