### PR TITLE
feat: improved Char/Stage layering, fixes

### DIFF
--- a/data/training.zss
+++ b/data/training.zss
@@ -102,7 +102,7 @@ ignoreHitPause if gameMode != "training" || isHelper || teamSide != 2 {
 								assertInput{flag: a; flag2: b; flag3: c}
 							}
 						} else {
-							assertCommand{name: "recovery"; buffertime: 2}
+							assertCommand{name: "recovery"; buffer.time: 2}
 							# Buffered 2 frames because asserting a command instead of inputting it has 1 frame of lag in custom fall recovery systems
 						}
 						# Random direction

--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -1623,7 +1623,7 @@ function main.f_warning(t, background, info, title, txt, overlay)
 		--draw clearcolor
 		clearColor(background.bgclearcolor[1], background.bgclearcolor[2], background.bgclearcolor[3])
 		--draw layerno = 0 backgrounds
-		bgDraw(background.bg, false)
+		bgDraw(background.bg, 0)
 		--draw overlay
 		overlay:draw()
 		--draw title
@@ -1637,7 +1637,7 @@ function main.f_warning(t, background, info, title, txt, overlay)
 			txt:draw()
 		end
 		--draw layerno = 1 backgrounds
-		bgDraw(background.bg, true)
+		bgDraw(background.bg, 1)
 		--end loop
 		refresh()
 	end
@@ -1699,7 +1699,7 @@ function main.f_drawInput(t, txt, overlay, offsetY, spacingY, background, catego
 		--draw clearcolor
 		clearColor(background.bgclearcolor[1], background.bgclearcolor[2], background.bgclearcolor[3])
 		--draw layerno = 0 backgrounds
-		bgDraw(background.bg, false)
+		bgDraw(background.bg, 0)
 		--draw overlay
 		overlay:draw()
 		--draw text
@@ -1711,7 +1711,7 @@ function main.f_drawInput(t, txt, overlay, offsetY, spacingY, background, catego
 			txt:draw()
 		end
 		--draw layerno = 1 backgrounds
-		bgDraw(background.bg, true)
+		bgDraw(background.bg, 1)
 		--end loop
 		main.f_cmdInput()
 		refresh()
@@ -3449,7 +3449,7 @@ function main.f_connect(server, t)
 		--draw clearcolor
 		clearColor(motif[main.background].bgclearcolor[1], motif[main.background].bgclearcolor[2], motif[main.background].bgclearcolor[3])
 		--draw layerno = 0 backgrounds
-		bgDraw(motif[main.background].bg, false)
+		bgDraw(motif[main.background].bg, 0)
 		--draw overlay
 		overlay_connecting:draw()
 		--draw text
@@ -3461,7 +3461,7 @@ function main.f_connect(server, t)
 			txt_connecting:draw()
 		end
 		--draw layerno = 1 backgrounds
-		bgDraw(motif[main.background].bg, true)
+		bgDraw(motif[main.background].bg, 1)
 		main.f_cmdInput()
 		refresh()
 	end
@@ -3586,7 +3586,7 @@ function main.f_attractStart()
 	while true do
 		counter = counter + 1
 		--draw layerno = 0 backgrounds
-		bgDraw(motif.attractbgdef.bg, false)
+		bgDraw(motif.attractbgdef.bg, 0)
 		--draw text
 		if main.credits ~= 0 then
 			if motif.attract_mode.start_press_blinktime > 0 and main.fadeType == 'fadein' then
@@ -3647,7 +3647,7 @@ function main.f_attractStart()
 			return false
 		end
 		--draw layerno = 1 backgrounds
-		bgDraw(motif.attractbgdef.bg, true)
+		bgDraw(motif.attractbgdef.bg, 1)
 		--draw fadein / fadeout
 		if main.fadeType == 'fadein' and not main.fadeActive and ((main.credits ~= 0 and main.f_input(main.t_players, {'s'})) or (not timerActive and counter >= motif.attract_mode.start_time)) then
 			if main.credits ~= 0 then
@@ -3883,7 +3883,7 @@ function main.f_menuCommonDraw(t, item, cursorPosY, moveTxt, section, bgdef, tit
 		clearColor(motif[bgdef].bgclearcolor[1], motif[bgdef].bgclearcolor[2], motif[bgdef].bgclearcolor[3])
 	end
 	--draw layerno = 0 backgrounds
-	bgDraw(motif[bgdef].bg, false)
+	bgDraw(motif[bgdef].bg, 0)
 	--draw menu box
 	if motif[section].menu_boxbg_visible == 1 then
 		rect_boxbg:update({
@@ -4073,7 +4073,7 @@ function main.f_menuCommonDraw(t, item, cursorPosY, moveTxt, section, bgdef, tit
 		txt_attract_credits:draw()
 	end
 	--draw layerno = 1 backgrounds
-	bgDraw(motif[bgdef].bg, true)
+	bgDraw(motif[bgdef].bg, 1)
 	--draw footer overlay
 	if motif[section].footer_overlay_window ~= nil then
 		overlay_footer:draw()

--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -2016,7 +2016,7 @@ function options.f_keyCfg(cfgType, controller, bgdef, skipClear)
 		clearColor(motif[bgdef].bgclearcolor[1], motif[bgdef].bgclearcolor[2], motif[bgdef].bgclearcolor[3])
 	end
 	--draw layerno = 0 backgrounds
-	bgDraw(motif[bgdef].bg, false)
+	bgDraw(motif[bgdef].bg, 0)
 	--draw menu box
 	if motif.option_info.menu_boxbg_visible == 1 then
 		for i = 1, 2 do
@@ -2263,7 +2263,7 @@ function options.f_keyCfg(cfgType, controller, bgdef, skipClear)
 		end
 	end
 	--draw layerno = 1 backgrounds
-	bgDraw(motif[bgdef].bg, true)
+	bgDraw(motif[bgdef].bg, 1)
 	main.f_cmdInput()
 	if not skipClear then
 		refresh()

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -2002,7 +2002,7 @@ function start.f_selectScreen()
 		--draw clearcolor
 		clearColor(motif.selectbgdef.bgclearcolor[1], motif.selectbgdef.bgclearcolor[2], motif.selectbgdef.bgclearcolor[3])
 		--draw layerno = 0 backgrounds
-		bgDraw(motif.selectbgdef.bg, false)
+		bgDraw(motif.selectbgdef.bg, 0)
 		--draw title
 		main.txt_mainSelect:draw()
 		--draw portraits
@@ -2235,7 +2235,7 @@ function start.f_selectScreen()
 		-- hook
 		hook.run("start.f_selectScreen")
 		--draw layerno = 1 backgrounds
-		bgDraw(motif.selectbgdef.bg, true)
+		bgDraw(motif.selectbgdef.bg, 1)
 		--draw fadein / fadeout
 		main.f_fadeAnim(motif.select_info)
 		--frame transition
@@ -2878,7 +2878,7 @@ function start.f_selectVersus(active, t_orderSelect)
 		--draw clearcolor
 		clearColor(motif.versusbgdef.bgclearcolor[1], motif.versusbgdef.bgclearcolor[2], motif.versusbgdef.bgclearcolor[3])
 		--draw layerno = 0 backgrounds
-		bgDraw(motif.versusbgdef.bg, false)
+		bgDraw(motif.versusbgdef.bg, 0)
 		--draw portraits and order icons
 		for side = 1, 2 do
 			start.f_drawPortraits(main.f_remapTable(start.p[side].t_selTemp, start.t_orderRemap[side]), side, motif.vs_screen, '', false, t_icon[side])
@@ -2936,7 +2936,7 @@ function start.f_selectVersus(active, t_orderSelect)
 		-- hook
 		hook.run("start.f_selectVersus")
 		--draw layerno = 1 backgrounds
-		bgDraw(motif.versusbgdef.bg, true)
+		bgDraw(motif.versusbgdef.bg, 1)
 		--draw fadein / fadeout
 		for side = 1, 2 do
 			if main.fadeType == 'fadein' and (
@@ -3150,13 +3150,13 @@ function start.f_result()
 	--draw text at layerno = 0
 	f_drawTextAtLayerNo(t, start.t_result.prefix, start.t_result.resultText, start.t_result.txt, 0)
 	--draw layerno = 0 backgrounds
-	bgDraw(motif[start.t_result.bgdef].bg, false)
+	bgDraw(motif[start.t_result.bgdef].bg, 0)
 	--draw text at layerno = 1
 	f_drawTextAtLayerNo(t, start.t_result.prefix, start.t_result.resultText, start.t_result.txt, 1)
 	-- hook
 	hook.run("start.f_result")
 	--draw layerno = 1 backgrounds
-	bgDraw(motif[start.t_result.bgdef].bg, true)
+	bgDraw(motif[start.t_result.bgdef].bg, 1)
 	--draw text at layerno = 2
 	f_drawTextAtLayerNo(t, start.t_result.prefix, start.t_result.resultText, start.t_result.txt, 2)
 	--draw fadein / fadeout
@@ -3341,7 +3341,7 @@ function start.f_victory()
 	--draw overlay
 	overlay_winquote:draw()
 	--draw layerno = 0 backgrounds
-	bgDraw(motif.victorybgdef.bg, false)
+	bgDraw(motif.victorybgdef.bg, 0)
 	--draw portraits (starting from losers)
 	for side = 2, 1, -1 do
 		start.f_drawPortraits(start.t_victory['team' .. side], side, motif.victory_screen, '', false)
@@ -3377,7 +3377,7 @@ function start.f_victory()
 	-- hook
 	hook.run("start.f_victory")
 	--draw layerno = 1 backgrounds
-	bgDraw(motif.victorybgdef.bg, true)
+	bgDraw(motif.victorybgdef.bg, 1)
 	--draw fadein / fadeout
 	if main.fadeType == 'fadein' and ((start.t_victory.textend and start.t_victory.counter - start.t_victory.textcnt >= motif.victory_screen.time) or main.f_input(main.t_players, {'pal', 's'})) then
 		main.f_fadeReset('fadeout', motif.victory_screen)
@@ -3483,7 +3483,7 @@ function start.f_continue()
 	--draw overlay
 	overlay_continue:draw()
 	--draw layerno = 0 backgrounds
-	bgDraw(motif.continuebgdef.bg, false)
+	bgDraw(motif.continuebgdef.bg, 0)
 	if motif.continue_screen.legacymode_enabled == 0 then --extended continue screen parameters
 		if not start.t_continue.selected then
 			if start.t_continue.counter < motif.continue_screen.counter_end_skiptime then
@@ -3654,7 +3654,7 @@ function start.f_continue()
 	-- hook
 	hook.run("start.f_continue")
 	--draw layerno = 1 backgrounds
-	bgDraw(motif.continuebgdef.bg, true)
+	bgDraw(motif.continuebgdef.bg, 1)
 	--draw fadein / fadeout
 	if main.fadeType == 'fadein' and (start.t_continue.counter > motif.continue_screen.counter_endtime or start.t_continue.continue or (main.f_input({1}, start.t_continue.t_btnSkip) and (motif.continue_screen.legacymode_enabled == 1 or start.t_continue.counter >= motif.continue_screen.counter_end_skiptime))) then
 		main.f_fadeReset('fadeout', motif.continue_screen)
@@ -3759,7 +3759,7 @@ function start.f_hiscore(t, playMusic, place, infinite)
 	end
 	start.t_hiscore.counter = start.t_hiscore.counter + 1
 	--draw layerno = 0 backgrounds
-	bgDraw(motif.hiscorebgdef.bg, false)
+	bgDraw(motif.hiscorebgdef.bg, 0)
 	--draw overlay
 	overlay_hiscore:draw()
 	--draw title
@@ -3900,7 +3900,7 @@ function start.f_hiscore(t, playMusic, place, infinite)
 	-- hook
 	hook.run("start.f_hiscore")
 	--draw layerno = 1 backgrounds
-	bgDraw(motif.hiscorebgdef.bg, true)
+	bgDraw(motif.hiscorebgdef.bg, 1)
 	--draw fadein / fadeout
 	if main.fadeType == 'fadein' and not main.fadeActive and not start.t_hiscore.input and (((not infinite and start.t_hiscore.counter >= motif.hiscore_info.time) or (motif.attract_mode.enabled == 0 and main.f_input(main.t_players, {'pal', 's'}))) or (motif.attract_mode.enabled == 1 and main.credits > 0)) then
 		main.f_fadeReset('fadeout', motif.hiscore_info)
@@ -3967,7 +3967,7 @@ function start.f_challenger()
 		f_drawTextAtLayerNo(motif.challenger_info, 'text', {motif.challenger_info.text_text}, txt_challenger, 0)
 	end
 	--draw layerno = 0 backgrounds
-	bgDraw(motif.challengerbgdef.bg, false)
+	bgDraw(motif.challengerbgdef.bg, 0)
 	--draw bg
 	if start.t_challenger.counter >= motif.challenger_info.bg_displaytime then
 		animUpdate(motif.challenger_info.bg_data)
@@ -3980,7 +3980,7 @@ function start.f_challenger()
 	-- hook
 	hook.run("start.f_challenger")
 	--draw layerno = 1 backgrounds
-	bgDraw(motif.challengerbgdef.bg, true)
+	bgDraw(motif.challengerbgdef.bg, 1)
 	--draw text at layerno = 2
 	if start.t_challenger.counter >= motif.challenger_info.text_displaytime then
 		f_drawTextAtLayerNo(motif.challenger_info, 'text', {motif.challenger_info.text_text}, txt_challenger, 2)

--- a/external/script/storyboard.lua
+++ b/external/script/storyboard.lua
@@ -62,7 +62,7 @@ local function f_play(t, attract)
 				clearColor(scene.clearcolor[1], scene.clearcolor[2], scene.clearcolor[3])
 				--draw layerno = 0 backgrounds
 				if scene.bg_name ~= '' then
-					bgDraw(scene.bg, false)
+					bgDraw(scene.bg, 0)
 				end
 				--loop through layers in order
 				for _, layer in main.f_sortKeys(scene.layer) do
@@ -98,7 +98,7 @@ local function f_play(t, attract)
 				end
 				--draw layerno = 1 backgrounds
 				if scene.bg_name ~= '' then
-					bgDraw(scene.bg, true)
+					bgDraw(scene.bg, 1)
 				end
 				--draw fadein / fadeout
 				if i == scene.end_time - scene.fadeout_time then

--- a/src/bgdef.go
+++ b/src/bgdef.go
@@ -280,17 +280,21 @@ func (s *BGDef) action() {
 		}
 	}
 }
-func (s *BGDef) draw(top bool, x, y, scl float32) {
-	if !top {
+
+func (s *BGDef) draw(layer int32, x, y, scl float32) {
+	// Action will only happen once per frame even though this function is called more times
+	// TODO: Doing this in layer 0 is currently necessary for it to work in screenpacks, but it might be introducing a frame of delay in layer -1
+	if layer == 0 {
 		s.action()
 	}
 	//x, y = x/s.localscl, y/s.localscl
 	for _, b := range s.bg {
-		if b.visible && b.toplayer == top && b.anim.spr != nil {
+		if b.layerno == layer && b.visible && b.anim.spr != nil {
 			b.draw([...]float32{x, y}, scl, s.localscl, 1, s.scale, 0, false)
 		}
 	}
 }
+
 func (s *BGDef) reset() {
 	s.bga.clear()
 	for i := range s.bg {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -686,6 +686,7 @@ const (
 	OC_ex2_gameoption_sound_bgmvolume
 	OC_ex2_gameoption_sound_maxvolume
 	OC_ex2_groundlevel
+	OC_ex2_layerno
 )
 const (
 	NumVar     = 60
@@ -2796,6 +2797,8 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(int32(sys.wavVolume))
 	case OC_ex2_groundlevel:
 		sys.bcStack.PushF(c.groundLevel)
+	case OC_ex2_layerno:
+		sys.bcStack.PushI(c.layerNo)
 	default:
 		sys.errLog.Printf("%v\n", be[*i-1])
 		c.panic()
@@ -3150,7 +3153,7 @@ func (sc stateDef) Run(c *Char) {
 				c.clearHitDef()
 			}
 		case stateDef_sprpriority:
-			c.setSprPriority(exp[0].evalI(c))
+			c.sprPriority = exp[0].evalI(c)
 		case stateDef_facep2:
 			if exp[0].evalB(c) && c.rdDistX(c.p2(), c).ToF() < 0 {
 				c.setFacing(-c.facing)
@@ -3197,7 +3200,7 @@ const (
 
 func (sc hitBy) Run(c *Char, _ []int32) bool {
 	crun := c
-	slot := int(0)
+	slot := int(-1)
 	attr := int32(-1)
 	time := int32(1)
 	pno := int(-1)
@@ -3216,42 +3219,39 @@ func (sc hitBy) Run(c *Char, _ []int32) bool {
 		switch id {
 		case hitBy_time:
 			time = exp[0].evalI(c)
-		// This redundancy is because all values can be set simultaneously in Mugen
 		case hitBy_value:
-			attr = exp[0].evalI(c)
-			set(0, attr, time, -1, -1, false)
+			val := exp[0].evalI(c)
+			set(0, val, time, -1, -1, false)
 			old = true
 		case hitBy_value2:
-			attr = exp[0].evalI(c)
-			set(1, attr, time, -1, -1, false)
+			val := exp[0].evalI(c)
+			set(1, val, time, -1, -1, false) // This redundancy is because both values can be set simultaneously in Mugen
 			old = true
-		}
-		if !old { // If old syntax not already used
-			switch id {
-			case hitBy_slot:
-				slot = int(Max(0, exp[0].evalI(c)))
-				if slot > 7 {
-					slot = 0
-				}
-			case hitBy_attr:
-				attr = exp[0].evalI(c)
-			case hitBy_playerno:
-				pno = int(exp[0].evalI(c))
-			case hitBy_playerid:
-				pid = exp[0].evalI(c)
-			case hitBy_stack:
-				stk = exp[0].evalB(c)
-			case hitBy_redirectid:
-				if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
-					crun = rid
-				} else {
-					return false
-				}
+		case hitBy_slot:
+			slot = int(Max(0, exp[0].evalI(c)))
+			if slot > 7 {
+				slot = 0
 			}
-			set(slot, attr, time, pno, pid, stk)
+		case hitBy_attr:
+			attr = exp[0].evalI(c)
+		case hitBy_playerno:
+			pno = int(exp[0].evalI(c))
+		case hitBy_playerid:
+			pid = exp[0].evalI(c)
+		case hitBy_stack:
+			stk = exp[0].evalB(c)
+		case hitBy_redirectid:
+			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
+				crun = rid
+			} else {
+				return false
+			}
 		}
 		return true
 	})
+	if !old && slot >= 0 && slot <= 7 {
+		set(slot, attr, time, pno, pid, stk)
+	}
 	return false
 }
 
@@ -3259,7 +3259,7 @@ type notHitBy hitBy
 
 func (sc notHitBy) Run(c *Char, _ []int32) bool {
 	crun := c
-	slot := int(0)
+	slot := int(-1)
 	attr := int32(-1)
 	time := int32(1)
 	pno := int(-1)
@@ -3278,42 +3278,39 @@ func (sc notHitBy) Run(c *Char, _ []int32) bool {
 		switch id {
 		case hitBy_time:
 			time = exp[0].evalI(c)
-		// This redundancy is because all values can be set simultaneously in Mugen
 		case hitBy_value:
-			attr = exp[0].evalI(c)
-			set(0, attr, time, -1, -1, false)
+			val := exp[0].evalI(c)
+			set(0, val, time, -1, -1, false)
 			old = true
 		case hitBy_value2:
-			attr = exp[0].evalI(c)
-			set(1, attr, time, -1, -1, false)
+			val := exp[0].evalI(c)
+			set(1, val, time, -1, -1, false)
 			old = true
-		}
-		if !old { // If old syntax not already used
-			switch id {
-			case hitBy_slot:
-				slot = int(Max(0, exp[0].evalI(c)))
-				if slot > 7 {
-					slot = 0
-				}
-			case hitBy_attr:
-				attr = exp[0].evalI(c)
-			case hitBy_playerno:
-				pno = int(exp[0].evalI(c))
-			case hitBy_playerid:
-				pid = exp[0].evalI(c)
-			case hitBy_stack:
-				stk = exp[0].evalB(c)
-			case hitBy_redirectid:
-				if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
-					crun = rid
-				} else {
-					return false
-				}
+		case hitBy_slot:
+			slot = int(Max(0, exp[0].evalI(c)))
+			if slot > 7 {
+				slot = 0
 			}
-			set(slot, attr, time, pno, pid, stk)
+		case hitBy_attr:
+			attr = exp[0].evalI(c)
+		case hitBy_playerno:
+			pno = int(exp[0].evalI(c))
+		case hitBy_playerid:
+			pid = exp[0].evalI(c)
+		case hitBy_stack:
+			stk = exp[0].evalB(c)
+		case hitBy_redirectid:
+			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
+				crun = rid
+			} else {
+				return false
+			}
 		}
 		return true
 	})
+	if !old && slot >= 0 && slot <= 7 {
+		set(slot, attr, time, pno, pid, stk)
+	}
 	return false
 }
 
@@ -4363,6 +4360,7 @@ const (
 	explod_supermovetime
 	explod_pausemovetime
 	explod_sprpriority
+	explod_layerno
 	explod_ontop
 	explod_strictontop
 	explod_under
@@ -4429,6 +4427,7 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 			if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 {
 				e.postype = PT_None
 			}
+			e.layerno = crun.layerNo // Default
 		}
 		switch id {
 		case explod_anim:
@@ -4511,15 +4510,29 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 			}
 		case explod_sprpriority:
 			e.sprpriority = exp[0].evalI(c)
+		case explod_layerno:
+			l := exp[0].evalI(c)
+			if l > 0 {
+				e.layerno = 1
+			} else if l < 0 {
+				e.layerno = -1
+			} else {
+				e.layerno = 0
+			}
 		case explod_ontop:
-			e.ontop = exp[0].evalB(c)
+			if exp[0].evalB(c) {
+				e.layerno = 1
+			} else {
+				e.layerno = 0
+			}
 		case explod_strictontop:
-			if e.ontop {
+			if e.layerno > 0 {
 				e.sprpriority = 0
 			}
 		case explod_under:
-			if !e.ontop {
-				e.under = exp[0].evalB(c)
+			if exp[0].evalB(c) {
+				e.layerno = 0
+				e.sprpriority = math.MinInt32
 			}
 		case explod_shadow:
 			e.shadow[0] = exp[0].evalI(c)
@@ -4868,29 +4881,43 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				})
 			case explod_sprpriority:
 				t := exp[0].evalI(c)
-				eachExpl(func(e *Explod) { e.sprpriority = t })
-			case explod_ontop:
-				t := exp[0].evalB(c)
 				eachExpl(func(e *Explod) {
-					e.ontop = t
-					if e.ontop && e.under {
-						e.under = false
+					e.sprpriority = t
+				})
+			case explod_layerno:
+				l := exp[0].evalI(c)
+				eachExpl(func(e *Explod) {
+					if l > 0 {
+						e.layerno = 1
+					} else if l < 0 {
+						e.layerno = -1
+					} else {
+						e.layerno = 0
 					}
 				})
+			case explod_ontop:
+				if exp[0].evalB(c) {
+					eachExpl(func(e *Explod) {
+						e.layerno = 1
+					})
+				} else {
+					eachExpl(func(e *Explod) {
+						e.layerno = 0
+					})
+				}
 			case explod_strictontop:
 				eachExpl(func(e *Explod) {
-					if e.ontop {
+					if e.layerno > 0 {
 						e.sprpriority = 0
 					}
 				})
 			case explod_under:
-				t := exp[0].evalB(c)
-				eachExpl(func(e *Explod) {
-					e.under = t
-					if e.under && e.ontop {
-						e.ontop = false
-					}
-				})
+				if exp[0].evalB(c) {
+					eachExpl(func(e *Explod) {
+						e.layerno = 0
+						e.sprpriority = math.MinInt32
+					})
+				}
 			case explod_shadow:
 				r := exp[0].evalI(c)
 				eachExpl(func(e *Explod) { e.shadow[0] = r })
@@ -5045,7 +5072,7 @@ func (sc gameMakeAnim) Run(c *Char, _ []int32) bool {
 				}
 				e.id = 0
 			}
-			e.ontop, e.sprpriority, e.ownpal = true, math.MinInt32, true
+			e.layerno, e.sprpriority, e.ownpal = 1, math.MinInt32, true
 		}
 		switch id {
 		case gameMakeAnim_pos:
@@ -5062,8 +5089,7 @@ func (sc gameMakeAnim) Run(c *Char, _ []int32) bool {
 			}
 		case gameMakeAnim_under:
 			if exp[0].evalB(c) {
-				e.under = true
-				e.ontop = false
+				e.layerno = 0
 			}
 		case gameMakeAnim_anim: // Minor: Mugen uses anim 0 if nothing is specified
 			e.anim = crun.getAnim(exp[1].evalI(c), string(*(*[]byte)(unsafe.Pointer(&exp[0]))), true)
@@ -5734,6 +5760,7 @@ const (
 	projectile_projrescaleclsn
 	projectile_offset
 	projectile_projsprpriority
+	projectile_projlayerno
 	projectile_projstagebound
 	projectile_projedgebound
 	projectile_projheightbound
@@ -5771,7 +5798,6 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 						return false
 					}
 					p.hitdef.playerNo = sys.workingState.playerNo
-
 				} else {
 					return false
 				}
@@ -5782,6 +5808,7 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 				}
 				p.hitdef.playerNo = sys.workingState.playerNo
 			}
+			p.layerno = crun.layerNo // Default
 		}
 		switch id {
 		case projectile_postype:
@@ -5850,6 +5877,15 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 			}
 		case projectile_projsprpriority:
 			p.sprpriority = exp[0].evalI(c)
+		case projectile_projlayerno:
+			l := exp[0].evalI(c)
+			if l > 0 {
+				p.layerno = 1
+			} else if l < 0 {
+				p.layerno = -1
+			} else {
+				p.layerno = 0
+			}
 		case projectile_projstagebound:
 			p.stagebound = int32(float32(exp[0].evalI(c)) * lclscround)
 		case projectile_projedgebound:
@@ -6113,6 +6149,17 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 			case projectile_projsprpriority:
 				eachProj(func(p *Projectile) {
 					p.sprpriority = exp[0].evalI(c)
+				})
+			case projectile_projlayerno:
+				l := exp[0].evalI(c)
+				eachProj(func(p *Projectile) {
+					if l > 0 {
+						p.layerno = 1
+					} else if l < 0 {
+						p.layerno = -1
+					} else {
+						p.layerno = 0
+					}
 				})
 			case projectile_projstagebound:
 				eachProj(func(p *Projectile) {
@@ -6678,16 +6725,20 @@ type sprPriority StateControllerBase
 
 const (
 	sprPriority_value byte = iota
+	sprPriority_layerno
 	sprPriority_redirectid
 )
 
 func (sc sprPriority) Run(c *Char, _ []int32) bool {
 	crun := c
-	v := int32(0) // Mugen uses 0 if no value is set at all
+	v := int32(0) // Mugen uses 0 even if no value is set at all
+	l := int32(0) // Defaults to 0 so that chars are less likely to be left forgotten in a different layer
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case sprPriority_value:
 			v = exp[0].evalI(c)
+		case sprPriority_layerno:
+			l = exp[0].evalI(c)
 		case sprPriority_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -6697,7 +6748,8 @@ func (sc sprPriority) Run(c *Char, _ []int32) bool {
 		}
 		return true
 	})
-	crun.setSprPriority(v)
+	crun.sprPriority = v
+	crun.layerNo = l
 	return false
 }
 

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -435,6 +435,7 @@ var triggerMap = map[string]int{
 	"runorder":   1,
 	"bgmvar":     1,
 	"gameoption": 1,
+	"layerno":    1,
 }
 
 func (c *Compiler) tokenizer(in *string) string {
@@ -2063,6 +2064,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_ex_, OC_ex_ishometeam)
 	case "index":
 		out.append(OC_ex2_, OC_ex2_index)
+	case "layerno":
+		out.append(OC_ex2_, OC_ex2_layerno)
 	case "leftedge":
 		out.append(OC_leftedge)
 	case "life", "p2life":
@@ -3307,8 +3310,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noailevel))
 		case "nointroreset":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nointroreset))
-		case "ignoreclsn2push":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_ignoreclsn2push))
+		case "sizepushonly":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_sizepushonly))
 		case "immovable":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_immovable))
 		case "cornerpriority":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -200,18 +200,14 @@ func (c *Compiler) assertSpecial(is IniSection, sc *StateControllerBase, _ int8)
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_noailevel)))
 			case "nointroreset":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nointroreset)))
-			case "ignoreclsn2push":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_ignoreclsn2push)))
+			case "sizepushonly":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_sizepushonly)))
 			case "immovable":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_immovable)))
 			case "animatehitpause":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_animatehitpause)))
 			case "cornerpriority":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_cornerpriority)))
-			case "drawontop":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_drawontop)))
-			case "drawunder":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_drawunder)))
 			case "runfirst":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_runfirst)))
 			case "runlast":
@@ -775,6 +771,10 @@ func (c *Compiler) explodSub(is IniSection,
 		}
 		return nil
 	}); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "layerno",
+		explod_layerno, VT_Int, 1, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "shadow",
@@ -2049,6 +2049,10 @@ func (c *Compiler) projectileSub(is IniSection, sc *StateControllerBase, ihp int
 		projectile_projsprpriority, VT_Int, 1, false); err != nil {
 		return err
 	}
+	if err := c.paramValue(is, sc, "projlayerno",
+		projectile_projlayerno, VT_Int, 1, false); err != nil {
+		return err
+	}
 	if err := c.paramValue(is, sc, "projstagebound",
 		projectile_projstagebound, VT_Int, 1, false); err != nil {
 		return err
@@ -2111,11 +2115,9 @@ func (c *Compiler) modifyProjectile(is IniSection, sc *StateControllerBase,
 			modifyProjectile_id, VT_Int, 1, false); err != nil {
 			return err
 		}
-
 		if err := c.projectileSub(is, sc, ihp); err != nil {
 			return err
 		}
-
 		return nil
 	})
 	return *ret, err
@@ -2160,6 +2162,10 @@ func (c *Compiler) sprPriority(is IniSection, sc *StateControllerBase, _ int8) (
 	ret, err := (*sprPriority)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			sprPriority_redirectid, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "layerno",
+			sprPriority_layerno, VT_Int, 1, false); err != nil {
 			return err
 		}
 		return c.paramValue(is, sc, "value",
@@ -5179,7 +5185,7 @@ func (c *Compiler) assertCommand(is IniSection, sc *StateControllerBase, _ int8)
 		}); err != nil {
 			return err
 		}
-		if err := c.paramValue(is, sc, "buffertime",
+		if err := c.paramValue(is, sc, "buffer.time",
 			assertCommand_buffertime, VT_Int, 1, false); err != nil {
 			return err
 		}

--- a/src/script.go
+++ b/src/script.go
@@ -390,10 +390,14 @@ func systemScriptInit(l *lua.LState) {
 		if !ok {
 			userDataError(l, 1, bg)
 		}
-		top := false
+		layer := int32(0)
 		var x, y, scl float32 = 0, 0, 1
 		if l.GetTop() >= 2 {
-			top = boolArg(l, 2)
+			if numArg(l, 2) == 1 {
+				layer = 1
+			} else {
+				layer = 0
+			}
 		}
 		if l.GetTop() >= 3 {
 			x = float32(numArg(l, 3))
@@ -404,7 +408,7 @@ func systemScriptInit(l *lua.LState) {
 		if l.GetTop() >= 5 {
 			scl = float32(numArg(l, 5))
 		}
-		bg.draw(top, x, y, scl)
+		bg.draw(layer, x, y, scl)
 		return 0
 	})
 	luaRegister(l, "bgNew", func(*lua.LState) int {
@@ -4620,8 +4624,8 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_noailevel)))
 		case "nointroreset":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_nointroreset)))
-		case "ignoreclsn2push":
-			l.Push(lua.LBool(sys.debugWC.asf(ASF_ignoreclsn2push)))
+		case "sizepushonly":
+			l.Push(lua.LBool(sys.debugWC.asf(ASF_sizepushonly)))
 		case "immovable":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_immovable)))
 		case "animatehitpause":


### PR DESCRIPTION
Layering logic revamped a little in order to allow characters to effectively be drawn "inside" a stage:
- Stage elements now also accept layerno = -1, which will be drawn under layer 0
- Chars can now change layers via new SprPriority state controller "layerno" parameter
- Added new LayerNo trigger to make it all easier to manage
- Stage reflections can use layerno parameter

Refactor:
- Refactored "ontop" and "under" to be legacy parameters that function by the new layering logic, since the new features make them obsolete
- Removed AssertSpecial flags "DrawOnTop" and "DrawUnder" as they will no longer be needed. At least for the time being
- AssertSpecial "IgnoreClsn2Push" renamed "SizePushOnly", as that is more descriptive of what it does
- AssertCommand "buffertime" parameter renamed "buffer.time", for consistency with command files

Fix:
- Fixes #1938
- Fixes #1940
- Fixes #1941