### PR TITLE
refactor: stage localcoord, StageVar, ModifyExplod

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -2041,23 +2041,23 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 	case OC_const_stagevar_camera_autocenter:
 		sys.bcStack.PushB(sys.stage.stageCamera.autocenter)
 	case OC_const_stagevar_camera_boundleft:
-		sys.bcStack.PushI(sys.stage.stageCamera.boundleft)
+		sys.bcStack.PushI(int32(float32(sys.stage.stageCamera.boundleft) * sys.stage.localscl/oc.localscl))
 	case OC_const_stagevar_camera_boundright:
-		sys.bcStack.PushI(sys.stage.stageCamera.boundright)
+		sys.bcStack.PushI(int32(float32(sys.stage.stageCamera.boundright) * sys.stage.localscl/oc.localscl))
 	case OC_const_stagevar_camera_boundhigh:
-		sys.bcStack.PushI(sys.stage.stageCamera.boundhigh)
+		sys.bcStack.PushI(int32(float32(sys.stage.stageCamera.boundhigh) * sys.stage.localscl/oc.localscl))
 	case OC_const_stagevar_camera_boundlow:
-		sys.bcStack.PushI(sys.stage.stageCamera.boundlow)
+		sys.bcStack.PushI(int32(float32(sys.stage.stageCamera.boundlow) * sys.stage.localscl/oc.localscl))
 	case OC_const_stagevar_camera_floortension:
-		sys.bcStack.PushI(sys.stage.stageCamera.floortension)
+		sys.bcStack.PushI(int32(float32(sys.stage.stageCamera.floortension) * sys.stage.localscl/oc.localscl))
 	case OC_const_stagevar_camera_lowestcap:
 		sys.bcStack.PushB(sys.stage.stageCamera.lowestcap)
 	case OC_const_stagevar_camera_tension:
-		sys.bcStack.PushI(sys.stage.stageCamera.tension)
+		sys.bcStack.PushI(int32(float32(sys.stage.stageCamera.tension) * sys.stage.localscl/oc.localscl))
 	case OC_const_stagevar_camera_tensionhigh:
-		sys.bcStack.PushI(sys.stage.stageCamera.tensionhigh)
+		sys.bcStack.PushI(int32(float32(sys.stage.stageCamera.tensionhigh) * sys.stage.localscl/oc.localscl))
 	case OC_const_stagevar_camera_tensionlow:
-		sys.bcStack.PushI(sys.stage.stageCamera.tensionlow)
+		sys.bcStack.PushI(int32(float32(sys.stage.stageCamera.tensionlow) * sys.stage.localscl/oc.localscl))
 	case OC_const_stagevar_camera_startzoom:
 		sys.bcStack.PushF(sys.stage.stageCamera.startzoom)
 	case OC_const_stagevar_camera_verticalfollow:
@@ -2077,9 +2077,9 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 	case OC_const_stagevar_camera_ytension_enable:
 		sys.bcStack.PushB(sys.stage.stageCamera.ytensionenable)
 	case OC_const_stagevar_playerinfo_leftbound:
-		sys.bcStack.PushF(sys.stage.leftbound)
+		sys.bcStack.PushF(sys.stage.leftbound * sys.stage.localscl/oc.localscl)
 	case OC_const_stagevar_playerinfo_rightbound:
-		sys.bcStack.PushF(sys.stage.rightbound)
+		sys.bcStack.PushF(sys.stage.rightbound * sys.stage.localscl/oc.localscl)
 	case OC_const_stagevar_scaling_topz:
 		sys.bcStack.PushF(sys.stage.stageCamera.topz)
 	case OC_const_stagevar_scaling_botz:
@@ -2089,9 +2089,9 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 	case OC_const_stagevar_scaling_botscale:
 		sys.bcStack.PushF(sys.stage.stageCamera.zbotscale)
 	case OC_const_stagevar_bound_screenleft:
-		sys.bcStack.PushI(sys.stage.screenleft)
+		sys.bcStack.PushI(int32(float32(sys.stage.screenleft) * sys.stage.localscl/oc.localscl))
 	case OC_const_stagevar_bound_screenright:
-		sys.bcStack.PushI(sys.stage.screenright)
+		sys.bcStack.PushI(int32(float32(sys.stage.screenright) * sys.stage.localscl/oc.localscl))
 	case OC_const_stagevar_stageinfo_localcoord_x:
 		sys.bcStack.PushI(sys.stage.stageCamera.localcoord[0])
 	case OC_const_stagevar_stageinfo_localcoord_y:
@@ -2101,7 +2101,7 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 	case OC_const_stagevar_stageinfo_yscale:
 		sys.bcStack.PushF(sys.stage.scale[1])
 	case OC_const_stagevar_stageinfo_zoffset:
-		sys.bcStack.PushI(sys.stage.stageCamera.zoffset)
+		sys.bcStack.PushI(int32(float32(sys.stage.stageCamera.zoffset) * sys.stage.localscl/oc.localscl))
 	case OC_const_stagevar_stageinfo_zoffsetlink:
 		sys.bcStack.PushI(sys.stage.zoffsetlink)
 	case OC_const_stagevar_shadow_intensity:
@@ -2115,23 +2115,23 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 	case OC_const_stagevar_shadow_yscale:
 		sys.bcStack.PushF(sys.stage.sdw.yscale)
 	case OC_const_stagevar_shadow_fade_range_begin:
-		sys.bcStack.PushI(sys.stage.sdw.fadebgn)
+		sys.bcStack.PushI(int32(float32(sys.stage.sdw.fadebgn) * sys.stage.localscl/oc.localscl))
 	case OC_const_stagevar_shadow_fade_range_end:
-		sys.bcStack.PushI(sys.stage.sdw.fadeend)
+		sys.bcStack.PushI(int32(float32(sys.stage.sdw.fadeend) * sys.stage.localscl/oc.localscl))
 	case OC_const_stagevar_shadow_xshear:
 		sys.bcStack.PushF(sys.stage.sdw.xshear)
 	case OC_const_stagevar_shadow_offset_x:
-		sys.bcStack.PushF(sys.stage.sdw.offset[0])
+		sys.bcStack.PushF(sys.stage.sdw.offset[0] * sys.stage.localscl/oc.localscl)
 	case OC_const_stagevar_shadow_offset_y:
-		sys.bcStack.PushF(sys.stage.sdw.offset[1])
+		sys.bcStack.PushF(sys.stage.sdw.offset[1] * sys.stage.localscl/oc.localscl)
 	case OC_const_stagevar_reflection_intensity:
 		sys.bcStack.PushI(sys.stage.reflection.intensity)
 	case OC_const_stagevar_reflection_yscale:
 		sys.bcStack.PushF(sys.stage.reflection.yscale)
 	case OC_const_stagevar_reflection_offset_x:
-		sys.bcStack.PushF(sys.stage.reflection.offset[0])
+		sys.bcStack.PushF(sys.stage.reflection.offset[0] * sys.stage.localscl/oc.localscl)
 	case OC_const_stagevar_reflection_offset_y:
-		sys.bcStack.PushF(sys.stage.reflection.offset[1])
+		sys.bcStack.PushF(sys.stage.reflection.offset[1] * sys.stage.localscl/oc.localscl)
 	case OC_const_stagevar_reflection_xshear:
 		sys.bcStack.PushF(sys.stage.reflection.xshear)
 	case OC_const_stagevar_reflection_color_r:
@@ -10990,42 +10990,42 @@ const (
 	modifyStageVar_reflection_xshear
 	modifyStageVar_reflection_color
 	modifyStageVar_reflection_offset
-	modifyStageVar_redirectid
 )
 
 func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
-	//crun := c
+	//crun := c RedirectID is pointless when modifying a stage
 	s := *&sys.stage
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
+		// Camera group
 		case modifyStageVar_camera_autocenter:
 			s.stageCamera.autocenter = exp[0].evalB(c)
 		case modifyStageVar_camera_boundleft:
-			s.stageCamera.boundleft = exp[0].evalI(c)
+			s.stageCamera.boundleft = int32(exp[0].evalF(c) * c.localscl / sys.stage.localscl)
 		case modifyStageVar_camera_boundright:
-			s.stageCamera.boundright = exp[0].evalI(c)
+			s.stageCamera.boundright = int32(exp[0].evalF(c) * c.localscl / sys.stage.localscl)
 		case modifyStageVar_camera_boundhigh:
-			s.stageCamera.boundhigh = exp[0].evalI(c)
+			s.stageCamera.boundhigh = int32(exp[0].evalF(c) * c.localscl / sys.stage.localscl)
 		case modifyStageVar_camera_boundlow:
-			s.stageCamera.boundlow = exp[0].evalI(c)
+			s.stageCamera.boundlow = int32(exp[0].evalF(c) * c.localscl / sys.stage.localscl)
 		case modifyStageVar_camera_verticalfollow:
 			s.stageCamera.verticalfollow = exp[0].evalF(c)
 		case modifyStageVar_camera_floortension:
-			s.stageCamera.floortension = exp[0].evalI(c)
+			s.stageCamera.floortension = int32(exp[0].evalF(c) * c.localscl / sys.stage.localscl)
 		case modifyStageVar_camera_lowestcap:
 			s.stageCamera.lowestcap = exp[0].evalB(c)
 		case modifyStageVar_camera_tensionhigh:
-			s.stageCamera.tensionhigh = exp[0].evalI(c)
+			s.stageCamera.tensionhigh = int32(exp[0].evalF(c) * c.localscl / sys.stage.localscl)
 		case modifyStageVar_camera_tensionlow:
-			s.stageCamera.tensionlow = exp[0].evalI(c)
+			s.stageCamera.tensionlow = int32(exp[0].evalF(c) * c.localscl / sys.stage.localscl)
 		case modifyStageVar_camera_tension:
-			s.stageCamera.tension = exp[0].evalI(c)
+			s.stageCamera.tension = int32(exp[0].evalF(c) * c.localscl / sys.stage.localscl)
 		case modifyStageVar_camera_tensionvel:
 			s.stageCamera.tensionvel = exp[0].evalF(c)
 		case modifyStageVar_camera_cuthigh:
-			s.stageCamera.cuthigh = exp[0].evalI(c)
+			s.stageCamera.cuthigh = int32(exp[0].evalF(c) * c.localscl / sys.stage.localscl)
 		case modifyStageVar_camera_cutlow:
-			s.stageCamera.cutlow = exp[0].evalI(c)
+			s.stageCamera.cutlow = int32(exp[0].evalF(c) * c.localscl / sys.stage.localscl)
 		case modifyStageVar_camera_startzoom:
 			s.stageCamera.startzoom = exp[0].evalF(c)
 		case modifyStageVar_camera_zoomout:
@@ -11042,10 +11042,12 @@ func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 			s.stageCamera.ytensionenable = exp[0].evalB(c)
 		case modifyStageVar_camera_yscrollspeed:
 			s.stageCamera.yscrollspeed = exp[0].evalF(c)
+		// PlayerInfo group
 		case modifyStageVar_playerinfo_leftbound:
-			s.leftbound = exp[0].evalF(c)
+			s.leftbound = exp[0].evalF(c) * sys.stage.localscl/c.localscl
 		case modifyStageVar_playerinfo_rightbound:
-			s.rightbound = exp[0].evalF(c)
+			s.rightbound = exp[0].evalF(c) * sys.stage.localscl/c.localscl
+		// Scaling group
 		case modifyStageVar_scaling_topz:
 			if s.mugenver[0] != 1 { // mugen 1.0+ removed support for topz
 				s.stageCamera.topz = exp[0].evalF(c)
@@ -11062,10 +11064,12 @@ func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 			if s.mugenver[0] != 1 { // mugen 1.0+ removed support for botscale
 				s.stageCamera.zbotscale = exp[0].evalF(c)
 			}
+		// Bound group
 		case modifyStageVar_bound_screenleft:
 			s.screenleft = exp[0].evalI(c)
 		case modifyStageVar_bound_screenright:
 			s.screenright = exp[0].evalI(c)
+		// StageInfo group
 		case modifyStageVar_stageinfo_zoffset:
 			s.stageCamera.zoffset = exp[0].evalI(c)
 		case modifyStageVar_stageinfo_zoffsetlink:
@@ -11074,6 +11078,7 @@ func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 			s.scale[0] = exp[0].evalF(c)
 		case modifyStageVar_stageinfo_yscale:
 			s.scale[1] = exp[0].evalF(c)
+		// Shadow group
 		case modifyStageVar_shadow_intensity:
 			s.sdw.intensity = Clamp(exp[0].evalI(c), 0, 255)
 		case modifyStageVar_shadow_color:
@@ -11094,6 +11099,7 @@ func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 		case modifyStageVar_shadow_offset:
 			s.sdw.offset[0] = exp[0].evalF(c)
 			s.sdw.offset[1] = exp[1].evalF(c)
+		// Reflection group
 		case modifyStageVar_reflection_intensity:
 			s.reflection.intensity = Clamp(exp[0].evalI(c), 0, 255)
 		case modifyStageVar_reflection_yscale:
@@ -11111,12 +11117,6 @@ func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 		case modifyStageVar_reflection_offset:
 			s.reflection.offset[0] = exp[0].evalF(c)
 			s.reflection.offset[1] = exp[1].evalF(c)
-		case modifyStageVar_redirectid:
-			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
-				//crun = rid - RedirectID is useless when modifying a stage
-			} else {
-				return false
-			}
 		}
 		return true
 	})

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1837,9 +1837,9 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 	case OC_const_velocity_walk_back_x:
 		sys.bcStack.PushF(c.gi().velocity.walk.back * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_walk_up_x:
-		sys.bcStack.PushF(c.gi().velocity.walk.up.x * ((320 / c.localcoord) / oc.localscl))
+		sys.bcStack.PushF(c.gi().velocity.walk.up * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_walk_down_x:
-		sys.bcStack.PushF(c.gi().velocity.walk.down.x * ((320 / c.localcoord) / oc.localscl))
+		sys.bcStack.PushF(c.gi().velocity.walk.down * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_run_fwd_x:
 		sys.bcStack.PushF(c.gi().velocity.run.fwd[0] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_run_fwd_y:
@@ -1849,13 +1849,13 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 	case OC_const_velocity_run_back_y:
 		sys.bcStack.PushF(c.gi().velocity.run.back[1] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_run_up_x:
-		sys.bcStack.PushF(c.gi().velocity.run.up.x * ((320 / c.localcoord) / oc.localscl))
+		sys.bcStack.PushF(c.gi().velocity.run.up[0] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_run_up_y:
-		sys.bcStack.PushF(c.gi().velocity.run.up.y * ((320 / c.localcoord) / oc.localscl))
+		sys.bcStack.PushF(c.gi().velocity.run.up[1] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_run_down_x:
-		sys.bcStack.PushF(c.gi().velocity.run.down.x * ((320 / c.localcoord) / oc.localscl))
+		sys.bcStack.PushF(c.gi().velocity.run.down[0] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_run_down_y:
-		sys.bcStack.PushF(c.gi().velocity.run.down.y * ((320 / c.localcoord) / oc.localscl))
+		sys.bcStack.PushF(c.gi().velocity.run.down[1] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_jump_y:
 		sys.bcStack.PushF(c.gi().velocity.jump.neu[1] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_jump_neu_x:
@@ -1865,9 +1865,9 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 	case OC_const_velocity_jump_fwd_x:
 		sys.bcStack.PushF(c.gi().velocity.jump.fwd * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_jump_up_x:
-		sys.bcStack.PushF(c.gi().velocity.jump.up.x * ((320 / c.localcoord) / oc.localscl))
+		sys.bcStack.PushF(c.gi().velocity.jump.up * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_jump_down_x:
-		sys.bcStack.PushF(c.gi().velocity.jump.down.x * ((320 / c.localcoord) / oc.localscl))
+		sys.bcStack.PushF(c.gi().velocity.jump.down * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_runjump_back_x:
 		sys.bcStack.PushF(c.gi().velocity.runjump.back[0] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_runjump_back_y:
@@ -1877,9 +1877,9 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 	case OC_const_velocity_runjump_fwd_x:
 		sys.bcStack.PushF(c.gi().velocity.runjump.fwd[0] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_runjump_up_x:
-		sys.bcStack.PushF(c.gi().velocity.runjump.up.x * ((320 / c.localcoord) / oc.localscl))
+		sys.bcStack.PushF(c.gi().velocity.runjump.up * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_runjump_down_x:
-		sys.bcStack.PushF(c.gi().velocity.runjump.down.x * ((320 / c.localcoord) / oc.localscl))
+		sys.bcStack.PushF(c.gi().velocity.runjump.down * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_airjump_y:
 		sys.bcStack.PushF(c.gi().velocity.airjump.neu[1] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_airjump_neu_x:
@@ -1889,9 +1889,9 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 	case OC_const_velocity_airjump_fwd_x:
 		sys.bcStack.PushF(c.gi().velocity.airjump.fwd * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_airjump_up_x:
-		sys.bcStack.PushF(c.gi().velocity.airjump.up.x * ((320 / c.localcoord) / oc.localscl))
+		sys.bcStack.PushF(c.gi().velocity.airjump.up * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_airjump_down_x:
-		sys.bcStack.PushF(c.gi().velocity.airjump.down.x * ((320 / c.localcoord) / oc.localscl))
+		sys.bcStack.PushF(c.gi().velocity.airjump.down * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_air_gethit_groundrecover_x:
 		sys.bcStack.PushF(c.gi().velocity.air.gethit.groundrecover[0] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_air_gethit_groundrecover_y:

--- a/src/char.go
+++ b/src/char.go
@@ -1183,20 +1183,6 @@ func (e *Explod) clear() {
 		ignorehitpause: true,
 	}
 }
-func (e *Explod) reset() {
-	e.facing = 1
-	e.offset[0], e.offset[1], e.offset[2] = 0, 0, 0
-	e.setX(e.offset[0])
-	e.setY(e.offset[1])
-	e.setZ(e.offset[2])
-	e.relativePos = [3]float32{0, 0, 0}
-	e.velocity = [3]float32{0, 0, 0}
-	e.accel[0], e.accel[1], e.accel[2] = 0, 0, 0
-	e.bindId = -2
-	if e.bindtime == 0 {
-		e.bindtime = 1
-	}
-}
 func (e *Explod) setX(x float32) {
 	e.pos[0], e.oldPos[0], e.newPos[0] = x, x, x
 }

--- a/src/char.go
+++ b/src/char.go
@@ -332,56 +332,34 @@ type CharVelocity struct {
 	walk struct {
 		fwd  float32
 		back float32
-		up   struct {
-			x float32
-		}
-		down struct {
-			x float32
-		}
+		up float32
+		down float32
 	}
 	run struct {
 		fwd  [2]float32
 		back [2]float32
-		up   struct {
-			x float32
-			y float32
-		}
-		down struct {
-			x float32
-			y float32
-		}
+		up   [2]float32
+		down [2]float32
 	}
 	jump struct {
 		neu  [2]float32
 		back float32
 		fwd  float32
-		up   struct {
-			x float32
-		}
-		down struct {
-			x float32
-		}
+		up   float32
+		down float32
 	}
 	runjump struct {
 		back [2]float32
 		fwd  [2]float32
-		up   struct {
-			x float32
-		}
-		down struct {
-			x float32
-		}
+		up   float32
+		down float32
 	}
 	airjump struct {
 		neu  [2]float32
 		back float32
 		fwd  float32
-		up   struct {
-			x float32
-		}
-		down struct {
-			x float32
-		}
+		up   float32
+		down float32
 	}
 	air struct {
 		gethit struct {
@@ -2725,72 +2703,79 @@ func (c *Char) load(def string) error {
 	// Correct engine default values to character's own localcoord
 	gi.data.init()
 	c.size.init()
-	originLs := c.localscl * (320 / float32(sys.gameWidth))
 
-	c.size.ground.back = c.size.ground.back / originLs
-	c.size.ground.front = c.size.ground.front / originLs
-	c.size.air.back = c.size.air.back / originLs
-	c.size.air.front = c.size.air.front / originLs
-	c.size.height.stand = c.size.height.stand / originLs
-	c.size.height.crouch = c.size.height.crouch / originLs
-	c.size.height.air[0] = c.size.height.air[0] / originLs
-	c.size.height.air[1] = c.size.height.air[1] / originLs
-	c.size.height.down = c.size.height.down / originLs
-	c.size.attack.dist.front = c.size.attack.dist.front / originLs
-	c.size.attack.dist.back = c.size.attack.dist.back / originLs
-	c.size.proj.attack.dist.front = c.size.proj.attack.dist.front / originLs
-	c.size.proj.attack.dist.back = c.size.proj.attack.dist.back / originLs
-	c.size.head.pos[0] = c.size.head.pos[0] / originLs
-	c.size.head.pos[1] = c.size.head.pos[1] / originLs
-	c.size.mid.pos[0] = c.size.mid.pos[0] / originLs
-	c.size.mid.pos[1] = c.size.mid.pos[1] / originLs
-	c.size.shadowoffset = c.size.shadowoffset / originLs
-	c.size.draw.offset[0] = c.size.draw.offset[0] / originLs
-	c.size.draw.offset[1] = c.size.draw.offset[1] / originLs
-	c.size.depth = c.size.depth / originLs
-	c.size.attack.depth.front = c.size.attack.depth.front / originLs
-	c.size.attack.depth.back = c.size.attack.depth.back / originLs
+	originLs := 320 / float32(c.gi().localcoord[0])
+
+	if originLs != 1 {
+		c.size.ground.back = c.size.ground.back / originLs
+		c.size.ground.front = c.size.ground.front / originLs
+		c.size.air.back = c.size.air.back / originLs
+		c.size.air.front = c.size.air.front / originLs
+		c.size.height.stand = c.size.height.stand / originLs
+		c.size.height.crouch = c.size.height.crouch / originLs
+		c.size.height.air[0] = c.size.height.air[0] / originLs
+		c.size.height.air[1] = c.size.height.air[1] / originLs
+		c.size.height.down = c.size.height.down / originLs
+		c.size.attack.dist.front = c.size.attack.dist.front / originLs
+		c.size.attack.dist.back = c.size.attack.dist.back / originLs
+		c.size.proj.attack.dist.front = c.size.proj.attack.dist.front / originLs
+		c.size.proj.attack.dist.back = c.size.proj.attack.dist.back / originLs
+		c.size.head.pos[0] = c.size.head.pos[0] / originLs
+		c.size.head.pos[1] = c.size.head.pos[1] / originLs
+		c.size.mid.pos[0] = c.size.mid.pos[0] / originLs
+		c.size.mid.pos[1] = c.size.mid.pos[1] / originLs
+		c.size.shadowoffset = c.size.shadowoffset / originLs
+		c.size.draw.offset[0] = c.size.draw.offset[0] / originLs
+		c.size.draw.offset[1] = c.size.draw.offset[1] / originLs
+		c.size.depth = c.size.depth / originLs
+		c.size.attack.depth.front = c.size.attack.depth.front / originLs
+		c.size.attack.depth.back = c.size.attack.depth.back / originLs
+	}
 
 	gi.velocity.init()
 
-	gi.velocity.air.gethit.groundrecover[0] /= originLs
-	gi.velocity.air.gethit.groundrecover[1] /= originLs
-	gi.velocity.air.gethit.airrecover.add[0] /= originLs
-	gi.velocity.air.gethit.airrecover.add[1] /= originLs
-	gi.velocity.air.gethit.airrecover.back /= originLs
-	gi.velocity.air.gethit.airrecover.fwd /= originLs
-	gi.velocity.air.gethit.airrecover.up /= originLs
-	gi.velocity.air.gethit.airrecover.down /= originLs
+	if originLs != 1 {
+		gi.velocity.air.gethit.groundrecover[0] /= originLs
+		gi.velocity.air.gethit.groundrecover[1] /= originLs
+		gi.velocity.air.gethit.airrecover.add[0] /= originLs
+		gi.velocity.air.gethit.airrecover.add[1] /= originLs
+		gi.velocity.air.gethit.airrecover.back /= originLs
+		gi.velocity.air.gethit.airrecover.fwd /= originLs
+		gi.velocity.air.gethit.airrecover.up /= originLs
+		gi.velocity.air.gethit.airrecover.down /= originLs
 
-	gi.velocity.airjump.neu[0] /= originLs
-	gi.velocity.airjump.neu[1] /= originLs
-	gi.velocity.airjump.back /= originLs
-	gi.velocity.airjump.fwd /= originLs
+		gi.velocity.airjump.neu[0] /= originLs
+		gi.velocity.airjump.neu[1] /= originLs
+		gi.velocity.airjump.back /= originLs
+		gi.velocity.airjump.fwd /= originLs
 
-	gi.velocity.air.gethit.ko.add[0] /= originLs
-	gi.velocity.air.gethit.ko.add[1] /= originLs
-	gi.velocity.air.gethit.ko.ymin /= originLs
-	gi.velocity.ground.gethit.ko.add[0] /= originLs
-	gi.velocity.ground.gethit.ko.add[1] /= originLs
-	gi.velocity.ground.gethit.ko.ymin /= originLs
+		gi.velocity.air.gethit.ko.add[0] /= originLs
+		gi.velocity.air.gethit.ko.add[1] /= originLs
+		gi.velocity.air.gethit.ko.ymin /= originLs
+		gi.velocity.ground.gethit.ko.add[0] /= originLs
+		gi.velocity.ground.gethit.ko.add[1] /= originLs
+		gi.velocity.ground.gethit.ko.ymin /= originLs
+	}
 
 	gi.movement.init()
 
-	gi.movement.airjump.height = int32(float32(gi.movement.airjump.height) / originLs)
-	gi.movement.yaccel /= originLs
-	gi.movement.stand.friction_threshold /= originLs
-	gi.movement.crouch.friction_threshold /= originLs
-	gi.movement.air.gethit.groundlevel /= originLs
-	gi.movement.air.gethit.groundrecover.ground.threshold /= originLs
-	gi.movement.air.gethit.groundrecover.groundlevel /= originLs
-	gi.movement.air.gethit.airrecover.threshold /= originLs
-	gi.movement.air.gethit.airrecover.yaccel /= originLs
-	gi.movement.air.gethit.trip.groundlevel /= originLs
-	gi.movement.down.bounce.offset[0] /= originLs
-	gi.movement.down.bounce.offset[1] /= originLs
-	gi.movement.down.bounce.yaccel /= originLs
-	gi.movement.down.bounce.groundlevel /= originLs
-	gi.movement.down.friction_threshold /= originLs
+	if originLs != 1 {
+		gi.movement.airjump.height = int32(float32(gi.movement.airjump.height) / originLs)
+		gi.movement.yaccel /= originLs
+		gi.movement.stand.friction_threshold /= originLs
+		gi.movement.crouch.friction_threshold /= originLs
+		gi.movement.air.gethit.groundlevel /= originLs
+		gi.movement.air.gethit.groundrecover.ground.threshold /= originLs
+		gi.movement.air.gethit.groundrecover.groundlevel /= originLs
+		gi.movement.air.gethit.airrecover.threshold /= originLs
+		gi.movement.air.gethit.airrecover.yaccel /= originLs
+		gi.movement.air.gethit.trip.groundlevel /= originLs
+		gi.movement.down.bounce.offset[0] /= originLs
+		gi.movement.down.bounce.offset[1] /= originLs
+		gi.movement.down.bounce.yaccel /= originLs
+		gi.movement.down.bounce.groundlevel /= originLs
+		gi.movement.down.friction_threshold /= originLs
+	}
 
 	gi.remapPreset = make(map[string]RemapPreset)
 
@@ -2886,14 +2871,9 @@ func (c *Char) load(def string) error {
 						velocity = false
 						is.ReadF32("walk.fwd", &gi.velocity.walk.fwd)
 						is.ReadF32("walk.back", &gi.velocity.walk.back)
-						is.ReadF32("walk.up.x", &gi.velocity.walk.up.x) // Should be Z
-						is.ReadF32("walk.down.x", &gi.velocity.walk.down.x)
 						is.ReadF32("run.fwd", &gi.velocity.run.fwd[0], &gi.velocity.run.fwd[1])
 						is.ReadF32("run.back",
 							&gi.velocity.run.back[0], &gi.velocity.run.back[1])
-						is.ReadF32("run.up", &gi.velocity.run.up.x, &gi.velocity.run.up.y)
-						is.ReadF32("run.down", // Z and Y?
-							&gi.velocity.run.down.x, &gi.velocity.run.down.y)
 						is.ReadF32("jump.neu",
 							&gi.velocity.jump.neu[0], &gi.velocity.jump.neu[1])
 						is.ReadF32("jump.back", &gi.velocity.jump.back)
@@ -2906,20 +2886,14 @@ func (c *Char) load(def string) error {
 						c.gi().velocity.airjump.neu = c.gi().velocity.jump.neu
 						c.gi().velocity.airjump.back = c.gi().velocity.jump.back
 						c.gi().velocity.airjump.fwd = c.gi().velocity.jump.fwd
-						is.ReadF32("jump.up.x", &gi.velocity.jump.up.x)
-						is.ReadF32("jump.down.x", &gi.velocity.jump.down.x)
 						is.ReadF32("runjump.back",
 							&gi.velocity.runjump.back[0], &gi.velocity.runjump.back[1])
 						is.ReadF32("runjump.fwd",
 							&gi.velocity.runjump.fwd[0], &gi.velocity.runjump.fwd[1])
-						is.ReadF32("runjump.up.x", &gi.velocity.runjump.up.x)
-						is.ReadF32("runjump.down.x", &gi.velocity.runjump.down.x)
 						is.ReadF32("airjump.neu",
 							&gi.velocity.airjump.neu[0], &gi.velocity.airjump.neu[1])
 						is.ReadF32("airjump.back", &gi.velocity.airjump.back)
 						is.ReadF32("airjump.fwd", &gi.velocity.airjump.fwd)
-						is.ReadF32("airjump.up.x", &gi.velocity.airjump.up.x)
-						is.ReadF32("airjump.down.x", &gi.velocity.airjump.down.x)
 						is.ReadF32("air.gethit.groundrecover",
 							&gi.velocity.air.gethit.groundrecover[0],
 							&gi.velocity.air.gethit.groundrecover[1])
@@ -2944,6 +2918,21 @@ func (c *Char) load(def string) error {
 						is.ReadF32("ground.gethit.ko.add", &gi.velocity.ground.gethit.ko.add[0],
 							&gi.velocity.ground.gethit.ko.add[1])
 						is.ReadF32("ground.gethit.ko.ymin", &gi.velocity.ground.gethit.ko.ymin)
+
+						// Mugen accepts these but they are not documented
+						// Possible leftovers of Z axis implementation
+						is.ReadF32("walk.up", &gi.velocity.walk.up) // Should be "z" but Elecbyte decided on "x"
+						is.ReadF32("walk.down", &gi.velocity.walk.down)
+						is.ReadF32("run.up",
+							&gi.velocity.run.up[0], &gi.velocity.run.up[1])
+						is.ReadF32("run.down",
+							&gi.velocity.run.down[0], &gi.velocity.run.down[1]) // Z and Y?
+						is.ReadF32("jump.up", &gi.velocity.jump.up) // Mugen accepts them with this syntax, but they need "x" when retrieved with const trigger
+						is.ReadF32("jump.down", &gi.velocity.jump.down)
+						is.ReadF32("runjump.up", &gi.velocity.runjump.up)
+						is.ReadF32("runjump.down", &gi.velocity.runjump.down)
+						is.ReadF32("airjump.up", &gi.velocity.airjump.up)
+						is.ReadF32("airjump.down", &gi.velocity.airjump.down)
 					}
 				case "movement":
 					if movement {
@@ -7378,7 +7367,6 @@ func (c *Char) actionRun() {
 	c.zWidthBound()
 
 	// Final scale calculations
-	// There's a minor issue here in that this scale is calculated
 	// Clsn and size box scale used to factor zScale here, but they shouldn't
 	// Game logic should stay the same regardless of Z scale. Only drawing changes
 	c.zScale = sys.updateZScale(c.pos[2], c.localscl)                                 // Must be placed after posUpdate()

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -700,11 +700,12 @@ func (c *Compiler) explodSub(is IniSection,
 		explod_id, VT_Int, 1, false); err != nil {
 		return err
 	}
-	// First, we see if postype parameter was declared, to see if
-	// an ikemenver character will modify facing, pos, random, vel
-	// or accel values without declaring postype.
-	if _, ok := is["postype"]; ok {
-		c.scAdd(sc, explod_postypeExists, "1", VT_Bool, 1)
+	// Postype must be placed before parameters such as pos, for the sake of ModifyExplod
+	if err := c.paramPostype(is, sc, explod_postype); err != nil {
+		return err
+	}
+	if err := c.paramSpace(is, sc, explod_space); err != nil {
+		return err
 	}
 	if err := c.paramValue(is, sc, "facing",
 		explod_facing, VT_Int, 1, false); err != nil {
@@ -737,12 +738,6 @@ func (c *Compiler) explodSub(is IniSection,
 	}
 	if err := c.paramValue(is, sc, "accel",
 		explod_accel, VT_Float, 3, false); err != nil {
-		return err
-	}
-	if err := c.paramSpace(is, sc, explod_space); err != nil {
-		return err
-	}
-	if err := c.paramPostype(is, sc, explod_postype); err != nil {
 		return err
 	}
 	if err := c.paramProjection(is, sc, explod_projection); err != nil {

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -4905,10 +4905,6 @@ func (c *Compiler) createPlatform(is IniSection, sc *StateControllerBase, _ int8
 }
 func (c *Compiler) modifyStageVar(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*modifyStageVar)(sc), c.stateSec(is, func() error {
-		if err := c.paramValue(is, sc, "redirectid",
-			modifyStageVar_redirectid, VT_Int, 1, false); err != nil {
-			return err
-		}
 		if err := c.paramValue(is, sc, "camera.boundleft",
 			modifyStageVar_camera_boundleft, VT_Int, 1, false); err != nil {
 			return err

--- a/src/script.go
+++ b/src/script.go
@@ -3280,9 +3280,9 @@ func triggerFunctions(l *lua.LState) {
 		case "velocity.walk.back.x":
 			ln = lua.LNumber(c.gi().velocity.walk.back)
 		case "velocity.walk.up.x":
-			ln = lua.LNumber(c.gi().velocity.walk.up.x)
+			ln = lua.LNumber(c.gi().velocity.walk.up)
 		case "velocity.walk.down.x":
-			ln = lua.LNumber(c.gi().velocity.walk.down.x)
+			ln = lua.LNumber(c.gi().velocity.walk.down)
 		case "velocity.run.fwd.x":
 			ln = lua.LNumber(c.gi().velocity.run.fwd[0])
 		case "velocity.run.fwd.y":
@@ -3292,13 +3292,13 @@ func triggerFunctions(l *lua.LState) {
 		case "velocity.run.back.y":
 			ln = lua.LNumber(c.gi().velocity.run.back[1])
 		case "velocity.run.up.x":
-			ln = lua.LNumber(c.gi().velocity.run.up.x)
+			ln = lua.LNumber(c.gi().velocity.run.up[0])
 		case "velocity.run.up.y":
-			ln = lua.LNumber(c.gi().velocity.run.up.y)
+			ln = lua.LNumber(c.gi().velocity.run.up[1])
 		case "velocity.run.down.x":
-			ln = lua.LNumber(c.gi().velocity.run.down.x)
+			ln = lua.LNumber(c.gi().velocity.run.down[0])
 		case "velocity.run.down.y":
-			ln = lua.LNumber(c.gi().velocity.run.down.y)
+			ln = lua.LNumber(c.gi().velocity.run.down[1])
 		case "velocity.jump.y":
 			ln = lua.LNumber(c.gi().velocity.jump.neu[1])
 		case "velocity.jump.neu.x":
@@ -3308,9 +3308,9 @@ func triggerFunctions(l *lua.LState) {
 		case "velocity.jump.fwd.x":
 			ln = lua.LNumber(c.gi().velocity.jump.fwd)
 		case "velocity.jump.up.x":
-			ln = lua.LNumber(c.gi().velocity.jump.up.x)
+			ln = lua.LNumber(c.gi().velocity.jump.up)
 		case "velocity.jump.down.x":
-			ln = lua.LNumber(c.gi().velocity.jump.down.x)
+			ln = lua.LNumber(c.gi().velocity.jump.down)
 		case "velocity.runjump.back.x":
 			ln = lua.LNumber(c.gi().velocity.runjump.back[0])
 		case "velocity.runjump.back.y":
@@ -3320,9 +3320,9 @@ func triggerFunctions(l *lua.LState) {
 		case "velocity.runjump.fwd.x":
 			ln = lua.LNumber(c.gi().velocity.runjump.fwd[0])
 		case "velocity.runjump.up.x":
-			ln = lua.LNumber(c.gi().velocity.runjump.up.x)
+			ln = lua.LNumber(c.gi().velocity.runjump.up)
 		case "velocity.runjump.down.x":
-			ln = lua.LNumber(c.gi().velocity.runjump.down.x)
+			ln = lua.LNumber(c.gi().velocity.runjump.down)
 		case "velocity.airjump.y":
 			ln = lua.LNumber(c.gi().velocity.airjump.neu[1])
 		case "velocity.airjump.neu.x":
@@ -3332,9 +3332,9 @@ func triggerFunctions(l *lua.LState) {
 		case "velocity.airjump.fwd.x":
 			ln = lua.LNumber(c.gi().velocity.airjump.fwd)
 		case "velocity.airjump.up.x":
-			ln = lua.LNumber(c.gi().velocity.airjump.up.x)
+			ln = lua.LNumber(c.gi().velocity.airjump.up)
 		case "velocity.airjump.down.x":
-			ln = lua.LNumber(c.gi().velocity.airjump.down.x)
+			ln = lua.LNumber(c.gi().velocity.airjump.down)
 		case "velocity.air.gethit.groundrecover.x":
 			ln = lua.LNumber(c.gi().velocity.air.gethit.groundrecover[0])
 		case "velocity.air.gethit.groundrecover.y":


### PR DESCRIPTION
- Stage default values now automatically scale to the stage's localcoord
- More work done on making the "up" and "down" char velocity constants closer to what we know about those unused Mugen constants
- StageVar and ModifyStageVar now automatically do the necessary conversions to the localcoord of the character that uses them
- Adjusted ModifyExplod logic to rely less on some quirks of the Mugen engine. Fixes #2065 