### PR TITLE
feat: Collisions Rotation feat and Text sctr/Debug text blend mode inverse bug fix

### DIFF
--- a/src/anim.go
+++ b/src/anim.go
@@ -944,6 +944,7 @@ func (dl DrawList) draw(x, y, scl float32) {
 		}
 		sys.brightness = ob
 	}
+	BlendReset()
 }
 
 type ShadowSprite struct {
@@ -1083,7 +1084,6 @@ func (sl ShadowList) drawReflection(x, y, scl float32) {
 					(s.pos[1]-s.reflectOffset[1]-offsetY), scl, scl, s.scl[0], s.scl[0], -s.scl[1]*sys.stage.reflection.yscale, 0,
 				s.rot, float32(sys.gameWidth)/2, s.fx, s.oldVer, s.facing, true, s.posLocalscl, s.projection, s.fLength)
 		}
-
 	}
 }
 

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6102,6 +6102,7 @@ const (
 	projectile_projscale
 	projectile_projangle
 	projectile_projrescaleclsn
+	projectile_projrotateclsn
 	projectile_offset
 	projectile_projsprpriority
 	projectile_projlayerno
@@ -6130,6 +6131,7 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 	var x, y float32 = 0, 0
 	op := false
 	rc := false
+	ran := false
 	rp := [...]int32{-1, 0}
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		if p == nil {
@@ -6276,6 +6278,8 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 		// 	p.platformAngle = exp[0].evalF(c)
 		// case projectile_platformfence:
 		// 	p.platformFence = exp[0].evalB(c)
+		case projectile_projrotateclsn:
+			ran = exp[0].evalB(c)
 		default:
 			if !hitDef(sc).runSub(c, &p.hitdef, id, exp) {
 				afterImage(sc).runSub(c, &p.aimg, id, exp)
@@ -6306,7 +6310,7 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 	} else {
 		p.localscl = crun.localscl
 	}
-	crun.projInit(p, pt, x, y, op, rp[0], rp[1], rc)
+	crun.projInit(p, pt, x, y, op, rp[0], rp[1], rc, ran)
 	return false
 }
 
@@ -8115,6 +8119,7 @@ const (
 	angleDraw_value byte = iota
 	angleDraw_scale
 	angleDraw_rescaleClsn
+	angleDraw_rotateClsn
 	angleDraw_redirectid
 )
 
@@ -8135,6 +8140,11 @@ func (sc angleDraw) Run(c *Char, _ []int32) bool {
 			if exp[0].evalB(c) {
 				crun.angleRescaleClsn = true
 				crun.updateClsnScale()
+			}
+		case angleDraw_rotateClsn:
+			if exp[0].evalB(c) {
+				crun.angleRotateClsn = true
+				crun.updateClsnAngle()
 			}
 		case angleDraw_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {

--- a/src/char.go
+++ b/src/char.go
@@ -192,6 +192,7 @@ func (cr ClsnRect) draw(trans int32) {
 		}
 		RenderSprite(params)
 	}
+
 }
 
 type CharData struct {
@@ -1492,7 +1493,12 @@ func (e *Explod) Interpolate(act bool, scale *[2]float32, alpha *[2]int32, angle
 		if i < 2 {
 			(*scale)[i] = e.interpolate_scale[i] * e.scale[i]
 			if e.blendmode == 1 {
-				(*alpha)[i] = int32(float32(e.interpolate_alpha[i]) * (float32(e.alpha[i]) / 255))
+				if (*alpha)[0] == 1 && (*alpha)[1] == 255 {
+					(*alpha)[0] = 0
+				} else {
+					(*alpha)[i] = int32(float32(e.interpolate_alpha[i]) * (float32(e.alpha[i]) / 255))
+				}
+
 			}
 		}
 		(*anglerot)[i] = e.interpolate_angle[i] + e.anglerot[i]

--- a/src/char.go
+++ b/src/char.go
@@ -164,23 +164,20 @@ type ClsnText struct {
 	r, g, b int32
 }
 
-type ClsnRect [][4]float32
+type ClsnRect [][7]float32
 
-func (cr *ClsnRect) Add(clsn []float32, x, y, xs, ys float32) {
+func (cr *ClsnRect) Add(clsn []float32, x, y, xs, ys, angle float32) {
 	x = (x - sys.cam.Pos[0]) * sys.cam.Scale
 	y = (y*sys.cam.Scale - sys.cam.Pos[1]) + sys.cam.GroundLevel()
 	xs *= sys.cam.Scale
 	ys *= sys.cam.Scale
 	for i := 0; i+3 < len(clsn); i += 4 {
-		rect := [...]float32{x + xs*clsn[i] + float32(sys.gameWidth)/2,
-			y + ys*clsn[i+1] + float32(sys.gameHeight-240),
-			xs * (clsn[i+2] - clsn[i]), ys * (clsn[i+3] - clsn[i+1])}
-		if xs < 0 {
-			rect[0] *= -1
-		}
-		if ys < 0 {
-			rect[1] *= -1
-		}
+		offx := (float32(sys.gameWidth)/2)
+		offy := (float32(sys.gameHeight-240))
+		rect := [...]float32{
+			AbsF(xs)*clsn[i],AbsF(ys)*clsn[i+1] ,
+			xs*(clsn[i+2] - clsn[i]),ys*(clsn[i+3] - clsn[i+1]),
+			(x+offx)*sys.widthScale, (y+offy)*sys.heightScale,angle}
 		*cr = append(*cr, rect)
 	}
 }
@@ -189,9 +186,9 @@ func (cr ClsnRect) draw(trans int32) {
 	for _, c := range cr {
 		params := RenderParams{
 			sys.clsnSpr.Tex, paltex, sys.clsnSpr.Size,
-			-c[0] * sys.widthScale, -c[1] * sys.heightScale, notiling,
-			c[2] * sys.widthScale, c[2] * sys.widthScale, c[3] * sys.heightScale, 1, 0,
-			1, 1, Rotation{}, 0, trans, -1, nil, &sys.scrrect, 0, 0, 0, 0, 0, 0,
+			-c[0]*sys.widthScale, -c[1]*sys.heightScale, notiling,
+			c[2]*sys.widthScale , c[2]*sys.widthScale , c[3]*sys.heightScale , 1, 0,
+			1, 1, Rotation{c[6],0,0}, 0, trans, -1, nil, &sys.scrrect, c[4], c[5], 0, 0, 0, 0,
 		}
 		RenderSprite(params)
 	}
@@ -1576,6 +1573,7 @@ type Projectile struct {
 	scale           [2]float32
 	angle           float32
 	clsnScale       [2]float32
+	clsnAngle       float32
 	remove          bool
 	removetime      int32
 	velocity        [2]float32
@@ -1630,6 +1628,7 @@ func (p *Projectile) clear() {
 		cancelanim:     IErr,
 		scale:          [...]float32{1, 1},
 		clsnScale:      [...]float32{1, 1},
+		clsnAngle:      0,
 		remove:         true,
 		localscl:       1,
 		removetime:     -1,
@@ -1822,9 +1821,9 @@ func (p *Projectile) tradeDetection(playerNo, index int) {
 			clsn2 := pr.ani.CurrentFrame().Clsn2()
 			if clsn1 != nil && clsn2 != nil {
 				if sys.clsnOverlap(clsn1, [...]float32{p.clsnScale[0] * p.localscl, p.clsnScale[1] * p.localscl},
-					[...]float32{p.pos[0] * p.localscl, p.pos[1] * p.localscl}, p.facing,
+					[...]float32{p.pos[0] * p.localscl, p.pos[1] * p.localscl}, p.facing, p.clsnAngle,
 					clsn2, [...]float32{pr.clsnScale[0] * p.localscl, pr.clsnScale[1] * p.localscl},
-					[...]float32{pr.pos[0] * pr.localscl, pr.pos[1] * pr.localscl}, pr.facing) {
+					[...]float32{pr.pos[0] * pr.localscl, pr.pos[1] * pr.localscl}, pr.facing, p.clsnAngle) {
 					// Subtract projectile hits from each other
 					pp := p.priorityPoints
 					opp := &sys.projs[i][j]
@@ -1884,10 +1883,10 @@ func (p *Projectile) cueDraw(oldVer bool, playerNo int) {
 		if frm := p.ani.drawFrame(); frm != nil {
 			xs := p.clsnScale[0] * p.localscl * p.facing
 			if clsn := frm.Clsn1(); len(clsn) > 0 {
-				sys.debugc1hit.Add(clsn, p.pos[0]*p.localscl, p.pos[1]*p.localscl, xs, p.clsnScale[1]*p.localscl)
+				sys.debugc1hit.Add(clsn, p.pos[0]*p.localscl, p.pos[1]*p.localscl, xs, p.clsnScale[1]*p.localscl, p.clsnAngle)
 			}
 			if clsn := frm.Clsn2(); len(clsn) > 0 {
-				sys.debugc2hb.Add(clsn, p.pos[0]*p.localscl, p.pos[1]*p.localscl, xs, p.clsnScale[1]*p.localscl)
+				sys.debugc2hb.Add(clsn, p.pos[0]*p.localscl, p.pos[1]*p.localscl, xs, p.clsnScale[1]*p.localscl, p.clsnAngle)
 			}
 		}
 	}
@@ -2053,6 +2052,7 @@ type CharSystemVar struct {
 	angleScale        [2]float32
 	angleScaleTrg     [2]float32
 	angleRescaleClsn  bool
+	angleRotateClsn   bool
 	alpha             [2]int32
 	alphaTrg          [2]int32
 	systemFlag        SystemCharFlag
@@ -2113,6 +2113,7 @@ type Char struct {
 	animlocalscl        float32
 	size                CharSize
 	clsnScale           [2]float32
+	clsnAngle           float32
 	hitdef              HitDef
 	ghv                 GetHitVar
 	mhv                 MoveHitVar
@@ -4798,7 +4799,7 @@ func (c *Char) newProj() *Projectile {
 	return nil
 }
 func (c *Char) projInit(p *Projectile, pt PosType, x, y float32,
-	op bool, rpg, rpn int32, rc bool) {
+	op bool, rpg, rpn int32, rc bool, ran bool) {
 	p.setPos(c.helperPos(pt, [...]float32{x, y}, 1, &p.facing, p.localscl, true))
 	p.parentAttackmul = c.attackMul
 	if p.anim < -1 {
@@ -4823,6 +4824,11 @@ func (c *Char) projInit(p *Projectile, pt PosType, x, y float32,
 		p.clsnScale = p.scale
 	} else {
 		p.clsnScale = c.clsnScale
+	}
+	if ran { // ProjRotateClsn
+		p.clsnAngle = p.angle
+	} else {
+		p.clsnAngle = c.clsnAngle
 	}
 	if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
 		p.hitdef.chainid = -1
@@ -5009,6 +5015,14 @@ func (c *Char) updateClsnScale() {
 	if c.angleRescaleClsn {
 		c.clsnScale[0] *= c.angleScale[0]
 		c.clsnScale[1] *= c.angleScale[1]
+	}
+}
+
+func (c *Char) updateClsnAngle() {
+	if c.angleRotateClsn {
+		c.clsnAngle = c.angle
+	} else {
+		c.clsnAngle = 0
 	}
 }
 
@@ -6539,10 +6553,10 @@ func (c *Char) projClsnCheck(p *Projectile, cbox, pbox int32) bool {
 	}
 
 	return sys.clsnOverlap(clsn1, [...]float32{p.clsnScale[0] * p.localscl, p.clsnScale[1] * p.localscl},
-		[...]float32{p.pos[0] * p.localscl, p.pos[1] * p.localscl}, p.facing,
+		[...]float32{p.pos[0] * p.localscl, p.pos[1] * p.localscl}, p.facing, p.clsnAngle,
 		clsn2, [...]float32{c.clsnScale[0] * c.animlocalscl, c.clsnScale[1] * c.animlocalscl},
 		[...]float32{c.pos[0]*c.localscl + c.offsetX()*c.localscl,
-			c.pos[1]*c.localscl + c.offsetY()*c.localscl}, c.facing)
+			c.pos[1]*c.localscl + c.offsetY()*c.localscl}, c.facing, c.clsnAngle)
 }
 
 func (c *Char) clsnCheck(getter *Char, cbox, gbox int32) bool {
@@ -6597,10 +6611,10 @@ func (c *Char) clsnCheck(getter *Char, cbox, gbox int32) bool {
 
 	return sys.clsnOverlap(clsn1, [...]float32{c.clsnScale[0] * c.animlocalscl, c.clsnScale[1] * c.animlocalscl},
 		[...]float32{c.pos[0]*c.localscl + c.offsetX()*c.localscl,
-			c.pos[1]*c.localscl + c.offsetY()*c.localscl}, c.facing,
+			c.pos[1]*c.localscl + c.offsetY()*c.localscl}, c.facing, c.clsnAngle,
 		clsn2, [...]float32{getter.clsnScale[0] * getter.animlocalscl, getter.clsnScale[1] * getter.animlocalscl},
 		[...]float32{getter.pos[0]*getter.localscl + getter.offsetX()*getter.localscl,
-			getter.pos[1]*getter.localscl + getter.offsetY()*getter.localscl}, getter.facing)
+			getter.pos[1]*getter.localscl + getter.offsetY()*getter.localscl}, getter.facing, getter.clsnAngle)
 }
 
 // Check if Hitdef attributes can hit a player
@@ -6881,6 +6895,10 @@ func (c *Char) actionPrepare() {
 		if c.angleRescaleClsn {
 			c.angleRescaleClsn = false
 			c.updateClsnScale()
+		}
+		if c.angleRotateClsn {
+			c.angleRotateClsn = false
+			c.updateClsnAngle()
 		}
 	}
 	// Decrease unhittable timer
@@ -7507,8 +7525,9 @@ func (c *Char) cueDraw() {
 	y := c.pos[1] * c.localscl
 	xoff := x + c.offsetX()*c.localscl
 	yoff := y + c.offsetY()*c.localscl
-	xs := c.clsnScale[0] * c.animlocalscl * c.facing
-	ys := c.clsnScale[1] * c.animlocalscl
+	xs := (c.clsnScale[0] * c.animlocalscl * c.facing)
+	ys := (c.clsnScale[1] * c.animlocalscl)
+	angle := c.clsnAngle*c.facing
 	nhbtxt := ""
 	// Debug Clsn display
 	if sys.clsnDraw && c.curFrame != nil {
@@ -7517,11 +7536,11 @@ func (c *Char) cueDraw() {
 			if c.scf(SCF_standby) {
 				// Add nothing
 			} else if c.atktmp != 0 && c.hitdef.reversal_attr > 0 {
-				sys.debugc1rev.Add(clsn, xoff, yoff, xs, ys)
+				sys.debugc1rev.Add(clsn, xoff, yoff, xs, ys, angle)
 			} else if c.atktmp != 0 && c.hitdef.attr > 0 {
-				sys.debugc1hit.Add(clsn, xoff, yoff, xs, ys)
+				sys.debugc1hit.Add(clsn, xoff, yoff, xs, ys, angle)
 			} else {
-				sys.debugc1not.Add(clsn, xoff, yoff, xs, ys)
+				sys.debugc1not.Add(clsn, xoff, yoff, xs, ys, angle)
 			}
 		}
 		// Check invincibility to decide box colors
@@ -7562,19 +7581,19 @@ func (c *Char) cueDraw() {
 				}
 			}
 			if c.scf(SCF_standby) {
-				sys.debugc2stb.Add(clsn, xoff, yoff, xs, ys)
+				sys.debugc2stb.Add(clsn, xoff, yoff, xs, ys, angle)
 			} else if mtk {
 				// Add fully invincible Clsn2
-				sys.debugc2mtk.Add(clsn, xoff, yoff, xs, ys)
+				sys.debugc2mtk.Add(clsn, xoff, yoff, xs, ys, angle)
 			} else if hb {
 				// Add partially invincible Clsn2
-				sys.debugc2hb.Add(clsn, xoff, yoff, xs, ys)
+				sys.debugc2hb.Add(clsn, xoff, yoff, xs, ys, angle)
 			} else if c.inguarddist && c.scf(SCF_guard) {
 				// Add guarding Clsn2
-				sys.debugc2grd.Add(clsn, xoff, yoff, xs, ys)
+				sys.debugc2grd.Add(clsn, xoff, yoff, xs, ys, angle)
 			} else {
 				// Add regular Clsn2
-				sys.debugc2.Add(clsn, xoff, yoff, xs, ys)
+				sys.debugc2.Add(clsn, xoff, yoff, xs, ys, angle)
 			}
 			// Add invulnerability text
 			if nhbtxt == "" {
@@ -7647,10 +7666,10 @@ func (c *Char) cueDraw() {
 		}
 		// Add size box (width * height)
 		if c.csf(CSF_playerpush) {
-			sys.debugcsize.Add(c.sizeBox, x, y, c.facing*c.localscl, c.localscl)
+			sys.debugcsize.Add(c.sizeBox, x, y, c.facing*c.localscl, c.localscl, 0)
 		}
 		// Add crosshair
-		sys.debugch.Add([]float32{-1, -1, 1, 1}, x, y, 1, 1)
+		sys.debugch.Add([]float32{-1, -1, 1, 1}, x, y, 1, 1, 0)
 	}
 	// Prepare information for debug text
 	if sys.debugDraw {

--- a/src/common.go
+++ b/src/common.go
@@ -238,7 +238,68 @@ func Atof(str string) float64 {
 	}
 	return f
 }
-
+func RectRotate(x, y, w, h, cx, cy, angle float32) ([][2]float32) {
+	rp := make([][2]float32, 4)
+	corners := [][2]float32{
+		{x, y},
+		{x+w, y},
+		{x+w, y+h},
+		{x, y+h},
+	}
+	for i := 0; i < 4; i++ {
+		p := corners[i]
+		tx := p[0]-cx
+		ty := p[1]-cy
+		newX := Cos(angle)*tx-Sin(angle)*ty+cx
+		newY := Sin(angle)*tx+Cos(angle)*ty+cy
+		rp[i] = [2]float32{newX, newY}
+	}
+	return rp
+}
+// Check if two rotated rectangles intersect.
+func RectIntersect(x1, y1, w1, h1, x2, y2, w2, h2, cx1, cy1, cx2, cy2, angle1, angle2 float32) bool {
+	rect1 := RectRotate(x1, y1, w1, h1, cx1, cy1, angle1)
+	rect2 := RectRotate(x2, y2, w2, h2, cx2, cy2, angle2)
+	projectionRange := func(rect [][2]float32, normal [2]float32) (min float32, max float32) {
+		min = math.MaxFloat32
+		max = -math.MaxFloat32
+		for _, p := range rect {
+			projected := normal[0]*p[0]+normal[1]*p[1]
+			if projected < min {
+				min = projected
+			}
+			if projected > max {
+				max = projected
+			}
+		}
+		return
+	}
+	for i1 := 0; i1 < len(rect1); i1++ {
+		i2 := (i1+1)%len(rect1)
+		p1 := rect1[i1]
+		p2 := rect1[i2]
+		nx := p2[1]-p1[1]
+		ny := p1[0]-p2[0]
+		minA, maxA := projectionRange(rect1, [2]float32{nx, ny})
+		minB, maxB := projectionRange(rect2, [2]float32{nx, ny})
+		if maxA < minB || maxB < minA {
+			return false
+		}
+	}
+	for i1 := 0; i1 < len(rect2); i1++ {
+		i2 := (i1 + 1) % len(rect2)
+		p1 := rect2[i1]
+		p2 := rect2[i2]
+		nx := p2[1] - p1[1]
+		ny := p1[0] - p2[0]
+		minA, maxA := projectionRange(rect1, [2]float32{nx, ny})
+		minB, maxB := projectionRange(rect2, [2]float32{nx, ny})
+		if maxA < minB || maxB < minA {
+			return false
+		}
+	}
+	return true
+}
 // Prevent overflow errors when converting float64 to int32
 func F64toI32(f float64) int32 {
 	if f >= float64(math.MaxInt32) {

--- a/src/common.go
+++ b/src/common.go
@@ -91,6 +91,40 @@ func ClampF(x, a, b float32) float32 {
 	return MaxF(a, MinF(x, b))
 }
 
+func Rad(f float32) float32 {
+	return float32(f * math.Pi / 180)
+}
+
+func Deg(f float32) float32 {
+	return float32(f * 180 / math.Pi)
+}
+
+func Cos(f float32) float32 {
+	return float32(math.Cos(float64(f)))
+}
+
+func Sin(f float32) float32 {
+	return float32(math.Sin(float64(f)))
+}
+func Sign(i int32) int32 {
+	if i < 0 {
+		return -1
+	} else if i > 0 {
+		return 1
+	} else {
+		return 0
+	}
+}
+
+func SignF(f float32) float32 {
+	if f < 0 {
+		return -1
+	} else if f > 0 {
+		return 1
+	} else {
+		return 0
+	}
+}
 func Abs(i int32) int32 {
 	if i < 0 {
 		return -i

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -2063,7 +2063,10 @@ func (c *Compiler) projectileSub(is IniSection, sc *StateControllerBase, ihp int
 		projectile_projrescaleclsn, VT_Bool, 1, false); err != nil {
 		return err
 	}
-
+	if err := c.paramValue(is, sc, "projrotateclsn",
+		projectile_projrotateclsn, VT_Bool, 1, false); err != nil {
+		return err
+	}
 	// HitDef section
 	if err := c.hitDefSub(is, sc); err != nil {
 		return err
@@ -3105,6 +3108,10 @@ func (c *Compiler) angleDraw(is IniSection, sc *StateControllerBase, _ int8) (St
 		}
 		if err := c.paramValue(is, sc, "rescaleclsn",
 			angleDraw_rescaleClsn, VT_Bool, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "rotateclsn",
+			angleDraw_rotateClsn, VT_Bool, 1, false); err != nil {
 			return err
 		}
 		return nil

--- a/src/render.go
+++ b/src/render.go
@@ -284,6 +284,9 @@ func rmInitSub(rp *RenderParams) {
 	rp.y += rp.rcy
 }
 
+func BlendReset() {
+	gfx.BlendReset()
+}
 func RenderSprite(rp RenderParams) {
 	if !rp.IsValid() {
 		return
@@ -339,7 +342,6 @@ func RenderSprite(rp RenderParams) {
 
 		gfx.ReleasePipeline()
 	}, rp.trans, rp.paltex != nil, invblend, &neg, &padd, &pmul, rp.paltex == nil)
-
 	gfx.DisableScissor()
 }
 

--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -417,6 +417,10 @@ func (r *Renderer) BeginFrame(clearColor bool) {
 	}
 }
 
+func (r *Renderer) BlendReset() {
+	gl.BlendEquation(BlendEquationLUT[BlendAdd])
+	gl.BlendFunc(BlendFunctionLUT[BlendSrcAlpha], BlendFunctionLUT[BlendOneMinusSrcAlpha])
+}
 func (r *Renderer) EndFrame() {
 	if sys.multisampleAntialiasing > 0 {
 		gl.BindFramebuffer(gl.DRAW_FRAMEBUFFER, r.fbo_f)

--- a/src/system.go
+++ b/src/system.go
@@ -831,13 +831,79 @@ func (s *System) loadTime(start time.Time, str string, shell, console bool) {
 	}
 }
 
-func (s *System) clsnOverlap(clsn1 []float32, scl1, pos1 [2]float32, facing1 float32,
-	clsn2 []float32, scl2, pos2 [2]float32, facing2 float32) bool {
+func rectrotate(x, y, w, h, cx, cy, angle float32) ([][2]float32) {
+	rp := make([][2]float32, 4)
+	corners := [][2]float32{
+		{x, y},
+		{x+w, y},
+		{x+w, y+h},
+		{x, y+h},
+	}
+	for i := 0; i < 4; i++ {
+		p := corners[i]
+		tx := p[0]-cx
+		ty := p[1]-cy
+		newX := Cos(angle)*tx-Sin(angle)*ty+cx
+		newY := Sin(angle)*tx+Cos(angle)*ty+cy
+		rp[i] = [2]float32{newX, newY}
+	}
+	return rp
+}
+
+// Check if two rotated rectangles intersect.
+func rectintersect(x1, y1, w1, h1, x2, y2, w2, h2, cx1, cy1, cx2, cy2, angle1, angle2 float32) bool {
+	rect1 := rectrotate(x1, y1, w1, h1, cx1, cy1, angle1)
+	rect2 := rectrotate(x2, y2, w2, h2, cx2, cy2, angle2)
+	projectionRange := func(rect [][2]float32, normal [2]float32) (min float32, max float32) {
+		min = math.MaxFloat32
+		max = -math.MaxFloat32
+		for _, p := range rect {
+			projected := normal[0]*p[0]+normal[1]*p[1]
+			if projected < min {
+				min = projected
+			}
+			if projected > max {
+				max = projected
+			}
+		}
+		return
+	}
+	for i1 := 0; i1 < len(rect1); i1++ {
+		i2 := (i1+1)%len(rect1)
+		p1 := rect1[i1]
+		p2 := rect1[i2]
+		nx := p2[1]-p1[1]
+		ny := p1[0]-p2[0]
+		minA, maxA := projectionRange(rect1, [2]float32{nx, ny})
+		minB, maxB := projectionRange(rect2, [2]float32{nx, ny})
+		if maxA < minB || maxB < minA {
+			return false
+		}
+	}
+	for i1 := 0; i1 < len(rect2); i1++ {
+		i2 := (i1 + 1) % len(rect2)
+		p1 := rect2[i1]
+		p2 := rect2[i2]
+		nx := p2[1] - p1[1]
+		ny := p1[0] - p2[0]
+		minA, maxA := projectionRange(rect1, [2]float32{nx, ny})
+		minB, maxB := projectionRange(rect2, [2]float32{nx, ny})
+		if maxA < minB || maxB < minA {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *System) clsnOverlap(clsn1 []float32, scl1, pos1 [2]float32, facing1 float32, angle1 float32,
+	clsn2 []float32, scl2, pos2 [2]float32, facing2 float32, angle2 float32) bool {
 
 	// Skip function if any boxes are missing
 	if clsn1 == nil || clsn2 == nil {
 		return false
 	}
+	anface1 := facing1
+	anface2 := facing2
 
 	// Flip boxes if scale < 0
 	if scl1[0] < 0 {
@@ -848,7 +914,6 @@ func (s *System) clsnOverlap(clsn1 []float32, scl1, pos1 [2]float32, facing1 flo
 		facing2 = -facing2
 		scl2[0] = -scl2[0]
 	}
-
 	// Loop through first set of boxes
 	for i := 0; i+3 < len(clsn1); i += 4 {
 		// Calculate positions
@@ -857,10 +922,10 @@ func (s *System) clsnOverlap(clsn1 []float32, scl1, pos1 [2]float32, facing1 flo
 		if facing1 < 0 {
 			l1, r1 = -r1, -l1
 		}
-		left1 := l1*scl1[0] + pos1[0]
-		right1 := r1*scl1[0] + pos1[0]
-		top1 := clsn1[i+1]*scl1[1] + pos1[1]
-		bottom1 := clsn1[i+3]*scl1[1] + pos1[1]
+		left1 := l1*scl1[0] //+ pos1[0]
+		right1 := r1*scl1[0] //+ pos1[0]
+		top1 := clsn1[i+1]*scl1[1] //+ pos1[1]
+		bottom1 := clsn1[i+3]*scl1[1] //+ pos1[1]
 
 		// Loop through second set of boxes
 		for j := 0; j+3 < len(clsn2); j += 4 {
@@ -870,15 +935,22 @@ func (s *System) clsnOverlap(clsn1 []float32, scl1, pos1 [2]float32, facing1 flo
 			if facing2 < 0 {
 				l2, r2 = -r2, -l2
 			}
-			left2 := l2*scl2[0] + pos2[0]
-			right2 := r2*scl2[0] + pos2[0]
-			top2 := clsn2[j+1]*scl2[1] + pos2[1]
-			bottom2 := clsn2[j+3]*scl2[1] + pos2[1]
+			left2 := l2*scl2[0] //+ pos2[0]
+			right2 := r2*scl2[0] //+ pos2[0]
+			top2 := clsn2[j+1]*scl2[1] //+ pos2[1]
+			bottom2 := clsn2[j+3]*scl2[1] //+ pos2[1]
 
 			// Check for overlap
-			if left1 <= right2 && left2 <= right1 && top1 <= bottom2 && top2 <= bottom1 {
-				return true
+			if angle1 != 0 || angle2  != 0 {
+				if rectintersect(left1+pos1[0], top1+pos1[1], right1-left1, bottom1-top1, left2+pos2[0], top2+pos2[1], right2-left2, bottom2-top2, pos1[0], pos1[1], pos2[0], pos2[1], -Rad(angle1*anface1), -Rad(angle2*anface2)) {
+					return true
+				}
+			} else {
+				if left1+ pos1[0] <= right2+pos2[0] && left2+pos2[0] <= right1+pos1[0] && top1+pos1[1] <= bottom2+pos2[1]  && top2+pos2[1]  <= bottom1+pos1[1]  {
+					return true
+				}
 			}
+
 		}
 	}
 	return false


### PR DESCRIPTION
Feat:

- Now Collision boxes can be rotated.In that case: **rotateclsn**, **projrotateclsn** parameters been added to Angledraw and Projectile sctrls. For enabling value need to be set to 1.

Fix:

- Text sctr/Debug text blend mode inverse bug fix #1091