### PR TITLE
feat: TransformClsn, minor feats, refactoring, fixes

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -11083,6 +11083,7 @@ const (
 	modifyPlayer_displayname
 	modifyPlayer_lifebarname
 	modifyPlayer_helperid
+	modifyPlayer_helpername
 	modifyPlayer_redirectid
 )
 
@@ -11139,6 +11140,11 @@ func (sc modifyPlayer) Run(c *Char, _ []int32) bool {
 				} else {
 					crun.helperId = 0
 				}
+			}
+		case modifyPlayer_helpername:
+			if crun.helperIndex != 0 {
+				hn := string(*(*[]byte)(unsafe.Pointer(&exp[0])))
+				crun.name = hn
 			}
 		case modifyPlayer_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6134,8 +6134,8 @@ const (
 	projectile_accel
 	projectile_projscale
 	projectile_projangle
-	projectile_projrescaleclsn
-	projectile_projrotateclsn
+	projectile_projclsnscale
+	projectile_projclsnangle
 	projectile_offset
 	projectile_projsprpriority
 	projectile_projlayerno
@@ -6163,8 +6163,7 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 	pt := PT_P1
 	var x, y float32 = 0, 0
 	op := false
-	rc := false
-	ran := false
+	clsnscale := false
 	rp := [...]int32{-1, 0}
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		if p == nil {
@@ -6293,8 +6292,16 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 			if len(exp) > 1 {
 				rp[1] = exp[1].evalI(c)
 			}
-		case projectile_projrescaleclsn:
-			rc = exp[0].evalB(c)
+		case projectile_projclsnscale:
+			clsnscale = true
+			p.clsnScale[0] = exp[0].evalF(c)
+			if len(exp) > 1 {
+				p.clsnScale[1] = exp[1].evalF(c)
+			} else {
+				p.clsnScale[1] = 1.0 // Default
+			}
+		case projectile_projclsnangle:
+			p.clsnAngle = exp[0].evalF(c)
 		// case projectile_platform:
 		// 	p.platform = exp[0].evalB(c)
 		// case projectile_platformwidth:
@@ -6311,8 +6318,6 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 		// 	p.platformAngle = exp[0].evalF(c)
 		// case projectile_platformfence:
 		// 	p.platformFence = exp[0].evalB(c)
-		case projectile_projrotateclsn:
-			ran = exp[0].evalB(c)
 		default:
 			if !hitDef(sc).runSub(c, &p.hitdef, id, exp) {
 				afterImage(sc).runSub(c, &p.aimg, id, exp)
@@ -6343,7 +6348,7 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 	} else {
 		p.localscl = crun.localscl
 	}
-	crun.projInit(p, pt, x, y, op, rp[0], rp[1], rc, ran)
+	crun.projInit(p, pt, x, y, op, rp[0], rp[1], clsnscale)
 	return false
 }
 
@@ -6585,13 +6590,18 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				})
 			//case projectile_ownpal: // TODO: Test these later. May cause issues
 			//case projectile_remappal:
-			case projectile_projrescaleclsn: // Must be placed after projectile_projscale
+			case projectile_projclsnscale:
 				eachProj(func(p *Projectile) {
-					if exp[0].evalB(c) {
-						p.clsnScale = p.scale
+					p.clsnScale[0] = exp[0].evalF(c)
+					if len(exp) > 1 {
+						p.clsnScale[1] = exp[1].evalF(c)
 					} else {
-						p.clsnScale = c.clsnScale
+						p.clsnScale[1] = 1.0 // Default
 					}
+				})
+			case projectile_projclsnangle:
+				eachProj(func(p *Projectile) {
+					p.clsnAngle = exp[0].evalF(c)
 				})
 			case hitDef_attr:
 				eachProj(func(p *Projectile) {
@@ -8148,8 +8158,6 @@ type angleDraw StateControllerBase
 const (
 	angleDraw_value byte = iota
 	angleDraw_scale
-	angleDraw_rescaleClsn
-	angleDraw_rotateClsn
 	angleDraw_redirectid
 )
 
@@ -8163,16 +8171,6 @@ func (sc angleDraw) Run(c *Char, _ []int32) bool {
 			crun.angleScale[0] *= exp[0].evalF(c)
 			if len(exp) > 1 {
 				crun.angleScale[1] *= exp[1].evalF(c)
-			}
-		case angleDraw_rescaleClsn:
-			if exp[0].evalB(c) {
-				crun.angleRescaleClsn = true
-				crun.updateClsnScale()
-			}
-		case angleDraw_rotateClsn:
-			if exp[0].evalB(c) {
-				crun.angleRotateClsn = true
-				crun.updateClsnAngle()
 			}
 		case angleDraw_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
@@ -10111,7 +10109,9 @@ func (sc modifyBGCtrl) Run(c *Char, _ []int32) bool {
 	t, v := [3]int32{IErr, IErr, IErr}, [3]int32{IErr, IErr, IErr}
 	x, y := float32(math.NaN()), float32(math.NaN())
 	src, dst := [2]int32{IErr, IErr}, [2]int32{IErr, IErr}
-	add, mul, sinadd, sinmul, sincolor, sinhue := [3]int32{IErr, IErr, IErr}, [3]int32{IErr, IErr, IErr}, [4]int32{IErr, IErr, IErr, IErr}, [4]int32{IErr, IErr, IErr, IErr}, [2]int32{IErr, IErr}, [2]int32{IErr, IErr}
+	add, mul := [3]int32{IErr, IErr, IErr}, [3]int32{IErr, IErr, IErr}
+	sinadd, sinmul := [4]int32{IErr, IErr, IErr, IErr}, [4]int32{IErr, IErr, IErr, IErr}
+	sincolor, sinhue := [2]int32{IErr, IErr}, [2]int32{IErr, IErr}
 	invall, invblend, color, hue := IErr, IErr, float32(math.NaN()), float32(math.NaN())
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
@@ -11346,6 +11346,37 @@ func (sc targetAdd) Run(c *Char, _ []int32) bool {
 				if done {
 					break
 				}
+			}
+		}
+		return true
+	})
+	return false
+}
+
+type transformClsn StateControllerBase
+
+const (
+	transformClsn_scale byte = iota
+	transformClsn_angle
+	transformClsn_redirectid
+)
+
+func (sc transformClsn) Run(c *Char, _ []int32) bool {
+	crun := c
+	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
+		switch id {
+		case transformClsn_scale:
+			crun.clsnScaleMul[0] *= exp[0].evalF(c)
+			if len(exp) > 1 {
+				crun.clsnScaleMul[1] *= exp[1].evalF(c)
+			}
+		case transformClsn_angle:
+			crun.clsnAngle = exp[0].evalF(c)
+		case transformClsn_redirectid:
+			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
+				crun = rid
+			} else {
+				return false
 			}
 		}
 		return true

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -2756,13 +2756,13 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		if c.csf(CSF_angledraw) {
 			sys.bcStack.PushF(c.angleScale[0])
 		} else {
-			sys.bcStack.PushF(0)
+			sys.bcStack.PushF(1)
 		}
 	case OC_ex_scale_y:
 		if c.csf(CSF_angledraw) {
 			sys.bcStack.PushF(c.angleScale[1])
 		} else {
-			sys.bcStack.PushF(0)
+			sys.bcStack.PushF(1)
 		}
 	case OC_ex_offset_x:
 		sys.bcStack.PushF(c.offset[0]) // Already in local scale
@@ -5705,7 +5705,6 @@ const (
 	hitDef_ground_hittime
 	hitDef_guard_hittime
 	hitDef_guard_dist
-	hitDef_guard_dist_back
 	hitDef_pausetime
 	hitDef_guard_pausetime
 	hitDef_air_velocity
@@ -5931,8 +5930,9 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 		hd.guard_hittime = exp[0].evalI(c)
 	case hitDef_guard_dist:
 		hd.guard_dist[0] = exp[0].evalI(c)
-	case hitDef_guard_dist_back:
-		hd.guard_dist[1] = exp[0].evalI(c)
+		if len(exp) > 1 {
+			hd.guard_dist[1] = exp[1].evalI(c)
+		}
 	case hitDef_pausetime:
 		hd.pausetime = exp[0].evalI(c)
 		hd.guard_pausetime = hd.pausetime
@@ -6888,10 +6888,9 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 			case hitDef_guard_dist:
 				eachProj(func(p *Projectile) {
 					p.hitdef.guard_dist[0] = exp[0].evalI(c)
-				})
-			case hitDef_guard_dist_back:
-				eachProj(func(p *Projectile) {
-					p.hitdef.guard_dist[1] = exp[0].evalI(c)
+					if len(exp) > 1 {
+						p.hitdef.guard_dist[1] = exp[1].evalI(c)
+					}
 				})
 			case hitDef_pausetime:
 				eachProj(func(p *Projectile) {
@@ -8435,7 +8434,6 @@ type attackDist StateControllerBase
 
 const (
 	attackDist_value byte = iota
-	attackDist_back
 	attackDist_redirectid
 )
 
@@ -8446,8 +8444,9 @@ func (sc attackDist) Run(c *Char, _ []int32) bool {
 		switch id {
 		case attackDist_value:
 			crun.attackDist[0] = exp[0].evalF(c) * lclscround
-		case attackDist_back:
-			crun.attackDist[1] = exp[0].evalF(c) * lclscround
+			if len(exp) > 1 {
+				crun.attackDist[1] = exp[1].evalF(c) * lclscround
+			}
 		case attackDist_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid

--- a/src/char.go
+++ b/src/char.go
@@ -1349,9 +1349,10 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 			// e.setY(e.pos[1])
 		}
 	} else {
+		// Explod position interpolation
+		spd := sys.tickInterpolation()
 		for i := range e.pos {
-			e.pos[i] = e.newPos[i] -
-				(e.newPos[i]-e.oldPos[i])*(1-sys.tickInterpola())
+			e.pos[i] = e.newPos[i] - (e.newPos[i]-e.oldPos[i])*(1-spd)
 		}
 	}
 	off := e.relativePos
@@ -1599,6 +1600,8 @@ type Projectile struct {
 	stagebound      int32
 	heightbound     [2]int32
 	pos             [2]float32
+	oldPos          [2]float32
+	drawPos         [2]float32
 	facing          float32
 	removefacing    float32
 	shadow          [3]int32
@@ -1607,8 +1610,6 @@ type Projectile struct {
 	ani             *Animation
 	curmisstime     int32
 	hitpause        int32
-	oldPos          [2]float32
-	newPos          [2]float32
 	aimg            AfterImage
 	palfx           *PalFX
 	localscl        float32
@@ -1657,8 +1658,11 @@ func (p *Projectile) clear() {
 }
 
 func (p *Projectile) setPos(pos [2]float32) {
-	p.pos, p.oldPos, p.newPos = pos, pos, pos
+	p.pos = pos
+	p.oldPos = pos
+	p.drawPos = pos
 }
+
 func (p *Projectile) paused(playerNo int) bool {
 	//if !sys.chars[playerNo][0].pause() {
 	if sys.super > 0 {
@@ -1741,15 +1745,15 @@ func (p *Projectile) update(playerNo int) {
 		// There's a minor issue here where a projectile will lag behind one frame relative to Mugen if created during a pause
 	} else {
 		if sys.tickFrame() {
-			p.newPos = [...]float32{p.pos[0] + p.velocity[0]*p.facing, p.pos[1] + p.velocity[1]}
-		}
-		ti := sys.tickInterpola()
-		for i, np := range p.newPos {
-			p.pos[i] = np - (np-p.oldPos[i])*(1-ti)
+			p.pos = [...]float32{p.pos[0] + p.velocity[0]*p.facing, p.pos[1] + p.velocity[1]}
+			p.drawPos = p.pos
+		} 
+		spd := sys.tickInterpolation()
+		for i := 0; i < 2; i++ {
+			p.drawPos[i] = p.pos[i] - (p.pos[i]-p.oldPos[i])*(1-spd)
 		}
 		if sys.tickNextFrame() {
 			p.oldPos = p.pos
-			p.pos = p.newPos
 			for i := range p.velocity {
 				p.velocity[i] += p.accel[i]
 				p.velocity[i] *= p.velmul[i]
@@ -1888,6 +1892,7 @@ func (p *Projectile) cueDraw(oldVer bool, playerNo int) {
 	if sys.tickFrame() && p.ani != nil && notpause {
 		p.ani.UpdateSprite()
 	}
+	// Projectie Clsn display
 	if sys.clsnDraw && p.ani != nil {
 		if frm := p.ani.drawFrame(); frm != nil {
 			xs := p.clsnScale[0] * p.localscl * p.facing
@@ -1912,7 +1917,7 @@ func (p *Projectile) cueDraw(oldVer bool, playerNo int) {
 	}
 	var c = sys.chars[playerNo][0]
 	if p.ani != nil {
-		sd := &SprData{p.ani, p.palfx, [...]float32{p.pos[0] * p.localscl, p.pos[1] * p.localscl},
+		sd := &SprData{p.ani, p.palfx, [...]float32{p.drawPos[0] * p.localscl, p.drawPos[1] * p.localscl},
 			[...]float32{p.facing * p.scale[0] * p.localscl, p.scale[1] * p.localscl}, [2]int32{-1},
 			p.sprpriority, Rotation{p.facing * p.angle, 0, 0}, [...]float32{1, 1}, false, playerNo == sys.superplayer,
 			sys.cgi[playerNo].mugenver[0] != 1, p.facing, 1, 0, 0, [4]float32{0, 0, 0, 0}}
@@ -7319,7 +7324,7 @@ func (c *Char) update() {
 		c.pushed = false
 	}
 	if c.acttmp > 0 {
-		spd := sys.tickInterpola()
+		spd := sys.tickInterpolation()
 		if c.pushed {
 			spd = 0
 		}
@@ -9087,6 +9092,7 @@ func (cl *CharList) collisionDetection() {
 	// Push detection for players
 	// This must happen before hit detection
 	// https://github.com/ikemen-engine/Ikemen-GO/issues/1941
+	// An attempt was made to skip redundant player pair checks, but that makes chars push each other too slowly in screen corners
 	for i := 0; i < len(cl.runOrder); i++ {
 		cl.pushDetection(cl.runOrder[sortedOrder[i]])
 	}

--- a/src/char.go
+++ b/src/char.go
@@ -7934,9 +7934,6 @@ func (cl *CharList) action() {
 	for i := 0; i < len(cl.runOrder); i++ {
 		cl.runOrder[i].actionFinish()
 	}
-
-	// Update chars
-	sys.charUpdate()
 }
 
 func (cl *CharList) xScreenBound() {
@@ -7946,6 +7943,7 @@ func (cl *CharList) xScreenBound() {
 		c.xScreenBound()
 	}
 }
+
 func (cl *CharList) update() {
 	ro := make([]*Char, len(cl.runOrder))
 	copy(ro, cl.runOrder)
@@ -7954,6 +7952,7 @@ func (cl *CharList) update() {
 		c.track()
 	}
 }
+
 func (cl *CharList) hitDetection(getter *Char, proj bool) {
 	if getter.scf(SCF_standby) || getter.scf(SCF_disabled) {
 		return // Stop entire function if getter is disabled

--- a/src/char.go
+++ b/src/char.go
@@ -4017,30 +4017,35 @@ func (c *Char) selfStatenoExist(stateno BytecodeValue) BytecodeValue {
 	_, ok := c.gi().states[stateno.ToI()]
 	return BytecodeBool(ok)
 }
+
+// If the stage is coded incorrectly we must check distance to "leftbound" or "rightbound"
+// https://github.com/ikemen-engine/Ikemen-GO/issues/1996
 func (c *Char) stageFrontEdgeDist() float32 {
-	side := float32(0)
+	corner := float32(0)
 	if c.facing < 0 {
-		side = sys.screenleft / c.localscl
+		corner = MaxF(sys.cam.XMin/c.localscl + sys.screenleft/c.localscl,
+			sys.stage.leftbound*sys.stage.localscl/c.localscl)
+		return c.pos[0] - corner
 	} else {
-		side = sys.screenright / c.localscl
+		corner = MinF(sys.cam.XMax/c.localscl - sys.screenright/c.localscl,
+			sys.stage.rightbound*sys.stage.localscl/c.localscl)
+		return corner - c.pos[0]
 	}
-	if c.facing > 0 {
-		return sys.cam.XMax/c.localscl - side - c.pos[0]
-	}
-	return c.pos[0] - sys.cam.XMin/c.localscl - side
 }
+
 func (c *Char) stageBackEdgeDist() float32 {
-	side := float32(0)
+	corner := float32(0)
 	if c.facing < 0 {
-		side = sys.screenleft / c.localscl
+		corner = MinF(sys.cam.XMax/c.localscl - sys.screenright/c.localscl,
+			sys.stage.rightbound*sys.stage.localscl/c.localscl)
+		return corner - c.pos[0]
 	} else {
-		side = sys.screenright / c.localscl
+		corner = MaxF(sys.cam.XMin/c.localscl + sys.screenleft/c.localscl,
+			sys.stage.leftbound*sys.stage.localscl/c.localscl)
+		return c.pos[0] - corner
 	}
-	if c.facing < 0 {
-		return sys.cam.XMax/c.localscl - side - c.pos[0]
-	}
-	return c.pos[0] - sys.cam.XMin/c.localscl - side
 }
+
 func (c *Char) teamLeader() int {
 	if c.teamside == -1 || sys.tmode[c.playerNo&1] == TM_Single || sys.tmode[c.playerNo&1] == TM_Turns {
 		return c.playerNo + 1

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -180,6 +180,7 @@ func newCompiler() *Compiler {
 		"teammapadd":           c.teamMapAdd,
 		"teammapset":           c.teamMapSet,
 		"text":                 c.text,
+		"transformclsn":        c.transformClsn,
 	}
 	return c
 }

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -5248,6 +5248,15 @@ func (c *Compiler) modifyPlayer(is IniSection, sc *StateControllerBase, _ int8) 
 			modifyPlayer_helperid, VT_Int, 1, false); err != nil {
 			return err
 		}
+		if err := c.stateParam(is, "helpername", false, func(data string) error {
+			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
+				return Error("Not enclosed in \"")
+			}
+			sc.add(modifyPlayer_helpername, sc.beToExp(BytecodeExp(data[1:len(data)-1])))
+			return nil
+		}); err != nil {
+			return err
+		}
 		return nil
 	})
 	return *ret, err

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1709,11 +1709,7 @@ func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 		return err
 	}
 	if err := c.paramValue(is, sc, "guard.dist",
-		hitDef_guard_dist, VT_Int, 1, false); err != nil {
-		return err
-	}
-	if err := c.paramValue(is, sc, "guard.dist.back",
-		hitDef_guard_dist_back, VT_Int, 1, false); err != nil {
+		hitDef_guard_dist, VT_Int, 2, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "pausetime",
@@ -3302,11 +3298,7 @@ func (c *Compiler) attackDist(is IniSection, sc *StateControllerBase, _ int8) (S
 			return err
 		}
 		if err := c.paramValue(is, sc, "value",
-			attackDist_value, VT_Float, 1, true); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "back",
-			attackDist_back, VT_Float, 1, false); err != nil {
+			attackDist_value, VT_Float, 2, true); err != nil {
 			return err
 		}
 		return nil

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -35,7 +35,7 @@ func (c *Compiler) hitBySub(is IniSection, sc *StateControllerBase) error {
 		}
 	}
 	// New syntax uses attr and slot
-	if err := c.stateParam(is, "attr", false, func(data string) error {
+	if err = c.stateParam(is, "attr", false, func(data string) error {
 		vnum = -1
 		attr, err = c.attr(data, false)
 		if err != nil {
@@ -49,23 +49,23 @@ func (c *Compiler) hitBySub(is IniSection, sc *StateControllerBase) error {
 	if attr == -1 {
 		return Error("Attributes not specified")
 	}
-	if err := c.paramValue(is, sc, "slot",
+	if err = c.paramValue(is, sc, "slot",
 		hitBy_slot, VT_Int, 1, false); err != nil {
 		return err
 	}
-	if err := c.paramValue(is, sc, "time",
+	if err = c.paramValue(is, sc, "time",
 		hitBy_time, VT_Int, 1, false); err != nil {
 		return err
 	}
-	if err := c.paramValue(is, sc, "playerno",
+	if err = c.paramValue(is, sc, "playerno",
 		hitBy_playerno, VT_Int, 1, false); err != nil {
 		return err
 	}
-	if err := c.paramValue(is, sc, "playerid",
+	if err = c.paramValue(is, sc, "playerid",
 		hitBy_playerid, VT_Int, 1, false); err != nil {
 		return err
 	}
-	if err := c.paramValue(is, sc, "stack",
+	if err = c.paramValue(is, sc, "stack",
 		hitBy_stack, VT_Bool, 1, false); err != nil {
 		return err
 	}
@@ -1941,7 +1941,7 @@ func (c *Compiler) reversalDef(is IniSection, sc *StateControllerBase, _ int8) (
 	ret, err := (*reversalDef)(sc), c.stateSec(is, func() error {
 		attr := int32(-1)
 		var err error
-		if err := c.paramValue(is, sc, "redirectid",
+		if err = c.paramValue(is, sc, "redirectid",
 			reversalDef_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
@@ -1964,7 +1964,7 @@ func (c *Compiler) modifyReversalDef(is IniSection, sc *StateControllerBase, _ i
 	ret, err := (*modifyReversalDef)(sc), c.stateSec(is, func() error {
 		attr := int32(-1)
 		var err error
-		if err := c.paramValue(is, sc, "redirectid",
+		if err = c.paramValue(is, sc, "redirectid",
 			modifyReversalDef_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
@@ -2063,12 +2063,12 @@ func (c *Compiler) projectileSub(is IniSection, sc *StateControllerBase, ihp int
 		projectile_projangle, VT_Float, 1, false); err != nil {
 		return err
 	}
-	if err := c.paramValue(is, sc, "projrescaleclsn",
-		projectile_projrescaleclsn, VT_Bool, 1, false); err != nil {
+	if err := c.paramValue(is, sc, "projclsnscale",
+		projectile_projclsnscale, VT_Float, 2, false); err != nil {
 		return err
 	}
-	if err := c.paramValue(is, sc, "projrotateclsn",
-		projectile_projrotateclsn, VT_Bool, 1, false); err != nil {
+	if err := c.paramValue(is, sc, "projclsnangle",
+		projectile_projclsnangle, VT_Float, 1, false); err != nil {
 		return err
 	}
 	// HitDef section
@@ -3108,14 +3108,6 @@ func (c *Compiler) angleDraw(is IniSection, sc *StateControllerBase, _ int8) (St
 		}
 		if err := c.paramValue(is, sc, "scale",
 			angleDraw_scale, VT_Float, 2, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "rescaleclsn",
-			angleDraw_rescaleClsn, VT_Bool, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "rotateclsn",
-			angleDraw_rotateClsn, VT_Bool, 1, false); err != nil {
 			return err
 		}
 		return nil
@@ -5448,6 +5440,33 @@ func (c *Compiler) targetAdd(is IniSection, sc *StateControllerBase, _ int8) (St
 		if err := c.paramValue(is, sc, "playerid",
 			targetAdd_playerid, VT_Int, 1, true); err != nil {
 			return err
+		}
+		return nil
+	})
+	return *ret, err
+}
+
+func (c *Compiler) transformClsn(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+	ret, err := (*transformClsn)(sc), c.stateSec(is, func() error {
+		if err := c.paramValue(is, sc, "redirectid",
+			transformClsn_redirectid, VT_Int, 1, false); err != nil {
+			return err
+		}
+		any := false
+		if err := c.stateParam(is, "scale", false, func(data string) error {
+			any = true
+			return c.scAdd(sc, transformClsn_scale, data, VT_Float, 2)
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "angle", false, func(data string) error {
+			any = true
+			return c.scAdd(sc, transformClsn_angle, data, VT_Float, 1)
+		}); err != nil {
+			return err
+		}
+		if !any {
+			return Error("no parameters specified")
 		}
 		return nil
 	})

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -3944,7 +3944,9 @@ func (l *Lifebar) step() {
 		} else {
 			l.textsprite[i].Draw()
 			if sys.tickNextFrame() {
-				l.textsprite[i].removetime--
+				if l.textsprite[i].removetime > 0 {
+					l.textsprite[i].removetime--
+				}
 			}
 		}
 	}

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -3836,6 +3836,7 @@ func (l *Lifebar) reloadLifebar() error {
 	sys.lifebar = *lb
 	return nil
 }
+
 func (l *Lifebar) step() {
 	if sys.paused && !sys.step {
 		return
@@ -3951,6 +3952,7 @@ func (l *Lifebar) step() {
 		}
 	}
 }
+
 func (l *Lifebar) reset() {
 	var num [2]int
 	for ti, tm := range sys.tmode {

--- a/src/script.go
+++ b/src/script.go
@@ -5020,7 +5020,7 @@ func triggerFunctions(l *lua.LState) {
 		if sys.debugWC.csf(CSF_angledraw) {
 			l.Push(lua.LNumber(sys.debugWC.angleScale[0]))
 		} else {
-			l.Push(lua.LNumber(0))
+			l.Push(lua.LNumber(1))
 		}
 		return 1
 	})
@@ -5028,7 +5028,7 @@ func triggerFunctions(l *lua.LState) {
 		if sys.debugWC.csf(CSF_angledraw) {
 			l.Push(lua.LNumber(sys.debugWC.angleScale[1]))
 		} else {
-			l.Push(lua.LNumber(0))
+			l.Push(lua.LNumber(1))
 		}
 		return 1
 	})

--- a/src/system.go
+++ b/src/system.go
@@ -3363,6 +3363,10 @@ func (l *Loader) loadStage() bool {
 					sys.appendToConsole("Stage with unknown engine version.")
 				}
 			}
+			// Warn when camera boundaries are smaller than player boundaries
+			if int32(sys.stage.leftbound) > sys.stage.stageCamera.boundleft || int32(sys.stage.rightbound) < sys.stage.stageCamera.boundright {
+				sys.appendToConsole("Warning: Stage player boundaries defined incorrectly")
+			}
 		}()
 		var def string
 		if sys.sel.selectedStageNo == 0 {

--- a/src/system.go
+++ b/src/system.go
@@ -861,10 +861,10 @@ func (s *System) clsnOverlap(clsn1 []float32, scl1, pos1 [2]float32, facing1 flo
 		if facing1 < 0 {
 			l1, r1 = -r1, -l1
 		}
-		left1 := l1 * scl1[0]           //+ pos1[0]
-		right1 := r1 * scl1[0]          //+ pos1[0]
-		top1 := clsn1[i+1] * scl1[1]    //+ pos1[1]
-		bottom1 := clsn1[i+3] * scl1[1] //+ pos1[1]
+		left1 := l1 * scl1[0]
+		right1 := r1 * scl1[0]
+		top1 := clsn1[i+1] * scl1[1]
+		bottom1 := clsn1[i+3] * scl1[1]
 
 		// Loop through second set of boxes
 		for j := 0; j+3 < len(clsn2); j += 4 {
@@ -874,18 +874,23 @@ func (s *System) clsnOverlap(clsn1 []float32, scl1, pos1 [2]float32, facing1 flo
 			if facing2 < 0 {
 				l2, r2 = -r2, -l2
 			}
-			left2 := l2 * scl2[0]           //+ pos2[0]
-			right2 := r2 * scl2[0]          //+ pos2[0]
-			top2 := clsn2[j+1] * scl2[1]    //+ pos2[1]
-			bottom2 := clsn2[j+3] * scl2[1] //+ pos2[1]
+			left2 := l2 * scl2[0]
+			right2 := r2 * scl2[0]
+			top2 := clsn2[j+1] * scl2[1]
+			bottom2 := clsn2[j+3] * scl2[1]
 
 			// Check for overlap
 			if angle1 != 0 || angle2 != 0 {
-				if RectIntersect(left1+pos1[0], top1+pos1[1], right1-left1, bottom1-top1, left2+pos2[0], top2+pos2[1], right2-left2, bottom2-top2, pos1[0], pos1[1], pos2[0], pos2[1], -Rad(angle1*anface1), -Rad(angle2*anface2)) {
+				if RectIntersect(left1+pos1[0], top1+pos1[1], right1-left1, bottom1-top1,
+					left2+pos2[0], top2+pos2[1], right2-left2, bottom2-top2, pos1[0], pos1[1], pos2[0], pos2[1],
+					-Rad(angle1*anface1), -Rad(angle2*anface2)) {
 					return true
 				}
 			} else {
-				if left1+pos1[0] <= right2+pos2[0] && left2+pos2[0] <= right1+pos1[0] && top1+pos1[1] <= bottom2+pos2[1] && top2+pos2[1] <= bottom1+pos1[1] {
+				if left1+pos1[0] <= right2+pos2[0] &&
+				left2+pos2[0] <= right1+pos1[0] &&
+				top1+pos1[1] <= bottom2+pos2[1] &&
+				top2+pos2[1] <= bottom1+pos1[1] {
 					return true
 				}
 			}
@@ -1611,7 +1616,7 @@ func (s *System) action() {
 	// Allows a combo to still end if a character is hit in the same frame where it exits movetype H
 	s.lifebar.step()
 	if s.tickNextFrame() {
-		s.globalCollision()
+		s.globalCollision() // This could perhaps happen during "tick frame" instead? Would need more testing
 		s.charList.tick()
 	}
 


### PR DESCRIPTION
Feat:
- More like a refactor, but AngleDraw's RescaleClsn and RotateClsn are split into a new TransformClsn sctrl. This allows sprite scale/angle and Clsn scale/angle to vary independently
- ModifyPlayer can now change a helper's name as well

Refactor:
- AttackDist value and HitDef guard.dist parameters now take a second value instead of using separate "back" parameters. This makes their format match the Width sctrl and upcoming Z width parameters
- Lifebars are now also updated during "tick frame". This was mistakenly changed in previous commits and caused a bug in how text from Text sctrl was updated
- Refactored char updating accordingly
- Separated projectile drawing logic from their game logic, like characters already do. This means for instance collision box position will not be interpolated
- Projectile ProjRescaleClsn replaced with ProjClsnScale parameter, which sets the Clsn scale indepently of animation scale
- Projectile ProjRotateClsn replaced with ProjClsnAngle parameter, which sets the Clsn angle indepently of animation angle
- StageBackEdgeDist and StageFrontEdgeDist will now account for when the stage's "leftbound" or "rightbound" are smaller than the camera boundaries. Such stages will also print a debug warning upon being loaded

Fix:
- When both players draw the match, both are considered losers for the purpose of tracking wins in the lifebars
- Fixed regression in player 2 sometimes being unable to end a match

Fixes #1996