### PR TITLE
feat: clsnVar, explodVar, projVar triggers, xAccel for hitdefs, expanded # of noChainID args

### DIFF
--- a/data/common1.cns.zss
+++ b/data/common1.cns.zss
@@ -568,7 +568,7 @@ if anim != [5000, 5199] && selfAnimExist(5030) {
 if time = 0 {
 	hitVelSet{x: 1; y: 1}
 } else {
-	velAdd{y: getHitVar(yAccel)}
+	velAdd{x: getHitVar(xAccel); y: getHitVar(yAccel)}
 }
 if hitOver || vel y > 0 && pos y >= const(movement.air.gethit.groundlevel) {
 	if hitFall {
@@ -589,7 +589,7 @@ if time = 0 && selfAnimExist(5035) && anim != [5051, 5059] && anim != 5090 {
 	changeAnim{value: 5035}
 }
 if time > 0 {
-	velAdd{y: getHitVar(yAccel)}
+	velAdd{x: getHitVar(xAccel); y: getHitVar(yAccel)}
 }
 if hitOver || animTime = 0 ||
 	vel y > 0 && pos y >= const(movement.air.gethit.groundlevel) ||
@@ -616,7 +616,7 @@ if hitOver {
 	stateTypeSet{movetype: I}
 }
 if time > 0 {
-	velAdd{y: getHitVar(yAccel)}
+	velAdd{x: getHitVar(xAccel); y: getHitVar(yAccel)}
 }
 if vel y > 0 && pos y >= 0 {
 	changeState{value: 52}
@@ -635,7 +635,7 @@ persistent(0) if anim = [5050, 5059] && vel y >= ifElse(anim = 5050,
 	changeAnim{value: anim + 10}
 }
 if time > 0 {
-	velAdd{y: getHitVar(yAccel)}
+	velAdd{x: getHitVar(xAccel); y: getHitVar(yAccel)}
 }
 if alive && canRecover && command = "recovery" {
 	if vel y > 0 &&
@@ -669,7 +669,7 @@ if time = 0 {
 if time = 0 {
 	hitVelSet{x: 1; y: 1}
 } else {
-	velAdd{y: getHitVar(yAccel)}
+	velAdd{x: getHitVar(xAccel); y: getHitVar(yAccel)}
 }
 if vel y > 0 && pos y >= const(movement.air.gethit.trip.groundlevel) {
 	changeState{value: 5110}
@@ -884,7 +884,7 @@ if anim = 5035 && animTime = 0 {
 	changeAnim{value: 5050}
 }
 if time > 0 {
-	velAdd{y: getHitVar(yAccel)}
+	velAdd{x: getHitVar(xAccel); y: getHitVar(yAccel)}
 }
 if vel y > 0 && pos y >= const(movement.air.gethit.groundrecover.groundlevel) {
 	selfState{value: 5201}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6444,9 +6444,13 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				})
 			case projectile_projanim:
 				eachProj(func(p *Projectile) {
-					p.anim = exp[1].evalI(c)
-					p.anim_ffx = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
-					p.ani = c.getAnim(p.anim, p.anim_ffx, true) // need to change anim ref too
+					tmp := exp[1].evalI(c)
+					ffx := string(*(*[]byte)(unsafe.Pointer(&exp[0])))
+					if p.anim != tmp || p.anim_ffx != ffx {
+						p.anim = tmp
+						p.anim_ffx = ffx
+						p.ani = c.getAnim(p.anim, p.anim_ffx, true) // need to change anim ref too
+					}
 				})
 			case projectile_supermovetime:
 				eachProj(func(p *Projectile) {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -2278,7 +2278,7 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_gethitvar_down_recover:
 		sys.bcStack.PushB(c.ghv.down_recover)
 	case OC_ex_gethitvar_xaccel:
-		sys.bcStack.PushF(c.ghv.getXaccel(oc) * (c.localscl / oc.localscl))
+		sys.bcStack.PushF(c.ghv.getXaccel(oc) * c.facing * (c.localscl / oc.localscl))
 	case OC_ex_ailevelf:
 		if !c.asf(ASF_noailevel) {
 			sys.bcStack.PushF(c.aiLevel())

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -496,6 +496,7 @@ const (
 	OC_ex_gethitvar_frame
 	OC_ex_gethitvar_down_recover
 	OC_ex_gethitvar_down_recovertime
+	OC_ex_gethitvar_xaccel
 	OC_ex_ailevelf
 	OC_ex_animelemlength
 	OC_ex_animframe_alphadest
@@ -687,6 +688,59 @@ const (
 	OC_ex2_gameoption_sound_maxvolume
 	OC_ex2_groundlevel
 	OC_ex2_layerno
+	OC_ex2_clsnvar_left
+	OC_ex2_clsnvar_top
+	OC_ex2_clsnvar_right
+	OC_ex2_clsnvar_bottom
+	OC_ex2_explodvar_anim
+	OC_ex2_explodvar_animelem
+	OC_ex2_explodvar_pos_x
+	OC_ex2_explodvar_pos_y
+	OC_ex2_explodvar_scale_x
+	OC_ex2_explodvar_scale_y
+	OC_ex2_explodvar_vel_x
+	OC_ex2_explodvar_vel_y
+	OC_ex2_explodvar_accel_x
+	OC_ex2_explodvar_accel_y
+	OC_ex2_explodvar_angle
+	OC_ex2_explodvar_angle_x
+	OC_ex2_explodvar_angle_y
+	OC_ex2_explodvar_removetime
+	OC_ex2_explodvar_pausemovetime
+	OC_ex2_explodvar_sprpriority
+	OC_ex2_projectilevar_projremove
+	OC_ex2_projectilevar_projremovetime
+	OC_ex2_projectilevar_projshadow_r
+	OC_ex2_projectilevar_projshadow_g
+	OC_ex2_projectilevar_projshadow_b
+	OC_ex2_projectilevar_projmisstime
+	OC_ex2_projectilevar_projhits
+	OC_ex2_projectilevar_projpriority
+	OC_ex2_projectilevar_projhitanim
+	OC_ex2_projectilevar_projremanim
+	OC_ex2_projectilevar_projcancelanim
+	OC_ex2_projectilevar_vel_x
+	OC_ex2_projectilevar_vel_y
+	OC_ex2_projectilevar_velmul_x
+	OC_ex2_projectilevar_velmul_y
+	OC_ex2_projectilevar_remvelocity_x
+	OC_ex2_projectilevar_remvelocity_y
+	OC_ex2_projectilevar_accel_x
+	OC_ex2_projectilevar_accel_y
+	OC_ex2_projectilevar_projscale_x
+	OC_ex2_projectilevar_projscale_y
+	OC_ex2_projectilevar_projangle
+	OC_ex2_projectilevar_pos_x
+	OC_ex2_projectilevar_pos_y
+	OC_ex2_projectilevar_projsprpriority
+	OC_ex2_projectilevar_projstagebound
+	OC_ex2_projectilevar_projedgebound
+	OC_ex2_projectilevar_lowbound
+	OC_ex2_projectilevar_highbound
+	OC_ex2_projectilevar_projanim
+	OC_ex2_projectilevar_animelem
+	OC_ex2_projectilevar_supermovetime
+	OC_ex2_projectilevar_pausemovetime
 )
 const (
 	NumVar     = 60
@@ -2223,6 +2277,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushB(c.ghv.frame)
 	case OC_ex_gethitvar_down_recover:
 		sys.bcStack.PushB(c.ghv.down_recover)
+	case OC_ex_gethitvar_xaccel:
+		sys.bcStack.PushF(c.ghv.getXaccel(oc) * (c.localscl / oc.localscl))
 	case OC_ex_ailevelf:
 		if !c.asf(ASF_noailevel) {
 			sys.bcStack.PushF(c.aiLevel())
@@ -2691,7 +2747,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 }
 func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	(*i)++
-	switch be[*i-1] {
+	opc := be[*i-1]
+	switch opc {
 	case OC_ex2_index:
 		sys.bcStack.PushI(c.index)
 	case OC_ex2_runorder:
@@ -2799,6 +2856,190 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.groundLevel)
 	case OC_ex2_layerno:
 		sys.bcStack.PushI(c.layerNo)
+	case OC_ex2_clsnvar_left:
+		idx := int(sys.bcStack.Pop().ToI())
+		id := int(sys.bcStack.Pop().ToI())
+		v := float32(math.NaN())
+		switch id {
+		case 0:
+			v = c.sizeBox[0]
+		case 1:
+			cf1 := c.anim.CurrentFrame().Clsn1()
+			if idx >= 0 && idx < len(cf1)/4 {
+				v = cf1[idx*4]
+			}
+		case 2:
+			cf2 := c.anim.CurrentFrame().Clsn2()
+			if idx >= 0 && idx < len(cf2)/4 {
+				v = cf2[idx*4]
+			}
+		}
+		sys.bcStack.PushF(v)
+	case OC_ex2_clsnvar_top:
+		idx := int(sys.bcStack.Pop().ToI())
+		id := int(sys.bcStack.Pop().ToI())
+		v := float32(math.NaN())
+		switch id {
+		case 0:
+			v = c.sizeBox[1]
+		case 1:
+			cf1 := c.anim.CurrentFrame().Clsn1()
+			if idx >= 0 && idx < len(cf1)/4 {
+				v = cf1[idx*4+1]
+			}
+		case 2:
+			cf2 := c.anim.CurrentFrame().Clsn2()
+			if idx >= 0 && idx < len(cf2)/4 {
+				v = cf2[idx*4+1]
+			}
+		}
+		sys.bcStack.PushF(v)
+	case OC_ex2_clsnvar_right:
+		idx := int(sys.bcStack.Pop().ToI())
+		id := int(sys.bcStack.Pop().ToI())
+		v := float32(math.NaN())
+		switch id {
+		case 0:
+			v = c.sizeBox[2]
+		case 1:
+			cf1 := c.anim.CurrentFrame().Clsn1()
+			if idx >= 0 && idx < len(cf1)/4 {
+				v = cf1[idx*4+2]
+			}
+		case 2:
+			cf2 := c.anim.CurrentFrame().Clsn2()
+			if idx >= 0 && idx < len(cf2)/4 {
+				v = cf2[idx*4+2]
+			}
+		}
+		sys.bcStack.PushF(v)
+	case OC_ex2_clsnvar_bottom:
+		idx := int(sys.bcStack.Pop().ToI())
+		id := int(sys.bcStack.Pop().ToI())
+		v := float32(math.NaN())
+		switch id {
+		case 0:
+			v = c.sizeBox[3]
+		case 1:
+			cf1 := c.anim.CurrentFrame().Clsn1()
+			if idx >= 0 && idx < len(cf1)/4 {
+				v = cf1[idx*4+3]
+			}
+		case 2:
+			cf2 := c.anim.CurrentFrame().Clsn2()
+			if idx >= 0 && idx < len(cf2)/4 {
+				v = cf2[idx*4+3]
+			}
+		}
+		sys.bcStack.PushF(v)
+	// BEGIN FALLTHROUGH (explodvar)
+	case OC_ex2_explodvar_anim:
+		fallthrough
+	case OC_ex2_explodvar_animelem:
+		fallthrough
+	case OC_ex2_explodvar_removetime:
+		fallthrough
+	case OC_ex2_explodvar_pausemovetime:
+		fallthrough
+	case OC_ex2_explodvar_sprpriority:
+		fallthrough
+	case OC_ex2_explodvar_pos_x:
+		fallthrough
+	case OC_ex2_explodvar_pos_y:
+		fallthrough
+	case OC_ex2_explodvar_scale_x:
+		fallthrough
+	case OC_ex2_explodvar_scale_y:
+		fallthrough
+	case OC_ex2_explodvar_vel_x:
+		fallthrough
+	case OC_ex2_explodvar_vel_y:
+		fallthrough
+	case OC_ex2_explodvar_accel_x:
+		fallthrough
+	case OC_ex2_explodvar_angle:
+		fallthrough
+	case OC_ex2_explodvar_angle_x:
+		fallthrough
+	case OC_ex2_explodvar_angle_y:
+		fallthrough
+	// END FALLTHROUGH (explodvar)
+	case OC_ex2_explodvar_accel_y:
+		idx := sys.bcStack.Pop()
+		id := sys.bcStack.Pop()
+		v := c.explodVar(id, idx, opc)
+		sys.bcStack.Push(v)
+	// BEGIN FALLTHROUGH (projvar)
+	case OC_ex2_projectilevar_projremove:
+		fallthrough
+	case OC_ex2_projectilevar_projremovetime:
+		fallthrough
+	case OC_ex2_projectilevar_projshadow_r:
+		fallthrough
+	case OC_ex2_projectilevar_projshadow_g:
+		fallthrough
+	case OC_ex2_projectilevar_projshadow_b:
+		fallthrough
+	case OC_ex2_projectilevar_projmisstime:
+		fallthrough
+	case OC_ex2_projectilevar_projhits:
+		fallthrough
+	case OC_ex2_projectilevar_projpriority:
+		fallthrough
+	case OC_ex2_projectilevar_projhitanim:
+		fallthrough
+	case OC_ex2_projectilevar_projremanim:
+		fallthrough
+	case OC_ex2_projectilevar_projcancelanim:
+		fallthrough
+	case OC_ex2_projectilevar_vel_x:
+		fallthrough
+	case OC_ex2_projectilevar_vel_y:
+		fallthrough
+	case OC_ex2_projectilevar_velmul_x:
+		fallthrough
+	case OC_ex2_projectilevar_velmul_y:
+		fallthrough
+	case OC_ex2_projectilevar_remvelocity_x:
+		fallthrough
+	case OC_ex2_projectilevar_remvelocity_y:
+		fallthrough
+	case OC_ex2_projectilevar_accel_x:
+		fallthrough
+	case OC_ex2_projectilevar_accel_y:
+		fallthrough
+	case OC_ex2_projectilevar_projscale_x:
+		fallthrough
+	case OC_ex2_projectilevar_projscale_y:
+		fallthrough
+	case OC_ex2_projectilevar_projangle:
+		fallthrough
+	case OC_ex2_projectilevar_pos_x:
+		fallthrough
+	case OC_ex2_projectilevar_pos_y:
+		fallthrough
+	case OC_ex2_projectilevar_projsprpriority:
+		fallthrough
+	case OC_ex2_projectilevar_projstagebound:
+		fallthrough
+	case OC_ex2_projectilevar_projedgebound:
+		fallthrough
+	case OC_ex2_projectilevar_lowbound:
+		fallthrough
+	case OC_ex2_projectilevar_highbound:
+		fallthrough
+	case OC_ex2_projectilevar_projanim:
+		fallthrough
+	case OC_ex2_projectilevar_animelem:
+		fallthrough
+	case OC_ex2_projectilevar_supermovetime:
+		fallthrough
+	// END FALLTHROUGH (projvar)
+	case OC_ex2_projectilevar_pausemovetime:
+		idx := sys.bcStack.Pop()
+		id := sys.bcStack.Pop()
+		v := c.projVar(id, idx, opc)
+		sys.bcStack.Push(v)
 	default:
 		sys.errLog.Printf("%v\n", be[*i-1])
 		c.panic()
@@ -4393,6 +4634,7 @@ const (
 	explod_interpolate_pfx_hue
 	explod_interpolation
 	explod_redirectid
+	explod_last = iota + palFX_last + 1 - 1
 )
 
 func (sc explod) Run(c *Char, _ []int32) bool {
@@ -4435,7 +4677,8 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 			if ffx != "" && ffx != "s" {
 				e.ownpal = true
 			}
-			e.anim = crun.getAnim(exp[1].evalI(c), ffx, true)
+			e.animNo = exp[1].evalI(c)
+			e.anim = crun.getAnim(e.animNo, ffx, true)
 		case explod_ownpal:
 			e.ownpal = exp[0].evalB(c)
 		case explod_remappal:
@@ -4695,10 +4938,16 @@ func (sc explod) setInterpolation(c *Char, e *Explod,
 
 type modifyExplod explod
 
+const (
+	modifyexplod_redirectid = iota + explod_last + 1
+	modifyexplod_index
+)
+
 func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 	crun := c
 	var lclscround float32 = 1.0
 	eid := int32(-1)
+	idx := int32(-1)
 	var expls []*Explod
 	rp := [...]int32{-1, 0}
 	remap := false
@@ -4706,8 +4955,14 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 	sp, pos, vel, accel := Space_none, [2]float32{0, 0}, [2]float32{0, 0}, [2]float32{0, 0}
 	ptexists := false
 	eachExpl := func(f func(e *Explod)) {
-		for _, e := range expls {
-			f(e)
+		if idx < 0 {
+			for _, e := range expls {
+				if idx < 0 {
+					f(e)
+				}
+			}
+		} else if idx < int32(len(expls)) {
+			f(expls[idx])
 		}
 	}
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
@@ -4729,6 +4984,8 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 			eid = exp[0].evalI(c)
 		case explod_postypeExists:
 			ptexists = true
+		case modifyexplod_index:
+			idx = exp[0].evalI(c)
 		default:
 			if len(expls) == 0 {
 				expls = crun.getExplods(eid)
@@ -4964,8 +5221,12 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				})
 			case explod_anim:
 				if c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
-					anim := crun.getAnim(exp[1].evalI(c), string(*(*[]byte)(unsafe.Pointer(&exp[0]))), true)
-					eachExpl(func(e *Explod) { e.anim = anim })
+					animNo := exp[1].evalI(c)
+					anim := crun.getAnim(animNo, string(*(*[]byte)(unsafe.Pointer(&exp[0]))), true)
+					eachExpl(func(e *Explod) {
+						e.anim = anim
+						e.animNo = animNo
+					})
 				}
 			case explod_animelem:
 				animelem := exp[0].evalI(c)
@@ -5365,6 +5626,7 @@ const (
 	hitDef_p2clsnrequire
 	hitDef_down_recover
 	hitDef_down_recovertime
+	hitDef_xaccel
 	hitDef_last = iota + afterImage_last + 1 - 1
 	hitDef_redirectid
 )
@@ -5404,9 +5666,8 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 	case hitDef_chainid:
 		hd.chainid = exp[0].evalI(c)
 	case hitDef_nochainid:
-		hd.nochainid[0] = exp[0].evalI(c)
-		if len(exp) > 1 {
-			hd.nochainid[1] = exp[1].evalI(c)
+		for i := 0; i < int(math.Min(MaxSimul, float64(len(exp)))); i++ {
+			hd.nochainid[i] = exp[i].evalI(c)
 		}
 	case hitDef_kill:
 		hd.kill = exp[0].evalB(c)
@@ -5660,6 +5921,8 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 		hd.down_recover = exp[0].evalB(c)
 	case hitDef_down_recovertime:
 		hd.down_recovertime = exp[0].evalI(c)
+	case hitDef_xaccel:
+		hd.xaccel = exp[0].evalF(c)
 	default:
 		if !palFX(sc).runSub(c, &hd.palfx, id, exp) {
 			return false
@@ -6029,17 +6292,22 @@ type modifyProjectile hitDef
 const (
 	modifyProjectile_redirectid = iota + hitDef_last + 1
 	modifyProjectile_id
-	// TODO: Maybe we could modify projectiles by their index as well
+	modifyProjectile_index
 )
 
 func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 	crun := c
 	var lclscround float32 = 1.0
 	mpid := int32(-1)
+	mpidx := int32(-1)
 	var projs []*Projectile
 	eachProj := func(f func(p *Projectile)) {
-		for _, p := range projs {
-			f(p)
+		if mpidx < 0 {
+			for _, p := range projs {
+				f(p)
+			}
+		} else if mpidx < int32(len(projs)) {
+			f(projs[mpidx])
 		}
 	}
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
@@ -6053,6 +6321,8 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 			}
 		case modifyProjectile_id: // ID's to modify
 			mpid = exp[0].evalI(c)
+		case modifyProjectile_index: // index to modify
+			mpidx = exp[0].evalI(c)
 		default:
 			if crun.helperIndex != 0 {
 				return false
@@ -6064,10 +6334,6 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				}
 			}
 			switch id {
-			case projectile_projid: // ID after modifying
-				eachProj(func(p *Projectile) {
-					p.id = exp[0].evalI(c)
-				})
 			case projectile_projremove:
 				eachProj(func(p *Projectile) {
 					p.remove = exp[0].evalB(c)
@@ -6180,6 +6446,7 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				eachProj(func(p *Projectile) {
 					p.anim = exp[1].evalI(c)
 					p.anim_ffx = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
+					p.ani = c.getAnim(p.anim, p.anim_ffx, true) // need to change anim ref too
 				})
 			case projectile_supermovetime:
 				eachProj(func(p *Projectile) {
@@ -6262,9 +6529,8 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				})
 			case hitDef_nochainid:
 				eachProj(func(p *Projectile) {
-					p.hitdef.nochainid[0] = exp[0].evalI(c)
-					if len(exp) > 1 {
-						p.hitdef.nochainid[1] = exp[1].evalI(c)
+					for i := 0; i < int(math.Min(MaxSimul, float64(len(exp)))); i++ {
+						p.hitdef.nochainid[i] = exp[i].evalI(c)
 					}
 				})
 			case hitDef_kill:
@@ -6661,6 +6927,10 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 			case hitDef_down_recovertime:
 				eachProj(func(p *Projectile) {
 					p.hitdef.down_recovertime = exp[0].evalI(c)
+				})
+			case hitDef_xaccel:
+				eachProj(func(p *Projectile) {
+					p.hitdef.xaccel = exp[0].evalF(c)
 				})
 			default:
 				eachProj(func(p *Projectile) {
@@ -8560,14 +8830,19 @@ type removeExplod StateControllerBase
 const (
 	removeExplod_id byte = iota
 	removeExplod_redirectid
+	removeExplod_index
 )
 
 func (sc removeExplod) Run(c *Char, _ []int32) bool {
 	crun := c
+	eid := int32(-1)
+	idx := int32(-1)
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case removeExplod_id:
-			crun.removeExplod(exp[0].evalI(c))
+			eid = exp[0].evalI(c)
+		case removeExplod_index:
+			idx = exp[0].evalI(c)
 		case removeExplod_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -8577,6 +8852,7 @@ func (sc removeExplod) Run(c *Char, _ []int32) bool {
 		}
 		return true
 	})
+	crun.removeExplod(eid, idx)
 	return false
 }
 
@@ -10741,6 +11017,7 @@ const (
 	getHitVarSet_recovertime
 	getHitVarSet_slidetime
 	getHitVarSet_xvel
+	getHitVarSet_xaccel
 	getHitVarSet_yaccel
 	getHitVarSet_yvel
 	getHitVarSet_redirectid
@@ -10807,6 +11084,8 @@ func (sc getHitVarSet) Run(c *Char, _ []int32) bool {
 			crun.ghv.slidetime = exp[0].evalI(c)
 		case getHitVarSet_xvel:
 			crun.ghv.xvel = exp[0].evalF(c) * crun.facing * lclscround
+		case getHitVarSet_xaccel:
+			crun.ghv.xaccel = exp[0].evalF(c) * lclscround
 		case getHitVarSet_yaccel:
 			crun.ghv.yaccel = exp[0].evalF(c) * lclscround
 		case getHitVarSet_yvel:

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -911,6 +911,10 @@ func (c *Compiler) modifyExplod(is IniSection, sc *StateControllerBase,
 			explod_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "index",
+			modifyexplod_index, VT_Int, 1, false); err != nil {
+			return err
+		}
 		if err := c.explodSub(is, sc); err != nil {
 			return err
 		}
@@ -1439,7 +1443,7 @@ func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 		return err
 	}
 	if err := c.paramValue(is, sc, "nochainid",
-		hitDef_nochainid, VT_Int, 2, false); err != nil {
+		hitDef_nochainid, VT_Int, MaxSimul*2, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "kill",
@@ -1880,6 +1884,10 @@ func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 		hitDef_down_recovertime, VT_Int, 1, false); err != nil {
 		return err
 	}
+	if err := c.paramValue(is, sc, "xaccel",
+		hitDef_xaccel, VT_Float, 1, false); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -2115,6 +2123,11 @@ func (c *Compiler) modifyProjectile(is IniSection, sc *StateControllerBase,
 			modifyProjectile_id, VT_Int, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "index",
+			modifyProjectile_index, VT_Int, 1, false); err != nil {
+			return err
+		}
+
 		if err := c.projectileSub(is, sc, ihp); err != nil {
 			return err
 		}
@@ -3550,6 +3563,11 @@ func (c *Compiler) removeExplod(is IniSection, sc *StateControllerBase, _ int8) 
 		if err := c.stateParam(is, "id", false, func(data string) error {
 			b = true
 			return c.scAdd(sc, removeExplod_id, data, VT_Int, 1)
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "index", false, func(data string) error {
+			return c.scAdd(sc, removeExplod_index, data, VT_Int, 1)
 		}); err != nil {
 			return err
 		}
@@ -5314,6 +5332,10 @@ func (c *Compiler) getHitVarSet(is IniSection, sc *StateControllerBase, _ int8) 
 		}
 		if err := c.paramValue(is, sc, "xvel",
 			getHitVarSet_xvel, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "xaccel",
+			getHitVarSet_xaccel, VT_Float, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "yaccel",

--- a/src/script.go
+++ b/src/script.go
@@ -2961,6 +2961,43 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LBool(sys.debugWC.canRecover()))
 		return 1
 	})
+	luaRegister(l, "clsnvar", func(l *lua.LState) int {
+		c := strArg(l, 1)
+		idx := int(numArg(l, 2))
+		t := strArg(l, 3)
+		v := lua.LNumber(math.NaN())
+
+		getClsnCoord := func(offset int) {
+			switch c {
+			case "size":
+				v = lua.LNumber(sys.debugWC.sizeBox[offset])
+			case "clsn1":
+				clsn := sys.debugWC.anim.CurrentFrame().Clsn1()
+				if idx >= 0 && idx < len(clsn)/4 {
+					v = lua.LNumber(clsn[idx*4+offset])
+				}
+			case "clsn2":
+				clsn := sys.debugWC.anim.CurrentFrame().Clsn2()
+				if idx >= 0 && idx < len(clsn)/4 {
+					v = lua.LNumber(clsn[idx*4+offset])
+				}
+			}
+		}
+
+		switch t {
+		case "left":
+			getClsnCoord(0)
+		case "top":
+			getClsnCoord(1)
+		case "right":
+			getClsnCoord(2)
+		case "bottom":
+			getClsnCoord(3)
+		}
+
+		l.Push(v)
+		return 1
+	})
 	luaRegister(l, "command", func(*lua.LState) int {
 		l.Push(lua.LBool(sys.debugWC.commandByName(strArg(l, 1))))
 		return 1
@@ -3233,6 +3270,54 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(ln)
 		return 1
 	})
+	luaRegister(l, "explodvar", func(*lua.LState) int {
+		ln := lua.LNumber(math.NaN())
+		id := int32(numArg(l, 1))
+		idx := int(numArg(l, 2))
+		vname := strArg(l, 3)
+
+		for i, e := range sys.debugWC.getExplods(id) {
+			if i == idx {
+				switch vname {
+				case "anim":
+					ln = lua.LNumber(e.animNo)
+				case "animelem":
+					ln = lua.LNumber(e.animelem)
+				case "pos x":
+					ln = lua.LNumber(e.drawPos[0])
+				case "pos y":
+					ln = lua.LNumber(e.drawPos[1])
+				case "vel x":
+					ln = lua.LNumber(e.velocity[0])
+				case "vel y":
+					ln = lua.LNumber(e.velocity[1])
+				case "accel x":
+					ln = lua.LNumber(e.accel[0])
+				case "accel y":
+					ln = lua.LNumber(e.accel[1])
+				case "scale x":
+					ln = lua.LNumber(e.scale[0])
+				case "scale y":
+					ln = lua.LNumber(e.scale[1])
+				case "angle":
+					ln = lua.LNumber(e.anglerot[0])
+				case "angle x":
+					ln = lua.LNumber(e.anglerot[1])
+				case "angle y":
+					ln = lua.LNumber(e.anglerot[2])
+				case "removetime":
+					ln = lua.LNumber(e.removetime)
+				case "pausemovetime":
+					ln = lua.LNumber(e.pausemovetime)
+				default:
+					l.RaiseError("\nInvalid argument: %v\n", vname)
+				}
+				break
+			}
+		}
+		l.Push(ln)
+		return 1
+	})
 	luaRegister(l, "facing", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.facing))
 		return 1
@@ -3339,6 +3424,8 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.ghv.xvel * c.facing)
 		case "yvel":
 			ln = lua.LNumber(c.ghv.yvel)
+		case "xaccel":
+			ln = lua.LNumber(c.ghv.getXaccel(c))
 		case "yaccel":
 			ln = lua.LNumber(c.ghv.getYaccel(c))
 		case "hitid", "chainid":
@@ -3924,6 +4011,90 @@ func triggerFunctions(l *lua.LState) {
 	luaRegister(l, "projhittime", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.projHitTime(
 			BytecodeInt(int32(numArg(l, 1)))).ToI()))
+		return 1
+	})
+	luaRegister(l, "projvar", func(*lua.LState) int {
+		var lv lua.LValue
+		id := int32(numArg(l, 1))
+		idx := int(numArg(l, 2))
+		vname := strArg(l, 3)
+
+		for i, p := range sys.debugWC.getProjs(id) {
+			if i == idx {
+				switch vname {
+				case "remove":
+					lv = lua.LBool(p.remove)
+				case "removetime":
+					lv = lua.LNumber(p.removetime)
+				case "shadow r":
+					lv = lua.LNumber(p.shadow[0])
+				case "shadow g":
+					lv = lua.LNumber(p.shadow[0])
+				case "shadow b":
+					lv = lua.LNumber(p.shadow[0])
+				case "misstime":
+					lv = lua.LNumber(p.curmisstime)
+				case "hits":
+					lv = lua.LNumber(p.hits)
+				case "priority":
+					lv = lua.LNumber(p.priority)
+				case "hitanim":
+					lv = lua.LNumber(p.hitanim)
+				case "remanim":
+					lv = lua.LNumber(p.remanim)
+				case "cancelanim":
+					lv = lua.LNumber(p.cancelanim)
+				case "vel x":
+					lv = lua.LNumber(p.velocity[0])
+				case "vel y":
+					lv = lua.LNumber(p.velocity[1])
+				case "velmul x":
+					lv = lua.LNumber(p.velmul[0])
+				case "velmul y":
+					lv = lua.LNumber(p.velmul[1])
+				case "remvelocity x":
+					lv = lua.LNumber(p.remvelocity[0])
+				case "remvelocity y":
+					lv = lua.LNumber(p.remvelocity[1])
+				case "accel x":
+					lv = lua.LNumber(p.accel[0])
+				case "accel y":
+					lv = lua.LNumber(p.accel[1])
+				case "scale x":
+					lv = lua.LNumber(p.scale[0])
+				case "scale y":
+					lv = lua.LNumber(p.scale[1])
+				case "angle":
+					lv = lua.LNumber(p.angle)
+				case "pos x":
+					lv = lua.LNumber(p.pos[0])
+				case "pos y":
+					lv = lua.LNumber(p.pos[1])
+				case "sprpriority":
+					lv = lua.LNumber(p.sprpriority)
+				case "stagebound":
+					lv = lua.LNumber(p.stagebound)
+				case "edgebound":
+					lv = lua.LNumber(p.edgebound)
+				case "lowbound":
+					lv = lua.LNumber(p.heightbound[0])
+				case "highbound":
+					lv = lua.LNumber(p.heightbound[1])
+				case "anim":
+					lv = lua.LNumber(p.anim)
+				case "animelem":
+					lv = lua.LNumber(p.ani.current)
+				case "supermovetime":
+					lv = lua.LNumber(p.supermovetime)
+				case "pausemovetime":
+					lv = lua.LNumber(p.pausemovetime)
+				default:
+					l.RaiseError("\nInvalid argument: %v\n", vname)
+				}
+				break
+			}
+		}
+		l.Push(lv)
 		return 1
 	})
 	luaRegister(l, "runorder", func(*lua.LState) int {

--- a/src/script.go
+++ b/src/script.go
@@ -3425,7 +3425,7 @@ func triggerFunctions(l *lua.LState) {
 		case "yvel":
 			ln = lua.LNumber(c.ghv.yvel)
 		case "xaccel":
-			ln = lua.LNumber(c.ghv.getXaccel(c))
+			ln = lua.LNumber(c.ghv.getXaccel(c) * c.facing)
 		case "yaccel":
 			ln = lua.LNumber(c.ghv.getYaccel(c))
 		case "hitid", "chainid":


### PR DESCRIPTION
* added clsnVar, explodVar, and projVar triggers (new 3-arg triggers which take an ID, index, and type, respectively)
* modifyProjectile, modifyExplod, and removeExplod now all have an optional index parameter that defaults to -1 (all)
* Expanded noChainID number of arguments to match the number of simul opponents (including friendlies) because I believe this is the tool Elecbyte gave us to help solve the "simul problem"
* Added optional xAccel parameter to hitDefs (defaults to 0, none) because Capcom games do this
* clsnVar accepts the following `type` parameters: `left`, `top`, `right`, `bottom`
* clsnVar accepts the following `clsnType` parameters: `clsn1`, `clsn2`, `size`
* explodVar accepts the following `type` parameters: `anim`, `animElem`, `pos X`, `pos Y`, `scale X`, `scale Y`, `vel X`, `vel Y`, `accel X`, `accel Y`, `angle`, `angle X`, `angle Y`, `removeTime`, `pauseMoveTime`, `sprPriority`
* projVar accepts the following `type` parameters: `projRemove`, `projRemoveTime`, `shadow r`, `shadow g`, `shadow b`, `missTime`, `hits`, `priority`, `hitanim`, `remanim`, `cancelanim`, `vel X`, `vel Y`, `velMul X`, `velMul Y`, `remVelocity X`, `remVelocity Y`, `accel X`, `accel Y`, `scale X`, `scale Y`, `angle`, `pos X`, `pos Y`, `sprPriority`, `stageBound`, `edgeBound`, `lowBound`, `highBound`, `anim`, `animElem`, `pauseMoveTime`
* fixes a bug where ModifyProjectile did not change the anim reference