### PR TITLE
fix: 3D stage rendering and postprocessing shaders on macOS, new trigger redirects

### DIFF
--- a/external/shaders/HQ2x.frag
+++ b/external/shaders/HQ2x.frag
@@ -1,3 +1,15 @@
+#if __VERSION__ >= 130
+#define COMPAT_VARYING in
+#define COMPAT_TEXTURE texture
+out vec4 FragColor;
+in vec4 TexCoord[7];
+#else
+#define COMPAT_VARYING varying
+#define FragColor gl_FragColor
+#define COMPAT_TEXTURE texture2D
+#define TexCoord gl_TexCoord
+#endif
+
 uniform sampler2D Texture;
 const float mx = 0.325;		// start smoothing wt.
 const float k = -0.250;		// wt. decrease factor
@@ -6,15 +18,15 @@ const float min_w =-0.05;	// min filter weigth
 const float lum_add = 0.25;	// effects smoothing
 
 void main() {
-	vec3 c00 = texture2D(Texture, gl_TexCoord[1].xy).xyz;
-	vec3 c10 = texture2D(Texture, gl_TexCoord[1].zw).xyz;
-	vec3 c20 = texture2D(Texture, gl_TexCoord[2].xy).xyz;
-	vec3 c01 = texture2D(Texture, gl_TexCoord[4].zw).xyz;
-	vec3 c11 = texture2D(Texture, gl_TexCoord[0].xy).xyz;
-	vec3 c21 = texture2D(Texture, gl_TexCoord[2].zw).xyz;
-	vec3 c02 = texture2D(Texture, gl_TexCoord[4].xy).xyz;
-	vec3 c12 = texture2D(Texture, gl_TexCoord[3].zw).xyz;
-	vec3 c22 = texture2D(Texture, gl_TexCoord[3].xy).xyz;
+	vec3 c00 = COMPAT_TEXTURE(Texture, TexCoord[1].xy).xyz;
+	vec3 c10 = COMPAT_TEXTURE(Texture, TexCoord[1].zw).xyz;
+	vec3 c20 = COMPAT_TEXTURE(Texture, TexCoord[2].xy).xyz;
+	vec3 c01 = COMPAT_TEXTURE(Texture, TexCoord[4].zw).xyz;
+	vec3 c11 = COMPAT_TEXTURE(Texture, TexCoord[0].xy).xyz;
+	vec3 c21 = COMPAT_TEXTURE(Texture, TexCoord[2].zw).xyz;
+	vec3 c02 = COMPAT_TEXTURE(Texture, TexCoord[4].xy).xyz;
+	vec3 c12 = COMPAT_TEXTURE(Texture, TexCoord[3].zw).xyz;
+	vec3 c22 = COMPAT_TEXTURE(Texture, TexCoord[3].xy).xyz;
 	vec3 dt = vec3(1.0, 1.0, 1.0);
 	float md1 = dot(abs(c00 - c22), dt);
 	float md2 = dot(abs(c02 - c20), dt);
@@ -32,5 +44,5 @@ void main() {
 	w2 = clamp(lc2 * dot(abs(c11 - c21), dt) + mx, min_w, max_w);
 	w3 = clamp(lc1 * dot(abs(c11 - c12), dt) + mx, min_w, max_w);
 	w4 = clamp(lc2 * dot(abs(c11 - c01), dt) + mx, min_w, max_w);
-	gl_FragColor.xyz = w1 * c10 + w2 * c21 + w3 * c12 + w4 * c01 + (1.0 - w1 - w2 - w3 - w4) * c11;
+	FragColor.xyz = w1 * c10 + w2 * c21 + w3 * c12 + w4 * c01 + (1.0 - w1 - w2 - w3 - w4) * c11;
 }

--- a/external/shaders/HQ2x.vert
+++ b/external/shaders/HQ2x.vert
@@ -1,10 +1,22 @@
-attribute vec2 VertCoord;
+#if __VERSION__ >= 130
+#define COMPAT_VARYING out
+#define COMPAT_ATTRIBUTE in
+#define COMPAT_TEXTURE texture
+out vec4 TexCoord[7];
+#else
+#define COMPAT_VARYING varying
+#define COMPAT_ATTRIBUTE attribute
+#define COMPAT_TEXTURE texture2D
+#define TexCoord gl_TexCoord
+#endif
+
+COMPAT_ATTRIBUTE vec2 VertCoord;
 uniform vec2 TextureSize;
 
 void main() {
 	gl_Position = vec4(VertCoord, 0.0, 1.0);
 	
-	vec2 TexCoord = (VertCoord + 1.0) / 2.0;
+	vec2 texCoord = (VertCoord + 1.0) / 2.0;
 	float x = 0.5 * (1.0 / TextureSize.x);
 	float y = 0.5 * (1.0 / TextureSize.y);
 	vec2 dg1 = vec2( x, y);
@@ -12,13 +24,13 @@ void main() {
 	vec2 dx = vec2(x, 0.0);
 	vec2 dy = vec2(0.0, y);
 	
-	gl_TexCoord[0].xy = TexCoord;
-	gl_TexCoord[1].xy = gl_TexCoord[0].xy - dg1;
-	gl_TexCoord[1].zw = gl_TexCoord[0].xy - dy;
-	gl_TexCoord[2].xy = gl_TexCoord[0].xy - dg2;
-	gl_TexCoord[2].zw = gl_TexCoord[0].xy + dx;
-	gl_TexCoord[3].xy = gl_TexCoord[0].xy + dg1;
-	gl_TexCoord[3].zw = gl_TexCoord[0].xy + dy;
-	gl_TexCoord[4].xy = gl_TexCoord[0].xy + dg2;
-	gl_TexCoord[4].zw = gl_TexCoord[0].xy - dx;
+	TexCoord[0].xy = texCoord;
+	TexCoord[1].xy = texCoord - dg1;
+	TexCoord[1].zw = texCoord - dy;
+	TexCoord[2].xy = texCoord - dg2;
+	TexCoord[2].zw = texCoord + dx;
+	TexCoord[3].xy = texCoord + dg1;
+	TexCoord[3].zw = texCoord + dy;
+	TexCoord[4].xy = texCoord + dg2;
+	TexCoord[4].zw = texCoord - dx;
 }

--- a/external/shaders/HQ4x.frag
+++ b/external/shaders/HQ4x.frag
@@ -1,3 +1,15 @@
+#if __VERSION__ >= 130
+#define COMPAT_VARYING in
+#define COMPAT_TEXTURE texture
+out vec4 FragColor;
+in vec4 TexCoord[7];
+#else
+#define COMPAT_VARYING varying
+#define FragColor gl_FragColor
+#define COMPAT_TEXTURE texture2D
+#define TexCoord gl_TexCoord
+#endif
+
 uniform sampler2D Texture;
 const float mx = 1.00;		// start smoothing wt.
 const float k = -1.10;		// wt. decrease factor
@@ -6,19 +18,19 @@ const float min_w = 0.03;	// min filter weigth
 const float lum_add = 0.33;	// effects smoothing
 
 void main() {
-	vec3 c  = texture2D(Texture, gl_TexCoord[0].xy).xyz;
-	vec3 i1 = texture2D(Texture, gl_TexCoord[1].xy).xyz;
-	vec3 i2 = texture2D(Texture, gl_TexCoord[2].xy).xyz;
-	vec3 i3 = texture2D(Texture, gl_TexCoord[3].xy).xyz;
-	vec3 i4 = texture2D(Texture, gl_TexCoord[4].xy).xyz;
-	vec3 o1 = texture2D(Texture, gl_TexCoord[5].xy).xyz;
-	vec3 o3 = texture2D(Texture, gl_TexCoord[6].xy).xyz;
-	vec3 o2 = texture2D(Texture, gl_TexCoord[5].zw).xyz;
-	vec3 o4 = texture2D(Texture, gl_TexCoord[6].zw).xyz;
-	vec3 s1 = texture2D(Texture, gl_TexCoord[1].zw).xyz;
-	vec3 s2 = texture2D(Texture, gl_TexCoord[2].zw).xyz;
-	vec3 s3 = texture2D(Texture, gl_TexCoord[3].zw).xyz;
-	vec3 s4 = texture2D(Texture, gl_TexCoord[4].zw).xyz;
+	vec3 c  = COMPAT_TEXTURE(Texture, TexCoord[0].xy).xyz;
+	vec3 i1 = COMPAT_TEXTURE(Texture, TexCoord[1].xy).xyz;
+	vec3 i2 = COMPAT_TEXTURE(Texture, TexCoord[2].xy).xyz;
+	vec3 i3 = COMPAT_TEXTURE(Texture, TexCoord[3].xy).xyz;
+	vec3 i4 = COMPAT_TEXTURE(Texture, TexCoord[4].xy).xyz;
+	vec3 o1 = COMPAT_TEXTURE(Texture, TexCoord[5].xy).xyz;
+	vec3 o3 = COMPAT_TEXTURE(Texture, TexCoord[6].xy).xyz;
+	vec3 o2 = COMPAT_TEXTURE(Texture, TexCoord[5].zw).xyz;
+	vec3 o4 = COMPAT_TEXTURE(Texture, TexCoord[6].zw).xyz;
+	vec3 s1 = COMPAT_TEXTURE(Texture, TexCoord[1].zw).xyz;
+	vec3 s2 = COMPAT_TEXTURE(Texture, TexCoord[2].zw).xyz;
+	vec3 s3 = COMPAT_TEXTURE(Texture, TexCoord[3].zw).xyz;
+	vec3 s4 = COMPAT_TEXTURE(Texture, TexCoord[4].zw).xyz;
 	vec3 dt = vec3(1.0,1.0,1.0);
 	float ko1=dot(abs(o1-c),dt);
 	float ko2=dot(abs(o2-c),dt);
@@ -39,6 +51,6 @@ void main() {
 	w2 = clamp(w2+mx,min_w,max_w);
 	w3 = clamp(w3+mx,min_w,max_w);
 	w4 = clamp(w4+mx,min_w,max_w);
-	gl_FragColor.xyz=(w1*(i1+i3)+w2*(i2+i4)+w3*(s1+s3)+w4*(s2+s4)+c)/(2.0*(w1+w2+w3+w4)+1.0);
-	gl_FragColor.a = 1.0;
+	FragColor.xyz=(w1*(i1+i3)+w2*(i2+i4)+w3*(s1+s3)+w4*(s2+s4)+c)/(2.0*(w1+w2+w3+w4)+1.0);
+	FragColor.a = 1.0;
 }

--- a/external/shaders/HQ4x.vert
+++ b/external/shaders/HQ4x.vert
@@ -1,8 +1,20 @@
-attribute vec2 VertCoord;
+#if __VERSION__ >= 130
+#define COMPAT_VARYING out
+#define COMPAT_ATTRIBUTE in
+#define COMPAT_TEXTURE texture
+out vec4 TexCoord[7];
+#else
+#define COMPAT_VARYING varying 
+#define COMPAT_ATTRIBUTE attribute 
+#define COMPAT_TEXTURE texture2D
+#define TexCoord gl_TexCoord
+#endif
+
+COMPAT_ATTRIBUTE vec2 VertCoord;
 uniform vec2 TextureSize;
 
 void main() {
-	vec2 TexCoord = (VertCoord + 1.0) / 2.0;
+	vec2 texCoord = (VertCoord + 1.0) / 2.0;
 	float x = 0.001;
 	float y = 0.001;
 	
@@ -12,17 +24,17 @@ void main() {
 	
 	gl_Position = vec4(VertCoord, 0.0, 1.0);
 	
-	gl_TexCoord[0].xy = TexCoord;
-	gl_TexCoord[1].xy = gl_TexCoord[0].xy - sd1;
-	gl_TexCoord[2].xy = gl_TexCoord[0].xy - sd2;
-	gl_TexCoord[3].xy = gl_TexCoord[0].xy + sd1;
-	gl_TexCoord[4].xy = gl_TexCoord[0].xy + sd2;
-	gl_TexCoord[5].xy = gl_TexCoord[0].xy - dg1;
-	gl_TexCoord[6].xy = gl_TexCoord[0].xy + dg1;
-	gl_TexCoord[5].zw = gl_TexCoord[0].xy - dg2;
-	gl_TexCoord[6].zw = gl_TexCoord[0].xy + dg2;
-	gl_TexCoord[1].zw = gl_TexCoord[0].xy - ddy;
-	gl_TexCoord[2].zw = gl_TexCoord[0].xy + ddx;
-	gl_TexCoord[3].zw = gl_TexCoord[0].xy + ddy;
-	gl_TexCoord[4].zw = gl_TexCoord[0].xy - ddx;
+	TexCoord[0].xy = texCoord;
+	TexCoord[1].xy = texCoord - sd1;
+	TexCoord[2].xy = texCoord - sd2;
+	TexCoord[3].xy = texCoord + sd1;
+	TexCoord[4].xy = texCoord + sd2;
+	TexCoord[5].xy = texCoord - dg1;
+	TexCoord[6].xy = texCoord + dg1;
+	TexCoord[5].zw = texCoord - dg2;
+	TexCoord[6].zw = texCoord + dg2;
+	TexCoord[1].zw = texCoord - ddy;
+	TexCoord[2].zw = texCoord + ddx;
+	TexCoord[3].zw = texCoord + ddy;
+	TexCoord[4].zw = texCoord - ddx;
 }

--- a/external/shaders/Scanline.frag
+++ b/external/shaders/Scanline.frag
@@ -1,13 +1,25 @@
+#if __VERSION__ >= 130
+#define COMPAT_VARYING in
+#define COMPAT_TEXTURE texture
+out vec4 FragColor;
+in vec3 vTexCoord;
+#else
+#define COMPAT_TEXTURE texture2D
+#define vTexCoord gl_TexCoord[0]
+#define FragColor gl_FragColor
+#endif
+
 uniform sampler2D Texture;
 uniform vec2 TextureSize;
 
 void main(void) {
-	vec4 rgb = texture2D(Texture, gl_TexCoord[0].xy);
-	vec4 intens ;
-	if (fract(gl_FragCoord.y * (0.5*4.0/3.0)) > 0.5)
-		intens = vec4(0);
-	else
-		intens = smoothstep(0.2,0.8,rgb) + normalize(vec4(rgb.xyz, 1.0));
-	float level = (4.0-gl_TexCoord[0].z) * 0.19;
-	gl_FragColor = intens * (0.5-level) + rgb * 1.1 ;
+    vec4 rgb = COMPAT_TEXTURE(Texture, vTexCoord.xy);
+    vec4 intens;
+    if (fract(gl_FragCoord.y * (0.5 * 4.0 / 3.0)) > 0.5)
+        intens = vec4(0);
+    else
+        intens = smoothstep(0.2, 0.8, rgb) + normalize(vec4(rgb.xyz, 1.0));
+
+    float level = (4.0 - vTexCoord.z) * 0.19;
+    FragColor = intens * (0.5 - level) + rgb * 1.1;
 }

--- a/external/shaders/Scanline.vert
+++ b/external/shaders/Scanline.vert
@@ -1,7 +1,21 @@
+#if __VERSION__ >= 130
+#define COMPAT_VARYING out
+#define COMPAT_ATTRIBUTE in
+in vec3 TexCoord;
+out vec3 vTexCoord;
+#else
+#define COMPAT_VARYING varying 
+#define COMPAT_ATTRIBUTE attribute 
+#endif
+
 uniform vec2 TextureSize;
-attribute vec2 VertCoord;
+COMPAT_ATTRIBUTE vec2 VertCoord;
 
 void main(void) {
 	gl_Position = vec4(VertCoord, 0.0, 1.0);
-	gl_TexCoord[0].xy = (VertCoord + 1.0) / 2.0;
+#if __VERSION__ >= 130
+    vTexCoord = vec3((VertCoord + 1.0) / 2.0, TexCoord.z);
+#else
+    gl_TexCoord[0].xy = (VertCoord + 1.0) / 2.0;
+#endif
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20231124074035-2de0cf0c80af
 	github.com/go-gl/mathgl v1.0.0
 	github.com/gopxl/beep/v2 v2.0.2
-	github.com/ikemen-engine/glfont v0.0.0-20240330150147-4c31e1f7aaf7
+	github.com/ikemen-engine/glfont v0.0.0-20240816074833-3b3b0c69a290
 	github.com/lukegb/dds v0.0.0-20190402175749-8b7170e64003
 	github.com/qmuntal/gltf v0.24.2
 	github.com/sqweek/dialog v0.0.0-20220809060634-e981b270ebbf
@@ -26,6 +26,6 @@ require (
 	github.com/jfreymuth/vorbis v1.0.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/samhocevar/go-meltysynth v0.0.0-20230403180939-aca4a036cb16 // indirect
-	golang.org/x/image v0.18.0 // indirect
+	golang.org/x/image v0.19.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/hajimehoshi/go-mp3 v0.3.4/go.mod h1:fRtZraRFcWb0pu7ok0LqyFhCUrPeMsGRS
 github.com/hajimehoshi/oto/v2 v2.3.1/go.mod h1:seWLbgHH7AyUMYKfKYT9pg7PhUu9/SisyJvNTT+ASQo=
 github.com/ikemen-engine/glfont v0.0.0-20240330150147-4c31e1f7aaf7 h1:ACKtf9510YpONj9bZ2D9XQsEOXvhe3abAS/2309ihM8=
 github.com/ikemen-engine/glfont v0.0.0-20240330150147-4c31e1f7aaf7/go.mod h1:7QcK+eKEO2FnoZx0L8YmI1hB+YxL3XzmFVuCbxI/BW4=
+github.com/ikemen-engine/glfont v0.0.0-20240816074833-3b3b0c69a290 h1:Mqn9W1IXXCqO6iISVbt6RxG8vrNXPszkQHyJsdPmpKQ=
+github.com/ikemen-engine/glfont v0.0.0-20240816074833-3b3b0c69a290/go.mod h1:7QcK+eKEO2FnoZx0L8YmI1hB+YxL3XzmFVuCbxI/BW4=
 github.com/jfreymuth/oggvorbis v1.0.5 h1:u+Ck+R0eLSRhgq8WTmffYnrVtSztJcYrl588DM4e3kQ=
 github.com/jfreymuth/oggvorbis v1.0.5/go.mod h1:1U4pqWmghcoVsCJJ4fRBKv9peUJMBHixthRlBeD6uII=
 github.com/jfreymuth/vorbis v1.0.2 h1:m1xH6+ZI4thH927pgKD8JOH4eaGRm18rEE9/0WKjvNE=
@@ -51,6 +53,8 @@ github.com/yuin/gopher-lua v1.1.0/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7
 golang.org/x/image v0.0.0-20190321063152-3fc05d484e9f/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.18.0 h1:jGzIakQa/ZXI1I0Fxvaa9W7yP25TqT6cHIHn+6CqvSQ=
 golang.org/x/image v0.18.0/go.mod h1:4yyo5vMFQjVjUcVk4jEQcU9MGy/rulF5WvUILseCM2E=
+golang.org/x/image v0.19.0 h1:D9FX4QWkLfkeqaC62SonffIIuYdOk/UE2XKUBgRIBIQ=
+golang.org/x/image v0.19.0/go.mod h1:y0zrRqlQRWQ5PXaYCOMLTW2fpsxZ8Qh9I/ohnInJEys=
 golang.org/x/mobile v0.0.0-20221110043201-43a038452099 h1:aIu0lKmfdgtn2uTj7JI2oN4TUrQvgB+wzTPO23bCKt8=
 golang.org/x/mobile v0.0.0-20221110043201-43a038452099/go.mod h1:aAjjkJNdrh3PMckS4B10TGS2nag27cbKR1y2BpUxsiY=
 golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1544,11 +1544,11 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		vname := c.token
 
 		switch vname {
-		case "left":
+		case "back":
 			opc = OC_ex2_clsnvar_left
 		case "top":
 			opc = OC_ex2_clsnvar_top
-		case "right":
+		case "front":
 			opc = OC_ex2_clsnvar_right
 		case "bottom":
 			opc = OC_ex2_clsnvar_bottom

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1560,16 +1560,19 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		if err := c.checkClosingBracket(); err != nil {
 			return bvNone(), err
 		}
-
-		if bv1.IsNone() || bv2.IsNone() {
-			if rd {
-				out.append(OC_rdreset)
-			}
+		be2.appendValue(bv2)
+		be1.appendValue(bv1)
+		if len(be2) > int(math.MaxUint8-1) {
+			be1.appendI32Op(OC_jz, int32(len(be2)+1))
+		} else {
+			be1.append(OC_jz8, OpCode(len(be2)+1))
+		}
+		be1.append(be2...)
+		be1.append(OC_ex2_, opc)
+		if rd {
+			out.appendI32Op(OC_run, int32(len(be1)))
 		}
 		out.append(be1...)
-		out.appendValue(bv1)
-		out.appendValue(bv2)
-		out.append(OC_ex2_, opc)
 	case "command", "selfcommand":
 		opc := OC_command
 		if c.token == "selfcommand" {
@@ -1949,16 +1952,19 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			}
 		}
 
-		if bv1.IsNone() || bv2.IsNone() {
-			if rd {
-				out.append(OC_rdreset)
-			}
+		be2.appendValue(bv2)
+		be1.appendValue(bv1)
+		if len(be2) > int(math.MaxUint8-1) {
+			be1.appendI32Op(OC_jz, int32(len(be2)+1))
+		} else {
+			be1.append(OC_jz8, OpCode(len(be2)+1))
+		}
+		be1.append(be2...)
+		be1.append(OC_ex2_, opc)
+		if rd {
+			out.appendI32Op(OC_run, int32(len(be1)))
 		}
 		out.append(be1...)
-		out.appendValue(bv1)
-		out.append(be2...)
-		out.appendValue(bv2)
-		out.append(OC_ex2_, opc)
 	case "facing":
 		out.append(OC_facing)
 	case "frontedge":
@@ -2606,16 +2612,19 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 
-		if bv1.IsNone() || bv2.IsNone() {
-			if rd {
-				out.append(OC_rdreset)
-			}
+		be2.appendValue(bv2)
+		be1.appendValue(bv1)
+		if len(be2) > int(math.MaxUint8-1) {
+			be1.appendI32Op(OC_jz, int32(len(be2)+1))
+		} else {
+			be1.append(OC_jz8, OpCode(len(be2)+1))
+		}
+		be1.append(be2...)
+		be1.append(OC_ex2_, opc)
+		if rd {
+			out.appendI32Op(OC_run, int32(len(be1)))
 		}
 		out.append(be1...)
-		out.appendValue(bv1)
-		out.append(be2...)
-		out.appendValue(bv2)
-		out.append(OC_ex2_, opc)
 	case "random":
 		out.append(OC_random)
 

--- a/src/main.go
+++ b/src/main.go
@@ -364,6 +364,10 @@ func setupConfig() configSettings {
 	sys.controllerStickSensitivity = tmp.ControllerStickSensitivity
 	sys.explodMax = tmp.MaxExplod
 	sys.externalShaderList = tmp.ExternalShaders
+	// Bump up shader version for macOS only
+	if runtime.GOOS == "darwin" {
+		tmp.FontShaderVer = max(150, tmp.FontShaderVer)
+	}
 	sys.fontShaderVer = tmp.FontShaderVer
 	// Resoluion stuff
 	sys.fullscreen = tmp.Fullscreen

--- a/src/script.go
+++ b/src/script.go
@@ -2985,11 +2985,11 @@ func triggerFunctions(l *lua.LState) {
 		}
 
 		switch t {
-		case "left":
+		case "back":
 			getClsnCoord(0)
 		case "top":
 			getClsnCoord(1)
-		case "right":
+		case "front":
 			getClsnCoord(2)
 		case "bottom":
 			getClsnCoord(3)

--- a/src/shaders/ident.frag.glsl
+++ b/src/shaders/ident.frag.glsl
@@ -1,7 +1,17 @@
+#if __VERSION__ >= 130
+#define COMPAT_VARYING in
+#define COMPAT_TEXTURE texture
+out vec4 FragColor;
+#else
+#define COMPAT_VARYING varying
+#define FragColor gl_FragColor
+#define COMPAT_TEXTURE texture2D
+#endif
+
 uniform sampler2D Texture;
 
-varying vec2 texcoord;
+COMPAT_VARYING vec2 texcoord;
 
 void main(void) {
-	gl_FragColor = texture2D(Texture, texcoord);
+    FragColor = COMPAT_TEXTURE(Texture, texcoord);
 }

--- a/src/shaders/ident.vert.glsl
+++ b/src/shaders/ident.vert.glsl
@@ -1,8 +1,17 @@
-attribute vec2 VertCoord;
+#if __VERSION__ >= 130
+#define COMPAT_VARYING out
+#define COMPAT_ATTRIBUTE in
+#define COMPAT_TEXTURE texture
+#else
+#define COMPAT_VARYING varying 
+#define COMPAT_ATTRIBUTE attribute 
+#define COMPAT_TEXTURE texture2D
+#endif
 
 uniform vec2 TextureSize;
 
-varying vec2 texcoord;
+COMPAT_ATTRIBUTE vec2 VertCoord;
+COMPAT_VARYING vec2 texcoord;
 
 void main()
 {

--- a/src/shaders/model.frag.glsl
+++ b/src/shaders/model.frag.glsl
@@ -1,3 +1,13 @@
+#if __VERSION__ >= 130
+#define COMPAT_VARYING in
+#define COMPAT_TEXTURE texture
+out vec4 FragColor;
+#else
+#define COMPAT_VARYING varying
+#define FragColor gl_FragColor
+#define COMPAT_TEXTURE texture2D
+#endif
+
 uniform sampler2D tex;
 uniform vec4 baseColorFactor;
 uniform vec3 add, mult;
@@ -7,8 +17,8 @@ uniform bool neg;
 uniform bool enableAlpha;
 uniform float alphaThreshold;
 
-varying vec2 texcoord;
-varying vec4 vColor;
+COMPAT_VARYING vec2 texcoord;
+COMPAT_VARYING vec4 vColor;
 
 vec3 hue_shift(vec3 color, float dhue) {
 	float s = sin(dhue);
@@ -19,29 +29,30 @@ vec3 hue_shift(vec3 color, float dhue) {
 		vec3(1.250268, -1.047561, -0.202707)
 	) + dot(vec3(0.299, 0.587, 0.114), color) * (1.0 - c);
 }
+
 void main(void) {
 	if(textured){
-		gl_FragColor = texture2D(tex, texcoord) * baseColorFactor;
+		FragColor = COMPAT_TEXTURE(tex, texcoord) * baseColorFactor;
 	} else {
-		gl_FragColor = baseColorFactor;
+		FragColor = baseColorFactor;
 	}
-	gl_FragColor *= vec4(pow(vColor.r, 1.0/2.2), pow(vColor.g, 1.0/2.2), pow(vColor.b, 1.0/2.2), vColor.a);
-	gl_FragColor.rgb *= vColor.a;
+	FragColor *= vec4(pow(vColor.r, 1.0/2.2), pow(vColor.g, 1.0/2.2), pow(vColor.b, 1.0/2.2), vColor.a);
+	FragColor.rgb *= vColor.a;
 	if(!enableAlpha){
-		if(gl_FragColor.a < alphaThreshold){
+		if(FragColor.a < alphaThreshold){
 			discard;
 		}else{
-			gl_FragColor.a = 1;
+			FragColor.a = 1;
 		}
-	}else if(gl_FragColor.a<=0.0){
+	}else if(FragColor.a<=0.0){
 		discard;
 	}
 	vec3 neg_base = vec3(1.0);
-	neg_base *= gl_FragColor.a;
+	neg_base *= FragColor.a;
 	if (hue != 0) {
-		gl_FragColor.rgb = hue_shift(gl_FragColor.rgb,hue);			
+		FragColor.rgb = hue_shift(FragColor.rgb,hue);			
 	}
-	if (neg) gl_FragColor.rgb = neg_base - gl_FragColor.rgb;
-	gl_FragColor.rgb = mix(gl_FragColor.rgb, vec3((gl_FragColor.r + gl_FragColor.g + gl_FragColor.b) / 3.0), gray) + add*gl_FragColor.a;
-	gl_FragColor.rgb *= mult;
+	if (neg) FragColor.rgb = neg_base - FragColor.rgb;
+	FragColor.rgb = mix(FragColor.rgb, vec3((FragColor.r + FragColor.g + FragColor.b) / 3.0), gray) + add*FragColor.a;
+	FragColor.rgb *= mult;
 }

--- a/src/shaders/model.vert.glsl
+++ b/src/shaders/model.vert.glsl
@@ -1,35 +1,45 @@
+#if __VERSION__ >= 130
+#define COMPAT_VARYING out
+#define COMPAT_ATTRIBUTE in
+#define COMPAT_TEXTURE texture
+#else
+#define COMPAT_VARYING varying 
+#define COMPAT_ATTRIBUTE attribute 
+#define COMPAT_TEXTURE texture2D
+#endif
+
 uniform mat4 modelview, projection;
 uniform sampler2D jointMatrices;
 uniform int numJoints;
 uniform vec4 morphTargetWeight[2];
 uniform int positionTargetCount;
 uniform int uvTargetCount;
-attribute vec3 position;
-attribute vec2 uv;
-attribute vec4 vertColor;
-attribute vec4 joints_0;
-attribute vec4 joints_1;
-attribute vec4 weights_0;
-attribute vec4 weights_1;
+
+COMPAT_ATTRIBUTE vec3 position;
+COMPAT_ATTRIBUTE vec2 uv;
+COMPAT_ATTRIBUTE vec4 vertColor;
+COMPAT_ATTRIBUTE vec4 joints_0;
+COMPAT_ATTRIBUTE vec4 joints_1;
+COMPAT_ATTRIBUTE vec4 weights_0;
+COMPAT_ATTRIBUTE vec4 weights_1;
 //Unfortunately the current OpenGL/shader version does not support attribute array
 //attribute vec4 morphTargets[8]
-attribute vec4 morphTargets_0;
-attribute vec4 morphTargets_1;
-attribute vec4 morphTargets_2;
-attribute vec4 morphTargets_3;
-attribute vec4 morphTargets_4;
-attribute vec4 morphTargets_5;
-attribute vec4 morphTargets_6;
-attribute vec4 morphTargets_7;
-varying vec2 texcoord;
-varying vec4 vColor;
-
+COMPAT_ATTRIBUTE vec4 morphTargets_0;
+COMPAT_ATTRIBUTE vec4 morphTargets_1;
+COMPAT_ATTRIBUTE vec4 morphTargets_2;
+COMPAT_ATTRIBUTE vec4 morphTargets_3;
+COMPAT_ATTRIBUTE vec4 morphTargets_4;
+COMPAT_ATTRIBUTE vec4 morphTargets_5;
+COMPAT_ATTRIBUTE vec4 morphTargets_6;
+COMPAT_ATTRIBUTE vec4 morphTargets_7;
+COMPAT_VARYING vec2 texcoord;
+COMPAT_VARYING vec4 vColor;
 
 mat4 getMatrixFromTexture(float index){
 	mat4 mat;
-	mat[0] = texture2D(jointMatrices,vec2(0.5/3.0,(index+0.5)/numJoints));
-	mat[1] = texture2D(jointMatrices,vec2(1.5/3.0,(index+0.5)/numJoints));
-	mat[2] = texture2D(jointMatrices,vec2(2.5/3.0,(index+0.5)/numJoints));
+	mat[0] = COMPAT_TEXTURE(jointMatrices,vec2(0.5/3.0,(index+0.5)/numJoints));
+	mat[1] = COMPAT_TEXTURE(jointMatrices,vec2(1.5/3.0,(index+0.5)/numJoints));
+	mat[2] = COMPAT_TEXTURE(jointMatrices,vec2(2.5/3.0,(index+0.5)/numJoints));
 	mat[3] = vec4(0,0,0,1);
 	return transpose(mat);
 }
@@ -49,6 +59,7 @@ mat4 getJointMatrix(){
 	}
 	return ret;
 }
+
 void main(void) {
 	texcoord = uv;
 	vColor = vertColor;

--- a/src/shaders/sprite.frag.glsl
+++ b/src/shaders/sprite.frag.glsl
@@ -1,3 +1,14 @@
+#if __VERSION__ >= 130
+#define COMPAT_VARYING in
+#define COMPAT_TEXTURE texture
+out vec4 FragColor;
+#else
+#define COMPAT_VARYING varying
+#define FragColor gl_FragColor
+#define COMPAT_TEXTURE texture2D
+#endif
+
+
 uniform sampler2D tex;
 uniform sampler2D pal;
 
@@ -8,7 +19,7 @@ uniform float alpha, gray, hue;
 uniform int mask;
 uniform bool isFlat, isRgba, isTrapez, neg;
 
-varying vec2 texcoord;
+COMPAT_VARYING vec2 texcoord;
 
 vec3 hue_shift(vec3 color, float dhue) {
 	float s = sin(dhue);
@@ -22,8 +33,7 @@ vec3 hue_shift(vec3 color, float dhue) {
 
 void main(void) {
 	if (isFlat) {
-		gl_FragColor = tint;
-
+		FragColor = tint;
 	} else {
 		vec2 uv = texcoord;
 		if (isTrapez) {
@@ -33,7 +43,7 @@ void main(void) {
 			uv.x = (gl_FragCoord.x - bounds[0]) / (bounds[1] - bounds[0]);
 		}
 
-		vec4 c = texture2D(tex, uv);
+		vec4 c = COMPAT_TEXTURE(tex, uv);
 		vec3 neg_base = vec3(1.0);
 		vec3 final_add = add;
 		vec4 final_mul = vec4(mult, alpha);
@@ -46,7 +56,7 @@ void main(void) {
 			final_add *= c.a;
 			final_mul.rgb *= alpha;
 		} else {
-			c = texture2D(pal, vec2(c.r*0.9966, 0.5));
+			c = COMPAT_TEXTURE(pal, vec2(c.r*0.9966, 0.5));
 			if (mask == -1) {
 				c.a = 1.0;
 			}
@@ -61,6 +71,6 @@ void main(void) {
 		// Add a final tint (used for shadows); make sure the result has premultiplied alpha
 		c.rgb = mix(c.rgb, tint.rgb * c.a, tint.a);
 
-		gl_FragColor = c;
+		FragColor = c;
 	}
 }

--- a/src/shaders/sprite.vert.glsl
+++ b/src/shaders/sprite.vert.glsl
@@ -1,8 +1,18 @@
+#if __VERSION__ >= 130
+#define COMPAT_VARYING out
+#define COMPAT_ATTRIBUTE in
+#define COMPAT_TEXTURE texture
+#else
+#define COMPAT_VARYING varying 
+#define COMPAT_ATTRIBUTE attribute 
+#define COMPAT_TEXTURE texture2D
+#endif
+
 uniform mat4 modelview, projection;
 
-attribute vec2 position;
-attribute vec2 uv;
-varying vec2 texcoord;
+COMPAT_ATTRIBUTE vec2 position;
+COMPAT_ATTRIBUTE vec2 uv;
+COMPAT_VARYING vec2 texcoord;
 
 void main(void) {
 	texcoord = uv;

--- a/src/system_glfw.go
+++ b/src/system_glfw.go
@@ -5,6 +5,7 @@ package main
 import (
 	"fmt"
 	"image"
+	"runtime"
 
 	glfw "github.com/go-gl/glfw/v3.3/glfw"
 )
@@ -36,8 +37,17 @@ func (s *System) newWindow(w, h int) (*Window, error) {
 	fullscreen := s.fullscreen && !forceWindowed
 
 	glfw.WindowHint(glfw.Resizable, glfw.True)
-	glfw.WindowHint(glfw.ContextVersionMajor, 2)
-	glfw.WindowHint(glfw.ContextVersionMinor, 1)
+
+	// only macOS needs this
+	if runtime.GOOS == "darwin" {
+		glfw.WindowHint(glfw.ContextVersionMajor, 3)
+		glfw.WindowHint(glfw.ContextVersionMinor, 2)
+		glfw.WindowHint(glfw.OpenGLForwardCompatible, glfw.True)
+		glfw.WindowHint(glfw.OpenGLProfile, glfw.OpenGLCoreProfile)
+	} else {
+		glfw.WindowHint(glfw.ContextVersionMajor, 2)
+		glfw.WindowHint(glfw.ContextVersionMinor, 1)
+	}
 
 	// Create main window.
 	// NOTE: Borderless fullscreen is in reality just a window without borders.


### PR DESCRIPTION
* Fix 3D stages not rendering on macOS (Intel and ARM).
* Fix postprocessing shaders not working on macOS (Intel and ARM).
* Fix redirects on explodVar, projVar, and clsnVar not working properly.

This will require updates to the glfont repo in order to work properly. macOS (Intel and ARM both) can only support a minimum OpenGL version of 3.2 and must make use of a VAO for proper 3D rendering hence the need for these changes. Shaders were rewritten with compatibility macros.

Huge thanks goes to assemblaj/fantasma for the initial 3D stage rendering fix with the VAO!