### PR TITLE
fix: explodVar positions, misc. sound related fixes

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -3790,11 +3790,11 @@ func (c *Char) explodVar(eid BytecodeValue, idx BytecodeValue, vtype OpCode) Byt
 			case OC_ex2_explodvar_animelem:
 				v = BytecodeInt(e.anim.current + 1)
 			case OC_ex2_explodvar_pos_x:
-				v = BytecodeFloat(e.drawPos[0])
+				v = BytecodeFloat(e.pos[0] + e.offset[0] + e.relativePos[0] + e.interpolate_pos[0])
 			case OC_ex2_explodvar_pos_y:
-				v = BytecodeFloat(e.drawPos[1])
+				v = BytecodeFloat(e.pos[1] + e.offset[1] + e.relativePos[1] + e.interpolate_pos[1])
 			case OC_ex2_explodvar_pos_z:
-				v = BytecodeFloat(e.drawPos[2])
+				v = BytecodeFloat(e.pos[2] + e.offset[2] + e.relativePos[2] + e.interpolate_pos[2])
 			case OC_ex2_explodvar_scale_x:
 				v = BytecodeFloat(e.scale[0])
 			case OC_ex2_explodvar_scale_y:

--- a/src/script.go
+++ b/src/script.go
@@ -3282,11 +3282,11 @@ func triggerFunctions(l *lua.LState) {
 				case "animelem":
 					ln = lua.LNumber(e.anim.current + 1)
 				case "pos x":
-					ln = lua.LNumber(e.drawPos[0])
+					ln = lua.LNumber(e.pos[0] + e.offset[0] + e.relativePos[0] + e.interpolate_pos[0])
 				case "pos y":
-					ln = lua.LNumber(e.drawPos[1])
+					ln = lua.LNumber(e.pos[1] + e.offset[1] + e.relativePos[1] + e.interpolate_pos[1])
 				case "pos z":
-					ln = lua.LNumber(e.drawPos[2])
+					ln = lua.LNumber(e.pos[2] + e.offset[2] + e.relativePos[2] + e.interpolate_pos[2])
 				case "vel x":
 					ln = lua.LNumber(e.velocity[0])
 				case "vel y":

--- a/src/sound.go
+++ b/src/sound.go
@@ -105,7 +105,7 @@ func newStreamLooper(s beep.StreamSeeker, loopcount, loopstart, loopend int) bee
 	if sl.loopstart < 0 || sl.loopstart >= s.Len() {
 		sl.loopstart = 0
 	}
-	if sl.loopend <= sl.loopstart {
+	if sl.loopend <= sl.loopstart || sl.loopend >= s.Len() {
 		sl.loopend = s.Len()
 	}
 	return sl


### PR DESCRIPTION
fixes:
* explodVar positions
* modifySnd loop count off by 1 error because of switching to new Loop2 base for StreamLooper
* made it so "stage" special case for playBGM recalls most original parameters (except loop and loopcount)
* fixed StreamLooper not defaulting to stream length when a longer length is passed in