### PR TITLE
fix: Re-use palette textures, evict SFF cache entries

### DIFF
--- a/src/anim.go
+++ b/src/anim.go
@@ -126,6 +126,7 @@ type Animation struct {
 	sff                *Sff
 	palettedata        *PaletteList
 	spr                *Sprite
+	tex		   *Texture
 	frames             []AnimFrame
 	tile               Tiling
 	loopstart          int32
@@ -158,7 +159,7 @@ type Animation struct {
 }
 
 func newAnimation(sff *Sff, pal *PaletteList) *Animation {
-	return &Animation{sff: sff, palettedata: pal, mask: -1, srcAlpha: -1, newframe: true,
+	return &Animation{sff: sff, tex: PaletteTexture(), palettedata: pal, mask: -1, srcAlpha: -1, newframe: true,
 		remap: make(RemapPreset), start_scale: [...]float32{1, 1}}
 }
 func ReadAnimation(sff *Sff, pal *PaletteList, lines []string, i *int) *Animation {
@@ -795,7 +796,7 @@ func (a *Animation) ShadowDraw(window *[4]int32, x, y, xscl, yscl, vscl, rxadd f
 					paltemp = a.spr.GetPal(&a.sff.palList)
 				}
 			}
-			rp.paltex = PaletteToTexture(paltemp[:])
+			rp.paltex = PaletteToTexture(a.tex, paltemp[:])
 		}
 	}
 

--- a/src/char.go
+++ b/src/char.go
@@ -186,8 +186,8 @@ func (cr *ClsnRect) Add(clsn []float32, x, y, xs, ys float32) {
 		*cr = append(*cr, rect)
 	}
 }
-func (cr ClsnRect) draw(trans int32) {
-	paltex := PaletteToTexture(sys.clsnSpr.Pal)
+func (cr ClsnRect) draw(tex *Texture, trans int32) {
+	paltex := PaletteToTexture(tex, sys.clsnSpr.Pal)
 	for _, c := range cr {
 		params := RenderParams{
 			sys.clsnSpr.Tex, paltex, sys.clsnSpr.Size,
@@ -2820,7 +2820,7 @@ func (c *Char) loadPalette() {
 					}
 					gi.palExist[i] = true
 					// Palette Texture Generation
-					gi.palettedata.palList.PalTex[i] = PaletteToTexture(pl)
+					gi.palettedata.palList.PalTex[i] = PaletteToTexture(PaletteTexture(), pl)
 					tmp = i + 1
 				}
 			}

--- a/src/script.go
+++ b/src/script.go
@@ -901,6 +901,7 @@ func systemScriptInit(l *lua.LState) {
 	luaRegister(l, "game", func(l *lua.LState) int {
 		// Anonymous function to load characters and stages, and/or wait for them to finish loading
 		load := func() error {
+			evictSFFCache()
 			sys.loader.runTread()
 			for sys.loader.state != LS_Complete {
 				if sys.loader.state == LS_Error {

--- a/src/stage.go
+++ b/src/stage.go
@@ -1819,7 +1819,9 @@ func loadglTFStage(filepath string) (*Model, error) {
 				rgba := image.NewRGBA(img.Bounds())
 				draw.Draw(rgba, img.Bounds(), img, img.Bounds().Min, draw.Src)
 				sys.mainThreadTask <- func() {
-					texture.tex = newTexture(int32(img.Bounds().Max.X), int32(img.Bounds().Max.Y), 32, false)
+					if texture.tex == nil {
+						texture.tex = newTexture(int32(img.Bounds().Max.X), int32(img.Bounds().Max.Y), 32, false)
+					}
 					texture.tex.SetDataG(rgba.Pix, mag, min, wrapS, wrapT)
 				}
 				textureMap[[2]int32{int32(*t.Source), int32(*t.Sampler)}] = texture

--- a/src/system.go
+++ b/src/system.go
@@ -256,6 +256,18 @@ type System struct {
 	drawc2stb               ClsnRect
 	drawwh                  ClsnRect
 	drawch                  ClsnRect
+
+	drawc1hitTex            *Texture
+	drawc1revTex            *Texture
+	drawc1notTex            *Texture
+	drawc2Tex               *Texture
+	drawc2hbTex             *Texture
+	drawc2mtkTex            *Texture
+	drawc2grdTex            *Texture
+	drawc2stbTex            *Texture
+	drawwhTex               *Texture
+	drawchTex               *Texture
+
 	autoguard               [MaxSimul*2 + MaxAttachedChar]bool
 	accel                   float32
 	clsnSpr                 Sprite
@@ -389,6 +401,7 @@ type System struct {
 // Initialize stuff, this is called after the config int at main.go
 func (s *System) init(w, h int32) *lua.LState {
 	s.setWindowSize(w, h)
+	
 	var err error
 	// Create a system window.
 	s.window, err = s.newWindow(int(s.scrrect[2]), int(s.scrrect[3]))
@@ -447,6 +460,18 @@ func (s *System) init(w, h int32) *lua.LState {
 	for i := range s.stringPool {
 		s.stringPool[i] = *NewStringPool()
 	}
+
+	s.drawc1hitTex = PaletteTexture()
+	s.drawc1revTex = PaletteTexture()
+	s.drawc1notTex = PaletteTexture()
+	s.drawc2Tex = PaletteTexture()
+	s.drawc2hbTex = PaletteTexture()
+	s.drawc2mtkTex = PaletteTexture()
+	s.drawc2grdTex = PaletteTexture()
+	s.drawc2stbTex = PaletteTexture()
+	s.drawwhTex = PaletteTexture()
+	s.drawchTex = PaletteTexture()
+
 	s.clsnSpr = *newSprite()
 	s.clsnSpr.Size, s.clsnSpr.Pal = [...]uint16{1, 1}, make([]uint32, 256)
 	s.clsnSpr.SetPxl([]byte{0})
@@ -1789,25 +1814,25 @@ func (s *System) drawTop() {
 	// Draw Clsn boxes
 	if s.clsnDraw {
 		s.clsnSpr.Pal[0] = 0xff0000ff
-		s.drawc1hit.draw(0x3feff)
+		s.drawc1hit.draw(s.drawc1hitTex, 0x3feff)
 		s.clsnSpr.Pal[0] = 0xff0040c0
-		s.drawc1rev.draw(0x3feff)
+		s.drawc1rev.draw(s.drawc1revTex, 0x3feff)
 		s.clsnSpr.Pal[0] = 0xff000080
-		s.drawc1not.draw(0x3feff)
+		s.drawc1not.draw(s.drawc1notTex, 0x3feff)
 		s.clsnSpr.Pal[0] = 0xffff0000
-		s.drawc2.draw(0x3feff)
+		s.drawc2.draw(s.drawc2Tex, 0x3feff)
 		s.clsnSpr.Pal[0] = 0xff808000
-		s.drawc2hb.draw(0x3feff)
+		s.drawc2hb.draw(s.drawc2hbTex, 0x3feff)
 		s.clsnSpr.Pal[0] = 0xff004000
-		s.drawc2mtk.draw(0x3feff)
+		s.drawc2mtk.draw(s.drawc2mtkTex, 0x3feff)
 		s.clsnSpr.Pal[0] = 0xffc00040
-		s.drawc2grd.draw(0x3feff)
+		s.drawc2grd.draw(s.drawc2grdTex, 0x3feff)
 		s.clsnSpr.Pal[0] = 0xff404040
-		s.drawc2stb.draw(0x3feff)
+		s.drawc2stb.draw(s.drawc2stbTex, 0x3feff)
 		s.clsnSpr.Pal[0] = 0xff303030
-		s.drawwh.draw(0x3feff)
+		s.drawwh.draw(s.drawwhTex, 0x3feff)
 		s.clsnSpr.Pal[0] = 0xffffffff
-		s.drawch.draw(0x3feff)
+		s.drawch.draw(s.drawchTex, 0x3feff)
 	}
 }
 func (s *System) drawDebugText() {


### PR DESCRIPTION
Reusing palette textures prevents flooding of garbage collection.  Evicting SFFCache entries prevents clawing of RAM over time.