### PR TITLE
fix: Z axis, explod crash

### DIFF
--- a/src/anim.go
+++ b/src/anim.go
@@ -558,6 +558,10 @@ func (a *Animation) UpdateSprite() {
 	}
 }
 func (a *Animation) Action() {
+	// Ignore invalid animation instead of crashing engine
+	if a == nil || a.frames == nil {
+		return
+	}
 	if len(a.frames) == 0 {
 		a.loopend = true
 		return

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -4524,10 +4524,10 @@ func (sc posAdd) Run(c *Char, _ []int32) bool {
 				crun.bindPosAdd[1] = y
 			}
 		case posSet_z:
-			if crun.size.z.enable {
-				crun.addZ(exp[0].evalF(c) * lclscround)
-			} else {
-				exp[0].run(c)
+			z := exp[0].evalF(c) * lclscround
+			crun.addZ(z)
+			if crun.bindToId > 0 && !math.IsNaN(float64(crun.bindPos[0])) && sys.playerID(crun.bindToId) != nil {
+				crun.bindPosAdd[0] = z
 			}
 		case posSet_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
@@ -4554,11 +4554,7 @@ func (sc velSet) Run(c *Char, _ []int32) bool {
 		case posSet_y:
 			crun.setYV(exp[0].evalF(c) * lclscround)
 		case posSet_z:
-			if crun.size.z.enable {
-				crun.setZV(exp[0].evalF(c) * lclscround)
-			} else {
-				exp[0].run(c)
-			}
+			crun.setZV(exp[0].evalF(c) * lclscround)
 		case posSet_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -6373,9 +6369,7 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 		case projectile_projmisstime:
 			p.misstime = exp[0].evalI(c)
 		case projectile_projhits:
-			tmp := p.totalhits
-			p.totalhits = exp[0].evalI(c)
-			p.hits += (p.totalhits - tmp)
+			p.hits = exp[0].evalI(c)
 		case projectile_projpriority:
 			p.priority = exp[0].evalI(c)
 			p.priorityPoints = p.priority
@@ -6654,7 +6648,6 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				})
 			case projectile_projhits:
 				eachProj(func(p *Projectile) {
-					// TODO: Maybe this should be adjusted so that the maximum (not current) number of hits is changed
 					p.hits = exp[0].evalI(c)
 				})
 			case projectile_projpriority:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -731,6 +731,8 @@ const (
 	OC_ex2_explodvar_sprpriority
 	OC_ex2_explodvar_layerno
 	OC_ex2_explodvar_id
+	OC_ex2_explodvar_bindtime
+	OC_ex2_explodvar_facing
 	OC_ex2_projectilevar_projremove
 	OC_ex2_projectilevar_projremovetime
 	OC_ex2_projectilevar_projshadow_r
@@ -3063,6 +3065,10 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	case OC_ex2_explodvar_layerno:
 		fallthrough
 	case OC_ex2_explodvar_id:
+		fallthrough
+	case OC_ex2_explodvar_bindtime:
+		fallthrough
+	case OC_ex2_explodvar_facing:
 		fallthrough
 	case OC_ex2_explodvar_scale_x:
 		fallthrough

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5055,7 +5055,7 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 		case explod_animelem:
 			animelem := exp[0].evalI(c)
 			e.animelem = animelem
-			e.anim.Action()
+			// e.anim.Action() This being in this place can cause a nil animation crash
 			e.setAnimElem()
 		case explod_animfreeze:
 			e.animfreeze = exp[0].evalB(c)
@@ -5501,7 +5501,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				eachExpl(func(e *Explod) {
 					e.interpolate_animelem[1] = -1
 					e.animelem = animelem
-					e.anim.Action()
+					// e.anim.Action() This being in this place can cause a nil animation crash
 					e.setAnimElem()
 				})
 			case explod_animfreeze:

--- a/src/char.go
+++ b/src/char.go
@@ -3842,6 +3842,10 @@ func (c *Char) explodVar(eid BytecodeValue, idx BytecodeValue, vtype OpCode) Byt
 				v = BytecodeInt(e.layerno)
 			case OC_ex2_explodvar_id:
 				v = BytecodeInt(e.id)
+			case OC_ex2_explodvar_bindtime:
+				v = BytecodeInt(e.bindtime)
+			case OC_ex2_explodvar_facing:
+				v = BytecodeInt(int32(e.facing))
 			}
 			break
 		}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2000,6 +2000,10 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			opc = OC_ex2_explodvar_layerno
 		case "id":
 			opc = OC_ex2_explodvar_id
+		case "bindtime":
+			opc = OC_ex2_explodvar_bindtime
+		case "facing":
+			opc = OC_ex2_explodvar_facing
 		case "pos":
 			c.token = c.tokenizer(in)
 

--- a/src/script.go
+++ b/src/script.go
@@ -3313,6 +3313,16 @@ func triggerFunctions(l *lua.LState) {
 					ln = lua.LNumber(e.removetime)
 				case "pausemovetime":
 					ln = lua.LNumber(e.pausemovetime)
+				case "sprpriority":
+					ln = lua.LNumber(e.sprpriority)
+				case "layerno":
+					ln = lua.LNumber(e.layerno)
+				case "id":
+					ln = lua.LNumber(e.id)
+				case "bindtime":
+					ln = lua.LNumber(e.bindtime)
+				case "facing":
+					ln = lua.LNumber(e.facing)
 				default:
 					l.RaiseError("\nInvalid argument: %v\n", vname)
 				}

--- a/src/script.go
+++ b/src/script.go
@@ -4127,11 +4127,11 @@ func triggerFunctions(l *lua.LState) {
 				case "angle":
 					lv = lua.LNumber(p.angle)
 				case "pos x":
-					lv = lua.LNumber(p.drawPos[0])
+					lv = lua.LNumber(p.pos[0])
 				case "pos y":
-					lv = lua.LNumber(p.drawPos[1])
+					lv = lua.LNumber(p.pos[1])
 				case "pos z":
-					lv = lua.LNumber(p.drawPos[2])
+					lv = lua.LNumber(p.pos[2])
 				case "projsprpriority":
 					lv = lua.LNumber(p.sprpriority)
 				case "projstagebound":

--- a/src/system.go
+++ b/src/system.go
@@ -880,6 +880,23 @@ func (s *System) loadTime(start time.Time, str string, shell, console bool) {
 	}
 }
 
+// Update Z scale
+// TODO: See if this still works correctly with Winmugen stages that scaled chars with Z
+func (s *System) updateZScale(pos, localscale float32) float32 {
+	topz := sys.stage.stageCamera.topz / localscale
+	botz := sys.stage.stageCamera.botz / localscale
+	scale := float32(1)
+	if topz != botz {
+		ztopscale, zbotscale := sys.stage.stageCamera.ztopscale, sys.stage.stageCamera.zbotscale
+		d := (pos - topz) / (botz - topz)
+		scale = ztopscale + d*(zbotscale-ztopscale)
+		if scale <= 0 {
+			scale = 0
+		}
+	}
+	return scale
+}
+
 // Z axis check
 // Changed to no longer check z enable constant, depends on stage now
 func (s *System) zAxisOverlap(posz1, front1, back1, localscl1, posz2, front2, back2, localscl2 float32) bool {


### PR DESCRIPTION
- More work done on the Z axis feature
- Explod position should be a bit more accurate
- Clsn boxes now rescale instead of offsetting
- Char Z drawing untangled from Y offset
- Renamed drawing position variables to interpolated position. Since interpolation now happens in 3 dimensions while drawing still happens in 2, it was confusing
- Centralized Clsn scale calculations so they don't have to be repeated in several places
- Other random things

Fix:
- Fixed a crash that could happen when using explod animelem parameter

Feat:
- ExplodVar bindtime and facing triggers