### PR TITLE
feat: added z for hitdef params and sctrls,topEdgeDist/bottomEdgeDist triggers, fixes

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -519,6 +519,7 @@ const (
 	OC_ex_gethitvar_down_velocity_y
 	OC_ex_gethitvar_down_velocity_z
 	OC_ex_gethitvar_guard_velocity_x
+	OC_ex_gethitvar_guard_velocity_y
 	OC_ex_gethitvar_guard_velocity_z
 	OC_ex_gethitvar_airguard_velocity_x
 	OC_ex_gethitvar_airguard_velocity_y
@@ -2381,8 +2382,10 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.ghv.down_velocity[2] * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_guard_velocity_x:
 		sys.bcStack.PushF(c.ghv.guard_velocity[0] * c.facing * (c.localscl / oc.localscl))
-	case OC_ex_gethitvar_guard_velocity_z:
+	case OC_ex_gethitvar_guard_velocity_y:
 		sys.bcStack.PushF(c.ghv.guard_velocity[1] * c.facing * (c.localscl / oc.localscl))
+	case OC_ex_gethitvar_guard_velocity_z:
+		sys.bcStack.PushF(c.ghv.guard_velocity[2] * c.facing * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_airguard_velocity_x:
 		sys.bcStack.PushF(c.ghv.airguard_velocity[0] * c.facing * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_airguard_velocity_y:
@@ -6243,6 +6246,9 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 		if len(exp) > 1 {
 			hd.guard_velocity[1] = exp[1].evalF(c)
 		}
+		if len(exp) > 2 {
+			hd.guard_velocity[2] = exp[2].evalF(c)
+		}
 	case hitDef_ground_cornerpush_veloff:
 		hd.ground_cornerpush_veloff = exp[0].evalF(c)
 	case hitDef_guard_cornerpush_veloff:
@@ -7283,6 +7289,9 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 					p.hitdef.guard_velocity[0] = exp[0].evalF(c)
 					if len(exp) > 1 {
 						p.hitdef.guard_velocity[1] = exp[0].evalF(c)
+					}
+					if len(exp) > 2 {
+						p.hitdef.guard_velocity[2] = exp[0].evalF(c)
 					}
 				})
 			//case hitDef_ground_cornerpush_veloff:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -139,6 +139,7 @@ const (
 	OC_pos_y
 	OC_vel_x
 	OC_vel_y
+	OC_vel_z
 	OC_screenpos_x
 	OC_screenpos_y
 	OC_facing
@@ -178,7 +179,9 @@ const (
 	OC_leftedge
 	OC_rightedge
 	OC_topedge
+	OC_topedgedist
 	OC_bottomedge
+	OC_bottomedgedist
 	OC_camerapos_x
 	OC_camerapos_y
 	OC_camerazoom
@@ -204,6 +207,7 @@ const (
 	OC_hitfall
 	OC_hitvel_x
 	OC_hitvel_y
+	OC_hitvel_z
 	OC_player
 	OC_parent
 	OC_root
@@ -369,6 +373,8 @@ const (
 	OC_const_stagevar_camera_lowestcap
 	OC_const_stagevar_playerinfo_leftbound
 	OC_const_stagevar_playerinfo_rightbound
+	OC_const_stagevar_playerinfo_topbound
+	OC_const_stagevar_playerinfo_botbound
 	OC_const_stagevar_scaling_topz
 	OC_const_stagevar_scaling_botz
 	OC_const_stagevar_scaling_topscale
@@ -463,9 +469,13 @@ const (
 	OC_ex_gethitvar_ctrltime
 	OC_ex_gethitvar_xoff
 	OC_ex_gethitvar_yoff
+	OC_ex_gethitvar_zoff
 	OC_ex_gethitvar_xvel
 	OC_ex_gethitvar_yvel
+	OC_ex_gethitvar_zvel
+	OC_ex_gethitvar_xaccel
 	OC_ex_gethitvar_yaccel
+	OC_ex_gethitvar_zaccel
 	OC_ex_gethitvar_chainid
 	OC_ex_gethitvar_guarded
 	OC_ex_gethitvar_isbound
@@ -473,6 +483,7 @@ const (
 	OC_ex_gethitvar_fall_damage
 	OC_ex_gethitvar_fall_xvel
 	OC_ex_gethitvar_fall_yvel
+	OC_ex_gethitvar_fall_zvel
 	OC_ex_gethitvar_fall_recover
 	OC_ex_gethitvar_fall_time
 	OC_ex_gethitvar_fall_recovertime
@@ -500,17 +511,21 @@ const (
 	OC_ex_gethitvar_facing
 	OC_ex_gethitvar_ground_velocity_x
 	OC_ex_gethitvar_ground_velocity_y
+	OC_ex_gethitvar_ground_velocity_z
 	OC_ex_gethitvar_air_velocity_x
 	OC_ex_gethitvar_air_velocity_y
+	OC_ex_gethitvar_air_velocity_z
 	OC_ex_gethitvar_down_velocity_x
 	OC_ex_gethitvar_down_velocity_y
+	OC_ex_gethitvar_down_velocity_z
 	OC_ex_gethitvar_guard_velocity_x
+	OC_ex_gethitvar_guard_velocity_z
 	OC_ex_gethitvar_airguard_velocity_x
 	OC_ex_gethitvar_airguard_velocity_y
+	OC_ex_gethitvar_airguard_velocity_z
 	OC_ex_gethitvar_frame
 	OC_ex_gethitvar_down_recover
 	OC_ex_gethitvar_down_recovertime
-	OC_ex_gethitvar_xaccel
 	OC_ex_ailevelf
 	OC_ex_animframe_alphadest
 	OC_ex_animframe_angle
@@ -1494,6 +1509,8 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushI(int32(c.backEdgeDist() * (c.localscl / oc.localscl)))
 		case OC_bottomedge:
 			sys.bcStack.PushF(c.bottomEdge() * (c.localscl / oc.localscl))
+		case OC_bottomedgedist:
+			sys.bcStack.PushF(c.bottomEdgeDist() * (c.localscl / oc.localscl))
 		case OC_camerapos_x:
 			sys.bcStack.PushF(sys.cam.Pos[0] / oc.localscl)
 		case OC_camerapos_y:
@@ -1575,6 +1592,8 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushF(c.hitVelX() * (c.localscl / oc.localscl))
 		case OC_hitvel_y:
 			sys.bcStack.PushF(c.hitVelY() * (c.localscl / oc.localscl))
+		case OC_hitvel_z:
+			sys.bcStack.PushF(c.hitVelZ() * (c.localscl / oc.localscl))
 		case OC_id:
 			sys.bcStack.PushI(c.id)
 		case OC_inguarddist:
@@ -1680,12 +1699,16 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushI(c.time())
 		case OC_topedge:
 			sys.bcStack.PushF(c.topEdge() * (c.localscl / oc.localscl))
+		case OC_topedgedist:
+			sys.bcStack.PushF(c.topEdgeDist() * (c.localscl / oc.localscl))
 		case OC_uniqhitcount:
 			sys.bcStack.PushI(c.uniqHitCount)
 		case OC_vel_x:
 			sys.bcStack.PushF(c.vel[0] * (c.localscl / oc.localscl))
 		case OC_vel_y:
 			sys.bcStack.PushF(c.vel[1] * (c.localscl / oc.localscl))
+		case OC_vel_z:
+			sys.bcStack.PushF(c.vel[2] * (c.localscl / oc.localscl))
 		case OC_st_:
 			be.run_st(c, &i)
 		case OC_const_:
@@ -2080,6 +2103,10 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(sys.stage.leftbound * sys.stage.localscl / oc.localscl)
 	case OC_const_stagevar_playerinfo_rightbound:
 		sys.bcStack.PushF(sys.stage.rightbound * sys.stage.localscl / oc.localscl)
+	case OC_const_stagevar_playerinfo_topbound:
+		sys.bcStack.PushF(sys.stage.topbound * sys.stage.localscl / oc.localscl)
+	case OC_const_stagevar_playerinfo_botbound:
+		sys.bcStack.PushF(sys.stage.botbound * sys.stage.localscl / oc.localscl)
 	case OC_const_stagevar_scaling_topz:
 		sys.bcStack.PushF(sys.stage.stageCamera.topz)
 	case OC_const_stagevar_scaling_botz:
@@ -2256,12 +2283,20 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.ghv.xoff * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_yoff:
 		sys.bcStack.PushF(c.ghv.yoff * (c.localscl / oc.localscl))
+	case OC_ex_gethitvar_zoff:
+		sys.bcStack.PushF(c.ghv.zoff * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_xvel:
 		sys.bcStack.PushF(c.ghv.xvel * c.facing * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_yvel:
 		sys.bcStack.PushF(c.ghv.yvel * (c.localscl / oc.localscl))
+	case OC_ex_gethitvar_zvel:
+		sys.bcStack.PushF(c.ghv.zvel * (c.localscl / oc.localscl))
+	case OC_ex_gethitvar_xaccel:
+		sys.bcStack.PushF(c.ghv.getXaccel(oc) * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_yaccel:
 		sys.bcStack.PushF(c.ghv.getYaccel(oc) * (c.localscl / oc.localscl))
+	case OC_ex_gethitvar_zaccel:
+		sys.bcStack.PushF(c.ghv.getZaccel(oc) * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_chainid:
 		sys.bcStack.PushI(c.ghv.chainId())
 	case OC_ex_gethitvar_guarded:
@@ -2276,6 +2311,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.ghv.fall.xvel() * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_fall_yvel:
 		sys.bcStack.PushF(c.ghv.fall.yvelocity * (c.localscl / oc.localscl))
+	case OC_ex_gethitvar_fall_zvel:
+		sys.bcStack.PushF(c.ghv.fall.zvelocity * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_fall_recover:
 		sys.bcStack.PushB(c.ghv.fall.recover)
 	case OC_ex_gethitvar_fall_time:
@@ -2328,26 +2365,34 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.ghv.ground_velocity[0] * c.facing * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_ground_velocity_y:
 		sys.bcStack.PushF(c.ghv.ground_velocity[1] * (c.localscl / oc.localscl))
+	case OC_ex_gethitvar_ground_velocity_z:
+		sys.bcStack.PushF(c.ghv.ground_velocity[2] * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_air_velocity_x:
 		sys.bcStack.PushF(c.ghv.air_velocity[0] * c.facing * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_air_velocity_y:
 		sys.bcStack.PushF(c.ghv.air_velocity[1] * (c.localscl / oc.localscl))
+	case OC_ex_gethitvar_air_velocity_z:
+		sys.bcStack.PushF(c.ghv.air_velocity[2] * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_down_velocity_x:
 		sys.bcStack.PushF(c.ghv.down_velocity[0] * c.facing * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_down_velocity_y:
 		sys.bcStack.PushF(c.ghv.down_velocity[1] * (c.localscl / oc.localscl))
+	case OC_ex_gethitvar_down_velocity_z:
+		sys.bcStack.PushF(c.ghv.down_velocity[2] * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_guard_velocity_x:
-		sys.bcStack.PushF(c.ghv.guard_velocity * c.facing * (c.localscl / oc.localscl))
+		sys.bcStack.PushF(c.ghv.guard_velocity[0] * c.facing * (c.localscl / oc.localscl))
+	case OC_ex_gethitvar_guard_velocity_z:
+		sys.bcStack.PushF(c.ghv.guard_velocity[1] * c.facing * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_airguard_velocity_x:
 		sys.bcStack.PushF(c.ghv.airguard_velocity[0] * c.facing * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_airguard_velocity_y:
 		sys.bcStack.PushF(c.ghv.airguard_velocity[1] * (c.localscl / oc.localscl))
+	case OC_ex_gethitvar_airguard_velocity_z:
+		sys.bcStack.PushF(c.ghv.airguard_velocity[2] * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_frame:
 		sys.bcStack.PushB(c.ghv.frame)
 	case OC_ex_gethitvar_down_recover:
 		sys.bcStack.PushB(c.ghv.down_recover)
-	case OC_ex_gethitvar_xaccel:
-		sys.bcStack.PushF(c.ghv.getXaccel(oc) * (c.localscl / oc.localscl))
 	case OC_ex_ailevelf:
 		if !c.asf(ASF_noailevel) {
 			sys.bcStack.PushF(c.aiLevel())
@@ -3086,6 +3131,19 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		}
 		fallthrough
 	case OC_ex2_explodvar_pos_y:
+		if !camCorrected {
+			camCorrected = true
+			correctScale = true
+		}
+		idx := sys.bcStack.Pop()
+		id := sys.bcStack.Pop()
+		v := c.explodVar(id, idx, opc)
+		if correctScale {
+			sys.bcStack.PushF(v.ToF()*(c.localscl/oc.localscl) - camOff)
+		} else {
+			sys.bcStack.Push(v)
+		}
+	case OC_ex2_explodvar_pos_z:
 		if !camCorrected {
 			camCorrected = true
 			correctScale = true
@@ -5872,6 +5930,7 @@ const (
 	hitDef_fall_damage
 	hitDef_fall_xvelocity
 	hitDef_fall_yvelocity
+	hitDef_fall_zvelocity
 	hitDef_fall_recover
 	hitDef_fall_recovertime
 	hitDef_sparkno
@@ -5906,12 +5965,14 @@ const (
 	hitDef_airguard_ctrltime
 	hitDef_ground_velocity_x
 	hitDef_ground_velocity_y
-	hitDef_ground_velocity
+	hitDef_ground_velocity_z
 	hitDef_guard_velocity
 	hitDef_ground_cornerpush_veloff
 	hitDef_guard_cornerpush_veloff
 	hitDef_airguard_cornerpush_veloff
+	hitDef_xaccel
 	hitDef_yaccel
+	hitDef_zaccel
 	hitDef_envshake_time
 	hitDef_envshake_ampl
 	hitDef_envshake_phase
@@ -5930,7 +5991,6 @@ const (
 	hitDef_p2clsnrequire
 	hitDef_down_recover
 	hitDef_down_recovertime
-	hitDef_xaccel
 	hitDef_attack_depth
 	hitDef_last = iota + afterImage_last + 1 - 1
 	hitDef_redirectid
@@ -6043,6 +6103,8 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 		hd.fall.xvelocity = exp[0].evalF(c)
 	case hitDef_fall_yvelocity:
 		hd.fall.yvelocity = exp[0].evalF(c)
+	case hitDef_fall_zvelocity:
+		hd.fall.zvelocity = exp[0].evalF(c)
 	case hitDef_fall_recover:
 		hd.fall.recover = exp[0].evalB(c)
 	case hitDef_fall_recovertime:
@@ -6073,7 +6135,7 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 		if len(exp) > 1 {
 			hd.mindist[1] = exp[1].evalF(c)
 			if len(exp) > 2 {
-				exp[2].run(c)
+				hd.mindist[2] = exp[2].evalF(c)
 			}
 		}
 	case hitDef_maxdist:
@@ -6081,7 +6143,7 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 		if len(exp) > 1 {
 			hd.maxdist[1] = exp[1].evalF(c)
 			if len(exp) > 2 {
-				exp[2].run(c)
+				hd.maxdist[2] = exp[2].evalF(c)
 			}
 		}
 	case hitDef_snap:
@@ -6089,9 +6151,9 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 		if len(exp) > 1 {
 			hd.snap[1] = exp[1].evalF(c)
 			if len(exp) > 2 {
-				exp[2].run(c)
+				hd.snap[2] = exp[2].evalF(c)
 				if len(exp) > 3 {
-					hd.snapt = exp[3].evalI(c)
+					hd.snaptime = exp[3].evalI(c)
 				}
 			}
 		}
@@ -6112,6 +6174,9 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 		hd.down_velocity[0] = exp[0].evalF(c)
 		if len(exp) > 1 {
 			hd.down_velocity[1] = exp[1].evalF(c)
+		}
+		if len(exp) > 2 {
+			hd.down_velocity[2] = exp[2].evalF(c)
 		}
 	case hitDef_down_cornerpush_veloff:
 		hd.down_cornerpush_veloff = exp[0].evalF(c)
@@ -6142,10 +6207,16 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 		if len(exp) > 1 {
 			hd.air_velocity[1] = exp[1].evalF(c)
 		}
+		if len(exp) > 2 {
+			hd.air_velocity[2] = exp[2].evalF(c)
+		}
 	case hitDef_airguard_velocity:
 		hd.airguard_velocity[0] = exp[0].evalF(c)
 		if len(exp) > 1 {
 			hd.airguard_velocity[1] = exp[1].evalF(c)
+		}
+		if len(exp) > 2 {
+			hd.airguard_velocity[2] = exp[2].evalF(c)
 		}
 	case hitDef_ground_slidetime:
 		hd.ground_slidetime = exp[0].evalI(c)
@@ -6165,16 +6236,25 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 		hd.ground_velocity[0] = exp[0].evalF(c)
 	case hitDef_ground_velocity_y:
 		hd.ground_velocity[1] = exp[0].evalF(c)
+	case hitDef_ground_velocity_z:
+		hd.ground_velocity[2] = exp[0].evalF(c)
 	case hitDef_guard_velocity:
-		hd.guard_velocity = exp[0].evalF(c)
+		hd.guard_velocity[0] = exp[0].evalF(c)
+		if len(exp) > 1 {
+			hd.guard_velocity[1] = exp[1].evalF(c)
+		}
 	case hitDef_ground_cornerpush_veloff:
 		hd.ground_cornerpush_veloff = exp[0].evalF(c)
 	case hitDef_guard_cornerpush_veloff:
 		hd.guard_cornerpush_veloff = exp[0].evalF(c)
 	case hitDef_airguard_cornerpush_veloff:
 		hd.airguard_cornerpush_veloff = exp[0].evalF(c)
+	case hitDef_xaccel:
+		hd.xaccel = exp[0].evalF(c)
 	case hitDef_yaccel:
 		hd.yaccel = exp[0].evalF(c)
+	case hitDef_zaccel:
+		hd.zaccel = exp[0].evalF(c)
 	case hitDef_envshake_time:
 		hd.envshake_time = exp[0].evalI(c)
 	case hitDef_envshake_ampl:
@@ -6227,8 +6307,6 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 		hd.down_recover = exp[0].evalB(c)
 	case hitDef_down_recovertime:
 		hd.down_recovertime = exp[0].evalI(c)
-	case hitDef_xaccel:
-		hd.xaccel = exp[0].evalF(c)
 	case hitDef_attack_depth:
 		hd.attack.depth[0] = exp[0].evalF(c)
 		if len(exp) > 1 {
@@ -7008,6 +7086,10 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				eachProj(func(p *Projectile) {
 					p.hitdef.fall.yvelocity = exp[0].evalF(c)
 				})
+			case hitDef_fall_zvelocity:
+				eachProj(func(p *Projectile) {
+					p.hitdef.fall.zvelocity = exp[0].evalF(c)
+				})
 			case hitDef_fall_recover:
 				eachProj(func(p *Projectile) {
 					p.hitdef.fall.recover = exp[0].evalB(c)
@@ -7054,7 +7136,7 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 					if len(exp) > 1 {
 						p.hitdef.mindist[1] = exp[1].evalF(c)
 						if len(exp) > 2 {
-							exp[2].run(c)
+							p.hitdef.mindist[2] = exp[2].evalF(c)
 						}
 					}
 				})
@@ -7064,7 +7146,7 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 					if len(exp) > 1 {
 						p.hitdef.maxdist[1] = exp[1].evalF(c)
 						if len(exp) > 2 {
-							exp[2].run(c)
+							p.hitdef.maxdist[2] = exp[2].evalF(c)
 						}
 					}
 				})
@@ -7074,9 +7156,9 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 					if len(exp) > 1 {
 						p.hitdef.snap[1] = exp[1].evalF(c)
 						if len(exp) > 2 {
-							exp[2].run(c)
+							p.hitdef.snap[2] = exp[2].evalF(c)
 							if len(exp) > 3 {
-								p.hitdef.snapt = exp[3].evalI(c)
+								p.hitdef.snaptime = exp[3].evalI(c)
 							}
 						}
 					}
@@ -7109,6 +7191,9 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 					p.hitdef.down_velocity[0] = exp[0].evalF(c)
 					if len(exp) > 1 {
 						p.hitdef.down_velocity[1] = exp[1].evalF(c)
+					}
+					if len(exp) > 2 {
+						p.hitdef.down_velocity[2] = exp[2].evalF(c)
 					}
 				})
 			//case hitDef_down_cornerpush_veloff:
@@ -7151,12 +7236,18 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 					if len(exp) > 1 {
 						p.hitdef.air_velocity[1] = exp[1].evalF(c)
 					}
+					if len(exp) > 2 {
+						p.hitdef.air_velocity[2] = exp[2].evalF(c)
+					}
 				})
 			case hitDef_airguard_velocity:
 				eachProj(func(p *Projectile) {
 					p.hitdef.airguard_velocity[0] = exp[0].evalF(c)
 					if len(exp) > 1 {
 						p.hitdef.airguard_velocity[1] = exp[1].evalF(c)
+					}
+					if len(exp) > 2 {
+						p.hitdef.airguard_velocity[2] = exp[2].evalF(c)
 					}
 				})
 			case hitDef_ground_slidetime:
@@ -7183,9 +7274,16 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				eachProj(func(p *Projectile) {
 					p.hitdef.ground_velocity[1] = exp[0].evalF(c)
 				})
+			case hitDef_ground_velocity_z:
+				eachProj(func(p *Projectile) {
+					p.hitdef.ground_velocity[2] = exp[0].evalF(c)
+				})
 			case hitDef_guard_velocity:
 				eachProj(func(p *Projectile) {
-					p.hitdef.guard_velocity = exp[0].evalF(c)
+					p.hitdef.guard_velocity[0] = exp[0].evalF(c)
+					if len(exp) > 1 {
+						p.hitdef.guard_velocity[1] = exp[0].evalF(c)
+					}
 				})
 			//case hitDef_ground_cornerpush_veloff:
 			//	p.hitdef.ground_cornerpush_veloff = exp[0].evalF(c)
@@ -7193,9 +7291,17 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 			//	p.hitdef.guard_cornerpush_veloff = exp[0].evalF(c)
 			//case hitDef_airguard_cornerpush_veloff:
 			//	p.hitdef.airguard_cornerpush_veloff = exp[0].evalF(c)
+			case hitDef_xaccel:
+				eachProj(func(p *Projectile) {
+					p.hitdef.xaccel = exp[0].evalF(c)
+			})
 			case hitDef_yaccel:
 				eachProj(func(p *Projectile) {
 					p.hitdef.yaccel = exp[0].evalF(c)
+				})
+			case hitDef_zaccel:
+				eachProj(func(p *Projectile) {
+					p.hitdef.zaccel = exp[0].evalF(c)
 				})
 			case hitDef_envshake_time:
 				eachProj(func(p *Projectile) {
@@ -7284,10 +7390,6 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 			case hitDef_down_recovertime:
 				eachProj(func(p *Projectile) {
 					p.hitdef.down_recovertime = exp[0].evalI(c)
-				})
-			case hitDef_xaccel:
-				eachProj(func(p *Projectile) {
-					p.hitdef.xaccel = exp[0].evalF(c)
 				})
 			case hitDef_attack_depth:
 				eachProj(
@@ -7688,6 +7790,7 @@ const (
 	targetVelSet_id byte = iota
 	targetVelSet_x
 	targetVelSet_y
+	targetVelSet_z
 	targetVelSet_redirectid
 )
 
@@ -7712,6 +7815,11 @@ func (sc targetVelSet) Run(c *Char, _ []int32) bool {
 				return false
 			}
 			crun.targetVelSetY(tar, exp[0].evalF(c)*lclscround)
+		case targetVelSet_z:
+			if len(tar) == 0 {
+				return false
+			}
+			crun.targetVelSetZ(tar, exp[0].evalF(c)*lclscround)
 		case targetVelSet_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -7735,6 +7843,7 @@ const (
 	targetVelAdd_id byte = iota
 	targetVelAdd_x
 	targetVelAdd_y
+	targetVelAdd_z
 	targetVelAdd_redirectid
 )
 
@@ -7759,6 +7868,11 @@ func (sc targetVelAdd) Run(c *Char, _ []int32) bool {
 				return false
 			}
 			crun.targetVelAddY(tar, exp[0].evalF(c)*lclscround)
+		case targetVelAdd_z:
+			if len(tar) == 0 {
+				return false
+			}
+			crun.targetVelAddZ(tar, exp[0].evalF(c)*lclscround)
 		case targetVelAdd_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -7970,6 +8084,7 @@ type hitVelSet StateControllerBase
 const (
 	hitVelSet_x byte = iota
 	hitVelSet_y
+	hitVelSet_z
 	hitVelSet_redirectid
 )
 
@@ -7984,6 +8099,10 @@ func (sc hitVelSet) Run(c *Char, _ []int32) bool {
 		case hitVelSet_y:
 			if exp[0].evalB(c) {
 				crun.hitVelSetY()
+			}
+		case hitVelSet_z:
+			if exp[0].evalB(c) {
+				crun.hitVelSetZ()
 			}
 		case hitVelSet_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
@@ -8893,12 +9012,13 @@ const (
 	hitFallSet_value byte = iota
 	hitFallSet_xvel
 	hitFallSet_yvel
+	hitFallSet_zvel
 	hitFallSet_redirectid
 )
 
 func (sc hitFallSet) Run(c *Char, _ []int32) bool {
 	crun := c
-	f, xv, yv := int32(-1), float32(math.NaN()), float32(math.NaN())
+	f, xv, yv, zv := int32(-1), float32(math.NaN()), float32(math.NaN()), float32(math.NaN())
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case hitFallSet_value:
@@ -8910,6 +9030,8 @@ func (sc hitFallSet) Run(c *Char, _ []int32) bool {
 			xv = exp[0].evalF(c)
 		case hitFallSet_yvel:
 			yv = exp[0].evalF(c)
+		case hitFallSet_zvel:
+			zv = exp[0].evalF(c)
 		case hitFallSet_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -8919,7 +9041,7 @@ func (sc hitFallSet) Run(c *Char, _ []int32) bool {
 		}
 		return true
 	})
-	crun.hitFallSet(f, xv, yv)
+	crun.hitFallSet(f, xv, yv, zv)
 	return false
 }
 
@@ -11032,6 +11154,8 @@ const (
 	modifyStageVar_camera_lowestcap
 	modifyStageVar_playerinfo_leftbound
 	modifyStageVar_playerinfo_rightbound
+	modifyStageVar_playerinfo_topbound
+	modifyStageVar_playerinfo_botbound
 	modifyStageVar_scaling_topz
 	modifyStageVar_scaling_botz
 	modifyStageVar_scaling_topscale
@@ -11110,6 +11234,10 @@ func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 			s.leftbound = exp[0].evalF(c) * sys.stage.localscl / c.localscl
 		case modifyStageVar_playerinfo_rightbound:
 			s.rightbound = exp[0].evalF(c) * sys.stage.localscl / c.localscl
+		case modifyStageVar_playerinfo_topbound:
+			s.topbound = exp[0].evalF(c) * sys.stage.localscl / c.localscl
+		case modifyStageVar_playerinfo_botbound:
+			s.botbound = exp[0].evalF(c) * sys.stage.localscl / c.localscl
 		// Scaling group
 		case modifyStageVar_scaling_topz:
 			if s.mugenver[0] != 1 { // mugen 1.0+ removed support for topz
@@ -11359,6 +11487,7 @@ const (
 	getHitVarSet_fall_recovertime
 	getHitVarSet_fall_xvel
 	getHitVarSet_fall_yvel
+	getHitVarSet_fall_zvel
 	getHitVarSet_fallcount
 	getHitVarSet_ground_animtype
 	getHitVarSet_groundtype
@@ -11372,7 +11501,9 @@ const (
 	getHitVarSet_xvel
 	getHitVarSet_xaccel
 	getHitVarSet_yaccel
+	getHitVarSet_zaccel
 	getHitVarSet_yvel
+	getHitVarSet_zvel
 	getHitVarSet_redirectid
 )
 
@@ -11419,6 +11550,8 @@ func (sc getHitVarSet) Run(c *Char, _ []int32) bool {
 			crun.ghv.fall.xvelocity = exp[0].evalF(c) * lclscround
 		case getHitVarSet_fall_yvel:
 			crun.ghv.fall.yvelocity = exp[0].evalF(c) * lclscround
+		case getHitVarSet_fall_zvel:
+			crun.ghv.fall.zvelocity = exp[0].evalF(c) * lclscround
 		case getHitVarSet_fallcount:
 			crun.ghv.fallcount = exp[0].evalI(c)
 		case getHitVarSet_groundtype:
@@ -11437,12 +11570,16 @@ func (sc getHitVarSet) Run(c *Char, _ []int32) bool {
 			crun.ghv.slidetime = exp[0].evalI(c)
 		case getHitVarSet_xvel:
 			crun.ghv.xvel = exp[0].evalF(c) * crun.facing * lclscround
+		case getHitVarSet_yvel:
+			crun.ghv.yvel = exp[0].evalF(c) * lclscround
+		case getHitVarSet_zvel:
+			crun.ghv.zvel = exp[0].evalF(c) * lclscround
 		case getHitVarSet_xaccel:
 			crun.ghv.xaccel = exp[0].evalF(c) * lclscround
 		case getHitVarSet_yaccel:
 			crun.ghv.yaccel = exp[0].evalF(c) * lclscround
-		case getHitVarSet_yvel:
-			crun.ghv.yvel = exp[0].evalF(c) * lclscround
+		case getHitVarSet_zaccel:
+			crun.ghv.zaccel = exp[0].evalF(c) * lclscround
 		case getHitVarSet_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid

--- a/src/char.go
+++ b/src/char.go
@@ -582,7 +582,7 @@ type HitDef struct {
 	yaccel                     float32
 	zaccel                     float32
 	ground_velocity            [3]float32
-	guard_velocity             [2]float32
+	guard_velocity             [3]float32
 	air_velocity               [3]float32
 	airguard_velocity          [3]float32
 	ground_cornerpush_veloff   float32
@@ -676,7 +676,7 @@ func (hd *HitDef) clear() {
 		xaccel:                     float32(math.NaN()),
 		yaccel:                     float32(math.NaN()),
 		zaccel:                     float32(math.NaN()),
-		guard_velocity:             [...]float32{float32(math.NaN()), float32(math.NaN())},
+		guard_velocity:             [...]float32{float32(math.NaN()), float32(math.NaN()), float32(math.NaN())},
 		airguard_velocity:          [...]float32{float32(math.NaN()), float32(math.NaN()), float32(math.NaN())},
 		ground_cornerpush_veloff:   float32(math.NaN()),
 		air_cornerpush_veloff:      float32(math.NaN()),
@@ -801,7 +801,7 @@ type GetHitVar struct {
 	ground_velocity   [3]float32
 	air_velocity      [3]float32
 	down_velocity     [3]float32
-	guard_velocity    [2]float32
+	guard_velocity    [3]float32
 	airguard_velocity [3]float32
 	frame             bool
 	cheeseKO          bool
@@ -5074,7 +5074,8 @@ func (c *Char) setHitdefDefault(hd *HitDef) {
 	ifnanset(&hd.air_velocity[1], 0)
 	ifnanset(&hd.air_velocity[2], 0)
 	ifnanset(&hd.guard_velocity[0], hd.ground_velocity[0])
-	ifnanset(&hd.guard_velocity[1], hd.ground_velocity[2])
+	ifnanset(&hd.guard_velocity[1], 0) // We don't want chars to be launched while blocking
+	ifnanset(&hd.guard_velocity[2], hd.ground_velocity[2])
 	ifnanset(&hd.airguard_velocity[0], hd.air_velocity[0]*1.5)
 	ifnanset(&hd.airguard_velocity[1], hd.air_velocity[1]*0.5)
 	ifnanset(&hd.airguard_velocity[2], hd.air_velocity[2]*1.5)
@@ -5086,7 +5087,7 @@ func (c *Char) setHitdefDefault(hd *HitDef) {
 	ifierrset(&hd.fall.envshake_ampl, -4)
 	ifnanset(&hd.xaccel, 0)
 	ifnanset(&hd.zaccel, 0) // Here too
-	//ifnanset(&hd.zaccel, 0)
+	
 	if hd.air_animtype == RA_Unknown {
 		hd.air_animtype = hd.animtype
 	}
@@ -8481,9 +8482,10 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 					} else {
 						ghv.ctrltime = hd.guard_ctrltime
 						ghv.xvel = hd.guard_velocity[0] * (c.localscl / getter.localscl)
-						ghv.zvel = hd.guard_velocity[1] * (c.localscl / getter.localscl)
 						// Mugen does not accept a Y component for ground guard velocity
-						//ghv.yvel = hd.ground_velocity[1] * c.localscl / getter.localscl
+						// But since we're adding Z to the other parameters, let's add Y here as well to keep things consistent
+						ghv.yvel = hd.guard_velocity[1] * (c.localscl / getter.localscl)
+						ghv.zvel = hd.guard_velocity[2] * (c.localscl / getter.localscl)
 					}
 					ghv.hitcount = hc
 					ghv.guardcount = gc + 1
@@ -8585,6 +8587,7 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 				ghv.down_velocity[2] = hd.down_velocity[2] * (c.localscl / getter.localscl)
 				ghv.guard_velocity[0] = hd.guard_velocity[0] * (c.localscl / getter.localscl)
 				ghv.guard_velocity[1] = hd.guard_velocity[1] * (c.localscl / getter.localscl)
+				ghv.guard_velocity[2] = hd.guard_velocity[2] * (c.localscl / getter.localscl)
 				ghv.airguard_velocity[0] = hd.airguard_velocity[0] * (c.localscl / getter.localscl)
 				ghv.airguard_velocity[1] = hd.airguard_velocity[1] * (c.localscl / getter.localscl)
 				ghv.airguard_velocity[2] = hd.airguard_velocity[2] * (c.localscl / getter.localscl)

--- a/src/char.go
+++ b/src/char.go
@@ -5074,7 +5074,7 @@ func (c *Char) setHitdefDefault(hd *HitDef) {
 	ifnanset(&hd.air_velocity[1], 0)
 	ifnanset(&hd.air_velocity[2], 0)
 	ifnanset(&hd.guard_velocity[0], hd.ground_velocity[0])
-	ifnanset(&hd.guard_velocity[1], 0) // We don't want chars to be launched while blocking
+	ifnanset(&hd.guard_velocity[1], 0) // We don't want chars to be launched while guarding
 	ifnanset(&hd.guard_velocity[2], hd.ground_velocity[2])
 	ifnanset(&hd.airguard_velocity[0], hd.air_velocity[0]*1.5)
 	ifnanset(&hd.airguard_velocity[1], hd.air_velocity[1]*0.5)

--- a/src/char.go
+++ b/src/char.go
@@ -501,6 +501,7 @@ type Fall struct {
 	animtype       Reaction
 	xvelocity      float32
 	yvelocity      float32
+	zvelocity      float32
 	recover        bool
 	recovertime    int32
 	damage         int32
@@ -514,12 +515,13 @@ type Fall struct {
 
 func (f *Fall) clear() {
 	*f = Fall{animtype: RA_Unknown, xvelocity: float32(math.NaN()),
-		yvelocity: -4.5}
+		yvelocity: -4.5, zvelocity: float32(math.NaN())}
 }
 func (f *Fall) setDefault() {
 	*f = Fall{animtype: RA_Unknown,
 		xvelocity:      float32(math.NaN()),
 		yvelocity:      float32(math.NaN()),
+		zvelocity:      float32(math.NaN()),
 		recover:        true,
 		recovertime:    4,
 		kill:           true,
@@ -578,10 +580,11 @@ type HitDef struct {
 	guard_dist                 [2]int32
 	xaccel                     float32
 	yaccel                     float32
-	ground_velocity            [2]float32
-	guard_velocity             float32
-	air_velocity               [2]float32
-	airguard_velocity          [2]float32
+	zaccel                     float32
+	ground_velocity            [3]float32
+	guard_velocity             [2]float32
+	air_velocity               [3]float32
+	airguard_velocity          [3]float32
 	ground_cornerpush_veloff   float32
 	air_cornerpush_veloff      float32
 	down_cornerpush_veloff     float32
@@ -600,7 +603,7 @@ type HitDef struct {
 	forcecrouch                int32
 	ground_fall                bool
 	air_fall                   bool
-	down_velocity              [2]float32
+	down_velocity              [3]float32
 	down_hittime               int32
 	down_bounce                bool
 	down_recover               bool
@@ -620,10 +623,10 @@ type HitDef struct {
 	envshake_ampl              int32
 	envshake_phase             float32
 	envshake_mul               float32
-	mindist                    [2]float32
-	maxdist                    [2]float32
-	snap                       [2]float32
-	snapt                      int32
+	mindist                    [3]float32
+	maxdist                    [3]float32
+	snap                       [3]float32
+	snaptime                   int32
 	fall                       Fall
 	playerNo                   int
 	kill                       bool
@@ -672,8 +675,9 @@ func (hd *HitDef) clear() {
 
 		xaccel:                     float32(math.NaN()),
 		yaccel:                     float32(math.NaN()),
-		guard_velocity:             float32(math.NaN()),
-		airguard_velocity:          [...]float32{float32(math.NaN()), float32(math.NaN())},
+		zaccel:                     float32(math.NaN()),
+		guard_velocity:             [...]float32{float32(math.NaN()), float32(math.NaN())},
+		airguard_velocity:          [...]float32{float32(math.NaN()), float32(math.NaN()), float32(math.NaN())},
 		ground_cornerpush_veloff:   float32(math.NaN()),
 		air_cornerpush_veloff:      float32(math.NaN()),
 		down_cornerpush_veloff:     float32(math.NaN()),
@@ -686,7 +690,7 @@ func (hd *HitDef) clear() {
 		forcestand:       IErr,
 		forcecrouch:      IErr,
 		guard_dist:       [...]int32{-1, -1},
-		down_velocity:    [...]float32{float32(math.NaN()), float32(math.NaN())},
+		down_velocity:    [...]float32{float32(math.NaN()), float32(math.NaN()), float32(math.NaN())},
 		chainid:          -1,
 		nochainid:        [8]int32{-1, -1, -1, -1, -1, -1, -1, -1},
 		numhits:          1,
@@ -698,9 +702,9 @@ func (hd *HitDef) clear() {
 		envshake_ampl:    -4,
 		envshake_phase:   float32(math.NaN()),
 		envshake_mul:     1.0,
-		mindist:          [...]float32{float32(math.NaN()), float32(math.NaN())},
-		maxdist:          [...]float32{float32(math.NaN()), float32(math.NaN())},
-		snap:             [...]float32{float32(math.NaN()), float32(math.NaN())},
+		mindist:          [...]float32{float32(math.NaN()), float32(math.NaN()), float32(math.NaN())},
+		maxdist:          [...]float32{float32(math.NaN()), float32(math.NaN()), float32(math.NaN())},
+		snap:             [...]float32{float32(math.NaN()), float32(math.NaN()), float32(math.NaN())},
 		hitonce:          -1,
 		kill:             true,
 		guard_kill:       true,
@@ -763,11 +767,14 @@ type GetHitVar struct {
 	ctrltime          int32
 	xvel              float32
 	yvel              float32
+	zvel              float32
 	xaccel            float32
 	yaccel            float32
+	zaccel            float32
 	hitid             int32
 	xoff              float32
 	yoff              float32
+	zoff              float32
 	fall              Fall
 	playerNo          int
 	fallflag          bool
@@ -791,11 +798,11 @@ type GetHitVar struct {
 	kill              bool
 	priority          int32
 	facing            int32
-	ground_velocity   [2]float32
-	air_velocity      [2]float32
-	down_velocity     [2]float32
-	guard_velocity    float32
-	airguard_velocity [2]float32
+	ground_velocity   [3]float32
+	air_velocity      [3]float32
+	down_velocity     [3]float32
+	guard_velocity    [2]float32
+	airguard_velocity [3]float32
 	frame             bool
 	cheeseKO          bool
 	down_recover      bool
@@ -804,11 +811,11 @@ type GetHitVar struct {
 
 func (ghv *GetHitVar) clear() {
 	*ghv = GetHitVar{hittime: -1, yaccel: float32(math.NaN()),
-		xoff: ghv.xoff, yoff: ghv.yoff, hitid: -1, playerNo: -1}
+		xoff: ghv.xoff, yoff: ghv.yoff, zoff: ghv.zoff, hitid: -1, playerNo: -1}
 	ghv.fall.clear()
 }
 func (ghv *GetHitVar) clearOff() {
-	ghv.xoff, ghv.yoff = 0, 0
+	ghv.xoff, ghv.yoff, ghv.zoff = 0, 0, 0
 }
 func (ghv GetHitVar) getXaccel(c *Char) float32 {
 	if math.IsNaN(float64(ghv.xaccel)) {
@@ -821,6 +828,12 @@ func (ghv GetHitVar) getYaccel(c *Char) float32 {
 		return 0.35 / (c.localscl * (320 / float32(sys.gameWidth)))
 	}
 	return ghv.yaccel
+}
+func (ghv GetHitVar) getZaccel(c *Char) float32 {
+	if math.IsNaN(float64(ghv.zaccel)) {
+		return 0
+	}
+	return ghv.zaccel
 }
 func (ghv GetHitVar) chainId() int32 {
 	if ghv.hitid > 0 {
@@ -3517,6 +3530,9 @@ func (c *Char) backEdgeDist() float32 {
 func (c *Char) bottomEdge() float32 {
 	return sys.cam.ScreenPos[1]/c.localscl + c.gameHeight()
 }
+func (c *Char) bottomEdgeDist() float32 {
+	return sys.stage.botbound / c.localscl - c.pos[2]
+}
 func (c *Char) canRecover() bool {
 	return c.ghv.fall.recover && c.fallTime >= c.ghv.fall.recovertime
 }
@@ -3635,6 +3651,9 @@ func (c *Char) hitVelX() float32 {
 }
 func (c *Char) hitVelY() float32 {
 	return c.ghv.yvel
+}
+func (c *Char) hitVelZ() float32 {
+	return c.ghv.zvel
 }
 func (c *Char) isHelper(hid BytecodeValue) BytecodeValue {
 	if hid.IsSF() {
@@ -4194,6 +4213,9 @@ func (c *Char) time() int32 {
 func (c *Char) topEdge() float32 {
 	return sys.cam.ScreenPos[1] / c.localscl
 }
+func (c *Char) topEdgeDist() float32 {
+	return sys.stage.topbound / c.localscl - c.pos[2]
+}
 func (c *Char) win() bool {
 	if c.teamside == -1 {
 		return false
@@ -4323,9 +4345,12 @@ func (c *Char) stateChange1(no int32, pn int) bool {
 
 		c.ghv.xvel *= lsRatio
 		c.ghv.yvel *= lsRatio
+		c.ghv.zvel *= lsRatio
 		c.ghv.fall.xvelocity *= lsRatio
 		c.ghv.fall.yvelocity *= lsRatio
+		c.ghv.fall.zvelocity *= lsRatio
 		c.ghv.yaccel *= lsRatio
+		c.ghv.zaccel *= lsRatio
 
 		c.width[0] *= lsRatio
 		c.width[1] *= lsRatio
@@ -4874,6 +4899,9 @@ func (c *Char) addXV(xv float32) {
 func (c *Char) addYV(yv float32) {
 	c.vel[1] += yv
 }
+func (c *Char) addZV(zv float32) {
+	c.vel[2] += zv
+}
 func (c *Char) setXV(xv float32) {
 	c.vel[0] = xv
 }
@@ -4882,9 +4910,6 @@ func (c *Char) setYV(yv float32) {
 }
 func (c *Char) setZV(zv float32) {
 	c.vel[2] = zv
-}
-func (c *Char) addZV(zv float32) {
-	c.vel[2] += zv
 }
 func (c *Char) mulXV(xv float32) {
 	c.vel[0] *= xv
@@ -5044,16 +5069,24 @@ func (c *Char) setHitdefDefault(hd *HitDef) {
 	}
 	ifnanset(&hd.ground_velocity[0], 0)
 	ifnanset(&hd.ground_velocity[1], 0)
+	ifnanset(&hd.ground_velocity[2], 0)
 	ifnanset(&hd.air_velocity[0], 0)
 	ifnanset(&hd.air_velocity[1], 0)
-	ifnanset(&hd.guard_velocity, hd.ground_velocity[0])
+	ifnanset(&hd.air_velocity[2], 0)
+	ifnanset(&hd.guard_velocity[0], hd.ground_velocity[0])
+	ifnanset(&hd.guard_velocity[1], hd.ground_velocity[2])
 	ifnanset(&hd.airguard_velocity[0], hd.air_velocity[0]*1.5)
 	ifnanset(&hd.airguard_velocity[1], hd.air_velocity[1]*0.5)
+	ifnanset(&hd.airguard_velocity[2], hd.air_velocity[2]*1.5)
 	ifnanset(&hd.down_velocity[0], hd.air_velocity[0])
 	ifnanset(&hd.down_velocity[1], hd.air_velocity[1])
+	ifnanset(&hd.down_velocity[2], hd.air_velocity[2])
 	ifnanset(&hd.fall.yvelocity, -4.5/c.localscl)
+	ifnanset(&hd.fall.zvelocity, 0) // Just to be sure
 	ifierrset(&hd.fall.envshake_ampl, -4)
 	ifnanset(&hd.xaccel, 0)
+	ifnanset(&hd.zaccel, 0) // Here too
+	//ifnanset(&hd.zaccel, 0)
 	if hd.air_animtype == RA_Unknown {
 		hd.air_animtype = hd.animtype
 	}
@@ -5073,7 +5106,7 @@ func (c *Char) setHitdefDefault(hd *HitDef) {
 		ifnanset(&hd.ground_cornerpush_veloff, 0)
 	} else {
 		if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
-			ifnanset(&hd.ground_cornerpush_veloff, hd.guard_velocity*1.3)
+			ifnanset(&hd.ground_cornerpush_veloff, hd.guard_velocity[0]*1.3)
 		} else {
 			ifnanset(&hd.ground_cornerpush_veloff, hd.ground_velocity[0])
 		}
@@ -5112,6 +5145,9 @@ func (c *Char) setHitdefDefault(hd *HitDef) {
 	}
 	if !math.IsNaN(float64(hd.snap[1])) {
 		hd.maxdist[1], hd.mindist[1] = hd.snap[1], hd.snap[1]
+	}
+	if !math.IsNaN(float64(hd.snap[2])) {
+		hd.maxdist[2], hd.mindist[2] = hd.snap[2], hd.snap[2]
 	}
 	if hd.teamside == -1 {
 		hd.teamside = c.teamside + 1
@@ -5389,7 +5425,7 @@ func (c *Char) setFacing(f float32) {
 			c.ghv.ground_velocity[0] *= -1
 			c.ghv.air_velocity[0] *= -1
 			c.ghv.down_velocity[0] *= -1
-			c.ghv.guard_velocity *= -1
+			c.ghv.guard_velocity[0] *= -1
 			c.ghv.airguard_velocity[0] *= -1
 		}
 	}
@@ -5448,6 +5484,9 @@ func (c *Char) bindToTarget(tar []int32, time int32, x, y, z float32, hmf HMF) {
 			}
 			if !math.IsNaN(float64(y)) {
 				c.setY(t.pos[1]*(t.localscl/c.localscl) + y)
+			}
+			if !math.IsNaN(float64(z)) {
+				c.setZ(t.pos[2]*(t.localscl/c.localscl) + z)
 			}
 			c.targetBind(tar[:1], time,
 				c.facing*c.distX(t, c),
@@ -5549,6 +5588,14 @@ func (c *Char) targetVelSetY(tar []int32, y float32) {
 		}
 	}
 }
+func (c *Char) targetVelSetZ(tar []int32, z float32) {
+	for _, tid := range tar {
+		if t := sys.playerID(tid); t != nil {
+			z *= c.localscl / t.localscl
+			t.setZV(z)
+		}
+	}
+}
 func (c *Char) targetVelAddX(tar []int32, x float32) {
 	for _, tid := range tar {
 		if t := sys.playerID(tid); t != nil {
@@ -5562,6 +5609,14 @@ func (c *Char) targetVelAddY(tar []int32, y float32) {
 		if t := sys.playerID(tid); t != nil {
 			y *= c.localscl / t.localscl
 			t.vel[1] += y
+		}
+	}
+}
+func (c *Char) targetVelAddZ(tar []int32, z float32) {
+	for _, tid := range tar {
+		if t := sys.playerID(tid); t != nil {
+			z *= c.localscl / t.localscl
+			t.vel[2] += z
 		}
 	}
 }
@@ -5991,6 +6046,10 @@ func (c *Char) hitVelSetY() {
 	// Movetype H is not required in Mugen
 	c.setYV(c.ghv.yvel)
 }
+func (c *Char) hitVelSetZ() {
+	// Movetype H is not required in Mugen
+	c.setZV(c.ghv.zvel)
+}
 func (c *Char) setPauseTime(pausetime, movetime int32) {
 	if ^pausetime < sys.pausetime || c.playerNo != c.ss.sb.playerNo ||
 		sys.pauseplayer == c.playerNo {
@@ -6094,10 +6153,13 @@ func (c *Char) hitFallVel() {
 		if !math.IsNaN(float64(c.ghv.fall.xvelocity)) {
 			c.setXV(c.ghv.fall.xvelocity)
 		}
+		if !math.IsNaN(float64(c.ghv.fall.zvelocity)) {
+			c.setZV(c.ghv.fall.zvelocity)
+		}
 		c.setYV(c.ghv.fall.yvelocity)
 	}
 }
-func (c *Char) hitFallSet(f int32, xv, yv float32) {
+func (c *Char) hitFallSet(f int32, xv, yv, zv float32) {
 	if f >= 0 {
 		c.ghv.fallflag = f != 0
 	}
@@ -6106,6 +6168,9 @@ func (c *Char) hitFallSet(f int32, xv, yv float32) {
 	}
 	if !math.IsNaN(float64(yv)) {
 		c.ghv.fall.yvelocity = yv
+	}
+	if !math.IsNaN(float64(zv)) {
+		c.ghv.fall.zvelocity = zv
 	}
 }
 func (c *Char) remapPal(pfx *PalFX, src [2]int32, dst [2]int32) {
@@ -6472,6 +6537,9 @@ func (c *Char) bind() {
 			if !math.IsNaN(float64(c.bindPos[1])) {
 				c.setYV(bt.vel[1])
 			}
+			if !math.IsNaN(float64(c.bindPos[2])) {
+				c.setZV(bt.vel[2])
+			}
 		}
 		if !math.IsNaN(float64(c.bindPos[0])) {
 			f := bt.facing
@@ -6494,6 +6562,7 @@ func (c *Char) bind() {
 			c.setZ(bt.pos[2]*bt.localscl/c.localscl + (c.bindPos[2] + c.bindPosAdd[2]))
 			c.interPos[2] += bt.interPos[2] - bt.pos[2]
 			c.oldPos[2] += bt.oldPos[2] - bt.pos[2]
+			c.ghv.zoff = 0
 		}
 		if AbsF(c.bindFacing) == 1 {
 			if c.bindFacing > 0 {
@@ -7444,6 +7513,10 @@ func (c *Char) update() {
 					c.setPosY(c.pos[1] + c.ghv.yoff)
 					c.ghv.yoff = 0
 				}
+				if c.ghv.zoff != 0 {
+					c.setPosZ(c.pos[2] + c.ghv.zoff)
+					c.ghv.zoff = 0
+				}
 			}
 		}
 		if c.ss.moveType == MT_H {
@@ -8379,6 +8452,7 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 				ghv.id = hd.attackerID
 				ghv.xaccel = hd.xaccel * (c.localscl / getter.localscl)
 				ghv.yaccel = hd.yaccel * (c.localscl / getter.localscl)
+				ghv.zaccel = hd.zaccel * (c.localscl / getter.localscl)
 				ghv.groundtype = hd.ground_type
 				ghv.airtype = hd.air_type
 				if hd.forcenofall {
@@ -8403,9 +8477,11 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 						ghv.ctrltime = hd.airguard_ctrltime
 						ghv.xvel = hd.airguard_velocity[0] * (c.localscl / getter.localscl)
 						ghv.yvel = hd.airguard_velocity[1] * (c.localscl / getter.localscl)
+						ghv.zvel = hd.airguard_velocity[2] * (c.localscl / getter.localscl)
 					} else {
 						ghv.ctrltime = hd.guard_ctrltime
-						ghv.xvel = hd.guard_velocity * (c.localscl / getter.localscl)
+						ghv.xvel = hd.guard_velocity[0] * (c.localscl / getter.localscl)
+						ghv.zvel = hd.guard_velocity[1] * (c.localscl / getter.localscl)
 						// Mugen does not accept a Y component for ground guard velocity
 						//ghv.yvel = hd.ground_velocity[1] * c.localscl / getter.localscl
 					}
@@ -8423,6 +8499,7 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 					ghv.fall.envshake_ampl = int32(float32(hd.fall.envshake_ampl) * (c.localscl / getter.localscl))
 					ghv.fall.xvelocity = hd.fall.xvelocity * (c.localscl / getter.localscl)
 					ghv.fall.yvelocity = hd.fall.yvelocity * (c.localscl / getter.localscl)
+					ghv.fall.zvelocity = hd.fall.zvelocity * (c.localscl / getter.localscl)
 
 					if getter.ss.stateType == ST_A {
 						ghv.hittime = hd.air_hittime
@@ -8431,6 +8508,7 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 						ghv.ctrltime = hd.air_hittime
 						ghv.xvel = hd.air_velocity[0] * (c.localscl / getter.localscl)
 						ghv.yvel = hd.air_velocity[1] * (c.localscl / getter.localscl)
+						ghv.zvel = hd.air_velocity[2] * (c.localscl / getter.localscl)
 						ghv.fallflag = hd.air_fall
 					} else if getter.ss.stateType == ST_L {
 						ghv.hittime = hd.down_hittime
@@ -8439,18 +8517,22 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 						if getter.pos[1] == 0 {
 							ghv.xvel = hd.down_velocity[0] * (c.localscl / getter.localscl)
 							ghv.yvel = hd.down_velocity[1] * (c.localscl / getter.localscl)
+							ghv.zvel = hd.down_velocity[2] * (c.localscl / getter.localscl)
 							if !hd.down_bounce && ghv.yvel != 0 {
 								ghv.fall.xvelocity = float32(math.NaN())
 								ghv.fall.yvelocity = 0
+								ghv.fall.zvelocity = float32(math.NaN())
 							}
 						} else {
 							ghv.xvel = hd.air_velocity[0] * (c.localscl / getter.localscl)
 							ghv.yvel = hd.air_velocity[1] * (c.localscl / getter.localscl)
+							ghv.zvel = hd.air_velocity[1] * (c.localscl / getter.localscl)
 						}
 					} else {
 						ghv.ctrltime = hd.ground_hittime
 						ghv.xvel = hd.ground_velocity[0] * (c.localscl / getter.localscl)
 						ghv.yvel = hd.ground_velocity[1] * (c.localscl / getter.localscl)
+						ghv.zvel = hd.ground_velocity[2] * (c.localscl / getter.localscl)
 						ghv.fallflag = hd.ground_fall
 						if ghv.fallflag && ghv.yvel == 0 {
 							// Mugen does this as some form of internal workaround
@@ -8494,13 +8576,18 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 				// Save velocities regardless of statetype
 				ghv.ground_velocity[0] = hd.ground_velocity[0] * (c.localscl / getter.localscl)
 				ghv.ground_velocity[1] = hd.ground_velocity[1] * (c.localscl / getter.localscl)
+				ghv.ground_velocity[2] = hd.ground_velocity[2] * (c.localscl / getter.localscl)
 				ghv.air_velocity[0] = hd.air_velocity[0] * (c.localscl / getter.localscl)
 				ghv.air_velocity[1] = hd.air_velocity[1] * (c.localscl / getter.localscl)
+				ghv.air_velocity[2] = hd.air_velocity[2] * (c.localscl / getter.localscl)
 				ghv.down_velocity[0] = hd.down_velocity[0] * (c.localscl / getter.localscl)
 				ghv.down_velocity[1] = hd.down_velocity[1] * (c.localscl / getter.localscl)
-				ghv.guard_velocity = hd.guard_velocity * (c.localscl / getter.localscl)
+				ghv.down_velocity[2] = hd.down_velocity[2] * (c.localscl / getter.localscl)
+				ghv.guard_velocity[0] = hd.guard_velocity[0] * (c.localscl / getter.localscl)
+				ghv.guard_velocity[1] = hd.guard_velocity[1] * (c.localscl / getter.localscl)
 				ghv.airguard_velocity[0] = hd.airguard_velocity[0] * (c.localscl / getter.localscl)
 				ghv.airguard_velocity[1] = hd.airguard_velocity[1] * (c.localscl / getter.localscl)
+				ghv.airguard_velocity[2] = hd.airguard_velocity[2] * (c.localscl / getter.localscl)
 				ghv.airanimtype = hd.air_animtype
 				ghv.groundanimtype = hd.animtype
 				ghv.animtype = getter.gethitAnimtype() // This must be placed after ghv.yvel
@@ -8511,7 +8598,7 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 						byPos[i] += p
 					}
 				}
-				snap := [...]float32{float32(math.NaN()), float32(math.NaN())}
+				snap := [...]float32{float32(math.NaN()), float32(math.NaN()), float32(math.NaN())}
 				if !math.IsNaN(float64(hd.mindist[0])) {
 					if byf < 0 {
 						if getter.pos[0] > byPos[0]-hd.mindist[0] {
@@ -8546,15 +8633,28 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 						}
 					}
 				}
+				if !math.IsNaN(float64(hd.mindist[2])) {
+					if getter.pos[2]*(getter.localscl/c.localscl) < byPos[2]+hd.mindist[2] {
+						snap[2] = byPos[2] + hd.mindist[2]
+					}
+				}
+				if !math.IsNaN(float64(hd.maxdist[2])) {
+					if getter.pos[2]*(getter.localscl/c.localscl) > byPos[2]+hd.maxdist[2] {
+						snap[2] = byPos[2] + hd.maxdist[2]
+					}
+				}
 				if !math.IsNaN(float64(snap[0])) {
 					ghv.xoff = snap[0]*(c.localscl/getter.localscl) - getter.pos[0]
 				}
 				if !math.IsNaN(float64(snap[1])) {
 					ghv.yoff = snap[1]*(c.localscl/getter.localscl) - getter.pos[1]
 				}
-				if hd.snapt != 0 && getter.hoIdx < 0 {
+				if !math.IsNaN(float64(snap[2])) {
+					ghv.zoff = snap[2]*(c.localscl/getter.localscl) - getter.pos[2]
+				}
+				if hd.snaptime != 0 && getter.hoIdx < 0 {
 					getter.setBindToId(c)
-					getter.setBindTime(hd.snapt + Btoi(hd.snapt > 0 && !c.pause()))
+					getter.setBindTime(hd.snaptime + Btoi(hd.snaptime > 0 && !c.pause()))
 					getter.bindFacing = 0
 					if !math.IsNaN(float64(snap[0])) {
 						getter.bindPos[0] = hd.mindist[0] * (c.localscl / getter.localscl)
@@ -8566,6 +8666,11 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 						getter.bindPos[1] = hd.mindist[1] * (c.localscl / getter.localscl)
 					} else {
 						getter.bindPos[1] = float32(math.NaN())
+					}
+					if !math.IsNaN(float64(snap[2])) {
+						getter.bindPos[2] = hd.mindist[2] * (c.localscl / getter.localscl)
+					} else {
+						getter.bindPos[2] = float32(math.NaN())
 					}
 				} else if getter.bindToId == c.id {
 					getter.setBindTime(0)
@@ -9167,6 +9272,7 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 									getter.ghv.fall.envshake_ampl = int32(float32(c.hitdef.fall.envshake_ampl) * (c.localscl / getter.localscl))
 									getter.ghv.fall.xvelocity = c.hitdef.fall.xvelocity * (c.localscl / getter.localscl)
 									getter.ghv.fall.yvelocity = c.hitdef.fall.yvelocity * (c.localscl / getter.localscl)
+									getter.ghv.fall.zvelocity = c.hitdef.fall.zvelocity * (c.localscl / getter.localscl)
 
 									if c.hitdef.forcenofall {
 										getter.ghv.fallflag = false

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2277,6 +2277,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				out.append(OC_ex_gethitvar_down_velocity_z)
 			case "guard.velocity.x":
 				out.append(OC_ex_gethitvar_guard_velocity_x)
+			case "guard.velocity.y":
+				out.append(OC_ex_gethitvar_guard_velocity_y)
 			case "guard.velocity.z":
 				out.append(OC_ex_gethitvar_guard_velocity_z)
 			case "airguard.velocity.x":

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -217,6 +217,7 @@ var triggerMap = map[string]int{
 	"backedgebodydist":  1,
 	"backedgedist":      1,
 	"bottomedge":        1,
+	"bottomedgedist":    1,
 	"camerapos":         1,
 	"camerazoom":        1,
 	"canrecover":        1,
@@ -325,6 +326,7 @@ var triggerMap = map[string]int{
 	"time":              1,
 	"timemod":           1,
 	"topedge":           1,
+	"topedgedist":       1,
 	"uniqhitcount":      1,
 	"var":               1,
 	"vel":               1,
@@ -1541,6 +1543,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		}
 	case "bottomedge":
 		out.append(OC_bottomedge)
+	case "bottomedgedist":
+		out.append(OC_bottomedgedist)
 	case "camerapos":
 		c.token = c.tokenizer(in)
 		switch c.token {
@@ -2134,8 +2138,6 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			bv.SetF(0)
 		case "yveladd":
 			bv.SetF(0)
-		case "zoff":
-			bv.SetF(0)
 		case "fall.envshake.dir":
 			bv.SetI(0)
 		default:
@@ -2177,12 +2179,20 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				out.append(OC_ex_gethitvar_xoff)
 			case "yoff":
 				out.append(OC_ex_gethitvar_yoff)
+			case "zoff":
+				out.append(OC_ex_gethitvar_zoff)
 			case "xvel":
 				out.append(OC_ex_gethitvar_xvel)
 			case "yvel":
 				out.append(OC_ex_gethitvar_yvel)
+			case "zvel":
+				out.append(OC_ex_gethitvar_zvel)
+			case "xaccel":
+				out.append(OC_ex_gethitvar_xaccel)
 			case "yaccel":
 				out.append(OC_ex_gethitvar_yaccel)
+			case "zaccel":
+				out.append(OC_ex_gethitvar_zaccel)
 			case "hitid", "chainid":
 				out.append(OC_ex_gethitvar_chainid)
 			case "guarded":
@@ -2197,6 +2207,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				out.append(OC_ex_gethitvar_fall_xvel)
 			case "fall.yvel":
 				out.append(OC_ex_gethitvar_fall_yvel)
+			case "fall.zvel":
+				out.append(OC_ex_gethitvar_fall_zvel)
 			case "fall.recover":
 				out.append(OC_ex_gethitvar_fall_recover)
 			case "fall.time":
@@ -2249,26 +2261,34 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				out.append(OC_ex_gethitvar_ground_velocity_x)
 			case "ground.velocity.y":
 				out.append(OC_ex_gethitvar_ground_velocity_y)
+			case "ground.velocity.z":
+				out.append(OC_ex_gethitvar_ground_velocity_z)
 			case "air.velocity.x":
 				out.append(OC_ex_gethitvar_air_velocity_x)
 			case "air.velocity.y":
 				out.append(OC_ex_gethitvar_air_velocity_y)
+			case "air.velocity.z":
+				out.append(OC_ex_gethitvar_air_velocity_z)
 			case "down.velocity.x":
 				out.append(OC_ex_gethitvar_down_velocity_x)
 			case "down.velocity.y":
 				out.append(OC_ex_gethitvar_down_velocity_y)
+			case "down.velocity.z":
+				out.append(OC_ex_gethitvar_down_velocity_z)
 			case "guard.velocity.x":
 				out.append(OC_ex_gethitvar_guard_velocity_x)
+			case "guard.velocity.z":
+				out.append(OC_ex_gethitvar_guard_velocity_z)
 			case "airguard.velocity.x":
 				out.append(OC_ex_gethitvar_airguard_velocity_x)
 			case "airguard.velocity.y":
 				out.append(OC_ex_gethitvar_airguard_velocity_y)
+			case "airguard.velocity.z":
+				out.append(OC_ex_gethitvar_airguard_velocity_z)
 			case "frame":
 				out.append(OC_ex_gethitvar_frame)
 			case "down.recover":
 				out.append(OC_ex_gethitvar_down_recover)
-			case "xaccel":
-				out.append(OC_ex_gethitvar_xaccel)
 			default:
 				return bvNone(), Error("Invalid data: " + c.token)
 			}
@@ -2365,7 +2385,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "y":
 			out.append(OC_hitvel_y)
 		case "z":
-			bv = BytecodeFloat(0)
+			out.append(OC_hitvel_z)
 		default:
 			return bvNone(), Error("Invalid data: " + c.token)
 		}
@@ -2944,6 +2964,10 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			opc = OC_const_stagevar_playerinfo_leftbound
 		case "playerinfo.rightbound":
 			opc = OC_const_stagevar_playerinfo_rightbound
+		case "playerinfo.topbound":
+			opc = OC_const_stagevar_playerinfo_topbound
+		case "playerinfo.botbound":
+			opc = OC_const_stagevar_playerinfo_botbound
 		case "scaling.topz":
 			opc = OC_const_stagevar_scaling_topz
 		case "scaling.botz":
@@ -3046,6 +3070,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_time)
 	case "topedge":
 		out.append(OC_topedge)
+	case "topedgedist":
+		out.append(OC_topedgedist)
 	case "uniqhitcount":
 		out.append(OC_uniqhitcount)
 	case "vel":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1616,6 +1616,10 @@ func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 		hitDef_fall_yvelocity, VT_Float, 1, false); err != nil {
 		return err
 	}
+	if err := c.paramValue(is, sc, "fall.zvelocity",
+		hitDef_fall_zvelocity, VT_Float, 1, false); err != nil {
+		return err
+	}
 	if err := c.paramValue(is, sc, "fall.recover",
 		hitDef_fall_recover, VT_Bool, 1, false); err != nil {
 		return err
@@ -1700,7 +1704,7 @@ func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 		return err
 	}
 	if err := c.paramValue(is, sc, "down.velocity",
-		hitDef_down_velocity, VT_Float, 2, false); err != nil {
+		hitDef_down_velocity, VT_Float, 3, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "down.cornerpush.veloff",
@@ -1728,11 +1732,11 @@ func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 		return err
 	}
 	if err := c.paramValue(is, sc, "air.velocity",
-		hitDef_air_velocity, VT_Float, 2, false); err != nil {
+		hitDef_air_velocity, VT_Float, 3, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "airguard.velocity",
-		hitDef_airguard_velocity, VT_Float, 2, false); err != nil {
+		hitDef_airguard_velocity, VT_Float, 3, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "ground.slidetime",
@@ -1773,11 +1777,26 @@ func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 				}
 			} else {
 				in = oldin
-				be, err := c.fullExpression(&in, VT_Float)
+				be, err := c.argExpression(&in, VT_Float)
 				if err != nil {
 					return err
 				}
 				sc.add(hitDef_ground_velocity_y, sc.beToExp(be))
+			}
+		}
+		if c.token == "," {
+			oldin := in
+			if c.token = c.tokenizer(&in); c.token == "n" {
+				if c.token = c.tokenizer(&in); len(c.token) > 0 {
+					return Error("Invalid data: " + c.token)
+				}
+			} else {
+				in = oldin
+				be, err := c.fullExpression(&in, VT_Float)
+				if err != nil {
+					return err
+				}
+				sc.add(hitDef_ground_velocity_z, sc.beToExp(be))
 			}
 		}
 		return nil
@@ -1785,7 +1804,7 @@ func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 		return err
 	}
 	if err := c.paramValue(is, sc, "guard.velocity",
-		hitDef_guard_velocity, VT_Float, 1, false); err != nil {
+		hitDef_guard_velocity, VT_Float, 2, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "ground.cornerpush.veloff",
@@ -1800,8 +1819,16 @@ func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 		hitDef_airguard_cornerpush_veloff, VT_Float, 1, false); err != nil {
 		return err
 	}
+	if err := c.paramValue(is, sc, "xaccel",
+		hitDef_xaccel, VT_Float, 1, false); err != nil {
+		return err
+	}
 	if err := c.paramValue(is, sc, "yaccel",
 		hitDef_yaccel, VT_Float, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "zaccel",
+		hitDef_zaccel, VT_Float, 1, false); err != nil {
 		return err
 	}
 	if err := c.palFXSub(is, sc, "palfx."); err != nil {
@@ -1913,10 +1940,6 @@ func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 	}
 	if err := c.paramValue(is, sc, "down.recovertime",
 		hitDef_down_recovertime, VT_Int, 1, false); err != nil {
-		return err
-	}
-	if err := c.paramValue(is, sc, "xaccel",
-		hitDef_xaccel, VT_Float, 1, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "attack.depth",
@@ -2532,7 +2555,7 @@ func (c *Compiler) targetBind(is IniSection, sc *StateControllerBase, _ int8) (S
 			return err
 		}
 		if err := c.paramValue(is, sc, "pos",
-			targetBind_pos, VT_Float, 2, false); err != nil {
+			targetBind_pos, VT_Float, 3, false); err != nil {
 			return err
 		}
 		return nil
@@ -2665,6 +2688,10 @@ func (c *Compiler) targetVelSet(is IniSection, sc *StateControllerBase, _ int8) 
 			targetVelSet_y, VT_Float, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "z",
+			targetVelSet_z, VT_Float, 1, false); err != nil {
+		return err
+		}
 		return nil
 	})
 	return *ret, err
@@ -2686,6 +2713,10 @@ func (c *Compiler) targetVelAdd(is IniSection, sc *StateControllerBase, _ int8) 
 		if err := c.paramValue(is, sc, "y",
 			targetVelAdd_y, VT_Float, 1, false); err != nil {
 			return err
+		}
+		if err := c.paramValue(is, sc, "z",
+			targetVelAdd_z, VT_Float, 1, false); err != nil {
+		return err
 		}
 		return nil
 	})
@@ -2792,6 +2823,10 @@ func (c *Compiler) hitVelSet(is IniSection, sc *StateControllerBase, _ int8) (St
 		if err := c.paramValue(is, sc, "y",
 			hitVelSet_y, VT_Bool, 1, false); err != nil {
 			return err
+		}
+		if err := c.paramValue(is, sc, "z",
+			hitVelSet_z, VT_Bool, 1, false); err != nil {
+		return err
 		}
 		return nil
 	})
@@ -4996,6 +5031,14 @@ func (c *Compiler) modifyStageVar(is IniSection, sc *StateControllerBase, _ int8
 			modifyStageVar_playerinfo_rightbound, VT_Float, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "playerinfo.topbound",
+			modifyStageVar_playerinfo_topbound, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "playerinfo.botbound",
+			modifyStageVar_playerinfo_botbound, VT_Float, 1, false); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "scaling.topz",
 			modifyStageVar_scaling_topz, VT_Float, 1, false); err != nil {
 			return err
@@ -5301,6 +5344,10 @@ func (c *Compiler) getHitVarSet(is IniSection, sc *StateControllerBase, _ int8) 
 			getHitVarSet_fall_yvel, VT_Float, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "fall.zvel",
+			getHitVarSet_fall_zvel, VT_Float, 1, false); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "fallcount",
 			getHitVarSet_fallcount, VT_Int, 1, false); err != nil {
 			return err
@@ -5349,8 +5396,16 @@ func (c *Compiler) getHitVarSet(is IniSection, sc *StateControllerBase, _ int8) 
 			getHitVarSet_yaccel, VT_Float, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "zaccel",
+			getHitVarSet_zaccel, VT_Float, 1, false); err != nil {
+		return err
+		}
 		if err := c.paramValue(is, sc, "yvel",
 			getHitVarSet_yvel, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "zvel",
+			getHitVarSet_zvel, VT_Float, 1, false); err != nil {
 			return err
 		}
 		return nil

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1804,7 +1804,7 @@ func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 		return err
 	}
 	if err := c.paramValue(is, sc, "guard.velocity",
-		hitDef_guard_velocity, VT_Float, 2, false); err != nil {
+		hitDef_guard_velocity, VT_Float, 3, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "ground.cornerpush.veloff",

--- a/src/script.go
+++ b/src/script.go
@@ -3128,6 +3128,10 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.debugWC.bottomEdge()))
 		return 1
 	})
+	luaRegister(l, "bottomedgedist", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.bottomEdgeDist()))
+		return 1
+	})
 	luaRegister(l, "cameraposX", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.cam.Pos[0]))
 		return 1
@@ -3621,8 +3625,6 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(0)
 		case "yveladd":
 			ln = lua.LNumber(0)
-		case "zoff":
-			ln = lua.LNumber(0)
 		case "fall.envshake.dir":
 			ln = lua.LNumber(0)
 		case "animtype":
@@ -3661,14 +3663,20 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.ghv.xoff)
 		case "yoff":
 			ln = lua.LNumber(c.ghv.yoff)
+		case "zoff":
+			ln = lua.LNumber(c.ghv.zoff)
 		case "xvel":
 			ln = lua.LNumber(c.ghv.xvel * c.facing)
 		case "yvel":
 			ln = lua.LNumber(c.ghv.yvel)
+		case "zvel":
+			ln = lua.LNumber(c.ghv.zvel)
 		case "xaccel":
 			ln = lua.LNumber(c.ghv.getXaccel(c))
 		case "yaccel":
 			ln = lua.LNumber(c.ghv.getYaccel(c))
+		case "zaccel":
+			ln = lua.LNumber(c.ghv.getZaccel(c))
 		case "hitid", "chainid":
 			ln = lua.LNumber(c.ghv.chainId())
 		case "guarded":
@@ -3683,6 +3691,8 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.ghv.fall.xvel())
 		case "fall.yvel":
 			ln = lua.LNumber(c.ghv.fall.yvelocity)
+		case "fall.zvel":
+			ln = lua.LNumber(c.ghv.fall.zvelocity)
 		case "fall.recover":
 			ln = lua.LNumber(Btoi(c.ghv.fall.recover))
 		case "fall.time":
@@ -3739,16 +3749,24 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.ghv.air_velocity[0])
 		case "air.velocity.y":
 			ln = lua.LNumber(c.ghv.air_velocity[1])
+		case "air.velocity.z":
+			ln = lua.LNumber(c.ghv.air_velocity[2])
 		case "down.velocity.x":
 			ln = lua.LNumber(c.ghv.down_velocity[0])
 		case "down.velocity.y":
 			ln = lua.LNumber(c.ghv.down_velocity[1])
+		case "down.velocity.z":
+			ln = lua.LNumber(c.ghv.down_velocity[2])
 		case "guard.velocity.x":
-			ln = lua.LNumber(c.ghv.guard_velocity)
+			ln = lua.LNumber(c.ghv.guard_velocity[0])
+		case "guard.velocity.z":
+			ln = lua.LNumber(c.ghv.guard_velocity[1])
 		case "airguard.velocity.x":
 			ln = lua.LNumber(c.ghv.airguard_velocity[0])
 		case "airguard.velocity.y":
 			ln = lua.LNumber(c.ghv.airguard_velocity[1])
+		case "airguard.velocity.z":
+			ln = lua.LNumber(c.ghv.airguard_velocity[2])
 		case "frame":
 			ln = lua.LNumber(Btoi(c.ghv.frame))
 		case "down.recover":
@@ -3840,6 +3858,10 @@ func triggerFunctions(l *lua.LState) {
 	})
 	luaRegister(l, "hitvelY", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.hitVelY()))
+		return 1
+	})
+	luaRegister(l, "hitvelZ", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.hitVelZ()))
 		return 1
 	})
 	luaRegister(l, "id", func(*lua.LState) int {
@@ -4522,6 +4544,10 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LNumber(sys.stage.leftbound))
 		case "playerinfo.rightbound":
 			l.Push(lua.LNumber(sys.stage.rightbound))
+		case "playerinfo.topbound":
+			l.Push(lua.LNumber(sys.stage.topbound))
+		case "playerinfo.botbound":
+			l.Push(lua.LNumber(sys.stage.botbound))
 		case "scaling.topz":
 			l.Push(lua.LNumber(sys.stage.stageCamera.topz))
 		case "scaling.botz":
@@ -4628,6 +4654,10 @@ func triggerFunctions(l *lua.LState) {
 	})
 	luaRegister(l, "topedge", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.topEdge()))
+		return 1
+	})
+	luaRegister(l, "topedgedist", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.topEdgeDist()))
 		return 1
 	})
 	luaRegister(l, "uniqhitcount", func(*lua.LState) int {

--- a/src/script.go
+++ b/src/script.go
@@ -3759,8 +3759,10 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.ghv.down_velocity[2])
 		case "guard.velocity.x":
 			ln = lua.LNumber(c.ghv.guard_velocity[0])
-		case "guard.velocity.z":
+		case "guard.velocity.y":
 			ln = lua.LNumber(c.ghv.guard_velocity[1])
+		case "guard.velocity.z":
+			ln = lua.LNumber(c.ghv.guard_velocity[2])
 		case "airguard.velocity.x":
 			ln = lua.LNumber(c.ghv.airguard_velocity[0])
 		case "airguard.velocity.y":


### PR DESCRIPTION
Feat: 
- HitDef will now accept z for: 

-ground.velocity: (3rd value)
-air.velocity: (3rd value)
-airguard.velocity: (3rd value)
-guard.velocity: (3nd value, will now actually accept y as the 2nd value to maintain consistency)
-down.velocity: (3rd value)
-mindist: (3rd value)
-maxdist: (3rd value)
-snap: (3rd value, the 4th value is bindtime)

- New HitDef Params:

-fall.zvelocity
-zaccel

- getHitVar can now return zoff, zvel and fall.zvel
- HitVelSet z parameter
- TargetVelSet and TargetVelAdd z parameter
- TargetBind pos z
- BindToTarget posz param,
 can be skipped, so it's backward compatible with lines having only x,y declared
- Added topbound/botbound to StageVar and ModifyStageVar
- New topEdgeDist and bottomEdgeDist triggers for z edges

Fix:
- explodVar now accepts pos z