### PR TITLE
fix: Swap & bind framebuffer when taking screenshots, skip viewport resize on window/game res being the same, add MSAA samples setting

### DIFF
--- a/data/system.base.def
+++ b/data/system.base.def
@@ -1638,8 +1638,11 @@
 	menu.itemname.menuvideo.resolution.customres = "Custom"
 	menu.itemname.menuvideo.resolution.back = "Back"
 	menu.itemname.menuvideo.fullscreen = "Fullscreen"
+	menu.itemname.menuvideo.keepaspect = "Keep Aspect Ratio"
+	menu.itemname.menuvideo.windowscalemode = "Bilinear Filtering"
 	menu.itemname.menuvideo.vretrace = "VSync"
 	menu.itemname.menuvideo.msaa = "MSAA"
+	menu.itemname.menuvideo.msaasamples = "MSAA Samples"
 	menu.itemname.menuvideo.shaders = "Shaders" ;reserved submenu
 	; This list is populated with shaders existing in 'external/shaders' directory
 	menu.itemname.menuvideo.shaders.empty = ""

--- a/data/system.base.def
+++ b/data/system.base.def
@@ -1642,7 +1642,6 @@
 	menu.itemname.menuvideo.windowscalemode = "Bilinear Filtering"
 	menu.itemname.menuvideo.vretrace = "VSync"
 	menu.itemname.menuvideo.msaa = "MSAA"
-	menu.itemname.menuvideo.msaasamples = "MSAA Samples"
 	menu.itemname.menuvideo.shaders = "Shaders" ;reserved submenu
 	; This list is populated with shaders existing in 'external/shaders' directory
 	menu.itemname.menuvideo.shaders.empty = ""

--- a/external/script/motif.lua
+++ b/external/script/motif.lua
@@ -2016,7 +2016,10 @@ function motif.setBaseOptionInfo()
 	motif.option_info.menu_itemname_menuvideo_resolution_back = "Back"
 	motif.option_info.menu_itemname_menuvideo_fullscreen = "Fullscreen"
 	motif.option_info.menu_itemname_menuvideo_vretrace = "VSync"
+	motif.option_info.menu_itemname_menuvideo_keepaspect = "Keep Aspect Ratio"
+	motif.option_info.menu_itemname_menuvideo_windowscalemode = "Bilinear Filtering"
 	motif.option_info.menu_itemname_menuvideo_msaa = "MSAA"
+	motif.option_info.menu_itemname_menuvideo_msaasamples = "MSAA Samples"
 	motif.option_info.menu_itemname_menuvideo_shaders = "Shaders" --reserved submenu
 	-- This list is populated with shaders existing in 'external/shaders' directory
 	motif.option_info.menu_itemname_menuvideo_shaders_empty = ""
@@ -2138,7 +2141,10 @@ function motif.setBaseOptionInfo()
 		"menuvideo_resolution_back",
 		"menuvideo_fullscreen",
 		"menuvideo_vretrace",
+		"menuvideo_keepaspect",
+		"menuvideo_windowscalemode",
 		"menuvideo_msaa",
+		"menuvideo_msaasamples",
 		"menuvideo_shaders",
 		"menuvideo_shaders_empty",
 		"menuvideo_shaders_noshader",

--- a/external/script/motif.lua
+++ b/external/script/motif.lua
@@ -2019,7 +2019,6 @@ function motif.setBaseOptionInfo()
 	motif.option_info.menu_itemname_menuvideo_keepaspect = "Keep Aspect Ratio"
 	motif.option_info.menu_itemname_menuvideo_windowscalemode = "Bilinear Filtering"
 	motif.option_info.menu_itemname_menuvideo_msaa = "MSAA"
-	motif.option_info.menu_itemname_menuvideo_msaasamples = "MSAA Samples"
 	motif.option_info.menu_itemname_menuvideo_shaders = "Shaders" --reserved submenu
 	-- This list is populated with shaders existing in 'external/shaders' directory
 	motif.option_info.menu_itemname_menuvideo_shaders_empty = ""
@@ -2144,7 +2143,6 @@ function motif.setBaseOptionInfo()
 		"menuvideo_keepaspect",
 		"menuvideo_windowscalemode",
 		"menuvideo_msaa",
-		"menuvideo_msaasamples",
 		"menuvideo_shaders",
 		"menuvideo_shaders_empty",
 		"menuvideo_shaders_noshader",

--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -163,8 +163,7 @@ options.t_itemname = {
 			config.MaxPlayerProjectile = 256
 			--config.Modules = {}
 			--config.Motif = "data/system.def"
-			config.MSAA = false
-			config.MSAASamples = 2
+			config.MSAA = 0
 			config.NumSimul = {2, 4}
 			config.NumTag = {2, 4}
 			config.NumTurns = {2, 4}
@@ -845,31 +844,24 @@ options.t_itemname = {
 	end,
 	--MSAA
 	['msaa'] = function(t, item, cursorPosY, moveTxt)
-		if main.f_input(main.t_players, {'$F', '$B', 'pal', 's'}) then
+		if main.f_input(main.t_players, {'$F'}) and config.MSAA < 16 then
 			sndPlay(motif.files.snd_data, motif.option_info.cursor_move_snd[1], motif.option_info.cursor_move_snd[2])
-			if config.MSAA then
-				config.MSAA = false
+			if config.MSAA == 0 then
+				config.MSAA = 2
 			else
-				config.MSAA = true
+				config.MSAA = config.MSAA * 2
 			end
-			t.items[item].vardisplay = options.f_boolDisplay(config.MSAA, motif.option_info.menu_valuename_enabled, motif.option_info.menu_valuename_disabled)
+			t.items[item].vardisplay = config.MSAA .. 'x'
 			options.modified = true
 			options.needReload = true
-		end
-		return true
-	end,
-	--MSAA samples
-	['msaasamples'] = function(t, item, cursorPosY, moveTxt)
-		if main.f_input(main.t_players, {'$F'}) and config.MSAASamples < 16 then
+		elseif main.f_input(main.t_players, {'$B'}) and config.MSAA > 1 then
 			sndPlay(motif.files.snd_data, motif.option_info.cursor_move_snd[1], motif.option_info.cursor_move_snd[2])
-			config.MSAASamples = config.MSAASamples * 2
-			t.items[item].vardisplay = config.MSAASamples
-			options.modified = true
-			options.needReload = true
-		elseif main.f_input(main.t_players, {'$B'}) and config.MSAASamples > 1 then
-			sndPlay(motif.files.snd_data, motif.option_info.cursor_move_snd[1], motif.option_info.cursor_move_snd[2])
-			config.MSAASamples = config.MSAASamples / 2
-			t.items[item].vardisplay = config.MSAASamples
+			if config.MSAA == 2 then
+				config.MSAA = 0
+			else
+				config.MSAA = config.MSAA / 2
+			end
+			t.items[item].vardisplay = options.f_definedDisplay(config.MSAA, {[0] = motif.option_info.menu_valuename_disabled}, config.MSAA .. 'x')
 			options.modified = true
 			options.needReload = true
 		end
@@ -1402,10 +1394,7 @@ options.t_vardisplay = {
 		return config.NumTurns[1]
 	end,
 	['msaa'] = function()
-		return options.f_boolDisplay(config.MSAA, motif.option_info.menu_valuename_enabled, motif.option_info.menu_valuename_disabled)
-	end,
-	['msaasamples'] = function()
-		return config.MSAASamples
+		return options.f_definedDisplay(config.MSAA, {[0] = motif.option_info.menu_valuename_disabled}, config.MSAA .. 'x')
 	end,
 	['panningrange'] = function()
 		return config.PanningRange .. '%'

--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -150,6 +150,7 @@ options.t_itemname = {
 			config.GameHeight = 480
 			config.GameFramerate = 60
 			--config.IP = {}
+			config.KeepAspect = true
 			config.LifeMul = 100
 			config.ListenPort = "7500"
 			config.LoseSimul = true
@@ -163,6 +164,7 @@ options.t_itemname = {
 			--config.Modules = {}
 			--config.Motif = "data/system.def"
 			config.MSAA = false
+			config.MSAASamples = 2
 			config.NumSimul = {2, 4}
 			config.NumTag = {2, 4}
 			config.NumTurns = {2, 4}
@@ -194,6 +196,7 @@ options.t_itemname = {
 			config.VolumeMaster = 80
 			config.VolumeSfx = 80
 			config.VRetrace = 1
+			config.WindowScaleMode = true
 			--config.WavChannels = 32
 			--config.WindowCentered = true
 			--config.WindowIcon = {"external/icons/IkemenCylia.png"}
@@ -237,6 +240,8 @@ options.t_itemname = {
 			--setZoomSpeed(config.ZoomSpeed)
 			toggleFullscreen(config.Fullscreen)
 			toggleVsync(config.VRetrace)
+			toggleWindowScaleMode(config.WindowScaleMode)
+			toggleKeepAspect(config.KeepAspect)
 			options.modified = true
 			options.needReload = true
 		end
@@ -853,6 +858,53 @@ options.t_itemname = {
 		end
 		return true
 	end,
+	--MSAA samples
+	['msaasamples'] = function(t, item, cursorPosY, moveTxt)
+		if main.f_input(main.t_players, {'$F'}) and config.MSAASamples < 16 then
+			sndPlay(motif.files.snd_data, motif.option_info.cursor_move_snd[1], motif.option_info.cursor_move_snd[2])
+			config.MSAASamples = config.MSAASamples * 2
+			t.items[item].vardisplay = config.MSAASamples
+			options.modified = true
+			options.needReload = true
+		elseif main.f_input(main.t_players, {'$B'}) and config.MSAASamples > 1 then
+			sndPlay(motif.files.snd_data, motif.option_info.cursor_move_snd[1], motif.option_info.cursor_move_snd[2])
+			config.MSAASamples = config.MSAASamples / 2
+			t.items[item].vardisplay = config.MSAASamples
+			options.modified = true
+			options.needReload = true
+		end
+		return true
+	end,
+	--Window scaling mode
+	['windowscalemode'] = function(t, item, cursorPosY, moveTxt)
+		if main.f_input(main.t_players, {'$F', '$B', 'pal', 's'}) then
+			sndPlay(motif.files.snd_data, motif.option_info.cursor_move_snd[1], motif.option_info.cursor_move_snd[2])
+			if config.WindowScaleMode then
+				config.WindowScaleMode = false
+			else
+				config.WindowScaleMode = true
+			end
+			toggleWindowScaleMode(config.WindowScaleMode)
+			t.items[item].vardisplay = options.f_boolDisplay(config.WindowScaleMode, motif.option_info.menu_valuename_enabled, motif.option_info.menu_valuename_disabled)
+			options.modified = true
+		end
+		return true
+	end,
+	--Keep Aspect Ratio
+	['keepaspect'] = function(t, item, cursorPosY, moveTxt)
+		if main.f_input(main.t_players, {'$F', '$B', 'pal', 's'}) then
+			sndPlay(motif.files.snd_data, motif.option_info.cursor_move_snd[1], motif.option_info.cursor_move_snd[2])
+			if config.KeepAspect then
+				config.KeepAspect = false
+			else
+				config.KeepAspect = true
+			end
+			toggleKeepAspect(config.KeepAspect)
+			t.items[item].vardisplay = options.f_boolDisplay(config.KeepAspect, motif.option_info.menu_valuename_enabled, motif.option_info.menu_valuename_disabled)
+			options.modified = true
+		end
+		return true
+	end,
 	--Shaders (submenu)
 	['shaders'] = function(t, item, cursorPosY, moveTxt)
 		if main.f_input(main.t_players, {'$F', '$B', 'pal', 's'}) then
@@ -1313,6 +1365,9 @@ options.t_vardisplay = {
 	['helpermax'] = function()
 		return config.MaxHelper
 	end,
+	['keepaspect'] = function()
+		return options.f_boolDisplay(config.KeepAspect, motif.option_info.menu_valuename_enabled, motif.option_info.menu_valuename_disabled)
+	end,
 	['lifemul'] = function()
 		return config.LifeMul .. '%'
 	end,
@@ -1348,6 +1403,9 @@ options.t_vardisplay = {
 	end,
 	['msaa'] = function()
 		return options.f_boolDisplay(config.MSAA, motif.option_info.menu_valuename_enabled, motif.option_info.menu_valuename_disabled)
+	end,
+	['msaasamples'] = function()
+		return config.MSAASamples
 	end,
 	['panningrange'] = function()
 		return config.PanningRange .. '%'
@@ -1444,6 +1502,9 @@ options.t_vardisplay = {
 	end,
 	['vretrace'] = function()
 		return options.f_definedDisplay(config.VRetrace, {[1] = motif.option_info.menu_valuename_enabled}, motif.option_info.menu_valuename_disabled)
+	end,
+	['windowscalemode'] = function()
+		return options.f_boolDisplay(config.WindowScaleMode, motif.option_info.menu_valuename_enabled, motif.option_info.menu_valuename_disabled)
 	end,
 }
 

--- a/src/main.go
+++ b/src/main.go
@@ -235,6 +235,7 @@ type configSettings struct {
 	Modules                    []string
 	Motif                      string
 	MSAA                       bool
+	MSAASamples                int32
 	NumSimul                   [2]int
 	NumTag                     [2]int
 	NumTurns                   [2]int
@@ -385,6 +386,10 @@ func setupConfig() configSettings {
 	sys.loseTag = tmp.LoseTag
 	sys.masterVolume = tmp.VolumeMaster
 	sys.multisampleAntialiasing = tmp.MSAA
+	if tmp.MSAASamples <= 0 {
+		tmp.MSAASamples = 1
+	}
+	sys.multisampleAntialiasingSamples = tmp.MSAASamples
 	sys.pauseMasterVolume = tmp.PauseMasterVolume
 	sys.panningRange = tmp.PanningRange
 	sys.playerProjectileMax = tmp.MaxPlayerProjectile

--- a/src/main.go
+++ b/src/main.go
@@ -234,8 +234,7 @@ type configSettings struct {
 	MaxPlayerProjectile        int
 	Modules                    []string
 	Motif                      string
-	MSAA                       bool
-	MSAASamples                int32
+	MSAA                       int32
 	NumSimul                   [2]int
 	NumTag                     [2]int
 	NumTurns                   [2]int
@@ -385,11 +384,10 @@ func setupConfig() configSettings {
 	sys.loseSimul = tmp.LoseSimul
 	sys.loseTag = tmp.LoseTag
 	sys.masterVolume = tmp.VolumeMaster
-	sys.multisampleAntialiasing = tmp.MSAA
-	if tmp.MSAASamples <= 0 {
-		tmp.MSAASamples = 1
+	if tmp.MSAA <= -1 {
+		tmp.MSAA = 0
 	}
-	sys.multisampleAntialiasingSamples = tmp.MSAASamples
+	sys.multisampleAntialiasing = tmp.MSAA
 	sys.pauseMasterVolume = tmp.PauseMasterVolume
 	sys.panningRange = tmp.PanningRange
 	sys.playerProjectileMax = tmp.MaxPlayerProjectile

--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -328,14 +328,14 @@ func (r *Renderer) Init() {
 		r.postShaderSelect[1+i].RegisterUniforms("Texture", "TextureSize")
 	}
 
-	if sys.multisampleAntialiasing {
+	if sys.multisampleAntialiasing > 0 {
 		gl.Enable(gl.MULTISAMPLE)
 	}
 
 	gl.ActiveTexture(gl.TEXTURE0)
 	gl.GenTextures(1, &r.fbo_texture)
 
-	if sys.multisampleAntialiasing {
+	if sys.multisampleAntialiasing > 0 {
 		gl.BindTexture(gl.TEXTURE_2D_MULTISAMPLE, r.fbo_texture)
 	} else {
 		gl.BindTexture(gl.TEXTURE_2D, r.fbo_texture)
@@ -346,8 +346,8 @@ func (r *Renderer) Init() {
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
 
-	if sys.multisampleAntialiasing {
-		gl.TexImage2DMultisample(gl.TEXTURE_2D_MULTISAMPLE, sys.multisampleAntialiasingSamples, gl.RGBA, sys.scrrect[2], sys.scrrect[3], true)
+	if sys.multisampleAntialiasing > 0 {
+		gl.TexImage2DMultisample(gl.TEXTURE_2D_MULTISAMPLE, sys.multisampleAntialiasing, gl.RGBA, sys.scrrect[2], sys.scrrect[3], true)
 
 	} else {
 		gl.TexImage2D(gl.TEXTURE_2D, 0, gl.RGBA, sys.scrrect[2], sys.scrrect[3], 0, gl.RGBA, gl.UNSIGNED_BYTE, nil)
@@ -359,14 +359,14 @@ func (r *Renderer) Init() {
 	gl.GenRenderbuffers(1, &r.rbo_depth)
 
 	gl.BindRenderbuffer(gl.RENDERBUFFER, r.rbo_depth)
-	if sys.multisampleAntialiasing {
+	if sys.multisampleAntialiasing > 0 {
 		//gl.RenderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT16, int(sys.scrrect[2]), int(sys.scrrect[3]))
-		gl.RenderbufferStorageMultisample(gl.RENDERBUFFER, sys.multisampleAntialiasingSamples, gl.DEPTH_COMPONENT16, sys.scrrect[2], sys.scrrect[3])
+		gl.RenderbufferStorageMultisample(gl.RENDERBUFFER, sys.multisampleAntialiasing, gl.DEPTH_COMPONENT16, sys.scrrect[2], sys.scrrect[3])
 	} else {
 		gl.RenderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT16, sys.scrrect[2], sys.scrrect[3])
 	}
 	gl.BindRenderbuffer(gl.RENDERBUFFER, 0)
-	if sys.multisampleAntialiasing {
+	if sys.multisampleAntialiasing > 0 {
 		r.fbo_f_texture = newTexture(sys.scrrect[2], sys.scrrect[3], 32, false)
 		r.fbo_f_texture.SetData(nil)
 	} else {
@@ -379,7 +379,7 @@ func (r *Renderer) Init() {
 	gl.GenFramebuffers(1, &r.fbo)
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo)
 
-	if sys.multisampleAntialiasing {
+	if sys.multisampleAntialiasing > 0 {
 		gl.FramebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D_MULTISAMPLE, r.fbo_texture, 0)
 		gl.FramebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, r.rbo_depth)
 		if status := gl.CheckFramebufferStatus(gl.FRAMEBUFFER); status != gl.FRAMEBUFFER_COMPLETE {
@@ -415,7 +415,7 @@ func (r *Renderer) BeginFrame(clearColor bool) {
 }
 
 func (r *Renderer) EndFrame() {
-	if sys.multisampleAntialiasing {
+	if sys.multisampleAntialiasing > 0 {
 		gl.BindFramebuffer(gl.DRAW_FRAMEBUFFER, r.fbo_f)
 		gl.BindFramebuffer(gl.READ_FRAMEBUFFER, r.fbo)
 		gl.BlitFramebuffer(0, 0, sys.scrrect[2], sys.scrrect[3], 0, 0, sys.scrrect[2], sys.scrrect[3], gl.COLOR_BUFFER_BIT, gl.LINEAR)
@@ -435,7 +435,7 @@ func (r *Renderer) EndFrame() {
 	gl.Disable(gl.BLEND)
 
 	gl.ActiveTexture(gl.TEXTURE0)
-	if sys.multisampleAntialiasing {
+	if sys.multisampleAntialiasing > 0 {
 		gl.BindTexture(gl.TEXTURE_2D, r.fbo_f_texture.handle)
 	} else {
 		gl.BindTexture(gl.TEXTURE_2D, r.fbo_texture)
@@ -454,7 +454,7 @@ func (r *Renderer) EndFrame() {
 	gl.DisableVertexAttribArray(uint32(loc))
 
 	// rebind to prepare frame for blitting to window
-	if sys.multisampleAntialiasing {
+	if sys.multisampleAntialiasing > 0 {
 		gl.BindFramebuffer(gl.READ_FRAMEBUFFER, r.fbo_f)
 	} else {
 		gl.BindFramebuffer(gl.READ_FRAMEBUFFER, r.fbo)

--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -627,6 +627,8 @@ func (r *Renderer) SetModelMorphTarget(offsets [8]uint32, weights [8]float32, po
 
 func (r *Renderer) ReadPixels(data []uint8, width, height int) {
 	r.EndFrame()
+	sys.window.SwapBuffers()
+	gl.BindFramebuffer(gl.READ_FRAMEBUFFER, 0)
 	gl.ReadPixels(0, 0, int32(width), int32(height), gl.RGBA, gl.UNSIGNED_BYTE, unsafe.Pointer(&data[0]))
 	r.BeginFrame(false)
 }

--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -347,7 +347,7 @@ func (r *Renderer) Init() {
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
 
 	if sys.multisampleAntialiasing {
-		gl.TexImage2DMultisample(gl.TEXTURE_2D_MULTISAMPLE, 16, gl.RGBA, sys.scrrect[2], sys.scrrect[3], true)
+		gl.TexImage2DMultisample(gl.TEXTURE_2D_MULTISAMPLE, sys.multisampleAntialiasingSamples, gl.RGBA, sys.scrrect[2], sys.scrrect[3], true)
 
 	} else {
 		gl.TexImage2D(gl.TEXTURE_2D, 0, gl.RGBA, sys.scrrect[2], sys.scrrect[3], 0, gl.RGBA, gl.UNSIGNED_BYTE, nil)
@@ -361,7 +361,7 @@ func (r *Renderer) Init() {
 	gl.BindRenderbuffer(gl.RENDERBUFFER, r.rbo_depth)
 	if sys.multisampleAntialiasing {
 		//gl.RenderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT16, int(sys.scrrect[2]), int(sys.scrrect[3]))
-		gl.RenderbufferStorageMultisample(gl.RENDERBUFFER, 16, gl.DEPTH_COMPONENT16, sys.scrrect[2], sys.scrrect[3])
+		gl.RenderbufferStorageMultisample(gl.RENDERBUFFER, sys.multisampleAntialiasingSamples, gl.DEPTH_COMPONENT16, sys.scrrect[2], sys.scrrect[3])
 	} else {
 		gl.RenderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT16, sys.scrrect[2], sys.scrrect[3])
 	}

--- a/src/resources/defaultConfig.json
+++ b/src/resources/defaultConfig.json
@@ -72,6 +72,7 @@
   "Modules": [],
   "Motif": "data/system.def",
   "MSAA": false,
+  "MSAASamples": 2,
   "NumSimul": [
     2,
     4

--- a/src/resources/defaultConfig.json
+++ b/src/resources/defaultConfig.json
@@ -71,8 +71,7 @@
   "MaxPlayerProjectile": 256,
   "Modules": [],
   "Motif": "data/system.def",
-  "MSAA": false,
-  "MSAASamples": 2,
+  "MSAA": 0,
   "NumSimul": [
     2,
     4

--- a/src/script.go
+++ b/src/script.go
@@ -2601,6 +2601,26 @@ func systemScriptInit(l *lua.LState) {
 		}
 		return 0
 	})
+	luaRegister(l, "toggleWindowScaleMode", func(*lua.LState) int {
+		wsm := !sys.windowScaleMode
+		if l.GetTop() >= 1 {
+			wsm = boolArg(l, 1)
+		}
+		if wsm != sys.windowScaleMode {
+			sys.windowScaleMode = !sys.windowScaleMode
+		}
+		return 0
+	})
+	luaRegister(l, "toggleKeepAspect", func(*lua.LState) int {
+		wsm := !sys.keepAspect
+		if l.GetTop() >= 1 {
+			wsm = boolArg(l, 1)
+		}
+		if wsm != sys.keepAspect {
+			sys.keepAspect = !sys.keepAspect
+		}
+		return 0
+	})
 	luaRegister(l, "toggleMaxPowerMode", func(*lua.LState) int {
 		if l.GetTop() >= 1 {
 			sys.maxPowerMode = boolArg(l, 1)

--- a/src/system.go
+++ b/src/system.go
@@ -319,9 +319,10 @@ type System struct {
 	lifebarLocalcoord    [2]int32
 
 	// Shader Vars
-	postProcessingShader    int32
-	multisampleAntialiasing bool
-	fontShaderVer           uint
+	postProcessingShader           int32
+	multisampleAntialiasing        bool
+	multisampleAntialiasingSamples int32
+	fontShaderVer                  uint
 
 	// External Shader Vars
 	externalShaderList  []string

--- a/src/system.go
+++ b/src/system.go
@@ -320,8 +320,7 @@ type System struct {
 
 	// Shader Vars
 	postProcessingShader           int32
-	multisampleAntialiasing        bool
-	multisampleAntialiasingSamples int32
+	multisampleAntialiasing        int32
 	fontShaderVer                  uint
 
 	// External Shader Vars

--- a/src/system_glfw.go
+++ b/src/system_glfw.go
@@ -111,7 +111,7 @@ func (w *Window) GetScaledViewportSize() (int32, int32, int32, int32) {
 	var ratio float32
 	var x, y, resizedWidth, resizedHeight int32 = 0, 0, int32(winWidth), int32(winHeight)
 
-	if sys.fullscreen {
+	if sys.fullscreen || int32(winWidth) == sys.scrrect[2] && int32(winHeight) == sys.scrrect[3] {
 		return 0, 0, int32(winWidth), int32(winHeight)
 	}
 


### PR DESCRIPTION
Fixes #1922.

For a more detailed explanation of this bug, see my replies to that issue. _Hopefully_ this is the last commit I have to make regarding screen resize regressions for a while!