### PR TITLE
feat: gethitvar(guardflag)

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -509,6 +509,7 @@ const (
 	OC_ex_gethitvar_down_recover
 	OC_ex_gethitvar_down_recovertime
 	OC_ex_gethitvar_xaccel
+	OC_ex_gethitvar_guardflag
 	OC_ex_ailevelf
 	OC_ex_animelemlength
 	OC_ex_animframe_alphadest
@@ -573,6 +574,7 @@ const (
 	OC_ex_movehitvar_spark_x
 	OC_ex_movehitvar_spark_y
 	OC_ex_movehitvar_uniqhit
+	OC_ex_movehitvar_guardflag
 	OC_ex_ikemenversion
 	OC_ex_incustomanim
 	OC_ex_incustomstate
@@ -2334,6 +2336,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushB(c.ghv.down_recover)
 	case OC_ex_gethitvar_xaccel:
 		sys.bcStack.PushF(c.ghv.getXaccel(oc) * (c.localscl / oc.localscl))
+	case OC_ex_gethitvar_guardflag:
+		sys.bcStack.PushI(c.ghv.guardflag)
 	case OC_ex_ailevelf:
 		if !c.asf(ASF_noailevel) {
 			sys.bcStack.PushF(c.aiLevel())
@@ -2684,6 +2688,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.mhv.sparkxy[1] * (c.localscl / oc.localscl))
 	case OC_ex_movehitvar_uniqhit:
 		sys.bcStack.PushI(c.mhv.uniqhit)
+	case OC_ex_movehitvar_guardflag:
+		sys.bcStack.PushI(c.mhv.guardflag)
 	case OC_ex_numplayer:
 		sys.bcStack.PushI(c.numPlayer())
 	case OC_ex_clamp:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -574,7 +574,6 @@ const (
 	OC_ex_movehitvar_spark_x
 	OC_ex_movehitvar_spark_y
 	OC_ex_movehitvar_uniqhit
-	OC_ex_movehitvar_guardflag
 	OC_ex_ikemenversion
 	OC_ex_incustomanim
 	OC_ex_incustomstate
@@ -2688,8 +2687,6 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.mhv.sparkxy[1] * (c.localscl / oc.localscl))
 	case OC_ex_movehitvar_uniqhit:
 		sys.bcStack.PushI(c.mhv.uniqhit)
-	case OC_ex_movehitvar_guardflag:
-		sys.bcStack.PushI(c.mhv.guardflag)
 	case OC_ex_numplayer:
 		sys.bcStack.PushI(c.numPlayer())
 	case OC_ex_clamp:

--- a/src/char.go
+++ b/src/char.go
@@ -913,7 +913,6 @@ type MoveHitVar struct {
 	playerNo   int
 	sparkxy    [2]float32
 	uniqhit    int32
-	guardflag  int32
 }
 
 func (mhv *MoveHitVar) clear() {
@@ -7640,7 +7639,6 @@ func (c *Char) tick() {
 				c.ss.clearWw()
 			}
 		}
-		c.mhv.guardflag = c.hitdef.guardflag;      // Set MoveHitVar(guardflag) regardless of HitDef
 		// Fast recovery from lie down
 		if c.ghv.down_recover && c.ghv.down_recovertime > 0 &&
 			!c.asf(ASF_nofastrecoverfromliedown) &&

--- a/src/char.go
+++ b/src/char.go
@@ -824,6 +824,7 @@ type GetHitVar struct {
 	cheeseKO          bool
 	down_recover      bool
 	down_recovertime  int32
+	guardflag         int32
 }
 
 func (ghv *GetHitVar) clear() {
@@ -912,6 +913,7 @@ type MoveHitVar struct {
 	playerNo   int
 	sparkxy    [2]float32
 	uniqhit    int32
+	guardflag  int32
 }
 
 func (mhv *MoveHitVar) clear() {
@@ -7278,6 +7280,7 @@ func (c *Char) actionRun() {
 					// HitOverride KeepState preserves some GetHitVars for 1 frame so they can be accessed by the char
 					if !c.hoKeepState {
 						c.ghv.hitshaketime = 0
+						c.ghv.guardflag = 0
 						c.ghv.attr = 0
 						c.ghv.id = 0
 						c.ghv.playerNo = -1
@@ -7637,6 +7640,7 @@ func (c *Char) tick() {
 				c.ss.clearWw()
 			}
 		}
+		c.mhv.guardflag = c.hitdef.guardflag;      // Set MoveHitVar(guardflag) regardless of HitDef
 		// Fast recovery from lie down
 		if c.ghv.down_recover && c.ghv.down_recovertime > 0 &&
 			!c.asf(ASF_nofastrecoverfromliedown) &&
@@ -8159,7 +8163,7 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 		if getter.csf(CSF_gethit) && getter.ghv.attr&int32(AT_AT) != 0 {
 			return 0
 		}
-
+	
 		// Check if the enemy can guard this attack
 		canguard := (proj || !c.asf(ASF_unguardable)) && getter.scf(SCF_guard) &&
 			(!getter.csf(CSF_gethit) || getter.ghv.guarded)
@@ -8339,6 +8343,7 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 				ghv.cheeseKO = cheese
 				// Update variables
 				ghv.attr = hd.attr
+				ghv.guardflag = hd.guardflag
 				ghv.hitid = hd.id
 				ghv.playerNo = hd.playerNo
 				ghv.id = hd.attackerID

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2237,6 +2237,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				out.append(OC_ex_gethitvar_down_recover)
 			case "xaccel":
 				out.append(OC_ex_gethitvar_xaccel)
+			case "guardflag":
+				out.append(OC_ex_gethitvar_guardflag)
 			default:
 				return bvNone(), Error("Invalid data: " + c.token)
 			}
@@ -3856,6 +3858,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.append(OC_ex_movehitvar_spark_y)
 		case "uniqhit":
 			out.append(OC_ex_movehitvar_uniqhit)
+		case "guardflag":
+			out.append(OC_ex_movehitvar_guardflag)
 		default:
 			return bvNone(), Error("Invalid data: " + c.token)
 		}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -3858,8 +3858,6 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.append(OC_ex_movehitvar_spark_y)
 		case "uniqhit":
 			out.append(OC_ex_movehitvar_uniqhit)
-		case "guardflag":
-			out.append(OC_ex_movehitvar_guardflag)
 		default:
 			return bvNone(), Error("Invalid data: " + c.token)
 		}

--- a/src/script.go
+++ b/src/script.go
@@ -3516,6 +3516,8 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(Btoi(c.ghv.frame))
 		case "down.recover":
 			ln = lua.LNumber(Btoi(c.ghv.down_recover))
+		case "guardflag":
+			ln = lua.LNumber(g.ghv.guardflag)
 		default:
 			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}
@@ -3693,6 +3695,8 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.mhv.sparkxy[1])
 		case "uniqhit":
 			ln = lua.LNumber(c.mhv.uniqhit)
+		case "guardflag":
+			ln = lua.LNumber(c.mhv.guardflag)
 		default:
 			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}

--- a/src/script.go
+++ b/src/script.go
@@ -3695,8 +3695,6 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.mhv.sparkxy[1])
 		case "uniqhit":
 			ln = lua.LNumber(c.mhv.uniqhit)
-		case "guardflag":
-			ln = lua.LNumber(c.mhv.guardflag)
 		default:
 			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}


### PR DESCRIPTION
This PR adds a `guardflag` parameter to the `gethitvar` trigger.

Using this parameter with the trigger returns a bitflag; to check for a specific type, use the `BitN` constants:

- `Const(Bit1)`: High
- `Const(Bit2)`: Low
- `Const(Bit3)`: Air

Mid is equivalent to `Const(Bit1)|Const(Bit2)`.