### PR TITLE
feat: ClsnOverlap trigger, PlayerPush priority, refactoring, fixes

### DIFF
--- a/data/common.const
+++ b/data/common.const
@@ -197,9 +197,9 @@ StateInitialize = 5900
 
 ; dizzy.zss states
 StateDizzy = 6565300
-StateDizzyFallDown_standCrouch = 6565301
-StateDizzyFallDown_air = 6565302
-StateDizzyLyingDown = 6565303
+StateDizzyFallDown_standCrouch = 6565301 ; Deprecated
+StateDizzyFallDown_air = 6565302         ; Deprecated
+StateDizzyLyingDown = 6565303            ; Deprecated
 StateDizzyBirdsHelper = 6565310
 
 ; guardbreak.zss states
@@ -240,7 +240,7 @@ FxGuardBreakShockwave = 5410
 FxTagSwitchAI = 5600
 FxTagSwitchP1 = 5601
 FxTagSwitchP2 = 5602
-FxBackgroundColor = 9000
+FxBackgroundColor = 9000 ; Deprecated
 
 ; fight.def
 MsgFirstAttack = 401
@@ -258,15 +258,15 @@ MsgCombo25 = 412
 MsgWinSpecial = 413
 MsgWinHyper = 414
 MsgWinPerfect = 415
-MsgPartnerAssist = 416 ;not used
+MsgPartnerAssist = 416   ; Not used by default tag system
 MsgPartnerChange = 417
 MsgPartnerDown = 418
-MsgPartnerAssistOK = 419 ;not used
-MsgActiveSwitch = 420
-MsgCounterSwitch = 421
+MsgPartnerAssistOK = 419 ; Not used by default tag system
+MsgActiveSwitch = 420    ; Not used by default tag system
+MsgCounterSwitch = 421   ; Not used by default tag system
 MsgGuardBreak = 422
 MsgParry = 423
-MsgJustDefend = 424 ;not used
+MsgJustDefend = 424
 
 ; GetHitVar(attr)
 AttrStandingNormalAttack = 65

--- a/data/dizzy.zss
+++ b/data/dizzy.zss
@@ -1,67 +1,7 @@
-# Dizzy code adopted from Shiyo Kakuge's add004
+# Dizzy code adapted from Shiyo Kakuge's add004
 #===============================================================================
 # Functions
 #===============================================================================
-# Dizzy Bird Helper
-[Function IkSys_DizzyBirdHelper()]
-if !numHelper(const(StateDizzyBirdsHelper)) {
-	# Background
-	explod{
-		# Do note that dizzy bird anims and sounds are called from gofx.def, not fightfx.air/common.snd
-		anim: GO const(FxBackgroundColor);
-		space: screen;
-		postype: left;
-		pos: const240p(-3 * 320), screenHeight / 2; # color 3 (red)
-		scale: 320, 7.5 * screenHeight / const240p(240);
-		bindtime: -1;
-		supermovetime: -1;
-		pausemovetime: -1;
-		ownpal: 1;
-		under: 1;
-		ignorehitpause: 1;
-	}
-	helper{
-		id: const(StateDizzyBirdsHelper);
-		stateno: const(StateDizzyBirdsHelper);
-		name: "Dizzy Birds";
-		ownpal: 1;
-	}
-}
-
-# Dizzy Bird Explod Creation [from Helper]
-[Function IkSys_DizzyBirdExplodCreation(arg)]
-if !numExplod($arg) {
-	explod{
-		id: $arg;
-		anim: GO const(FxDizzyEffect) + map(birdType);
-		postype: p1;
-		ownpal: 1;
-		vel: 0, 0;
-		facing: -1;
-		removetime: 600;
-	}
-}
-
-# Dizzy Bird Explod Update [from Helper]
-[Function IkSys_DizzyBirdExplodUpdate(arg)]
-if numExplod($arg) {
-	let circleTime = ((gameTime % 90) + 22.5 * $arg) / 45.0 * pi;
-	let circleHeight = cos($circleTime) * map(birdRadius) * 0.25;
-	let birdScale = (cos($circleTime) + 3) * 0.12 * ifElse(($circleHeight < 0), -1, 1);
-	let fadeTime = ifElse(map(birdState) <= 0, 0, ifElse(map(birdState) >= 32, 32, map(birdState))); # Effects are faded out by code rather than animation
-	modifyExplod{
-		id: $arg;
-		anim: GO const(FxDizzyEffect) + map(birdType);
-		postype: p1;
-		pos: sin($circleTime) * map(birdRadius), $circleHeight + fVar(11) + $fadeTime * const240p(-1);
-		angle: 15 * sin($circleTime * 3);
-		sprpriority: ifElse($circleHeight > 0, 10, -10);
-		scale: ifElse(map(birdType) = 5, abs($birdScale), $birdScale), abs($birdScale); # Musical notes don't flip
-		trans: addAlpha;
-		alpha: 256 - $fadeTime * 8, $fadeTime * 8;
-	}
-}
-
 # Dizzy Hit Ground Explod (direct copy from common1)
 [Function IkSys_DizzyHitGroundExplod(vely)]
 explod{
@@ -119,10 +59,17 @@ if map(birdState) <= 0 {
 	fVar(11) := fVar(11) + (fVar(12) - fVar(11)) * 0.10;
 
 	# Create dizzy bird explods
-	call IkSys_DizzyBirdExplodCreation(0);
-	call IkSys_DizzyBirdExplodCreation(1);
-	call IkSys_DizzyBirdExplodCreation(2);
-	call IkSys_DizzyBirdExplodCreation(3);
+	# Do note that dizzy bird anims and sounds are called from gofx.def, not fightfx.air/common.snd
+	if numExplod < 4 {
+		explod{
+			anim: GO const(FxDizzyEffect) + map(birdType);
+			postype: p1;
+			ownpal: 1;
+			vel: 0, 0;
+			facing: -1;
+			removetime: 600;
+		}
+	}
 
 	# Play sound again as soon as it stops
 	# Volume goes down as character recovers from dizzy
@@ -131,186 +78,60 @@ if map(birdState) <= 0 {
 		value: GO 5300, 0;
 		channel: 2;
 		lowpriority: 1;
-		volumescale: ifElse(parent,stateNo = const(StateDizzy), 100 * (180 - min(120, parent,time)) / 180.0, 100)
 	}
-
 }
 
 # Update dizzy bird explods
-# Replaces creating new explods every frame
-call IkSys_DizzyBirdExplodUpdate(0);
-call IkSys_DizzyBirdExplodUpdate(1);
-call IkSys_DizzyBirdExplodUpdate(2);
-call IkSys_DizzyBirdExplodUpdate(3);
+for i = 0; numExplod; 1 {
+	let circleTime = ((gameTime % 90) + 22.5 * $i) / 45.0 * pi;
+	let circleHeight = cos($circleTime) * map(birdRadius) * 0.25;
+	let birdScale = (cos($circleTime) + 3) * 0.12 * ifElse(($circleHeight < 0), -1, 1);
+	let fadeTime = ifElse(map(birdState) <= 0, 0, ifElse(map(birdState) >= 32, 32, map(birdState))); # Effects are faded out by code rather than animation
+	modifyExplod{
+		id: -1;
+		index: $i;
+		anim: GO const(FxDizzyEffect) + map(birdType);
+		postype: p1;
+		pos: sin($circleTime) * map(birdRadius), $circleHeight + fVar(11) + $fadeTime * const240p(-1);
+		angle: 15 * sin($circleTime * 3);
+		sprpriority: ifElse($circleHeight > 0, 10, -10);
+		scale: ifElse(map(birdType) = 5, abs($birdScale) * facing, $birdScale), abs($birdScale); # Musical notes don't flip
+		trans: addAlpha;
+		alpha: 256 - $fadeTime * 8, $fadeTime * 8;
+	}
+}
+
+# Fade out bird sound
+if parent, stateNo = const(StateDizzy) {
+	modifySnd{
+		channel: 2;
+		volumescale: 100.0 * (240.0 - min(120, parent, time)) / 240.0; # Fade to 50%
+	}
+}
 
 #===============================================================================
 # StateDizzyFallDown_standCrouch
+# StateDizzyFallDown_air
+# StateDizzyLyingDown
 #===============================================================================
+
+# These states are deprecated in Ikemen 1.0. They are currently only kept to prevent older characters from entering invalid states
+
 [StateDef const(StateDizzyFallDown_standCrouch); type: U; movetype: H; physics: N; velset: 0, 0; ctrl: 0;]
 
-notHitBy{value: SCA}
-
-if time = 0 {
-	dizzySet{value: 1}
-	if stateType = S {
-		if anim > const(AnimStandOrAirHitLow_light) {
-			changeAnim{value: const(AnimStandOrAirHitHigh_hard)}
-		} else {
-			changeAnim{value: const(AnimStandOrAirHitLow_hard)}
-		}
-	} else {
-		changeAnim{value: const(AnimCrouchHit_hard)}
-	}
-}
-
-if anim = [const(AnimStandOrAirHitHigh_hard), const(AnimStandOrAirHitLow_hard)] && (animTime = 0 || time > 16) {
-	changeAnim{value: const(AnimCrouchHit_hard)}
-	stateTypeSet{statetype: C}
-}
-if (anim = const(AnimCrouchHit_hard) && animTime = 0) || time > 26 {
-	call IkSys_DizzyHitGroundExplod(0);
-	selfState{value: const(StateDizzyLyingDown)}
-}
-
-# Failsafe
-if !dizzy || time > 300 {
+if time > 0 { # Avoid ChangeState loops
 	selfState{value: const(StateStandGetHit_knockedBack)}
 }
 
-#===============================================================================
-# StateDizzyFallDown_air
-#===============================================================================
 [StateDef const(StateDizzyFallDown_air); type: A; movetype: H; physics: N; anim: const(AnimAirFall); ctrl: 0;]
 
-notHitBy{value: SCA}
-
-# Acceleration
-velAdd{y: ifElse(stateType = A, getHitVar(yAccel), const240p(0.5))}
-
-# Set dizzy flag and initial animation
-if time = 0 {
-	dizzySet{value: 1}
-	if selfAnimExist(const(AnimAirFall_hitUpDiagonal)) {
-		changeAnim{value: const(AnimAirFall_hitUpDiagonal)}
-	} else {
-		changeAnim{value: const(AnimStandOrAirHitBack)}
-	}
-}
-
-# Falling through the air animations
-if anim = const(AnimStandOrAirHitBack) {
-	if animTime = 0 {
-		changeAnim{value: ifElse(selfAnimExist(const(AnimStandOrAirHitTransition)), const(AnimStandOrAirHitTransition), const(AnimAirFall))}
-	}
-}
-if anim = const(AnimStandOrAirHitTransition) {
-	if animTime = 0 {
-		changeAnim{value: const(AnimAirFall)}
-	}
-}
-if anim = [const(AnimAirFall), const(AnimAirFall) + 9] {
-	if vel y > 0 {
-		if SelfAnimExist(const(AnimAirFall_comingDown) + (anim % 10)) {
-			changeAnim{value: const(AnimAirFall_comingDown) + (anim % 10)}
-		}
-	}
-}
-
-# Hit ground from fall
-if anim = [const(AnimStandOrAirHitBack), const(AnimLieDownHit_hitUpIntoAir)] {
-	if vel y > 0 &&
-	pos y >= ifElse(anim = [const(AnimAirFall) + 1, const(AnimAirFall) + 9] || anim = [const(AnimAirFall_comingDown) + 1, const(AnimAirFall_comingDown) + 9], 0, const(movement.air.gethit.groundlevel)) {
-		stateTypeSet{statetype: L}
-		changeAnim{value: const(AnimHittingGroundFromFall) + (anim % 10) * SelfAnimExist(const(AnimHittingGroundFromFall) + (anim % 10))}
-	}
-}
-
-if anim = [const(AnimHittingGroundFromFall), const(AnimHittingGroundFromFall) + 9] {
-	posSet{y: 0}
-	velSet{y: 0}
-	posFreeze{}
-	persistent(0) if getHitVar(fall.yVel) {
-		call IkSys_DizzyHitGroundExplod(floor(vel y));
-	}
-}
-
-# Bounce into air
-if animTime = 0 && anim = [const(AnimHittingGroundFromFall), const(AnimHittingGroundFromFall) + 9] {
-	stateTypeSet{statetype: L}
-	changeAnim{value: const(AnimBounceIntoAir) + (anim % 10) * SelfAnimExist(const(AnimBounceIntoAir) + (anim % 10))}
-}
-
-persistent(0) if anim = [const(AnimBounceIntoAir), const(AnimBounceIntoAir) + 9] {
-	hitFallVel{}
-	posSet{y: const(movement.down.bounce.offset.y)}
-	posAdd{
-		x: const(movement.down.bounce.offset.x);
-		y: ifElse(const(movement.down.bounce.offset.y) > -5, -5, const(movement.down.bounce.offset.y));
-	}
-}
-
-# Hit ground from bounce
-if anim = [const(AnimBounceIntoAir), const(AnimBounceIntoAir) + 9] {
-	if vel y > 0 && pos y >= const(movement.down.bounce.groundlevel) {
-		call IkSys_DizzyHitGroundExplod(floor(vel y));
-		selfState{value: const(StateDizzyLyingDown)}
-	}
-}
-
-# Failsafe
-if !dizzy || time > 300 {
+if time > 0 {
 	selfState{value: const(StateAirGetHit_falling)}
 }
 
-#===============================================================================
-# StateDizzyLyingDown
-#===============================================================================
 [StateDef const(StateDizzyLyingDown); type: L; movetype: H; physics: N; ctrl: 0;]
 
-notHitBy{value: SCA; time: 1}
-
-# Friction
-if abs(vel x) < const(movement.down.friction.threshold) {
-	velSet{x: 0}
-} else {
-	velMul{x: 0.85}
-}
-
-if time = 0 {
-	posSet{y: 0}
-	velSet{y: 0}
-	dizzySet{value: 1}
-}
-
-# Hitting ground animation
-if time = 0 {
-	if anim = [const(AnimAirFall), const(AnimAirFall) + 9]
-	|| anim = [const(AnimAirFall_comingDown), const(AnimAirFall_comingDown) + 9]
-	|| anim = [const(AnimHittingGroundFromFall), const(AnimHittingGroundFromFall) + 9]
-	|| anim = [const(AnimBounceIntoAir), const(AnimBounceIntoAir) + 9] {
-		changeAnim{value: const(AnimHitGroundFromBounce) + (anim % 10) * SelfAnimExist(const(AnimHitGroundFromBounce) + (anim % 10))}
-	} else {
-		changeAnim{value: const(AnimHitGroundFromBounce)}
-	}
-}
-
-# Lying down animation
-if animTime = 0 && anim = [const(AnimHitGroundFromBounce), const(AnimHitGroundFromBounce) + 9] {
-	changeAnim{value: const(AnimLieDown) + (anim % 10) * SelfAnimExist(const(AnimLieDown) + (anim % 10))}
-}
-
-# Getting up animation
-if time >= 30 && anim = [const(AnimLieDown), const(AnimLieDown) + 9] {
-	changeAnim{value: const(AnimGetUpFromLieDown) + (anim % 10) * SelfAnimExist(const(AnimGetUpFromLieDown) + (anim % 10))}
-}
-
-# End state
-if (animTime = 0 && anim = [const(AnimGetUpFromLieDown), const(AnimGetUpFromLieDown) + 9]) || time >= 90 {
-	selfState{value: const(StateDizzy)}
-}
-
-# Failsafe
-if !dizzy || time > 300 {
+if time > 0 {
 	selfState{value: const(StateDownedGetHit_gettingUp)}
 }
 
@@ -338,15 +159,20 @@ if !numHelper(const(StateDizzyBirdsHelper)) {
 
 if time > 0 {
 	mapAdd{map: "_iksys_dizzyRecoveryTime"; value: -1}
+	# Mash buttons to recover faster
 	if aiLevel = 0 {
-		if (command = "x" || command = "y" || command = "z" || command = "a" || command = "b" || command = "c") {
-			mapAdd{map: "_iksys_dizzyRecoveryTime"; value: -3} # Directions should also reduce time, but single directional inputs currently aren't common inputs
+		if inputTime(U) = 1 || inputTime(D) = 1 || inputTime(B) = 1 || inputTime(F) = 1 ||
+		inputTime(a) = 1 || inputTime(b) = 1 || inputTime(c) = 1 || inputTime(x) = 1 || inputTime(y) = 1 || inputTime(z) = 1 {
+			mapAdd{map: "_iksys_dizzyRecoveryTime"; value: -3}
+			palFx{add: 32, 32, 32; time: 1}
 		}
 	} else if max(4, aiLevel) >= randomRange(1, 12) { # 33% - 66,67% chance, depending on aiLevel
 		mapAdd{map: "_iksys_dizzyRecoveryTime"; value: -3}
+		palFx{add: 32, 32, 32; time: 1}
 	}
 }
 
+# Must stay dizzy for at least 60 frames
 if time >= 60 {
 	if map(_iksys_dizzyRecoveryTime) <= 0 || roundState > 2 {
 		dizzySet{value: 0}
@@ -367,6 +193,7 @@ if !dizzy || time > 300 {
 if !const(Default.Enable.Dizzy) || isHelper || teamSide = 0 {
 	# Do nothing, global code disabled locally or executed by helper/stage
 } else if roundState = 0 {
+	# Initialize points and variables
 	dizzyPointsSet{value: dizzyPointsMax}
 	map(_iksys_dizzyPointsTimer) := 0;
 	map(_iksys_dizzyLimit) := 0;
@@ -376,7 +203,7 @@ if !const(Default.Enable.Dizzy) || isHelper || teamSide = 0 {
 		mapAdd{map: "_iksys_dizzyPointsTimer"; value: -1}
 	}
 	# Set cooldown timer while getting hit
-	if dizzy || moveType = H && getHitVar(guarded) = 0 || stateNo = const(StateDownedGetHit_gettingUp) {
+	if dizzy || moveType = H && !getHitVar(guarded) || stateNo = const(StateDownedGetHit_gettingUp) {
 		map(_iksys_dizzyPointsTimer) := 60;
 	}
 
@@ -391,43 +218,80 @@ if !const(Default.Enable.Dizzy) || isHelper || teamSide = 0 {
 
 	# Set dizzy flag
 	if !dizzy && dizzyPoints = 0 && !getHitVar(guarded) {
+		# Prevent dizzy if current attack does no dizzy damage
+		# Similar to using kill = 0 in LifeAdd
 		if getHitVar(frame) && getHitVar(dizzyPoints) <= 0 {
-			dizzyPointsSet{value: 1} # Similar to using kill = 0 in LifeAdd
+			dizzyPointsSet{value: 1}
 		} else if moveType = H && !inCustomState {
+			# Change get hit properties when becoming dizzy
 			dizzySet{value: 1}
-			hitFallSet{value: 1}
-			getHitVarSet{fall.recover: 0}
+			getHitVarSet{
+				xvel: getHitVar(air.velocity.x) + const(velocity.air.gethit.ko.add.y) * facing;
+				yvel: min(getHitVar(air.velocity.y), const(velocity.air.gethit.ko.ymin));
+				fall.recover: 0;
+				down.recover: 0;
+				down.recovertime: 30;
+			}
+			if !hitfall {
+				hitFallSet{value: 1}
+				if anim = [const(AnimCrouchHit_light), const(AnimCrouchHit_hard)] {
+					changeAnim{value: const(AnimStandOrAirHitBack)}
+				}
+			}
+			# Use diagonal hit animation if available
+			if anim != const(AnimAirFall_hitUpDiagonal) && selfAnimExist(const(AnimAirFall_hitUpDiagonal)) {
+				changeAnim{value: const(AnimAirFall_hitUpDiagonal)}
+			}
 		}
 	}
 
 	# Start dizzy behavior
 	if dizzy {
-		# Create dizzy effects
-		call IkSys_DizzyBirdHelper();
 
-		# Become invulnerable until moving into Dizzy states for the first time
+		# Compatibility safeguard
+		if stateNo != const(StateDizzy) {
+			assertSpecial{flag: noInput; flag2: noAIlevel}
+		}
+
+		# Become invulnerable until moving into Dizzy state for the first time
 		if stateNo != const(StateDizzy) && !map(_iksys_dizzyLimit) {
 			notHitBy{value: SCA}
 		}
 
-		# Dizzy initial state depending on hit type
-		# Character can't enter dizzy state more than once per combo
+		# Enter Dizzy state
+		# Only allowed once per combo
 		if !map(_iksys_dizzyLimit) {
-			if stateNo = const(StateStandGetHit_knockedBack) || stateNo = const(StateCrouchGetHit_knockedBack) {
-				if hitOver {
-					selfState{value: const(StateDizzyFallDown_standCrouch)}
-				}
-			} else if (stateNo = const(StateAirGetHit_knockedAway) || stateNo = const(StateTrippedGetHit_knockedAway)) && hitShakeOver {
-				selfState{value: const(StateDizzyFallDown_air)}
-			} else if stateNo = const(StateDownedGetHit_lyingDown) || stateNo = const(StateDownedGetHit_lyingDown) + 1 {
-				selfState{value: const(StateDizzyLyingDown)}
+			if stateNo = [const(StateStand), const(StateGuard_end)] ||
+				(stateType = S || stateType = C) && hitShakeOver && hitOver ||
+				stateNo = const(StateDownedGetHit_gettingUp) && animTime = 0 {
+				selfState{value: const(StateDizzy)}
 			}
 		}
 
 		# Reset dizzy points and remove dizzy flag if the player is no longer being hit
-		if moveType != H && stateNo != const(StateDizzy) {
+		if moveType != H && stateType != L && stateNo != const(StateDizzy) {
 			dizzyPointsSet{value: dizzyPointsMax}
 			dizzySet{value: 0}
+		}
+
+		# Special effects
+		if !numHelper(const(StateDizzyBirdsHelper)) {
+			# Red screen
+			if palFxVar(bg.time) = 0 {
+				bgPalFx{
+					time: 30;
+					sincolor: -255, 60;
+					sinmul: 0, -255, -255, 60;
+				}
+			}
+			# Dizzy birds
+			helper{
+				id: const(StateDizzyBirdsHelper);
+				stateno: const(StateDizzyBirdsHelper);
+				name: "Dizzy Birds";
+				facing: ifelse(random < 500, -1, 1);
+				ownpal: 1;
+			}
 		}
 	}
 

--- a/data/dizzy.zss
+++ b/data/dizzy.zss
@@ -3,7 +3,7 @@
 # Functions
 #===============================================================================
 # Dizzy Bird Helper
-[Function DizzyBirdHelper()]
+[Function IkSys_DizzyBirdHelper()]
 if !numHelper(const(StateDizzyBirdsHelper)) {
 	# Background
 	explod{
@@ -29,7 +29,7 @@ if !numHelper(const(StateDizzyBirdsHelper)) {
 }
 
 # Dizzy Bird Explod Creation [from Helper]
-[Function DizzyBirdExplodCreation(arg)]
+[Function IkSys_DizzyBirdExplodCreation(arg)]
 if !numExplod($arg) {
 	explod{
 		id: $arg;
@@ -43,7 +43,7 @@ if !numExplod($arg) {
 }
 
 # Dizzy Bird Explod Update [from Helper]
-[Function DizzyBirdExplodUpdate(arg)]
+[Function IkSys_DizzyBirdExplodUpdate(arg)]
 if numExplod($arg) {
 	let circleTime = ((gameTime % 90) + 22.5 * $arg) / 45.0 * pi;
 	let circleHeight = cos($circleTime) * map(birdRadius) * 0.25;
@@ -63,7 +63,7 @@ if numExplod($arg) {
 }
 
 # Dizzy Hit Ground Explod (direct copy from common1)
-[Function DizzyHitGroundExplod(vely)]
+[Function IkSys_DizzyHitGroundExplod(vely)]
 explod{
 	anim: F (60 + ($vely > const240p(5)) + ($vely > const240p(14)));
 	postype: p1;
@@ -119,10 +119,10 @@ if map(birdState) <= 0 {
 	fVar(11) := fVar(11) + (fVar(12) - fVar(11)) * 0.10;
 
 	# Create dizzy bird explods
-	call DizzyBirdExplodCreation(0);
-	call DizzyBirdExplodCreation(1);
-	call DizzyBirdExplodCreation(2);
-	call DizzyBirdExplodCreation(3);
+	call IkSys_DizzyBirdExplodCreation(0);
+	call IkSys_DizzyBirdExplodCreation(1);
+	call IkSys_DizzyBirdExplodCreation(2);
+	call IkSys_DizzyBirdExplodCreation(3);
 
 	# Play sound again as soon as it stops
 	# Volume goes down as character recovers from dizzy
@@ -138,10 +138,10 @@ if map(birdState) <= 0 {
 
 # Update dizzy bird explods
 # Replaces creating new explods every frame
-call DizzyBirdExplodUpdate(0);
-call DizzyBirdExplodUpdate(1);
-call DizzyBirdExplodUpdate(2);
-call DizzyBirdExplodUpdate(3);
+call IkSys_DizzyBirdExplodUpdate(0);
+call IkSys_DizzyBirdExplodUpdate(1);
+call IkSys_DizzyBirdExplodUpdate(2);
+call IkSys_DizzyBirdExplodUpdate(3);
 
 #===============================================================================
 # StateDizzyFallDown_standCrouch
@@ -168,7 +168,7 @@ if anim = [const(AnimStandOrAirHitHigh_hard), const(AnimStandOrAirHitLow_hard)] 
 	stateTypeSet{statetype: C}
 }
 if (anim = const(AnimCrouchHit_hard) && animTime = 0) || time > 26 {
-	call DizzyHitGroundExplod(0);
+	call IkSys_DizzyHitGroundExplod(0);
 	selfState{value: const(StateDizzyLyingDown)}
 }
 
@@ -230,7 +230,7 @@ if anim = [const(AnimHittingGroundFromFall), const(AnimHittingGroundFromFall) + 
 	velSet{y: 0}
 	posFreeze{}
 	persistent(0) if getHitVar(fall.yVel) {
-		call DizzyHitGroundExplod(floor(vel y));
+		call IkSys_DizzyHitGroundExplod(floor(vel y));
 	}
 }
 
@@ -252,7 +252,7 @@ persistent(0) if anim = [const(AnimBounceIntoAir), const(AnimBounceIntoAir) + 9]
 # Hit ground from bounce
 if anim = [const(AnimBounceIntoAir), const(AnimBounceIntoAir) + 9] {
 	if vel y > 0 && pos y >= const(movement.down.bounce.groundlevel) {
-		call DizzyHitGroundExplod(floor(vel y));
+		call IkSys_DizzyHitGroundExplod(floor(vel y));
 		selfState{value: const(StateDizzyLyingDown)}
 	}
 }
@@ -371,12 +371,13 @@ if !const(Default.Enable.Dizzy) || isHelper || teamSide = 0 {
 	map(_iksys_dizzyPointsTimer) := 0;
 	map(_iksys_dizzyLimit) := 0;
 } else if alive {
-	# Upon getting hit, set cooldown timer
-	if dizzy || moveType = H || stateNo = const(StateDownedGetHit_gettingUp) {
-		map(_iksys_dizzyPointsTimer) := 60;
-	# Otherwise decrease cooldown timer by 1 each frame
-	} else if map(_iksys_dizzyPointsTimer) > 0 {
+	# Decrease cooldown timer
+	if map(_iksys_dizzyPointsTimer) > 0 {
 		mapAdd{map: "_iksys_dizzyPointsTimer"; value: -1}
+	}
+	# Set cooldown timer while getting hit
+	if dizzy || moveType = H && getHitVar(guarded) = 0 || stateNo = const(StateDownedGetHit_gettingUp) {
+		map(_iksys_dizzyPointsTimer) := 60;
 	}
 
 	# Freeze dizzy points if character was already dizzied once in the combo
@@ -402,7 +403,7 @@ if !const(Default.Enable.Dizzy) || isHelper || teamSide = 0 {
 	# Start dizzy behavior
 	if dizzy {
 		# Create dizzy effects
-		call DizzyBirdHelper();
+		call IkSys_DizzyBirdHelper();
 
 		# Become invulnerable until moving into Dizzy states for the first time
 		if stateNo != const(StateDizzy) && !map(_iksys_dizzyLimit) {
@@ -434,7 +435,7 @@ if !const(Default.Enable.Dizzy) || isHelper || teamSide = 0 {
 	if !dizzy && dizzyPoints < dizzyPointsMax && map(_iksys_dizzyPointsTimer) = 0 {
 		# Fixed value. Characters with a longer dizzy bar take longer to recover
 		# This property could use a character constant as well instead
-		dizzyPointsAdd{value: 5; absolute: 1}
+		dizzyPointsAdd{value: 3; absolute: 1}
 	}
 
 	# Reset dizzy limit once character can act again

--- a/data/guardbreak.zss
+++ b/data/guardbreak.zss
@@ -1,4 +1,4 @@
-# Guard Break code adopted from Shiyo Kakuge's add004
+# Guard Break code adapted from Shiyo Kakuge's add004
 #===============================================================================
 # StateGuardBreakHit
 #===============================================================================
@@ -12,57 +12,8 @@ if time = 0 {
 	if pos y < 0 {
 		stateTypeSet{statetype: A} # Just in case
 	}
-	playSnd{value: GO 5400, 0}
-	explod{
-		# Do note all anims and playsnds on this file are called from gofx.def, not fightfx.air/common.snd
-		anim: GO const(FxGuardBreakShockwave);
-		postype: p1;
-		pos: floor((const(size.mid.pos.x)) * const(size.xscale)), floor(const(size.mid.pos.y) * const(size.yscale) * ifElse(stateType = C, 0.5, 1));
-		sprpriority: 7;
-		ownpal: 1;
-		scale: 0.15, 4.5;
-		trans: add;
-		alpha: 256, 256;
-		pausemovetime: -1;
-		ignorehitpause: 1;
-	}
-}
-
-if time < 13 {
-	explod{
-		anim: GO const(FxGuardBreakSpark) + randomRange(0, 2);
-		postype: p1;
-		pos: floor((const(size.mid.pos.x)) * const(size.xscale)), floor(const(size.mid.pos.y) * const(size.yscale) * ifElse(stateType = C, 0.5, 1));
-		sprpriority: 6;
-		ownpal: 1;
-		random: floor(const(size.height) / 8 * const(size.xscale)), floor(const(size.height) * const(size.yscale));
-		scale: randomRange(0, 8) * 0.03 + 0.25, randomRange(0, 8) * 0.03 + 0.25;
-		vel: -(randomRange(0, 17) + 5) * 0.36, (randomRange(0, 18) - 8) * 0.36;
-		accel: 0.038, 0;
-		facing: ifElse(random < 500, 1, -1);
-		vfacing: ifElse(random < 500, 1, -1);
-		pausemovetime: -1;
-		ignorehitpause: 1;
-	}
-}
-
-if time = 0 {
-	explod{
-		anim: GO const(FxBackgroundColor);
-		sprpriority: -6000;
-		space: screen;
-		postype: left;
-		pos: 0, screenHeight / 2; # color 0 (blue)
-		scale: 320, 7.5 * screenHeight / const240p(240);
-		bindtime: -1;
-		supermovetime: -1;
-		pausemovetime: -1;
-		ownpal: 1;
-		ignorehitpause: 1;
-	}
-	# Removed the pause as it doesn't exist in the main reference game and it affected every player on screen
-	stateTypeSet{physics: stateType}
-	# Changed animations a bit. I think all of them could use common guard break constants later
+	# Decide animation type
+	# These could perhaps use common guard break constants later
 	if stateType = S {
 		changeAnim{value: const(AnimStandOrAirHitHigh_hard)}
 	} else if stateType = C {
@@ -72,6 +23,53 @@ if time = 0 {
 	}
 } else {
 	changeAnim{value: anim}
+}
+
+# Special effects
+if time < 13 {
+	if time = 0 {
+		# Guard break sound
+		playSnd{value: GO 5400, 0}
+		# Blue screen
+		if palFxVar(bg.time) = 0 {
+			bgPalFx{
+				time: 30;
+				sincolor: -255, 60;
+				sinmul: -255, -255, 0, 60;
+			}
+		}
+		# Shockwave
+		explod{
+			# Do note all anims and playsnds on this file are called from gofx.def, not fightfx.air/common.snd
+			anim: GO const(FxGuardBreakShockwave);
+			postype: p1;
+			pos: const(size.ground.front), const(size.mid.pos.y) * ifElse(stateType = C, 0.5, 1);
+			sprpriority: 7;
+			ownpal: 1;
+			scale: 0.25, 0.25;
+			vfacing: ifElse(random < 500, 1, -1);
+			pausemovetime: -1;
+			ignorehitpause: 1;
+		}
+	}
+	# Glass shards
+	let direction = (random / 1000.0) * ifelse(random < 667, -1, 1);
+	explod{
+		anim: GO const(FxGuardBreakSpark) + randomRange(0, 2);
+		postype: p1;
+		pos: 0, const(size.mid.pos.y) * ifElse(stateType = C, 0.5, 1) - 0.5 * const(size.mid.pos.y) * $direction;
+		sprpriority: 6;
+		ownpal: 1;
+		random: const(size.ground.front), 0;
+		scale: 0.20 + (random / 5000.0), 0.20 + (random / 5000.0);
+		angle: (random % 360);
+		vel: const240p(-3.0 - (random / 333.3)), const240p(random / 200.0) * $direction;
+		accel: 0, const240p(0.1);
+		facing: ifElse(random < 500, 1, -1);
+		vfacing: ifElse(random < 500, 1, -1);
+		pausemovetime: -1;
+		ignorehitpause: 1;
+	}
 }
 
 # Every character stays in these states the same time, regardless of animation timing
@@ -147,6 +145,7 @@ if time >= 60 {
 if !const(Default.Enable.GuardBreak) || isHelper || teamSide = 0 {
 	# Do nothing, global code disabled locally or executed by helper/stage
 } else if roundState = 0 {
+	# Initialize points and variables
 	guardPointsSet{value: guardPointsMax}
 	map(_iksys_guardPointsTimer) := 0;
 } else if roundState = 2 && alive {

--- a/data/guardbreak.zss
+++ b/data/guardbreak.zss
@@ -150,17 +150,17 @@ if !const(Default.Enable.GuardBreak) || isHelper || teamSide = 0 {
 	guardPointsSet{value: guardPointsMax}
 	map(_iksys_guardPointsTimer) := 0;
 } else if roundState = 2 && alive {
-	# Manage cooldown timer
-	if moveType = H {
-		map(_iksys_guardPointsTimer) := 60;
-	} else if map(_iksys_guardPointsTimer) > 0 {
+	# Decrease cooldown timer
+	if map(_iksys_guardPointsTimer) > 0 {
 		mapAdd{map: "_iksys_guardPointsTimer"; value: -1}
 	}
 	# Upon block
 	if stateNo = const(StateStandGuardHit_shaking) || stateNo = const(StateCrouchGuardHit_shaking) || stateNo = const(StateAirGuardHit_shaking) {
-		# Coloring if guard points left are under 333 or 50% for characters with a small guard bar
-		if (gameTime % 5) = 0 && guardPoints <= min((0.5 * guardPointsMax), 333) {
-			palFx{time: 2; add: 200, 0, 0}
+		# Start cooldown timer
+		map(_iksys_guardPointsTimer) := 60;
+		# Warning if guard points left are under 333 or 50% for characters with a small guard bar
+		if getHitVar(frame) && guardPoints <= min((0.5 * guardPointsMax), 333) {
+			palFx{time: 20; add: 64, 0, 0; sinadd: 64, 0, 0, 4}
 		}
 		# Enter guard break state
 		if !guardBreak && guardPoints = 0 {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1505,7 +1505,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 				pno := c.playerNo
 				// For a Mugen character, the command position is checked in the redirecting char
 				// Recovery command is an exception in that its position is always checked in the final char
-				if cmdName != "recovery" && oc.stWgi().ikemenver[0] == 0 && oc.stWgi().ikemenver[1] == 0 {
+				if cmdName != "recovery" && oc.ss.sb.ikemenver[0] == 0 && oc.ss.sb.ikemenver[1] == 0 {
 					redir = oc.ss.sb.playerNo
 					pno = c.ss.sb.playerNo
 				}
@@ -1526,7 +1526,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushI(int32(c.frontEdgeDist() * (c.localscl / oc.localscl)))
 		case OC_gameheight:
 			// Optional exception preventing GameHeight from being affected by stage zoom.
-			if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 0 &&
+			if c.ss.sb.mugenver[0] == 1 && c.ss.sb.mugenver[1] == 0 &&
 				c.gi().constants["default.legacygamedistancespec"] == 1 {
 				sys.bcStack.PushF(c.screenHeight())
 			} else {
@@ -1544,7 +1544,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushI(sys.gameTime + pfTime)
 		case OC_gamewidth:
 			// Optional exception preventing GameWidth from being affected by stage zoom.
-			if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 0 &&
+			if c.ss.sb.mugenver[0] == 1 && c.ss.sb.mugenver[1] == 0 &&
 				c.gi().constants["default.legacygamedistancespec"] == 1 {
 				sys.bcStack.PushF(c.screenWidth())
 			} else {
@@ -1608,7 +1608,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushI(c.palno())
 		case OC_pos_x:
 			var bindVelx float32
-			if c.bindToId > 0 && !math.IsNaN(float64(c.bindPos[0])) && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
+			if c.bindToId > 0 && !math.IsNaN(float64(c.bindPos[0])) && c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
 				if sys.playerID(c.bindToId) != nil {
 					bindVelx = c.vel[0]
 				}
@@ -1616,7 +1616,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushF(((c.pos[0]+bindVelx)*(c.localscl/oc.localscl) - sys.cam.Pos[0]/oc.localscl))
 		case OC_pos_y:
 			var bindVely float32
-			if c.bindToId > 0 && !math.IsNaN(float64(c.bindPos[1])) && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
+			if c.bindToId > 0 && !math.IsNaN(float64(c.bindPos[1])) && c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
 				if sys.playerID(c.bindToId) != nil {
 					bindVely = c.vel[1]
 				}
@@ -2710,7 +2710,7 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_movecountered:
 		sys.bcStack.PushI(c.moveCountered())
 	case OC_ex_mugenversion:
-		sys.bcStack.PushF(c.mugenVersion())
+		sys.bcStack.PushF(c.mugenVersionF())
 	case OC_ex_pausetime:
 		sys.bcStack.PushI(c.pauseTime())
 	case OC_ex_physics:
@@ -3736,7 +3736,7 @@ func (sc assertSpecial) Run(c *Char, _ []int32) bool {
 			sys.setGSF(GlobalSpecialFlag(exp[0].evalI(c)))
 		case assertSpecial_noko:
 			// NoKO affects all characters in Mugen, so legacy chars do so as well
-			if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
+			if c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
 				sys.setGSF(GlobalSpecialFlag(GSF_globalnoko))
 			} else {
 				crun.setASF(AssertSpecialFlag(ASF_noko))
@@ -4751,7 +4751,7 @@ func (sc palFX) Run(c *Char, _ []int32) bool {
 			}
 			pf.clear2(true)
 			// Mugen 1.1 behavior if invertblend param is omitted (Only if char mugenversion = 1.1)
-			if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
+			if c.ss.sb.mugenver[0] == 1 && c.ss.sb.mugenver[1] == 1 && c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
 				pf.invertblend = -2
 			}
 			doOnce = true
@@ -4875,7 +4875,7 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 				e.id = 0
 			}
 			// Mugenversion 1.1 chars default postype to "None"
-			if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 {
+			if c.ss.sb.mugenver[0] == 1 && c.ss.sb.mugenver[1] == 1 {
 				e.postype = PT_None
 			}
 		}
@@ -5059,7 +5059,7 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 		case explod_window:
 			e.window = [4]float32{exp[0].evalF(c) * lclscround, exp[1].evalF(c) * lclscround, exp[2].evalF(c) * lclscround, exp[3].evalF(c) * lclscround}
 		default:
-			if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
+			if c.ss.sb.mugenver[0] == 1 && c.ss.sb.mugenver[1] == 1 && c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
 				e.palfxdef.invertblend = -2
 			}
 			palFX(sc).runSub(c, &e.palfxdef, id, exp)
@@ -5224,7 +5224,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				if exp[0].evalI(c) < 0 {
 					f = -1
 				}
-				if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
+				if (c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0) && !ptexists {
 					eachExpl(func(e *Explod) {
 						e.relativef = f
 					})
@@ -5233,24 +5233,24 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				if exp[0].evalI(c) < 0 {
 					vf = -1
 				}
-				if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
+				if (c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0) && !ptexists {
 					eachExpl(func(e *Explod) {
 						e.vfacing = vf
 					})
 				}
 			case explod_pos:
 				pos[0] = exp[0].evalF(c) * lclscround
-				if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
+				if (c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0) && !ptexists {
 					eachExpl(func(e *Explod) { e.relativePos[0] = pos[0] })
 				}
 				if len(exp) > 1 {
 					pos[1] = exp[1].evalF(c) * lclscround
-					if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
+					if (c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0) && !ptexists {
 						eachExpl(func(e *Explod) { e.relativePos[1] = pos[1] })
 					}
 					if len(exp) > 2 {
 						pos[2] = exp[2].evalF(c) * lclscround
-						if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
+						if (c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0) && !ptexists {
 							eachExpl(func(e *Explod) { e.relativePos[2] = pos[2] })
 						}
 					}
@@ -5259,62 +5259,62 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				rndx := (exp[0].evalF(c) / 2) * lclscround
 				rndx = RandF(-rndx, rndx)
 				pos[0] += rndx
-				if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
+				if (c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0) && !ptexists {
 					eachExpl(func(e *Explod) { e.relativePos[0] += rndx })
 				}
 				if len(exp) > 1 {
 					rndy := (exp[1].evalF(c) / 2) * lclscround
 					rndy = RandF(-rndy, rndy)
 					pos[1] += rndy
-					if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
+					if (c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0) && !ptexists {
 						eachExpl(func(e *Explod) { e.relativePos[1] += rndy })
 					}
 					if len(exp) > 2 {
 						rndz := (exp[2].evalF(c) / 2) * lclscround
 						rndz = RandF(-rndz, rndz)
 						pos[2] += rndz
-						if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
+						if (c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0) && !ptexists {
 							eachExpl(func(e *Explod) { e.relativePos[2] += rndz })
 						}
 					}
 				}
 			case explod_velocity:
 				vel[0] = exp[0].evalF(c) * lclscround
-				if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
+				if (c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0) && !ptexists {
 					eachExpl(func(e *Explod) { e.velocity[0] = vel[0] })
 				}
 				if len(exp) > 1 {
 					vel[1] = exp[1].evalF(c) * lclscround
-					if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
+					if (c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0) && !ptexists {
 						eachExpl(func(e *Explod) { e.velocity[1] = vel[1] })
 					}
 					if len(exp) > 2 {
 						vel[2] = exp[2].evalF(c) * lclscround
-						if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
+						if (c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0) && !ptexists {
 							eachExpl(func(e *Explod) { e.velocity[2] = vel[2] })
 						}
 					}
 				}
 			case explod_accel:
 				accel[0] = exp[0].evalF(c) * lclscround
-				if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
+				if (c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0) && !ptexists {
 					eachExpl(func(e *Explod) { e.accel[0] = accel[0] })
 				}
 				if len(exp) > 1 {
 					accel[1] = exp[1].evalF(c) * lclscround
-					if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
+					if (c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0) && !ptexists {
 						eachExpl(func(e *Explod) { e.accel[1] = accel[1] })
 					}
 					if len(exp) > 2 {
 						accel[2] = exp[2].evalF(c) * lclscround
-						if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
+						if (c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0) && !ptexists {
 							eachExpl(func(e *Explod) { e.accel[2] = accel[2] })
 						}
 					}
 				}
 			case explod_space:
 				sp = Space(exp[0].evalI(c))
-				if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
+				if (c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0) && !ptexists {
 					eachExpl(func(e *Explod) { e.space = sp })
 				}
 			case explod_postype:
@@ -5344,7 +5344,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				eachExpl(func(e *Explod) {
 					e.bindtime = t
 					// Bindtime fix (update bindtime according to current explod time)
-					if (crun.stWgi().ikemenver[0] > 0 || crun.stWgi().ikemenver[1] > 0) && t > 0 {
+					if (crun.ss.sb.ikemenver[0] > 0 || crun.ss.sb.ikemenver[1] > 0) && t > 0 {
 						e.bindtime = e.time + t
 					}
 					e.setX(e.pos[0])
@@ -5356,7 +5356,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				eachExpl(func(e *Explod) {
 					e.removetime = t
 					// Removetime fix (update removetime according to current explod time)
-					if (crun.stWgi().ikemenver[0] > 0 || crun.stWgi().ikemenver[1] > 0) && t > 0 {
+					if (crun.ss.sb.ikemenver[0] > 0 || crun.ss.sb.ikemenver[1] > 0) && t > 0 {
 						e.removetime = e.time + t
 					}
 				})
@@ -5371,7 +5371,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				eachExpl(func(e *Explod) {
 					e.supermovetime = t
 					// Supermovetime fix (update supermovetime according to current explod time)
-					if (crun.stWgi().ikemenver[0] > 0 || crun.stWgi().ikemenver[1] > 0) && t > 0 {
+					if (crun.ss.sb.ikemenver[0] > 0 || crun.ss.sb.ikemenver[1] > 0) && t > 0 {
 						e.supermovetime = e.time + t
 					}
 				})
@@ -5380,7 +5380,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				eachExpl(func(e *Explod) {
 					e.pausemovetime = t
 					// Pausemovetime fix (update pausemovetime according to current explod time)
-					if (crun.stWgi().ikemenver[0] > 0 || crun.stWgi().ikemenver[1] > 0) && t > 0 {
+					if (crun.ss.sb.ikemenver[0] > 0 || crun.ss.sb.ikemenver[1] > 0) && t > 0 {
 						e.pausemovetime = e.time + t
 					}
 				})
@@ -5467,7 +5467,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 					e.blendmode = int32(blendmode)
 				})
 			case explod_anim:
-				if c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
+				if c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0 {
 					animNo := exp[1].evalI(c)
 					anim := crun.getAnim(animNo, string(*(*[]byte)(unsafe.Pointer(&exp[0]))), true)
 					eachExpl(func(e *Explod) {
@@ -5504,7 +5504,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 					e.window = [4]float32{exp[0].evalF(c) * lclscround, exp[1].evalF(c) * lclscround, exp[2].evalF(c) * lclscround, exp[3].evalF(c) * lclscround}
 				})
 			case explod_ignorehitpause:
-				if c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
+				if c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0 {
 					ihp := exp[0].evalB(c)
 					eachExpl(func(e *Explod) { e.ignorehitpause = ihp })
 				}
@@ -5515,7 +5515,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				}
 				eachExpl(func(e *Explod) { e.setBind(bId) })
 			case explod_interpolation:
-				if c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
+				if c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0 {
 					interpolation := exp[0].evalB(c)
 					eachExpl(func(e *Explod) {
 						if e.interpolate != interpolation && e.interpolate_time[0] > 0 {
@@ -5726,7 +5726,7 @@ func (sc afterImage) Run(c *Char, _ []int32) bool {
 		if !doOnce {
 			crun.aimg.clear()
 			// Mugen 1.1 behavior if invertblend param is omitted (Only if char mugenversion = 1.1)
-			if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
+			if c.ss.sb.mugenver[0] == 1 && c.ss.sb.mugenver[1] == 1 && c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
 				crun.aimg.palfx[0].invertblend = -2
 			}
 			crun.aimg.time = 1
@@ -6206,7 +6206,7 @@ func (sc hitDef) Run(c *Char, _ []int32) bool {
 			}
 		}
 		// Mugen 1.1 behavior if invertblend param is omitted (Only if char mugenversion = 1.1)
-		if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
+		if c.ss.sb.mugenver[0] == 1 && c.ss.sb.mugenver[1] == 1 && c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
 			crun.hitdef.palfx.invertblend = -2
 		}
 		sc.runSub(c, &crun.hitdef, id, exp)
@@ -7816,7 +7816,7 @@ func (sc lifeAdd) Run(c *Char, _ []int32) bool {
 		case lifeAdd_value:
 			v := exp[0].evalI(c)
 			// Mugen forces absolute parameter when healing characters
-			if v > 0 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
+			if v > 0 && c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
 				a = true
 			}
 			crun.lifeAdd(float64(v), k, a)
@@ -8711,7 +8711,7 @@ func (sc defenceMulSet) Run(c *Char, _ []int32) bool {
 	var mulType int32 = 1
 
 	// Change default behavior for Mugen chars
-	if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
+	if c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
 		onHit = true
 		mulType = 0
 	}
@@ -10823,7 +10823,7 @@ func (sc targetRedLifeAdd) Run(c *Char, _ []int32) bool {
 			}
 			v := exp[0].evalI(c)
 			// Mugen forces absolute parameter when healing characters
-			if v > 0 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
+			if v > 0 && c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
 				a = true
 			}
 			crun.targetRedLifeAdd(tar, exp[0].evalI(c), a)
@@ -11639,6 +11639,8 @@ type StateBytecode struct {
 	block     StateBlock
 	ctrlsps   []int32
 	numVars   int32
+	ikemenver [3]uint16
+	mugenver  [2]uint16
 }
 
 // StateDef bytecode creation function

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -528,6 +528,7 @@ const (
 	OC_ex_animlength
 	OC_ex_animplayerno
 	OC_ex_attack
+	OC_ex_clsnoverlap
 	OC_ex_combocount
 	OC_ex_consecutivewins
 	OC_ex_defence
@@ -2443,6 +2444,11 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(int32(c.animPN) + 1)
 	case OC_ex_attack:
 		sys.bcStack.PushF(c.attackMul[0] * 100)
+	case OC_ex_clsnoverlap:
+		c2 := sys.bcStack.Pop().ToI()
+		id := sys.bcStack.Pop().ToI()
+		c1 := sys.bcStack.Pop().ToI()
+		sys.bcStack.PushB(c.clsnOverlapTrigger(c1, id, c2))
 	case OC_ex_combocount:
 		sys.bcStack.PushI(c.comboCount())
 	case OC_ex_consecutivewins:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -8277,6 +8277,7 @@ type playerPush StateControllerBase
 
 const (
 	playerPush_value byte = iota
+	playerPush_priority
 	playerPush_redirectid
 )
 
@@ -8290,6 +8291,8 @@ func (sc playerPush) Run(c *Char, _ []int32) bool {
 			} else {
 				crun.unsetCSF(CSF_playerpush)
 			}
+		case playerPush_priority:
+			crun.pushPriority = exp[0].evalI(c)
 		case playerPush_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid

--- a/src/char.go
+++ b/src/char.go
@@ -2365,6 +2365,47 @@ func (c *Char) clear1() {
 	c.kovelocity = false
 	c.preserve = 0
 }
+
+func (c *Char) clsnOverlapTrigger(box1, pid, box2 int32) bool {
+
+	getter := sys.playerID(pid)
+
+	// No animations to check
+	if c.curFrame == nil || getter.curFrame == nil {
+		return false
+	}
+
+	var clsn1, clsn2 []float32
+
+	if box1 == 2 {
+		clsn1 = c.curFrame.Clsn2()
+	} else {
+		clsn1 = c.curFrame.Clsn1()
+	}
+
+	if box2 == 1 {
+		clsn2 = getter.curFrame.Clsn1()
+	} else if box2 == 3 {
+		clsn2 = getter.sizeBox
+	} else {
+		clsn2 = getter.curFrame.Clsn2()
+	}
+
+	if clsn1 == nil || clsn2 == nil {
+		return false
+	}
+
+	return sys.clsnOverlap(clsn1, [...]float32{c.clsnScale[0] * c.clsnScaleMul[0] * c.animlocalscl,
+		c.clsnScale[1] * c.clsnScaleMul[1] * c.animlocalscl},
+		[...]float32{c.pos[0]*c.localscl + c.offsetX()*c.localscl,
+			c.pos[1]*c.localscl + c.offsetY()*c.localscl}, c.facing, c.clsnAngle,
+		clsn2, [...]float32{getter.clsnScale[0] * getter.clsnScaleMul[0] * getter.animlocalscl,
+		getter.clsnScale[1] * getter.clsnScaleMul[1] * getter.animlocalscl},
+		[...]float32{getter.pos[0]*getter.localscl + getter.offsetX()*getter.localscl,
+			getter.pos[1]*getter.localscl + getter.offsetY()*getter.localscl}, getter.facing, getter.clsnAngle)
+
+}
+
 func (c *Char) copyParent(p *Char) {
 	c.parentIndex = p.helperIndex
 	c.name, c.key, c.size, c.teamside = p.name+"'s helper", p.key, p.size, p.teamside

--- a/src/char.go
+++ b/src/char.go
@@ -1459,7 +1459,7 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 	// Add sprite to draw list
 	sd := &SprData{e.anim, pfx, [2]float32{e.drawPos[0], e.drawPos[1] + e.drawPos[2]},
 		[...]float32{(facing * scale[0]) * e.localscl * zscale,
-			(e.vfacing * scale[1]) * e.localscl * zscale}, alp, e.sprpriority + int32(e.drawPos[2]), rot, [...]float32{1, 1},
+			(e.vfacing * scale[1]) * e.localscl * zscale}, alp, e.sprpriority + int32(e.pos[2] * e.localscl), rot, [...]float32{1, 1},
 		e.space == Space_screen, playerNo == sys.superplayer, oldVer, facing, 1, int32(e.projection), fLength, ewin}
 	sprs.add(sd)
 	// Add shadow if color is not 0
@@ -1989,7 +1989,7 @@ func (p *Projectile) cueDraw(oldVer bool, playerNo int) {
 		// Add sprite to draw list
 		sd := &SprData{p.ani, p.palfx, [...]float32{p.drawPos[0] * p.localscl, (p.drawPos[1] + p.drawPos[2]) * p.localscl},
 			[...]float32{p.facing * p.scale[0] * p.localscl * zscale, p.scale[1] * p.localscl * zscale}, [2]int32{-1},
-			p.sprpriority + int32(p.pos[2]), Rotation{p.facing * p.angle, 0, 0}, [...]float32{1, 1}, false, playerNo == sys.superplayer,
+			p.sprpriority + int32(p.pos[2] * p.localscl), Rotation{p.facing * p.angle, 0, 0}, [...]float32{1, 1}, false, playerNo == sys.superplayer,
 			sys.cgi[playerNo].mugenver[0] != 1, p.facing, 1, 0, 0, [4]float32{0, 0, 0, 0}}
 		p.aimg.recAndCue(sd, sys.tickNextFrame() && notpause, false, p.layerno)
 		sprs.add(sd)
@@ -7876,7 +7876,7 @@ func (c *Char) cueDraw() {
 		//}
 
 		sd := &SprData{c.anim, c.getPalfx(), pos,
-			scl, c.alpha, c.sprPriority + int32(c.pos[2]), Rotation{agl, 0, 0}, c.angleScale, false,
+			scl, c.alpha, c.sprPriority + int32(c.pos[2] * c.localscl), Rotation{agl, 0, 0}, c.angleScale, false,
 			c.playerNo == sys.superplayer, c.gi().mugenver[0] != 1, c.facing,
 			c.localcoord / sys.chars[c.animPN][0].localcoord, // https://github.com/ikemen-engine/Ikemen-GO/issues/1459 and 1778
 			0, 0, [4]float32{0, 0, 0, 0}}
@@ -9257,8 +9257,11 @@ func (cl *CharList) pushDetection(getter *Char) {
 				gfactor := float32(c.size.weight) / float32(c.size.weight+getter.size.weight) * getter.size.pushfactor * gpushed
 
 				// Determine in which axes to push the players
-				pushx := sys.stage.topbound == sys.stage.botbound || getter.vel[0] != 0 || c.vel[0] != 0
-				pushz := sys.stage.topbound != sys.stage.botbound && (getter.vel[2] != 0 || c.vel[2] != 0)
+				// This needs to check both if the players have velocity or if their positions changed
+				pushx := sys.stage.topbound == sys.stage.botbound ||
+					getter.vel[0] != 0 || c.vel[0] != 0 || getter.pos[0] != getter.oldPos[0] || c.pos[0] != c.oldPos[0]
+				pushz := sys.stage.topbound != sys.stage.botbound &&
+					(getter.vel[2] != 0 || c.vel[2] != 0 || getter.pos[2] != getter.oldPos[2] || c.pos[2] != c.oldPos[2])
 
 				if pushx {
 					tmp := getter.distX(c, getter)

--- a/src/char.go
+++ b/src/char.go
@@ -3536,27 +3536,30 @@ func (c *Char) comboCount() int32 {
 	}
 	return sys.lifebar.co[c.teamside].combo
 }
+
 func (c *Char) command(pn, i int) bool {
 	if !c.keyctrl[0] || c.cmd == nil {
 		return false
 	}
 	cl := c.cmd[pn].At(i)
-	if len(cl) > 0 && c.key < 0 {
-		if c.helperIndex != 0 || len(cl[0].cmd) != 1 || len(cl[0].cmd[0].key) !=
-			1 || int(Btoi(cl[0].cmd[0].slash)) != len(cl[0].hold) {
-			return i == int(c.cpucmd)
-		}
-		if c.helperIndex != 0 {
-			return false
-		}
-	}
+	// Check if any command with that name is buffered
 	for _, c := range cl {
 		if c.curbuftime > 0 {
 			return true
 		}
 	}
+	// AI cheating for commands longer than 1 button
+	if c.key < 0 && len(cl) > 0 {
+		if c.helperIndex != 0 || len(cl[0].cmd) > 1 || len(cl[0].cmd[0].key) > 1 ||
+			int(Btoi(cl[0].cmd[0].slash)) != len(cl[0].hold) {
+			if i == int(c.cpucmd) {
+				return true
+			}
+		}
+	}
 	return false
 }
+
 func (c *Char) commandByName(name string) bool {
 	if c.cmd == nil {
 		return false

--- a/src/char.go
+++ b/src/char.go
@@ -1316,7 +1316,7 @@ func (e *Explod) setPos(c *Char) {
 	// In MUGEN 1.1, there's a bug where, when an explod gets to face left
 	// The engine will leave the sprite facing to that side indefinitely.
 	// Ikemen chars aren't affected by this.
-	if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[0] == 0 && !e.lockSpriteFacing &&
+	if c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[0] == 0 && !e.lockSpriteFacing &&
 		e.facing*e.relativef < 0 {
 		e.lockSpriteFacing = true
 	}
@@ -2070,7 +2070,8 @@ type StateState struct {
 	physics         StateType
 	ps              []int32
 	wakegawakaranai [MaxSimul*2 + MaxAttachedChar][]bool
-	no, prevno      int32
+	no              int32
+	prevno          int32
 	time            int32
 	sb              StateBytecode
 }
@@ -2370,6 +2371,11 @@ func (c *Char) clsnOverlapTrigger(box1, pid, box2 int32) bool {
 
 	getter := sys.playerID(pid)
 
+	// Invalid ID
+	if getter == nil {
+		return false
+	}
+
 	// No animations to check
 	if c.curFrame == nil || getter.curFrame == nil {
 		return false
@@ -2505,20 +2511,6 @@ func (c *Char) gi() *CharGlobalInfo {
 // Return Char Global Info from the state owner
 func (c *Char) stOgi() *CharGlobalInfo {
 	return &sys.cgi[c.ss.sb.playerNo]
-}
-
-// Return Char Global Info according to working state
-// Essentially check it in the character itself during negative states and in the state owner otherwise
-// There was a bug in the default values of DefenceMulSet and Explod when a character threw another character with a different engine version
-// This showed that engine version should always be checked in the player that owns the code
-// So this function was added to replace stOgi() in version checks
-// Version checks should probably be refactored in the future, regardless
-func (c *Char) stWgi() *CharGlobalInfo {
-	if c.minus == 0 {
-		return &sys.cgi[c.ss.sb.playerNo]
-	} else {
-		return &sys.cgi[c.playerNo]
-	}
 }
 
 func (c *Char) ocd() *OverrideCharData {
@@ -3516,7 +3508,7 @@ func (c *Char) backEdgeBodyDist() float32 {
 	// In Mugen, edge body distance is changed when the character is in statetype A or L
 	// This is undocumented and doesn't seem to offer any benefit
 	offset := float32(0)
-	if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
+	if c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
 		if c.ss.stateType == ST_A {
 			offset = 0.5 / c.localscl
 		} else if c.ss.stateType == ST_L {
@@ -3602,7 +3594,7 @@ func (c *Char) frontEdge() float32 {
 func (c *Char) frontEdgeBodyDist() float32 {
 	// See BackEdgeBodyDist
 	offset := float32(0)
-	if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
+	if c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
 		if c.ss.stateType == ST_A {
 			offset = 0.5 / c.localscl
 		} else if c.ss.stateType == ST_L {
@@ -3725,7 +3717,7 @@ func (c *Char) moveReversed() int32 {
 }
 
 // Mugen version trigger
-func (c *Char) mugenVersion() float32 {
+func (c *Char) mugenVersionF() float32 {
 	// Here the version is always checked directly in the character instead of the working state
 	// This is because in a custom state this trigger will be used to know the enemy's version rather than our own
 	if c.gi().ikemenver[0] != 0 || c.gi().ikemenver[1] != 0 {
@@ -4367,7 +4359,7 @@ func (c *Char) stateChange1(no int32, pn int) bool {
 	// due to a MUGEN 1.1 problem where persistent was not getting reset until the end
 	// of a hitpause when attempting to change state during the hitpause.
 	// Ikemenver chars aren't affected by this.
-	if c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
+	if c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0 {
 		c.ss.sb.ctrlsps = make([]int32, len(c.ss.sb.ctrlsps))
 	}
 	c.stchtmp = true
@@ -4377,7 +4369,7 @@ func (c *Char) stateChange2() bool {
 	if c.stchtmp && !c.hitPause() {
 		c.ss.sb.init(c)
 		// Reset persistent counters for this state (MUGEN chars)
-		if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
+		if c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
 			c.ss.sb.ctrlsps = make([]int32, len(c.ss.sb.ctrlsps))
 		}
 		// Flag RemoveOnChangeState explods for removal
@@ -4594,7 +4586,7 @@ func (c *Char) helperInit(h *Char, st int32, pt PosType, x, y, z float32,
 		}
 	}
 	// Mugen 1.1 behavior if invertblend param is omitted(Only if char mugenversion = 1.1)
-	if h.stWgi().mugenver[0] == 1 && h.stWgi().mugenver[1] == 1 && h.stWgi().ikemenver[0] == 0 && h.stWgi().ikemenver[1] == 0 {
+	if h.ss.sb.mugenver[0] == 1 && h.ss.sb.mugenver[1] == 1 && h.ss.sb.ikemenver[0] == 0 && h.ss.sb.ikemenver[1] == 0 {
 		h.palfx.invertblend = -2
 	}
 	h.changeStateEx(st, c.playerNo, 0, 1, "")
@@ -4615,7 +4607,7 @@ func (c *Char) newExplod() (*Explod, int) {
 		expl.layerno = c.layerNo
 		expl.palfx = c.getPalfx()
 		expl.palfxdef = PalFXDef{color: 1, hue: 0, mul: [...]int32{256, 256, 256}}
-		if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
+		if c.ss.sb.mugenver[0] == 1 && c.ss.sb.mugenver[1] == 1 && c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
 			expl.projection = Projection_Perspective
 		} else {
 			expl.projection = Projection_Orthographic
@@ -4970,7 +4962,7 @@ func (c *Char) projInit(p *Projectile, pt PosType, x, y, z float32,
 	if !clsnscale {
 		p.clsnScale = c.clsnScale
 	}
-	if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
+	if c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
 		p.hitdef.chainid = -1
 		p.hitdef.nochainid = [...]int32{-1, -1, -1, -1, -1, -1, -1, -1}
 	}
@@ -5058,7 +5050,7 @@ func (c *Char) setHitdefDefault(hd *HitDef, proj bool) {
 	if hd.attr&int32(ST_A) != 0 {
 		ifnanset(&hd.ground_cornerpush_veloff, 0)
 	} else {
-		if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
+		if c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
 			ifnanset(&hd.ground_cornerpush_veloff, hd.guard_velocity*1.3)
 		} else {
 			ifnanset(&hd.ground_cornerpush_veloff, hd.ground_velocity[0])
@@ -5636,7 +5628,7 @@ func (c *Char) computeDamage(damage float64, kill, absolute bool,
 	// https://github.com/ikemen-engine/Ikemen-GO/issues/1200
 	if !kill && damage >= float64(c.life) {
 		// If a Mugen character attacks a char with 0 life and kill = 0, the attack will actually heal
-		if c.life > 0 || c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
+		if c.life > 0 || c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
 			damage = float64(c.life - 1)
 		}
 	}
@@ -5659,7 +5651,7 @@ func (c *Char) lifeAdd(add float64, kill, absolute bool) {
 	}
 	// Limit value if kill is false
 	if !kill && add <= float64(-c.life) {
-		if c.life > 0 || c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 { // See computeDamage
+		if c.life > 0 || c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 { // See computeDamage
 			add = float64(1 - c.life)
 		}
 	}
@@ -5831,7 +5823,7 @@ func (c *Char) distX(opp *Char, oc *Char) float32 {
 	cpos := c.pos[0] * c.localscl
 	opos := opp.pos[0] * opp.localscl
 	// Update distance while bound. Mugen chars only
-	if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
+	if c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
 		if c.bindToId > 0 && !math.IsNaN(float64(c.bindPos[0])) {
 			if bt := sys.playerID(c.bindToId); bt != nil {
 				f := bt.facing
@@ -5852,7 +5844,7 @@ func (c *Char) distY(opp *Char, oc *Char) float32 {
 	cpos := c.pos[1] * c.localscl
 	opos := opp.pos[1] * opp.localscl
 	// Update distance while bound. Mugen chars only
-	if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
+	if c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
 		if c.bindToId > 0 && !math.IsNaN(float64(c.bindPos[0])) {
 			if bt := sys.playerID(c.bindToId); bt != nil {
 				cpos = bt.pos[1]*bt.localscl + (c.bindPos[1]+c.bindPosAdd[1])*c.localscl
@@ -5890,8 +5882,8 @@ func (c *Char) rdDistX(rd *Char, oc *Char) BytecodeValue {
 		return BytecodeSF()
 	}
 	dist := c.facing * c.distX(rd, oc)
-	if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
-		if c.stWgi().mugenver[0] != 1 {
+	if c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
+		if c.ss.sb.mugenver[0] != 1 {
 			// Before Mugen 1.0, rounding down to the nearest whole number was performed.
 			dist = float32(int32(dist))
 		}
@@ -5903,8 +5895,8 @@ func (c *Char) rdDistY(rd *Char, oc *Char) BytecodeValue {
 		return BytecodeSF()
 	}
 	dist := c.distY(rd, oc)
-	if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
-		if c.stWgi().mugenver[0] != 1 {
+	if c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
+		if c.ss.sb.mugenver[0] != 1 {
 			// Before Mugen 1.0, rounding down to the nearest whole number was performed.
 			dist = float32(int32(dist))
 		}
@@ -5916,7 +5908,7 @@ func (c *Char) p2BodyDistX(oc *Char) BytecodeValue {
 		return BytecodeSF()
 	} else {
 		dist := c.facing * c.bodyDistX(p2, oc)
-		if c.stWgi().mugenver[0] != 1 {
+		if c.ss.sb.mugenver[0] != 1 {
 			dist = float32(int32(dist)) // In the old version, decimal truncation was used
 		}
 		return BytecodeFloat(dist)
@@ -5925,7 +5917,7 @@ func (c *Char) p2BodyDistX(oc *Char) BytecodeValue {
 func (c *Char) p2BodyDistY(oc *Char) BytecodeValue {
 	if p2 := c.p2(); p2 == nil {
 		return BytecodeSF()
-	} else if oc.stWgi().ikemenver[0] == 0 && oc.stWgi().ikemenver[1] == 0 {
+	} else if oc.ss.sb.ikemenver[0] == 0 && oc.ss.sb.ikemenver[1] == 0 {
 		return c.rdDistY(c.p2(), oc) // In Mugen, P2BodyDist Y simply does the same as P2Dist Y
 	} else {
 		return BytecodeFloat(c.bodyDistY(p2, oc))
@@ -5985,7 +5977,7 @@ func (c *Char) getPalfx() *PalFX {
 	}
 	c.palfx = newPalFX()
 	// Mugen 1.1 behavior if invertblend param is omitted(Only if char mugenversion = 1.1)
-	if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 && c.palfx != nil {
+	if c.ss.sb.mugenver[0] == 1 && c.ss.sb.mugenver[1] == 1 && c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 && c.palfx != nil {
 		c.palfx.PalFXDef.invertblend = -2
 	}
 	return c.palfx
@@ -6431,7 +6423,7 @@ func (c *Char) posUpdate() {
 					c.mhv.cornerpush = c.cornerVelOff
 				}
 				// In Ikemen the cornerpush friction is defined by the target instead
-				if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
+				if c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
 					friction = 0.7
 				} else {
 					if p[0].ss.stateType == ST_C || p[0].ss.stateType == ST_L {
@@ -7057,7 +7049,7 @@ func (c *Char) actionPrepare() {
 		// This flag is special in that it must always reset regardless of hitpause
 		c.unsetASF(ASF_animatehitpause)
 		// In WinMugen all of these flags persisted during hitpause
-		if !c.hitPause() || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 || c.stWgi().mugenver[0] == 1 {
+		if !c.hitPause() || c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0 || c.ss.sb.mugenver[0] == 1 {
 			c.unsetCSF(CSF_angledraw | CSF_trans)
 			c.angleScale = [...]float32{1, 1}
 			c.offset = [2]float32{}
@@ -8438,7 +8430,7 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 						ghv.down_recovertime = hd.down_recovertime
 					}
 					// This compensates for characters being able to guard one frame sooner in Ikemen than in Mugen
-					if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
+					if c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
 						ghv.hittime += 1
 					}
 				}

--- a/src/char.go
+++ b/src/char.go
@@ -8315,6 +8315,7 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 				pwr, hpwr, gpwr := ghv.power, ghv.hitpower, ghv.guardpower
 				dpnt, gpnt := ghv.dizzypoints, ghv.guardpoints
 				fall, hc, gc, fc, by := ghv.fallflag, ghv.hitcount, ghv.guardcount, ghv.fallcount, ghv.hitBy
+				drec := ghv.down_recovertime
 				kill := ghv.kill
 				cheese := ghv.cheeseKO
 				// Clear variables
@@ -8330,6 +8331,7 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 				ghv.guardpower = gpwr
 				ghv.dizzypoints = dpnt
 				ghv.guardpoints = gpnt
+				ghv.down_recovertime = drec
 				ghv.kill = kill
 				ghv.cheeseKO = cheese
 				// Update variables
@@ -8432,10 +8434,17 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 					ghv.fallcount = fc
 					ghv.fallflag = ghv.fallflag || fall // If falling now or before the hit
 					ghv.down_recover = hd.down_recover
-					if hd.down_recovertime < 0 {
-						ghv.down_recovertime = getter.gi().data.liedown.time
+					// Down recovery time
+					// When the char is already down this can't normally be increased
+					// https://github.com/ikemen-engine/Ikemen-GO/issues/2026
+					if hd.down_recovertime < 0 { // Default to char constant
+						if ghv.down_recovertime > getter.gi().data.liedown.time || getter.ss.stateType != ST_L {
+							ghv.down_recovertime = getter.gi().data.liedown.time
+						}
 					} else {
-						ghv.down_recovertime = hd.down_recovertime
+						if ghv.down_recovertime > hd.down_recovertime || getter.ss.stateType != ST_L {
+							ghv.down_recovertime = hd.down_recovertime
+						}
 					}
 					// This compensates for characters being able to guard one frame sooner in Ikemen than in Mugen
 					if c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -5119,7 +5119,7 @@ func cnsStringArray(arg string) ([]string, error) {
 
 // Compile a state file
 func (c *Compiler) stateCompile(states map[int32]StateBytecode,
-	filename string, dirs []string, negoverride bool, constants map[string]float32) error {
+	filename string, dirs []string, constants map[string]float32, iscommon bool) error {
 	var str string
 	zss := HasExtension(filename, ".zss")
 	fnz := filename
@@ -5133,7 +5133,7 @@ func (c *Compiler) stateCompile(states map[int32]StateBytecode,
 				return err
 			}
 			str = string(b)
-			return c.stateCompileZ(states, fnz, str, constants)
+			return c.stateCompileZ(states, fnz, str, constants, iscommon)
 		}
 
 		// Try reading as an st file
@@ -5150,7 +5150,7 @@ func (c *Compiler) stateCompile(states map[int32]StateBytecode,
 			str = string(b)
 			return nil
 		}); err == nil {
-			return c.stateCompileZ(states, fnz, str, constants)
+			return c.stateCompileZ(states, fnz, str, constants, iscommon)
 		}
 		return err
 	}
@@ -5193,6 +5193,7 @@ func (c *Compiler) stateCompile(states map[int32]StateBytecode,
 			return errmes(err)
 		}
 		sbc := newStateBytecode(c.playerNo)
+
 		if _, ok := states[c.stateNo]; ok && c.stateNo < 0 {
 			*sbc = states[c.stateNo]
 		}
@@ -5200,6 +5201,9 @@ func (c *Compiler) stateCompile(states map[int32]StateBytecode,
 		if err := c.stateDef(is, sbc); err != nil {
 			return errmes(err)
 		}
+
+		// Set state engine version
+		c.stateEngineVersion(sbc, iscommon)
 
 		// Continue looping through state file lines to define the current state
 		for c.i++; c.i < len(c.lines); c.i++ {
@@ -5432,7 +5436,9 @@ func (c *Compiler) stateCompile(states map[int32]StateBytecode,
 			}
 		}
 
-		// Skip appending if already declared. Exception for negative states present in CommonStates and files belonging to char flagged with ikemenversion
+		// Skip appending if already declared
+		// Exception for negative states present in CommonStates and files belonging to chars flagged with ikemenversion
+		negoverride := !iscommon && sys.cgi[c.playerNo].ikemenver[0] == 0 && sys.cgi[c.playerNo].ikemenver[1] == 0
 		if _, ok := states[c.stateNo]; !ok || (!negoverride && c.stateNo < 0) {
 			states[c.stateNo] = *sbc
 		}
@@ -6257,7 +6263,7 @@ func (c *Compiler) stateBlock(line *string, bl *StateBlock, root bool,
 	return c.wrongClosureToken()
 }
 func (c *Compiler) stateCompileZ(states map[int32]StateBytecode,
-	filename, src string, constants map[string]float32) error {
+	filename, src string, constants map[string]float32, iscommon bool) error {
 	defer func(oime bool) {
 		sys.ignoreMostErrors = oime
 	}(sys.ignoreMostErrors)
@@ -6352,6 +6358,10 @@ func (c *Compiler) stateCompileZ(states map[int32]StateBytecode,
 			if _, ok := states[c.stateNo]; ok && c.stateNo < 0 {
 				*sbc = states[c.stateNo]
 			}
+
+			// Set state engine version
+			c.stateEngineVersion(sbc, iscommon)
+
 			c.vars = make(map[string]uint8)
 			if err := c.stateDef(is, sbc); err != nil {
 				return errmes(err)
@@ -6427,6 +6437,19 @@ func (c *Compiler) stateCompileZ(states map[int32]StateBytecode,
 		}
 	}
 	return nil
+}
+
+// Note: This block should be updated to use current Ikemen version in common states
+// TODO: Make current version check automatic
+// NOTE: Maybe local scale could be defined by the state itself as well
+func (c *Compiler) stateEngineVersion(sbc *StateBytecode, iscommon bool) {
+	if iscommon {
+		sbc.ikemenver = [3]uint16{1, 0, 0} // Use current Ikemen version
+		sbc.mugenver = [2]uint16{1, 1} // Just in case
+	} else {
+		sbc.ikemenver = sys.cgi[c.playerNo].ikemenver
+		sbc.mugenver = sys.cgi[c.playerNo].mugenver
+	}
 }
 
 // Compile a character definition file
@@ -6640,33 +6663,27 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 	// Compile state files
 	for _, s := range st {
 		if len(s) > 0 {
-			if err := c.stateCompile(states, s, []string{def, "", sys.motifDir, "data/"},
-				sys.cgi[pn].ikemenver[0] == 0 &&
-					sys.cgi[pn].ikemenver[1] == 0, constants); err != nil {
+			if err := c.stateCompile(states, s, []string{def, "", sys.motifDir, "data/"}, constants, false); err != nil {
 				return nil, err
 			}
 		}
 	}
 	// Compile states in command file
 	if len(cmd) > 0 {
-		if err := c.stateCompile(states, cmd, []string{def, "", sys.motifDir, "data/"},
-			sys.cgi[pn].ikemenver[0] == 0 &&
-				sys.cgi[pn].ikemenver[1] == 0, constants); err != nil {
+		if err := c.stateCompile(states, cmd, []string{def, "", sys.motifDir, "data/"}, constants, false); err != nil {
 			return nil, err
 		}
 	}
 	// Compile states in stcommon state file
+	// These use the character's own engine version, unlike common state files
 	if len(stcommon) > 0 {
-		if err := c.stateCompile(states, stcommon, []string{def, "", sys.motifDir, "data/"},
-			sys.cgi[pn].ikemenver[0] == 0 &&
-				sys.cgi[pn].ikemenver[1] == 0, constants); err != nil {
+		if err := c.stateCompile(states, stcommon, []string{def, "", sys.motifDir, "data/"}, constants, false); err != nil {
 			return nil, err
 		}
 	}
 	// Compile common states
 	for _, s := range sys.commonStates {
-		if err := c.stateCompile(states, s, []string{def, sys.motifDir, sys.lifebar.def, "", "data/"},
-			false, constants); err != nil {
+		if err := c.stateCompile(states, s, []string{def, sys.motifDir, sys.lifebar.def, "", "data/"}, constants, true); err != nil {
 			return nil, err
 		}
 	}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -3690,10 +3690,6 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nointroreset))
 		case "sizepushonly":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_sizepushonly))
-		case "immovable":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_immovable))
-		case "cornerpriority":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_cornerpriority))
 		case "drawunder":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_drawunder))
 		case "runfirst":
@@ -4656,6 +4652,8 @@ func (c *Compiler) scAdd(sc *StateControllerBase, id byte,
 	sc.add(id, append(topbe, bes...))
 	return nil
 }
+
+// ParamValue adds the parameter immediately, unlike StateParam which only reads it
 func (c *Compiler) paramValue(is IniSection, sc *StateControllerBase,
 	paramname string, id byte, vt ValueType, numArg int, mandatory bool) error {
 	found := false
@@ -4670,6 +4668,7 @@ func (c *Compiler) paramValue(is IniSection, sc *StateControllerBase,
 	}
 	return nil
 }
+
 func (c *Compiler) paramPostype(is IniSection, sc *StateControllerBase,
 	id byte) error {
 	return c.stateParam(is, "postype", false, func(data string) error {

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -202,12 +202,8 @@ func (c *Compiler) assertSpecial(is IniSection, sc *StateControllerBase, _ int8)
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nointroreset)))
 			case "sizepushonly":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_sizepushonly)))
-			case "immovable":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_immovable)))
 			case "animatehitpause":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_animatehitpause)))
-			case "cornerpriority":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_cornerpriority)))
 			case "drawunder":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_drawunder)))
 			case "runfirst":
@@ -246,7 +242,7 @@ func (c *Compiler) assertSpecial(is IniSection, sc *StateControllerBase, _ int8)
 			return err
 		}
 		if !f {
-			return Error("flag parameter not specified")
+			return Error("AssertSpecial flags not specified")
 		}
 		if err := c.stateParam(is, "flag2", false, func(data string) error {
 			return foo(data)
@@ -598,15 +594,15 @@ func (c *Compiler) helper(is IniSection, sc *StateControllerBase, _ int8) (State
 			helper_size_shadowoffset, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.paramValue(is, sc, "z.width",
+		if err := c.paramValue(is, sc, "size.z.width",
 			helper_size_z_width, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.paramValue(is, sc, "weight",
+		if err := c.paramValue(is, sc, "size.weight",
 			helper_size_weight, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.paramValue(is, sc, "pushfactor",
+		if err := c.paramValue(is, sc, "size.pushfactor",
 			helper_size_pushfactor, VT_Float, 1, false); err != nil {
 			return err
 		}
@@ -1972,7 +1968,7 @@ func (c *Compiler) reversalDef(is IniSection, sc *StateControllerBase, _ int8) (
 			return err
 		}
 		if attr == -1 {
-			return Error("reversal.attr parameter not specified")
+			return Error("ReversalDef reversal.attr not specified")
 		}
 		sc.add(reversalDef_reversal_attr, sc.iToExp(attr))
 		return c.hitDefSub(is, sc)
@@ -2431,7 +2427,7 @@ func (c *Compiler) varSetSub(is IniSection,
 	if b {
 		return nil
 	}
-	return Error("value parameter not specified")
+	return Error("Value parameter not specified")
 }
 func (c *Compiler) varSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*varSet)(sc), c.stateSec(is, func() error {
@@ -3025,10 +3021,21 @@ func (c *Compiler) playerPush(is IniSection, sc *StateControllerBase, _ int8) (S
 			playerPush_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "value", true, func(data string) error {
+		any := false
+		if err := c.stateParam(is, "value", false, func(data string) error {
+			any = true
 			return c.scAdd(sc, playerPush_value, data, VT_Bool, 1)
 		}); err != nil {
 			return err
+		}
+		if err := c.stateParam(is, "priority", false, func(data string) error {
+			any = true
+			return c.scAdd(sc, playerPush_priority, data, VT_Int, 1)
+		}); err != nil {
+			return err
+		}
+		if !any {
+			return Error("Must specify at least one PlayerPush parameter")
 		}
 		return nil
 	})
@@ -3188,7 +3195,7 @@ func (c *Compiler) envColor(is IniSection, sc *StateControllerBase, _ int8) (Sta
 				return err
 			}
 			if len(bes) < 3 {
-				return Error("value - not enough arguments")
+				return Error("Value - not enough arguments")
 			}
 			sc.add(envColor_value, bes)
 			return nil
@@ -3246,7 +3253,7 @@ func (c *Compiler) displayToClipboardSub(is IniSection,
 		return err
 	}
 	if !b {
-		return Error("text parameter not specified")
+		return Error("Text parameter not specified")
 	}
 	return nil
 }
@@ -3359,7 +3366,7 @@ func (c *Compiler) attackMulSet(is IniSection, sc *StateControllerBase, _ int8) 
 			return err
 		}
 		if !any {
-			return Error("no multipliers specified")
+			return Error("Must specify at least one AttackMulSet multiplier")
 		}
 		return nil
 	})
@@ -3504,7 +3511,7 @@ func (c *Compiler) varRangeSet(is IniSection, sc *StateControllerBase, _ int8) (
 				return err
 			}
 			if !b {
-				return Error("value parameter not specified")
+				return Error("Value parameter not specified")
 			}
 		}
 		return nil
@@ -3869,7 +3876,7 @@ func (c *Compiler) assertInput(is IniSection, sc *StateControllerBase, _ int8) (
 			return err
 		}
 		if !f {
-			return Error("flag parameter not specified")
+			return Error("No AssertInput flags specified")
 		}
 		if err := c.stateParam(is, "flag2", false, func(data string) error {
 			return foo(data)
@@ -5523,7 +5530,7 @@ func (c *Compiler) transformClsn(is IniSection, sc *StateControllerBase, _ int8)
 			return err
 		}
 		if !any {
-			return Error("no parameters specified")
+			return Error("Must specify at least one TransformClsn parameter")
 		}
 		return nil
 	})

--- a/src/input.go
+++ b/src/input.go
@@ -1875,11 +1875,11 @@ func ReadCommand(name, cmdstr string, kr *CommandKeyRemap) (*Command, error) {
 	return c, nil
 }
 
-func (c *Command) Clear(buf bool) {
+func (c *Command) Clear(bufreset bool) {
 	c.cmdi = 0
 	c.chargei = -1
 	c.curtime = 0
-	if !buf { // Otherwise keep buffer time. Mugen doesn't do this but it seems like the right thing to do
+	if bufreset {
 		c.curbuftime = 0
 	}
 	for i := range c.held {
@@ -2178,7 +2178,7 @@ func (cl *CommandList) ClearName(name string) {
 	for i := range cl.Commands {
 		for j := range cl.Commands[i] {
 			if !cl.Commands[i][j].completeflag && cl.Commands[i][j].name == name {
-				cl.Commands[i][j].Clear(true)
+				cl.Commands[i][j].Clear(false) // Keep their buffer time. Mugen doesn't do this but it seems like the right thing to do
 			}
 		}
 	}
@@ -2211,7 +2211,7 @@ func (cl *CommandList) BufReset() {
 		cl.Buffer.Reset()
 		for i := range cl.Commands {
 			for j := range cl.Commands[i] {
-				cl.Commands[i][j].Clear(false)
+				cl.Commands[i][j].Clear(true)
 			}
 		}
 	}

--- a/src/script.go
+++ b/src/script.go
@@ -4954,7 +4954,7 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "mugenversion", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.mugenVersion()))
+		l.Push(lua.LNumber(sys.debugWC.mugenVersionF()))
 		return 1
 	})
 	luaRegister(l, "numplayer", func(*lua.LState) int {

--- a/src/script.go
+++ b/src/script.go
@@ -4851,12 +4851,8 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_nointroreset)))
 		case "sizepushonly":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_sizepushonly)))
-		case "immovable":
-			l.Push(lua.LBool(sys.debugWC.asf(ASF_immovable)))
 		case "animatehitpause":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_animatehitpause)))
-		case "cornerpriority":
-			l.Push(lua.LBool(sys.debugWC.asf(ASF_cornerpriority)))
 		case "drawunder":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_drawunder)))
 		case "runfirst":


### PR DESCRIPTION
Feat:
- PlayerPush now accepts a priority parameter. A player with higher priority can't be pushed by a player with lower priority
- This makes AssertSpecial flags CornerPriority and Immovable obsolete, so they have been removed
- ClsnOverlap trigger. Returns true if a specific type of box is overlapping a specific player

Refactor:
- Code execution will now check the engine version of the state being run rather than the characters'
- Common states enforce Ikemenversion = current version
- This refactor is significant so char compatibility between versions should be monitored

Fix:
- Made X or Z axis player push decision also check if char positions have changed, rather than simply if they have any velocity
- Stage window parameter should work a bit better now. Still not entirely fixed but should be more usable
- Setting a helper to "preserve" between rounds allowed other helpers to reuse its ID. Now a check is run to see if the ID is already being used
- When the char is already down, down recovery time can be decreased but not increased
- Fixes #2026
- Fixed conflict where AI cheating would prevent asserting commands longer than one button from working

Dizzy and Guard Break:
- Getting hit (not blocking) no longer prevents guard points from recovering
- Conversely, blocking (not getting hit) no longer prevents dizzy points from recovering
- Players now use their own falling down states when entering the dizzy status
- Full screen backgrounds replaced with BGPalFX
- Some changes may require merging https://github.com/ikemen-engine/Ikemen_GO-Elecbyte-Screenpack/pull/22