### PR TITLE
feat: Added ShadowOffset SCTRL, fix: CLSNVar, ExplodVar, ProjVar LocalCoord

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -2889,7 +2889,7 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 				v = cf2[idx*4]
 			}
 		}
-		sys.bcStack.PushF(v * c.localscl)
+		sys.bcStack.PushF(v * (c.localscl / oc.localscl))
 	case OC_ex2_clsnvar_top:
 		idx := int(sys.bcStack.Pop().ToI())
 		id := int(sys.bcStack.Pop().ToI())
@@ -2908,7 +2908,7 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 				v = cf2[idx*4+1]
 			}
 		}
-		sys.bcStack.PushF(v * c.localscl)
+		sys.bcStack.PushF(v * (c.localscl / oc.localscl))
 	case OC_ex2_clsnvar_right:
 		idx := int(sys.bcStack.Pop().ToI())
 		id := int(sys.bcStack.Pop().ToI())
@@ -2927,7 +2927,7 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 				v = cf2[idx*4+2]
 			}
 		}
-		sys.bcStack.PushF(v * c.localscl)
+		sys.bcStack.PushF(v * (c.localscl / oc.localscl))
 	case OC_ex2_clsnvar_bottom:
 		idx := int(sys.bcStack.Pop().ToI())
 		id := int(sys.bcStack.Pop().ToI())
@@ -2946,7 +2946,7 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 				v = cf2[idx*4+3]
 			}
 		}
-		sys.bcStack.PushF(v * c.localscl)
+		sys.bcStack.PushF(v * (c.localscl / oc.localscl))
 	// BEGIN FALLTHROUGH (explodvar)
 	case OC_ex2_explodvar_anim:
 		fallthrough
@@ -4431,6 +4431,38 @@ func (sc velMul) Run(c *Char, _ []int32) bool {
 			} else {
 				exp[0].run(c)
 			}
+		case posSet_redirectid:
+			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
+				crun = rid
+			} else {
+				return false
+			}
+		}
+		return true
+	})
+	return false
+}
+
+type shadowOffset posSet
+
+const (
+	shadowoffset_reflection = iota + posSet_redirectid + 1
+)
+
+func (sc shadowOffset) Run(c *Char, _ []int32) bool {
+	crun := c
+	isReflect := false
+	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
+		switch id {
+		case shadowoffset_reflection:
+			isReflect = exp[0].evalB(c)
+		case posSet_x:
+			crun.shadXOff(exp[0].evalF(c), isReflect)
+		case posSet_y:
+			crun.shadYOff(exp[0].evalF(c), isReflect)
+		case posSet_z:
+			// the Y offset is all that's needed
+			exp[0].run(c)
 		case posSet_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -2293,7 +2293,7 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_gethitvar_down_recover:
 		sys.bcStack.PushB(c.ghv.down_recover)
 	case OC_ex_gethitvar_xaccel:
-		sys.bcStack.PushF(c.ghv.getXaccel(oc) * c.facing * (c.localscl / oc.localscl))
+		sys.bcStack.PushF(c.ghv.getXaccel(oc) * (c.localscl / oc.localscl))
 	case OC_ex_ailevelf:
 		if !c.asf(ASF_noailevel) {
 			sys.bcStack.PushF(c.aiLevel())

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -2767,6 +2767,7 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	(*i)++
 	opc := be[*i-1]
+	correctScale := false
 	switch opc {
 	case OC_ex2_index:
 		sys.bcStack.PushI(c.index)
@@ -2948,6 +2949,24 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		}
 		sys.bcStack.PushF(v * (c.localscl / oc.localscl))
 	// BEGIN FALLTHROUGH (explodvar)
+	case OC_ex2_explodvar_pos_x:
+		correctScale = true
+		fallthrough
+	case OC_ex2_explodvar_pos_y:
+		correctScale = true
+		fallthrough
+	case OC_ex2_explodvar_vel_x:
+		correctScale = true
+		fallthrough
+	case OC_ex2_explodvar_vel_y:
+		correctScale = true
+		fallthrough
+	case OC_ex2_explodvar_accel_x:
+		correctScale = true
+		fallthrough
+	case OC_ex2_explodvar_accel_y:
+		correctScale = true
+		fallthrough
 	case OC_ex2_explodvar_anim:
 		fallthrough
 	case OC_ex2_explodvar_animelem:
@@ -2958,33 +2977,61 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		fallthrough
 	case OC_ex2_explodvar_sprpriority:
 		fallthrough
-	case OC_ex2_explodvar_pos_x:
-		fallthrough
-	case OC_ex2_explodvar_pos_y:
-		fallthrough
 	case OC_ex2_explodvar_scale_x:
 		fallthrough
 	case OC_ex2_explodvar_scale_y:
-		fallthrough
-	case OC_ex2_explodvar_vel_x:
-		fallthrough
-	case OC_ex2_explodvar_vel_y:
-		fallthrough
-	case OC_ex2_explodvar_accel_x:
 		fallthrough
 	case OC_ex2_explodvar_angle:
 		fallthrough
 	case OC_ex2_explodvar_angle_x:
 		fallthrough
-	case OC_ex2_explodvar_angle_y:
-		fallthrough
 	// END FALLTHROUGH (explodvar)
-	case OC_ex2_explodvar_accel_y:
+	case OC_ex2_explodvar_angle_y:
 		idx := sys.bcStack.Pop()
 		id := sys.bcStack.Pop()
 		v := c.explodVar(id, idx, opc)
-		sys.bcStack.Push(v)
+		if correctScale {
+			sys.bcStack.PushF(v.ToF() * (c.localscl / oc.localscl))
+		} else {
+			sys.bcStack.Push(v)
+		}
 	// BEGIN FALLTHROUGH (projvar)
+	case OC_ex2_projectilevar_accel_x:
+		correctScale = true
+		fallthrough
+	case OC_ex2_projectilevar_accel_y:
+		correctScale = true
+		fallthrough
+	case OC_ex2_projectilevar_pos_x:
+		correctScale = true
+		fallthrough
+	case OC_ex2_projectilevar_pos_y:
+		correctScale = true
+		fallthrough
+	case OC_ex2_projectilevar_vel_x:
+		correctScale = true
+		fallthrough
+	case OC_ex2_projectilevar_vel_y:
+		correctScale = true
+		fallthrough
+	case OC_ex2_projectilevar_projstagebound:
+		correctScale = true
+		fallthrough
+	case OC_ex2_projectilevar_projedgebound:
+		correctScale = true
+		fallthrough
+	case OC_ex2_projectilevar_lowbound:
+		correctScale = true
+		fallthrough
+	case OC_ex2_projectilevar_highbound:
+		correctScale = true
+		fallthrough
+	case OC_ex2_projectilevar_remvelocity_x:
+		correctScale = true
+		fallthrough
+	case OC_ex2_projectilevar_remvelocity_y:
+		correctScale = true
+		fallthrough
 	case OC_ex2_projectilevar_projremove:
 		fallthrough
 	case OC_ex2_projectilevar_projremovetime:
@@ -3007,21 +3054,9 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		fallthrough
 	case OC_ex2_projectilevar_projcancelanim:
 		fallthrough
-	case OC_ex2_projectilevar_vel_x:
-		fallthrough
-	case OC_ex2_projectilevar_vel_y:
-		fallthrough
 	case OC_ex2_projectilevar_velmul_x:
 		fallthrough
 	case OC_ex2_projectilevar_velmul_y:
-		fallthrough
-	case OC_ex2_projectilevar_remvelocity_x:
-		fallthrough
-	case OC_ex2_projectilevar_remvelocity_y:
-		fallthrough
-	case OC_ex2_projectilevar_accel_x:
-		fallthrough
-	case OC_ex2_projectilevar_accel_y:
 		fallthrough
 	case OC_ex2_projectilevar_projscale_x:
 		fallthrough
@@ -3029,19 +3064,7 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		fallthrough
 	case OC_ex2_projectilevar_projangle:
 		fallthrough
-	case OC_ex2_projectilevar_pos_x:
-		fallthrough
-	case OC_ex2_projectilevar_pos_y:
-		fallthrough
 	case OC_ex2_projectilevar_projsprpriority:
-		fallthrough
-	case OC_ex2_projectilevar_projstagebound:
-		fallthrough
-	case OC_ex2_projectilevar_projedgebound:
-		fallthrough
-	case OC_ex2_projectilevar_lowbound:
-		fallthrough
-	case OC_ex2_projectilevar_highbound:
 		fallthrough
 	case OC_ex2_projectilevar_projanim:
 		fallthrough
@@ -3054,7 +3077,11 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		idx := sys.bcStack.Pop()
 		id := sys.bcStack.Pop()
 		v := c.projVar(id, idx, opc)
-		sys.bcStack.Push(v)
+		if correctScale {
+			sys.bcStack.PushF(v.ToF() * (c.localscl / oc.localscl))
+		} else {
+			sys.bcStack.Push(v)
+		}
 	default:
 		sys.errLog.Printf("%v\n", be[*i-1])
 		c.panic()

--- a/src/char.go
+++ b/src/char.go
@@ -5048,6 +5048,7 @@ func (c *Char) setFacing(f float32) {
 			c.vel[0] *= -1
 			// Flip gethitvars on x axis
 			c.ghv.xvel *= -1
+			c.ghv.xaccel *= -1
 			c.ghv.ground_velocity[0] *= -1
 			c.ghv.air_velocity[0] *= -1
 			c.ghv.down_velocity[0] *= -1
@@ -8026,7 +8027,7 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 				ghv.hitid = hd.id
 				ghv.playerNo = hd.playerNo
 				ghv.id = hd.attackerID
-				ghv.xaccel = hd.xaccel * (c.localscl / getter.localscl) * getter.facing
+				ghv.xaccel = hd.xaccel * (c.localscl / getter.localscl)
 				ghv.yaccel = hd.yaccel * (c.localscl / getter.localscl)
 				ghv.groundtype = hd.ground_type
 				ghv.airtype = hd.air_type

--- a/src/char.go
+++ b/src/char.go
@@ -8026,7 +8026,7 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 				ghv.hitid = hd.id
 				ghv.playerNo = hd.playerNo
 				ghv.id = hd.attackerID
-				ghv.xaccel = hd.xaccel * (c.localscl / getter.localscl)
+				ghv.xaccel = hd.xaccel * (c.localscl / getter.localscl) * getter.facing
 				ghv.yaccel = hd.yaccel * (c.localscl / getter.localscl)
 				ghv.groundtype = hd.ground_type
 				ghv.airtype = hd.air_type

--- a/src/char.go
+++ b/src/char.go
@@ -1083,7 +1083,7 @@ func (ai *AfterImage) recAndCue(sd *SprData, rec bool, hitpause bool, layer int3
 			ai.palfx[i/ai.framegap-1].remap = sd.fx.remap
 			sprs.add(&SprData{&img.anim, &ai.palfx[i/ai.framegap-1], img.pos,
 				img.scl, ai.alpha, sd.priority - 2, img.rot, img.ascl,
-				false, sd.bright, sd.oldVer, sd.facing, sd.posLocalscl, img.projection, img.fLength, sd.window}, 0, 0, 0, 0)
+				false, sd.bright, sd.oldVer, sd.facing, sd.posLocalscl, img.projection, img.fLength, sd.window}, 0, 0, [2]float32{0, 0}, [2]float32{0, 0}, 0, 0)
 		}
 	}
 	if rec || hitpause && ai.ignorehitpause {
@@ -1402,7 +1402,7 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 	sprs.add(&SprData{e.anim, pfx, e.drawPos, [...]float32{(facing * scale[0]) * e.localscl,
 		(e.vfacing * scale[1]) * e.localscl}, alp, e.sprpriority, rot, [...]float32{1, 1},
 		e.space == Space_screen, playerNo == sys.superplayer, oldVer, facing, 1, int32(e.projection), fLength, ewin},
-		e.shadow[0]<<16|e.shadow[1]&0xff<<8|e.shadow[2]&0xff, sdwalp, 0, 0)
+		e.shadow[0]<<16|e.shadow[1]&0xff<<8|e.shadow[2]&0xff, sdwalp, [2]float32{0, 0}, [2]float32{0, 0}, 0, 0)
 	if sys.tickNextFrame() {
 
 		//if e.space == Space_screen && e.bindtime == 0 {
@@ -1836,13 +1836,14 @@ func (p *Projectile) cueDraw(oldVer bool, playerNo int) {
 	} else if p.layerno < 0 {
 		sprs = &sys.spritesLayerN1
 	}
+	var c = sys.chars[playerNo][0]
 	if p.ani != nil {
 		sd := &SprData{p.ani, p.palfx, [...]float32{p.pos[0] * p.localscl, p.pos[1] * p.localscl},
 			[...]float32{p.facing * p.scale[0] * p.localscl, p.scale[1] * p.localscl}, [2]int32{-1},
 			p.sprpriority, Rotation{p.facing * p.angle, 0, 0}, [...]float32{1, 1}, false, playerNo == sys.superplayer,
 			sys.cgi[playerNo].mugenver[0] != 1, p.facing, 1, 0, 0, [4]float32{0, 0, 0, 0}}
 		p.aimg.recAndCue(sd, sys.tickNextFrame() && notpause, false, p.layerno)
-		sprs.add(sd, p.shadow[0]<<16|p.shadow[1]&255<<8|p.shadow[2]&255, 256, 0, 0)
+		sprs.add(sd, p.shadow[0]<<16|p.shadow[1]&255<<8|p.shadow[2]&255, 256, c.shadowOffset, c.reflectOffset, 0, 0)
 	}
 }
 
@@ -2109,6 +2110,8 @@ type Char struct {
 	koEchoTime      int32
 	groundLevel     float32
 	sizeBox         []float32
+	shadowOffset    [2]float32
+	reflectOffset   [2]float32
 }
 
 func newChar(n int, idx int32) (c *Char) {
@@ -4639,6 +4642,20 @@ func (c *Char) mulYV(yv float32) {
 }
 func (c *Char) mulZV(zv float32) {
 	c.vel[2] *= zv
+}
+func (c *Char) shadXOff(xv float32, isReflect bool) {
+	if !isReflect {
+		c.shadowOffset[0] = xv
+	} else {
+		c.reflectOffset[0] = xv
+	}
+}
+func (c *Char) shadYOff(yv float32, isReflect bool) {
+	if !isReflect {
+		c.shadowOffset[1] = yv
+	} else {
+		c.reflectOffset[1] = yv
+	}
 }
 
 // --------------------
@@ -7608,7 +7625,7 @@ func (c *Char) cueDraw() {
 			if c.csf(CSF_trans) {
 				sa = 255 - c.alpha[1]
 			}
-			sprs.add(sd, sc, sa, float32(c.size.shadowoffset), c.offsetY())
+			sprs.add(sd, sc, sa, c.shadowOffset, c.reflectOffset, c.size.shadowoffset, c.offsetY())
 		}
 	}
 	if sys.tickNextFrame() {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -169,6 +169,7 @@ func newCompiler() *Compiler {
 		"roundtimeset":         c.roundTimeSet,
 		"savefile":             c.saveFile,
 		"scoreadd":             c.scoreAdd,
+		"shadowoffset":         c.shadowOffset,
 		"tagin":                c.tagIn,
 		"tagout":               c.tagOut,
 		"targetadd":            c.targetAdd,

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1570,10 +1570,13 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			be1.append(OC_jz8, OpCode(len(be2)+1))
 		}
 		be1.append(be2...)
-		be1.append(OC_ex2_, opc)
 		if rd {
-			out.appendI32Op(OC_run, int32(len(be1)))
+			out.appendI32Op(OC_nordrun, int32(len(be1)))
 		}
+		// Just in case anybody else bangs their head against a wall with redirects:
+		// it is imperative that the be1.append(opcodetype, opcode) comes after the
+		// rd out.appendI32Op(OC_nordrun, int32(len(be1)))
+		be1.append(OC_ex2_, opc)
 		out.append(be1...)
 	case "command", "selfcommand":
 		opc := OC_command
@@ -1962,10 +1965,13 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			be1.append(OC_jz8, OpCode(len(be2)+1))
 		}
 		be1.append(be2...)
-		be1.append(OC_ex2_, opc)
 		if rd {
-			out.appendI32Op(OC_run, int32(len(be1)))
+			out.appendI32Op(OC_nordrun, int32(len(be1)))
 		}
+		// Just in case anybody else bangs their head against a wall with redirects:
+		// it is imperative that the be1.append(opcodetype, opcode) comes after the
+		// rd out.appendI32Op(OC_nordrun, int32(len(be1)))
+		be1.append(OC_ex2_, opc)
 		out.append(be1...)
 	case "facing":
 		out.append(OC_facing)
@@ -2622,10 +2628,13 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			be1.append(OC_jz8, OpCode(len(be2)+1))
 		}
 		be1.append(be2...)
-		be1.append(OC_ex2_, opc)
 		if rd {
-			out.appendI32Op(OC_run, int32(len(be1)))
+			out.appendI32Op(OC_nordrun, int32(len(be1)))
 		}
+		// Just in case anybody else bangs their head against a wall with redirects:
+		// it is imperative that the be1.append(opcodetype, opcode) comes after the
+		// rd out.appendI32Op(OC_nordrun, int32(len(be1)))
+		be1.append(OC_ex2_, opc)
 		out.append(be1...)
 	case "random":
 		out.append(OC_random)

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1073,6 +1073,20 @@ func (c *Compiler) velMul(is IniSection, sc *StateControllerBase, _ int8) (State
 	})
 	return *ret, err
 }
+func (c *Compiler) shadowOffset(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+	ret, err := (*shadowOffset)(sc), c.stateSec(is, func() error {
+		if err := c.paramValue(is, sc, "redirectid",
+			posSet_redirectid, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "reflection",
+			shadowoffset_reflection, VT_Bool, 1, false); err != nil {
+			return err
+		}
+		return c.posSetSub(is, sc)
+	})
+	return *ret, err
+}
 func (c *Compiler) palFXSub(is IniSection,
 	sc *StateControllerBase, prefix string) error {
 	if err := c.paramValue(is, sc, prefix+"time",

--- a/src/system.go
+++ b/src/system.go
@@ -1619,7 +1619,7 @@ func (s *System) action() {
 	if s.superanim != nil {
 		s.spritesLayer1.add(&SprData{s.superanim, &s.superpmap, s.superpos,
 			[...]float32{s.superfacing, 1}, [2]int32{-1}, 5, Rotation{}, [2]float32{},
-			false, true, s.cgi[s.superplayer].mugenver[0] != 1, 1, 1, 0, 0, [4]float32{0, 0, 0, 0}}, 0, 0, 0, 0)
+			false, true, s.cgi[s.superplayer].mugenver[0] != 1, 1, 1, 0, 0, [4]float32{0, 0, 0, 0}}, 0, 0, [2]float32{0, 0}, [2]float32{0, 0}, 0, 0)
 		if s.superanim.loopend {
 			s.superanim = nil
 		}


### PR DESCRIPTION
New feature: ShadowOffset SCTRL. Use `reflection = 1` to affect reflections instead.

Usage example (ZSS):
```sh
[Statedef +1]
for i=0; numPlayer; 1 {
    # Hide reflection when outside the water region
    if (player($i), Pos X + player($i), cameraPos X) < 245 {
        shadowOffset { reflection: 1; y: -9000; redirectID: player($i), ID; }
    # Normal
    } else {
        shadowOffset { reflection: 1; y: 0; redirectID: player($i), ID; }
    }
}
```


Fixes:
* CLSNVar apparently still had issues with localcoord (always converting to 240p). ExplodVar and ProjVar's fields that needed to be converted to LocalCoord now do so. This was a tricky one so I left comments so that anyone else attempting the same in the future doesn't get stuck on what I did.
* GetHitVar(xaccel) sign-flipping on each frame fixed