### PR TITLE
fix: size box hit detection, modify helper, revert state version check

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1505,7 +1505,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 				pno := c.playerNo
 				// For a Mugen character, the command position is checked in the redirecting char
 				// Recovery command is an exception in that its position is always checked in the final char
-				if cmdName != "recovery" && oc.ss.sb.ikemenver[0] == 0 && oc.ss.sb.ikemenver[1] == 0 {
+				if cmdName != "recovery" && oc.stWgi().ikemenver[0] == 0 && oc.stWgi().ikemenver[1] == 0 {
 					redir = oc.ss.sb.playerNo
 					pno = c.ss.sb.playerNo
 				}
@@ -1526,7 +1526,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushI(int32(c.frontEdgeDist() * (c.localscl / oc.localscl)))
 		case OC_gameheight:
 			// Optional exception preventing GameHeight from being affected by stage zoom.
-			if c.ss.sb.mugenver[0] == 1 && c.ss.sb.mugenver[1] == 0 &&
+			if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 0 &&
 				c.gi().constants["default.legacygamedistancespec"] == 1 {
 				sys.bcStack.PushF(c.screenHeight())
 			} else {
@@ -1544,7 +1544,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushI(sys.gameTime + pfTime)
 		case OC_gamewidth:
 			// Optional exception preventing GameWidth from being affected by stage zoom.
-			if c.ss.sb.mugenver[0] == 1 && c.ss.sb.mugenver[1] == 0 &&
+			if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 0 &&
 				c.gi().constants["default.legacygamedistancespec"] == 1 {
 				sys.bcStack.PushF(c.screenWidth())
 			} else {
@@ -1608,7 +1608,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushI(c.palno())
 		case OC_pos_x:
 			var bindVelx float32
-			if c.bindToId > 0 && !math.IsNaN(float64(c.bindPos[0])) && c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
+			if c.bindToId > 0 && !math.IsNaN(float64(c.bindPos[0])) && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
 				if sys.playerID(c.bindToId) != nil {
 					bindVelx = c.vel[0]
 				}
@@ -1616,7 +1616,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushF(((c.pos[0]+bindVelx)*(c.localscl/oc.localscl) - sys.cam.Pos[0]/oc.localscl))
 		case OC_pos_y:
 			var bindVely float32
-			if c.bindToId > 0 && !math.IsNaN(float64(c.bindPos[1])) && c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
+			if c.bindToId > 0 && !math.IsNaN(float64(c.bindPos[1])) && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
 				if sys.playerID(c.bindToId) != nil {
 					bindVely = c.vel[1]
 				}
@@ -3736,7 +3736,7 @@ func (sc assertSpecial) Run(c *Char, _ []int32) bool {
 			sys.setGSF(GlobalSpecialFlag(exp[0].evalI(c)))
 		case assertSpecial_noko:
 			// NoKO affects all characters in Mugen, so legacy chars do so as well
-			if c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
+			if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
 				sys.setGSF(GlobalSpecialFlag(GSF_globalnoko))
 			} else {
 				crun.setASF(AssertSpecialFlag(ASF_noko))
@@ -4751,7 +4751,7 @@ func (sc palFX) Run(c *Char, _ []int32) bool {
 			}
 			pf.clear2(true)
 			// Mugen 1.1 behavior if invertblend param is omitted (Only if char mugenversion = 1.1)
-			if c.ss.sb.mugenver[0] == 1 && c.ss.sb.mugenver[1] == 1 && c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
+			if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
 				pf.invertblend = -2
 			}
 			doOnce = true
@@ -4875,7 +4875,7 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 				e.id = 0
 			}
 			// Mugenversion 1.1 chars default postype to "None"
-			if c.ss.sb.mugenver[0] == 1 && c.ss.sb.mugenver[1] == 1 {
+			if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 {
 				e.postype = PT_None
 			}
 		}
@@ -5059,7 +5059,7 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 		case explod_window:
 			e.window = [4]float32{exp[0].evalF(c) * lclscround, exp[1].evalF(c) * lclscround, exp[2].evalF(c) * lclscround, exp[3].evalF(c) * lclscround}
 		default:
-			if c.ss.sb.mugenver[0] == 1 && c.ss.sb.mugenver[1] == 1 && c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
+			if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
 				e.palfxdef.invertblend = -2
 			}
 			palFX(sc).runSub(c, &e.palfxdef, id, exp)
@@ -5224,7 +5224,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				if exp[0].evalI(c) < 0 {
 					f = -1
 				}
-				if (c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0) && !ptexists {
+				if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
 					eachExpl(func(e *Explod) {
 						e.relativef = f
 					})
@@ -5233,24 +5233,24 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				if exp[0].evalI(c) < 0 {
 					vf = -1
 				}
-				if (c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0) && !ptexists {
+				if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
 					eachExpl(func(e *Explod) {
 						e.vfacing = vf
 					})
 				}
 			case explod_pos:
 				pos[0] = exp[0].evalF(c) * lclscround
-				if (c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0) && !ptexists {
+				if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
 					eachExpl(func(e *Explod) { e.relativePos[0] = pos[0] })
 				}
 				if len(exp) > 1 {
 					pos[1] = exp[1].evalF(c) * lclscround
-					if (c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0) && !ptexists {
+					if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
 						eachExpl(func(e *Explod) { e.relativePos[1] = pos[1] })
 					}
 					if len(exp) > 2 {
 						pos[2] = exp[2].evalF(c) * lclscround
-						if (c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0) && !ptexists {
+						if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
 							eachExpl(func(e *Explod) { e.relativePos[2] = pos[2] })
 						}
 					}
@@ -5259,62 +5259,62 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				rndx := (exp[0].evalF(c) / 2) * lclscround
 				rndx = RandF(-rndx, rndx)
 				pos[0] += rndx
-				if (c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0) && !ptexists {
+				if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
 					eachExpl(func(e *Explod) { e.relativePos[0] += rndx })
 				}
 				if len(exp) > 1 {
 					rndy := (exp[1].evalF(c) / 2) * lclscround
 					rndy = RandF(-rndy, rndy)
 					pos[1] += rndy
-					if (c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0) && !ptexists {
+					if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
 						eachExpl(func(e *Explod) { e.relativePos[1] += rndy })
 					}
 					if len(exp) > 2 {
 						rndz := (exp[2].evalF(c) / 2) * lclscround
 						rndz = RandF(-rndz, rndz)
 						pos[2] += rndz
-						if (c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0) && !ptexists {
+						if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
 							eachExpl(func(e *Explod) { e.relativePos[2] += rndz })
 						}
 					}
 				}
 			case explod_velocity:
 				vel[0] = exp[0].evalF(c) * lclscround
-				if (c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0) && !ptexists {
+				if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
 					eachExpl(func(e *Explod) { e.velocity[0] = vel[0] })
 				}
 				if len(exp) > 1 {
 					vel[1] = exp[1].evalF(c) * lclscround
-					if (c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0) && !ptexists {
+					if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
 						eachExpl(func(e *Explod) { e.velocity[1] = vel[1] })
 					}
 					if len(exp) > 2 {
 						vel[2] = exp[2].evalF(c) * lclscround
-						if (c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0) && !ptexists {
+						if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
 							eachExpl(func(e *Explod) { e.velocity[2] = vel[2] })
 						}
 					}
 				}
 			case explod_accel:
 				accel[0] = exp[0].evalF(c) * lclscround
-				if (c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0) && !ptexists {
+				if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
 					eachExpl(func(e *Explod) { e.accel[0] = accel[0] })
 				}
 				if len(exp) > 1 {
 					accel[1] = exp[1].evalF(c) * lclscround
-					if (c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0) && !ptexists {
+					if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
 						eachExpl(func(e *Explod) { e.accel[1] = accel[1] })
 					}
 					if len(exp) > 2 {
 						accel[2] = exp[2].evalF(c) * lclscround
-						if (c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0) && !ptexists {
+						if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
 							eachExpl(func(e *Explod) { e.accel[2] = accel[2] })
 						}
 					}
 				}
 			case explod_space:
 				sp = Space(exp[0].evalI(c))
-				if (c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0) && !ptexists {
+				if (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) && !ptexists {
 					eachExpl(func(e *Explod) { e.space = sp })
 				}
 			case explod_postype:
@@ -5344,7 +5344,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				eachExpl(func(e *Explod) {
 					e.bindtime = t
 					// Bindtime fix (update bindtime according to current explod time)
-					if (crun.ss.sb.ikemenver[0] > 0 || crun.ss.sb.ikemenver[1] > 0) && t > 0 {
+					if (crun.stWgi().ikemenver[0] > 0 || crun.stWgi().ikemenver[1] > 0) && t > 0 {
 						e.bindtime = e.time + t
 					}
 					e.setX(e.pos[0])
@@ -5356,7 +5356,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				eachExpl(func(e *Explod) {
 					e.removetime = t
 					// Removetime fix (update removetime according to current explod time)
-					if (crun.ss.sb.ikemenver[0] > 0 || crun.ss.sb.ikemenver[1] > 0) && t > 0 {
+					if (crun.stWgi().ikemenver[0] > 0 || crun.stWgi().ikemenver[1] > 0) && t > 0 {
 						e.removetime = e.time + t
 					}
 				})
@@ -5371,7 +5371,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				eachExpl(func(e *Explod) {
 					e.supermovetime = t
 					// Supermovetime fix (update supermovetime according to current explod time)
-					if (crun.ss.sb.ikemenver[0] > 0 || crun.ss.sb.ikemenver[1] > 0) && t > 0 {
+					if (crun.stWgi().ikemenver[0] > 0 || crun.stWgi().ikemenver[1] > 0) && t > 0 {
 						e.supermovetime = e.time + t
 					}
 				})
@@ -5380,7 +5380,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				eachExpl(func(e *Explod) {
 					e.pausemovetime = t
 					// Pausemovetime fix (update pausemovetime according to current explod time)
-					if (crun.ss.sb.ikemenver[0] > 0 || crun.ss.sb.ikemenver[1] > 0) && t > 0 {
+					if (crun.stWgi().ikemenver[0] > 0 || crun.stWgi().ikemenver[1] > 0) && t > 0 {
 						e.pausemovetime = e.time + t
 					}
 				})
@@ -5467,7 +5467,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 					e.blendmode = int32(blendmode)
 				})
 			case explod_anim:
-				if c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0 {
+				if c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
 					animNo := exp[1].evalI(c)
 					anim := crun.getAnim(animNo, string(*(*[]byte)(unsafe.Pointer(&exp[0]))), true)
 					eachExpl(func(e *Explod) {
@@ -5504,7 +5504,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 					e.window = [4]float32{exp[0].evalF(c) * lclscround, exp[1].evalF(c) * lclscround, exp[2].evalF(c) * lclscround, exp[3].evalF(c) * lclscround}
 				})
 			case explod_ignorehitpause:
-				if c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0 {
+				if c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
 					ihp := exp[0].evalB(c)
 					eachExpl(func(e *Explod) { e.ignorehitpause = ihp })
 				}
@@ -5515,7 +5515,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				}
 				eachExpl(func(e *Explod) { e.setBind(bId) })
 			case explod_interpolation:
-				if c.ss.sb.ikemenver[0] != 0 || c.ss.sb.ikemenver[1] != 0 {
+				if c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
 					interpolation := exp[0].evalB(c)
 					eachExpl(func(e *Explod) {
 						if e.interpolate != interpolation && e.interpolate_time[0] > 0 {
@@ -5726,7 +5726,7 @@ func (sc afterImage) Run(c *Char, _ []int32) bool {
 		if !doOnce {
 			crun.aimg.clear()
 			// Mugen 1.1 behavior if invertblend param is omitted (Only if char mugenversion = 1.1)
-			if c.ss.sb.mugenver[0] == 1 && c.ss.sb.mugenver[1] == 1 && c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
+			if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
 				crun.aimg.palfx[0].invertblend = -2
 			}
 			crun.aimg.time = 1
@@ -6206,7 +6206,7 @@ func (sc hitDef) Run(c *Char, _ []int32) bool {
 			}
 		}
 		// Mugen 1.1 behavior if invertblend param is omitted (Only if char mugenversion = 1.1)
-		if c.ss.sb.mugenver[0] == 1 && c.ss.sb.mugenver[1] == 1 && c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
+		if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
 			crun.hitdef.palfx.invertblend = -2
 		}
 		sc.runSub(c, &crun.hitdef, id, exp)
@@ -7816,7 +7816,7 @@ func (sc lifeAdd) Run(c *Char, _ []int32) bool {
 		case lifeAdd_value:
 			v := exp[0].evalI(c)
 			// Mugen forces absolute parameter when healing characters
-			if v > 0 && c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
+			if v > 0 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
 				a = true
 			}
 			crun.lifeAdd(float64(v), k, a)
@@ -8711,7 +8711,7 @@ func (sc defenceMulSet) Run(c *Char, _ []int32) bool {
 	var mulType int32 = 1
 
 	// Change default behavior for Mugen chars
-	if c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
+	if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
 		onHit = true
 		mulType = 0
 	}
@@ -10823,7 +10823,7 @@ func (sc targetRedLifeAdd) Run(c *Char, _ []int32) bool {
 			}
 			v := exp[0].evalI(c)
 			// Mugen forces absolute parameter when healing characters
-			if v > 0 && c.ss.sb.ikemenver[0] == 0 && c.ss.sb.ikemenver[1] == 0 {
+			if v > 0 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
 				a = true
 			}
 			crun.targetRedLifeAdd(tar, exp[0].evalI(c), a)
@@ -11639,8 +11639,6 @@ type StateBytecode struct {
 	block     StateBlock
 	ctrlsps   []int32
 	numVars   int32
-	ikemenver [3]uint16
-	mugenver  [2]uint16
 }
 
 // StateDef bytecode creation function

--- a/src/char.go
+++ b/src/char.go
@@ -2478,11 +2478,20 @@ func (c *Char) stOgi() *CharGlobalInfo {
 }
 
 func (c *Char) ocd() *OverrideCharData {
+	team := c.teamside
 	if c.teamside == -1 {
-		return &sys.sel.ocd[2][c.memberNo]
+		team = 2
 	}
-	return &sys.sel.ocd[c.teamside][c.memberNo]
+	// This check prevents a crash when modifying helpers to be teamside 0
+	// This happens because OverrideCharData is indexed by teamside
+	// TODO: Perhaps ModifyPlayer or OverrideCharData could be refactored to not need this and be safer overall
+	if c.memberNo < len(sys.sel.ocd[team]) {
+		return &sys.sel.ocd[team][c.memberNo]
+	}
+	// Return default values as safeguard
+	return newOverrideCharData()
 }
+
 func (c *Char) load(def string) error {
 	gi := &sys.cgi[c.playerNo]
 	gi.def, gi.displayname, gi.lifebarname, gi.author = def, "", "", ""

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1538,18 +1538,18 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "size":
 			bv1 = BytecodeInt(3)
 		default:
-			return bvNone(), Error("Invalid clsn1 type")
+			return bvNone(), Error("Invalid collision box type")
 		}
 		c.token = c.tokenizer(in)
 		if c.token != "," {
-			return bvNone(), Error("Missing A ','")
+			return bvNone(), Error("Missing ','")
 		}
 		c.token = c.tokenizer(in)
 		if bv2, err = c.expBoolOr(&be2, in); err != nil {
 			return bvNone(), err
 		}
 		if c.token != "," {
-			return bvNone(), Error("Missing B ','")
+			return bvNone(), Error("Missing ','")
 		}
 		c.token = c.tokenizer(in)
 		c2type := c.token
@@ -1561,7 +1561,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "size":
 			bv3 = BytecodeInt(3)
 		default:
-			return bvNone(), Error("Invalid clsn2 type")
+			return bvNone(), Error("Invalid collision box type")
 		}
 		c.token = c.tokenizer(in)
 		if err := c.checkClosingBracket(); err != nil {


### PR DESCRIPTION
- Added exceptions where hit detection will not use angle and rescaling when it happens on size boxes
- Simplified implementation of ClsnOverlap trigger by cutting redundancy
- Fixed possible crash when modifying helpers to teamside 0
- Reverted previous Mugen/Ikemen state version refactor