### PR TITLE
feat: Helper OwnClsnScale, InCustomAnim, AnimPlayerNo, IkemenVersion

### DIFF
--- a/data/training.zss
+++ b/data/training.zss
@@ -36,266 +36,220 @@ if player($pn),ctrl = 0 {
 #===============================================================================
 [StateDef -4]
 
-ignoreHitPause if gameMode != "training" || teamSide != 2 || isHelper {
-	# Do nothing
-} else if roundState = 0 {
-	# Round start reset
-	powerSet{value: player(1),powerMax; redirectid: player(1),id}
-	powerSet{value: player(2),powerMax; redirectid: player(2),id}
-	map(_iksys_trainingLifeTimer) := 0;
-	map(_iksys_trainingPowerTimer) := 0;
-	map(_iksys_trainingDirection) := 0;
-	map(_iksys_trainingAirJumpNum) := 0;
-} else if roundState = 1 {
-	# Skip round and fight calls
-	assertSpecial{flag: noRoundDisplay; flag2: noFightDisplay}
-} else if roundState = 2 {
-	assertSpecial{flag: globalNoKo}
-	# Life and Power recovery
-	for i = 1; player(1),numPartner + 1; 1 {
-		call TrainingRecovery($i * 2 - 1);
+ignoreHitPause if gameMode = "training" && teamSide = 2 && !isHelper {
+	if roundState = 0 {
+		# Round start reset
+		powerSet{value: player(1),powerMax; redirectid: player(1),id}
+		powerSet{value: player(2),powerMax; redirectid: player(2),id}
+		map(_iksys_trainingLifeTimer) := 0;
+		map(_iksys_trainingPowerTimer) := 0;
+		map(_iksys_trainingDirection) := 0;
+		map(_iksys_trainingAirJumpNum) := 0;
 	}
-	for i = 1; player(2),numPartner + 1; 1 {
-		call TrainingRecovery($i * 2);
+	if roundState < 2 {
+		# Skip round and fight calls
+		assertSpecial{flag: noRoundDisplay; flag2: noFightDisplay}
 	}
-	# Dummy Control: Cooperative
-	if aiLevel = 0 && map(_iksys_trainingDummyControl) = 0 {
-		# Guard mode: Random
-		if map(_iksys_trainingGuardMode) = 3 {
-			if random < 500 {
-				assertSpecial{flag: autoGuard}
-			}
-		# Guard mode: All
-		} else if map(_iksys_trainingGuardMode) = 2 {
-			assertSpecial{flag: autoGuard}
-		# Guard mode: Auto
-		} else if map(_iksys_trainingGuardMode) = 1 {
-			if moveType = H || stateNo = const(StateDownedGetHit_gettingUp) {
-				map(_iksys_trainingAutoGuardTimer) := 15;
-			} else {
-				map(_iksys_trainingAutoGuardTimer) := (map(_iksys_trainingAutoGuardTimer) - 1);
-			}
-			if map(_iksys_trainingAutoGuardTimer) > 0 {
-				assertSpecial{flag: autoGuard}
-			}
+	if roundState = 2 {
+		assertSpecial{flag: globalNoKo}
+		# Life and Power recovery
+		for i = 1; player(1),numPartner + 1; 1 {
+			call TrainingRecovery($i * 2 - 1);
 		}
-		# Fall Recovery
-		if map(_iksys_trainingFallRecovery) {
-			if stateNo != [const(StateAirGetHit_fallRecoveryOnGroundStillFalling), const(StateAirGetHit_fallRecoveryInAir)] {
-				if moveType = H && stateType = A && hitFall && !getHitVar(isbound) && (pos y || vel y) {
-					# Ground recovery. Attempt only if common1 conditions are met
-					if vel y > 0 && pos y >= const(movement.air.gethit.groundrecover.ground.threshold) {
-						if map(_iksys_trainingFallRecovery) = 1 { 
+		for i = 1; player(2),numPartner + 1; 1 {
+			call TrainingRecovery($i * 2);
+		}
+		# Dummy Control: Cooperative
+		if aiLevel = 0 && map(_iksys_trainingDummyControl) = 0 {
+			# Guard mode: Random
+			if map(_iksys_trainingGuardMode) = 3 {
+				if random < 500 {
+					assertSpecial{flag: autoGuard}
+				}
+			# Guard mode: All
+			} else if map(_iksys_trainingGuardMode) = 2 {
+				assertSpecial{flag: autoGuard}
+			# Guard mode: Auto
+			} else if map(_iksys_trainingGuardMode) = 1 {
+				if moveType = H || stateNo = const(StateDownedGetHit_gettingUp) {
+					map(_iksys_trainingAutoGuardTimer) := 15;
+				} else {
+					map(_iksys_trainingAutoGuardTimer) := (map(_iksys_trainingAutoGuardTimer) - 1);
+				}
+				if map(_iksys_trainingAutoGuardTimer) > 0 {
+					assertSpecial{flag: autoGuard}
+				}
+			}
+			# Fall Recovery
+			if map(_iksys_trainingFallRecovery) {
+				if stateNo != [const(StateAirGetHit_fallRecoveryOnGroundStillFalling), const(StateAirGetHit_fallRecoveryInAir)] {
+					if moveType = H && stateType = A && hitFall && !getHitVar(isbound) && (pos y || vel y) {
+						# Ground recovery. Attempt only if common1 conditions are met
+						if vel y > 0 && pos y >= const(movement.air.gethit.groundrecover.ground.threshold) {
+							if map(_iksys_trainingFallRecovery) = 1 { 
+								let rcv = 1;
+							}
+						# Air recovery. Attempt only if conditions for ground recovery are not met
+						} else if map(_iksys_trainingFallRecovery) = 2 {
 							let rcv = 1;
 						}
-					# Air recovery. Attempt only if conditions for ground recovery are not met
-					} else if map(_iksys_trainingFallRecovery) = 2 {
-						let rcv = 1;
-					}
-					# Random recovery. Attempt regardless of conditions
-					if map(_iksys_trainingFallRecovery) = 3 && random < 100 {
-						let rcv = 1;
-					}
-					if $rcv {
-						# WinMugen characters assert inputs because asserting commands directly may trigger their AI activation codes
-						if mugenVersion < 1.0 {
-							if gametime % 2 {
-								assertInput{flag: x; flag2: y; flag3: z}
-							} else {
-								assertInput{flag: a; flag2: b; flag3: c}
-							}
-						} else {
-							assertCommand{name: "recovery"; buffer.time: 2}
-							# Buffered 2 frames because asserting a command instead of inputting it has 1 frame of lag in custom fall recovery systems
+						# Random recovery. Attempt regardless of conditions
+						if map(_iksys_trainingFallRecovery) = 3 && random < 100 {
+							let rcv = 1;
 						}
-						# Random direction
-						if map(_iksys_trainingFallRecovery) = 3 {
-							if random < 333 {
-								assertInput{flag: L}
-							} else if random < 500 {
-								assertInput{flag: R}
+						if $rcv {
+							# WinMugen characters assert inputs because asserting commands directly may trigger their AI activation codes
+							if mugenVersion < 1.0 {
+								if gametime % 2 {
+									assertInput{flag: x; flag2: y; flag3: z}
+								} else {
+									assertInput{flag: a; flag2: b; flag3: c}
+								}
+							} else {
+								assertCommand{name: "recovery"; buffer.time: 2}
+								# Buffered 2 frames because asserting a command instead of inputting it has 1 frame of lag in custom fall recovery systems
 							}
-							if random < 333 {
-								assertInput{flag: U}
-							} else if random < 500 {
-								assertInput{flag: D}
+							# Random direction
+							if map(_iksys_trainingFallRecovery) = 3 {
+								if random < 333 {
+									assertInput{flag: L}
+								} else if random < 500 {
+									assertInput{flag: R}
+								}
+								if random < 333 {
+									assertInput{flag: U}
+								} else if random < 500 {
+									assertInput{flag: D}
+								}
 							}
 						}
 					}
 				}
 			}
-		}
-		# Distance
-		let dir = 0;
-		if map(_iksys_trainingDistance) != 0 {
-			# Close
-			if map(_iksys_trainingDistance) = 1 && p2BodyDist x > const240p(10) {
-				let dir = 1;
-				map(_iksys_trainingDirection) := 1;
-			# Medium
-			} else if map(_iksys_trainingDistance) = 2 {
-				if p2BodyDist x > const240p(130) {
+			# Distance
+			let dir = 0;
+			if map(_iksys_trainingDistance) != 0 {
+				# Close
+				if map(_iksys_trainingDistance) = 1 && p2BodyDist x > const240p(10) {
 					let dir = 1;
 					map(_iksys_trainingDirection) := 1;
-				} else if p2BodyDist x < const240p(80) && backEdgeBodyDist > const240p(10) {
-					let dir = -1;
-					map(_iksys_trainingDirection) := -1;
-				}
-			# Far
-			} else if map(_iksys_trainingDistance) = 3 {
-				if p2BodyDist x < const240p(260) && backEdgeBodyDist > const240p(10) {
-					let dir = -1;
-					map(_iksys_trainingDirection) := -1;
-				}
-			}
-		}
-		if map(_iksys_trainingDirection) != 0 {
-			# if adjusting position is no longer needed
-			if $dir = 0 {
-				# maintain assertion only if dummy and nearest P1 are moving in the same direction
-				if vel x * p2,vel x >= 0 || backEdgeBodyDist = 0 || p2,backEdgeBodyDist = 0 {
-					map(_iksys_trainingDirection) := 0;
-				}
-			}
-			# if dummy should move forward and player is not trying to move dummy back
-			if map(_iksys_trainingDirection) = 1 && command != "holdback" {
-				if facing = 1 {
-					assertInput{flag: R}
-					if numHelper {
-						for i = 1; numHelper; 1 {
-							assertInput{flag: R; redirectID: helperIndex($i), ID}
-						}
+				# Medium
+				} else if map(_iksys_trainingDistance) = 2 {
+					if p2BodyDist x > const240p(130) {
+						let dir = 1;
+						map(_iksys_trainingDirection) := 1;
+					} else if p2BodyDist x < const240p(80) && backEdgeBodyDist > const240p(10) {
+						let dir = -1;
+						map(_iksys_trainingDirection) := -1;
 					}
-				} else {
-					assertInput{flag: L}
-					if numHelper {
-						for i = 1; numHelper; 1 {
+				# Far
+				} else if map(_iksys_trainingDistance) = 3 {
+					if p2BodyDist x < const240p(260) && backEdgeBodyDist > const240p(10) {
+						let dir = -1;
+						map(_iksys_trainingDirection) := -1;
+					}
+				}
+			}
+			if map(_iksys_trainingDirection) != 0 {
+				# If adjusting position is no longer needed
+				if $dir = 0 {
+					# maintain assertion only if dummy and nearest P1 are moving in the same direction
+					if vel x * p2,vel x >= 0 || backEdgeBodyDist = 0 || p2,backEdgeBodyDist = 0 {
+						map(_iksys_trainingDirection) := 0;
+					}
+				}
+				# If dummy should move forward and player is not trying to move dummy back
+				if map(_iksys_trainingDirection) = 1 && command != "holdback" {
+					if facing = 1 {
+						for i = 0; numHelper; 1 {
+							assertInput{flag: R; redirectID: helperIndex($i), ID} # Index 0 being the root
+						}
+					} else {
+						for i = 0; numHelper; 1 {
 							assertInput{flag: L; redirectID: helperIndex($i), ID}
 						}
 					}
-				}
-			# if dummy should move backward and player is not trying to move dummy forward
-			} else if map(_iksys_trainingDirection) = -1 && command != "holdfwd" {
-				if facing = 1 {
-					assertInput{flag: L}
-					if numHelper {
-						for i = 1; numHelper; 1 {
+				# If dummy should move backward and player is not trying to move dummy forward
+				} else if map(_iksys_trainingDirection) = -1 && command != "holdfwd" {
+					if facing = 1 {
+						for i = 0; numHelper; 1 {
 							assertInput{flag: L; redirectID: helperIndex($i), ID}
 						}
-					}
-				} else {
-					assertInput{flag: R}
-					if numHelper {
-						for i = 1; numHelper; 1 {
+					} else {
+						for i = 0; numHelper; 1 {
 							assertInput{flag: R; redirectID: helperIndex($i), ID}
 						}
 					}
 				}
-			}
-		} else {
-			# Dummy mode
-			switch map(_iksys_trainingDummyMode) {
-			# Crouch
-			case 1:
-				assertInput{flag: D}
-				if numHelper {
-					for i = 1; numHelper; 1 {
+			} else {
+				# Dummy mode
+				switch map(_iksys_trainingDummyMode) {
+				# Crouch
+				case 1:
+					for i = 0; numHelper; 1 {
 						assertInput{flag: D; redirectID: helperIndex($i), ID}
 					}
-				}
-			# Jump
-			case 2:
-				assertInput{flag: U}
-				if numHelper {
-					for i = 1; numHelper; 1 {
+				# Jump
+				case 2:
+					for i = 0; numHelper; 1 {
 						assertInput{flag: U; redirectID: helperIndex($i), ID}
 					}
-				}
-			# W Jump
-			case 3:
-				if vel y >= 0 {
-					assertInput{flag: U}
-					if numHelper {
-						for i = 1; numHelper; 1 {
+				# W Jump
+				case 3:
+					if vel y >= 0 {
+						for i = 0; numHelper; 1 {
 							assertInput{flag: U; redirectID: helperIndex($i), ID}
 						}
 					}
+				default:
+					# Do nothing
 				}
-			default:
-				# Do nothing
-			}
-			# Button jam
-			if map(_iksys_trainingButtonJam) > 0 {
-				if map(_iksys_trainingButtonJamDelay) > 0 {
-					mapAdd{map: "_iksys_trainingButtonJamDelay"; value: -1}
-				} else {
-					map(_iksys_trainingButtonJamDelay) := 11;
-					switch map(_iksys_trainingButtonJam) {
-					case 1:
-						assertInput{flag: a}
-						if numHelper {
-							for i = 1; numHelper; 1 {
+				# Button jam
+				if map(_iksys_trainingButtonJam) > 0 {
+					if map(_iksys_trainingButtonJamDelay) > 0 {
+						mapAdd{map: "_iksys_trainingButtonJamDelay"; value: -1}
+					} else {
+						map(_iksys_trainingButtonJamDelay) := 11;
+						switch map(_iksys_trainingButtonJam) {
+						case 1:
+							for i = 0; numHelper; 1 {
 								assertInput{flag: a; redirectID: helperIndex($i), ID}
 							}
-						}
-					case 2:
-						assertInput{flag: b}
-						if numHelper {
-							for i = 1; numHelper; 1 {
+						case 2:
+							for i = 0; numHelper; 1 {
 								assertInput{flag: b; redirectID: helperIndex($i), ID}
 							}
-						}
-					case 3:
-						assertInput{flag: c}
-						if numHelper {
-							for i = 1; numHelper; 1 {
+						case 3:
+							for i = 0; numHelper; 1 {
 								assertInput{flag: c; redirectID: helperIndex($i), ID}
 							}
-						}
-					case 4:
-						assertInput{flag: x}
-						if numHelper {
-							for i = 1; numHelper; 1 {
+						case 4:
+							for i = 0; numHelper; 1 {
 								assertInput{flag: x; redirectID: helperIndex($i), ID}
 							}
-						}
-					case 5:
-						assertInput{flag: y}
-						if numHelper {
-							for i = 1; numHelper; 1 {
+						case 5:
+							for i = 0; numHelper; 1 {
 								assertInput{flag: y; redirectID: helperIndex($i), ID}
 							}
-						}
-					case 6:
-						assertInput{flag: z}
-						if numHelper {
-							for i = 1; numHelper; 1 {
+						case 6:
+							for i = 0; numHelper; 1 {
 								assertInput{flag: z; redirectID: helperIndex($i), ID}
 							}
-						}
-					case 7:
-						assertInput{flag: s}
-						if numHelper {
-							for i = 1; numHelper; 1 {
+						case 7:
+							for i = 0; numHelper; 1 {
 								assertInput{flag: s; redirectID: helperIndex($i), ID}
 							}
-						}
-					case 8:
-						assertInput{flag: d}
-						if numHelper {
-							for i = 1; numHelper; 1 {
+						case 8:
+							for i = 0; numHelper; 1 {
 								assertInput{flag: d; redirectID: helperIndex($i), ID}
 							}
-						}
-					case 9:
-						assertInput{flag: w}
-						if numHelper {
-							for i = 1; numHelper; 1 {
+						case 9:
+							for i = 0; numHelper; 1 {
 								assertInput{flag: w; redirectID: helperIndex($i), ID}
 							}
+						default:
+							map(_iksys_trainingButtonJamDelay) := 0;
 						}
-					default:
-						map(_iksys_trainingButtonJamDelay) := 0;
 					}
 				}
 			}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -4209,6 +4209,7 @@ const (
 	helper_kovelocity
 	helper_preserve
 	helper_standby
+	helper_ownclsnscale
 )
 
 func (sc helper) Run(c *Char, _ []int32) bool {
@@ -4333,6 +4334,8 @@ func (sc helper) Run(c *Char, _ []int32) bool {
 			if exp[0].evalB(c) {
 				h.preserve = sys.round
 			}
+		case helper_ownclsnscale:
+			h.ownclsnscale = exp[0].evalB(c)
 		case helper_standby:
 			if exp[0].evalB(c) {
 				h.setSCF(SCF_standby)

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -572,6 +572,7 @@ const (
 	OC_ex_movehitvar_spark_x
 	OC_ex_movehitvar_spark_y
 	OC_ex_movehitvar_uniqhit
+	OC_ex_ikemenversion
 	OC_ex_incustomanim
 	OC_ex_incustomstate
 	OC_ex_indialogue
@@ -2528,6 +2529,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		*sys.bcStack.Top() = c.helperByIndexExist(*sys.bcStack.Top())
 	case OC_ex_hitoverridden:
 		sys.bcStack.PushB(c.hoIdx >= 0)
+	case OC_ex_ikemenversion:
+		sys.bcStack.PushF(c.gi().ikemenverF)
 	case OC_ex_incustomanim:
 		sys.bcStack.PushB(c.animPN != c.playerNo)
 	case OC_ex_incustomstate:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -571,6 +571,7 @@ const (
 	OC_ex_movehitvar_spark_x
 	OC_ex_movehitvar_spark_y
 	OC_ex_movehitvar_uniqhit
+	OC_ex_incustomanim
 	OC_ex_incustomstate
 	OC_ex_indialogue
 	OC_ex_isassertedchar
@@ -2524,6 +2525,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		*sys.bcStack.Top() = c.helperByIndexExist(*sys.bcStack.Top())
 	case OC_ex_hitoverridden:
 		sys.bcStack.PushB(c.hoIdx >= 0)
+	case OC_ex_incustomanim:
+		sys.bcStack.PushB(c.animPN != c.playerNo)
 	case OC_ex_incustomstate:
 		sys.bcStack.PushB(c.ss.sb.playerNo != c.playerNo)
 	case OC_ex_indialogue:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -526,6 +526,7 @@ const (
 	OC_ex_animframe_numclsn1
 	OC_ex_animframe_numclsn2
 	OC_ex_animlength
+	OC_ex_animplayerno
 	OC_ex_attack
 	OC_ex_combocount
 	OC_ex_consecutivewins
@@ -2437,6 +2438,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		}
 	case OC_ex_animlength:
 		sys.bcStack.PushI(c.anim.totaltime)
+	case OC_ex_animplayerno:
+		sys.bcStack.PushI(int32(c.animPN) + 1)
 	case OC_ex_attack:
 		sys.bcStack.PushF(c.attackMul[0] * 100)
 	case OC_ex_combocount:

--- a/src/char.go
+++ b/src/char.go
@@ -1931,10 +1931,10 @@ func (p *Projectile) cueDraw(oldVer bool, playerNo int) {
 		if frm := p.ani.drawFrame(); frm != nil {
 			xs := p.clsnScale[0] * p.localscl * p.facing
 			if clsn := frm.Clsn1(); len(clsn) > 0 {
-				sys.debugc1hit.Add(clsn, p.pos[0]*p.localscl, p.pos[1]*p.localscl, xs, p.clsnScale[1]*p.localscl, p.clsnAngle)
+				sys.debugc1hit.Add(clsn, p.pos[0]*p.localscl, p.pos[1]*p.localscl, xs, p.clsnScale[1]*p.localscl, p.clsnAngle*p.facing)
 			}
 			if clsn := frm.Clsn2(); len(clsn) > 0 {
-				sys.debugc2hb.Add(clsn, p.pos[0]*p.localscl, p.pos[1]*p.localscl, xs, p.clsnScale[1]*p.localscl, p.clsnAngle)
+				sys.debugc2hb.Add(clsn, p.pos[0]*p.localscl, p.pos[1]*p.localscl, xs, p.clsnScale[1]*p.localscl, p.clsnAngle*p.facing)
 			}
 		}
 	}
@@ -5111,7 +5111,7 @@ func (c *Char) updateClsnScale() {
 	// Index range checks. Prevents crashing if chars don't have animations
 	// https://github.com/ikemen-engine/Ikemen-GO/issues/1982
 	if c.animPN >= 0 && c.animPN < len(sys.chars) && len(sys.chars[c.animPN]) > 0 {
-		// The char's own Clsn scale
+		// The char's base Clsn scale
 		// Based on the animation owner's scale constants
 		c.clsnScale = [...]float32{
 			sys.chars[c.animPN][0].size.xscale,
@@ -5138,7 +5138,20 @@ func (c *Char) widthToSizeBox() {
 	if len(c.width) < 2 || len(c.height) < 2 {
 		c.sizeBox = []float32{0, 0, 0, 0}
 	} else {
-		c.sizeBox = []float32{-c.width[1], -c.height[0], c.width[0], c.height[1]}
+		// Correct left/right and top/bottom
+		// Same behavior as Clsn boxes
+		// https://github.com/ikemen-engine/Ikemen-GO/issues/2008
+		back := -c.width[1]
+		front := c.width[0]
+		top := -c.height[0]
+		bottom := c.height[1]
+		if back > front {
+			back, front = front, back
+		}
+		if top > bottom { // Negative sign
+			top, bottom = bottom, top
+		}
+		c.sizeBox = []float32{back, top, front, bottom}
 	}
 }
 

--- a/src/char.go
+++ b/src/char.go
@@ -2231,6 +2231,7 @@ type Char struct {
 	sizeBox         []float32
 	shadowOffset    [2]float32
 	reflectOffset   [2]float32
+	ownclsnscale    bool
 }
 
 func newChar(n int, idx int32) (c *Char) {
@@ -5108,6 +5109,11 @@ func (c *Char) setBHeight(bh float32) {
 }
 
 func (c *Char) updateClsnScale() {
+	// Helper parameter
+	if c.ownclsnscale && c.animPN == c.playerNo {
+		c.clsnScale = [...]float32{c.size.xscale, c.size.yscale}
+		return
+	}
 	// Index range checks. Prevents crashing if chars don't have animations
 	// https://github.com/ikemen-engine/Ikemen-GO/issues/1982
 	if c.animPN >= 0 && c.animPN < len(sys.chars) && len(sys.chars[c.animPN]) > 0 {

--- a/src/char.go
+++ b/src/char.go
@@ -2000,6 +2000,8 @@ type CharGlobalInfo struct {
 	pal              [MaxPalNo]string
 	palExist         [MaxPalNo]bool
 	palSelectable    [MaxPalNo]bool
+	ikemenver        [3]uint16
+	ikemenverF       float32
 	mugenver         [2]uint16
 	data             CharData
 	velocity         CharVelocity
@@ -2015,7 +2017,6 @@ type CharGlobalInfo struct {
 	remapPreset      map[string]RemapPreset
 	remappedpal      [2]int32
 	localcoord       [2]float32
-	ikemenver        [3]uint16
 	fnt              [10]*Fnt
 }
 
@@ -3658,6 +3659,8 @@ func (c *Char) moveReversed() int32 {
 	}
 	return 0
 }
+
+// Mugen version trigger
 func (c *Char) mugenVersion() float32 {
 	// Here the version is always checked directly in the character instead of the working state
 	// This is because in a custom state this trigger will be used to know the enemy's version rather than our own
@@ -3673,6 +3676,7 @@ func (c *Char) mugenVersion() float32 {
 		return 0
 	}
 }
+
 func (c *Char) numEnemy() int32 {
 	var n int32
 	if c.teamside == -1 {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -379,7 +379,8 @@ var triggerMap = map[string]int{
 	"helperindexexist":   1,
 	"helpername":         1,
 	"hitoverridden":      1,
-	"incustomanim":      1,
+	"ikemenversion":      1,
+	"incustomanim":       1,
 	"incustomstate":      1,
 	"index":              1,
 	"indialogue":         1,
@@ -3531,6 +3532,14 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		}
 	case "hitoverridden":
 		out.append(OC_ex_, OC_ex_hitoverridden)
+	case "ikemenversion":
+		out.append(OC_ex_, OC_ex_ikemenversion)
+	case "incustomanim":
+		out.append(OC_ex_, OC_ex_incustomanim)
+	case "incustomstate":
+		out.append(OC_ex_, OC_ex_incustomstate)
+	case "indialogue":
+		out.append(OC_ex_, OC_ex_indialogue)
 	case "inputtime":
 		if err := c.checkOpeningBracketCS(in); err != nil {
 			return bvNone(), err
@@ -3576,41 +3585,6 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		default:
 			return bvNone(), Error("Invalid data: " + key)
 		}
-	case "movehitvar":
-		if err := c.checkOpeningBracket(in); err != nil {
-			return bvNone(), err
-		}
-		out.append(OC_ex_)
-		switch c.token {
-		case "cornerpush":
-			out.append(OC_ex_movehitvar_cornerpush)
-		case "frame":
-			out.append(OC_ex_movehitvar_frame)
-		case "id":
-			out.append(OC_ex_movehitvar_id)
-		case "overridden":
-			out.append(OC_ex_movehitvar_overridden)
-		case "playerno":
-			out.append(OC_ex_movehitvar_playerno)
-		case "sparkx":
-			out.append(OC_ex_movehitvar_spark_x)
-		case "sparky":
-			out.append(OC_ex_movehitvar_spark_y)
-		case "uniqhit":
-			out.append(OC_ex_movehitvar_uniqhit)
-		default:
-			return bvNone(), Error("Invalid data: " + c.token)
-		}
-		c.token = c.tokenizer(in)
-		if err := c.checkClosingBracket(); err != nil {
-			return bvNone(), err
-		}
-	case "incustomanim":
-		out.append(OC_ex_, OC_ex_incustomanim)
-	case "incustomstate":
-		out.append(OC_ex_, OC_ex_incustomstate)
-	case "indialogue":
-		out.append(OC_ex_, OC_ex_indialogue)
 	case "isasserted":
 		if err := c.checkOpeningBracket(in); err != nil {
 			return bvNone(), err
@@ -3807,6 +3781,35 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_ex_, OC_ex_memberno)
 	case "movecountered":
 		out.append(OC_ex_, OC_ex_movecountered)
+	case "movehitvar":
+		if err := c.checkOpeningBracket(in); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_ex_)
+		switch c.token {
+		case "cornerpush":
+			out.append(OC_ex_movehitvar_cornerpush)
+		case "frame":
+			out.append(OC_ex_movehitvar_frame)
+		case "id":
+			out.append(OC_ex_movehitvar_id)
+		case "overridden":
+			out.append(OC_ex_movehitvar_overridden)
+		case "playerno":
+			out.append(OC_ex_movehitvar_playerno)
+		case "sparkx":
+			out.append(OC_ex_movehitvar_spark_x)
+		case "sparky":
+			out.append(OC_ex_movehitvar_spark_y)
+		case "uniqhit":
+			out.append(OC_ex_movehitvar_uniqhit)
+		default:
+			return bvNone(), Error("Invalid data: " + c.token)
+		}
+		c.token = c.tokenizer(in)
+		if err := c.checkClosingBracket(); err != nil {
+			return bvNone(), err
+		}
 	case "mugenversion":
 		out.append(OC_ex_, OC_ex_mugenversion)
 	case "numplayer":
@@ -6419,6 +6422,19 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 						} else {
 							break
 						}
+					}
+					// Convert into a float for triggers
+					// TODO: Same thing for stages etc
+					re := regexp.MustCompile(`[^0-9.]`)
+					str = re.ReplaceAllString(str, "")
+					// Keep only the first decimal point
+					parts := strings.Split(str, ".")
+					if len(parts) > 1 {
+						str = parts[0] + "." + strings.Join(parts[1:], "")
+					}
+					// Convert clean string to float
+					if result, err := strconv.ParseFloat(str, 32); err == nil {
+						sys.cgi[pn].ikemenverF = float32(result)
 					}
 				}
 				// Ikemen characters adopt Mugen 1.1 version as a safeguard

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -377,6 +377,7 @@ var triggerMap = map[string]int{
 	"helperindexexist":   1,
 	"helpername":         1,
 	"hitoverridden":      1,
+	"incustomanim":      1,
 	"incustomstate":      1,
 	"index":              1,
 	"indialogue":         1,
@@ -3600,6 +3601,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		if err := c.checkClosingBracket(); err != nil {
 			return bvNone(), err
 		}
+	case "incustomanim":
+		out.append(OC_ex_, OC_ex_incustomanim)
 	case "incustomstate":
 		out.append(OC_ex_, OC_ex_incustomstate)
 	case "indialogue":

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -339,7 +339,9 @@ var triggerMap = map[string]int{
 	"alpha":              1,
 	"angle":              1,
 	"animelemlength":     1,
+	"animframe":          1,
 	"animlength":         1,
+	"animplayerno":       1,
 	"atan2":              1,
 	"attack":             1,
 	"bgmlength":          1,
@@ -3415,6 +3417,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		}
 	case "animlength":
 		out.append(OC_ex_, OC_ex_animlength)
+	case "animplayerno":
+		out.append(OC_ex_, OC_ex_animplayerno)
 	case "attack":
 		out.append(OC_ex_, OC_ex_attack)
 	case "combocount":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -664,6 +664,10 @@ func (c *Compiler) helper(is IniSection, sc *StateControllerBase, _ int8) (State
 			helper_standby, VT_Bool, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "ownclsnscale",
+			helper_ownclsnscale, VT_Bool, 1, false); err != nil {
+			return err
+		}
 		return nil
 	})
 	return *ret, err

--- a/src/script.go
+++ b/src/script.go
@@ -4451,126 +4451,124 @@ func triggerFunctions(l *lua.LState) {
 		}
 		return 1
 	})
-	luaRegister(l, "animframealphadest", func(*lua.LState) int {
-		if f := sys.debugWC.anim.CurrentFrame(); f != nil {
-			l.Push(lua.LNumber(f.DstAlpha))
-		} else {
-			l.Push(lua.LNumber(0))
-		}
-		return 1
-	})
-	luaRegister(l, "animframeangle", func(*lua.LState) int {
-		if f := sys.debugWC.anim.CurrentFrame(); f != nil {
-			if len(f.Ex) > 2 && len(f.Ex[2]) > 2 {
-				l.Push(lua.LNumber(f.Ex[2][2]))
+	luaRegister(l, "animframe", func(*lua.LState) int {
+		c := sys.debugWC
+		switch strArg(l, 1) {
+		case "alphadest":
+			if f := c.anim.CurrentFrame(); f != nil {
+				l.Push(lua.LNumber(f.DstAlpha))
 			} else {
 				l.Push(lua.LNumber(0))
 			}
-		}
-		return 1
-	})
-	luaRegister(l, "animframealphasource", func(*lua.LState) int {
-		if f := sys.debugWC.anim.CurrentFrame(); f != nil {
-			l.Push(lua.LNumber(f.SrcAlpha))
-		} else {
-			l.Push(lua.LNumber(0))
-		}
-		return 1
-	})
-	luaRegister(l, "animframegroup", func(*lua.LState) int {
-		if f := sys.debugWC.anim.CurrentFrame(); f != nil {
-			l.Push(lua.LNumber(f.Group))
-		} else {
-			l.Push(lua.LNumber(-1))
-		}
-		return 1
-	})
-	luaRegister(l, "animframehflip", func(*lua.LState) int {
-		if f := sys.debugWC.anim.CurrentFrame(); f != nil {
-			l.Push(lua.LBool(f.H < 0))
-		} else {
-			l.Push(lua.LBool(false))
-		}
-		return 1
-	})
-	luaRegister(l, "animframeimage", func(*lua.LState) int {
-		if f := sys.debugWC.anim.CurrentFrame(); f != nil {
-			l.Push(lua.LNumber(f.Number))
-		} else {
-			l.Push(lua.LNumber(-1))
-		}
-		return 1
-	})
-	luaRegister(l, "animframetime", func(*lua.LState) int { // Same as AnimElemLength
-		if f := sys.debugWC.anim.CurrentFrame(); f != nil {
-			l.Push(lua.LNumber(f.Time))
-		} else {
-			l.Push(lua.LNumber(-1))
-		}
-		return 1
-	})
-	luaRegister(l, "animframevflip", func(*lua.LState) int {
-		if f := sys.debugWC.anim.CurrentFrame(); f != nil {
-			l.Push(lua.LBool(f.V < 0))
-		} else {
-			l.Push(lua.LBool(false))
-		}
-		return 1
-	})
-	luaRegister(l, "animframexoffset", func(*lua.LState) int {
-		if f := sys.debugWC.anim.CurrentFrame(); f != nil {
-			l.Push(lua.LNumber(f.X))
-		} else {
-			l.Push(lua.LNumber(0))
-		}
-		return 1
-	})
-	luaRegister(l, "animframexscale", func(*lua.LState) int {
-		if f := sys.debugWC.anim.CurrentFrame(); f != nil {
-			if len(f.Ex) > 2 {
-				l.Push(lua.LNumber(f.Ex[2][0]))
+			return 1
+		case "alphasource":
+			if f := c.anim.CurrentFrame(); f != nil {
+				l.Push(lua.LNumber(f.SrcAlpha))
 			} else {
 				l.Push(lua.LNumber(0))
 			}
-		}
-		return 1
-	})
-	luaRegister(l, "animframeyoffset", func(*lua.LState) int {
-		if f := sys.debugWC.anim.CurrentFrame(); f != nil {
-			l.Push(lua.LNumber(f.Y))
-		} else {
-			l.Push(lua.LNumber(0))
-		}
-		return 1
-	})
-	luaRegister(l, "animframeyscale", func(*lua.LState) int {
-		if f := sys.debugWC.anim.CurrentFrame(); f != nil {
-			if len(f.Ex) > 2 && len(f.Ex[2]) > 1 {
-				l.Push(lua.LNumber(f.Ex[2][0]))
+			return 1
+		case "angle":
+			if f := c.anim.CurrentFrame(); f != nil {
+				if len(f.Ex) > 2 && len(f.Ex[2]) > 2 {
+					l.Push(lua.LNumber(f.Ex[2][2]))
+				} else {
+					l.Push(lua.LNumber(0))
+				}
+			}
+			return 1
+		case "group":
+			if f := c.anim.CurrentFrame(); f != nil {
+				l.Push(lua.LNumber(f.Group))
+			} else {
+				l.Push(lua.LNumber(-1))
+			}
+			return 1
+		case "hflip":
+			if f := c.anim.CurrentFrame(); f != nil {
+				l.Push(lua.LBool(f.H < 0))
+			} else {
+				l.Push(lua.LBool(false))
+			}
+			return 1
+		case "image":
+			if f := c.anim.CurrentFrame(); f != nil {
+				l.Push(lua.LNumber(f.Number))
+			} else {
+				l.Push(lua.LNumber(-1))
+			}
+			return 1
+		case "numclsn1":
+			if f := c.anim.CurrentFrame(); f != nil {
+				l.Push(lua.LNumber(len(f.Clsn1()) / 4))
 			} else {
 				l.Push(lua.LNumber(0))
 			}
+			return 1
+		case "numclsn2":
+			if f := c.anim.CurrentFrame(); f != nil {
+				l.Push(lua.LNumber(len(f.Clsn2()) / 4))
+			} else {
+				l.Push(lua.LNumber(0))
+			}
+			return 1
+		case "time": // Same as AnimElemLength
+			if f := c.anim.CurrentFrame(); f != nil {
+				l.Push(lua.LNumber(f.Time))
+			} else {
+				l.Push(lua.LNumber(-1))
+			}
+			return 1
+		case "vflip":
+			if f := c.anim.CurrentFrame(); f != nil {
+				l.Push(lua.LBool(f.V < 0))
+			} else {
+				l.Push(lua.LBool(false))
+			}
+			return 1
+		case "xoffset":
+			if f := c.anim.CurrentFrame(); f != nil {
+				l.Push(lua.LNumber(f.X))
+			} else {
+				l.Push(lua.LNumber(0))
+			}
+			return 1
+		case "xscale":
+			if f := c.anim.CurrentFrame(); f != nil {
+				if len(f.Ex) > 2 {
+					l.Push(lua.LNumber(f.Ex[2][0]))
+				} else {
+					l.Push(lua.LNumber(0))
+				}
+			}
+			return 1
+		case "yoffset":
+			if f := c.anim.CurrentFrame(); f != nil {
+				l.Push(lua.LNumber(f.Y))
+			} else {
+				l.Push(lua.LNumber(0))
+			}
+			return 1
+		case "yscale":
+			if f := c.anim.CurrentFrame(); f != nil {
+				if len(f.Ex) > 2 && len(f.Ex[2]) > 1 {
+					l.Push(lua.LNumber(f.Ex[2][0]))
+				} else {
+					l.Push(lua.LNumber(0))
+				}
+			}
+			return 1
+		default:
+			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
+			return 1
 		}
-		return 1
-	})
-	luaRegister(l, "animframenumclsn1", func(*lua.LState) int {
-		if f := sys.debugWC.anim.CurrentFrame(); f != nil {
-			l.Push(lua.LNumber(len(f.Clsn1()) / 4))
-		} else {
-			l.Push(lua.LNumber(0))
-		}
-		return 1
-	})
-	luaRegister(l, "animframenumclsn2", func(*lua.LState) int {
-		if f := sys.debugWC.anim.CurrentFrame(); f != nil {
-			l.Push(lua.LNumber(len(f.Clsn2()) / 4))
-		} else {
-			l.Push(lua.LNumber(0))
-		}
-		return 1
 	})
 	luaRegister(l, "animlength", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.anim.totaltime))
+		return 1
+	})
+	luaRegister(l, "animplayerno", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.animPN + 1))
 		return 1
 	})
 	luaRegister(l, "attack", func(*lua.LState) int {

--- a/src/script.go
+++ b/src/script.go
@@ -4686,6 +4686,10 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LBool(sys.debugWC.hoIdx >= 0))
 		return 1
 	})
+	luaRegister(l, "incustomanim", func(*lua.LState) int {
+		l.Push(lua.LBool(sys.debugWC.animPN != sys.debugWC.playerNo))
+		return 1
+	})
 	luaRegister(l, "incustomstate", func(*lua.LState) int {
 		l.Push(lua.LBool(sys.debugWC.ss.sb.playerNo != sys.debugWC.playerNo))
 		return 1

--- a/src/script.go
+++ b/src/script.go
@@ -4684,6 +4684,10 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LBool(sys.debugWC.hoIdx >= 0))
 		return 1
 	})
+	luaRegister(l, "ikemenversion", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.gi().ikemenverF))
+		return 1
+	})
 	luaRegister(l, "incustomanim", func(*lua.LState) int {
 		l.Push(lua.LBool(sys.debugWC.animPN != sys.debugWC.playerNo))
 		return 1

--- a/src/stage.go
+++ b/src/stage.go
@@ -1115,7 +1115,7 @@ func loadStage(def string, main bool) (*Stage, error) {
 			}
 		}
 	}
-	reflect := true
+	// Shadow group
 	if sec = defmap[fmt.Sprintf("%v.shadow", sys.language)]; len(sec) > 0 {
 		sectionExists = true
 	} else {
@@ -1138,48 +1138,46 @@ func loadStage(def string, main bool) (*Stage, error) {
 		}
 		s.sdw.color = uint32(r<<16 | g<<8 | b)
 		sec[0].ReadF32("yscale", &s.sdw.yscale)
-		// sec[0].ReadBool("reflect", &reflect) // this does nothing in MUGEN
 		sec[0].readI32ForStage("fade.range", &s.sdw.fadeend, &s.sdw.fadebgn)
 		sec[0].ReadF32("xshear", &s.sdw.xshear)
 		sec[0].readF32ForStage("offset", &s.sdw.offset[0], &s.sdw.offset[1])
 	}
-	if reflect {
-		if sec = defmap[fmt.Sprintf("%v.reflection", sys.language)]; len(sec) > 0 {
+	// Reflection group
+	if sec = defmap[fmt.Sprintf("%v.reflection", sys.language)]; len(sec) > 0 {
+		sectionExists = true
+	} else {
+		if sec = defmap["reflection"]; len(sec) > 0 {
 			sectionExists = true
-		} else {
-			if sec = defmap["reflection"]; len(sec) > 0 {
-				sectionExists = true
-			}
 		}
-		if sectionExists {
-			s.reflection.yscale = 1.0
-			s.reflection.xshear = 0
-			s.reflection.color = 0xFFFFFF
-			sectionExists = false
-			var tmp int32
-			var tmp2 float32
-			var tmp3 [2]float32
-			if sec[0].ReadI32("intensity", &tmp) {
-				s.reflection.intensity = Clamp(tmp, 0, 255)
-			}
-			var r, g, b int32 = 0, 0, 0
-			sec[0].readI32ForStage("color", &r, &g, &b)
-			r, g, b = Clamp(r, 0, 255), Clamp(g, 0, 255), Clamp(b, 0, 255)
-			s.reflection.color = uint32(r<<16 | g<<8 | b)
-
-			if sec[0].ReadI32("layerno", &tmp) {
-				s.reflectionlayerno = Clamp(tmp, -1, 0)
-			}
-			if sec[0].ReadF32("yscale", &tmp2) {
-				s.reflection.yscale = tmp2
-			}
-			if sec[0].ReadF32("xshear", &tmp2) {
-				s.reflection.xshear = tmp2
-			}
-			if sec[0].readF32ForStage("offset", &tmp3[0], &tmp3[1]) {
-				s.reflection.offset[0] = tmp3[0]
-				s.reflection.offset[1] = tmp3[1]
-			}
+	}
+	if sectionExists {
+		sectionExists = false
+		s.reflection.yscale = 1.0
+		s.reflection.xshear = 0
+		s.reflection.color = 0xFFFFFF
+		var tmp int32
+		var tmp2 float32
+		var tmp3 [2]float32
+		//sec[0].ReadBool("reflect", &reflect) // This parameter is documented in Mugen but doesn't do anything
+		if sec[0].ReadI32("intensity", &tmp) {
+			s.reflection.intensity = Clamp(tmp, 0, 255)
+		}
+		var r, g, b int32 = 0, 0, 0
+		sec[0].readI32ForStage("color", &r, &g, &b)
+		r, g, b = Clamp(r, 0, 255), Clamp(g, 0, 255), Clamp(b, 0, 255)
+		s.reflection.color = uint32(r<<16 | g<<8 | b)
+		if sec[0].ReadI32("layerno", &tmp) {
+			s.reflectionlayerno = Clamp(tmp, -1, 0)
+		}
+		if sec[0].ReadF32("yscale", &tmp2) {
+			s.reflection.yscale = tmp2
+		}
+		if sec[0].ReadF32("xshear", &tmp2) {
+			s.reflection.xshear = tmp2
+		}
+		if sec[0].readF32ForStage("offset", &tmp3[0], &tmp3[1]) {
+			s.reflection.offset[0] = tmp3[0]
+			s.reflection.offset[1] = tmp3[1]
 		}
 	}
 	var bglink *backGround

--- a/src/system.go
+++ b/src/system.go
@@ -1733,7 +1733,7 @@ func (s *System) action() {
 	if s.superanim != nil {
 		s.spritesLayer1.add(&SprData{s.superanim, &s.superpmap, s.superpos,
 			[...]float32{s.superfacing, 1}, [2]int32{-1}, 5, Rotation{}, [2]float32{},
-			false, true, s.cgi[s.superplayer].mugenver[0] != 1, 1, 1, 0, 0, [4]float32{0, 0, 0, 0}}, 0, 0, [2]float32{0, 0}, [2]float32{0, 0}, 0, 0)
+			false, true, s.cgi[s.superplayer].mugenver[0] != 1, 1, 1, 0, 0, [4]float32{0, 0, 0, 0}})
 		if s.superanim.loopend {
 			s.superanim = nil
 		}


### PR DESCRIPTION
Feat:
- Helper OwnClsnScale. Using this parameter when creating a helper will make its Clsn box scale use its own scale instead of the root's. Implements #1984 
- InCustomAnim trigger. Returns 1 if the player is using someone else's animations (mostly after ChangeAnim2)
- AnimPlayerNo trigger. Returns player number of animation owner
- IkemenVersion trigger. Returns the char's Ikemen version as a float

Refactor:
- Untangled "shadow add" logic from "sprite add" logic
- Front/back and top/bottom size dimensions will now automatically flip when for instance front is behind back. Much like Clsn boxes. Partial fix for #2008. At this point not sure if a complete "fix" is desirable
- Improved syntax of AnimFrame lua version
- Moved width check outside of Clsn check. This allows manipulating its variables more freely. Fixes Reversaldef not accounting for width
- Player pushing can now also happen in the Z axis

Fixes:
- Fixed bug where specifying "reflect = 0" under stage shadow group would disable reflections
- Fixed the announcer still calling the fight in Training mode when the intros are skipped immediately