### PR TITLE
feat: expanded AttackMulSet, fixes, refactoring

### DIFF
--- a/data/dizzy.zss
+++ b/data/dizzy.zss
@@ -385,6 +385,7 @@ if !const(Default.Enable.Dizzy) || isHelper || teamSide = 0 {
 			dizzyPointsSet{value: dizzyPointsMax}
 			dizzySet{value: 0}
 		}
+		assertSpecial{flag: noDizzyPointsDamage}
 	}
 
 	# Set dizzy flag

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -4123,7 +4123,7 @@ func (sc helper) Run(c *Char, _ []int32) bool {
 			case 1:
 				h.player = true
 			case 2:
-				h.hprojectile = true
+				h.hprojectile = true // Currently unused
 			}
 		case helper_name:
 			h.name = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
@@ -4602,9 +4602,9 @@ const (
 	explod_pausemovetime
 	explod_sprpriority
 	explod_layerno
+	explod_under
 	explod_ontop
 	explod_strictontop
-	explod_under
 	explod_shadow
 	explod_removeongethit
 	explod_removeonchangestate
@@ -4669,7 +4669,6 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 			if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 {
 				e.postype = PT_None
 			}
-			e.layerno = crun.layerNo // Default
 		}
 		switch id {
 		case explod_anim:
@@ -4773,10 +4772,7 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 				e.sprpriority = 0
 			}
 		case explod_under:
-			if exp[0].evalB(c) {
-				e.layerno = 0
-				e.sprpriority = math.MinInt32
-			}
+			e.under = exp[0].evalB(c)
 		case explod_shadow:
 			e.shadow[0] = exp[0].evalI(c)
 			if len(exp) > 1 {
@@ -5171,8 +5167,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 			case explod_under:
 				if exp[0].evalB(c) {
 					eachExpl(func(e *Explod) {
-						e.layerno = 0
-						e.sprpriority = math.MinInt32
+						e.under = exp[0].evalB(c)
 					})
 				}
 			case explod_shadow:
@@ -6071,7 +6066,6 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 				}
 				p.hitdef.playerNo = sys.workingState.playerNo
 			}
-			p.layerno = crun.layerNo // Default
 		}
 		switch id {
 		case projectile_postype:

--- a/src/char.go
+++ b/src/char.go
@@ -1593,7 +1593,7 @@ type Projectile struct {
 	aimg            AfterImage
 	palfx           *PalFX
 	localscl        float32
-	parentAttackmul float32
+	parentAttackmul [4]float32
 	platform        bool
 	platformWidth   [2]float32
 	platformHeight  [2]float32
@@ -2000,7 +2000,7 @@ type CharSystemVar struct {
 	width             [2]float32
 	edge              [2]float32
 	height            [2]float32
-	attackMul         float32
+	attackMul         [4]float32 // 0 Damage, 1 Red Life, 2 Dizzy Points, 3 Guard Points
 	superDefenseMul   float32
 	fallDefenseMul    float32
 	customDefense     float32
@@ -2237,15 +2237,18 @@ func (c *Char) enemyNearClear() {
 func (c *Char) clear2() {
 	c.sysVarRangeSet(0, int32(NumSysVar)-1, 0)
 	c.sysFvarRangeSet(0, int32(NumSysFvar)-1, 0)
-	c.CharSystemVar = CharSystemVar{bindToId: -1,
-		angleScale: [...]float32{1, 1}, angleScaleTrg: [...]float32{1, 1}, alphaTrg: [...]int32{255, 0}, alpha: [...]int32{255, 0},
+	atk := float32(c.gi().data.attack) * c.ocd().attackRatio / 100
+	c.CharSystemVar = CharSystemVar{
+		bindToId: -1,
+		angleScale:      [...]float32{1, 1}, angleScaleTrg: [...]float32{1, 1}, alphaTrg: [...]int32{255, 0}, alpha: [...]int32{255, 0},
 		width:           [...]float32{c.defFW(), c.defBW()},
 		height:          [...]float32{c.defTHeight(), c.defBHeight()},
-		attackMul:       float32(c.gi().data.attack) * c.ocd().attackRatio / 100,
+		attackMul:       [4]float32{atk, atk, atk, atk},
 		fallDefenseMul:  1,
 		superDefenseMul: 1,
 		customDefense:   1,
-		finalDefense:    1.0}
+		finalDefense:    1.0,
+	}
 	c.widthToSizeBox()
 	c.oldPos, c.drawPos = c.pos, c.pos
 	if c.helperIndex == 0 && c.teamside != -1 {
@@ -5099,6 +5102,7 @@ func (c *Char) targetLifeAdd(tar []int32, add int32, kill, absolute, dizzy, redl
 	for _, tid := range tar {
 		if t := sys.playerID(tid); t != nil {
 			// We flip the sign of "add" so that it operates under the same logic as Hitdef damage
+			// Note: LifeAdd and similar state controllers always ignore the attack multiplier
 			dmg := float64(t.computeDamage(-float64(add), kill, absolute, 1, c, true))
 			// Subtract life
 			t.lifeAdd(-dmg, true, true)
@@ -7791,8 +7795,7 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 		return // Stop entire function if getter is disabled
 	}
 	// hit() function definition start.
-	hit := func(c *Char, hd *HitDef, pos [2]float32,
-		projf, attackMul float32, hits int32) (hitType int32) {
+	hit := func(c *Char, hd *HitDef, pos [2]float32, projf float32, attackMul [4]float32, hits int32) (hitType int32) {
 		if !proj && c.ss.stateType == ST_L && hd.reversal_attr <= 0 {
 			c.hitdef.ltypehit = true
 			return 0
@@ -7828,7 +7831,7 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 		if guard && int32(getter.ss.stateType)&hd.guardflag != 0 {
 			getter.ghv.kill = hd.guard_kill
 			// We only switch to guard behavior if the enemy can survive guarding the attack
-			if getter.life > getter.computeDamage(float64(hd.guarddamage)*float64(hits), hd.guard_kill, false, attackMul, c, true) ||
+			if getter.life > getter.computeDamage(float64(hd.guarddamage)*float64(hits), hd.guard_kill, false, attackMul[0], c, true) ||
 				sys.gsf(GSF_globalnoko) || getter.asf(ASF_noko) || getter.asf(ASF_noguardko) {
 				hitType = 2
 			} else {
@@ -8196,17 +8199,17 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 				// Life
 				if !getter.asf(ASF_nohitdamage) {
 					getter.ghv.damage += getter.computeDamage(
-						float64(hd.hitdamage)*float64(hits), getter.ghv.kill, false, attackMul, c, bnd)
+						float64(hd.hitdamage)*float64(hits), getter.ghv.kill, false, attackMul[0], c, bnd)
 				}
 				// Red life
 				if !getter.asf(ASF_noredlifedamage) {
 					getter.ghv.redlife += getter.computeDamage(
-						float64(hd.hitredlife)*float64(hits), true, false, attackMul, c, bnd)
+						float64(hd.hitredlife)*float64(hits), true, false, attackMul[1], c, bnd)
 				}
 				// Dizzy points
 				if !getter.asf(ASF_nodizzypointsdamage) && !getter.scf(SCF_dizzy) {
 					getter.ghv.dizzypoints += getter.computeDamage(
-						float64(hd.dizzypoints)*float64(hits), true, false, attackMul, c, false)
+						float64(hd.dizzypoints)*float64(hits), true, false, attackMul[2], c, false)
 				}
 			}
 			// Damage on guard
@@ -8214,17 +8217,17 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 				// Life
 				if !getter.asf(ASF_noguarddamage) {
 					getter.ghv.damage += getter.computeDamage(
-						float64(hd.guarddamage)*float64(hits), getter.ghv.kill, false, attackMul, c, bnd)
+						float64(hd.guarddamage)*float64(hits), getter.ghv.kill, false, attackMul[0], c, bnd)
 				}
 				// Red life
 				if !getter.asf(ASF_noredlifedamage) {
 					getter.ghv.redlife += getter.computeDamage(
-						float64(hd.guardredlife)*float64(hits), true, false, attackMul, c, bnd)
+						float64(hd.guardredlife)*float64(hits), true, false, attackMul[1], c, bnd)
 				}
 				// Guard points
 				if !getter.asf(ASF_noguardpointsdamage) {
 					getter.ghv.guardpoints += getter.computeDamage(
-						float64(hd.guardpoints)*float64(hits), true, false, attackMul, c, false)
+						float64(hd.guardpoints)*float64(hits), true, false, attackMul[3], c, false)
 				}
 			}
 			// Absolute values
@@ -8232,13 +8235,13 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 			getter.ghv.hitpower += hd.hitgivepower
 			getter.ghv.guardpower += hd.guardgivepower
 			getter.ghv.hitdamage += getter.computeDamage(
-				float64(hd.hitdamage)*float64(hits), true, false, attackMul, c, false)
+				float64(hd.hitdamage)*float64(hits), true, false, attackMul[0], c, false)
 			getter.ghv.guarddamage += getter.computeDamage(
-				float64(hd.guarddamage)*float64(hits), true, false, attackMul, c, false)
+				float64(hd.guarddamage)*float64(hits), true, false, attackMul[0], c, false)
 			getter.ghv.hitredlife += getter.computeDamage(
-				float64(hd.hitredlife)*float64(hits), true, false, attackMul, c, bnd)
+				float64(hd.hitredlife)*float64(hits), true, false, attackMul[1], c, bnd)
 			getter.ghv.guardredlife += getter.computeDamage(
-				float64(hd.guardredlife)*float64(hits), true, false, attackMul, c, bnd)
+				float64(hd.guardredlife)*float64(hits), true, false, attackMul[1], c, bnd)
 			// Hit behavior on KO
 			if ghvset && getter.ghv.damage >= getter.life {
 				if getter.ghv.kill || !getter.alive() {

--- a/src/char.go
+++ b/src/char.go
@@ -95,8 +95,10 @@ const (
 	ASF_sizepushonly
 	ASF_animatehitpause
 	ASF_cornerpriority
+	ASF_drawunder
 	ASF_runfirst
 	ASF_runlast
+	ASF_projtypecollision // TODO: Make this a parameter for normal projectiles as well?
 )
 
 type GlobalSpecialFlag uint32
@@ -553,7 +555,7 @@ type HitDef struct {
 	reversal_attr              int32
 	hitflag                    int32
 	guardflag                  int32
-	affectteam                 int32
+	affectteam                 int32 // -1F, 0B, 1E
 	teamside                   int
 	animtype                   Reaction
 	air_animtype               Reaction
@@ -1120,7 +1122,7 @@ type Explod struct {
 	animelem            int32
 	animfreeze          bool
 	//ontop                bool
-	//under                bool
+	under                bool
 	alpha                [2]int32
 	ownpal               bool
 	ignorehitpause       bool
@@ -1360,6 +1362,8 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 		sprs = &sys.spritesLayer1
 	} else if e.layerno < 0 {
 		sprs = &sys.spritesLayerN1
+	} else if e.under {
+		sprs = &sys.spritesLayerU
 	}
 	var pfx *PalFX
 	if e.palfx != nil && (e.anim.sff != sys.ffx["f"].fsff || e.ownpal) {
@@ -1711,7 +1715,7 @@ func (p *Projectile) update(playerNo int) {
 }
 
 // This function only checks if a projectile hits another projectile
-func (p *Projectile) tradeDetection(playerNo int) {
+func (p *Projectile) tradeDetection(playerNo, index int) {
 	if p.ani == nil || len(p.ani.frames) == 0 {
 		return
 	}
@@ -1729,13 +1733,22 @@ func (p *Projectile) tradeDetection(playerNo int) {
 	}
 
 	for i := 0; i < len(sys.chars) && p.hits >= 0; i++ {
-		if len(sys.chars[i]) == 0 || i == playerNo {
+		// In Mugen projectiles could not hit projectiles from the same player
+		//if len(sys.chars[i]) == 0 {//|| i == playerNo {
+		if len(sys.chars[i]) == 0 {
 			continue
 		}
 		for j, pr := range sys.projs[i] {
-			if pr.hits < 0 || pr.id < 0 || (pr.hitdef.affectteam != 0 &&
-				(p.hitdef.teamside-1 != pr.hitdef.teamside-1) != (pr.hitdef.affectteam > 0)) ||
-				pr.ani == nil || len(pr.ani.frames) == 0 {
+			if i == playerNo && j == index { // Self
+				continue
+			}
+			if pr.hits < 0 || pr.id < 0 || pr.ani == nil || len(pr.ani.frames) == 0 {
+				continue
+			}
+			// Teamside check
+			if pr.hitdef.affectteam != 0 &&
+				((p.hitdef.teamside-1 != pr.hitdef.teamside-1) != (pr.hitdef.affectteam > 0) ||
+				(p.hitdef.teamside-1 == pr.hitdef.teamside-1) != (pr.hitdef.affectteam < 0)) {
 				continue
 			}
 			clsn1 := pr.ani.CurrentFrame().Clsn2() // Projectiles trade with their Clsn2 only
@@ -2014,7 +2027,7 @@ type Char struct {
 	teamside            int
 	keyctrl             [4]bool
 	player              bool
-	hprojectile         bool
+	hprojectile         bool // Currently unused
 	animPN              int
 	animNo              int32
 	prevAnimNo          int32
@@ -4353,7 +4366,12 @@ func (c *Char) helperInit(h *Char, st int32, pt PosType, x, y float32,
 func (c *Char) newExplod() (*Explod, int) {
 	explinit := func(expl *Explod) *Explod {
 		expl.clear()
-		expl.id, expl.playerId, expl.palfx, expl.palfxdef = -1, c.id, c.getPalfx(), PalFXDef{color: 1, hue: 0, mul: [...]int32{256, 256, 256}}
+		// Explod defaults
+		expl.id = -1
+		expl.playerId = c.id
+		expl.layerno = c.layerNo
+		expl.palfx = c.getPalfx()
+		expl.palfxdef = PalFXDef{color: 1, hue: 0, mul: [...]int32{256, 256, 256}}
 		if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
 			expl.projection = Projection_Perspective
 		} else {
@@ -4651,7 +4669,9 @@ func (c *Char) newProj() *Projectile {
 	for i := c.gi().projidcount; i < len(sys.projs[c.playerNo]); i++ {
 		if sys.projs[c.playerNo][i].id < 0 {
 			sys.projs[c.playerNo][i].clear()
+			// Projectile defaults
 			sys.projs[c.playerNo][i].id = 0
+			sys.projs[c.playerNo][i].layerno = c.layerNo
 			sys.projs[c.playerNo][i].palfx = c.getPalfx()
 			c.gi().projidcount = i
 			return &sys.projs[c.playerNo][i]
@@ -5091,7 +5111,7 @@ func (c *Char) targetLifeAdd(tar []int32, add int32, kill, absolute, dizzy, redl
 				}
 			}
 			// Subtract dizzy points
-			if dizzy && !t.scf(SCF_dizzy) && !c.asf(ASF_nodizzypointsdamage) {
+			if dizzy && !t.scf(SCF_dizzy) && !t.asf(ASF_nodizzypointsdamage) {
 				if t.ghv.attr&int32(AT_AH) != 0 {
 					t.dizzyPointsAdd(-dmg*float64(c.gi().constants["super.lifetodizzypointsmul"]), true)
 				} else {
@@ -5111,21 +5131,21 @@ func (c *Char) targetPowerAdd(tar []int32, power int32) {
 }
 func (c *Char) targetDizzyPointsAdd(tar []int32, add int32, absolute bool) {
 	for _, tid := range tar {
-		if t := sys.playerID(tid); t != nil && !t.scf(SCF_dizzy) && !c.asf(ASF_nodizzypointsdamage) {
+		if t := sys.playerID(tid); t != nil && !t.scf(SCF_dizzy) && !t.asf(ASF_nodizzypointsdamage) {
 			t.dizzyPointsAdd(float64(t.computeDamage(float64(add), false, absolute, 1, c, false)), true)
 		}
 	}
 }
 func (c *Char) targetGuardPointsAdd(tar []int32, add int32, absolute bool) {
 	for _, tid := range tar {
-		if t := sys.playerID(tid); t != nil && !c.asf(ASF_noguardpointsdamage) {
+		if t := sys.playerID(tid); t != nil && !t.asf(ASF_noguardpointsdamage) {
 			t.guardPointsAdd(float64(t.computeDamage(float64(add), false, absolute, 1, c, false)), true)
 		}
 	}
 }
 func (c *Char) targetRedLifeAdd(tar []int32, add int32, absolute bool) {
 	for _, tid := range tar {
-		if t := sys.playerID(tid); t != nil && !c.asf(ASF_noredlifedamage) {
+		if t := sys.playerID(tid); t != nil && !t.asf(ASF_noredlifedamage) {
 			t.redLifeAdd(float64(t.computeDamage(float64(add), false, absolute, 1, c, true)), true)
 		}
 	}
@@ -6363,7 +6383,7 @@ func (c *Char) projClsnCheck(p *Projectile, cbox, pbox int32) bool {
 
 	// Decide which box types should collide
 	var clsn1, clsn2 []float32
-	if c.hprojectile { // Projectiles trade with their Clsn2 only
+	if c.asf(ASF_projtypecollision) { // Projectiles trade with their Clsn2 only
 		clsn1 = frm.Clsn2()
 		clsn2 = c.curFrame.Clsn2()
 	} else {
@@ -6427,7 +6447,7 @@ func (c *Char) clsnCheck(getter *Char, cbox, gbox int32) bool {
 
 	// Decide which box types should collide
 	var clsn1, clsn2 []float32
-	if c.hprojectile && getter.hprojectile { // Projectiles trade with their Clsn2 only
+	if c.asf(ASF_projtypecollision) && getter.asf(ASF_projtypecollision) { // Projectiles trade with their Clsn2 only
 		clsn1 = c.curFrame.Clsn2()
 		clsn2 = getter.curFrame.Clsn2()
 	} else {
@@ -6683,6 +6703,7 @@ func (c *Char) actionPrepare() {
 				}
 			}
 			// HitOverride timers
+			// In Mugen they decrease even during hitpause. However no issues have arised from not doing that yet
 			for i, ho := range c.ho {
 				if ho.time > 0 {
 					c.ho[i].time--
@@ -6866,29 +6887,29 @@ func (c *Char) actionRun() {
 			}
 			c.ghv.damage = 0
 		}
-		c.ghv.hitdamage = 0
-		c.ghv.guarddamage = 0
-		c.ghv.power = 0
-		c.ghv.hitpower = 0
-		c.ghv.guardpower = 0
+		if c.ghv.redlife != 0 {
+			if c.ss.moveType == MT_H || c.hoKeepState {
+				c.redLifeAdd(-float64(c.ghv.redlife), true)
+			}
+			c.ghv.redlife = 0
+		}
 		if c.ghv.dizzypoints != 0 {
-			if c.ss.moveType == MT_H && !c.inGuardState() {
+			if c.ss.moveType == MT_H || c.hoKeepState {
 				c.dizzyPointsAdd(-float64(c.ghv.dizzypoints), true)
 			}
 			c.ghv.dizzypoints = 0
 		}
 		if c.ghv.guardpoints != 0 {
-			if c.ss.moveType == MT_H && c.inGuardState() {
+			if c.ss.moveType == MT_H || c.hoKeepState {
 				c.guardPointsAdd(-float64(c.ghv.guardpoints), true)
 			}
 			c.ghv.guardpoints = 0
 		}
-		if c.ghv.redlife != 0 {
-			if c.ss.moveType == MT_H {
-				c.redLifeAdd(-float64(c.ghv.redlife), true)
-			}
-			c.ghv.redlife = 0
-		}
+		c.ghv.hitdamage = 0
+		c.ghv.guarddamage = 0
+		c.ghv.power = 0
+		c.ghv.hitpower = 0
+		c.ghv.guardpower = 0
 		// The following block used to be in char.update()
 		// That however caused a breaking difference with Mugen when checking these variables between different players
 		// https://github.com/ikemen-engine/Ikemen-GO/issues/1540
@@ -6945,8 +6966,6 @@ func (c *Char) actionRun() {
 				c.ghv.hittime--
 			}
 		}
-		c.ghv.frame = false
-		c.mhv.frame = false
 		if c.helperIndex == 0 && c.gi().pctime >= 0 {
 			c.gi().pctime++
 		}
@@ -6971,6 +6990,9 @@ func (c *Char) actionFinish() {
 		if c.palfx != nil && c.ownpal {
 			c.palfx.step()
 		}
+		// Placing these two in Finish instead of Run makes them less susceptible to processing order inconsistency
+		c.ghv.frame = false
+		c.mhv.frame = false
 	}
 	c.minus = 1
 }
@@ -7544,6 +7566,8 @@ func (c *Char) cueDraw() {
 			sprs = &sys.spritesLayer1
 		} else if c.layerNo < 0 {
 			sprs = &sys.spritesLayerN1
+		} else if c.asf(ASF_drawunder) {
+			sprs = &sys.spritesLayerU
 		}
 		if !c.asf(ASF_invisible) {
 			var sc, sa int32 = -1, 255
@@ -7723,7 +7747,7 @@ func (cl *CharList) action() {
 	// Sorting the characters first makes new helpers wait for their turn and allows RunOrder trigger accuracy
 	sortedOrder := cl.sortActionRunOrder()
 	for i := 0; i < len(sortedOrder); i++ {
-		if sortedOrder[i] <= len(cl.runOrder) {
+		if sortedOrder[i] < len(cl.runOrder) {
 			cl.runOrder[sortedOrder[i]].actionRun()
 		}
 	}
@@ -7872,7 +7896,7 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 			c.hitdefTargetsBuffer = append(c.hitdefTargetsBuffer, getter.id)
 			c.mhv.uniqhit = int32(len(c.hitdefTargets))
 		}
-		ghvset := !getter.stchtmp || p2s || !getter.csf(CSF_gethit)
+		ghvset := !getter.csf(CSF_gethit) || !getter.stchtmp || p2s
 		// Variables that are set even if Hitdef type is "None"
 		if ghvset {
 			if !proj {
@@ -7925,8 +7949,6 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 			if getter.bindToId == c.id {
 				getter.setBindTime(0)
 			}
-			var absdamage, hitdamage, guarddamage int32
-			var absredlife int32
 			if ghvset {
 				ghv := &getter.ghv
 				cmb := (getter.ss.moveType == MT_H || getter.csf(CSF_gethit)) && !ghv.guarded
@@ -7973,8 +7995,6 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 					ghv.score = hd.score[0]
 				}
 				ghv.fatal = false
-				hitdamage = hd.hitdamage
-				guarddamage = hd.guarddamage
 				// If attack is guarded
 				if hitType == 2 {
 					ghv.guarded = true
@@ -7990,10 +8010,6 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 						ghv.xvel = hd.guard_velocity * (c.localscl / getter.localscl)
 						// Mugen does not accept a Y component for ground guard velocity
 						//ghv.yvel = hd.ground_velocity[1] * c.localscl / getter.localscl
-					}
-					if !getter.asf(ASF_noguarddamage) {
-						absdamage = hd.guarddamage
-						absredlife = hd.guardredlife
 					}
 					ghv.hitcount = hc
 					ghv.guardcount = gc + 1
@@ -8045,10 +8061,6 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 					}
 					if ghv.hittime < 0 {
 						ghv.hittime = 0
-					}
-					if !getter.asf(ASF_nohitdamage) {
-						absdamage = hd.hitdamage
-						absredlife = hd.hitredlife
 					}
 					if cmb {
 						ghv.hitcount = hc + 1
@@ -8148,15 +8160,17 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 				} else if getter.bindToId == c.id {
 					getter.setBindTime(0)
 				}
-			} else if hitType == 1 {
-				if !getter.asf(ASF_nohitdamage) {
-					absdamage = hd.hitdamage
-					absredlife = hd.hitredlife
-				}
-			} else if !getter.asf(ASF_noguarddamage) {
-				absdamage = hd.guarddamage
-				absredlife = hd.guardredlife
 			}
+			// This currently seems redundant
+			//} else if hitType == 1 {
+			//	if !getter.asf(ASF_nohitdamage) {
+			//		absdamage = hd.hitdamage
+			//		absredlife = hd.hitredlife
+			//	}
+			//} else if !getter.asf(ASF_noguarddamage) {
+			//	absdamage = hd.guarddamage
+			//	absredlife = hd.guardredlife
+			//}
 			if sys.super > 0 {
 				getter.superMovetime =
 					Max(getter.superMovetime, getter.ghv.hitshaketime)
@@ -8177,30 +8191,54 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 					break
 				}
 			}
-			getter.ghv.damage += getter.computeDamage(
-				float64(absdamage)*float64(hits), getter.ghv.kill, false, attackMul, c, bnd)
-			getter.ghv.hitdamage += getter.computeDamage(
-				float64(hitdamage)*float64(hits), true, false, attackMul, c, false)
-			getter.ghv.guarddamage += getter.computeDamage(
-				float64(guarddamage)*float64(hits), true, false, attackMul, c, false)
+			// Damage on hit
+			if hitType == 1 {
+				// Life
+				if !getter.asf(ASF_nohitdamage) {
+					getter.ghv.damage += getter.computeDamage(
+						float64(hd.hitdamage)*float64(hits), getter.ghv.kill, false, attackMul, c, bnd)
+				}
+				// Red life
+				if !getter.asf(ASF_noredlifedamage) {
+					getter.ghv.redlife += getter.computeDamage(
+						float64(hd.hitredlife)*float64(hits), true, false, attackMul, c, bnd)
+				}
+				// Dizzy points
+				if !getter.asf(ASF_nodizzypointsdamage) && !getter.scf(SCF_dizzy) {
+					getter.ghv.dizzypoints += getter.computeDamage(
+						float64(hd.dizzypoints)*float64(hits), true, false, attackMul, c, false)
+				}
+			}
+			// Damage on guard
+			if hitType == 2 {
+				// Life
+				if !getter.asf(ASF_noguarddamage) {
+					getter.ghv.damage += getter.computeDamage(
+						float64(hd.guarddamage)*float64(hits), getter.ghv.kill, false, attackMul, c, bnd)
+				}
+				// Red life
+				if !getter.asf(ASF_noredlifedamage) {
+					getter.ghv.redlife += getter.computeDamage(
+						float64(hd.guardredlife)*float64(hits), true, false, attackMul, c, bnd)
+				}
+				// Guard points
+				if !getter.asf(ASF_noguardpointsdamage) {
+					getter.ghv.guardpoints += getter.computeDamage(
+						float64(hd.guardpoints)*float64(hits), true, false, attackMul, c, false)
+				}
+			}
+			// Absolute values
+			// These do not affect the player and are only used in GetHitVar
 			getter.ghv.hitpower += hd.hitgivepower
 			getter.ghv.guardpower += hd.guardgivepower
-			if !c.asf(ASF_nodizzypointsdamage) && !getter.scf(SCF_dizzy) {
-				getter.ghv.dizzypoints += getter.computeDamage(
-					float64(hd.dizzypoints)*float64(hits), true, false, attackMul, c, false)
-			}
-			if !c.asf(ASF_noguardpointsdamage) {
-				getter.ghv.guardpoints += getter.computeDamage(
-					float64(hd.guardpoints)*float64(hits), true, false, attackMul, c, false)
-			}
-			if !c.asf(ASF_noredlifedamage) {
-				getter.ghv.redlife += getter.computeDamage(
-					float64(absredlife)*float64(hits), true, false, attackMul, c, bnd)
-				getter.ghv.hitredlife += getter.computeDamage(
-					float64(hd.hitredlife)*float64(hits), true, false, attackMul, c, bnd)
-				getter.ghv.guardredlife += getter.computeDamage(
-					float64(hd.guardredlife)*float64(hits), true, false, attackMul, c, bnd)
-			}
+			getter.ghv.hitdamage += getter.computeDamage(
+				float64(hd.hitdamage)*float64(hits), true, false, attackMul, c, false)
+			getter.ghv.guarddamage += getter.computeDamage(
+				float64(hd.guarddamage)*float64(hits), true, false, attackMul, c, false)
+			getter.ghv.hitredlife += getter.computeDamage(
+				float64(hd.hitredlife)*float64(hits), true, false, attackMul, c, bnd)
+			getter.ghv.guardredlife += getter.computeDamage(
+				float64(hd.guardredlife)*float64(hits), true, false, attackMul, c, bnd)
 			// Hit behavior on KO
 			if ghvset && getter.ghv.damage >= getter.life {
 				if getter.ghv.kill || !getter.alive() {
@@ -8466,7 +8504,7 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 	if getter.scf(SCF_standby) || getter.scf(SCF_disabled) {
 		return
 	}
-	// Projectile check
+	// Projectile hitting player check
 	// TODO: Disable projectiles if player is disabled?
 	if proj {
 		for i, pr := range sys.projs {
@@ -8479,9 +8517,19 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 			ap_projhit := false
 			for j := range pr {
 				p := &pr[j]
-				if (i == getter.playerNo && getter.helperIndex == 0 && !p.platform) ||
-					p.id < 0 || p.hits < 0 || p.hitdef.affectteam != 0 &&
-					(getter.teamside != p.hitdef.teamside-1) != (p.hitdef.affectteam > 0) {
+				if p.id < 0 || p.hits < 0 {
+					continue
+				}
+				// In Mugen, projectiles couldn't hit their root even with the proper affectteam
+				if i == getter.playerNo && getter.helperIndex == 0 &&
+					(getter.teamside == p.hitdef.teamside-1) && !p.platform {
+					continue
+				}
+				// Teamside check
+				// Since the teamside parameter is new to Ikemen, we can make that one allow the projectile to hit the root
+				if p.hitdef.affectteam != 0 &&
+					((getter.teamside != p.hitdef.teamside-1) != (p.hitdef.affectteam > 0) ||
+					(getter.teamside == p.hitdef.teamside-1) != (p.hitdef.affectteam < 0)) {
 					continue
 				}
 				dist := (getter.pos[0]*getter.localscl - (p.pos[0])*p.localscl) * p.facing

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -3636,6 +3636,14 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_immovable))
 		case "cornerpriority":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_cornerpriority))
+		case "drawunder":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_drawunder))
+		case "runfirst":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_runfirst))
+		case "runlast":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_runlast))
+		case "projtypecollision":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_projtypecollision))
 		// Ikemen global flags
 		case "globalnoko":
 			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_globalnoko))

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -208,10 +208,14 @@ func (c *Compiler) assertSpecial(is IniSection, sc *StateControllerBase, _ int8)
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_animatehitpause)))
 			case "cornerpriority":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_cornerpriority)))
+			case "drawunder":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_drawunder)))
 			case "runfirst":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_runfirst)))
 			case "runlast":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_runlast)))
+			case "projtypecollision":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_projtypecollision)))
 			// Ikemen global flags
 			case "globalnoko":
 				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_globalnoko)))

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -3288,9 +3288,39 @@ func (c *Compiler) attackMulSet(is IniSection, sc *StateControllerBase, _ int8) 
 			attackMulSet_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.paramValue(is, sc, "value",
-			attackMulSet_value, VT_Float, 1, true); err != nil {
+		any := false
+		if err := c.stateParam(is, "value", false, func(data string) error {
+			any = true
+			return c.scAdd(sc, attackMulSet_value, data, VT_Float, 1)
+		}); err != nil {
 			return err
+		}
+		if err := c.stateParam(is, "damage", false, func(data string) error {
+			any = true
+			return c.scAdd(sc, attackMulSet_damage, data, VT_Float, 1)
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "redlife", false, func(data string) error {
+			any = true
+			return c.scAdd(sc, attackMulSet_redlife, data, VT_Float, 1)
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "dizzypoints", false, func(data string) error {
+			any = true
+			return c.scAdd(sc, attackMulSet_dizzypoints, data, VT_Float, 1)
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "guardpoints", false, func(data string) error {
+			any = true
+			return c.scAdd(sc, attackMulSet_guardpoints, data, VT_Float, 1)
+		}); err != nil {
+			return err
+		}
+		if !any {
+			return Error("no multipliers specified")
 		}
 		return nil
 	})

--- a/src/script.go
+++ b/src/script.go
@@ -4803,6 +4803,14 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_animatehitpause)))
 		case "cornerpriority":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_cornerpriority)))
+		case "drawunder":
+			l.Push(lua.LBool(sys.debugWC.asf(ASF_drawunder)))
+		case "runfirst":
+			l.Push(lua.LBool(sys.debugWC.asf(ASF_runfirst)))
+		case "runlast":
+			l.Push(lua.LBool(sys.debugWC.asf(ASF_runlast)))
+		case "projtypecollision":
+			l.Push(lua.LBool(sys.debugWC.asf(ASF_projtypecollision)))
 		// GlobalSpecialFlag
 		case "intro":
 			l.Push(lua.LBool(sys.gsf(GSF_intro)))

--- a/src/script.go
+++ b/src/script.go
@@ -4533,7 +4533,7 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "attack", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.attackMul * 100))
+		l.Push(lua.LNumber(sys.debugWC.attackMul[0] * 100))
 		return 1
 	})
 	luaRegister(l, "clamp", func(*lua.LState) int {


### PR DESCRIPTION
Feat:
- AttackMulSet can now set multipliers for red life, dizzy points and guard points as well

Refactor:
- After more testing it appears not all the main fighting games check projectile clashing with their Clsn2. For that reason having that behavior hardcoded for helpertype Projectile is undesirable
- Added ProjTypeCollision AssertSpecial to restore previous behavior of helpertype Projectile
- Helpertype Projectile dummied out as it currently offers no unique properties after that change
- Restored previous "under" behavior for Explods
- Restored "DrawUnder" AssertSpecial
- Projectiles can now hit their root or other projectiles of same player by changing their teamside parameter
- Fixed "NoDizzyPointsDamage", "NoGuardPointsDamage" and "NoRedLifeDamage" to work as described in the Wiki. That is they disable the damage the char receives, not gives