### PR TITLE
feat: Added support for Sony DualSense controllers, added loopcount to playBGM, Go 1.20 revert & fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,15 @@
 module github.com/ikemen-engine/Ikemen-GO
 
-go 1.21
+go 1.20
+
+replace github.com/gopxl/beep/v2 => github.com/gopxl/beep/v2 v2.1.1-0.20240921133731-defe79638e99
 
 require (
 	github.com/flopp/go-findfont v0.1.0
 	github.com/go-gl/gl v0.0.0-20231021071112-07e5d0ea2e71
 	github.com/go-gl/glfw/v3.3/glfw v0.0.0-20240506104042-037f3cc74f2a
 	github.com/go-gl/mathgl v1.0.0
-	github.com/gopxl/beep/v2 v2.0.2
+	github.com/gopxl/beep/v2 v2.1.1-0.20240921133731-defe79638e99
 	github.com/ikemen-engine/glfont v0.0.0-20240816074833-3b3b0c69a290
 	github.com/lukegb/dds v0.0.0-20190402175749-8b7170e64003
 	github.com/qmuntal/gltf v0.24.2

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,10 @@ github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF0
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/gopxl/beep/v2 v2.0.2 h1:cwyFs9p3qBGjTw9K//qjtyHPk3xgf5X9jMkHgvLPl40=
 github.com/gopxl/beep/v2 v2.0.2/go.mod h1:sQvj2oSsu8fmmDWH3t0DzIe0OZzTW6/TJEHW4Ku+22o=
+github.com/gopxl/beep/v2 v2.1.0 h1:Jv95iHw3aNWoAa/J78YyXvOvMHH2ZGeAYD5ug8tVt8c=
+github.com/gopxl/beep/v2 v2.1.0/go.mod h1:sQvj2oSsu8fmmDWH3t0DzIe0OZzTW6/TJEHW4Ku+22o=
+github.com/gopxl/beep/v2 v2.1.1-0.20240921133731-defe79638e99 h1:NWZSubpAEbmsAp6qwjHsQLmz9x2xAVY2THDx6Kd4r5o=
+github.com/gopxl/beep/v2 v2.1.1-0.20240921133731-defe79638e99/go.mod h1:VZr3fM8tYQdJW5BwiCddz3xbuVGdzmgfdt4hRz4P2mM=
 github.com/hajimehoshi/go-mp3 v0.3.4 h1:NUP7pBYH8OguP4diaTZ9wJbUbk3tC0KlfzsEpWmYj68=
 github.com/hajimehoshi/go-mp3 v0.3.4/go.mod h1:fRtZraRFcWb0pu7ok0LqyFhCUrPeMsGRSVop0eemFmo=
 github.com/hajimehoshi/oto/v2 v2.3.1/go.mod h1:seWLbgHH7AyUMYKfKYT9pg7PhUu9/SisyJvNTT+ASQo=

--- a/src/anim.go
+++ b/src/anim.go
@@ -1096,9 +1096,9 @@ func (sl ShadowList) drawReflection(x, y, scl float32) {
 		if sys.stage.reflection.yscale < 0 {
 			sign = -1
 		}
-		offsetX := (s.reflectOffset[0] + sys.stage.reflection.offset[0]) * sys.cam.Scale
-		offsetY := (s.reflectOffset[1] + sys.stage.reflection.offset[1]) * sys.cam.Scale
-		xrotoff := sign * xshear * (float32(s.anim.spr.Size[1]) * s.scl[1]) * sys.cam.Scale
+		offsetX := (s.reflectOffset[0] + sys.stage.reflection.offset[0])
+		offsetY := (s.reflectOffset[1] + sys.stage.reflection.offset[1])
+		xrotoff := sign * xshear * (float32(s.anim.spr.Size[1]) * s.scl[1])
 		if s.rot.angle != 0 {
 			xshear = -xshear
 			offsetX -= xrotoff

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -2838,6 +2838,7 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	opc := be[*i-1]
 	correctScale := false
 	camOff := float32(0)
+	camCorrected := false
 	switch opc {
 	case OC_ex2_index:
 		sys.bcStack.PushI(c.index)
@@ -3027,14 +3028,6 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		}
 		sys.bcStack.PushF(v * (c.localscl / oc.localscl))
 	// BEGIN FALLTHROUGH (explodvar)
-	case OC_ex2_explodvar_pos_x:
-		correctScale = true
-		camOff = -sys.cam.Pos[0] / oc.localscl
-		fallthrough
-	case OC_ex2_explodvar_pos_y:
-		correctScale = true
-		camOff = -sys.cam.Pos[1] / oc.localscl
-		fallthrough
 	case OC_ex2_explodvar_vel_x:
 		correctScale = true
 		fallthrough
@@ -3069,8 +3062,23 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		fallthrough
 	case OC_ex2_explodvar_angle_x:
 		fallthrough
-	// END FALLTHROUGH (explodvar)
 	case OC_ex2_explodvar_angle_y:
+		camCorrected = true // gotta do this
+		fallthrough
+		// END FALLTHROUGH (explodvar)
+	case OC_ex2_explodvar_pos_x:
+		correctScale = true
+		if !camCorrected {
+			camOff = -sys.cam.Pos[0] / oc.localscl
+			camCorrected = true
+		}
+		fallthrough
+	case OC_ex2_explodvar_pos_y:
+		correctScale = true
+		if !camCorrected {
+			camOff = -sys.cam.Pos[1] / oc.localscl
+			camCorrected = true
+		}
 		idx := sys.bcStack.Pop()
 		id := sys.bcStack.Pop()
 		v := c.explodVar(id, idx, opc)
@@ -3084,13 +3092,6 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		correctScale = true
 		fallthrough
 	case OC_ex2_projectilevar_accel_y:
-		correctScale = true
-		fallthrough
-	case OC_ex2_projectilevar_pos_x:
-		correctScale = true
-		camOff = -sys.cam.Pos[0] / oc.localscl
-		fallthrough
-	case OC_ex2_projectilevar_pos_y:
 		correctScale = true
 		fallthrough
 	case OC_ex2_projectilevar_vel_x:
@@ -3163,8 +3164,23 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		fallthrough
 	case OC_ex2_projectilevar_teamside:
 		fallthrough
-	// END FALLTHROUGH (projvar)
 	case OC_ex2_projectilevar_pausemovetime:
+		camCorrected = true // gotta do this
+		fallthrough
+		// END FALLTHROUGH (projvar)
+	case OC_ex2_projectilevar_pos_x:
+		correctScale = true
+		if !camCorrected {
+			camOff = -sys.cam.Pos[0] / oc.localscl
+			camCorrected = true
+		}
+		fallthrough
+	case OC_ex2_projectilevar_pos_y:
+		correctScale = true
+		if !camCorrected {
+			camOff = -sys.cam.Pos[1] / oc.localscl
+			camCorrected = true
+		}
 		idx := sys.bcStack.Pop()
 		id := sys.bcStack.Pop()
 		v := c.projVar(id, idx, opc)

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3029,9 +3029,11 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	// BEGIN FALLTHROUGH (explodvar)
 	case OC_ex2_explodvar_pos_x:
 		correctScale = true
+		camOff = -sys.cam.Pos[0] / oc.localscl
 		fallthrough
 	case OC_ex2_explodvar_pos_y:
 		correctScale = true
+		camOff = -sys.cam.Pos[1] / oc.localscl
 		fallthrough
 	case OC_ex2_explodvar_vel_x:
 		correctScale = true
@@ -3073,7 +3075,7 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		id := sys.bcStack.Pop()
 		v := c.explodVar(id, idx, opc)
 		if correctScale {
-			sys.bcStack.PushF(v.ToF() * (c.localscl / oc.localscl))
+			sys.bcStack.PushF(v.ToF()*(c.localscl/oc.localscl) + camOff)
 		} else {
 			sys.bcStack.Push(v)
 		}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -2913,13 +2913,21 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		if sys.bgm.volctrl != nil {
 			if sl, ok := sys.bgm.volctrl.Streamer.(*StreamLooper); ok {
 				sys.bcStack.PushI(int32(sl.loopstart))
+			} else {
+				sys.bcStack.PushI(0)
 			}
+		} else {
+			sys.bcStack.PushI(0)
 		}
 	case OC_ex2_bgmvar_loopend:
 		if sys.bgm.volctrl != nil {
 			if sl, ok := sys.bgm.volctrl.Streamer.(*StreamLooper); ok {
 				sys.bcStack.PushI(int32(sl.loopend))
+			} else {
+				sys.bcStack.PushI(0)
 			}
+		} else {
+			sys.bcStack.PushI(0)
 		}
 	case OC_ex2_bgmvar_startposition:
 		sys.bcStack.PushI(int32(sys.bgm.startPos))
@@ -10593,6 +10601,7 @@ const (
 	playBgm_loopend
 	playBgm_startposition
 	playBgm_freqmul
+	playBgm_loopcount
 	playBgm_redirectid
 )
 
@@ -10600,7 +10609,7 @@ func (sc playBgm) Run(c *Char, _ []int32) bool {
 	crun := c
 	var b bool
 	var bgm string
-	var loop, volume, loopstart, loopend, startposition int = 1, 100, 0, 0, 0
+	var loop, loopcount, volume, loopstart, loopend, startposition int = 1, -1, 100, 0, 0, 0
 	var freqmul float32 = 1.0
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
@@ -10630,6 +10639,8 @@ func (sc playBgm) Run(c *Char, _ []int32) bool {
 			startposition = int(exp[0].evalI(c))
 		case playBgm_freqmul:
 			freqmul = exp[0].evalF(c)
+		case playBgm_loopcount:
+			loopcount = int(exp[0].evalI(c))
 		case playBgm_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -10640,7 +10651,7 @@ func (sc playBgm) Run(c *Char, _ []int32) bool {
 		return true
 	})
 	if b {
-		sys.bgm.Open(bgm, loop, volume, loopstart, loopend, startposition, freqmul)
+		sys.bgm.Open(bgm, loop, volume, loopstart, loopend, startposition, freqmul, loopcount)
 		sys.playBgmFlg = true
 	}
 	return false

--- a/src/char.go
+++ b/src/char.go
@@ -5137,9 +5137,11 @@ func (c *Char) updateZScale(z float32) float32 {
 	topz, botz, scale := sys.stage.stageCamera.topz, sys.stage.stageCamera.botz, float32(1)
 	if topz != botz {
 		ztopscale, zbotscale := sys.stage.stageCamera.ztopscale, sys.stage.stageCamera.zbotscale
-		clampedZ := ClampF(z, topz, botz)
-		d := (clampedZ - topz) / (botz - topz)
+		d := (z - topz) / (botz - topz)
 		scale = ztopscale + d*(zbotscale-ztopscale)
+		if scale <= 0 {
+			scale = 0
+		}
 	}
 	return scale
 }

--- a/src/common.go
+++ b/src/common.go
@@ -83,6 +83,24 @@ func MaxF(arg ...float32) (max float32) {
 	return
 }
 
+func MinI(arg ...int) (min int) {
+	for i, x := range arg {
+		if i == 0 || x < min {
+			min = x
+		}
+	}
+	return
+}
+
+func MaxI(arg ...int) (max int) {
+	for i, x := range arg {
+		if i == 0 || x > max {
+			max = x
+		}
+	}
+	return
+}
+
 func Clamp(x, a, b int32) int32 {
 	return Max(a, Min(x, b))
 }

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2532,7 +2532,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			default:
 				return bvNone(), Error(fmt.Sprint("Invalid argument: %s", c.token))
 			}
-		case "misstime":
+		case "projmisstime":
 			opc = OC_ex2_projectilevar_projmisstime
 		case "projhits":
 			opc = OC_ex2_projectilevar_projhits

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -4452,6 +4452,10 @@ func (c *Compiler) playBgm(is IniSection, sc *StateControllerBase, _ int8) (Stat
 			playBgm_startposition, VT_Int, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "loopcount",
+			playBgm_loopcount, VT_Int, 1, false); err != nil {
+			return err
+		}
 		return nil
 	})
 	return *ret, err

--- a/src/input_glfw.go
+++ b/src/input_glfw.go
@@ -276,6 +276,7 @@ func CheckAxisForTrigger(joy int, axes *[]float32) string {
 			name := input.GetJoystickName(joy)
 			os := runtime.GOOS
 			joyName := name + "." + os + "." + runtime.GOARCH + ".glfw"
+
 			if strings.Contains(name, "XInput") || strings.Contains(name, "X360") ||
 				strings.Contains(name, "Xbox Wireless") || strings.Contains(name, "Xbox Elite") || strings.Contains(name, "Xbox One") ||
 				strings.Contains(name, "Xbox Series") || strings.Contains(name, "Xbox Adaptive") {
@@ -297,6 +298,8 @@ func CheckAxisForTrigger(joy int, axes *[]float32) string {
 			} else if (i == 2 || i == 5) && joyName == "Logitech Dual Action.linux.amd64.sdl" {
 				// do nothing
 			} else if (i == 3 || i == 4) && name == "PS4 Controller" {
+				// do nothing
+			} else if (i == 3 || i == 4) && (name == "Sony DualSense" || name == "PS5 Controller") {
 				// do nothing
 			} else {
 				s = strconv.Itoa(-i*2 - 1)

--- a/src/main.go
+++ b/src/main.go
@@ -381,7 +381,7 @@ func setupConfig() configSettings {
 	sys.externalShaderList = tmp.ExternalShaders
 	// Bump up shader version for macOS only
 	if runtime.GOOS == "darwin" {
-		tmp.FontShaderVer = max(150, tmp.FontShaderVer)
+		tmp.FontShaderVer = uint(MaxI(150, int(tmp.FontShaderVer)))
 	}
 	sys.fontShaderVer = tmp.FontShaderVer
 	// Resoluion stuff

--- a/src/script.go
+++ b/src/script.go
@@ -1150,7 +1150,7 @@ func systemScriptInit(l *lua.LState) {
 				l.Push(lua.LNumber(winp))
 				l.Push(tbl)
 				if sys.playBgmFlg {
-					sys.bgm.Open("", 1, 100, 0, 0, 0, 1.0)
+					sys.bgm.Open("", 1, 100, 0, 0, 0, 1.0, 1)
 					sys.playBgmFlg = false
 				}
 				sys.clearAllSound()
@@ -1633,7 +1633,7 @@ func systemScriptInit(l *lua.LState) {
 		return 0
 	})
 	luaRegister(l, "playBGM", func(l *lua.LState) int {
-		var loop, volume, loopstart, loopend, startposition int = 1, 100, 0, 0, 0
+		var loop, loopcount, volume, loopstart, loopend, startposition int = 1, -1, 100, 0, 0, 0
 		var freqmul float32 = 1.0
 		if l.GetTop() >= 2 {
 			loop = int(numArg(l, 2))
@@ -1653,7 +1653,10 @@ func systemScriptInit(l *lua.LState) {
 		if l.GetTop() >= 7 {
 			freqmul = ClampF(float32(numArg(l, 7)), 0.01, 5.0)
 		}
-		sys.bgm.Open(strArg(l, 1), loop, volume, loopstart, loopend, startposition, freqmul)
+		if l.GetTop() >= 8 {
+			loopcount = int(numArg(l, 8))
+		}
+		sys.bgm.Open(strArg(l, 1), loop, volume, loopstart, loopend, startposition, freqmul, loopcount)
 		return 0
 	})
 	luaRegister(l, "playerBufReset", func(*lua.LState) int {

--- a/src/script.go
+++ b/src/script.go
@@ -4036,7 +4036,7 @@ func triggerFunctions(l *lua.LState) {
 					lv = lua.LNumber(p.shadow[0])
 				case "shadow b":
 					lv = lua.LNumber(p.shadow[0])
-				case "misstime":
+				case "projmisstime":
 					lv = lua.LNumber(p.curmisstime)
 				case "projhits":
 					lv = lua.LNumber(p.hits)

--- a/src/sound.go
+++ b/src/sound.go
@@ -236,7 +236,11 @@ func (bgm *Bgm) Open(filename string, loop, bgmVolume, bgmLoopStart, bgmLoopEnd,
 	}
 	lc := 0
 	if loop != 0 {
-		lc = MaxI(0, loopcount-1)
+		if loopcount >= 0 {
+			lc = MaxI(0, loopcount-1)
+		} else {
+			lc = -1
+		}
 	}
 	bgm.startPos = startPosition
 	// we're going to continue to use our own modified streamLooper because beep doesn't allow

--- a/src/system.go
+++ b/src/system.go
@@ -2305,7 +2305,7 @@ func (s *System) fight() (reload bool) {
 
 	// default bgm playback, used only in Quick VS or if externalized Lua implementaion is disabled
 	if s.round == 1 && (s.gameMode == "" || len(sys.commonLua) == 0) {
-		s.bgm.Open(s.stage.bgmusic, 1, int(s.stage.bgmvolume), int(s.stage.bgmloopstart), int(s.stage.bgmloopend), int(s.stage.bgmstartposition), s.stage.bgmfreqmul)
+		s.bgm.Open(s.stage.bgmusic, 1, int(s.stage.bgmvolume), int(s.stage.bgmloopstart), int(s.stage.bgmloopend), int(s.stage.bgmstartposition), s.stage.bgmfreqmul, -1)
 	}
 
 	oldWins, oldDraws := s.wins, s.draws


### PR DESCRIPTION
Features:
* Added support for Sony DualSense (PS5) controllers
* Added loopcount to playBGM so it matches playSND in feature set.

Fixes:
* BGMVar crashing with certain arguments when the volctrl is nil
* Reverted BGMVolume to old formula
* Z Scale fixes for bounds
* Updated Beepv2 to the latest version which uses the new ikemen-support branch (fixes #1956)
* Went back to Go 1.20 because of ikemen-support branch for Beepv2 (Win7 support should be back now) (addresses #1951)
* Reflections offsetting wrong on zoomout on Z-axis
* correct projvar misstime > projmisstime
* explodVar Pos not accounting for camera offset