### PR TITLE
refactor: juggling system, misc

### DIFF
--- a/src/anim.go
+++ b/src/anim.go
@@ -927,25 +927,31 @@ func (dl DrawList) draw(x, y, scl float32) {
 				(sys.cam.GroundLevel()+sys.cam.Offset[1]-sys.envShake.getOffset())/cs -
 					(y/cs - s.pos[1])}
 		}
+
+		drawwindow := &sys.scrrect
+
 		if s.window[0] != 0 || s.window[1] != 0 || s.window[2] != 0 || s.window[3] != 0 {
 			w := s.window
+			var window [4]int32
+
 			if w[0] > w[2] {
 				w[0], w[2] = w[2], w[0]
 			}
 			if w[1] > w[3] {
 				w[1], w[3] = w[3], w[1]
 			}
-			var window [4]int32
+
 			window[0] = int32((cs*(p[0]+float32(w[0])) + float32(sys.gameWidth)/2) * sys.widthScale)
 			window[1] = int32(cs * (p[1] + float32(w[1])) * sys.heightScale)
 			window[2] = int32(cs * (w[2] - w[0]) * sys.widthScale)
 			window[3] = int32(cs * (w[3] - w[1]) * sys.heightScale)
-			s.anim.Draw(&window, p[0], p[1], cs, cs, s.scl[0], s.scl[0],
-				s.scl[1], 0, s.rot, float32(sys.gameWidth)/2, s.fx, s.oldVer, s.facing, false, s.posLocalscl, s.projection, s.fLength, 0)
-		} else {
-			s.anim.Draw(&sys.scrrect, p[0], p[1], cs, cs, s.scl[0], s.scl[0],
-				s.scl[1], 0, s.rot, float32(sys.gameWidth)/2, s.fx, s.oldVer, s.facing, false, s.posLocalscl, s.projection, s.fLength, 0)
+
+			drawwindow = &window
 		}
+
+		s.anim.Draw(drawwindow, p[0], p[1], cs, cs, s.scl[0], s.scl[0],
+			s.scl[1], 0, s.rot, float32(sys.gameWidth)/2, s.fx, s.oldVer, s.facing, false, s.posLocalscl, s.projection, s.fLength, 0)
+
 		sys.brightness = ob
 	}
 	BlendReset()
@@ -1032,8 +1038,13 @@ func (sl ShadowList) draw(x, y, scl float32) {
 		} else {
 			xshearoff += xrotoff
 		}
+
+		drawwindow := &sys.scrrect
+
 		if s.window[0] != 0 || s.window[1] != 0 || s.window[2] != 0 || s.window[3] != 0 {
 			w := s.window
+			var window [4]int32
+
 			w[1], w[3] = -w[1], -w[3]
 			if w[0] > w[2] {
 				w[0], w[2] = w[2], w[0]
@@ -1041,24 +1052,22 @@ func (sl ShadowList) draw(x, y, scl float32) {
 			if (w[1] > w[3] && sys.stage.sdw.yscale > 0) || (w[1] < w[3] && sys.stage.sdw.yscale < 0) {
 				w[1], w[3] = w[3], w[1]
 			}
-			var window [4]int32
-
+			
 			window[0] = int32((sys.cam.Offset[0] - ((x - s.pos[0] - xshearoff) * scl) + w[0]*scl + float32(sys.gameWidth)/2) * sys.widthScale)
 			window[1] = int32((sys.cam.GroundLevel() + sys.cam.Offset[1] - sys.envShake.getOffset() - y - (s.pos[1]*sys.stage.sdw.yscale-s.shadowOffset[1])*scl + w[1]*sys.stage.sdw.yscale*scl) * sys.heightScale)
 			window[2] = int32(scl * (w[2] - w[0]) * sys.widthScale)
 			window[3] = int32(scl * (w[3] - w[1]) * sys.heightScale * sys.stage.sdw.yscale)
-			s.anim.ShadowDraw(&window, sys.cam.Offset[0]-(x-s.pos[0]-xshearoff)*scl,
-				sys.cam.GroundLevel()+sys.cam.Offset[1]-sys.envShake.getOffset()-y-
-					(s.pos[1]*sys.stage.sdw.yscale-s.shadowOffset[1]-sys.stage.sdw.offset[1])*scl,
-				scl*s.scl[0], scl*-s.scl[1], sys.stage.sdw.yscale, xshear, s.rot,
-				s.fx, s.oldVer, uint32(color), intensity, s.facing, s.posLocalscl, s.projection, s.fLength)
-		} else {
-			s.anim.ShadowDraw(&sys.scrrect, sys.cam.Offset[0]-((x-s.pos[0]-xshearoff)*scl),
-				sys.cam.GroundLevel()+sys.cam.Offset[1]-sys.envShake.getOffset()-y-
-					(s.pos[1]*sys.stage.sdw.yscale-s.shadowOffset[1]-sys.stage.sdw.offset[1])*scl,
-				scl*s.scl[0], scl*-s.scl[1], sys.stage.sdw.yscale, xshear, s.rot,
-				s.fx, s.oldVer, uint32(color), intensity, s.facing, s.posLocalscl, s.projection, s.fLength)
+
+			drawwindow = &window
 		}
+
+		s.anim.ShadowDraw(drawwindow,
+			sys.cam.Offset[0]-((x-s.pos[0]-xshearoff)*scl),
+			sys.cam.GroundLevel()+sys.cam.Offset[1]-sys.envShake.getOffset()-y-
+				(s.pos[1]*sys.stage.sdw.yscale-s.shadowOffset[1]-sys.stage.sdw.offset[1])*scl,
+			scl*s.scl[0], scl*-s.scl[1],
+			sys.stage.sdw.yscale, xshear, s.rot,
+			s.fx, s.oldVer, uint32(color), intensity, s.facing, s.posLocalscl, s.projection, s.fLength)
 	}
 }
 
@@ -1110,8 +1119,12 @@ func (sl ShadowList) drawReflection(x, y, scl float32) {
 			offsetX += xrotoff
 		}
 
+		drawwindow := &sys.scrrect
+
 		if s.window[0] != 0 || s.window[1] != 0 || s.window[2] != 0 || s.window[3] != 0 {
 			w := s.window
+			var window [4]int32
+
 			w[1], w[3] = -w[1], -w[3]
 			if w[0] > w[2] {
 				w[0], w[2] = w[2], w[0]
@@ -1119,22 +1132,22 @@ func (sl ShadowList) drawReflection(x, y, scl float32) {
 			if w[1] > w[3] {
 				w[1], w[3] = w[3], w[1]
 			}
-			var window [4]int32
+
 			window[0] = int32((scl*(sys.cam.Offset[0]/scl-(x-s.pos[0])+float32(w[0])) + float32(sys.gameWidth)/2) * sys.widthScale)
 			window[1] = int32(scl * ((sys.cam.GroundLevel()+sys.cam.Offset[1]-sys.envShake.getOffset()-y)/scl - (s.pos[1] - s.shadowOffset[1]) + float32(w[1])) * sys.heightScale)
 			window[2] = int32(scl * (w[2] - w[0]) * sys.widthScale)
 			window[3] = int32(scl * (w[3] - w[1]) * sys.heightScale)
 
-			s.anim.Draw(&window, sys.cam.Offset[0]/scl-(x-s.pos[0]-offsetX),
-				(sys.cam.GroundLevel()+sys.cam.Offset[1]-sys.envShake.getOffset())/scl-y-
-					(s.pos[1]*sys.stage.reflection.yscale-offsetY), scl, scl, s.scl[0], s.scl[0], -s.scl[1]*sys.stage.reflection.yscale, xshear,
-				s.rot, float32(sys.gameWidth)/2, s.fx, s.oldVer, s.facing, true, s.posLocalscl, s.projection, s.fLength, color)
-		} else {
-			s.anim.Draw(&sys.scrrect, sys.cam.Offset[0]/scl-(x-s.pos[0]-offsetX),
-				(sys.cam.GroundLevel()+sys.cam.Offset[1]-sys.envShake.getOffset())/scl-y-
-					(s.pos[1]*sys.stage.reflection.yscale-offsetY), scl, scl, s.scl[0], s.scl[0], -s.scl[1]*sys.stage.reflection.yscale, xshear,
-				s.rot, float32(sys.gameWidth)/2, s.fx, s.oldVer, s.facing, true, s.posLocalscl, s.projection, s.fLength, color)
+			drawwindow = &window
 		}
+
+		s.anim.Draw(drawwindow,
+			sys.cam.Offset[0]/scl-(x-s.pos[0]-offsetX),
+			(sys.cam.GroundLevel()+sys.cam.Offset[1]-sys.envShake.getOffset())/scl - y/scl -
+				(s.pos[1]*sys.stage.reflection.yscale-offsetY),
+			scl, scl, s.scl[0], s.scl[0],
+			-s.scl[1]*sys.stage.reflection.yscale, xshear, s.rot, float32(sys.gameWidth)/2,
+			s.fx, s.oldVer, s.facing, true, s.posLocalscl, s.projection, s.fLength, color)
 	}
 }
 

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1807,9 +1807,9 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 	case OC_const_size_attack_dist_back:
 		sys.bcStack.PushF(c.size.attack.dist.back * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_attack_z_width_back:
-		sys.bcStack.PushF(c.size.attack.z.width.back * ((320 / c.localcoord) / oc.localscl))
+		sys.bcStack.PushF(c.size.attack.width.back * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_attack_z_width_front:
-		sys.bcStack.PushF(c.size.attack.z.width.front * ((320 / c.localcoord) / oc.localscl))
+		sys.bcStack.PushF(c.size.attack.width.front * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_proj_attack_dist_front:
 		sys.bcStack.PushF(c.size.proj.attack.dist.front * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_proj_attack_dist_back:
@@ -1832,8 +1832,6 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.size.draw.offset[1] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_z_width:
 		sys.bcStack.PushF(c.size.z.width * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_size_z_enable:
-		sys.bcStack.PushB(c.size.z.enable)
 	case OC_const_velocity_walk_fwd_x:
 		sys.bcStack.PushF(c.gi().velocity.walk.fwd * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_walk_back_x:
@@ -4468,11 +4466,7 @@ func (sc posSet) Run(c *Char, _ []int32) bool {
 				crun.bindPosAdd[1] = y
 			}
 		case posSet_z:
-			if crun.size.z.enable {
-				crun.setZ(exp[0].evalF(c) * lclscround)
-			} else {
-				exp[0].run(c)
-			}
+			crun.setZ(exp[0].evalF(c) * lclscround)
 		case posSet_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -4562,11 +4556,7 @@ func (sc velAdd) Run(c *Char, _ []int32) bool {
 		case posSet_y:
 			crun.addYV(exp[0].evalF(c) * lclscround)
 		case posSet_z:
-			if crun.size.z.enable {
-				crun.addZV(exp[0].evalF(c) * lclscround)
-			} else {
-				exp[0].run(c)
-			}
+			crun.addZV(exp[0].evalF(c) * lclscround)
 		case posSet_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -4591,11 +4581,7 @@ func (sc velMul) Run(c *Char, _ []int32) bool {
 		case posSet_y:
 			crun.mulYV(exp[0].evalF(c))
 		case posSet_z:
-			if crun.size.z.enable {
-				crun.mulZV(exp[0].evalF(c))
-			} else {
-				exp[0].run(c)
-			}
+			crun.mulZV(exp[0].evalF(c))
 		case posSet_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3569,7 +3569,7 @@ func (sc stateDef) Run(c *Char) {
 				c.setFacing(-c.facing)
 			}
 		case stateDef_juggle:
-			c.setJuggle(exp[0].evalI(c))
+			c.juggle = exp[0].evalI(c)
 		case stateDef_velset:
 			c.setXV(exp[0].evalF(c))
 			if len(exp) > 1 {
@@ -5920,7 +5920,7 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 	case hitDef_chainid:
 		hd.chainid = exp[0].evalI(c)
 	case hitDef_nochainid:
-		for i := 0; i < int(math.Min(MaxSimul, float64(len(exp)))); i++ {
+		for i := 0; i < int(math.Min(8, float64(len(exp)))); i++ {
 			hd.nochainid[i] = exp[i].evalI(c)
 		}
 	case hitDef_kill:
@@ -6226,7 +6226,7 @@ func (sc hitDef) Run(c *Char, _ []int32) bool {
 		crun.hitdef.attr = 0
 		return false
 	}
-	crun.setHitdefDefault(&crun.hitdef, false)
+	crun.setHitdefDefault(&crun.hitdef)
 	return false
 }
 
@@ -6258,7 +6258,7 @@ func (sc reversalDef) Run(c *Char, _ []int32) bool {
 		}
 		return true
 	})
-	crun.setHitdefDefault(&crun.hitdef, false)
+	crun.setHitdefDefault(&crun.hitdef)
 	return false
 }
 
@@ -6319,21 +6319,16 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 				if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 					crun = rid
 					lclscround = c.localscl / crun.localscl
-					p = crun.newProj()
-					if p == nil {
-						return false
-					}
-					p.hitdef.playerNo = sys.workingState.playerNo
 				} else {
 					return false
 				}
-			} else {
-				p = crun.newProj()
-				if p == nil {
-					return false
-				}
-				p.hitdef.playerNo = sys.workingState.playerNo
 			}
+			p = crun.newProj()
+			if p == nil {
+				return false
+			}
+			p.hitdef.playerNo = sys.workingState.playerNo
+			p.hitdef.isprojectile = true
 		}
 		switch id {
 		case projectile_postype:
@@ -6491,7 +6486,7 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 	if p == nil {
 		return false
 	}
-	crun.setHitdefDefault(&p.hitdef, true)
+	crun.setHitdefDefault(&p.hitdef)
 	if p.hitanim == -1 {
 		p.hitanim_ffx = p.anim_ffx
 	}
@@ -6834,7 +6829,7 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				})
 			case hitDef_nochainid:
 				eachProj(func(p *Projectile) {
-					for i := 0; i < int(math.Min(MaxSimul, float64(len(exp)))); i++ {
+					for i := 0; i < int(math.Min(8, float64(len(exp)))); i++ {
 						p.hitdef.nochainid[i] = exp[i].evalI(c)
 					}
 				})

--- a/src/char.go
+++ b/src/char.go
@@ -271,11 +271,9 @@ type CharSize struct {
 			front float32
 			back  float32
 		}
-		z struct {
-			width struct {
-				front float32
-				back  float32
-			}
+		width struct {
+			front float32
+			back  float32
 		}
 	}
 	proj struct {
@@ -299,7 +297,6 @@ type CharSize struct {
 	}
 	z struct {
 		width  float32
-		enable bool
 	}
 	weight     int32
 	pushfactor float32
@@ -327,8 +324,8 @@ func (cs *CharSize) init() {
 	cs.shadowoffset = 0
 	cs.draw.offset = [...]float32{0, 0}
 	cs.z.width = 3
-	cs.z.enable = false
-	cs.attack.z.width.front, cs.attack.z.width.back = 4, 4
+	cs.attack.width.front = 4
+	cs.attack.width.back = 4
 	cs.weight = 100
 	cs.pushfactor = 1
 }
@@ -2740,8 +2737,8 @@ func (c *Char) load(def string) error {
 	c.size.draw.offset[0] = c.size.draw.offset[0] / originLs
 	c.size.draw.offset[1] = c.size.draw.offset[1] / originLs
 	c.size.z.width = c.size.z.width / originLs
-	c.size.attack.z.width.front = c.size.attack.z.width.front / originLs
-	c.size.attack.z.width.back = c.size.attack.z.width.back / originLs
+	c.size.attack.width.front = c.size.attack.width.front / originLs
+	c.size.attack.width.back = c.size.attack.width.back / originLs
 
 	gi.velocity.init()
 
@@ -2869,13 +2866,7 @@ func (c *Char) load(def string) error {
 						is.ReadF32("draw.offset",
 							&c.size.draw.offset[0], &c.size.draw.offset[1])
 						is.ReadF32("z.width", &c.size.z.width)
-						var ztemp int32 = 0
-						is.ReadI32("z.enable", &ztemp)
-						if ztemp == 1 {
-							c.size.z.enable = true
-						}
-						is.ReadF32("attack.z.width",
-							&c.size.attack.z.width.front, &c.size.attack.z.width.back)
+						is.ReadF32("attack.width", &c.size.attack.width.front, &c.size.attack.width.back)
 						is.ReadI32("weight", &c.size.weight)
 						is.ReadF32("pushfactor", &c.size.pushfactor)
 					}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1755,9 +1755,9 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.append(OC_const_size_attack_dist_front)
 		case "size.attack.dist.back":
 			out.append(OC_const_size_attack_dist_back)
-		case "size.attack.z.width.back":
+		case "size.attack.width.back":
 			out.append(OC_const_size_attack_z_width_back)
-		case "size.attack.z.width.front":
+		case "size.attack.width.front":
 			out.append(OC_const_size_attack_z_width_front)
 		case "size.proj.attack.dist", "size.proj.attack.dist.front":
 			out.append(OC_const_size_proj_attack_dist_front)
@@ -1781,8 +1781,6 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.append(OC_const_size_draw_offset_y)
 		case "size.z.width":
 			out.append(OC_const_size_z_width)
-		case "size.z.enable":
-			out.append(OC_const_size_z_enable)
 		case "velocity.walk.fwd.x":
 			out.append(OC_const_velocity_walk_fwd_x)
 		case "velocity.walk.back.x":

--- a/src/script.go
+++ b/src/script.go
@@ -3050,10 +3050,10 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.size.attack.dist.front)
 		case "size.attack.dist.back":
 			ln = lua.LNumber(c.size.attack.dist.back)
-		case "size.attack.z.width.back":
-			ln = lua.LNumber(c.size.attack.z.width.back)
-		case "size.attack.z.width.front":
-			ln = lua.LNumber(c.size.attack.z.width.front)
+		case "size.attack.width.back":
+			ln = lua.LNumber(c.size.attack.width.back)
+		case "size.attack.width.front":
+			ln = lua.LNumber(c.size.attack.width.front)
 		case "size.proj.attack.dist", "size.proj.attack.dist.front":
 			ln = lua.LNumber(c.size.proj.attack.dist.front)
 		case "size.proj.attack.dist.back":
@@ -3076,8 +3076,6 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.size.draw.offset[1])
 		case "size.z.width":
 			ln = lua.LNumber(c.size.z.width)
-		case "size.z.enable":
-			ln = lua.LNumber(Btoi(c.size.z.enable))
 		case "velocity.walk.fwd.x":
 			ln = lua.LNumber(c.gi().velocity.walk.fwd)
 		case "velocity.walk.back.x":


### PR DESCRIPTION
Refactor:
- Characters with ikemenversion can now use the Hitdef's air.juggle parameter to update their juggle points at will, increasing the native juggling system's flexibility
- Ikemenversion chars will now have their juggle points reset automatically outside of Movetype A
- NoChainID number of slots adjusted to a fixed 8. Previously varied depending on the maximum number of simul characters
- Removed z.enable constant from the code. Z movement is currently enabled if the stage allows it
- Renamed "attack.z.width" constant to "attack.width", to match the original Mugen name as well the respective Hitdef parameter
- All the characters in each sprite text call now share common render parameters, only modifying those that need modifying

Shadow/reflection fixes:
- Fixed incorrect reflection offset during zoomout
- Fixed offsets not accounting for localcoord
- Fixed offsets persisting indefinitely unlike most char code
- Reduced some function call redundancy