### PR TITLE
fix: Fixes debug logging on MacOS

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -197,7 +197,7 @@ end
 function main.f_exists(file)
 	local ok, err, code = os.rename(file, file)
 	if not ok then
-		if code == 13 then
+		if code == 13 or string.match(err, "file exists") then
 			--permission denied, but it exists
 			return true
 		end


### PR DESCRIPTION
This small change to main.lua fixes debug logging on MacOS - error codes from `os.rename` are not properly reported on MacOS, which was leading to Ikemen not writing the Lua tables to the debug folder. However, the error string still contains the correct information to proceed. This small change fixes this issue.