### PR TITLE
fix: Language Options: Fix a crash and changed how languages are set

### DIFF
--- a/external/script/motif.lua
+++ b/external/script/motif.lua
@@ -2083,7 +2083,6 @@ function motif.setBaseOptionInfo()
 	end
 	main.t_sort.option_info.menu = {
 		"menugame",
-		"menugame_language",
 		"menugame_difficulty",
 		"menugame_roundtime",
 		"menugame_lifemul",

--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -60,6 +60,25 @@ local function f_externalShaderName()
 	return motif.option_info.menu_valuename_disabled
 end
 
+local function changeLanguageSetting(val)
+	sndPlay(motif.files.snd_data, motif.option_info.cursor_move_snd[1], motif.option_info.cursor_move_snd[2])
+	languageCounter = 0
+	currentLanguage = -1
+	for x, c in ipairs(motif.languages.languages) do
+		if c == config.Language then
+			currentLanguage = x
+		end
+		languageCounter = languageCounter + 1
+	end
+	if currentLanguage > 0 then
+		config.Language = motif.languages.languages[((currentLanguage + val) % languageCounter) + 1]
+	else
+		config.Language = motif.languages.languages[1] or "en"
+	end
+	options.modified = true
+	options.needReload = true
+end
+
 -- Associative elements table storing functions controlling behaviour of each
 -- option screen item. Can be appended via external module.
 options.t_itemname = {
@@ -280,41 +299,13 @@ options.t_itemname = {
 	--Language Setting
 	['language'] = function(t, item, cursorPosY, moveTxt)
 		if main.f_input(main.t_players, {'$F'}) then
-			sndPlay(motif.files.snd_data, motif.option_info.cursor_move_snd[1], motif.option_info.cursor_move_snd[2])
-			languageCounter = 0
-			for x, c in ipairs(motif.languages.languages) do
-				if c == config.Language then
-					currentLanguage = x
-				end
-				languageCounter = languageCounter + 1
-			end
-			if languageCounter == currentLanguage then
-				config.Language = motif.languages.languages[1]
-			else
-				config.Language = motif.languages.languages[currentLanguage + 1]
-			end
-			options.modified = true
-			options.needReload = true
-			loadstring("sfs = " .. "motif.languages." .. config.Language)()
-			t.items[item].vardisplay = sfs or config.Language
+			changeLanguageSetting(0)
+			loadstring("LanguageName = " .. "motif.languages." .. config.Language)()
+			t.items[item].vardisplay = LanguageName or config.Language
 		elseif main.f_input(main.t_players, {'$B'}) then
-			sndPlay(motif.files.snd_data, motif.option_info.cursor_move_snd[1], motif.option_info.cursor_move_snd[2])
-			languageCounter = 0
-			for x, c in ipairs(motif.languages.languages) do
-				if c == config.Language then
-					currentLanguage = x
-				end
-				languageCounter = languageCounter + 1
-			end
-			if currentLanguage == 1 then
-				config.Language = motif.languages.languages[languageCounter]
-			else
-				config.Language = motif.languages.languages[currentLanguage - 1]
-			end
-			options.modified = true
-			options.needReload = true
-			loadstring("sfs = " .. "motif.languages." .. config.Language)()
-			t.items[item].vardisplay = sfs or config.Language
+			changeLanguageSetting(-2)
+			loadstring("LanguageName = " .. "motif.languages." .. config.Language)()
+			t.items[item].vardisplay = LanguageName or config.Language
 		end
 		return true
 	end,
@@ -1789,6 +1780,7 @@ function options.f_keyDefault()
 	resetRemapInput()
 end
 if config.FirstRun then
+	config.Language = motif.languages.languages[1] or "en"
 	options.f_keyDefault()
 end
 


### PR DESCRIPTION
Primary purpose for this PR is fix issue #2028. The error occured when the user changed the language option when the language was already set to one that is unavailable.

=Options.lua
-During First Run of the program, the script now automatically chooses the first language available in the screenpack, or if none are available default to English(previously always set to English).
-If there current language is not one that is available, the game will now set itself to the first available language in the screenpack, or if none are available default to English(previously caused a crash).
-General code improvements.

=Motif.lua
-Removed language from default options menu. The functionality is still there for easy implementation in the screenpack, but I believe this is best, as we had previously decided only to have the option for English by default. Because of this, this option does nothing by default, and could be confusing for that reason.

Fixes #2028