### PR TITLE
feat: weight and push factor constants, more Z axis work, fixes

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -2276,7 +2276,7 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_gethitvar_fall_envshake_ampl:
 		sys.bcStack.PushI(int32(float32(c.ghv.fall.envshake_ampl) * (c.localscl / oc.localscl)))
 	case OC_ex_gethitvar_fall_envshake_phase:
-		sys.bcStack.PushF(c.ghv.fall.envshake_phase * (c.localscl / oc.localscl))
+		sys.bcStack.PushF(c.ghv.fall.envshake_phase)
 	case OC_ex_gethitvar_fall_envshake_mul:
 		sys.bcStack.PushF(c.ghv.fall.envshake_mul)
 	case OC_ex_gethitvar_attr:
@@ -7979,7 +7979,7 @@ func (sc envShake) Run(c *Char, _ []int32) bool {
 		case envShake_ampl:
 			sys.envShake.ampl = float32(int32(float32(exp[0].evalI(c)) * c.localscl))
 		case envShake_phase:
-			sys.envShake.phase = MaxF(0, exp[0].evalF(c)*float32(math.Pi)/180) * c.localscl
+			sys.envShake.phase = MaxF(0, exp[0].evalF(c)*float32(math.Pi)/180)
 		case envShake_freq:
 			sys.envShake.freq = MaxF(0, exp[0].evalF(c)*float32(math.Pi)/180)
 		case envShake_mul:
@@ -8700,8 +8700,9 @@ func (sc fallEnvShake) Run(c *Char, _ []int32) bool {
 			if crun.ghv.fall.envshake_time > 0 {
 				sys.envShake = EnvShake{time: crun.ghv.fall.envshake_time,
 					freq:  crun.ghv.fall.envshake_freq * math.Pi / 180,
-					ampl:  float32(crun.ghv.fall.envshake_ampl),
-					phase: crun.ghv.fall.envshake_phase, mul: crun.ghv.fall.envshake_mul}
+					ampl:  float32(crun.ghv.fall.envshake_ampl) * c.localscl,
+					phase: crun.ghv.fall.envshake_phase, 
+					mul: crun.ghv.fall.envshake_mul}
 				sys.envShake.setDefPhase()
 				crun.ghv.fall.envshake_time = 0
 			}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6080,20 +6080,20 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 		hd.envshake_time = exp[0].evalI(c)
 	case hitDef_envshake_ampl:
 		hd.envshake_ampl = exp[0].evalI(c)
-	case hitDef_envshake_phase:
-		hd.envshake_phase = exp[0].evalF(c)
 	case hitDef_envshake_freq:
 		hd.envshake_freq = MaxF(0, exp[0].evalF(c))
+	case hitDef_envshake_phase:
+		hd.envshake_phase = exp[0].evalF(c)
 	case hitDef_envshake_mul:
 		hd.envshake_mul = exp[0].evalF(c)
 	case hitDef_fall_envshake_time:
 		hd.fall.envshake_time = exp[0].evalI(c)
 	case hitDef_fall_envshake_ampl:
 		hd.fall.envshake_ampl = exp[0].evalI(c)
-	case hitDef_fall_envshake_phase:
-		hd.fall.envshake_phase = exp[0].evalF(c)
 	case hitDef_fall_envshake_freq:
 		hd.fall.envshake_freq = MaxF(0, exp[0].evalF(c))
+	case hitDef_fall_envshake_phase:
+		hd.fall.envshake_phase = exp[0].evalF(c)
 	case hitDef_fall_envshake_mul:
 		hd.fall.envshake_mul = exp[0].evalF(c)
 	case hitDef_dizzypoints:
@@ -7089,13 +7089,13 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				eachProj(func(p *Projectile) {
 					p.hitdef.envshake_ampl = exp[0].evalI(c)
 				})
-			case hitDef_envshake_phase:
-				eachProj(func(p *Projectile) {
-					p.hitdef.envshake_phase = exp[0].evalF(c)
-				})
 			case hitDef_envshake_freq:
 				eachProj(func(p *Projectile) {
 					p.hitdef.envshake_freq = MaxF(0, exp[0].evalF(c))
+				})
+			case hitDef_envshake_phase:
+				eachProj(func(p *Projectile) {
+					p.hitdef.envshake_phase = exp[0].evalF(c)
 				})
 			case hitDef_envshake_mul:
 				eachProj(func(p *Projectile) {
@@ -7109,13 +7109,13 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				eachProj(func(p *Projectile) {
 					p.hitdef.fall.envshake_ampl = exp[0].evalI(c)
 				})
-			case hitDef_fall_envshake_phase:
-				eachProj(func(p *Projectile) {
-					p.hitdef.fall.envshake_phase = exp[0].evalF(c)
-				})
 			case hitDef_fall_envshake_freq:
 				eachProj(func(p *Projectile) {
 					p.hitdef.fall.envshake_freq = MaxF(0, exp[0].evalF(c))
+				})
+			case hitDef_fall_envshake_phase:
+				eachProj(func(p *Projectile) {
+					p.hitdef.fall.envshake_phase = exp[0].evalF(c)
 				})
 			case hitDef_fall_envshake_mul:
 				eachProj(func(p *Projectile) {
@@ -7965,9 +7965,9 @@ type envShake StateControllerBase
 const (
 	envShake_time byte = iota
 	envShake_ampl
-	envShake_phase
 	envShake_freq
 	envShake_mul
+	envShake_phase
 )
 
 func (sc envShake) Run(c *Char, _ []int32) bool {
@@ -7978,16 +7978,16 @@ func (sc envShake) Run(c *Char, _ []int32) bool {
 			sys.envShake.time = exp[0].evalI(c)
 		case envShake_ampl:
 			sys.envShake.ampl = float32(int32(float32(exp[0].evalI(c)) * c.localscl))
-		case envShake_phase:
-			sys.envShake.phase = MaxF(0, exp[0].evalF(c)*float32(math.Pi)/180)
 		case envShake_freq:
 			sys.envShake.freq = MaxF(0, exp[0].evalF(c)*float32(math.Pi)/180)
+		case envShake_phase:
+			sys.envShake.phase = MaxF(0, exp[0].evalF(c)*float32(math.Pi)/180)
 		case envShake_mul:
 			sys.envShake.mul = exp[0].evalF(c)
 		}
 		return true
 	})
-	sys.envShake.setDefPhase()
+	sys.envShake.setDefaultPhase()
 	return false
 }
 
@@ -8703,7 +8703,7 @@ func (sc fallEnvShake) Run(c *Char, _ []int32) bool {
 					ampl:  float32(crun.ghv.fall.envshake_ampl) * c.localscl,
 					phase: crun.ghv.fall.envshake_phase, 
 					mul: crun.ghv.fall.envshake_mul}
-				sys.envShake.setDefPhase()
+				sys.envShake.setDefaultPhase()
 				crun.ghv.fall.envshake_time = 0
 			}
 		case fallEnvShake_redirectid:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -4202,6 +4202,9 @@ const (
 	helper_size_head_pos
 	helper_size_mid_pos
 	helper_size_shadowoffset
+	helper_size_z_width
+	helper_size_weight
+	helper_size_pushfactor
 	helper_stateno
 	helper_keyctrl
 	helper_id
@@ -4299,6 +4302,12 @@ func (sc helper) Run(c *Char, _ []int32) bool {
 			}
 		case helper_size_shadowoffset:
 			h.size.shadowoffset = exp[0].evalF(c)
+		case helper_size_z_width:
+			h.size.z.width = exp[0].evalF(c)
+		case helper_size_weight:
+			h.size.weight = exp[0].evalI(c)
+		case helper_size_pushfactor:
+			h.size.pushfactor = exp[0].evalF(c)
 		case helper_stateno:
 			st = exp[0].evalI(c)
 		case helper_keyctrl:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6335,6 +6335,9 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 			p.velocity[0] = exp[0].evalF(c) * lclscround
 			if len(exp) > 1 {
 				p.velocity[1] = exp[1].evalF(c) * lclscround
+				if len(exp) > 2 {
+					p.velocity[2] = exp[2].evalF(c) * lclscround
+				}
 			}
 		case projectile_velmul:
 			p.velmul[0] = exp[0].evalF(c)
@@ -6348,6 +6351,9 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 			p.remvelocity[0] = exp[0].evalF(c) * lclscround
 			if len(exp) > 1 {
 				p.remvelocity[1] = exp[1].evalF(c) * lclscround
+				if len(exp) > 2 {
+					p.remvelocity[2] = exp[2].evalF(c) * lclscround
+				}
 			}
 		case projectile_accel:
 			p.accel[0] = exp[0].evalF(c) * lclscround
@@ -6619,6 +6625,9 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 					p.velocity[0] = exp[0].evalF(c) * lclscround
 					if len(exp) > 1 {
 						p.velocity[1] = exp[1].evalF(c) * lclscround
+						if len(exp) > 2 {
+							p.velocity[2] = exp[2].evalF(c) * lclscround
+						}
 					}
 				})
 			case projectile_velmul:
@@ -6626,6 +6635,9 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 					p.velmul[0] = exp[0].evalF(c)
 					if len(exp) > 1 {
 						p.velmul[1] = exp[1].evalF(c)
+						if len(exp) > 2 {
+							p.velmul[2] = exp[2].evalF(c)
+						}
 					}
 				})
 			case projectile_remvelocity:
@@ -6633,6 +6645,9 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 					p.remvelocity[0] = exp[0].evalF(c) * lclscround
 					if len(exp) > 1 {
 						p.remvelocity[1] = exp[1].evalF(c) * lclscround
+						if len(exp) > 2 {
+							p.remvelocity[2] = exp[2].evalF(c) * lclscround
+						}
 					}
 				})
 			case projectile_accel:
@@ -6640,6 +6655,9 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 					p.accel[0] = exp[0].evalF(c) * lclscround
 					if len(exp) > 1 {
 						p.accel[1] = exp[1].evalF(c) * lclscround
+						if len(exp) > 2 {
+							p.accel[2] = exp[2].evalF(c) * lclscround
+						}
 					}
 				})
 			case projectile_projscale:

--- a/src/char.go
+++ b/src/char.go
@@ -4988,7 +4988,6 @@ func (c *Char) setHitdefDefault(hd *HitDef, proj bool) {
 	ifnanset(&hd.down_velocity[1], hd.air_velocity[1])
 	ifnanset(&hd.fall.yvelocity, -4.5/c.localscl)
 	ifierrset(&hd.fall.envshake_ampl, -4)
-	ifnanset(&hd.fall.envshake_phase, 0)
 	ifnanset(&hd.xaccel, 0)
 	if hd.air_animtype == RA_Unknown {
 		hd.air_animtype = hd.animtype
@@ -8790,7 +8789,7 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 				sys.envShake.ampl = float32(int32(float32(hd.envshake_ampl) * c.localscl))
 				sys.envShake.phase = hd.envshake_phase
 				sys.envShake.mul = hd.envshake_mul
-				sys.envShake.setDefPhase()
+				sys.envShake.setDefaultPhase()
 			}
 			// Set corner push
 			// In Mugen it is only set if the enemy is already in the corner before the hit

--- a/src/char.go
+++ b/src/char.go
@@ -1457,8 +1457,9 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 	e.drawPos = [3]float32{(e.pos[0] + e.offset[0] + off[0] + e.interpolate_pos[0]) * zscale * e.localscl, zscale * (e.pos[1] + e.offset[1] + off[1] + e.interpolate_pos[1]) * e.localscl, zscale * (e.pos[2] + e.offset[2] + off[2] + e.interpolate_pos[2]) * e.localscl}
 	var ewin = [4]float32{e.window[0] * e.localscl * facing, e.window[1] * e.localscl * e.vfacing, e.window[2] * e.localscl * facing, e.window[3] * e.localscl * e.vfacing}
 	// Add sprite to draw list
-	sd := &SprData{e.anim, pfx, [2]float32{e.drawPos[0], e.drawPos[1] + e.drawPos[2]}, [...]float32{(facing * scale[0]) * e.localscl * zscale,
-		(e.vfacing * scale[1]) * e.localscl * zscale}, alp, e.sprpriority, rot, [...]float32{1, 1},
+	sd := &SprData{e.anim, pfx, [2]float32{e.drawPos[0], e.drawPos[1] + e.drawPos[2]},
+		[...]float32{(facing * scale[0]) * e.localscl * zscale,
+		(e.vfacing * scale[1]) * e.localscl * zscale}, alp, e.sprpriority + int32(e.drawPos[2]), rot, [...]float32{1, 1},
 		e.space == Space_screen, playerNo == sys.superplayer, oldVer, facing, 1, int32(e.projection), fLength, ewin}
 	sprs.add(sd)
 	// Add shadow if color is not 0
@@ -1982,7 +1983,7 @@ func (p *Projectile) cueDraw(oldVer bool, playerNo int) {
 		// Add sprite to draw list
 		sd := &SprData{p.ani, p.palfx, [...]float32{p.drawPos[0] * p.localscl, p.drawPos[1]*p.localscl + p.drawPos[2]*p.localscl},
 			[...]float32{p.facing * p.scale[0] * p.localscl * zscale, p.scale[1] * p.localscl * zscale}, [2]int32{-1},
-			p.sprpriority, Rotation{p.facing * p.angle, 0, 0}, [...]float32{1, 1}, false, playerNo == sys.superplayer,
+			p.sprpriority + int32(p.pos[2]), Rotation{p.facing * p.angle, 0, 0}, [...]float32{1, 1}, false, playerNo == sys.superplayer,
 			sys.cgi[playerNo].mugenver[0] != 1, p.facing, 1, 0, 0, [4]float32{0, 0, 0, 0}}
 		p.aimg.recAndCue(sd, sys.tickNextFrame() && notpause, false, p.layerno)
 		sprs.add(sd)
@@ -7849,7 +7850,7 @@ func (c *Char) cueDraw() {
 		//}
 
 		sd := &SprData{c.anim, c.getPalfx(), pos,
-			scl, c.alpha, c.sprPriority, Rotation{agl, 0, 0}, c.angleScale, false,
+			scl, c.alpha, c.sprPriority + int32(c.pos[2]), Rotation{agl, 0, 0}, c.angleScale, false,
 			c.playerNo == sys.superplayer, c.gi().mugenver[0] != 1, c.facing,
 			c.localcoord / sys.chars[c.animPN][0].localcoord, // https://github.com/ikemen-engine/Ikemen-GO/issues/1459 and 1778
 			0, 0, [4]float32{0, 0, 0, 0}}

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -598,6 +598,18 @@ func (c *Compiler) helper(is IniSection, sc *StateControllerBase, _ int8) (State
 			helper_size_shadowoffset, VT_Int, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "z.width",
+			helper_size_z_width, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "weight",
+			helper_size_weight, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "pushfactor",
+			helper_size_pushfactor, VT_Float, 1, false); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "stateno",
 			helper_stateno, VT_Int, 1, false); err != nil {
 			return err

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1812,12 +1812,12 @@ func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 		hitDef_envshake_ampl, VT_Int, 1, false); err != nil {
 		return err
 	}
-	if err := c.paramValue(is, sc, "envshake.phase",
-		hitDef_envshake_phase, VT_Float, 1, false); err != nil {
-		return err
-	}
 	if err := c.paramValue(is, sc, "envshake.freq",
 		hitDef_envshake_freq, VT_Float, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "envshake.phase",
+		hitDef_envshake_phase, VT_Float, 1, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "envshake.mul",
@@ -1832,12 +1832,12 @@ func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 		hitDef_fall_envshake_ampl, VT_Int, 1, false); err != nil {
 		return err
 	}
-	if err := c.paramValue(is, sc, "fall.envshake.phase",
-		hitDef_fall_envshake_phase, VT_Float, 1, false); err != nil {
-		return err
-	}
 	if err := c.paramValue(is, sc, "fall.envshake.freq",
 		hitDef_fall_envshake_freq, VT_Float, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "fall.envshake.phase",
+		hitDef_fall_envshake_phase, VT_Float, 1, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "fall.envshake.mul",

--- a/src/stage.go
+++ b/src/stage.go
@@ -35,46 +35,6 @@ func newStageProps() StageProps {
 	return sp
 }
 
-type EnvShake struct {
-	time  int32
-	freq  float32
-	ampl  float32
-	phase float32
-	mul   float32
-}
-
-func (es *EnvShake) clear() {
-	*es = EnvShake{freq: float32(math.Pi / 3), ampl: -4.0,
-		phase: float32(math.NaN()), mul: 1.0}
-}
-func (es *EnvShake) setDefPhase() {
-	if math.IsNaN(float64(es.phase)) {
-		if es.freq >= math.Pi/2 {
-			es.phase = math.Pi / 2
-		} else {
-			es.phase = 0
-		}
-	}
-}
-func (es *EnvShake) next() {
-	if es.time > 0 {
-		es.time--
-		es.phase += es.freq
-		if es.phase > math.Pi*2 {
-			es.ampl *= es.mul
-			es.phase -= math.Pi * 2
-		}
-	} else {
-		es.ampl = 0
-	}
-}
-func (es *EnvShake) getOffset() float32 {
-	if es.time > 0 {
-		return es.ampl * float32(math.Sin(float64(es.phase)))
-	}
-	return 0
-}
-
 type BgcType int32
 
 const (

--- a/src/system.go
+++ b/src/system.go
@@ -3535,3 +3535,46 @@ func (l *Loader) runTread() bool {
 	go l.load()
 	return true
 }
+
+type EnvShake struct {
+	time  int32
+	freq  float32
+	ampl  float32
+	phase float32
+	mul   float32
+}
+
+func (es *EnvShake) clear() {
+	*es = EnvShake{freq: float32(math.Pi / 3), ampl: -4.0,
+		phase: float32(math.NaN()), mul: 1.0}
+}
+
+func (es *EnvShake) setDefaultPhase() {
+	if math.IsNaN(float64(es.phase)) {
+		if es.freq >= math.Pi/2 {
+			es.phase = math.Pi / 2
+		} else {
+			es.phase = 0
+		}
+	}
+}
+
+func (es *EnvShake) next() {
+	if es.time > 0 {
+		es.time--
+		es.phase += es.freq
+		if es.phase > math.Pi*2 {
+			es.ampl *= es.mul
+			es.phase -= math.Pi * 2
+		}
+	} else {
+		es.ampl = 0
+	}
+}
+
+func (es *EnvShake) getOffset() float32 {
+	if es.time > 0 {
+		return es.ampl * float32(math.Sin(float64(es.phase)))
+	}
+	return 0
+}

--- a/src/system.go
+++ b/src/system.go
@@ -879,6 +879,19 @@ func (s *System) loadTime(start time.Time, str string, shell, console bool) {
 		s.appendToConsole(str)
 	}
 }
+
+// Z axis check
+// Changed to no longer check z enable constant, depends on stage now
+func (s *System) zAxisOverlap(posz1, front1, back1, localscl1, posz2, front2, back2, localscl2 float32) bool {
+	if sys.stage.topbound != sys.stage.botbound {
+		if (posz1 + front1) * localscl1 < (posz2 - back2) * localscl2 ||
+			(posz1 - back1) * localscl1 > (posz2 + front2) * localscl2 {
+			return false
+		}
+	}
+	return true
+}
+
 func (s *System) clsnOverlap(clsn1 []float32, scl1, pos1 [2]float32, facing1 float32, angle1 float32,
 	clsn2 []float32, scl2, pos2 [2]float32, facing2 float32, angle2 float32) bool {
 


### PR DESCRIPTION
Feat:
- Added projectile collision check in Z axis
- Two new [Size] constants: Weight and PushFactor
- Weight constant makes heavier characters push lighter characters more. Default 100
- Push factor controls how smoothly player overlap is resolved. A lower value makes players push away from each other more slowly. Default 1.0

Fix:
- Fixed issue where fall envshake would set the wrong frequency, making the shake invisible
- Reversaldefs can now assign fall envshake gethitvars. Fixes #2012

Refactor:
- Refactored Z axis collision check so it can check either chars or projectiles
- Applied a tentative formula for drawing order when Z axis is enabled. Objects will be layered according to "sprpriority + pos z"
- Projectiles act a bit more like Mugen when they trade hits with each other, pausing in place while they do it
- Moved EnvShake code to system.go since it doesn't belong to stages where it was
- Afterimages now decrease in drawing priority over time, as in Mugen