### PR TITLE
feat: Added shadow and reflection offsets, made reflection a shadow, clsnVar fixes, shadow offset fixes

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -2861,7 +2861,7 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		id := int(sys.bcStack.Pop().ToI())
 		v := float32(math.NaN())
 		switch id {
-		case 0:
+		case 3: // DON'T ASK WHY BUT 0 CAUSES ERRORS, 3 DOES NOT
 			v = c.sizeBox[0]
 		case 1:
 			cf1 := c.anim.CurrentFrame().Clsn1()
@@ -2874,13 +2874,13 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 				v = cf2[idx*4]
 			}
 		}
-		sys.bcStack.PushF(v)
+		sys.bcStack.PushF(v * (c.localscl / oc.localscl))
 	case OC_ex2_clsnvar_top:
 		idx := int(sys.bcStack.Pop().ToI())
 		id := int(sys.bcStack.Pop().ToI())
 		v := float32(math.NaN())
 		switch id {
-		case 0:
+		case 3: // DON'T ASK WHY BUT 0 CAUSES ERRORS, 3 DOES NOT
 			v = c.sizeBox[1]
 		case 1:
 			cf1 := c.anim.CurrentFrame().Clsn1()
@@ -2893,13 +2893,13 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 				v = cf2[idx*4+1]
 			}
 		}
-		sys.bcStack.PushF(v)
+		sys.bcStack.PushF(v * (c.localscl / oc.localscl))
 	case OC_ex2_clsnvar_right:
 		idx := int(sys.bcStack.Pop().ToI())
 		id := int(sys.bcStack.Pop().ToI())
 		v := float32(math.NaN())
 		switch id {
-		case 0:
+		case 3: // DON'T ASK WHY BUT 0 CAUSES ERRORS, 3 DOES NOT
 			v = c.sizeBox[2]
 		case 1:
 			cf1 := c.anim.CurrentFrame().Clsn1()
@@ -2912,13 +2912,13 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 				v = cf2[idx*4+2]
 			}
 		}
-		sys.bcStack.PushF(v)
+		sys.bcStack.PushF(v * (c.localscl / oc.localscl))
 	case OC_ex2_clsnvar_bottom:
 		idx := int(sys.bcStack.Pop().ToI())
 		id := int(sys.bcStack.Pop().ToI())
 		v := float32(math.NaN())
 		switch id {
-		case 0:
+		case 3: // DON'T ASK WHY BUT 0 CAUSES ERRORS, 3 DOES NOT
 			v = c.sizeBox[3]
 		case 1:
 			cf1 := c.anim.CurrentFrame().Clsn1()
@@ -2931,7 +2931,7 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 				v = cf2[idx*4+3]
 			}
 		}
-		sys.bcStack.PushF(v)
+		sys.bcStack.PushF(v * (c.localscl / oc.localscl))
 	// BEGIN FALLTHROUGH (explodvar)
 	case OC_ex2_explodvar_anim:
 		fallthrough

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -387,7 +387,12 @@ const (
 	OC_const_stagevar_shadow_fade_range_begin
 	OC_const_stagevar_shadow_fade_range_end
 	OC_const_stagevar_shadow_xshear
+	OC_const_stagevar_shadow_offset_x
+	OC_const_stagevar_shadow_offset_y
 	OC_const_stagevar_reflection_intensity
+	OC_const_stagevar_reflection_yscale
+	OC_const_stagevar_reflection_offset_x
+	OC_const_stagevar_reflection_offset_y
 	OC_const_constants
 	OC_const_stage_constants
 )
@@ -2077,8 +2082,18 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(sys.stage.sdw.fadeend)
 	case OC_const_stagevar_shadow_xshear:
 		sys.bcStack.PushF(sys.stage.sdw.xshear)
+	case OC_const_stagevar_shadow_offset_x:
+		sys.bcStack.PushF(sys.stage.sdw.offset[0])
+	case OC_const_stagevar_shadow_offset_y:
+		sys.bcStack.PushF(sys.stage.sdw.offset[1])
 	case OC_const_stagevar_reflection_intensity:
-		sys.bcStack.PushI(sys.stage.reflection)
+		sys.bcStack.PushI(sys.stage.reflection.intensity)
+	case OC_const_stagevar_reflection_yscale:
+		sys.bcStack.PushF(sys.stage.reflection.yscale)
+	case OC_const_stagevar_reflection_offset_x:
+		sys.bcStack.PushF(sys.stage.reflection.offset[0])
+	case OC_const_stagevar_reflection_offset_y:
+		sys.bcStack.PushF(sys.stage.reflection.offset[1])
 	case OC_const_constants:
 		sys.bcStack.PushF(c.gi().constants[sys.stringPool[sys.workingState.playerNo].List[*(*int32)(
 			unsafe.Pointer(&be[*i]))]])
@@ -2874,7 +2889,7 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 				v = cf2[idx*4]
 			}
 		}
-		sys.bcStack.PushF(v * (c.localscl / oc.localscl))
+		sys.bcStack.PushF(v * c.localscl)
 	case OC_ex2_clsnvar_top:
 		idx := int(sys.bcStack.Pop().ToI())
 		id := int(sys.bcStack.Pop().ToI())
@@ -2893,7 +2908,7 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 				v = cf2[idx*4+1]
 			}
 		}
-		sys.bcStack.PushF(v * (c.localscl / oc.localscl))
+		sys.bcStack.PushF(v * c.localscl)
 	case OC_ex2_clsnvar_right:
 		idx := int(sys.bcStack.Pop().ToI())
 		id := int(sys.bcStack.Pop().ToI())
@@ -2912,7 +2927,7 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 				v = cf2[idx*4+2]
 			}
 		}
-		sys.bcStack.PushF(v * (c.localscl / oc.localscl))
+		sys.bcStack.PushF(v * c.localscl)
 	case OC_ex2_clsnvar_bottom:
 		idx := int(sys.bcStack.Pop().ToI())
 		id := int(sys.bcStack.Pop().ToI())
@@ -2931,7 +2946,7 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 				v = cf2[idx*4+3]
 			}
 		}
-		sys.bcStack.PushF(v * (c.localscl / oc.localscl))
+		sys.bcStack.PushF(v * c.localscl)
 	// BEGIN FALLTHROUGH (explodvar)
 	case OC_ex2_explodvar_anim:
 		fallthrough
@@ -10771,7 +10786,10 @@ const (
 	modifyStageVar_shadow_yscale
 	modifyStageVar_shadow_fade_range
 	modifyStageVar_shadow_xshear
+	modifyStageVar_shadow_offset
 	modifyStageVar_reflection_intensity
+	modifyStageVar_reflection_yscale
+	modifyStageVar_reflection_offset
 	modifyStageVar_redirectid
 )
 
@@ -10861,8 +10879,16 @@ func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 			s.sdw.fadebgn = exp[1].evalI(c)
 		case modifyStageVar_shadow_xshear:
 			s.sdw.xshear = exp[0].evalF(c)
+		case modifyStageVar_shadow_offset:
+			s.sdw.offset[0] = exp[0].evalF(c)
+			s.sdw.offset[1] = exp[1].evalF(c)
 		case modifyStageVar_reflection_intensity:
-			s.reflection = Clamp(exp[0].evalI(c), 0, 255)
+			s.reflection.intensity = Clamp(exp[0].evalI(c), 0, 255)
+		case modifyStageVar_reflection_yscale:
+			s.reflection.yscale = exp[0].evalF(c)
+		case modifyStageVar_reflection_offset:
+			s.reflection.offset[0] = exp[0].evalF(c)
+			s.reflection.offset[1] = exp[1].evalF(c)
 		case modifyStageVar_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				//crun = rid - RedirectID is useless when modifying a stage

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1524,7 +1524,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		ctype := c.token
 		switch ctype {
 		case "size":
-			bv1 = BytecodeInt(0)
+			bv1 = BytecodeInt(3)
 		case "clsn1":
 			bv1 = BytecodeInt(1)
 		case "clsn2":

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2813,8 +2813,18 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			opc = OC_const_stagevar_shadow_fade_range_end
 		case "shadow.xshear":
 			opc = OC_const_stagevar_shadow_xshear
+		case "shadow.offset.x":
+			opc = OC_const_stagevar_shadow_offset_x
+		case "shadow.offset.y":
+			opc = OC_const_stagevar_shadow_offset_y
 		case "reflection.intensity":
 			opc = OC_const_stagevar_reflection_intensity
+		case "reflection.yscale":
+			opc = OC_const_stagevar_reflection_yscale
+		case "reflection.offset.x":
+			opc = OC_const_stagevar_reflection_offset_x
+		case "reflection.offset.y":
+			opc = OC_const_stagevar_reflection_offset_y
 		default:
 			return bvNone(), Error("Invalid data: " + svname)
 		}

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -5116,8 +5116,20 @@ func (c *Compiler) modifyStageVar(is IniSection, sc *StateControllerBase, _ int8
 			modifyStageVar_shadow_xshear, VT_Float, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "shadow.offset",
+			modifyStageVar_shadow_offset, VT_Float, 2, false); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "reflection.intensity",
 			modifyStageVar_reflection_intensity, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "reflection.yscale",
+			modifyStageVar_reflection_yscale, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "reflection.offset",
+			modifyStageVar_reflection_offset, VT_Float, 2, false); err != nil {
 			return err
 		}
 		return nil

--- a/src/script.go
+++ b/src/script.go
@@ -785,6 +785,15 @@ func systemScriptInit(l *lua.LState) {
 		sys.fileInput = OpenFileInput(strArg(l, 1))
 		return 0
 	})
+	luaRegister(l, "entityMapSet", func(*lua.LState) int {
+		// map_name, value, map_type
+		var scType int32
+		if l.GetTop() >= 3 && strArg(l, 3) == "add" {
+			scType = 1
+		}
+		sys.debugWC.mapSet(strArg(l, 1), float32(numArg(l, 2)), scType)
+		return 0
+	})
 	luaRegister(l, "esc", func(l *lua.LState) int {
 		if l.GetTop() >= 1 {
 			sys.esc = boolArg(l, 1)

--- a/src/script.go
+++ b/src/script.go
@@ -4302,8 +4302,18 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LNumber(sys.stage.sdw.fadeend))
 		case "shadow.xshear":
 			l.Push(lua.LNumber(sys.stage.sdw.xshear))
+		case "shadow.offset.x":
+			l.Push(lua.LNumber(sys.stage.sdw.offset[0]))
+		case "shadow.offset.y":
+			l.Push(lua.LNumber(sys.stage.sdw.offset[1]))
 		case "reflection.intensity":
-			l.Push(lua.LNumber(sys.stage.reflection))
+			l.Push(lua.LNumber(sys.stage.reflection.intensity))
+		case "reflection.yscale":
+			l.Push(lua.LNumber(sys.stage.reflection.yscale))
+		case "reflection.offset.x":
+			l.Push(lua.LNumber(sys.stage.reflection.offset[0]))
+		case "reflection.offset.y":
+			l.Push(lua.LNumber(sys.stage.reflection.offset[1]))
 		default:
 			l.Push(lua.LString(""))
 		}

--- a/src/stage.go
+++ b/src/stage.go
@@ -1264,6 +1264,8 @@ func (s *Stage) copyStageVars(src *Stage) {
 	s.sdw.fadeend = src.sdw.fadeend
 	s.sdw.fadebgn = src.sdw.fadebgn
 	s.sdw.xshear = src.sdw.xshear
+	s.sdw.offset[0] = src.sdw.offset[0]
+	s.sdw.offset[1] = src.sdw.offset[1]
 	s.reflection.intensity = src.reflection.intensity
 	s.reflection.offset[0] = src.reflection.offset[0]
 	s.reflection.offset[1] = src.reflection.offset[1]

--- a/src/stage.go
+++ b/src/stage.go
@@ -695,6 +695,7 @@ type stageShadow struct {
 	fadeend   int32
 	fadebgn   int32
 	xshear    float32
+	offset    [2]float32
 }
 type stagePlayer struct {
 	startx, starty, startz int32
@@ -722,7 +723,7 @@ type Stage struct {
 	screenleft        int32
 	screenright       int32
 	zoffsetlink       int32
-	reflection        int32
+	reflection        stageShadow
 	reflectionlayerno int32
 	hires             bool
 	autoturn          bool
@@ -1132,6 +1133,7 @@ func loadStage(def string, main bool) (*Stage, error) {
 		sec[0].ReadBool("reflect", &reflect)
 		sec[0].readI32ForStage("fade.range", &s.sdw.fadeend, &s.sdw.fadebgn)
 		sec[0].ReadF32("xshear", &s.sdw.xshear)
+		sec[0].readF32ForStage("offset", &s.sdw.offset[0], &s.sdw.offset[1])
 	}
 	if reflect {
 		if sec = defmap[fmt.Sprintf("%v.reflection", sys.language)]; len(sec) > 0 {
@@ -1142,13 +1144,23 @@ func loadStage(def string, main bool) (*Stage, error) {
 			}
 		}
 		if sectionExists {
+			s.reflection.yscale = 1.0
 			sectionExists = false
 			var tmp int32
+			var tmp2 float32
+			var tmp3 [2]float32
 			if sec[0].ReadI32("intensity", &tmp) {
-				s.reflection = Clamp(tmp, 0, 255)
+				s.reflection.intensity = Clamp(tmp, 0, 255)
 			}
 			if sec[0].ReadI32("layerno", &tmp) {
 				s.reflectionlayerno = Clamp(tmp, -1, 0)
+			}
+			if sec[0].ReadF32("yscale", &tmp2) {
+				s.reflection.yscale = tmp2
+			}
+			if sec[0].readF32ForStage("offset", &tmp3[0], &tmp3[1]) {
+				s.reflection.offset[0] = tmp3[0]
+				s.reflection.offset[1] = tmp3[1]
 			}
 		}
 	}
@@ -1252,7 +1264,9 @@ func (s *Stage) copyStageVars(src *Stage) {
 	s.sdw.fadeend = src.sdw.fadeend
 	s.sdw.fadebgn = src.sdw.fadebgn
 	s.sdw.xshear = src.sdw.xshear
-	s.reflection = src.reflection
+	s.reflection.intensity = src.reflection.intensity
+	s.reflection.offset[0] = src.reflection.offset[0]
+	s.reflection.offset[1] = src.reflection.offset[1]
 }
 func (s *Stage) getBg(id int32) (bg []*backGround) {
 	if id >= 0 {

--- a/src/system.go
+++ b/src/system.go
@@ -1709,7 +1709,7 @@ func (s *System) draw(x, y, scl float32) {
 
 		// Draw reflections on layer -1
 		if !s.gsf(GSF_globalnoshadow) {
-			if s.stage.reflection > 0 && s.stage.reflectionlayerno < 0 {
+			if s.stage.reflection.intensity > 0 && s.stage.reflectionlayerno < 0 {
 				s.shadows.drawReflection(x, y, scl*s.cam.BaseScale())
 			}
 		}
@@ -1729,7 +1729,7 @@ func (s *System) draw(x, y, scl float32) {
 		// Draw reflections on layer 0
 		// TODO: Make shadows render in same layers as their sources?
 		if !s.gsf(GSF_globalnoshadow) {
-			if s.stage.reflection > 0 && s.stage.reflectionlayerno >= 0 {
+			if s.stage.reflection.intensity > 0 && s.stage.reflectionlayerno >= 0 {
 				s.shadows.drawReflection(x, y, scl*s.cam.BaseScale())
 			}
 			s.shadows.draw(x, y, scl*s.cam.BaseScale())


### PR DESCRIPTION
This feature gives users more control over the reflections and shadows in stages by introducing offsets to all, and making reflection use the same struct that stores shadows.

Additions:
* Adds yscale to reflection:
* Adds offset to shadow and reflection (goes at very end)
e.g.
```
[Reflection]
 ;Intensity of reflection (from 0 to 256). Set to 0 to have no
 ;reflection. Defaults to 0.
intensity = 100
yscale = -1.0      ; reflect up
offset = -20,-60   ; offset by -20 x, -60 y
```
* Adds the necessary parameters to ModifyStageVar and StageVar

Fixes:
* Mostly fixes the shear offsets for stage shadows (rotation TODO)
* Fixes CLSNVar Size parameter not working properly.
* Fixes CLSNVar local scale.