### PR TITLE
feat: Preliminary Z-axis support, fix: shadow/reflection fixes, XInput fixes, BGM volume scaling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,23 @@ Ikemen_GO_Linux: ${srcFiles}
 # MacOS x64 target
 Ikemen_GO_MacOS: ${srcFiles}
 	cd ./build && bash ./build.sh MacOS
+
+# MacOS app bundle
+appbundle:
+	mkdir -p I.K.E.M.E.N-Go.app
+	mkdir -p I.K.E.M.E.N-Go.app/Contents
+	mkdir -p I.K.E.M.E.N-Go.app/Contents/MacOS
+	mkdir -p I.K.E.M.E.N-Go.app/Contents/Resources
+	cp bin/Ikemen_GO_MacOS I.K.E.M.E.N-Go.app/Contents/MacOS/Ikemen_GO_MacOS
+	cp ./build/Info.plist I.K.E.M.E.N-Go.app/Contents/Info.plist
+	cp ./build/bundle_run.sh I.K.E.M.E.N-Go.app/Contents/MacOS/bundle_run.sh
+	chmod +x I.K.E.M.E.N-Go.app/Contents/MacOS/bundle_run.sh
+	chmod +x I.K.E.M.E.N-Go.app/Contents/MacOS/Ikemen_GO_MacOS
+	cd ./build && mkdir -p ./icontmp/icon.iconset && \
+	cp ../external/icons/IkemenCylia_256.png ./icontmp/icon.iconset/icon_256x256.png && \
+	iconutil -c icns ./icontmp/icon.iconset && \
+	cp icontmp/icon.icns ../I.K.E.M.E.N-Go.app/Contents/Resources/icon.icns && \
+	rm -rf icontmp
+
+clean_appbundle:
+	rm -rf I.K.E.M.E.N-Go.app

--- a/build/Info.plist
+++ b/build/Info.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>bundle_run.sh</string>
+    <key>CFBundleName</key>
+    <string>I.K.E.M.E.N-Go</string>
+    <key>CFBundleIconFile</key>
+    <string>icon</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.github.ikemen-engine.ikemen-go</string>
+    <key>CFBundleVersion</key>
+    <string>1.0</string>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.games</string>
+    <key>com.apple.security.device.hid</key>
+    <true/>
+    <key>com.apple.developer.game-controller-access</key>
+    <true/>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <true/>
+    </dict>
+</dict>
+</plist>

--- a/build/bundle_run.sh
+++ b/build/bundle_run.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Get the directory of this script (MacOS directory)
+SCRIPT_DIR="$(dirname "$0")"
+
+# Determine the directory containing the .app bundle
+APP_DIR="$(cd "$SCRIPT_DIR/../../" && pwd)"
+
+# Define the path to the app executable relative to the MacOS directory
+APP_EXEC="$SCRIPT_DIR/Ikemen_GO_MacOS"
+
+# Output for debugging
+echo "SCRIPT_DIR: $SCRIPT_DIR"
+echo "APP_DIR: $APP_DIR"
+echo "APP_EXEC: $APP_EXEC"
+
+# Check if the executable exists
+if [ ! -x "$APP_EXEC" ]; then
+    echo "Executable $APP_EXEC not found or not executable"
+    exit 1
+fi
+
+# Change directory to the parent directory of the .app bundle
+cd "$APP_DIR/../" || {
+    echo "Failed to change directory to $APP_DIR/../"
+    exit 1
+}
+
+# Output the current working directory for debugging
+echo "Current working directory: $(pwd)"
+
+# Launch the macOS app executable
+"$APP_EXEC" "$@" -AppleMagnifiedMode YES

--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -1858,6 +1858,14 @@ function options.f_keyCfg(cfgType, controller, bgdef, skipClear)
 		--gamepad key detection
 		else
 			local tmp = getJoystickKey(joyNum)
+			local guid = getJoystickGUID(joyNum)
+
+			-- Fix the GUID so that configs are preserved between boots for macOS
+			if config[cfgType][player].GUID ~= guid then
+				config[cfgType][player].GUID = guid
+				options.modified = true
+			end
+
 			if tonumber(tmp) == nil then
 				btnReleased = true
 			elseif btnReleased then

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/flopp/go-findfont v0.1.0
 	github.com/go-gl/gl v0.0.0-20231021071112-07e5d0ea2e71
-	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20231124074035-2de0cf0c80af
+	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20240506104042-037f3cc74f2a
 	github.com/go-gl/mathgl v1.0.0
 	github.com/gopxl/beep/v2 v2.0.2
 	github.com/ikemen-engine/glfont v0.0.0-20240816074833-3b3b0c69a290

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/go-gl/gl v0.0.0-20231021071112-07e5d0ea2e71 h1:5BVwOaUSBTlVZowGO6VZGw
 github.com/go-gl/gl v0.0.0-20231021071112-07e5d0ea2e71/go.mod h1:9YTyiznxEY1fVinfM7RvRcjRHbw2xLBJ3AAGIT0I4Nw=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20231124074035-2de0cf0c80af h1:zclgNFqP+NXDgGX2BiDvIonxKIom8j65wQlOyFtyujc=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20231124074035-2de0cf0c80af/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/go-gl/glfw/v3.3/glfw v0.0.0-20240506104042-037f3cc74f2a h1:vxnBhFDDT+xzxf1jTJKMKZw3H0swfWk9RpWbBbDK5+0=
+github.com/go-gl/glfw/v3.3/glfw v0.0.0-20240506104042-037f3cc74f2a/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/mathgl v1.0.0 h1:t9DznWJlXxxjeeKLIdovCOVJQk/GzDEL7h/h+Ro2B68=
 github.com/go-gl/mathgl v1.0.0/go.mod h1:yhpkQzEiH9yPyxDUGzkmgScbaBVlhC06qodikEM0ZwQ=
 github.com/go-test/deep v1.0.1 h1:UQhStjbkDClarlmv0am7OXXO4/GaPdCGiUiMTvi28sg=

--- a/src/anim.go
+++ b/src/anim.go
@@ -1085,7 +1085,7 @@ func (sl ShadowList) drawReflection(x, y, scl float32) {
 			s.fx.setColor(s.fx.eMul[0]+add[0], s.fx.eMul[1]+add[1], s.fx.eMul[2]+add[2])
 		}
 
-		xshear := sys.stage.reflection.xshear * sys.cam.Scale / sys.cam.BaseScale()
+		xshear := sys.stage.reflection.xshear
 		// Have to do it this way, -xshear results in improper behavior for the rotation offset
 		sign := float32(1)
 		if sys.stage.reflection.yscale < 0 {

--- a/src/anim.go
+++ b/src/anim.go
@@ -1069,21 +1069,10 @@ func (sl ShadowList) drawReflection(x, y, scl float32) {
 		// Set the tint if it's there
 		color := sys.stage.reflection.color
 
-		// Add full alpha if color is specified
+		// Add alpha if color is specified
 		if color != 0 {
-			color |= 0xFF000000
+			color |= uint32(ref << 24)
 		}
-
-		// the below makes tint work with PalFX (TODO)
-		// add := [...]int32{0, 0, 0}
-		// if !s.fx.enable {
-		// 	s.fx.clear()
-		// 	s.fx.eMul = [...]int32{256, 256, 256}
-		// 	s.fx.enable = true
-		// }
-		// s.fx.eAdd[0] = Clamp(s.fx.eAdd[0]+add[0], 0, 255)
-		// s.fx.eAdd[1] = Clamp(s.fx.eAdd[1]+add[1], 0, 255)
-		// s.fx.eAdd[2] = Clamp(s.fx.eAdd[2]+add[2], 0, 255)
 
 		xshear := sys.stage.reflection.xshear
 		// Have to do it this way, -xshear results in improper behavior for the rotation offset

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -370,7 +370,10 @@ const (
 	OC_const_stagevar_camera_lowestcap
 	OC_const_stagevar_playerinfo_leftbound
 	OC_const_stagevar_playerinfo_rightbound
+	OC_const_stagevar_scaling_topz
+	OC_const_stagevar_scaling_botz
 	OC_const_stagevar_scaling_topscale
+	OC_const_stagevar_scaling_botscale
 	OC_const_stagevar_bound_screenleft
 	OC_const_stagevar_bound_screenright
 	OC_const_stagevar_stageinfo_localcoord_x
@@ -393,6 +396,10 @@ const (
 	OC_const_stagevar_reflection_yscale
 	OC_const_stagevar_reflection_offset_x
 	OC_const_stagevar_reflection_offset_y
+	OC_const_stagevar_reflection_xshear
+	OC_const_stagevar_reflection_color_r
+	OC_const_stagevar_reflection_color_g
+	OC_const_stagevar_reflection_color_b
 	OC_const_constants
 	OC_const_stage_constants
 )
@@ -703,12 +710,15 @@ const (
 	OC_ex2_explodvar_animelem
 	OC_ex2_explodvar_pos_x
 	OC_ex2_explodvar_pos_y
+	OC_ex2_explodvar_pos_z
 	OC_ex2_explodvar_scale_x
 	OC_ex2_explodvar_scale_y
 	OC_ex2_explodvar_vel_x
 	OC_ex2_explodvar_vel_y
+	OC_ex2_explodvar_vel_z
 	OC_ex2_explodvar_accel_x
 	OC_ex2_explodvar_accel_y
+	OC_ex2_explodvar_accel_z
 	OC_ex2_explodvar_angle
 	OC_ex2_explodvar_angle_x
 	OC_ex2_explodvar_angle_y
@@ -724,23 +734,29 @@ const (
 	OC_ex2_projectilevar_projshadow_b
 	OC_ex2_projectilevar_projmisstime
 	OC_ex2_projectilevar_projhits
+	OC_ex2_projectilevar_projhitsmax
 	OC_ex2_projectilevar_projpriority
 	OC_ex2_projectilevar_projhitanim
 	OC_ex2_projectilevar_projremanim
 	OC_ex2_projectilevar_projcancelanim
 	OC_ex2_projectilevar_vel_x
 	OC_ex2_projectilevar_vel_y
+	OC_ex2_projectilevar_vel_z
 	OC_ex2_projectilevar_velmul_x
 	OC_ex2_projectilevar_velmul_y
+	OC_ex2_projectilevar_velmul_z
 	OC_ex2_projectilevar_remvelocity_x
 	OC_ex2_projectilevar_remvelocity_y
+	OC_ex2_projectilevar_remvelocity_z
 	OC_ex2_projectilevar_accel_x
 	OC_ex2_projectilevar_accel_y
+	OC_ex2_projectilevar_accel_z
 	OC_ex2_projectilevar_projscale_x
 	OC_ex2_projectilevar_projscale_y
 	OC_ex2_projectilevar_projangle
 	OC_ex2_projectilevar_pos_x
 	OC_ex2_projectilevar_pos_y
+	OC_ex2_projectilevar_pos_z
 	OC_ex2_projectilevar_projsprpriority
 	OC_ex2_projectilevar_projstagebound
 	OC_ex2_projectilevar_projedgebound
@@ -1779,9 +1795,9 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 	case OC_const_size_attack_dist_back:
 		sys.bcStack.PushF(c.size.attack.dist.back * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_attack_z_width_back:
-		sys.bcStack.PushF(c.size.attack.z.width[1] * ((320 / c.localcoord) / oc.localscl))
+		sys.bcStack.PushF(c.size.attack.z.width.back * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_attack_z_width_front:
-		sys.bcStack.PushF(c.size.attack.z.width[0] * ((320 / c.localcoord) / oc.localscl))
+		sys.bcStack.PushF(c.size.attack.z.width.front * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_proj_attack_dist_front:
 		sys.bcStack.PushF(c.size.proj.attack.dist.front * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_proj_attack_dist_back:
@@ -2054,8 +2070,14 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(sys.stage.leftbound)
 	case OC_const_stagevar_playerinfo_rightbound:
 		sys.bcStack.PushF(sys.stage.rightbound)
+	case OC_const_stagevar_scaling_topz:
+		sys.bcStack.PushF(sys.stage.stageCamera.topz)
+	case OC_const_stagevar_scaling_botz:
+		sys.bcStack.PushF(sys.stage.stageCamera.botz)
 	case OC_const_stagevar_scaling_topscale:
 		sys.bcStack.PushF(sys.stage.stageCamera.ztopscale)
+	case OC_const_stagevar_scaling_botscale:
+		sys.bcStack.PushF(sys.stage.stageCamera.zbotscale)
 	case OC_const_stagevar_bound_screenleft:
 		sys.bcStack.PushI(sys.stage.screenleft)
 	case OC_const_stagevar_bound_screenright:
@@ -2100,6 +2122,14 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(sys.stage.reflection.offset[0])
 	case OC_const_stagevar_reflection_offset_y:
 		sys.bcStack.PushF(sys.stage.reflection.offset[1])
+	case OC_const_stagevar_reflection_xshear:
+		sys.bcStack.PushF(sys.stage.reflection.xshear)
+	case OC_const_stagevar_reflection_color_r:
+		sys.bcStack.PushI(int32((sys.stage.reflection.color & 0xFF0000) >> 16))
+	case OC_const_stagevar_reflection_color_g:
+		sys.bcStack.PushI(int32((sys.stage.reflection.color & 0xFF00) >> 8))
+	case OC_const_stagevar_reflection_color_b:
+		sys.bcStack.PushI(int32(sys.stage.reflection.color & 0xFF))
 	case OC_const_constants:
 		sys.bcStack.PushF(c.gi().constants[sys.stringPool[sys.workingState.playerNo].List[*(*int32)(
 			unsafe.Pointer(&be[*i]))]])
@@ -2798,6 +2828,7 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	(*i)++
 	opc := be[*i-1]
 	correctScale := false
+	camOff := float32(0)
 	switch opc {
 	case OC_ex2_index:
 		sys.bcStack.PushI(c.index)
@@ -3038,6 +3069,7 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		fallthrough
 	case OC_ex2_projectilevar_pos_x:
 		correctScale = true
+		camOff = -sys.cam.Pos[0] / oc.localscl
 		fallthrough
 	case OC_ex2_projectilevar_pos_y:
 		correctScale = true
@@ -3080,6 +3112,8 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		fallthrough
 	case OC_ex2_projectilevar_projhits:
 		fallthrough
+	case OC_ex2_projectilevar_projhitsmax:
+		fallthrough
 	case OC_ex2_projectilevar_projpriority:
 		fallthrough
 	case OC_ex2_projectilevar_projhitanim:
@@ -3116,7 +3150,7 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		id := sys.bcStack.Pop()
 		v := c.projVar(id, idx, opc)
 		if correctScale {
-			sys.bcStack.PushF(v.ToF() * (c.localscl / oc.localscl))
+			sys.bcStack.PushF(v.ToF()*(c.localscl/oc.localscl) + camOff)
 		} else {
 			sys.bcStack.Push(v)
 		}
@@ -3493,7 +3527,7 @@ func (sc stateDef) Run(c *Char) {
 			if len(exp) > 1 {
 				c.setYV(exp[1].evalF(c))
 				if len(exp) > 2 {
-					exp[2].run(c)
+					c.setZV(exp[2].evalF(c))
 				}
 			}
 		case stateDef_anim:
@@ -4184,7 +4218,7 @@ func (sc helper) Run(c *Char, _ []int32) bool {
 	pt := PT_P1
 	var f, st int32 = 1, 0
 	var extmap bool
-	var x, y float32 = 0, 0
+	var x, y, z float32 = 0, 0, 0
 	rp := [...]int32{-1, 0}
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		if h == nil {
@@ -4270,6 +4304,9 @@ func (sc helper) Run(c *Char, _ []int32) bool {
 			x = exp[0].evalF(c) * lclscround
 			if len(exp) > 1 {
 				y = exp[1].evalF(c) * lclscround
+				if len(exp) > 2 {
+					z = exp[2].evalF(c) * lclscround
+				}
 			}
 		case helper_facing:
 			f = exp[0].evalI(c)
@@ -4315,7 +4352,7 @@ func (sc helper) Run(c *Char, _ []int32) bool {
 		h.localscl = crun.localscl
 		h.localcoord = crun.localcoord
 	}
-	crun.helperInit(h, st, pt, x, y, f, rp, extmap)
+	crun.helperInit(h, st, pt, x, y, z, f, rp, extmap)
 	return false
 }
 
@@ -4822,6 +4859,9 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 			e.relativePos[0] = exp[0].evalF(c) * lclscround
 			if len(exp) > 1 {
 				e.relativePos[1] = exp[1].evalF(c) * lclscround
+				if len(exp) > 2 {
+					e.relativePos[2] = exp[2].evalF(c) * lclscround
+				}
 			}
 		case explod_random:
 			rndx := (exp[0].evalF(c) / 2) * lclscround
@@ -4829,6 +4869,10 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 			if len(exp) > 1 {
 				rndy := (exp[1].evalF(c) / 2) * lclscround
 				e.relativePos[1] += RandF(-rndy, rndy)
+				if len(exp) > 2 {
+					rndz := (exp[2].evalF(c) / 2) * lclscround
+					e.relativePos[2] += RandF(-rndz, rndz)
+				}
 			}
 		case explod_space:
 			e.space = Space(exp[0].evalI(c))
@@ -4838,11 +4882,17 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 			e.velocity[0] = exp[0].evalF(c) * lclscround
 			if len(exp) > 1 {
 				e.velocity[1] = exp[1].evalF(c) * lclscround
+				if len(exp) > 2 {
+					e.velocity[2] = exp[2].evalF(c) * lclscround
+				}
 			}
 		case explod_accel:
 			e.accel[0] = exp[0].evalF(c) * lclscround
 			if len(exp) > 1 {
 				e.accel[1] = exp[1].evalF(c) * lclscround
+				if len(exp) > 2 {
+					e.accel[2] = exp[2].evalF(c) * lclscround
+				}
 			}
 		case explod_scale:
 			e.scale[0] = exp[0].evalF(c)
@@ -5002,9 +5052,12 @@ func (sc explod) setInterpolation(c *Char, e *Explod,
 		e.interpolate_animelem[0] = e.animelem
 		e.interpolate_animelem[2] = e.interpolate_animelem[1]
 	case explod_interpolate_pos:
-		e.interpolate_pos[2] = exp[0].evalF(c)
+		e.interpolate_pos[3] = exp[0].evalF(c)
 		if len(exp) > 1 {
-			e.interpolate_pos[3] = exp[1].evalF(c)
+			e.interpolate_pos[4] = exp[1].evalF(c)
+			if len(exp) > 2 {
+				e.interpolate_pos[5] = exp[2].evalF(c)
+			}
 		}
 	case explod_interpolate_scale:
 		e.interpolate_scale[2] = exp[0].evalF(c)
@@ -5067,7 +5120,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 	rp := [...]int32{-1, 0}
 	remap := false
 	var f, vf float32 = 1, 1
-	sp, pos, vel, accel := Space_none, [2]float32{0, 0}, [2]float32{0, 0}, [2]float32{0, 0}
+	sp, pos, vel, accel := Space_none, [3]float32{0, 0, 0}, [3]float32{0, 0, 0}, [3]float32{0, 0, 0}
 	ptexists := false
 	eachExpl := func(f func(e *Explod)) {
 		if idx < 0 {
@@ -5142,6 +5195,12 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 					if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
 						eachExpl(func(e *Explod) { e.relativePos[1] = pos[1] })
 					}
+					if len(exp) > 2 {
+						pos[2] = exp[2].evalF(c) * lclscround
+						if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
+							eachExpl(func(e *Explod) { e.relativePos[2] = pos[2] })
+						}
+					}
 				}
 			case explod_random:
 				rndx := (exp[0].evalF(c) / 2) * lclscround
@@ -5157,6 +5216,14 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 					if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
 						eachExpl(func(e *Explod) { e.relativePos[1] += rndy })
 					}
+					if len(exp) > 2 {
+						rndz := (exp[2].evalF(c) / 2) * lclscround
+						rndz = RandF(-rndz, rndz)
+						pos[2] += rndz
+						if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
+							eachExpl(func(e *Explod) { e.relativePos[2] += rndz })
+						}
+					}
 				}
 			case explod_velocity:
 				vel[0] = exp[0].evalF(c) * lclscround
@@ -5168,6 +5235,12 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 					if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
 						eachExpl(func(e *Explod) { e.velocity[1] = vel[1] })
 					}
+					if len(exp) > 2 {
+						vel[2] = exp[2].evalF(c) * lclscround
+						if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
+							eachExpl(func(e *Explod) { e.velocity[2] = vel[2] })
+						}
+					}
 				}
 			case explod_accel:
 				accel[0] = exp[0].evalF(c) * lclscround
@@ -5178,6 +5251,12 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 					accel[1] = exp[1].evalF(c) * lclscround
 					if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
 						eachExpl(func(e *Explod) { e.accel[1] = accel[1] })
+					}
+					if len(exp) > 2 {
+						accel[2] = exp[2].evalF(c) * lclscround
+						if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
+							eachExpl(func(e *Explod) { e.accel[2] = accel[2] })
+						}
 					}
 				}
 			case explod_space:
@@ -5217,6 +5296,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 					}
 					e.setX(e.pos[0])
 					e.setY(e.pos[1])
+					e.setZ(e.pos[2])
 				})
 			case explod_removetime:
 				t := exp[0].evalI(c)
@@ -5740,6 +5820,7 @@ const (
 	hitDef_down_recover
 	hitDef_down_recovertime
 	hitDef_xaccel
+	hitDef_attack_width
 	hitDef_last = iota + afterImage_last + 1 - 1
 	hitDef_redirectid
 )
@@ -6037,6 +6118,13 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 		hd.down_recovertime = exp[0].evalI(c)
 	case hitDef_xaccel:
 		hd.xaccel = exp[0].evalF(c)
+	case hitDef_attack_width:
+		hd.attack.width[0] = exp[0].evalF(c)
+		if len(exp) > 1 {
+			hd.attack.width[1] = exp[1].evalF(c)
+		} else {
+			hd.attack.width[1] = hd.attack.width[0]
+		}
 	default:
 		if !palFX(sc).runSub(c, &hd.palfx, id, exp) {
 			return false
@@ -6161,7 +6249,7 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 	var lclscround float32 = 1.0
 	var p *Projectile
 	pt := PT_P1
-	var x, y float32 = 0, 0
+	var x, y, z float32 = 0, 0, 0
 	op := false
 	clsnscale := false
 	rp := [...]int32{-1, 0}
@@ -6207,7 +6295,9 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 		case projectile_projmisstime:
 			p.misstime = exp[0].evalI(c)
 		case projectile_projhits:
-			p.hits = exp[0].evalI(c)
+			tmp := p.totalhits
+			p.totalhits = exp[0].evalI(c)
+			p.hits += (p.totalhits - tmp)
 		case projectile_projpriority:
 			p.priority = exp[0].evalI(c)
 			p.priorityPoints = p.priority
@@ -6229,6 +6319,9 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 			p.velmul[0] = exp[0].evalF(c)
 			if len(exp) > 1 {
 				p.velmul[1] = exp[1].evalF(c)
+				if len(exp) > 2 {
+					p.velmul[2] = exp[2].evalF(c)
+				}
 			}
 		case projectile_remvelocity:
 			p.remvelocity[0] = exp[0].evalF(c) * lclscround
@@ -6239,6 +6332,9 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 			p.accel[0] = exp[0].evalF(c) * lclscround
 			if len(exp) > 1 {
 				p.accel[1] = exp[1].evalF(c) * lclscround
+				if len(exp) > 2 {
+					p.accel[2] = exp[2].evalF(c)
+				}
 			}
 		case projectile_projscale:
 			p.scale[0] = exp[0].evalF(c)
@@ -6251,6 +6347,9 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 			x = exp[0].evalF(c) * lclscround
 			if len(exp) > 1 {
 				y = exp[1].evalF(c) * lclscround
+				if len(exp) > 2 {
+					z = exp[2].evalF(c) * lclscround
+				}
 			}
 		case projectile_projsprpriority:
 			p.sprpriority = exp[0].evalI(c)
@@ -6348,7 +6447,7 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 	} else {
 		p.localscl = crun.localscl
 	}
-	crun.projInit(p, pt, x, y, op, rp[0], rp[1], clsnscale)
+	crun.projInit(p, pt, x, y, z, op, rp[0], rp[1], clsnscale)
 	return false
 }
 
@@ -7062,6 +7161,16 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				eachProj(func(p *Projectile) {
 					p.hitdef.xaccel = exp[0].evalF(c)
 				})
+			case hitDef_attack_width:
+				eachProj(
+					func(p *Projectile) {
+						p.hitdef.attack.width[0] = exp[0].evalF(c)
+						if len(exp) > 1 {
+							p.hitdef.attack.width[1] = exp[1].evalF(c)
+						} else {
+							p.hitdef.attack.width[1] = p.hitdef.attack.width[0]
+						}
+					})
 			default:
 				eachProj(func(p *Projectile) {
 					if !hitDef(sc).runSub(c, &p.hitdef, id, exp) {
@@ -7260,7 +7369,7 @@ func (sc targetBind) Run(c *Char, _ []int32) bool {
 	var lclscround float32 = 1.0
 	tar := crun.getTarget(-1)
 	t := int32(1)
-	var x, y float32 = 0, 0
+	var x, y, z float32 = 0, 0, 0
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case targetBind_id:
@@ -7274,6 +7383,9 @@ func (sc targetBind) Run(c *Char, _ []int32) bool {
 			x = exp[0].evalF(c) * lclscround
 			if len(exp) > 1 {
 				y = exp[1].evalF(c) * lclscround
+				if len(exp) > 2 {
+					z = exp[2].evalF(c) * lclscround
+				}
 			}
 		case targetBind_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
@@ -7293,7 +7405,7 @@ func (sc targetBind) Run(c *Char, _ []int32) bool {
 	if len(tar) == 0 {
 		return false
 	}
-	crun.targetBind(tar, t, x, y)
+	crun.targetBind(tar, t, x, y, z)
 	return false
 }
 
@@ -7303,6 +7415,7 @@ const (
 	bindToTarget_id byte = iota
 	bindToTarget_time
 	bindToTarget_pos
+	bindToTarget_posz
 	bindToTarget_redirectid
 )
 
@@ -7310,7 +7423,7 @@ func (sc bindToTarget) Run(c *Char, _ []int32) bool {
 	crun := c
 	var lclscround float32 = 1.0
 	tar := crun.getTarget(-1)
-	t, x, y, hmf := int32(1), float32(0), float32(math.NaN()), HMF_F
+	t, x, y, z, hmf := int32(1), float32(0), float32(math.NaN()), float32(math.NaN()), HMF_F
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case bindToTarget_id:
@@ -7328,6 +7441,8 @@ func (sc bindToTarget) Run(c *Char, _ []int32) bool {
 					hmf = HMF(exp[2].evalI(c))
 				}
 			}
+		case bindToTarget_posz:
+			z = exp[0].evalF(c) * lclscround
 		case bindToTarget_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -7345,7 +7460,7 @@ func (sc bindToTarget) Run(c *Char, _ []int32) bool {
 	if len(tar) == 0 {
 		return false
 	}
-	crun.bindToTarget(tar, t, x, y, hmf)
+	crun.bindToTarget(tar, t, x, y, z, hmf)
 	return false
 }
 
@@ -8403,19 +8518,25 @@ func (sc makeDust) Run(c *Char, _ []int32) bool {
 				return false
 			}
 		case makeDust_pos:
-			x, y := exp[0].evalF(c), float32(0)
+			x, y, z := exp[0].evalF(c), float32(0), float32(0)
 			if len(exp) > 1 {
 				y = exp[1].evalF(c)
+				if len(exp) > 2 {
+					z = exp[2].evalF(c)
+				}
 			}
 			crun.makeDust(x-float32(crun.size.draw.offset[0]),
-				y-float32(crun.size.draw.offset[1]))
+				y-float32(crun.size.draw.offset[1]), z)
 		case makeDust_pos2:
-			x, y := exp[0].evalF(c), float32(0)
+			x, y, z := exp[0].evalF(c), float32(0), float32(0)
 			if len(exp) > 1 {
 				y = exp[1].evalF(c)
+				if len(exp) > 2 {
+					z = exp[2].evalF(c)
+				}
 			}
 			crun.makeDust(x-float32(crun.size.draw.offset[0]),
-				y-float32(crun.size.draw.offset[1]))
+				y-float32(crun.size.draw.offset[1]), z)
 		case makeDust_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -8889,7 +9010,7 @@ func (sc bindToParent) Run(c *Char, _ []int32) bool {
 	crun := c
 	var lclscround float32 = 1.0
 	p := crun.parent()
-	var x, y float32 = 0, 0
+	var x, y, z float32 = 0, 0, 0
 	var time int32 = 1
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
@@ -8905,6 +9026,9 @@ func (sc bindToParent) Run(c *Char, _ []int32) bool {
 			x = exp[0].evalF(c) * lclscround
 			if len(exp) > 1 {
 				y = exp[1].evalF(c) * lclscround
+				if len(exp) > 2 {
+					z = exp[2].evalF(c) * lclscround
+				}
 			}
 		case bindToParent_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
@@ -8922,6 +9046,7 @@ func (sc bindToParent) Run(c *Char, _ []int32) bool {
 	}
 	crun.bindPos[0] = x
 	crun.bindPos[1] = y
+	crun.bindPos[2] = z
 	crun.setBindToId(p)
 	crun.setBindTime(time)
 	return false
@@ -8933,7 +9058,7 @@ func (sc bindToRoot) Run(c *Char, _ []int32) bool {
 	crun := c
 	var lclscround float32 = 1.0
 	r := crun.root()
-	var x, y float32 = 0, 0
+	var x, y, z float32 = 0, 0, 0
 	var time int32 = 1
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
@@ -8949,6 +9074,9 @@ func (sc bindToRoot) Run(c *Char, _ []int32) bool {
 			x = exp[0].evalF(c) * lclscround
 			if len(exp) > 1 {
 				y = exp[1].evalF(c) * lclscround
+				if len(exp) > 2 {
+					z = exp[2].evalF(c) * lclscround
+				}
 			}
 		case bindToParent_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
@@ -8966,6 +9094,7 @@ func (sc bindToRoot) Run(c *Char, _ []int32) bool {
 	}
 	crun.bindPos[0] = x
 	crun.bindPos[1] = y
+	crun.bindPos[2] = z
 	crun.setBindToId(r)
 	crun.setBindTime(time)
 	return false
@@ -10464,7 +10593,12 @@ func (sc playBgm) Run(c *Char, _ []int32) bool {
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case playBgm_bgm:
-			if bgm = string(*(*[]byte)(unsafe.Pointer(&exp[0]))); bgm != "" {
+			bgm = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
+			// Default to stage BGM if string is stage
+			if bgm == "stage" {
+				// Search .def directory last in this instance
+				bgm = SearchFile(sys.stage.bgmusic, []string{"", "sound/", crun.gi().def})
+			} else if bgm != "" {
 				bgm = SearchFile(bgm, []string{crun.gi().def, "", "sound/"})
 			}
 			b = true
@@ -10880,7 +11014,10 @@ const (
 	modifyStageVar_camera_lowestcap
 	modifyStageVar_playerinfo_leftbound
 	modifyStageVar_playerinfo_rightbound
+	modifyStageVar_scaling_topz
+	modifyStageVar_scaling_botz
 	modifyStageVar_scaling_topscale
+	modifyStageVar_scaling_botscale
 	modifyStageVar_bound_screenleft
 	modifyStageVar_bound_screenright
 	modifyStageVar_stageinfo_zoffset
@@ -10895,6 +11032,7 @@ const (
 	modifyStageVar_shadow_offset
 	modifyStageVar_reflection_intensity
 	modifyStageVar_reflection_yscale
+	modifyStageVar_reflection_xshear
 	modifyStageVar_reflection_offset
 	modifyStageVar_redirectid
 )
@@ -10952,9 +11090,21 @@ func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 			s.leftbound = exp[0].evalF(c)
 		case modifyStageVar_playerinfo_rightbound:
 			s.rightbound = exp[0].evalF(c)
+		case modifyStageVar_scaling_topz:
+			if s.mugenver[0] != 1 { // mugen 1.0+ removed support for topz
+				s.stageCamera.topz = exp[0].evalF(c)
+			}
+		case modifyStageVar_scaling_botz:
+			if s.mugenver[0] != 1 { // mugen 1.0+ removed support for botz
+				s.stageCamera.botz = exp[0].evalF(c)
+			}
 		case modifyStageVar_scaling_topscale:
 			if s.mugenver[0] != 1 { // mugen 1.0+ removed support for topscale
 				s.stageCamera.ztopscale = exp[0].evalF(c)
+			}
+		case modifyStageVar_scaling_botscale:
+			if s.mugenver[0] != 1 { // mugen 1.0+ removed support for botscale
+				s.stageCamera.zbotscale = exp[0].evalF(c)
 			}
 		case modifyStageVar_bound_screenleft:
 			s.screenleft = exp[0].evalI(c)
@@ -10992,6 +11142,8 @@ func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 			s.reflection.intensity = Clamp(exp[0].evalI(c), 0, 255)
 		case modifyStageVar_reflection_yscale:
 			s.reflection.yscale = exp[0].evalF(c)
+		case modifyStageVar_reflection_xshear:
+			s.reflection.xshear = exp[0].evalF(c)
 		case modifyStageVar_reflection_offset:
 			s.reflection.offset[0] = exp[0].evalF(c)
 			s.reflection.offset[1] = exp[1].evalF(c)

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -11033,6 +11033,7 @@ const (
 	modifyStageVar_reflection_intensity
 	modifyStageVar_reflection_yscale
 	modifyStageVar_reflection_xshear
+	modifyStageVar_reflection_color
 	modifyStageVar_reflection_offset
 	modifyStageVar_redirectid
 )
@@ -11144,6 +11145,14 @@ func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 			s.reflection.yscale = exp[0].evalF(c)
 		case modifyStageVar_reflection_xshear:
 			s.reflection.xshear = exp[0].evalF(c)
+		case modifyStageVar_reflection_color:
+			// mugen 1.1 removed support for color
+			if (s.mugenver[0] != 1 || s.mugenver[1] != 1) && (s.sff.header.Ver0 != 2 || s.sff.header.Ver2 != 1) {
+				r := Clamp(exp[0].evalI(c), 0, 255)
+				g := Clamp(exp[1].evalI(c), 0, 255)
+				b := Clamp(exp[2].evalI(c), 0, 255)
+				s.reflection.color = uint32(r<<16 | g<<8 | b)
+			}
 		case modifyStageVar_reflection_offset:
 			s.reflection.offset[0] = exp[0].evalF(c)
 			s.reflection.offset[1] = exp[1].evalF(c)

--- a/src/camera.go
+++ b/src/camera.go
@@ -24,6 +24,9 @@ type stageCamera struct {
 	localscl                float32
 	zoffset                 int32
 	ztopscale               float32
+	zbotscale               float32
+	topz                    float32
+	botz                    float32
 	startzoom               float32
 	zoomin                  float32
 	zoomout                 float32
@@ -59,8 +62,8 @@ func newStageCamera() *stageCamera {
 	return &stageCamera{verticalfollow: 0.2, tensionvel: 1, tension: 50,
 		cuthigh: 0, cutlow: math.MinInt32,
 		localcoord: [...]int32{320, 240}, localscl: float32(sys.gameWidth / 320),
-		ztopscale: 1, startzoom: 1, zoomin: 1, zoomout: 1, ytensionenable: false,
-		tensionhigh: 0, tensionlow: 0,
+		topz: 0, botz: 0, ztopscale: 1, zbotscale: 1, startzoom: 1, zoomin: 1, zoomout: 1,
+		ytensionenable: false, tensionhigh: 0, tensionlow: 0,
 		fov: 40, yshift: 0, far: 10000, near: 0.1,
 		zoomindelay: 0, zoominspeed: 1, zoomoutspeed: 1, yscrollspeed: 1,
 		boundhighzoomdelta: 0, verticalfollowzoomdelta: 0}

--- a/src/char.go
+++ b/src/char.go
@@ -1623,7 +1623,7 @@ type Projectile struct {
 	stagebound      int32
 	heightbound     [2]int32
 	pos             [3]float32
-	drawPos         [2]float32
+	drawPos         [3]float32
 	facing          float32
 	removefacing    float32
 	shadow          [3]int32
@@ -1769,10 +1769,10 @@ func (p *Projectile) update(playerNo int) {
 	} else {
 		if sys.tickFrame() {
 			p.pos = [...]float32{p.pos[0] + p.velocity[0]*p.facing, p.pos[1] + p.velocity[1], p.pos[2] + p.velocity[2]}
-			p.drawPos = [...]float32{p.pos[0], p.pos[1] + p.pos[2]}
+			p.drawPos = [...]float32{p.pos[0], p.pos[1], p.pos[2]}
 		}
 		spd := sys.tickInterpolation()
-		for i := 0; i < 2; i++ {
+		for i := 0; i < 3; i++ {
 			p.drawPos[i] = p.pos[i] - (p.pos[i]-p.oldPos[i])*(1-spd)
 		}
 		if sys.tickNextFrame() {
@@ -1941,7 +1941,7 @@ func (p *Projectile) cueDraw(oldVer bool, playerNo int) {
 	var c = sys.chars[playerNo][0]
 	zscale := c.updateZScale(p.pos[2])
 	if p.ani != nil {
-		sd := &SprData{p.ani, p.palfx, [...]float32{p.drawPos[0] * p.localscl, p.drawPos[1]*p.localscl + p.pos[2]*p.localscl},
+		sd := &SprData{p.ani, p.palfx, [...]float32{p.drawPos[0] * p.localscl, p.drawPos[1]*p.localscl + p.drawPos[2]*p.localscl},
 			[...]float32{p.facing * p.scale[0] * p.localscl * zscale, p.scale[1] * p.localscl * zscale}, [2]int32{-1},
 			p.sprpriority, Rotation{p.facing * p.angle, 0, 0}, [...]float32{1, 1}, false, playerNo == sys.superplayer,
 			sys.cgi[playerNo].mugenver[0] != 1, p.facing, 1, 0, 0, [4]float32{0, 0, 0, 0}}
@@ -3803,9 +3803,11 @@ func (c *Char) projVar(pid BytecodeValue, idx BytecodeValue, vtype OpCode) Bytec
 			case OC_ex2_projectilevar_projangle:
 				v = BytecodeFloat(p.angle)
 			case OC_ex2_projectilevar_pos_x:
-				v = BytecodeFloat(p.pos[0])
+				v = BytecodeFloat(p.drawPos[0])
 			case OC_ex2_projectilevar_pos_y:
-				v = BytecodeFloat(p.pos[1])
+				v = BytecodeFloat(p.drawPos[1])
+			case OC_ex2_projectilevar_pos_z:
+				v = BytecodeFloat(p.drawPos[2])
 			case OC_ex2_projectilevar_projsprpriority:
 				v = BytecodeInt(p.sprpriority)
 			case OC_ex2_projectilevar_projstagebound:

--- a/src/char.go
+++ b/src/char.go
@@ -2771,8 +2771,6 @@ func (c *Char) load(def string) error {
 						}
 						is.ReadF32("attack.z.width",
 							&c.size.attack.z.width.front, &c.size.attack.z.width.back)
-						is.ReadF32("attack.z.width.back", &c.size.attack.z.width.back)
-						is.ReadF32("attack.z.width.front", &c.size.attack.z.width.front)
 					}
 				case "velocity":
 					if velocity {

--- a/src/char.go
+++ b/src/char.go
@@ -272,7 +272,10 @@ type CharSize struct {
 			back  float32
 		}
 		z struct {
-			width [2]float32
+			width struct {
+				front float32
+				back  float32
+			}
 		}
 	}
 	proj struct {
@@ -323,7 +326,7 @@ func (cs *CharSize) init() {
 	cs.draw.offset = [...]float32{0, 0}
 	cs.z.width = 3
 	cs.z.enable = false
-	cs.attack.z.width = [...]float32{4, 4}
+	cs.attack.z.width.front, cs.attack.z.width.back = 4, 4
 }
 
 type CharVelocity struct {
@@ -651,6 +654,9 @@ type HitDef struct {
 	score                      [2]float32
 	p2clsncheck                int32
 	p2clsnrequire              int32
+	attack                     struct {
+		width [2]float32
+	}
 }
 
 func (hd *HitDef) clear() {
@@ -724,6 +730,9 @@ func (hd *HitDef) clear() {
 		p2clsnrequire:    -1,
 		down_recover:     true,
 		down_recovertime: -1,
+		attack: struct{ width [2]float32 }{
+			[2]float32{float32(4), float32(4)},
+		},
 	}
 	hd.palfx.mul, hd.palfx.color, hd.palfx.hue = [...]int32{255, 255, 255}, 1, 0
 	hd.fall.setDefault()
@@ -1099,9 +1108,9 @@ type Explod struct {
 	space               Space
 	bindId              int32
 	bindtime            int32
-	pos                 [2]float32
-	relativePos         [2]float32
-	offset              [2]float32
+	pos                 [3]float32
+	relativePos         [3]float32
+	offset              [3]float32
 	relativef           float32
 	facing              float32
 	vfacing             float32
@@ -1110,8 +1119,8 @@ type Explod struct {
 	removeonchangestate bool
 	statehaschanged     bool
 	removetime          int32
-	velocity            [2]float32
-	accel               [2]float32
+	velocity            [3]float32
+	accel               [3]float32
 	sprpriority         int32
 	layerno             int32
 	shadow              [3]int32
@@ -1129,8 +1138,8 @@ type Explod struct {
 	anglerot             [3]float32
 	projection           Projection
 	fLength              float32
-	oldPos               [2]float32
-	newPos               [2]float32
+	oldPos               [3]float32
+	newPos               [3]float32
 	playerId             int32
 	palfx                *PalFX
 	palfxdef             PalFXDef
@@ -1148,11 +1157,11 @@ type Explod struct {
 	interpolate_animelem [3]int32
 	interpolate_scale    [4]float32
 	interpolate_alpha    [5]int32
-	interpolate_pos      [4]float32
+	interpolate_pos      [6]float32
 	interpolate_angle    [6]float32
 	interpolate_fLength  [2]float32
 	animNo               int32
-	drawPos              [2]float32
+	drawPos              [3]float32
 }
 
 func (e *Explod) clear() {
@@ -1179,12 +1188,13 @@ func (e *Explod) clear() {
 }
 func (e *Explod) reset() {
 	e.facing = 1
-	e.offset[0], e.offset[1] = 0, 0
+	e.offset[0], e.offset[1], e.offset[2] = 0, 0, 0
 	e.setX(e.offset[0])
 	e.setY(e.offset[1])
-	e.relativePos[0], e.relativePos[1] = 0, 0
-	e.velocity[0], e.velocity[1] = 0, 0
-	e.accel[0], e.accel[1] = 0, 0
+	e.setZ(e.offset[2])
+	e.relativePos[0], e.relativePos[1], e.relativePos[2] = 0, 0, 0
+	e.velocity[0], e.velocity[1], e.velocity[2] = 0, 0, 0
+	e.accel[0], e.accel[1], e.accel[2] = 0, 0, 0
 	e.bindId = -2
 	if e.bindtime == 0 {
 		e.bindtime = 1
@@ -1195,6 +1205,9 @@ func (e *Explod) setX(x float32) {
 }
 func (e *Explod) setY(y float32) {
 	e.pos[1], e.oldPos[1], e.newPos[1] = y, y, y
+}
+func (e *Explod) setZ(z float32) {
+	e.pos[2], e.oldPos[2], e.newPos[2] = z, z, z
 }
 func (e *Explod) setBind(bId int32) {
 	if e.space == Space_screen && (e.postype == PT_P1 || e.postype == PT_P2) {
@@ -1211,10 +1224,12 @@ func (e *Explod) setPos(c *Char) {
 		if e.space == Space_screen {
 			e.offset[0] = c.pos[0]*c.localscl/e.localscl + c.offsetX()*c.localscl/e.localscl
 			e.offset[1] = sys.cam.GroundLevel()*e.localscl +
-				c.pos[1]*c.localscl/e.localscl + c.offsetY()*c.localscl/e.localscl
+				c.pos[1]*c.localscl/e.localscl + (c.offsetY()-(c.pos[2]/c.localscl))*c.localscl/e.localscl // we need to subtract the Z pos in the offset here
+			e.offset[2] = ClampF(c.pos[2]*c.localscl/e.localscl, sys.stage.stageCamera.topz, sys.stage.stageCamera.botz)
 		} else {
 			e.setX(c.pos[0]*c.localscl/e.localscl + c.offsetX()*c.localscl/e.localscl)
-			e.setY(c.pos[1]*c.localscl/e.localscl + c.offsetY()*c.localscl/e.localscl)
+			e.setY(c.pos[1]*c.localscl/e.localscl + (c.offsetY()-(c.pos[2]/c.localscl))*c.localscl/e.localscl) // we need to subtract the Z pos in the offset here
+			e.setZ(c.pos[2] * c.localscl / e.localscl)
 		}
 	}
 	lPos := func() {
@@ -1340,7 +1355,8 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 		(e.space == Space_screen && e.postype <= PT_P2)) {
 		if c := sys.playerID(e.bindId); c != nil {
 			e.pos[0] = c.drawPos[0]*c.localscl/e.localscl + c.offsetX()*c.localscl/e.localscl
-			e.pos[1] = c.drawPos[1]*c.localscl/e.localscl + c.offsetY()*c.localscl/e.localscl
+			e.pos[1] = c.drawPos[1]*c.localscl/e.localscl + (c.offsetY()-(c.pos[2]/c.localscl))*c.localscl/e.localscl // we need to subtract the Z pos in the offset here
+			e.pos[2] = c.drawPos[2] * c.localscl / e.localscl
 		} else {
 			// Doesn't seem necessary to do this, since MUGEN 1.1 seems to carry bindtime even if
 			// you change bindId to something that doesn't point to any character
@@ -1413,10 +1429,14 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 	rot.angle = anglerot[0]
 	rot.xangle = anglerot[1]
 	rot.yangle = anglerot[2]
-	e.drawPos = [2]float32{(e.pos[0] + e.offset[0] + off[0] + e.interpolate_pos[0]) * e.localscl, (e.pos[1] + e.offset[1] + off[1] + e.interpolate_pos[1]) * e.localscl}
+	zscale := float32(1)
+	if e.space == Space_stage {
+		zscale = c.updateZScale(e.pos[2])
+	}
+	e.drawPos = [3]float32{(e.pos[0] + e.offset[0] + off[0] + e.interpolate_pos[0]) * zscale * e.localscl, zscale * (e.pos[1] + e.offset[1] + off[1] + e.interpolate_pos[1]) * e.localscl, zscale * (e.pos[2] + e.offset[2] + off[2] + e.interpolate_pos[2]) * e.localscl}
 	var ewin = [4]float32{e.window[0] * e.localscl * facing, e.window[1] * e.localscl * e.vfacing, e.window[2] * e.localscl * facing, e.window[3] * e.localscl * e.vfacing}
-	sprs.add(&SprData{e.anim, pfx, e.drawPos, [...]float32{(facing * scale[0]) * e.localscl,
-		(e.vfacing * scale[1]) * e.localscl}, alp, e.sprpriority, rot, [...]float32{1, 1},
+	sprs.add(&SprData{e.anim, pfx, [2]float32{e.drawPos[0], e.drawPos[1] + e.drawPos[2]}, [...]float32{(facing * scale[0]) * e.localscl * zscale,
+		(e.vfacing * scale[1]) * e.localscl * zscale}, alp, e.sprpriority, rot, [...]float32{1, 1},
 		e.space == Space_screen, playerNo == sys.superplayer, oldVer, facing, 1, int32(e.projection), fLength, ewin},
 		e.shadow[0]<<16|e.shadow[1]&0xff<<8|e.shadow[2]&0xff, sdwalp, [2]float32{0, 0}, [2]float32{0, 0}, 0, 0)
 	if sys.tickNextFrame() {
@@ -1450,6 +1470,7 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 			e.oldPos = e.pos
 			e.newPos[0] = e.pos[0] + e.velocity[0]*e.facing
 			e.newPos[1] = e.pos[1] + e.velocity[1]
+			e.newPos[2] = e.pos[2] + e.velocity[2]
 			for i := range e.velocity {
 				e.velocity[i] += e.accel[i]
 			}
@@ -1463,6 +1484,7 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 		} else {
 			e.setX(e.pos[0])
 			e.setY(e.pos[1])
+			e.setZ(e.pos[2])
 		}
 	}
 }
@@ -1480,8 +1502,8 @@ func (e *Explod) Interpolate(act bool, scale *[2]float32, alpha *[2]int32, angle
 			e.animelem = Clamp(elem, Min(e.interpolate_animelem[0], e.interpolate_animelem[1]), Max(e.interpolate_animelem[0], e.interpolate_animelem[1]))
 		}
 		for i := 0; i < 3; i++ {
+			e.interpolate_pos[i] = Lerp(e.interpolate_pos[i+3], 0, t)
 			if i < 2 {
-				e.interpolate_pos[i] = Lerp(e.interpolate_pos[i+2], 0, t)
 				e.interpolate_scale[i] = Lerp(e.interpolate_scale[i+2], e.start_scale[i], t) //-e.start_scale[i]
 				if e.blendmode == 1 {
 					e.interpolate_alpha[i] = Clamp(int32(Lerp(float32(e.interpolate_alpha[i+2]), float32(e.start_alpha[i]), t)), 0, 255)
@@ -1586,11 +1608,12 @@ type Projectile struct {
 	clsnAngle       float32
 	remove          bool
 	removetime      int32
-	velocity        [2]float32
-	remvelocity     [2]float32
-	accel           [2]float32
-	velmul          [2]float32
+	velocity        [3]float32
+	remvelocity     [3]float32
+	accel           [3]float32
+	velmul          [3]float32
 	hits            int32
+	totalhits       int32
 	misstime        int32
 	priority        int32
 	priorityPoints  int32
@@ -1599,8 +1622,7 @@ type Projectile struct {
 	edgebound       int32
 	stagebound      int32
 	heightbound     [2]int32
-	pos             [2]float32
-	oldPos          [2]float32
+	pos             [3]float32
 	drawPos         [2]float32
 	facing          float32
 	removefacing    float32
@@ -1610,6 +1632,8 @@ type Projectile struct {
 	ani             *Animation
 	curmisstime     int32
 	hitpause        int32
+	oldPos          [3]float32
+	newPos          [3]float32
 	aimg            AfterImage
 	palfx           *PalFX
 	localscl        float32
@@ -1642,8 +1666,9 @@ func (p *Projectile) clear() {
 		remove:         true,
 		localscl:       1,
 		removetime:     -1,
-		velmul:         [...]float32{1, 1},
+		velmul:         [...]float32{1, 1, 1},
 		hits:           1,
+		totalhits:      1,
 		priority:       1,
 		priorityPoints: 1,
 		sprpriority:    3,
@@ -1657,10 +1682,8 @@ func (p *Projectile) clear() {
 	p.hitdef.clear()
 }
 
-func (p *Projectile) setPos(pos [2]float32) {
-	p.pos = pos
-	p.oldPos = pos
-	p.drawPos = pos
+func (p *Projectile) setPos(pos [3]float32) {
+	p.pos, p.oldPos, p.newPos = pos, pos, pos
 }
 
 func (p *Projectile) paused(playerNo int) bool {
@@ -1721,8 +1744,8 @@ func (p *Projectile) update(playerNo int) {
 					} else {
 						p.velocity[0] *= -1
 					}
-					p.accel = [2]float32{0, 0}
-					p.velmul = [2]float32{1, 1}
+					p.accel = [3]float32{0, 0, 0}
+					p.velmul = [3]float32{1, 1, 1}
 					p.anim = -1
 					// In Mugen, projectiles can hit even after their removetime expires - https://github.com/ikemen-engine/Ikemen-GO/issues/1362
 					//if p.hits >= 0 {
@@ -1745,8 +1768,8 @@ func (p *Projectile) update(playerNo int) {
 		// There's a minor issue here where a projectile will lag behind one frame relative to Mugen if created during a pause
 	} else {
 		if sys.tickFrame() {
-			p.pos = [...]float32{p.pos[0] + p.velocity[0]*p.facing, p.pos[1] + p.velocity[1]}
-			p.drawPos = p.pos
+			p.pos = [...]float32{p.pos[0] + p.velocity[0]*p.facing, p.pos[1] + p.velocity[1], p.pos[2] + p.velocity[2]}
+			p.drawPos = [...]float32{p.pos[0], p.pos[1] + p.pos[2]}
 		}
 		spd := sys.tickInterpolation()
 		for i := 0; i < 2; i++ {
@@ -1916,13 +1939,14 @@ func (p *Projectile) cueDraw(oldVer bool, playerNo int) {
 		sprs = &sys.spritesLayerN1
 	}
 	var c = sys.chars[playerNo][0]
+	zscale := c.updateZScale(p.pos[2])
 	if p.ani != nil {
-		sd := &SprData{p.ani, p.palfx, [...]float32{p.drawPos[0] * p.localscl, p.drawPos[1] * p.localscl},
-			[...]float32{p.facing * p.scale[0] * p.localscl, p.scale[1] * p.localscl}, [2]int32{-1},
+		sd := &SprData{p.ani, p.palfx, [...]float32{p.drawPos[0] * p.localscl, p.drawPos[1]*p.localscl + p.pos[2]*p.localscl},
+			[...]float32{p.facing * p.scale[0] * p.localscl * zscale, p.scale[1] * p.localscl * zscale}, [2]int32{-1},
 			p.sprpriority, Rotation{p.facing * p.angle, 0, 0}, [...]float32{1, 1}, false, playerNo == sys.superplayer,
 			sys.cgi[playerNo].mugenver[0] != 1, p.facing, 1, 0, 0, [4]float32{0, 0, 0, 0}}
 		p.aimg.recAndCue(sd, sys.tickNextFrame() && notpause, false, p.layerno)
-		sprs.add(sd, p.shadow[0]<<16|p.shadow[1]&255<<8|p.shadow[2]&255, 256, c.shadowOffset, c.reflectOffset, 0, 0)
+		sprs.add(sd, p.shadow[0]<<16|p.shadow[1]&255<<8|p.shadow[2]&255, 0, [2]float32{0, p.pos[2]}, [2]float32{0, p.pos[2]}, 0, 0)
 	}
 }
 
@@ -2057,8 +2081,8 @@ type CharSystemVar struct {
 	unhittableTime    int32
 	bindTime          int32
 	bindToId          int32
-	bindPos           [2]float32
-	bindPosAdd        [2]float32
+	bindPos           [3]float32
+	bindPosAdd        [3]float32
 	bindFacing        float32
 	hitPauseTime      int32
 	angle             float32
@@ -2124,6 +2148,7 @@ type Char struct {
 	clsnScale           [2]float32
 	clsnScaleMul        [2]float32
 	clsnAngle           float32
+	zScale              float32
 	hitdef              HitDef
 	ghv                 GetHitVar
 	mhv                 MoveHitVar
@@ -2192,7 +2217,7 @@ type Char struct {
 }
 
 func newChar(n int, idx int32) (c *Char) {
-	c = &Char{aimg: *newAfterImage()}
+	c = &Char{aimg: *newAfterImage(), zScale: 1}
 	c.init(n, idx)
 	return c
 }
@@ -2610,8 +2635,8 @@ func (c *Char) load(def string) error {
 	c.size.draw.offset[0] = c.size.draw.offset[0] / originLs
 	c.size.draw.offset[1] = c.size.draw.offset[1] / originLs
 	c.size.z.width = c.size.z.width / originLs
-	c.size.attack.z.width[0] = c.size.attack.z.width[0] / originLs
-	c.size.attack.z.width[1] = c.size.attack.z.width[1] / originLs
+	c.size.attack.z.width.front = c.size.attack.z.width.front / originLs
+	c.size.attack.z.width.back = c.size.attack.z.width.back / originLs
 
 	gi.velocity.init()
 
@@ -2745,7 +2770,9 @@ func (c *Char) load(def string) error {
 							c.size.z.enable = true
 						}
 						is.ReadF32("attack.z.width",
-							&c.size.attack.z.width[0], &c.size.attack.z.width[1])
+							&c.size.attack.z.width.front, &c.size.attack.z.width.back)
+						is.ReadF32("attack.z.width.back", &c.size.attack.z.width.back)
+						is.ReadF32("attack.z.width.front", &c.size.attack.z.width.front)
 					}
 				case "velocity":
 					if velocity {
@@ -3143,6 +3170,7 @@ func (c *Char) changeAnimEx(animNo int32, playerNo int, ffx string, alt bool) {
 		}
 		// Update animation local scale
 		c.animlocalscl = 320 / sys.chars[c.animPN][0].localcoord
+		c.zScale = c.updateZScale(c.pos[2])
 		// Clsn scale depends on the animation owner's scale, so it must be updated
 		c.updateClsnScale()
 		if c.hitPause() {
@@ -3686,6 +3714,8 @@ func (c *Char) explodVar(eid BytecodeValue, idx BytecodeValue, vtype OpCode) Byt
 				v = BytecodeFloat(e.drawPos[0])
 			case OC_ex2_explodvar_pos_y:
 				v = BytecodeFloat(e.drawPos[1])
+			case OC_ex2_explodvar_pos_z:
+				v = BytecodeFloat(e.drawPos[2])
 			case OC_ex2_explodvar_scale_x:
 				v = BytecodeFloat(e.scale[0])
 			case OC_ex2_explodvar_scale_y:
@@ -3700,6 +3730,8 @@ func (c *Char) explodVar(eid BytecodeValue, idx BytecodeValue, vtype OpCode) Byt
 				v = BytecodeFloat(e.velocity[0])
 			case OC_ex2_explodvar_vel_y:
 				v = BytecodeFloat(e.velocity[1])
+			case OC_ex2_explodvar_vel_z:
+				v = BytecodeFloat(e.velocity[2])
 			case OC_ex2_explodvar_removetime:
 				v = BytecodeInt(e.removetime)
 			case OC_ex2_explodvar_pausemovetime:
@@ -3740,6 +3772,8 @@ func (c *Char) projVar(pid BytecodeValue, idx BytecodeValue, vtype OpCode) Bytec
 				v = BytecodeInt(p.curmisstime)
 			case OC_ex2_projectilevar_projhits:
 				v = BytecodeInt(p.hits)
+			case OC_ex2_projectilevar_projhitsmax:
+				v = BytecodeInt(p.totalhits)
 			case OC_ex2_projectilevar_projpriority:
 				v = BytecodeInt(p.priority)
 			case OC_ex2_projectilevar_projhitanim:
@@ -4392,8 +4426,8 @@ func (c *Char) newHelper() (h *Char) {
 	sys.charList.add(h)
 	return
 }
-func (c *Char) helperPos(pt PosType, pos [2]float32, facing int32,
-	dstFacing *float32, localscl float32, isProj bool) (p [2]float32) {
+func (c *Char) helperPos(pt PosType, pos [3]float32, facing int32,
+	dstFacing *float32, localscl float32, isProj bool) (p [3]float32) {
 	if facing < 0 {
 		*dstFacing *= -1
 	}
@@ -4401,11 +4435,13 @@ func (c *Char) helperPos(pt PosType, pos [2]float32, facing int32,
 	case PT_P1:
 		p[0] = c.pos[0]*(c.localscl/localscl) + pos[0]*c.facing
 		p[1] = c.pos[1]*(c.localscl/localscl) + pos[1]
+		p[2] = c.pos[2]*(c.localscl/localscl) + pos[2]
 		*dstFacing *= c.facing
 	case PT_P2:
 		if p2 := sys.charList.enemyNear(c, 0, true, true, false); p2 != nil {
 			p[0] = p2.pos[0]*(p2.localscl/localscl) + pos[0]*p2.facing
 			p[1] = p2.pos[1]*(p2.localscl/localscl) + pos[1]
+			p[2] = p2.pos[2]*(p2.localscl/localscl) + pos[2]
 			if isProj {
 				*dstFacing *= c.facing
 			} else {
@@ -4424,6 +4460,7 @@ func (c *Char) helperPos(pt PosType, pos [2]float32, facing int32,
 			p[0] -= pos[0]
 		}
 		p[1] = pos[1]
+		p[2] = c.pos[2]
 		*dstFacing *= c.facing
 	case PT_Left:
 		p[0] = c.leftEdge()*(c.localscl/localscl) + pos[0]
@@ -4437,19 +4474,21 @@ func (c *Char) helperPos(pt PosType, pos [2]float32, facing int32,
 		if isProj {
 			*dstFacing *= c.facing
 		}
+		p[2] = c.pos[2]
 	case PT_None:
-		p = pos
+		p = [3]float32{pos[0], pos[1], c.pos[2]}
 		if isProj {
 			*dstFacing *= c.facing
 		}
 	}
 	return
 }
-func (c *Char) helperInit(h *Char, st int32, pt PosType, x, y float32,
+func (c *Char) helperInit(h *Char, st int32, pt PosType, x, y, z float32,
 	facing int32, rp [2]int32, extmap bool) {
-	p := c.helperPos(pt, [...]float32{x, y}, facing, &h.facing, h.localscl, false)
+	p := c.helperPos(pt, [...]float32{x, y, z}, facing, &h.facing, h.localscl, false)
 	h.setX(p[0])
 	h.setY(p[1])
+	h.setZ(p[2])
 	h.vel = [3]float32{}
 	if h.ownpal {
 		h.palfx = newPalFX()
@@ -4687,7 +4726,8 @@ func (c *Char) setPosY(y float32) {
 	c.pos[1] = y
 }
 func (c *Char) setPosZ(z float32) {
-	c.pos[2] = z
+	cz := ClampF(z, sys.stage.topbound, sys.stage.botbound)
+	c.pos[2] = cz
 }
 func (c *Char) posReset() {
 	if c.teamside == -1 {
@@ -4715,7 +4755,7 @@ func (c *Char) setY(y float32) {
 	c.setPosY(y)
 }
 func (c *Char) setZ(z float32) {
-	c.oldPos[2], c.drawPos[1] = z, z
+	c.oldPos[2], c.drawPos[2] = z, z
 	c.setPosZ(z)
 }
 func (c *Char) addX(x float32) {
@@ -4818,9 +4858,10 @@ func (c *Char) newProj() *Projectile {
 	return nil
 }
 
-func (c *Char) projInit(p *Projectile, pt PosType, x, y float32,
+func (c *Char) projInit(p *Projectile, pt PosType, x, y, z float32,
 	op bool, rpg, rpn int32, clsnscale bool) {
-	p.setPos(c.helperPos(pt, [...]float32{x, y}, 1, &p.facing, p.localscl, true))
+	pos := c.helperPos(pt, [...]float32{x, y, z}, 1, &p.facing, p.localscl, true)
+	p.setPos([...]float32{pos[0], pos[1], pos[2]})
 	p.parentAttackmul = c.attackMul
 	if p.anim < -1 {
 		p.anim = 0
@@ -4913,6 +4954,7 @@ func (c *Char) setHitdefDefault(hd *HitDef, proj bool) {
 	ifnanset(&hd.fall.yvelocity, -4.5/c.localscl)
 	ifierrset(&hd.fall.envshake_ampl, -4)
 	ifnanset(&hd.fall.envshake_phase, 0)
+	ifnanset(&hd.xaccel, 0)
 	if hd.air_animtype == RA_Unknown {
 		hd.air_animtype = hd.animtype
 	}
@@ -5024,6 +5066,17 @@ func (c *Char) updateClsnScale() {
 		// Normally not used. Just a safeguard
 		c.clsnScale = [...]float32{1.0, 1.0}
 	}
+}
+
+func (c *Char) updateZScale(z float32) float32 {
+	topz, botz, scale := sys.stage.stageCamera.topz, sys.stage.stageCamera.botz, float32(1)
+	if topz != botz {
+		ztopscale, zbotscale := sys.stage.stageCamera.ztopscale, sys.stage.stageCamera.zbotscale
+		clampedZ := ClampF(z, topz, botz)
+		d := (clampedZ - topz) / (botz - topz)
+		scale = ztopscale + d*(zbotscale-ztopscale)
+	}
+	return scale
 }
 
 func (c *Char) widthToSizeBox() {
@@ -5211,7 +5264,7 @@ func (c *Char) targetFacing(tar []int32, f int32) {
 		}
 	}
 }
-func (c *Char) targetBind(tar []int32, time int32, x, y float32) {
+func (c *Char) targetBind(tar []int32, time int32, x, y, z float32) {
 	for _, tid := range tar {
 		if t := sys.playerID(tid); t != nil {
 			t.setBindToId(c)
@@ -5219,11 +5272,12 @@ func (c *Char) targetBind(tar []int32, time int32, x, y float32) {
 			t.bindFacing = 0
 			x *= c.localscl / t.localscl
 			y *= c.localscl / t.localscl
-			t.bindPos = [...]float32{x, y}
+			z *= c.localscl / t.localscl
+			t.bindPos = [...]float32{x, y, z}
 		}
 	}
 }
-func (c *Char) bindToTarget(tar []int32, time int32, x, y float32, hmf HMF) {
+func (c *Char) bindToTarget(tar []int32, time int32, x, y, z float32, hmf HMF) {
 	if len(tar) > 0 {
 		if t := sys.playerID(tar[0]); t != nil {
 			switch hmf {
@@ -5240,7 +5294,10 @@ func (c *Char) bindToTarget(tar []int32, time int32, x, y float32, hmf HMF) {
 			if !math.IsNaN(float64(y)) {
 				c.setY(t.pos[1]*(t.localscl/c.localscl) + y)
 			}
-			c.targetBind(tar[:1], time, c.facing*c.distX(t, c), (t.pos[1]*(t.localscl/c.localscl))-(c.pos[1]*(c.localscl/t.localscl)))
+			c.targetBind(tar[:1], time,
+				c.facing*c.distX(t, c),
+				(t.pos[1]*(t.localscl/c.localscl))-(c.pos[1]*(c.localscl/t.localscl)),
+				(t.pos[2]*(t.localscl/c.localscl))-(c.pos[2]*(c.localscl/t.localscl)))
 		}
 	}
 }
@@ -5843,7 +5900,7 @@ func (c *Char) inputOver() bool {
 func (c *Char) over() bool {
 	return c.scf(SCF_over) || c.ss.no == 5150
 }
-func (c *Char) makeDust(x, y float32) {
+func (c *Char) makeDust(x, y, z float32) {
 	if c.asf(ASF_nomakedust) {
 		return
 	}
@@ -5856,7 +5913,7 @@ func (c *Char) makeDust(x, y float32) {
 		e.sprpriority = math.MaxInt32
 		e.layerno = c.layerNo
 		e.ownpal = true
-		e.relativePos = [...]float32{x, y}
+		e.relativePos = [...]float32{x, y, z}
 		e.setPos(c)
 		c.insertExplod(i)
 	}
@@ -6274,7 +6331,8 @@ func (c *Char) posUpdate() {
 		}
 	}
 	nobind := [...]bool{c.bindTime == 0 || math.IsNaN(float64(c.bindPos[0])),
-		c.bindTime == 0 || math.IsNaN(float64(c.bindPos[1]))}
+		c.bindTime == 0 || math.IsNaN(float64(c.bindPos[1])),
+		c.bindTime == 0 || math.IsNaN(float64(c.bindPos[2]))}
 	for i := range nobind {
 		if nobind[i] {
 			c.oldPos[i], c.drawPos[i] = c.pos[i], c.pos[i]
@@ -6292,7 +6350,9 @@ func (c *Char) posUpdate() {
 		if nobind[1] {
 			c.setPosY(c.oldPos[1] + c.vel[1])
 		}
-		c.setPosZ(c.oldPos[2] + c.vel[2])
+		if nobind[2] {
+			c.setPosZ(c.oldPos[2] + c.vel[2])
+		}
 
 		switch c.ss.physics {
 		case ST_S:
@@ -6312,7 +6372,7 @@ func (c *Char) posUpdate() {
 			c.cornerVelOff = 0
 		}
 	}
-	c.bindPosAdd = [...]float32{0, 0}
+	c.bindPosAdd = [...]float32{0, 0, 0}
 }
 func (c *Char) addTarget(id int32) {
 	if !c.hasTarget(id) {
@@ -6397,6 +6457,11 @@ func (c *Char) bind() {
 			c.drawPos[1] += bt.drawPos[1] - bt.pos[1]
 			c.oldPos[1] += bt.oldPos[1] - bt.pos[1]
 			c.ghv.yoff = 0
+		}
+		if !math.IsNaN(float64(c.bindPos[2])) {
+			c.setZ(bt.pos[2]*bt.localscl/c.localscl + (c.bindPos[2] + c.bindPosAdd[2]))
+			c.drawPos[2] += bt.drawPos[2] - bt.pos[2]
+			c.oldPos[2] += bt.oldPos[2] - bt.pos[2]
 		}
 		if AbsF(c.bindFacing) == 1 {
 			if c.bindFacing > 0 {
@@ -6497,7 +6562,7 @@ func (c *Char) offsetX() float32 {
 	return float32(c.size.draw.offset[0])*c.facing + c.offset[0]/c.localscl
 }
 func (c *Char) offsetY() float32 {
-	return float32(c.size.draw.offset[1]) + c.offset[1]/c.localscl
+	return float32(c.size.draw.offset[1]) + c.offset[1]/c.localscl + c.pos[2]/c.localscl
 }
 
 func (c *Char) projClsnCheck(p *Projectile, cbox, pbox int32) bool {
@@ -6559,7 +6624,7 @@ func (c *Char) projClsnCheck(p *Projectile, cbox, pbox int32) bool {
 			c.pos[1]*c.localscl + c.offsetY()*c.localscl}, c.facing, c.clsnAngle)
 }
 
-func (c *Char) clsnCheck(getter *Char, cbox, gbox int32) bool {
+func (c *Char) clsnCheck(getter *Char, attackerbox, getterbox int32) bool {
 	// Nil anim & standby check.
 	if c.curFrame == nil || getter.curFrame == nil ||
 		c.scf(SCF_standby) || getter.scf(SCF_standby) ||
@@ -6568,7 +6633,7 @@ func (c *Char) clsnCheck(getter *Char, cbox, gbox int32) bool {
 	}
 
 	// Accepted box types
-	if gbox != 1 && gbox != 2 && gbox != 3 {
+	if getterbox != 1 && getterbox != 2 && getterbox != 3 {
 		return false
 	}
 
@@ -6578,30 +6643,34 @@ func (c *Char) clsnCheck(getter *Char, cbox, gbox int32) bool {
 		return false
 	}
 
-	// Z axis check.
-	if c.size.z.enable && getter.size.z.enable &&
-		((c.pos[2]-c.size.z.width)*c.localscl > (getter.pos[2]+getter.size.z.width)*getter.localscl ||
-			(c.pos[2]+c.size.z.width)*c.localscl < (getter.pos[2]-getter.size.z.width)*getter.localscl) {
-		return false
-	}
-
 	// Decide which box types should collide
 	var clsn1, clsn2 []float32
 	if c.asf(ASF_projtypecollision) && getter.asf(ASF_projtypecollision) { // Projectiles trade with their Clsn2 only
 		clsn1 = c.curFrame.Clsn2()
 		clsn2 = getter.curFrame.Clsn2()
 	} else {
-		if cbox == 2 {
+		if attackerbox == 2 {
 			clsn1 = c.curFrame.Clsn2() // For push checking
 		} else {
 			clsn1 = c.curFrame.Clsn1()
 		}
-		if gbox == 1 {
+		if getterbox == 1 {
 			clsn2 = getter.curFrame.Clsn1()
-		} else if gbox == 3 {
+		} else if getterbox == 3 {
 			clsn2 = getter.sizeBox
 		} else {
 			clsn2 = getter.curFrame.Clsn2()
+		}
+	}
+
+	// Z axis check (changed to no longer check z enable constant, depends on stage now)
+	if sys.stage.topbound != sys.stage.botbound {
+		if (((c.pos[2]-c.size.z.width)*c.localscl > (getter.pos[2]+getter.size.z.width)*getter.localscl ||
+			(c.pos[2]+c.size.z.width)*c.localscl < (getter.pos[2]-getter.size.z.width)*getter.localscl) && attackerbox == 2 && getterbox == 2) ||
+			// Attack width Check
+			((((c.pos[2]+c.hitdef.attack.width[0])*c.localscl < (getter.pos[2]-getter.size.z.width)*getter.localscl) ||
+				((c.pos[2]-c.hitdef.attack.width[1])*c.localscl > (getter.pos[2]+getter.size.z.width)*getter.localscl)) && (attackerbox == 1 && getterbox != 1)) {
+			return false
 		}
 	}
 
@@ -6891,6 +6960,7 @@ func (c *Char) actionPrepare() {
 			c.assertFlag = (c.assertFlag&ASF_nostandguard | c.assertFlag&ASF_nocrouchguard | c.assertFlag&ASF_noairguard |
 				c.assertFlag&ASF_runfirst | c.assertFlag&ASF_runlast)
 		}
+		c.zScale = c.updateZScale(c.pos[2])
 		// Reset Clsn modifiers
 		c.clsnScaleMul = [...]float32{1.0, 1.0}
 		c.clsnAngle = 0
@@ -7279,7 +7349,7 @@ func (c *Char) update() {
 			}
 			if ((c.ss.moveType == MT_H && (c.ss.stateType == ST_S || c.ss.stateType == ST_C)) || c.ss.no == 52) && c.pos[1] == 0 &&
 				AbsF(c.pos[0]-c.dustOldPos) >= 1 && c.ss.time%3 == 0 {
-				c.makeDust(0, 0)
+				c.makeDust(0, 0, 0)
 			}
 		}
 
@@ -7679,7 +7749,7 @@ func (c *Char) cueDraw() {
 	// Add char sprite
 	if c.anim != nil {
 		pos := [...]float32{c.drawPos[0]*c.localscl + c.offsetX()*c.localscl, c.drawPos[1]*c.localscl + c.offsetY()*c.localscl}
-		scl := [...]float32{c.facing * c.size.xscale * (320 / c.localcoord), c.size.yscale * (320 / c.localcoord)}
+		scl := [...]float32{c.facing * c.size.xscale * c.zScale * (320 / c.localcoord), c.size.yscale * c.zScale * (320 / c.localcoord)}
 		agl := float32(0)
 		if c.csf(CSF_angledraw) {
 			agl = c.angle
@@ -7732,7 +7802,7 @@ func (c *Char) cueDraw() {
 			if c.csf(CSF_trans) {
 				sa = 255 - c.alpha[1]
 			}
-			sprs.add(sd, sc, sa, c.shadowOffset, c.reflectOffset, c.size.shadowoffset, c.offsetY())
+			sprs.add(sd, sc, sa, [2]float32{c.shadowOffset[0], c.shadowOffset[1] + sys.stage.sdw.yscale*c.pos[2] + c.pos[2]}, [2]float32{c.reflectOffset[0], c.reflectOffset[1] + sys.stage.reflection.yscale*c.pos[2] + c.pos[2]}, c.size.shadowoffset, c.offsetY())
 		}
 	}
 	if sys.tickNextFrame() {
@@ -8459,7 +8529,7 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 				e.layerno = 1
 				e.sprpriority = math.MinInt32
 				e.ownpal = true
-				e.relativePos = off
+				e.relativePos = [...]float32{off[0], off[1], 0}
 				e.supermovetime = -1
 				e.pausemovetime = -1
 				e.localscl = 1

--- a/src/common.go
+++ b/src/common.go
@@ -769,7 +769,7 @@ func (l *Layout) DrawAnim(r *[4]int32, x, y, scl float32, ln int16,
 		a.Draw(r, x+l.offset[0], y+l.offset[1]+float32(sys.gameHeight-240),
 			scl, scl, l.scale[0]*float32(l.facing), l.scale[0]*float32(l.facing),
 			l.scale[1]*float32(l.vfacing), 0, Rotation{l.angle, 0, 0},
-			float32(sys.gameWidth-320)/2, palfx, false, 1, false, 1, 0, 0)
+			float32(sys.gameWidth-320)/2, palfx, false, 1, false, 1, 0, 0, 0)
 	}
 }
 func (l *Layout) DrawText(x, y, scl float32, ln int16,

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1904,6 +1904,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				opc = OC_ex2_explodvar_pos_x
 			case "y":
 				opc = OC_ex2_explodvar_pos_y
+			case "z":
+				opc = OC_ex2_explodvar_pos_z
 			default:
 				return bvNone(), Error(fmt.Sprint("Invalid argument: %s", c.token))
 			}
@@ -1915,6 +1917,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				opc = OC_ex2_explodvar_vel_x
 			case "y":
 				opc = OC_ex2_explodvar_vel_y
+			case "z":
+				opc = OC_ex2_explodvar_vel_z
 			default:
 				return bvNone(), Error(fmt.Sprint("Invalid argument: %s", c.token))
 			}
@@ -1926,6 +1930,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				opc = OC_ex2_explodvar_accel_x
 			case "y":
 				opc = OC_ex2_explodvar_accel_y
+			case "z":
+				opc = OC_ex2_explodvar_accel_z
 			default:
 				return bvNone(), Error(fmt.Sprint("Invalid argument: %s", c.token))
 			}
@@ -2524,15 +2530,17 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			}
 		case "misstime":
 			opc = OC_ex2_projectilevar_projmisstime
-		case "hits":
+		case "projhits":
 			opc = OC_ex2_projectilevar_projhits
-		case "priority":
+		case "projhitsmax":
+			opc = OC_ex2_projectilevar_projhitsmax
+		case "projpriority":
 			opc = OC_ex2_projectilevar_projpriority
-		case "hitanim":
+		case "projhitanim":
 			opc = OC_ex2_projectilevar_projhitanim
-		case "remanim":
+		case "projremanim":
 			opc = OC_ex2_projectilevar_projremanim
-		case "cancelanim":
+		case "projcancelanim":
 			opc = OC_ex2_projectilevar_projcancelanim
 		case "vel":
 			c.token = c.tokenizer(in)
@@ -2542,6 +2550,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				opc = OC_ex2_projectilevar_vel_x
 			case "y":
 				opc = OC_ex2_projectilevar_vel_y
+			case "z":
+				opc = OC_ex2_projectilevar_vel_z
 			default:
 				return bvNone(), Error(fmt.Sprint("Invalid argument: %s", c.token))
 			}
@@ -2553,6 +2563,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				opc = OC_ex2_projectilevar_velmul_x
 			case "y":
 				opc = OC_ex2_projectilevar_velmul_y
+			case "z":
+				opc = OC_ex2_projectilevar_velmul_z
 			default:
 				return bvNone(), Error(fmt.Sprint("Invalid argument: %s", c.token))
 			}
@@ -2564,6 +2576,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				opc = OC_ex2_projectilevar_remvelocity_x
 			case "y":
 				opc = OC_ex2_projectilevar_remvelocity_y
+			case "z":
+				opc = OC_ex2_projectilevar_remvelocity_z
 			default:
 				return bvNone(), Error(fmt.Sprint("Invalid argument: %s", c.token))
 			}
@@ -2575,6 +2589,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				opc = OC_ex2_projectilevar_accel_x
 			case "y":
 				opc = OC_ex2_projectilevar_accel_y
+			case "z":
+				opc = OC_ex2_projectilevar_accel_z
 			default:
 				return bvNone(), Error(fmt.Sprint("Invalid argument: %s", c.token))
 			}
@@ -2599,14 +2615,16 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				opc = OC_ex2_projectilevar_pos_x
 			case "y":
 				opc = OC_ex2_projectilevar_pos_y
+			case "z":
+				opc = OC_ex2_projectilevar_pos_z
 			default:
 				return bvNone(), Error(fmt.Sprint("Invalid argument: %s", c.token))
 			}
-		case "sprpriority":
+		case "projsprpriority":
 			opc = OC_ex2_projectilevar_projsprpriority
-		case "stagebound":
+		case "projstagebound":
 			opc = OC_ex2_projectilevar_projstagebound
-		case "edgebound":
+		case "projedgebound":
 			opc = OC_ex2_projectilevar_projedgebound
 		case "lowbound":
 			opc = OC_ex2_projectilevar_lowbound
@@ -2801,8 +2819,14 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			opc = OC_const_stagevar_playerinfo_leftbound
 		case "playerinfo.rightbound":
 			opc = OC_const_stagevar_playerinfo_rightbound
+		case "scaling.topz":
+			opc = OC_const_stagevar_scaling_topz
+		case "scaling.botz":
+			opc = OC_const_stagevar_scaling_botz
 		case "scaling.topscale":
 			opc = OC_const_stagevar_scaling_topscale
+		case "scaling.botscale":
+			opc = OC_const_stagevar_scaling_botscale
 		case "bound.screenleft":
 			opc = OC_const_stagevar_bound_screenleft
 		case "bound.screenright":
@@ -2847,6 +2871,14 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			opc = OC_const_stagevar_reflection_offset_x
 		case "reflection.offset.y":
 			opc = OC_const_stagevar_reflection_offset_y
+		case "reflection.xshear":
+			opc = OC_const_stagevar_reflection_xshear
+		case "reflection.color.r":
+			opc = OC_const_stagevar_reflection_color_r
+		case "reflection.color.g":
+			opc = OC_const_stagevar_reflection_color_g
+		case "reflection.color.b":
+			opc = OC_const_stagevar_reflection_color_b
 		default:
 			return bvNone(), Error("Invalid data: " + svname)
 		}

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -703,28 +703,28 @@ func (c *Compiler) explodSub(is IniSection,
 		return err
 	}
 	if err := c.paramValue(is, sc, "pos",
-		explod_pos, VT_Float, 2, false); err != nil {
+		explod_pos, VT_Float, 3, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "random",
-		explod_random, VT_Float, 2, false); err != nil {
+		explod_random, VT_Float, 3, false); err != nil {
 		return err
 	}
 	found := false
 	if err := c.stateParam(is, "vel", false, func(data string) error {
 		found = true
-		return c.scAdd(sc, explod_velocity, data, VT_Float, 2)
+		return c.scAdd(sc, explod_velocity, data, VT_Float, 3)
 	}); err != nil {
 		return err
 	}
 	if !found {
 		if err := c.paramValue(is, sc, "velocity",
-			explod_velocity, VT_Float, 2, false); err != nil {
+			explod_velocity, VT_Float, 3, false); err != nil {
 			return err
 		}
 	}
 	if err := c.paramValue(is, sc, "accel",
-		explod_accel, VT_Float, 2, false); err != nil {
+		explod_accel, VT_Float, 3, false); err != nil {
 		return err
 	}
 	if err := c.paramSpace(is, sc, explod_space); err != nil {
@@ -838,7 +838,7 @@ func (c *Compiler) explodInterpolate(is IniSection,
 		return err
 	}
 	if err := c.paramValue(is, sc, "interpolation.offset",
-		explod_interpolate_pos, VT_Float, 2, false); err != nil {
+		explod_interpolate_pos, VT_Float, 3, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "interpolation.focallength",
@@ -1912,6 +1912,10 @@ func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 		hitDef_xaccel, VT_Float, 1, false); err != nil {
 		return err
 	}
+	if err := c.paramValue(is, sc, "attack.width",
+		hitDef_attack_width, VT_Float, 2, false); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -2040,19 +2044,19 @@ func (c *Compiler) projectileSub(is IniSection, sc *StateControllerBase, ihp int
 		return err
 	}
 	if err := c.paramValue(is, sc, "velocity",
-		projectile_velocity, VT_Float, 2, false); err != nil {
+		projectile_velocity, VT_Float, 3, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "velmul",
-		projectile_velmul, VT_Float, 2, false); err != nil {
+		projectile_velmul, VT_Float, 3, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "remvelocity",
-		projectile_remvelocity, VT_Float, 2, false); err != nil {
+		projectile_remvelocity, VT_Float, 3, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "accel",
-		projectile_accel, VT_Float, 2, false); err != nil {
+		projectile_accel, VT_Float, 3, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "projscale",
@@ -2077,7 +2081,7 @@ func (c *Compiler) projectileSub(is IniSection, sc *StateControllerBase, ihp int
 	}
 
 	if err := c.paramValue(is, sc, "offset",
-		projectile_offset, VT_Float, 2, false); err != nil {
+		projectile_offset, VT_Float, 3, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "projsprpriority",
@@ -2570,6 +2574,10 @@ func (c *Compiler) bindToTarget(is IniSection, sc *StateControllerBase, _ int8) 
 			sc.add(bindToTarget_pos, append(exp, sc.iToExp(int32(hmf))...))
 			return nil
 		}); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "posz",
+			bindToTarget_posz, VT_Float, 1, false); err != nil {
 			return err
 		}
 		return nil
@@ -3585,7 +3593,7 @@ func (c *Compiler) bindToParentSub(is IniSection,
 		return err
 	}
 	if err := c.paramValue(is, sc, "pos",
-		bindToParent_pos, VT_Float, 2, false); err != nil {
+		bindToParent_pos, VT_Float, 3, false); err != nil {
 		return err
 	}
 	return nil
@@ -5083,8 +5091,20 @@ func (c *Compiler) modifyStageVar(is IniSection, sc *StateControllerBase, _ int8
 			modifyStageVar_playerinfo_rightbound, VT_Float, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "scaling.topz",
+			modifyStageVar_scaling_topz, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "scaling.botz",
+			modifyStageVar_scaling_botz, VT_Float, 1, false); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "scaling.topscale",
 			modifyStageVar_scaling_topscale, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "scaling.botscale",
+			modifyStageVar_scaling_botscale, VT_Float, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "bound.screenleft",
@@ -5141,6 +5161,10 @@ func (c *Compiler) modifyStageVar(is IniSection, sc *StateControllerBase, _ int8
 		}
 		if err := c.paramValue(is, sc, "reflection.yscale",
 			modifyStageVar_reflection_yscale, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "reflection.xshear",
+			modifyStageVar_reflection_xshear, VT_Float, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "reflection.offset",

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -5167,6 +5167,10 @@ func (c *Compiler) modifyStageVar(is IniSection, sc *StateControllerBase, _ int8
 			modifyStageVar_reflection_xshear, VT_Float, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "reflection.color",
+			modifyStageVar_reflection_xshear, VT_Int, 3, false); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "reflection.offset",
 			modifyStageVar_reflection_offset, VT_Float, 2, false); err != nil {
 			return err

--- a/src/main.go
+++ b/src/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -48,6 +49,18 @@ func closeLog(f *os.File) {
 }
 
 func main() {
+
+	exePath, err := os.Executable()
+	if err != nil {
+		fmt.Println("Error getting executable path:", err)
+	} else {
+		// Change the context for Darwin if we're in an app bundle
+		if isRunningInsideAppBundle(exePath) {
+			os.Chdir(path.Dir(exePath))
+			os.Chdir("../../../")
+		}
+	}
+
 	// Make save directories, if they don't exist
 	os.Mkdir("save", os.ModeSticky|0755)
 	os.Mkdir("save/replays", os.ModeSticky|0755)
@@ -278,10 +291,12 @@ type configSettings struct {
 	ZoomSpeed                  float32
 	KeyConfig                  []struct {
 		Joystick int
+		GUID     string
 		Buttons  []interface{}
 	}
 	JoystickConfig []struct {
 		Joystick int
+		GUID     string
 		Buttons  []interface{}
 	}
 }
@@ -433,7 +448,7 @@ func setupConfig() configSettings {
 			stoki(b[3].(string)), stoki(b[4].(string)), stoki(b[5].(string)),
 			stoki(b[6].(string)), stoki(b[7].(string)), stoki(b[8].(string)),
 			stoki(b[9].(string)), stoki(b[10].(string)), stoki(b[11].(string)),
-			stoki(b[12].(string)), stoki(b[13].(string))})
+			stoki(b[12].(string)), stoki(b[13].(string)), kc.GUID, false})
 	}
 	if _, ok := sys.cmdFlags["-nojoy"]; !ok {
 		for _, jc := range tmp.JoystickConfig {
@@ -443,7 +458,7 @@ func setupConfig() configSettings {
 				Atoi(b[3].(string)), Atoi(b[4].(string)), Atoi(b[5].(string)),
 				Atoi(b[6].(string)), Atoi(b[7].(string)), Atoi(b[8].(string)),
 				Atoi(b[9].(string)), Atoi(b[10].(string)), Atoi(b[11].(string)),
-				Atoi(b[12].(string)), Atoi(b[13].(string))})
+				Atoi(b[12].(string)), Atoi(b[13].(string)), jc.GUID, false})
 		}
 	}
 

--- a/src/render.go
+++ b/src/render.go
@@ -139,7 +139,7 @@ func rmTileHSub(modelview mgl.Mat4, x1, y1, x2, y2, x3, y3, x4, y4, dy, width fl
 }
 
 func rmTileSub(modelview mgl.Mat4, rp RenderParams) {
-	x1, y1 := rp.x+rp.rxadd*rp.ys*float32(rp.size[1]), rp.rcy+((rp.y-rp.ys*float32(rp.size[1]))-rp.rcy)*rp.vs
+	x1, y1 := rp.x, rp.rcy+((rp.y-rp.ys*float32(rp.size[1]))-rp.rcy)*rp.vs
 	x2, y2 := x1+rp.xbs*float32(rp.size[0]), y1
 	x3, y3 := rp.x+rp.xts*float32(rp.size[0]), rp.rcy+(rp.y-rp.rcy)*rp.vs
 	x4, y4 := rp.x, y3
@@ -176,6 +176,15 @@ func rmTileSub(modelview mgl.Mat4, rp RenderParams) {
 			modelview = modelview.Mul4(mgl.Translate3D(rp.xOffset, -rp.yOffset, -rp.fLength))
 		}
 
+		// Apply shear matrix before rotation
+		shearMatrix := mgl.Mat4{
+			1, 0, 0, 0,
+			rp.rxadd, 1, 0, 0,
+			0, 0, 1, 0,
+			0, 0, 0, 1}
+		modelview = modelview.Mul4(shearMatrix)
+		modelview = modelview.Mul4(mgl.Translate3D(rp.rxadd*rp.ys*float32(rp.size[1]), 0, 0))
+
 		modelview = modelview.Mul4(mgl.Scale3D(1, rp.vs, 1))
 		modelview = modelview.Mul4(
 			mgl.Rotate3DX(-rp.rot.xangle * math.Pi / 180.0).Mul3(
@@ -187,6 +196,8 @@ func rmTileSub(modelview mgl.Mat4, rp RenderParams) {
 		return
 	}
 	if rp.tile.y == 1 && rp.xbs != 0 {
+		x1 += rp.rxadd * rp.ys * float32(rp.size[1])
+		x2 = x1 + rp.xbs*float32(rp.size[0])
 		x1d, y1d, x2d, y2d, x3d, y3d, x4d, y4d := x1, y1, x2, y2, x3, y3, x4, y4
 		n := 0
 		var xy []float32
@@ -222,6 +233,8 @@ func rmTileSub(modelview mgl.Mat4, rp RenderParams) {
 		}
 	}
 	if rp.tile.y == 0 || rp.xts != 0 {
+		x1 += rp.rxadd * rp.ys * float32(rp.size[1])
+		x2 = x1 + rp.xbs*float32(rp.size[0])
 		n := rp.tile.y
 		oy := y1
 		for {

--- a/src/resources/defaultConfig.json
+++ b/src/resources/defaultConfig.json
@@ -133,7 +133,7 @@
   ],
   "WindowScaleMode": true,
   "WindowTitle": "Ikemen GO",
-  "XinputTriggerSensitivity": 0,
+  "XinputTriggerSensitivity": 0.5,
   "ZoomActive": true,
   "ZoomDelay": false,
   "ZoomSpeed": 1,

--- a/src/script.go
+++ b/src/script.go
@@ -4070,9 +4070,11 @@ func triggerFunctions(l *lua.LState) {
 				case "angle":
 					lv = lua.LNumber(p.angle)
 				case "pos x":
-					lv = lua.LNumber(p.pos[0])
+					lv = lua.LNumber(p.drawPos[0])
 				case "pos y":
-					lv = lua.LNumber(p.pos[1])
+					lv = lua.LNumber(p.drawPos[1])
+				case "pos z":
+					lv = lua.LNumber(p.drawPos[2])
 				case "projsprpriority":
 					lv = lua.LNumber(p.sprpriority)
 				case "projstagebound":

--- a/src/script.go
+++ b/src/script.go
@@ -1402,6 +1402,10 @@ func systemScriptInit(l *lua.LState) {
 		l.Push(lua.LNumber(sys.frameCounter))
 		return 1
 	})
+	luaRegister(l, "getJoystickGUID", func(*lua.LState) int {
+		l.Push(lua.LString(input.GetJoystickGUID(int(numArg(l, 1)))))
+		return 1
+	})
 	luaRegister(l, "getJoystickName", func(*lua.LState) int {
 		l.Push(lua.LString(input.GetJoystickName(int(numArg(l, 1)))))
 		return 1
@@ -1421,32 +1425,14 @@ func systemScriptInit(l *lua.LState) {
 			if input.IsJoystickPresent(joy) {
 				axes := input.GetJoystickAxes(joy)
 				btns := input.GetJoystickButtons(joy)
-				name := input.GetJoystickName(joy)
-				for i := range axes {
-					if strings.Contains(name, "XInput") || strings.Contains(name, "X360") {
-						if axes[i] > 0.5 {
-							s = strconv.Itoa(-i*2 - 2)
-						} else if axes[i] < -0.5 && i < 4 {
-							s = strconv.Itoa(-i*2 - 1)
-						}
-					} else if name == "PS3 Controller" {
-						if (len(axes) == 8 && i != 3 && i != 4 && i != 6 && i != 7) ||
-							(len(axes) == 6 && i != 2 && i != 5) {
-							// 8 axes in Windows (need to skip 3, 4, 6, 7) and
-							// 6 axes in Linux (need to skip 2 and 5)
-							if axes[i] < -0.2 {
-								s = strconv.Itoa(-i*2 - 1)
-							} else if axes[i] > 0.2 {
-								s = strconv.Itoa(-i*2 - 2)
-							}
-						}
-					} else if name != "PS4 Controller" || !(i == 3 || i == 4) {
-						if axes[i] < -0.2 {
-							s = strconv.Itoa(-i*2 - 1)
-						} else if axes[i] > 0.2 {
-							s = strconv.Itoa(-i*2 - 2)
-						}
-					}
+
+				s = CheckAxisForDpad(joy, &axes, len(btns))
+				if s != "" {
+					break
+				}
+				s = CheckAxisForTrigger(joy, &axes)
+				if s != "" {
+					break
 				}
 				for i := range btns {
 					if btns[i] > 0 {
@@ -3076,9 +3062,9 @@ func triggerFunctions(l *lua.LState) {
 		case "size.attack.dist.back":
 			ln = lua.LNumber(c.size.attack.dist.back)
 		case "size.attack.z.width.back":
-			ln = lua.LNumber(c.size.attack.z.width[1])
+			ln = lua.LNumber(c.size.attack.z.width.back)
 		case "size.attack.z.width.front":
-			ln = lua.LNumber(c.size.attack.z.width[0])
+			ln = lua.LNumber(c.size.attack.z.width.front)
 		case "size.proj.attack.dist", "size.proj.attack.dist.front":
 			ln = lua.LNumber(c.size.proj.attack.dist.front)
 		case "size.proj.attack.dist.back":
@@ -3296,14 +3282,20 @@ func triggerFunctions(l *lua.LState) {
 					ln = lua.LNumber(e.drawPos[0])
 				case "pos y":
 					ln = lua.LNumber(e.drawPos[1])
+				case "pos z":
+					ln = lua.LNumber(e.drawPos[2])
 				case "vel x":
 					ln = lua.LNumber(e.velocity[0])
 				case "vel y":
 					ln = lua.LNumber(e.velocity[1])
+				case "vel z":
+					ln = lua.LNumber(e.velocity[2])
 				case "accel x":
 					ln = lua.LNumber(e.accel[0])
 				case "accel y":
 					ln = lua.LNumber(e.accel[1])
+				case "accel z":
+					ln = lua.LNumber(e.accel[2])
 				case "scale x":
 					ln = lua.LNumber(e.scale[0])
 				case "scale y":
@@ -3434,7 +3426,7 @@ func triggerFunctions(l *lua.LState) {
 		case "yvel":
 			ln = lua.LNumber(c.ghv.yvel)
 		case "xaccel":
-			ln = lua.LNumber(c.ghv.getXaccel(c) * c.facing)
+			ln = lua.LNumber(c.ghv.getXaccel(c))
 		case "yaccel":
 			ln = lua.LNumber(c.ghv.getYaccel(c))
 		case "hitid", "chainid":
@@ -4031,9 +4023,9 @@ func triggerFunctions(l *lua.LState) {
 		for i, p := range sys.debugWC.getProjs(id) {
 			if i == idx {
 				switch vname {
-				case "remove":
+				case "projremove":
 					lv = lua.LBool(p.remove)
-				case "removetime":
+				case "projremovetime":
 					lv = lua.LNumber(p.removetime)
 				case "shadow r":
 					lv = lua.LNumber(p.shadow[0])
@@ -4043,15 +4035,17 @@ func triggerFunctions(l *lua.LState) {
 					lv = lua.LNumber(p.shadow[0])
 				case "misstime":
 					lv = lua.LNumber(p.curmisstime)
-				case "hits":
+				case "projhits":
 					lv = lua.LNumber(p.hits)
-				case "priority":
+				case "projhitsmax":
+					lv = lua.LNumber(p.totalhits)
+				case "projpriority":
 					lv = lua.LNumber(p.priority)
-				case "hitanim":
+				case "projhitanim":
 					lv = lua.LNumber(p.hitanim)
-				case "remanim":
+				case "projremanim":
 					lv = lua.LNumber(p.remanim)
-				case "cancelanim":
+				case "projcancelanim":
 					lv = lua.LNumber(p.cancelanim)
 				case "vel x":
 					lv = lua.LNumber(p.velocity[0])
@@ -4079,11 +4073,11 @@ func triggerFunctions(l *lua.LState) {
 					lv = lua.LNumber(p.pos[0])
 				case "pos y":
 					lv = lua.LNumber(p.pos[1])
-				case "sprpriority":
+				case "projsprpriority":
 					lv = lua.LNumber(p.sprpriority)
-				case "stagebound":
+				case "projstagebound":
 					lv = lua.LNumber(p.stagebound)
-				case "edgebound":
+				case "projedgebound":
 					lv = lua.LNumber(p.edgebound)
 				case "lowbound":
 					lv = lua.LNumber(p.heightbound[0])
@@ -4268,7 +4262,13 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LNumber(sys.stage.leftbound))
 		case "playerinfo.rightbound":
 			l.Push(lua.LNumber(sys.stage.rightbound))
+		case "scaling.topz":
+			l.Push(lua.LNumber(sys.stage.stageCamera.topz))
+		case "scaling.botz":
+			l.Push(lua.LNumber(sys.stage.stageCamera.botz))
 		case "scaling.topscale":
+			l.Push(lua.LNumber(sys.stage.stageCamera.ztopscale))
+		case "scaling.botscale":
 			l.Push(lua.LNumber(sys.stage.stageCamera.ztopscale))
 		case "bound.screenleft":
 			l.Push(lua.LNumber(sys.stage.screenleft))
@@ -4314,6 +4314,14 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LNumber(sys.stage.reflection.offset[0]))
 		case "reflection.offset.y":
 			l.Push(lua.LNumber(sys.stage.reflection.offset[1]))
+		case "reflection.xshear":
+			l.Push(lua.LNumber(sys.stage.reflection.xshear))
+		case "reflection.color.r":
+			l.Push(lua.LNumber(int32((sys.stage.reflection.color & 0xFF0000) >> 16)))
+		case "reflection.color.g":
+			l.Push(lua.LNumber(int32((sys.stage.reflection.color & 0xFF00) >> 8)))
+		case "reflection.color.b":
+			l.Push(lua.LNumber(int32(sys.stage.reflection.color & 0xFF)))
 		default:
 			l.Push(lua.LString(""))
 		}

--- a/src/sound.go
+++ b/src/sound.go
@@ -270,8 +270,16 @@ func (bgm *Bgm) UpdateVolume() {
 		sys.errLog.Printf("WARNING: BGM volume set beyond expected range (value: %v). Clamped to MaxBgmVolume", bgm.bgmVolume)
 		bgm.bgmVolume = sys.maxBgmVolume
 	}
-	volume := -5 + float64(sys.bgmVolume)*0.06*(float64(sys.masterVolume)/100)*(float64(bgm.bgmVolume)/100)
-	silent := volume <= -5
+	volume := -5 + 6*(math.Pow(2, 0.0000008125*float64(sys.bgmVolume)*float64(sys.masterVolume)*float64(bgm.bgmVolume))-0.8125)
+
+	// leaving the following below in case we ever need to revert to the old method
+	// volume := -5 + float64(sys.bgmVolume)*0.06*(float64(sys.masterVolume)/100)*(float64(bgm.bgmVolume)/100)
+
+	// clamp to 1
+	if volume >= 1 {
+		volume = 1
+	}
+	silent := volume <= -3.875
 	speaker.Lock()
 	bgm.volctrl.Volume = volume
 	bgm.volctrl.Silent = silent

--- a/src/stage.go
+++ b/src/stage.go
@@ -750,6 +750,8 @@ type Stage struct {
 	stageprops        StageProps
 	model             *Model
 	ikemenver         [3]uint16
+	topbound          float32
+	botbound          float32
 }
 
 func newStage(def string) *Stage {
@@ -761,6 +763,7 @@ func newStage(def string) *Stage {
 		constants: make(map[string]float32), p1p3dist: 25, bgmvolume: 100}
 	s.sdw.intensity = 128
 	s.sdw.color = 0x808080
+	s.reflection.color = 0xFFFFFF
 	s.sdw.yscale = 0.4
 	s.p[0].startx, s.p[1].startx = -70, 70
 	s.stageprops = newStageProps()
@@ -900,6 +903,8 @@ func loadStage(def string, main bool) (*Stage, error) {
 		sec[0].ReadF32("leftbound", &s.leftbound)
 		sec[0].ReadF32("rightbound", &s.rightbound)
 		sec[0].ReadF32("p1p3dist", &s.p1p3dist)
+		sec[0].ReadF32("topbound", &s.topbound)
+		sec[0].ReadF32("botbound", &s.botbound)
 	}
 	if sec = defmap[fmt.Sprintf("%v.scaling", sys.language)]; len(sec) > 0 {
 		sectionExists = true
@@ -911,7 +916,10 @@ func loadStage(def string, main bool) (*Stage, error) {
 	if sectionExists {
 		sectionExists = false
 		if s.mugenver[0] != 1 { // mugen 1.0+ removed support for topscale
+			sec[0].ReadF32("topz", &s.stageCamera.topz)
+			sec[0].ReadF32("botz", &s.stageCamera.botz)
 			sec[0].ReadF32("topscale", &s.stageCamera.ztopscale)
+			sec[0].ReadF32("botscale", &s.stageCamera.zbotscale)
 		}
 	}
 	if sec = defmap[fmt.Sprintf("%v.bound", sys.language)]; len(sec) > 0 {
@@ -1130,7 +1138,7 @@ func loadStage(def string, main bool) (*Stage, error) {
 		}
 		s.sdw.color = uint32(r<<16 | g<<8 | b)
 		sec[0].ReadF32("yscale", &s.sdw.yscale)
-		sec[0].ReadBool("reflect", &reflect)
+		// sec[0].ReadBool("reflect", &reflect) // this does nothing in MUGEN
 		sec[0].readI32ForStage("fade.range", &s.sdw.fadeend, &s.sdw.fadebgn)
 		sec[0].ReadF32("xshear", &s.sdw.xshear)
 		sec[0].readF32ForStage("offset", &s.sdw.offset[0], &s.sdw.offset[1])
@@ -1145,6 +1153,8 @@ func loadStage(def string, main bool) (*Stage, error) {
 		}
 		if sectionExists {
 			s.reflection.yscale = 1.0
+			s.reflection.xshear = 0
+			s.reflection.color = 0xFFFFFF
 			sectionExists = false
 			var tmp int32
 			var tmp2 float32
@@ -1152,11 +1162,22 @@ func loadStage(def string, main bool) (*Stage, error) {
 			if sec[0].ReadI32("intensity", &tmp) {
 				s.reflection.intensity = Clamp(tmp, 0, 255)
 			}
+			var r, g, b int32 = 255, 255, 255
+			sec[0].readI32ForStage("color", &r, &g, &b)
+			r, g, b = Clamp(r, 0, 255), Clamp(g, 0, 255), Clamp(b, 0, 255)
+			// Disable color parameter specifically in Mugen 1.1 stages
+			if s.ikemenver[0] == 0 && s.ikemenver[1] == 0 && s.mugenver[0] == 1 && s.mugenver[1] == 1 {
+				r, g, b = 255, 255, 255
+			}
+			s.reflection.color = uint32(r<<16 | g<<8 | b)
 			if sec[0].ReadI32("layerno", &tmp) {
 				s.reflectionlayerno = Clamp(tmp, -1, 0)
 			}
 			if sec[0].ReadF32("yscale", &tmp2) {
 				s.reflection.yscale = tmp2
+			}
+			if sec[0].ReadF32("xshear", &tmp2) {
+				s.reflection.xshear = tmp2
 			}
 			if sec[0].readF32ForStage("offset", &tmp3[0], &tmp3[1]) {
 				s.reflection.offset[0] = tmp3[0]
@@ -1251,7 +1272,10 @@ func (s *Stage) copyStageVars(src *Stage) {
 	s.stageCamera.ytensionenable = src.stageCamera.ytensionenable
 	s.leftbound = src.leftbound
 	s.rightbound = src.rightbound
+	s.stageCamera.topz = src.stageCamera.topz
+	s.stageCamera.botz = src.stageCamera.botz
 	s.stageCamera.ztopscale = src.stageCamera.ztopscale
+	s.stageCamera.zbotscale = src.stageCamera.zbotscale
 	s.screenleft = src.screenleft
 	s.screenright = src.screenright
 	s.stageCamera.zoffset = src.stageCamera.zoffset
@@ -1269,6 +1293,8 @@ func (s *Stage) copyStageVars(src *Stage) {
 	s.reflection.intensity = src.reflection.intensity
 	s.reflection.offset[0] = src.reflection.offset[0]
 	s.reflection.offset[1] = src.reflection.offset[1]
+	s.reflection.xshear = src.reflection.xshear
+	s.reflection.yscale = src.reflection.yscale
 }
 func (s *Stage) getBg(id int32) (bg []*backGround) {
 	if id >= 0 {

--- a/src/stage.go
+++ b/src/stage.go
@@ -452,7 +452,7 @@ func (bg backGround) draw(pos [2]float32, scl, bgscl, lclscl float32,
 	if rect[0] < sys.scrrect[2] && rect[1] < sys.scrrect[3] && rect[0]+rect[2] > 0 && rect[1]+rect[3] > 0 {
 		bg.anim.Draw(&rect, x, y, sclx, scly, bg.xscale[0]*bgscl*(bg.scalestart[0]+xs)*xs3, xbs*bgscl*(bg.scalestart[0]+xs)*xs3, ys*ys3,
 			xras*x/(AbsF(ys*ys3)*lscl[1]*float32(bg.anim.spr.Size[1])*bg.scalestart[1])*sclx_recip*bg.scalestart[1],
-			Rotation{}, float32(sys.gameWidth)/2, bg.palfx, true, 1, false, 1, 0, 0)
+			Rotation{}, float32(sys.gameWidth)/2, bg.palfx, true, 1, false, 1, 0, 0, 0)
 	}
 }
 
@@ -915,7 +915,7 @@ func loadStage(def string, main bool) (*Stage, error) {
 	}
 	if sectionExists {
 		sectionExists = false
-		if s.mugenver[0] != 1 { // mugen 1.0+ removed support for topscale
+		if s.mugenver[0] != 1 || s.ikemenver[0] >= 1 { // mugen 1.0+ removed support for z-axis, IKEMEN-Go 1.0 adds it back
 			sec[0].ReadF32("topz", &s.stageCamera.topz)
 			sec[0].ReadF32("botz", &s.stageCamera.botz)
 			sec[0].ReadF32("topscale", &s.stageCamera.ztopscale)
@@ -1162,14 +1162,11 @@ func loadStage(def string, main bool) (*Stage, error) {
 			if sec[0].ReadI32("intensity", &tmp) {
 				s.reflection.intensity = Clamp(tmp, 0, 255)
 			}
-			var r, g, b int32 = 255, 255, 255
+			var r, g, b int32 = 0, 0, 0
 			sec[0].readI32ForStage("color", &r, &g, &b)
 			r, g, b = Clamp(r, 0, 255), Clamp(g, 0, 255), Clamp(b, 0, 255)
-			// Disable color parameter specifically in Mugen 1.1 stages
-			if s.ikemenver[0] == 0 && s.ikemenver[1] == 0 && s.mugenver[0] == 1 && s.mugenver[1] == 1 {
-				r, g, b = 255, 255, 255
-			}
 			s.reflection.color = uint32(r<<16 | g<<8 | b)
+
 			if sec[0].ReadI32("layerno", &tmp) {
 				s.reflectionlayerno = Clamp(tmp, -1, 0)
 			}


### PR DESCRIPTION
This PR primarily adds preliminary Z-axis support. Expect some bugs.

Features
* Preliminary Z-axis support (ought to have a lot of the same parameters in characters and stages as DOS 2000.01.01)
* Reflection now supports more of the parameters shadow does (specifically, xshear, color)
* Added support for building and running app from within app bundle for macOS (command is `make appbundle` and to clean is `make clean_appbundle` from the I.K.E.M.E.N-Go root directory)

Note: macOS users for the app bundle, since it would be an unsigned app downloaded from the Internet, it would be placed in quarantine by default even after accepting all permissions. This will result in a "read-only filesystem" or "save/stats.json" file not found error. The app can be removed from the quarantine by running this command in the same folder as I.K.E.M.E.N-Go.app (which should reside in the same place as the executable would normally go):

```
xattr -r -d com.apple.quarantine "I.K.E.M.E.N-Go.app"
```

Fixes
* Shadow/reflection fixes including rotation
* Joysticks now resolve swapped configs (but does not swap resolved indices, yet) on macOS only. Definitely preferable to the whole config being messed up and having to get lucky on a relaunch.
* Bumped xInputSensitivity default to 0.5
* Made joystick algorithm account for xInputSensitivity for XInput devices
* Added more XInput device types for detection
* Switched BGM volume to logarithmic scale
* Bumped up GLFW version
* ProjVar renames (hits > projhits, etc.)
* GetHitVar(xaccel) in Lua potentially returning the wrong sign


Huge thanks goes to @leonkasovan for his branch containing some nice GLFW input fixes that I used as a base as part of the input fixes for this PR.