### PR TITLE
feat: HitDefVar trigger

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -772,6 +772,10 @@ const (
 	OC_ex2_projectilevar_pausemovetime
 	OC_ex2_projectilevar_projid
 	OC_ex2_projectilevar_teamside
+	OC_ex2_hitdefvar_guardflag
+	OC_ex2_hitdefvar_hitflag
+	OC_ex2_hitdefvar_guarddamage
+	OC_ex2_hitdefvar_hitdamage
 )
 const (
 	NumVar     = 60
@@ -3194,6 +3198,22 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		} else {
 			sys.bcStack.Push(v)
 		}
+	case OC_ex2_hitdefvar_guardflag:
+		attr := (*(*int32)(unsafe.Pointer(&be[*i])))
+		sys.bcStack.PushB(
+			c.hitdef.guardflag & attr == attr,
+		)
+		*i += 4
+	case OC_ex2_hitdefvar_hitflag:
+		attr := (*(*int32)(unsafe.Pointer(&be[*i])))
+		sys.bcStack.PushB(
+			c.hitdef.hitflag & attr == attr,
+		)
+		*i += 4
+	case OC_ex2_hitdefvar_hitdamage:
+		sys.bcStack.PushI(c.hitdef.hitdamage)
+	case OC_ex2_hitdefvar_guarddamage:
+		sys.bcStack.PushI(c.hitdef.guarddamage)
 	default:
 		sys.errLog.Printf("%v\n", be[*i-1])
 		c.panic()

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3201,13 +3201,13 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	case OC_ex2_hitdefvar_guardflag:
 		attr := (*(*int32)(unsafe.Pointer(&be[*i])))
 		sys.bcStack.PushB(
-			c.hitdef.guardflag & attr == attr,
+			c.hitdef.guardflag & attr != 0,
 		)
 		*i += 4
 	case OC_ex2_hitdefvar_hitflag:
 		attr := (*(*int32)(unsafe.Pointer(&be[*i])))
 		sys.bcStack.PushB(
-			c.hitdef.hitflag & attr == attr,
+			c.hitdef.hitflag & attr != 0,
 		)
 		*i += 4
 	case OC_ex2_hitdefvar_hitdamage:

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1220,19 +1220,21 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 					case 'P', 'p':
 						flg |= int32(ST_P)
 					default:
-						return Error("Invalid flags: "+c.token)
+						return Error("Invalid flags: "+base)
 				}
 			}
 			// peek ahead to see if we have signs in the flag
-			sign := c.tokenizer(in)
-			switch sign[0]{
-				case '+':
-					flg |= int32(MT_PLS)
-				case '-':
-					flg |= int32(MT_MNS)
-				default:
-					// no sign? step back
-					*in = base
+			if(len(*in) > 0){
+				switch (*in)[0]{
+					case '+':
+						// move forward
+						flg |= int32(MT_PLS)
+						*in = (*in)[1:]
+					case '-':
+						// move forward
+						flg |= int32(MT_MNS)
+						*in = (*in)[1:]
+				}
 			}
 			out.append(opct)
 			out.appendI32Op(opc, flg)

--- a/src/script.go
+++ b/src/script.go
@@ -3376,6 +3376,34 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.debugWC.gameWidth()))
 		return 1
 	})
+	luaRegister(l, "hitdefvar", func(*lua.LState) int {
+		c := sys.debugWC
+		flagStr := func(flag int32) lua.LString {
+			str := ""
+			if(flag&int32(ST_S)!=0){ str += "H" }
+			if(flag&int32(ST_C)!=0){ str += "L" }
+			if(flag&int32(ST_A)!=0){ str += "A" }
+			if(flag&int32(ST_F)!=0){ str += "F" }
+			if(flag&int32(ST_D)!=0){ str += "D" }
+			if(flag&int32(ST_P)!=0){ str += "P" }
+			if(flag&int32(MT_MNS)!=0){ str += "-" }
+			if(flag&int32(MT_PLS)!=0){ str += "+" }
+			return lua.LString(str)
+		}
+		switch strArg(l, 1) {
+			case "guardflag":
+				l.Push(flagStr(c.hitdef.guardflag))
+			case "hitflag":
+				l.Push(flagStr(c.hitdef.hitflag))
+			case "hitdamage":
+				l.Push(lua.LNumber(c.hitdef.hitdamage))
+			case "guarddamage":
+				l.Push(lua.LNumber(c.hitdef.guarddamage))
+			default:
+				l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
+		}
+		return 1
+	})
 	luaRegister(l, "gethitvar", func(*lua.LState) int {
 		c := sys.debugWC
 		var ln lua.LNumber


### PR DESCRIPTION
This PR adds a new trigger, `HitDefVar(param)`, to retrieve information about the char's current HitDef.

Available params:
- `guardflag`: Check the HitDef flags using `HitDefVar(guardflag) = [HLMAFDP+-]`.
- `hitflag`: Same as above, but for `hitflag`.
- `hitdamage`: Damage the HitDef would do if it hit.
- `guarddamage`: Damage the HitDef would do if it was guarded.