### PR TITLE
fix: Resolve issue with stage's reflection after language update.

### DIFF
--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -280,6 +280,7 @@ options.t_itemname = {
 	--Language Setting
 	['language'] = function(t, item, cursorPosY, moveTxt)
 		if main.f_input(main.t_players, {'$F'}) then
+			sndPlay(motif.files.snd_data, motif.option_info.cursor_move_snd[1], motif.option_info.cursor_move_snd[2])
 			languageCounter = 0
 			for x, c in ipairs(motif.languages.languages) do
 				if c == config.Language then
@@ -297,6 +298,7 @@ options.t_itemname = {
 			loadstring("sfs = " .. "motif.languages." .. config.Language)()
 			t.items[item].vardisplay = sfs or config.Language
 		elseif main.f_input(main.t_players, {'$B'}) then
+			sndPlay(motif.files.snd_data, motif.option_info.cursor_move_snd[1], motif.option_info.cursor_move_snd[2])
 			languageCounter = 0
 			for x, c in ipairs(motif.languages.languages) do
 				if c == config.Language then

--- a/src/stage.go
+++ b/src/stage.go
@@ -1138,10 +1138,10 @@ func loadStage(def string, main bool) (*Stage, error) {
 		sec[0].ReadF32("xshear", &s.sdw.xshear)
 	}
 	if reflect {
-		if sec = defmap[fmt.Sprintf("%v.constants", sys.language)]; len(sec) > 0 {
+		if sec = defmap[fmt.Sprintf("%v.reflection", sys.language)]; len(sec) > 0 {
 			sectionExists = true
 		} else {
-			if sec = defmap["constants"]; len(sec) > 0 {
+			if sec = defmap["reflection"]; len(sec) > 0 {
 				sectionExists = true
 			}
 		}


### PR DESCRIPTION
I have been advised that I made an error with the addition of the localization/language feature, in which the reflection section of the stage's definition file is never read. This was due to the section attempting to search for the constants section a second time rather than the proper reflection section.
I have also been advised that the language option in the menu does not play on option when changing language. This also adds the part of the script that plays that sound.
This is a fix for that issue.