### PR TITLE
feat: projdepthbound, Scale Z trigger; refactor: Z axis rescaling

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1655,9 +1655,9 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 		case OC_screenheight:
 			sys.bcStack.PushF(c.screenHeight())
 		case OC_screenpos_x:
-			sys.bcStack.PushF((c.screenPosX()) / oc.localscl)
+			sys.bcStack.PushF(c.screenPosX() / oc.localscl)
 		case OC_screenpos_y:
-			sys.bcStack.PushF((c.screenPosY()) / oc.localscl)
+			sys.bcStack.PushF(c.screenPosY() / oc.localscl)
 		case OC_screenwidth:
 			sys.bcStack.PushF(c.screenWidth())
 		case OC_selfanimexist:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -9332,22 +9332,20 @@ const (
 	zoom_pos byte = iota
 	zoom_scale
 	zoom_lag
-	zoom_redirectid
 	zoom_camerabound
 	zoom_time
 	zoom_stagebound
 )
 
 func (sc zoom) Run(c *Char, _ []int32) bool {
-	crun := c
-	zoompos := [2]float32{0, 0}
+	pos := [2]float32{0, 0}
 	t := int32(1)
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case zoom_pos:
-			zoompos[0] = exp[0].evalF(c) * crun.localscl
+			pos[0] = exp[0].evalF(c) * c.localscl
 			if len(exp) > 1 {
-				zoompos[1] = exp[1].evalF(c) * crun.localscl
+				pos[1] = exp[1].evalF(c) * c.localscl
 			}
 		case zoom_scale:
 			sys.zoomScale = exp[0].evalF(c)
@@ -9359,17 +9357,13 @@ func (sc zoom) Run(c *Char, _ []int32) bool {
 			sys.zoomlag = exp[0].evalF(c)
 		case zoom_time:
 			t = exp[0].evalI(c)
-		case zoom_redirectid:
-			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
-				crun = rid
-			} else {
-				return false
-			}
 		}
 		return true
 	})
-	sys.zoomPos[0] = sys.zoomScale * zoompos[0]
-	sys.zoomPos[1] = zoompos[1]
+	// This old calculation is both less accurate to Mugen and less intuitive to work with
+	// sys.zoomPos[0] = sys.zoomScale * pos[0]
+	sys.zoomPos[0] = pos[0]
+	sys.zoomPos[1] = pos[1]
 	sys.enableZoomtime = t
 	return false
 }

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -634,6 +634,7 @@ const (
 	OC_ex_angle
 	OC_ex_scale_x
 	OC_ex_scale_y
+	OC_ex_scale_z
 	OC_ex_offset_x
 	OC_ex_offset_y
 	OC_ex_alpha_s
@@ -2796,6 +2797,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		} else {
 			sys.bcStack.PushF(1)
 		}
+	case OC_ex_scale_z:
+		sys.bcStack.PushF(c.zScale)
 	case OC_ex_offset_x:
 		sys.bcStack.PushF(c.offset[0]) // Already in local scale
 	case OC_ex_offset_y:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -254,8 +254,8 @@ const (
 	OC_const_size_height_down
 	OC_const_size_attack_dist_front
 	OC_const_size_attack_dist_back
-	OC_const_size_attack_z_width_back
-	OC_const_size_attack_z_width_front
+	OC_const_size_attack_depth_back
+	OC_const_size_attack_depth_front
 	OC_const_size_proj_attack_dist_front
 	OC_const_size_proj_attack_dist_back
 	OC_const_size_proj_doscale
@@ -266,8 +266,7 @@ const (
 	OC_const_size_shadowoffset
 	OC_const_size_draw_offset_x
 	OC_const_size_draw_offset_y
-	OC_const_size_z_width
-	OC_const_size_z_enable
+	OC_const_size_depth
 	OC_const_velocity_walk_fwd_x
 	OC_const_velocity_walk_back_x
 	OC_const_velocity_walk_up_x
@@ -1806,10 +1805,10 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.size.attack.dist.front * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_attack_dist_back:
 		sys.bcStack.PushF(c.size.attack.dist.back * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_size_attack_z_width_back:
-		sys.bcStack.PushF(c.size.attack.width.back * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_size_attack_z_width_front:
-		sys.bcStack.PushF(c.size.attack.width.front * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_size_attack_depth_back:
+		sys.bcStack.PushF(c.size.attack.depth.back * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_size_attack_depth_front:
+		sys.bcStack.PushF(c.size.attack.depth.front * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_proj_attack_dist_front:
 		sys.bcStack.PushF(c.size.proj.attack.dist.front * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_proj_attack_dist_back:
@@ -1830,8 +1829,8 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.size.draw.offset[0] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_draw_offset_y:
 		sys.bcStack.PushF(c.size.draw.offset[1] * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_size_z_width:
-		sys.bcStack.PushF(c.size.z.width * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_size_depth:
+		sys.bcStack.PushF(c.size.depth * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_walk_fwd_x:
 		sys.bcStack.PushF(c.gi().velocity.walk.fwd * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_walk_back_x:
@@ -4239,7 +4238,7 @@ const (
 	helper_size_head_pos
 	helper_size_mid_pos
 	helper_size_shadowoffset
-	helper_size_z_width
+	helper_size_depth
 	helper_size_weight
 	helper_size_pushfactor
 	helper_stateno
@@ -4339,8 +4338,8 @@ func (sc helper) Run(c *Char, _ []int32) bool {
 			}
 		case helper_size_shadowoffset:
 			h.size.shadowoffset = exp[0].evalF(c)
-		case helper_size_z_width:
-			h.size.z.width = exp[0].evalF(c)
+		case helper_size_depth:
+			h.size.depth = exp[0].evalF(c)
 		case helper_size_weight:
 			h.size.weight = exp[0].evalI(c)
 		case helper_size_pushfactor:
@@ -5866,7 +5865,7 @@ const (
 	hitDef_down_recover
 	hitDef_down_recovertime
 	hitDef_xaccel
-	hitDef_attack_width
+	hitDef_attack_depth
 	hitDef_last = iota + afterImage_last + 1 - 1
 	hitDef_redirectid
 )
@@ -6164,12 +6163,12 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 		hd.down_recovertime = exp[0].evalI(c)
 	case hitDef_xaccel:
 		hd.xaccel = exp[0].evalF(c)
-	case hitDef_attack_width:
-		hd.attack.width[0] = exp[0].evalF(c)
+	case hitDef_attack_depth:
+		hd.attack.depth[0] = exp[0].evalF(c)
 		if len(exp) > 1 {
-			hd.attack.width[1] = exp[1].evalF(c)
+			hd.attack.depth[1] = exp[1].evalF(c)
 		} else {
-			hd.attack.width[1] = hd.attack.width[0]
+			hd.attack.depth[1] = hd.attack.depth[0]
 		}
 	default:
 		if !palFX(sc).runSub(c, &hd.palfx, id, exp) {
@@ -6276,6 +6275,7 @@ const (
 	projectile_projstagebound
 	projectile_projedgebound
 	projectile_projheightbound
+	projectile_projdepthbound
 	projectile_projanim
 	projectile_supermovetime
 	projectile_pausemovetime
@@ -6416,6 +6416,8 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 			if len(exp) > 1 {
 				p.heightbound[1] = int32(float32(exp[1].evalI(c)) * lclscround)
 			}
+		case projectile_projdepthbound:
+			p.depthbound= int32(float32(exp[0].evalI(c)) * lclscround)
 		case projectile_projanim:
 			p.anim = exp[1].evalI(c)
 			p.anim_ffx = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
@@ -6718,6 +6720,10 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 					if len(exp) > 1 {
 						p.heightbound[1] = int32(float32(exp[1].evalI(c)) * lclscround)
 					}
+				})
+			case projectile_projdepthbound:
+				eachProj(func(p *Projectile) {
+					p.depthbound = int32(float32(exp[0].evalI(c)) * lclscround)
 				})
 			case projectile_projanim:
 				eachProj(func(p *Projectile) {
@@ -7217,14 +7223,14 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				eachProj(func(p *Projectile) {
 					p.hitdef.xaccel = exp[0].evalF(c)
 				})
-			case hitDef_attack_width:
+			case hitDef_attack_depth:
 				eachProj(
 					func(p *Projectile) {
-						p.hitdef.attack.width[0] = exp[0].evalF(c)
+						p.hitdef.attack.depth[0] = exp[0].evalF(c)
 						if len(exp) > 1 {
-							p.hitdef.attack.width[1] = exp[1].evalF(c)
+							p.hitdef.attack.depth[1] = exp[1].evalF(c)
 						} else {
-							p.hitdef.attack.width[1] = p.hitdef.attack.width[0]
+							p.hitdef.attack.depth[1] = p.hitdef.attack.depth[0]
 						}
 					})
 			default:

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1755,10 +1755,10 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.append(OC_const_size_attack_dist_front)
 		case "size.attack.dist.back":
 			out.append(OC_const_size_attack_dist_back)
-		case "size.attack.width.back":
-			out.append(OC_const_size_attack_z_width_back)
-		case "size.attack.width.front":
-			out.append(OC_const_size_attack_z_width_front)
+		case "size.attack.depth.back":
+			out.append(OC_const_size_attack_depth_back)
+		case "size.attack.depth.front":
+			out.append(OC_const_size_attack_depth_front)
 		case "size.proj.attack.dist", "size.proj.attack.dist.front":
 			out.append(OC_const_size_proj_attack_dist_front)
 		case "size.proj.attack.dist.back":
@@ -1779,8 +1779,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.append(OC_const_size_draw_offset_x)
 		case "size.draw.offset.y":
 			out.append(OC_const_size_draw_offset_y)
-		case "size.z.width":
-			out.append(OC_const_size_z_width)
+		case "size.depth":
+			out.append(OC_const_size_depth)
 		case "velocity.walk.fwd.x":
 			out.append(OC_const_velocity_walk_fwd_x)
 		case "velocity.walk.back.x":

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -4014,6 +4014,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.append(OC_ex_, OC_ex_scale_x)
 		case "y":
 			out.append(OC_ex_, OC_ex_scale_y)
+		case "z":
+			out.append(OC_ex_, OC_ex_scale_z)
 		default:
 			return bvNone(), Error("Invalid data: " + c.token)
 		}

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -2812,7 +2812,7 @@ func (c *Compiler) screenBound(is IniSection, sc *StateControllerBase, _ int8) (
 			return err
 		}
 		if !b {
-			sc.add(screenBound_value, sc.iToExp(0))
+			sc.add(screenBound_value, sc.iToExp(0)) // In Mugen everything defaults to 0/false if you don't specify any parameters
 		}
 		b = false
 		if err := c.stateParam(is, "movecamera", false, func(data string) error {
@@ -3744,10 +3744,6 @@ func (c *Compiler) victoryQuote(is IniSection, sc *StateControllerBase, _ int8) 
 }
 func (c *Compiler) zoom(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*zoom)(sc), c.stateSec(is, func() error {
-		if err := c.paramValue(is, sc, "redirectid",
-			zoom_redirectid, VT_Int, 1, false); err != nil {
-			return err
-		}
 		if err := c.paramValue(is, sc, "pos",
 			zoom_pos, VT_Float, 2, false); err != nil {
 			return err

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -594,8 +594,8 @@ func (c *Compiler) helper(is IniSection, sc *StateControllerBase, _ int8) (State
 			helper_size_shadowoffset, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.paramValue(is, sc, "size.z.width",
-			helper_size_z_width, VT_Int, 1, false); err != nil {
+		if err := c.paramValue(is, sc, "size.depth",
+			helper_size_depth, VT_Int, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "size.weight",
@@ -1924,8 +1924,8 @@ func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 		hitDef_xaccel, VT_Float, 1, false); err != nil {
 		return err
 	}
-	if err := c.paramValue(is, sc, "attack.width",
-		hitDef_attack_width, VT_Float, 2, false); err != nil {
+	if err := c.paramValue(is, sc, "attack.depth",
+		hitDef_attack_depth, VT_Float, 2, false); err != nil {
 		return err
 	}
 	return nil
@@ -2114,6 +2114,10 @@ func (c *Compiler) projectileSub(is IniSection, sc *StateControllerBase, ihp int
 	}
 	if err := c.paramValue(is, sc, "projheightbound",
 		projectile_projheightbound, VT_Int, 2, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "projdepthbound",
+		projectile_projdepthbound, VT_Int, 1, false); err != nil {
 		return err
 	}
 	if err := c.stateParam(is, "projanim", false, func(data string) error {

--- a/src/script.go
+++ b/src/script.go
@@ -3050,10 +3050,10 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.size.attack.dist.front)
 		case "size.attack.dist.back":
 			ln = lua.LNumber(c.size.attack.dist.back)
-		case "size.attack.width.back":
-			ln = lua.LNumber(c.size.attack.width.back)
-		case "size.attack.width.front":
-			ln = lua.LNumber(c.size.attack.width.front)
+		case "size.attack.depth.back":
+			ln = lua.LNumber(c.size.attack.depth.back)
+		case "size.attack.depth.front":
+			ln = lua.LNumber(c.size.attack.depth.front)
 		case "size.proj.attack.dist", "size.proj.attack.dist.front":
 			ln = lua.LNumber(c.size.proj.attack.dist.front)
 		case "size.proj.attack.dist.back":
@@ -3074,8 +3074,8 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.size.draw.offset[0])
 		case "size.draw.offset.y":
 			ln = lua.LNumber(c.size.draw.offset[1])
-		case "size.z.width":
-			ln = lua.LNumber(c.size.z.width)
+		case "size.depth":
+			ln = lua.LNumber(c.size.depth)
 		case "velocity.walk.fwd.x":
 			ln = lua.LNumber(c.gi().velocity.walk.fwd)
 		case "velocity.walk.back.x":

--- a/src/script.go
+++ b/src/script.go
@@ -5077,6 +5077,10 @@ func triggerFunctions(l *lua.LState) {
 		}
 		return 1
 	})
+	luaRegister(l, "scaleZ", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.zScale))
+		return 1
+	})
 	luaRegister(l, "sign", func(*lua.LState) int {
 		v, retv := float32(numArg(l, 1)), int32(0)
 		if v < 0 {


### PR DESCRIPTION
Refactor:
- The Z axis rescaling no longer affects the game logic, meaning positions, collision boxes etc stay the same. The feeling of depth is now handled only by the rendering of the players
- If top and bottom scale are different, the chars will now move with a feeling of perspective
- Adjusted how characters are "clamped" inside the Z boundaries to be more in line with the other char logic. Chars can now move freely outside of them if they use screenbound with stagebound = 0
- Since "width" is commonly associated with the X axis, most Z axis parameters were renamed to use "depth" instead
- The X position parameter in Zoom sctrl was changed to not recursively be affected by the scale. This makes the sctrl easier to work with as well as act closer to Mugen. Also removed redirectID from it since it affects the system environment, making that redundant


Feat:
- Added "projdepthbound", which limits a projectile's ability to travel outside the Z boundaries
- Added Scale Z trigger. Returns the rescaling factor when moving in the Z axis