### PR TITLE
fix: motif.lua nil reference

### DIFF
--- a/external/script/motif.lua
+++ b/external/script/motif.lua
@@ -2777,28 +2777,34 @@ function motif.f_start()
 				end
 				if subt_k == 'teammenu' then
 					for i = 1, 2 do
-						motif.f_loadSprData(real_t, {
-							s = 'p' .. i .. '_' .. subt_k .. '_bg_' .. v .. '_',
-							x = real_t['p' .. i .. '_teammenu_pos'][1],
-							y = real_t['p' .. i .. '_teammenu_pos'][2]
-						})
-						motif.f_loadSprData(real_t, {
-							s = 'p' .. i .. '_' .. subt_k .. '_bg_active_' .. v .. '_',
-							x = real_t['p' .. i .. '_teammenu_pos'][1],
-							y = real_t['p' .. i .. '_teammenu_pos'][2]
-						})
+						local teammenu_pos = real_t['p' .. i .. '_teammenu_pos']
+						if teammenu_pos ~= nil then
+							motif.f_loadSprData(real_t, {
+								s = 'p' .. i .. '_' .. subt_k .. '_bg_' .. v .. '_',
+								x = teammenu_pos[1],
+								y = teammenu_pos[2]
+							})
+							motif.f_loadSprData(real_t, {
+								s = 'p' .. i .. '_' .. subt_k .. '_bg_active_' .. v .. '_',
+								x = teammenu_pos[1],
+								y = teammenu_pos[2]
+							})
+						end
 					end
 				else--if subt_k == 'menu' or subt_k == 'keymenu' then
-					motif.f_loadSprData(real_t, {
-						s = subt_k .. '_bg_' .. v .. '_',
-						x = real_t.menu_pos[1],
-						y = real_t.menu_pos[2]
-					})
-					motif.f_loadSprData(real_t, {
-						s = subt_k .. '_bg_active_' .. v .. '_',
-						x = real_t.menu_pos[1],
-						y = real_t.menu_pos[2]
-					})
+					local menu_pos = real_t.menu_pos
+					if menu_pos ~= nil then
+						motif.f_loadSprData(real_t, {
+							s = subt_k .. '_bg_' .. v .. '_',
+							x = menu_pos[1],
+							y = menu_pos[2]
+						})
+						motif.f_loadSprData(real_t, {
+							s = subt_k .. '_bg_active_' .. v .. '_',
+							x = menu_pos[1],
+							y = menu_pos[2]
+						})
+					end
 				end
 			end
 		end


### PR DESCRIPTION
When the motif has a section without `menu.pos` or `p<n>.teammenu.pos`, Lua throws a nil error; this can happen when a language section doesn't have these parameters.

This PR fixes that by adding nil checks around the `f_loadSprData` calls.