### PR TITLE
feat: Restored Mugen behavior to accept p3start and onward, removed p1p3dist

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -4860,10 +4860,9 @@ func (c *Char) posReset() {
 		c.setZ(0)
 	} else {
 		c.facing = 1 - 2*float32(c.playerNo&1)
-		c.setX((float32(sys.stage.p[c.playerNo&1].startx)*
-			sys.stage.localscl - c.facing*float32(c.playerNo>>1)*sys.stage.p1p3dist) / c.localscl)
-		c.setY(float32(sys.stage.p[c.playerNo&1].starty) * sys.stage.localscl / c.localscl)
-		c.setZ(float32(sys.stage.p[c.playerNo&1].startz))
+		c.setX((float32(sys.stage.p[c.playerNo].startx) * sys.stage.localscl) / c.localscl)
+		c.setY(float32(sys.stage.p[c.playerNo].starty) * sys.stage.localscl / c.localscl)
+		c.setZ(float32(sys.stage.p[c.playerNo].startz))
 	}
 	c.setXV(0)
 	c.setYV(0)


### PR DESCRIPTION
Feat:
- Added support for pXstart x y or z for all players. If no values are declared in the stage def, partners will default to a standard relative distance from the leader. If any values are declared, the partners will use those values regardless of the leader's pos.

Refactor:
- Removed p1p3dist since it was just acting as a default spacing value between the leader and partners and wasn’t really used otherwise. I added actual logic for the standard spacing of characters instead.