### PR TITLE
feat: New "LifeToPowerMul" constants, redundancy refactor, minor fixes

### DIFF
--- a/data/common.const
+++ b/data/common.const
@@ -17,8 +17,10 @@ Default.IgnoreDefeatedEnemies = 1   ; 1 prevents EnemyNear from redirecting defe
 Input.PauseOnHitPause = 1           ; 1 makes inputs to be retained during hit pause
 
 ; Rules
-Default.Attack.LifeToPowerMul = 0.7 ; multiplier for power the attacker gets when an attack successfully hits (overridden by getpower HitDef option)
-Default.GetHit.LifeToPowerMul = 0.6 ; multiplier for power the receiver gets when an attack successfully hits (overridden by givepower HitDef option)
+Default.Attack.LifeToPowerMul = 0.7 ; multiplier for power the attacker gets when a normal/special attack successfully hits (overridden by getpower HitDef option)
+Super.Attack.LifeToPowerMul = 0     ; multiplier for power the attacker gets when a super attack successfully hits (overridden by getpower HitDef option)
+Default.GetHit.LifeToPowerMul = 0.6 ; multiplier for power the receiver gets when a normal/special attack successfully hits (overridden by givepower HitDef option)
+Super.GetHit.LifeToPowerMul = 0.6   ; multiplier for power the receiver gets when a super attack successfully hits (overridden by givepower HitDef option)
 Super.TargetDefenceMul = 1.5        ; multiplier for how much a SuperPause increases the opponent's defence during combos (ignored if SuperPause p2defmul option is set)
 Default.LifeToGuardPointsMul = 1.5  ; multiplier for guard points the receiver loses when a normal/special attack is blocked (overridden by guardpoints HitDef option)
 Super.LifeToGuardPointsMul = 0.33   ; multiplier for guard points the receiver loses when a super attack is blocked (overridden by guardpoints HitDef option)

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3632,11 +3632,11 @@ func (sc stateDef) Run(c *Char) {
 		case stateDef_juggle:
 			c.juggle = exp[0].evalI(c)
 		case stateDef_velset:
-			c.setXV(exp[0].evalF(c))
+			c.vel[0] = exp[0].evalF(c)
 			if len(exp) > 1 {
-				c.setYV(exp[1].evalF(c))
+				c.vel[1] = exp[1].evalF(c)
 				if len(exp) > 2 {
-					c.setZV(exp[2].evalF(c))
+					c.vel[2] = exp[2].evalF(c)
 				}
 			}
 		case stateDef_anim:
@@ -4326,7 +4326,7 @@ const (
 
 func (sc helper) Run(c *Char, _ []int32) bool {
 	crun := c
-	var lclscround float32 = 1.0
+	var redirscale float32 = 1.0
 	var h *Char
 	pt := PT_P1
 	var f, st int32 = 1, 0
@@ -4338,7 +4338,7 @@ func (sc helper) Run(c *Char, _ []int32) bool {
 			if id == helper_redirectid {
 				if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 					crun = rid
-					lclscround = c.localscl / crun.localscl
+					redirscale = c.localscl / crun.localscl
 					h = crun.newHelper()
 				} else {
 					return false
@@ -4420,11 +4420,11 @@ func (sc helper) Run(c *Char, _ []int32) bool {
 		case helper_id:
 			h.helperId = exp[0].evalI(c)
 		case helper_pos:
-			x = exp[0].evalF(c) * lclscround
+			x = exp[0].evalF(c) * redirscale
 			if len(exp) > 1 {
-				y = exp[1].evalF(c) * lclscround
+				y = exp[1].evalF(c) * redirscale
 				if len(exp) > 2 {
-					z = exp[2].evalF(c) * lclscround
+					z = exp[2].evalF(c) * redirscale
 				}
 			}
 		case helper_facing:
@@ -4513,27 +4513,27 @@ const (
 
 func (sc posSet) Run(c *Char, _ []int32) bool {
 	crun := c
-	var lclscround float32 = 1.0
+	var redirscale float32 = 1.0
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case posSet_x:
-			x := sys.cam.Pos[0]/crun.localscl + exp[0].evalF(c)*lclscround
+			x := sys.cam.Pos[0]/crun.localscl + exp[0].evalF(c)*redirscale
 			crun.setX(x)
 			if crun.bindToId > 0 && !math.IsNaN(float64(crun.bindPos[0])) && sys.playerID(crun.bindToId) != nil {
 				crun.bindPosAdd[0] = x
 			}
 		case posSet_y:
-			y := exp[0].evalF(c)*lclscround + crun.groundLevel + crun.platformPosY
+			y := exp[0].evalF(c)*redirscale + crun.groundLevel + crun.platformPosY
 			crun.setY(y)
 			if crun.bindToId > 0 && !math.IsNaN(float64(crun.bindPos[1])) && sys.playerID(crun.bindToId) != nil {
 				crun.bindPosAdd[1] = y
 			}
 		case posSet_z:
-			crun.setZ(exp[0].evalF(c) * lclscround)
+			crun.setZ(exp[0].evalF(c) * redirscale)
 		case posSet_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				lclscround = c.localscl / crun.localscl
+				redirscale = c.localscl / crun.localscl
 			} else {
 				return false
 			}
@@ -4547,23 +4547,23 @@ type posAdd posSet
 
 func (sc posAdd) Run(c *Char, _ []int32) bool {
 	crun := c
-	var lclscround float32 = 1.0
+	var redirscale float32 = 1.0
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case posSet_x:
-			x := exp[0].evalF(c) * lclscround
+			x := exp[0].evalF(c) * redirscale
 			crun.addX(x)
 			if crun.bindToId > 0 && !math.IsNaN(float64(crun.bindPos[0])) && sys.playerID(crun.bindToId) != nil {
 				crun.bindPosAdd[0] = x
 			}
 		case posSet_y:
-			y := exp[0].evalF(c) * lclscround
+			y := exp[0].evalF(c) * redirscale
 			crun.addY(y)
 			if crun.bindToId > 0 && !math.IsNaN(float64(crun.bindPos[1])) && sys.playerID(crun.bindToId) != nil {
 				crun.bindPosAdd[1] = y
 			}
 		case posSet_z:
-			z := exp[0].evalF(c) * lclscround
+			z := exp[0].evalF(c) * redirscale
 			crun.addZ(z)
 			if crun.bindToId > 0 && !math.IsNaN(float64(crun.bindPos[0])) && sys.playerID(crun.bindToId) != nil {
 				crun.bindPosAdd[0] = z
@@ -4571,7 +4571,7 @@ func (sc posAdd) Run(c *Char, _ []int32) bool {
 		case posSet_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				lclscround = c.localscl / crun.localscl
+				redirscale = c.localscl / crun.localscl
 			} else {
 				return false
 			}
@@ -4585,19 +4585,19 @@ type velSet posSet
 
 func (sc velSet) Run(c *Char, _ []int32) bool {
 	crun := c
-	var lclscround float32 = 1.0
+	var redirscale float32 = 1.0
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case posSet_x:
-			crun.setXV(exp[0].evalF(c) * lclscround)
+			crun.vel[0] = exp[0].evalF(c) * redirscale
 		case posSet_y:
-			crun.setYV(exp[0].evalF(c) * lclscround)
+			crun.vel[1] = exp[0].evalF(c) * redirscale
 		case posSet_z:
-			crun.setZV(exp[0].evalF(c) * lclscround)
+			crun.vel[2] = exp[0].evalF(c) * redirscale
 		case posSet_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				lclscround = c.localscl / crun.localscl
+				redirscale = c.localscl / crun.localscl
 			} else {
 				return false
 			}
@@ -4611,19 +4611,19 @@ type velAdd posSet
 
 func (sc velAdd) Run(c *Char, _ []int32) bool {
 	crun := c
-	var lclscround float32 = 1.0
+	var redirscale float32 = 1.0
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case posSet_x:
-			crun.addXV(exp[0].evalF(c) * lclscround)
+			crun.vel[0] += exp[0].evalF(c) * redirscale
 		case posSet_y:
-			crun.addYV(exp[0].evalF(c) * lclscround)
+			crun.vel[1] += exp[0].evalF(c) * redirscale
 		case posSet_z:
-			crun.addZV(exp[0].evalF(c) * lclscround)
+			crun.vel[2] += exp[0].evalF(c) * redirscale
 		case posSet_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				lclscround = c.localscl / crun.localscl
+				redirscale = c.localscl / crun.localscl
 			} else {
 				return false
 			}
@@ -4640,11 +4640,11 @@ func (sc velMul) Run(c *Char, _ []int32) bool {
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case posSet_x:
-			crun.mulXV(exp[0].evalF(c))
+			crun.vel[0] *= exp[0].evalF(c)
 		case posSet_y:
-			crun.mulYV(exp[0].evalF(c))
+			crun.vel[1] *= exp[0].evalF(c)
 		case posSet_z:
-			crun.mulZV(exp[0].evalF(c))
+			crun.vel[2] *= exp[0].evalF(c)
 		case posSet_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -4899,7 +4899,7 @@ const (
 
 func (sc explod) Run(c *Char, _ []int32) bool {
 	crun := c
-	var lclscround float32 = 1.0
+	var redirscale float32 = 1.0
 	var e *Explod
 	var i int
 	//e, i := crun.newExplod()
@@ -4909,7 +4909,7 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 			if id == explod_redirectid {
 				if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 					crun = rid
-					lclscround = c.localscl / crun.localscl
+					redirscale = c.localscl / crun.localscl
 					e, i = crun.newExplod()
 					if e == nil {
 						return false
@@ -4960,21 +4960,21 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 				e.vfacing = 1
 			}
 		case explod_pos:
-			e.relativePos[0] = exp[0].evalF(c) * lclscround
+			e.relativePos[0] = exp[0].evalF(c) * redirscale
 			if len(exp) > 1 {
-				e.relativePos[1] = exp[1].evalF(c) * lclscround
+				e.relativePos[1] = exp[1].evalF(c) * redirscale
 				if len(exp) > 2 {
-					e.relativePos[2] = exp[2].evalF(c) * lclscround
+					e.relativePos[2] = exp[2].evalF(c) * redirscale
 				}
 			}
 		case explod_random:
-			rndx := (exp[0].evalF(c) / 2) * lclscround
+			rndx := (exp[0].evalF(c) / 2) * redirscale
 			e.relativePos[0] += RandF(-rndx, rndx)
 			if len(exp) > 1 {
-				rndy := (exp[1].evalF(c) / 2) * lclscround
+				rndy := (exp[1].evalF(c) / 2) * redirscale
 				e.relativePos[1] += RandF(-rndy, rndy)
 				if len(exp) > 2 {
-					rndz := (exp[2].evalF(c) / 2) * lclscround
+					rndz := (exp[2].evalF(c) / 2) * redirscale
 					e.relativePos[2] += RandF(-rndz, rndz)
 				}
 			}
@@ -4983,19 +4983,19 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 		case explod_postype:
 			e.postype = PosType(exp[0].evalI(c))
 		case explod_velocity:
-			e.velocity[0] = exp[0].evalF(c) * lclscround
+			e.velocity[0] = exp[0].evalF(c) * redirscale
 			if len(exp) > 1 {
-				e.velocity[1] = exp[1].evalF(c) * lclscround
+				e.velocity[1] = exp[1].evalF(c) * redirscale
 				if len(exp) > 2 {
-					e.velocity[2] = exp[2].evalF(c) * lclscround
+					e.velocity[2] = exp[2].evalF(c) * redirscale
 				}
 			}
 		case explod_accel:
-			e.accel[0] = exp[0].evalF(c) * lclscround
+			e.accel[0] = exp[0].evalF(c) * redirscale
 			if len(exp) > 1 {
-				e.accel[1] = exp[1].evalF(c) * lclscround
+				e.accel[1] = exp[1].evalF(c) * redirscale
 				if len(exp) > 2 {
-					e.accel[2] = exp[2].evalF(c) * lclscround
+					e.accel[2] = exp[2].evalF(c) * redirscale
 				}
 			}
 		case explod_scale:
@@ -5110,7 +5110,7 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 		case explod_projection:
 			e.projection = Projection(exp[0].evalI(c))
 		case explod_window:
-			e.window = [4]float32{exp[0].evalF(c) * lclscround, exp[1].evalF(c) * lclscround, exp[2].evalF(c) * lclscround, exp[3].evalF(c) * lclscround}
+			e.window = [4]float32{exp[0].evalF(c) * redirscale, exp[1].evalF(c) * redirscale, exp[2].evalF(c) * redirscale, exp[3].evalF(c) * redirscale}
 		default:
 			if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
 				e.palfxdef.invertblend = -2
@@ -5219,7 +5219,7 @@ const (
 
 func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 	crun := c
-	var lclscround float32 = 1.0
+	var redirscale float32 = 1.0
 	eid := int32(-1)
 	idx := int32(-1)
 	var expls []*Explod
@@ -5242,7 +5242,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 		case explod_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				lclscround = c.localscl / crun.localscl
+				redirscale = c.localscl / crun.localscl
 			} else {
 				return false
 			}
@@ -5326,21 +5326,21 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				}
 			case explod_pos:
 				if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
-					pos := exp[0].evalF(c) * lclscround
+					pos := exp[0].evalF(c) * redirscale
 					eachExpl(func(e *Explod) {
 						e.relativePos[0] = pos
 					})
 				}
 				if len(exp) > 1 {
 					if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
-						pos := exp[1].evalF(c) * lclscround
+						pos := exp[1].evalF(c) * redirscale
 						eachExpl(func(e *Explod) {
 							e.relativePos[1] = pos
 						})
 					}
 					if len(exp) > 2 {
 						if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
-							pos := exp[2].evalF(c) * lclscround
+							pos := exp[2].evalF(c) * redirscale
 							eachExpl(func(e *Explod) {
 								e.relativePos[2] = pos
 							})
@@ -5349,7 +5349,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				}
 			case explod_random:
 				if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
-					rndx := (exp[0].evalF(c) / 2) * lclscround
+					rndx := (exp[0].evalF(c) / 2) * redirscale
 					rndx = RandF(-rndx, rndx)
 					eachExpl(func(e *Explod) {
 						e.relativePos[0] += rndx
@@ -5357,7 +5357,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				}
 				if len(exp) > 1 {
 					if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
-						rndy := (exp[1].evalF(c) / 2) * lclscround
+						rndy := (exp[1].evalF(c) / 2) * redirscale
 						rndy = RandF(-rndy, rndy)
 						eachExpl(func(e *Explod) {
 							e.relativePos[1] += rndy
@@ -5365,7 +5365,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 					}
 					if len(exp) > 2 {
 						if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
-							rndz := (exp[2].evalF(c) / 2) * lclscround
+							rndz := (exp[2].evalF(c) / 2) * redirscale
 							rndz = RandF(-rndz, rndz)
 							eachExpl(func(e *Explod) {
 								e.relativePos[2] += rndz
@@ -5375,21 +5375,21 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				}
 			case explod_velocity:
 				if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
-					vel := exp[0].evalF(c) * lclscround
+					vel := exp[0].evalF(c) * redirscale
 					eachExpl(func(e *Explod) {
 						e.velocity[0] = vel
 					})
 				}
 				if len(exp) > 1 {
 					if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
-						vel := exp[1].evalF(c) * lclscround
+						vel := exp[1].evalF(c) * redirscale
 						eachExpl(func(e *Explod) {
 							e.velocity[1] = vel
 						})
 					}
 					if len(exp) > 2 {
 						if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
-							vel := exp[2].evalF(c) * lclscround
+							vel := exp[2].evalF(c) * redirscale
 							eachExpl(func(e *Explod) {
 								e.velocity[2] = vel
 							})
@@ -5398,21 +5398,21 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				}
 			case explod_accel:
 				if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
-					accel := exp[0].evalF(c) * lclscround
+					accel := exp[0].evalF(c) * redirscale
 					eachExpl(func(e *Explod) {
 						e.accel[0] = accel
 					})
 				}
 				if len(exp) > 1 {
 					if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
-						accel := exp[1].evalF(c) * lclscround
+						accel := exp[1].evalF(c) * redirscale
 						eachExpl(func(e *Explod) {
 							e.accel[1] = accel
 						})
 					}
 					if len(exp) > 2 {
 						if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
-							accel := exp[2].evalF(c) * lclscround
+							accel := exp[2].evalF(c) * redirscale
 							eachExpl(func(e *Explod) {
 								e.accel[2] = accel
 							})
@@ -5620,7 +5620,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				})
 			case explod_window:
 				eachExpl(func(e *Explod) {
-					e.window = [4]float32{exp[0].evalF(c) * lclscround, exp[1].evalF(c) * lclscround, exp[2].evalF(c) * lclscround, exp[3].evalF(c) * lclscround}
+					e.window = [4]float32{exp[0].evalF(c) * redirscale, exp[1].evalF(c) * redirscale, exp[2].evalF(c) * redirscale, exp[3].evalF(c) * redirscale}
 				})
 			case explod_ignorehitpause:
 				if c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 { // You could not modify this one in Mugen
@@ -5685,7 +5685,7 @@ const (
 
 func (sc gameMakeAnim) Run(c *Char, _ []int32) bool {
 	crun := c
-	var lclscround float32 = 1.0
+	var redirscale float32 = 1.0
 	var e *Explod
 	var i int
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
@@ -5693,7 +5693,7 @@ func (sc gameMakeAnim) Run(c *Char, _ []int32) bool {
 			if id == gameMakeAnim_redirectid {
 				if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 					crun = rid
-					lclscround = c.localscl / crun.localscl
+					redirscale = c.localscl / crun.localscl
 					e, i = crun.newExplod()
 					if e == nil {
 						return false
@@ -5713,15 +5713,15 @@ func (sc gameMakeAnim) Run(c *Char, _ []int32) bool {
 		}
 		switch id {
 		case gameMakeAnim_pos:
-			e.relativePos[0] = exp[0].evalF(c) * lclscround
+			e.relativePos[0] = exp[0].evalF(c) * redirscale
 			if len(exp) > 1 {
-				e.relativePos[1] = exp[1].evalF(c) * lclscround
+				e.relativePos[1] = exp[1].evalF(c) * redirscale
 			}
 		case gameMakeAnim_random:
-			rndx := (exp[0].evalF(c) / 2) * lclscround
+			rndx := (exp[0].evalF(c) / 2) * redirscale
 			e.relativePos[0] += RandF(-rndx, rndx)
 			if len(exp) > 1 {
-				rndy := (exp[1].evalF(c) / 2) * lclscround
+				rndy := (exp[1].evalF(c) / 2) * redirscale
 				e.relativePos[1] += RandF(-rndy, rndy)
 			}
 		case gameMakeAnim_under:
@@ -6452,7 +6452,7 @@ const (
 // Additions to this state controller should also be done to ModifyProjectile
 func (sc projectile) Run(c *Char, _ []int32) bool {
 	crun := c
-	var lclscround float32 = 1.0
+	var redirscale float32 = 1.0
 	var p *Projectile
 	pt := PT_P1
 	var x, y, z float32 = 0, 0, 0
@@ -6464,7 +6464,7 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 			if id == projectile_redirectid {
 				if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 					crun = rid
-					lclscround = c.localscl / crun.localscl
+					redirscale = c.localscl / crun.localscl
 				} else {
 					return false
 				}
@@ -6510,11 +6510,11 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 			p.cancelanim = Max(-1, exp[1].evalI(c))
 			p.cancelanim_ffx = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
 		case projectile_velocity:
-			p.velocity[0] = exp[0].evalF(c) * lclscround
+			p.velocity[0] = exp[0].evalF(c) * redirscale
 			if len(exp) > 1 {
-				p.velocity[1] = exp[1].evalF(c) * lclscround
+				p.velocity[1] = exp[1].evalF(c) * redirscale
 				if len(exp) > 2 {
-					p.velocity[2] = exp[2].evalF(c) * lclscround
+					p.velocity[2] = exp[2].evalF(c) * redirscale
 				}
 			}
 		case projectile_velmul:
@@ -6526,17 +6526,17 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 				}
 			}
 		case projectile_remvelocity:
-			p.remvelocity[0] = exp[0].evalF(c) * lclscround
+			p.remvelocity[0] = exp[0].evalF(c) * redirscale
 			if len(exp) > 1 {
-				p.remvelocity[1] = exp[1].evalF(c) * lclscround
+				p.remvelocity[1] = exp[1].evalF(c) * redirscale
 				if len(exp) > 2 {
-					p.remvelocity[2] = exp[2].evalF(c) * lclscround
+					p.remvelocity[2] = exp[2].evalF(c) * redirscale
 				}
 			}
 		case projectile_accel:
-			p.accel[0] = exp[0].evalF(c) * lclscround
+			p.accel[0] = exp[0].evalF(c) * redirscale
 			if len(exp) > 1 {
-				p.accel[1] = exp[1].evalF(c) * lclscround
+				p.accel[1] = exp[1].evalF(c) * redirscale
 				if len(exp) > 2 {
 					p.accel[2] = exp[2].evalF(c)
 				}
@@ -6549,11 +6549,11 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 		case projectile_projangle:
 			p.angle = exp[0].evalF(c)
 		case projectile_offset:
-			x = exp[0].evalF(c) * lclscround
+			x = exp[0].evalF(c) * redirscale
 			if len(exp) > 1 {
-				y = exp[1].evalF(c) * lclscround
+				y = exp[1].evalF(c) * redirscale
 				if len(exp) > 2 {
-					z = exp[2].evalF(c) * lclscround
+					z = exp[2].evalF(c) * redirscale
 				}
 			}
 		case projectile_projsprpriority:
@@ -6568,16 +6568,16 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 				p.layerno = 0
 			}
 		case projectile_projstagebound:
-			p.stagebound = int32(float32(exp[0].evalI(c)) * lclscround)
+			p.stagebound = int32(float32(exp[0].evalI(c)) * redirscale)
 		case projectile_projedgebound:
-			p.edgebound = int32(float32(exp[0].evalI(c)) * lclscround)
+			p.edgebound = int32(float32(exp[0].evalI(c)) * redirscale)
 		case projectile_projheightbound:
-			p.heightbound[0] = int32(float32(exp[0].evalI(c)) * lclscround)
+			p.heightbound[0] = int32(float32(exp[0].evalI(c)) * redirscale)
 			if len(exp) > 1 {
-				p.heightbound[1] = int32(float32(exp[1].evalI(c)) * lclscround)
+				p.heightbound[1] = int32(float32(exp[1].evalI(c)) * redirscale)
 			}
 		case projectile_projdepthbound:
-			p.depthbound = int32(float32(exp[0].evalI(c)) * lclscround)
+			p.depthbound = int32(float32(exp[0].evalI(c)) * redirscale)
 		case projectile_projanim:
 			p.anim = exp[1].evalI(c)
 			p.anim_ffx = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
@@ -6611,14 +6611,14 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 		// case projectile_platform:
 		// 	p.platform = exp[0].evalB(c)
 		// case projectile_platformwidth:
-		// 	p.platformWidth[0] = exp[0].evalF(c) * lclscround
+		// 	p.platformWidth[0] = exp[0].evalF(c) * redirscale
 		// 	if len(exp) > 1 {
-		// 		p.platformWidth[1] = exp[1].evalF(c) * lclscround
+		// 		p.platformWidth[1] = exp[1].evalF(c) * redirscale
 		// 	}
 		// case projectile_platformheight:
-		// 	p.platformHeight[0] = exp[0].evalF(c) * lclscround
+		// 	p.platformHeight[0] = exp[0].evalF(c) * redirscale
 		// 	if len(exp) > 1 {
-		// 		p.platformHeight[1] = exp[1].evalF(c) * lclscround
+		// 		p.platformHeight[1] = exp[1].evalF(c) * redirscale
 		// 	}
 		// case projectile_platformangle:
 		// 	p.platformAngle = exp[0].evalF(c)
@@ -6725,7 +6725,7 @@ const (
 
 func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 	crun := c
-	var lclscround float32 = 1.0
+	var redirscale float32 = 1.0
 	mpid := int32(-1)
 	mpidx := int32(-1)
 	var projs []*Projectile
@@ -6743,7 +6743,7 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 		case modifyProjectile_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				lclscround = c.localscl / crun.localscl
+				redirscale = c.localscl / crun.localscl
 			} else {
 				return false
 			}
@@ -6801,11 +6801,11 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				})
 			case projectile_velocity:
 				eachProj(func(p *Projectile) {
-					p.velocity[0] = exp[0].evalF(c) * lclscround
+					p.velocity[0] = exp[0].evalF(c) * redirscale
 					if len(exp) > 1 {
-						p.velocity[1] = exp[1].evalF(c) * lclscround
+						p.velocity[1] = exp[1].evalF(c) * redirscale
 						if len(exp) > 2 {
-							p.velocity[2] = exp[2].evalF(c) * lclscround
+							p.velocity[2] = exp[2].evalF(c) * redirscale
 						}
 					}
 				})
@@ -6821,21 +6821,21 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				})
 			case projectile_remvelocity:
 				eachProj(func(p *Projectile) {
-					p.remvelocity[0] = exp[0].evalF(c) * lclscround
+					p.remvelocity[0] = exp[0].evalF(c) * redirscale
 					if len(exp) > 1 {
-						p.remvelocity[1] = exp[1].evalF(c) * lclscround
+						p.remvelocity[1] = exp[1].evalF(c) * redirscale
 						if len(exp) > 2 {
-							p.remvelocity[2] = exp[2].evalF(c) * lclscround
+							p.remvelocity[2] = exp[2].evalF(c) * redirscale
 						}
 					}
 				})
 			case projectile_accel:
 				eachProj(func(p *Projectile) {
-					p.accel[0] = exp[0].evalF(c) * lclscround
+					p.accel[0] = exp[0].evalF(c) * redirscale
 					if len(exp) > 1 {
-						p.accel[1] = exp[1].evalF(c) * lclscround
+						p.accel[1] = exp[1].evalF(c) * redirscale
 						if len(exp) > 2 {
-							p.accel[2] = exp[2].evalF(c) * lclscround
+							p.accel[2] = exp[2].evalF(c) * redirscale
 						}
 					}
 				})
@@ -6868,22 +6868,22 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				})
 			case projectile_projstagebound:
 				eachProj(func(p *Projectile) {
-					p.stagebound = int32(float32(exp[0].evalI(c)) * lclscround)
+					p.stagebound = int32(float32(exp[0].evalI(c)) * redirscale)
 				})
 			case projectile_projedgebound:
 				eachProj(func(p *Projectile) {
-					p.edgebound = int32(float32(exp[0].evalI(c)) * lclscround)
+					p.edgebound = int32(float32(exp[0].evalI(c)) * redirscale)
 				})
 			case projectile_projheightbound:
 				eachProj(func(p *Projectile) {
-					p.heightbound[0] = int32(float32(exp[0].evalI(c)) * lclscround)
+					p.heightbound[0] = int32(float32(exp[0].evalI(c)) * redirscale)
 					if len(exp) > 1 {
-						p.heightbound[1] = int32(float32(exp[1].evalI(c)) * lclscround)
+						p.heightbound[1] = int32(float32(exp[1].evalI(c)) * redirscale)
 					}
 				})
 			case projectile_projdepthbound:
 				eachProj(func(p *Projectile) {
-					p.depthbound = int32(float32(exp[0].evalI(c)) * lclscround)
+					p.depthbound = int32(float32(exp[0].evalI(c)) * redirscale)
 				})
 			case projectile_projanim:
 				eachProj(func(p *Projectile) {
@@ -7444,32 +7444,32 @@ const (
 
 func (sc width) Run(c *Char, _ []int32) bool {
 	crun := c
-	var lclscround float32 = 1.0
+	var redirscale float32 = 1.0
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case width_edge:
-			crun.setFEdge(exp[0].evalF(c) * lclscround)
+			crun.setFEdge(exp[0].evalF(c) * redirscale)
 			if len(exp) > 1 {
-				crun.setBEdge(exp[1].evalF(c) * lclscround)
+				crun.setBEdge(exp[1].evalF(c) * redirscale)
 			}
 		case width_player:
-			crun.setFWidth(exp[0].evalF(c) * lclscround)
+			crun.setFWidth(exp[0].evalF(c) * redirscale)
 			if len(exp) > 1 {
-				crun.setBWidth(exp[1].evalF(c) * lclscround)
+				crun.setBWidth(exp[1].evalF(c) * redirscale)
 			}
 		case width_value:
-			v1 := exp[0].evalF(c) * lclscround
+			v1 := exp[0].evalF(c) * redirscale
 			crun.setFEdge(v1)
 			crun.setFWidth(v1)
 			if len(exp) > 1 {
-				v2 := exp[1].evalF(c) * lclscround
+				v2 := exp[1].evalF(c) * redirscale
 				crun.setBEdge(v2)
 				crun.setBWidth(v2)
 			}
 		case width_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				lclscround = (320 / c.localcoord) / (320 / crun.localcoord)
+				redirscale = (320 / c.localcoord) / (320 / crun.localcoord)
 			} else {
 				return false
 			}
@@ -7615,7 +7615,7 @@ const (
 
 func (sc targetBind) Run(c *Char, _ []int32) bool {
 	crun := c
-	var lclscround float32 = 1.0
+	var redirscale float32 = 1.0
 	tar := crun.getTarget(-1)
 	t := int32(1)
 	var x, y, z float32 = 0, 0, 0
@@ -7629,17 +7629,17 @@ func (sc targetBind) Run(c *Char, _ []int32) bool {
 		case targetBind_time:
 			t = exp[0].evalI(c)
 		case targetBind_pos:
-			x = exp[0].evalF(c) * lclscround
+			x = exp[0].evalF(c) * redirscale
 			if len(exp) > 1 {
-				y = exp[1].evalF(c) * lclscround
+				y = exp[1].evalF(c) * redirscale
 				if len(exp) > 2 {
-					z = exp[2].evalF(c) * lclscround
+					z = exp[2].evalF(c) * redirscale
 				}
 			}
 		case targetBind_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				lclscround = c.localscl / crun.localscl
+				redirscale = c.localscl / crun.localscl
 				tar = crun.getTarget(-1)
 				if len(tar) == 0 {
 					return false
@@ -7670,7 +7670,7 @@ const (
 
 func (sc bindToTarget) Run(c *Char, _ []int32) bool {
 	crun := c
-	var lclscround float32 = 1.0
+	var redirscale float32 = 1.0
 	tar := crun.getTarget(-1)
 	t, x, y, z, hmf := int32(1), float32(0), float32(math.NaN()), float32(math.NaN()), HMF_F
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
@@ -7683,19 +7683,19 @@ func (sc bindToTarget) Run(c *Char, _ []int32) bool {
 		case bindToTarget_time:
 			t = exp[0].evalI(c)
 		case bindToTarget_pos:
-			x = exp[0].evalF(c) * lclscround
+			x = exp[0].evalF(c) * redirscale
 			if len(exp) > 1 {
-				y = exp[1].evalF(c) * lclscround
+				y = exp[1].evalF(c) * redirscale
 				if len(exp) > 2 {
 					hmf = HMF(exp[2].evalI(c))
 				}
 			}
 		case bindToTarget_posz:
-			z = exp[0].evalF(c) * lclscround
+			z = exp[0].evalF(c) * redirscale
 		case bindToTarget_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				lclscround = c.localscl / crun.localscl
+				redirscale = c.localscl / crun.localscl
 				tar = crun.getTarget(-1)
 				if len(tar) == 0 {
 					return false
@@ -7815,7 +7815,7 @@ const (
 
 func (sc targetVelSet) Run(c *Char, _ []int32) bool {
 	crun := c
-	var lclscround float32 = 1.0
+	var redirscale float32 = 1.0
 	tar := crun.getTarget(-1)
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
@@ -7828,21 +7828,21 @@ func (sc targetVelSet) Run(c *Char, _ []int32) bool {
 			if len(tar) == 0 {
 				return false
 			}
-			crun.targetVelSetX(tar, exp[0].evalF(c)*lclscround)
+			crun.targetVelSetX(tar, exp[0].evalF(c)*redirscale)
 		case targetVelSet_y:
 			if len(tar) == 0 {
 				return false
 			}
-			crun.targetVelSetY(tar, exp[0].evalF(c)*lclscround)
+			crun.targetVelSetY(tar, exp[0].evalF(c)*redirscale)
 		case targetVelSet_z:
 			if len(tar) == 0 {
 				return false
 			}
-			crun.targetVelSetZ(tar, exp[0].evalF(c)*lclscround)
+			crun.targetVelSetZ(tar, exp[0].evalF(c)*redirscale)
 		case targetVelSet_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				lclscround = c.localscl / crun.localscl
+				redirscale = c.localscl / crun.localscl
 				tar = crun.getTarget(-1)
 				if len(tar) == 0 {
 					return false
@@ -7868,7 +7868,7 @@ const (
 
 func (sc targetVelAdd) Run(c *Char, _ []int32) bool {
 	crun := c
-	var lclscround float32 = 1.0
+	var redirscale float32 = 1.0
 	tar := crun.getTarget(-1)
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
@@ -7881,21 +7881,21 @@ func (sc targetVelAdd) Run(c *Char, _ []int32) bool {
 			if len(tar) == 0 {
 				return false
 			}
-			crun.targetVelAddX(tar, exp[0].evalF(c)*lclscround)
+			crun.targetVelAddX(tar, exp[0].evalF(c)*redirscale)
 		case targetVelAdd_y:
 			if len(tar) == 0 {
 				return false
 			}
-			crun.targetVelAddY(tar, exp[0].evalF(c)*lclscround)
+			crun.targetVelAddY(tar, exp[0].evalF(c)*redirscale)
 		case targetVelAdd_z:
 			if len(tar) == 0 {
 				return false
 			}
-			crun.targetVelAddZ(tar, exp[0].evalF(c)*lclscround)
+			crun.targetVelAddZ(tar, exp[0].evalF(c)*redirscale)
 		case targetVelAdd_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				lclscround = c.localscl / crun.localscl
+				redirscale = c.localscl / crun.localscl
 				tar = crun.getTarget(-1)
 				if len(tar) == 0 {
 					return false
@@ -8108,20 +8108,21 @@ const (
 )
 
 func (sc hitVelSet) Run(c *Char, _ []int32) bool {
+	// Note: HitVelSet doesn't require Movetype H in Mugen
 	crun := c
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case hitVelSet_x:
 			if exp[0].evalB(c) {
-				crun.hitVelSetX()
+				crun.vel[0] = crun.ghv.xvel
 			}
 		case hitVelSet_y:
 			if exp[0].evalB(c) {
-				crun.hitVelSetY()
+				crun.vel[1] = crun.ghv.yvel
 			}
 		case hitVelSet_z:
 			if exp[0].evalB(c) {
-				crun.hitVelSetZ()
+				crun.vel[2] = crun.ghv.zvel
 			}
 		case hitVelSet_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
@@ -8827,18 +8828,18 @@ const (
 
 func (sc attackDist) Run(c *Char, _ []int32) bool {
 	crun := c
-	var lclscround float32 = 1.0
+	var redirscale float32 = 1.0
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case attackDist_value:
-			crun.attackDist[0] = exp[0].evalF(c) * lclscround
+			crun.attackDist[0] = exp[0].evalF(c) * redirscale
 			if len(exp) > 1 {
-				crun.attackDist[1] = exp[1].evalF(c) * lclscround
+				crun.attackDist[1] = exp[1].evalF(c) * redirscale
 			}
 		case attackDist_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				lclscround = c.localscl / crun.localscl
+				redirscale = c.localscl / crun.localscl
 			} else {
 				return false
 			}
@@ -9281,7 +9282,7 @@ const (
 
 func (sc bindToParent) Run(c *Char, _ []int32) bool {
 	crun := c
-	var lclscround float32 = 1.0
+	var redirscale float32 = 1.0
 	p := crun.parent()
 	var x, y, z float32 = 0, 0, 0
 	var time int32 = 1
@@ -9296,17 +9297,17 @@ func (sc bindToParent) Run(c *Char, _ []int32) bool {
 				crun.bindFacing = 1
 			}
 		case bindToParent_pos:
-			x = exp[0].evalF(c) * lclscround
+			x = exp[0].evalF(c) * redirscale
 			if len(exp) > 1 {
-				y = exp[1].evalF(c) * lclscround
+				y = exp[1].evalF(c) * redirscale
 				if len(exp) > 2 {
-					z = exp[2].evalF(c) * lclscround
+					z = exp[2].evalF(c) * redirscale
 				}
 			}
 		case bindToParent_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				lclscround = c.localscl / crun.localscl
+				redirscale = c.localscl / crun.localscl
 				p = crun.parent()
 			} else {
 				return false
@@ -9329,7 +9330,7 @@ type bindToRoot bindToParent
 
 func (sc bindToRoot) Run(c *Char, _ []int32) bool {
 	crun := c
-	var lclscround float32 = 1.0
+	var redirscale float32 = 1.0
 	r := crun.root()
 	var x, y, z float32 = 0, 0, 0
 	var time int32 = 1
@@ -9344,17 +9345,17 @@ func (sc bindToRoot) Run(c *Char, _ []int32) bool {
 				crun.bindFacing = 1
 			}
 		case bindToParent_pos:
-			x = exp[0].evalF(c) * lclscround
+			x = exp[0].evalF(c) * redirscale
 			if len(exp) > 1 {
-				y = exp[1].evalF(c) * lclscround
+				y = exp[1].evalF(c) * redirscale
 				if len(exp) > 2 {
-					z = exp[2].evalF(c) * lclscround
+					z = exp[2].evalF(c) * redirscale
 				}
 			}
 		case bindToParent_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				lclscround = c.localscl / crun.localscl
+				redirscale = c.localscl / crun.localscl
 				r = crun.root()
 			} else {
 				return false
@@ -11377,18 +11378,18 @@ const (
 
 func (sc height) Run(c *Char, _ []int32) bool {
 	crun := c
-	var lclscround float32 = 1.0
+	var redirscale float32 = 1.0
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case height_value:
-			crun.setTHeight(exp[0].evalF(c) * lclscround)
+			crun.setTHeight(exp[0].evalF(c) * redirscale)
 			if len(exp) > 1 {
-				crun.setBHeight(exp[1].evalF(c) * lclscround)
+				crun.setBHeight(exp[1].evalF(c) * redirscale)
 			}
 		case height_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				lclscround = (320 / c.localcoord) / (320 / crun.localcoord)
+				redirscale = (320 / c.localcoord) / (320 / crun.localcoord)
 			} else {
 				return false
 			}
@@ -11528,7 +11529,7 @@ const (
 
 func (sc getHitVarSet) Run(c *Char, _ []int32) bool {
 	crun := c
-	var lclscround float32 = 1.0
+	var redirscale float32 = 1.0
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case getHitVarSet_airtype:
@@ -11550,7 +11551,7 @@ func (sc getHitVarSet) Run(c *Char, _ []int32) bool {
 		case getHitVarSet_fall_damage:
 			crun.ghv.fall.damage = exp[0].evalI(c)
 		case getHitVarSet_fall_envshake_ampl:
-			crun.ghv.fall.envshake_ampl = int32(exp[0].evalF(c) * lclscround)
+			crun.ghv.fall.envshake_ampl = int32(exp[0].evalF(c) * redirscale)
 		case getHitVarSet_fall_envshake_freq:
 			crun.ghv.fall.envshake_freq = exp[0].evalF(c)
 		case getHitVarSet_fall_envshake_mul:
@@ -11566,11 +11567,11 @@ func (sc getHitVarSet) Run(c *Char, _ []int32) bool {
 		case getHitVarSet_fall_recovertime:
 			crun.ghv.fall.recovertime = exp[0].evalI(c)
 		case getHitVarSet_fall_xvel:
-			crun.ghv.fall.xvelocity = exp[0].evalF(c) * lclscround
+			crun.ghv.fall.xvelocity = exp[0].evalF(c) * redirscale
 		case getHitVarSet_fall_yvel:
-			crun.ghv.fall.yvelocity = exp[0].evalF(c) * lclscround
+			crun.ghv.fall.yvelocity = exp[0].evalF(c) * redirscale
 		case getHitVarSet_fall_zvel:
-			crun.ghv.fall.zvelocity = exp[0].evalF(c) * lclscround
+			crun.ghv.fall.zvelocity = exp[0].evalF(c) * redirscale
 		case getHitVarSet_fallcount:
 			crun.ghv.fallcount = exp[0].evalI(c)
 		case getHitVarSet_groundtype:
@@ -11588,21 +11589,21 @@ func (sc getHitVarSet) Run(c *Char, _ []int32) bool {
 		case getHitVarSet_slidetime:
 			crun.ghv.slidetime = exp[0].evalI(c)
 		case getHitVarSet_xvel:
-			crun.ghv.xvel = exp[0].evalF(c) * crun.facing * lclscround
+			crun.ghv.xvel = exp[0].evalF(c) * crun.facing * redirscale
 		case getHitVarSet_yvel:
-			crun.ghv.yvel = exp[0].evalF(c) * lclscround
+			crun.ghv.yvel = exp[0].evalF(c) * redirscale
 		case getHitVarSet_zvel:
-			crun.ghv.zvel = exp[0].evalF(c) * lclscround
+			crun.ghv.zvel = exp[0].evalF(c) * redirscale
 		case getHitVarSet_xaccel:
-			crun.ghv.xaccel = exp[0].evalF(c) * lclscround
+			crun.ghv.xaccel = exp[0].evalF(c) * redirscale
 		case getHitVarSet_yaccel:
-			crun.ghv.yaccel = exp[0].evalF(c) * lclscround
+			crun.ghv.yaccel = exp[0].evalF(c) * redirscale
 		case getHitVarSet_zaccel:
-			crun.ghv.zaccel = exp[0].evalF(c) * lclscround
+			crun.ghv.zaccel = exp[0].evalF(c) * redirscale
 		case getHitVarSet_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				lclscround = c.localscl / crun.localscl
+				redirscale = c.localscl / crun.localscl
 			} else {
 				return false
 			}
@@ -11621,15 +11622,15 @@ const (
 
 func (sc groundLevelOffset) Run(c *Char, _ []int32) bool {
 	crun := c
-	var lclscround float32 = 1.0
+	var redirscale float32 = 1.0
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case groundLevelOffset_value:
-			crun.groundLevel = exp[0].evalF(c) * lclscround
+			crun.groundLevel = exp[0].evalF(c) * redirscale
 		case groundLevelOffset_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				lclscround = c.localscl / crun.localscl
+				redirscale = c.localscl / crun.localscl
 			} else {
 				return false
 			}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -2293,11 +2293,11 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_gethitvar_zvel:
 		sys.bcStack.PushF(c.ghv.zvel * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_xaccel:
-		sys.bcStack.PushF(c.ghv.getXaccel(oc) * (c.localscl / oc.localscl))
+		sys.bcStack.PushF(c.ghv.xaccel * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_yaccel:
-		sys.bcStack.PushF(c.ghv.getYaccel(oc) * (c.localscl / oc.localscl))
+		sys.bcStack.PushF(c.ghv.yaccel * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_zaccel:
-		sys.bcStack.PushF(c.ghv.getZaccel(oc) * (c.localscl / oc.localscl))
+		sys.bcStack.PushF(c.ghv.zaccel * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_chainid:
 		sys.bcStack.PushI(c.ghv.chainId())
 	case OC_ex_gethitvar_guarded:
@@ -2309,11 +2309,19 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_gethitvar_fall_damage:
 		sys.bcStack.PushI(c.ghv.fall.damage)
 	case OC_ex_gethitvar_fall_xvel:
-		sys.bcStack.PushF(c.ghv.fall.xvel() * (c.localscl / oc.localscl))
+		if math.IsNaN(float64(c.ghv.fall.xvelocity)) {
+			sys.bcStack.PushF(-32760) // Winmugen behavior
+		} else {
+			sys.bcStack.PushF(c.ghv.fall.xvelocity * (c.localscl / oc.localscl))
+		}
 	case OC_ex_gethitvar_fall_yvel:
 		sys.bcStack.PushF(c.ghv.fall.yvelocity * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_fall_zvel:
-		sys.bcStack.PushF(c.ghv.fall.zvelocity * (c.localscl / oc.localscl))
+		if math.IsNaN(float64(c.ghv.fall.zvelocity)) {
+			sys.bcStack.PushF(-32760) // Winmugen behavior
+		} else {
+			sys.bcStack.PushF(c.ghv.fall.zvelocity * (c.localscl / oc.localscl))
+		}
 	case OC_ex_gethitvar_fall_recover:
 		sys.bcStack.PushB(c.ghv.fall.recover)
 	case OC_ex_gethitvar_fall_time:
@@ -6339,7 +6347,7 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 }
 func (sc hitDef) Run(c *Char, _ []int32) bool {
 	crun := c
-	crun.hitdef.clear()
+	crun.hitdef.clear(crun.localscl)
 	crun.hitdef.playerNo = sys.workingState.playerNo
 	crun.hitdef.sparkno = c.gi().data.sparkno
 	crun.hitdef.guard_sparkno = c.gi().data.guard.sparkno
@@ -6349,7 +6357,7 @@ func (sc hitDef) Run(c *Char, _ []int32) bool {
 		if id == hitDef_redirectid {
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				crun.hitdef.clear()
+				crun.hitdef.clear(crun.localscl)
 				crun.hitdef.playerNo = sys.workingState.playerNo
 				crun.hitdef.sparkno = c.gi().data.sparkno
 				crun.hitdef.guard_sparkno = c.gi().data.guard.sparkno
@@ -6384,7 +6392,7 @@ const (
 
 func (sc reversalDef) Run(c *Char, _ []int32) bool {
 	crun := c
-	crun.hitdef.clear()
+	crun.hitdef.clear(crun.localscl)
 	crun.hitdef.playerNo = sys.workingState.playerNo
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
@@ -6393,7 +6401,7 @@ func (sc reversalDef) Run(c *Char, _ []int32) bool {
 		case reversalDef_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				crun.hitdef.clear()
+				crun.hitdef.clear(crun.localscl)
 				crun.hitdef.playerNo = sys.workingState.playerNo
 			} else {
 				return false

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -2287,7 +2287,7 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_gethitvar_zoff:
 		sys.bcStack.PushF(c.ghv.zoff * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_xvel:
-		sys.bcStack.PushF(c.ghv.xvel * c.facing * (c.localscl / oc.localscl))
+		sys.bcStack.PushF(c.ghv.xvel * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_yvel:
 		sys.bcStack.PushF(c.ghv.yvel * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_zvel:
@@ -2371,31 +2371,31 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_gethitvar_facing:
 		sys.bcStack.PushI(c.ghv.facing)
 	case OC_ex_gethitvar_ground_velocity_x:
-		sys.bcStack.PushF(c.ghv.ground_velocity[0] * c.facing * (c.localscl / oc.localscl))
+		sys.bcStack.PushF(c.ghv.ground_velocity[0] * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_ground_velocity_y:
 		sys.bcStack.PushF(c.ghv.ground_velocity[1] * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_ground_velocity_z:
 		sys.bcStack.PushF(c.ghv.ground_velocity[2] * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_air_velocity_x:
-		sys.bcStack.PushF(c.ghv.air_velocity[0] * c.facing * (c.localscl / oc.localscl))
+		sys.bcStack.PushF(c.ghv.air_velocity[0] * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_air_velocity_y:
 		sys.bcStack.PushF(c.ghv.air_velocity[1] * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_air_velocity_z:
 		sys.bcStack.PushF(c.ghv.air_velocity[2] * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_down_velocity_x:
-		sys.bcStack.PushF(c.ghv.down_velocity[0] * c.facing * (c.localscl / oc.localscl))
+		sys.bcStack.PushF(c.ghv.down_velocity[0] * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_down_velocity_y:
 		sys.bcStack.PushF(c.ghv.down_velocity[1] * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_down_velocity_z:
 		sys.bcStack.PushF(c.ghv.down_velocity[2] * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_guard_velocity_x:
-		sys.bcStack.PushF(c.ghv.guard_velocity[0] * c.facing * (c.localscl / oc.localscl))
+		sys.bcStack.PushF(c.ghv.guard_velocity[0] * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_guard_velocity_y:
-		sys.bcStack.PushF(c.ghv.guard_velocity[1] * c.facing * (c.localscl / oc.localscl))
+		sys.bcStack.PushF(c.ghv.guard_velocity[1] * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_guard_velocity_z:
-		sys.bcStack.PushF(c.ghv.guard_velocity[2] * c.facing * (c.localscl / oc.localscl))
+		sys.bcStack.PushF(c.ghv.guard_velocity[2] * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_airguard_velocity_x:
-		sys.bcStack.PushF(c.ghv.airguard_velocity[0] * c.facing * (c.localscl / oc.localscl))
+		sys.bcStack.PushF(c.ghv.airguard_velocity[0] * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_airguard_velocity_y:
 		sys.bcStack.PushF(c.ghv.airguard_velocity[1] * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_airguard_velocity_z:
@@ -8122,7 +8122,7 @@ func (sc hitVelSet) Run(c *Char, _ []int32) bool {
 		switch id {
 		case hitVelSet_x:
 			if exp[0].evalB(c) {
-				crun.vel[0] = crun.ghv.xvel
+				crun.vel[0] = crun.ghv.xvel * crun.facing
 			}
 		case hitVelSet_y:
 			if exp[0].evalB(c) {
@@ -11597,7 +11597,7 @@ func (sc getHitVarSet) Run(c *Char, _ []int32) bool {
 		case getHitVarSet_slidetime:
 			crun.ghv.slidetime = exp[0].evalI(c)
 		case getHitVarSet_xvel:
-			crun.ghv.xvel = exp[0].evalF(c) * crun.facing * redirscale
+			crun.ghv.xvel = exp[0].evalF(c) * redirscale
 		case getHitVarSet_yvel:
 			crun.ghv.yvel = exp[0].evalF(c) * redirscale
 		case getHitVarSet_zvel:

--- a/src/char.go
+++ b/src/char.go
@@ -1438,7 +1438,7 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 	drawscale := [2]float32{facing * scale[0] * e.localscl, e.vfacing * scale[1] * e.localscl}
 
 	// Apply Z axis perspective
-	if e.space == Space_stage && sys.stage.topbound != sys.stage.botbound {
+	if e.space == Space_stage && sys.zmin != sys.zmax {
 		zscale := sys.updateZScale(e.pos[2], e.localscl)
 		drawpos[0] *= zscale
 		drawpos[1] *= zscale
@@ -1755,8 +1755,8 @@ func (p *Projectile) update(playerNo int) {
 					p.velocity[0]*p.facing > 0 && p.pos[0] > sys.cam.XMax/p.localscl+float32(p.stagebound) ||
 					p.velocity[1] > 0 && p.pos[1] > float32(p.heightbound[1]) ||
 					p.velocity[1] < 0 && p.pos[1] < float32(p.heightbound[0]) ||
-					p.pos[2] < (sys.stage.topbound/p.localscl-float32(p.depthbound)) ||
-					p.pos[2] > (sys.stage.botbound/p.localscl+float32(p.depthbound)) {
+					p.pos[2] < (sys.zmin/p.localscl-float32(p.depthbound)) ||
+					p.pos[2] > (sys.zmax/p.localscl+float32(p.depthbound)) {
 					if p.remanim != p.anim || p.remanim_ffx != p.anim_ffx {
 						p.ani = sys.chars[playerNo][0].getAnim(p.remanim, p.remanim_ffx, true)
 					}
@@ -1995,7 +1995,7 @@ func (p *Projectile) cueDraw(oldVer bool, playerNo int) {
 		p.scale[1] * p.localscl * p.zScale}
 
 	// Apply Z axis perspective
-	if sys.stage.topbound != sys.stage.botbound {
+	if sys.zmin != sys.zmax {
 		pos[0] *= p.zScale
 		pos[1] *= p.zScale
 		pos[1] += p.interPos[2] * p.localscl
@@ -3528,7 +3528,7 @@ func (c *Char) bottomEdge() float32 {
 	return sys.cam.ScreenPos[1]/c.localscl + c.gameHeight()
 }
 func (c *Char) bottomEdgeDist() float32 {
-	return sys.stage.botbound/c.localscl - c.pos[2]
+	return sys.zmax/c.localscl - c.pos[2]
 }
 func (c *Char) canRecover() bool {
 	return c.ghv.fall.recover && c.fallTime >= c.ghv.fall.recovertime
@@ -4211,7 +4211,7 @@ func (c *Char) topEdge() float32 {
 	return sys.cam.ScreenPos[1] / c.localscl
 }
 func (c *Char) topEdgeDist() float32 {
-	return sys.stage.topbound/c.localscl - c.pos[2]
+	return sys.zmin/c.localscl - c.pos[2]
 }
 func (c *Char) win() bool {
 	if c.teamside == -1 {
@@ -6596,7 +6596,7 @@ func (c *Char) xScreenBound() {
 func (c *Char) zWidthBound() {
 	posz := c.pos[2]
 	if c.csf(CSF_stagebound) {
-		posz = ClampF(posz, sys.stage.topbound/c.localscl, sys.stage.botbound/c.localscl)
+		posz = ClampF(posz, sys.zmin/c.localscl, sys.zmax/c.localscl)
 	}
 	c.setPosZ(posz)
 }
@@ -7958,12 +7958,12 @@ func (c *Char) cueDraw() {
 			c.size.yscale * c.zScale * (320 / c.localcoord)}
 
 		// Apply Z axis perspective
-		if sys.stage.topbound != sys.stage.botbound {
+		if sys.zmin != sys.zmax {
 			pos[0] *= c.zScale
 			pos[1] *= c.zScale
 			pos[1] += c.interPos[2] * c.localscl
 		}
-		//if sys.stage.topbound != sys.stage.botbound {
+		//if sys.zmin != sys.zmax {
 		//	ratio := float32(1.618) // Possible stage parameter?
 		//	pos[0] *= 1 + (ratio-1)*(c.zScale-1)
 		//	pos[1] *= 1 + (ratio-1)*(c.zScale-1)
@@ -9414,9 +9414,9 @@ func (cl *CharList) pushDetection(getter *Char) {
 
 				// Determine in which axes to push the players
 				// This needs to check both if the players have velocity or if their positions changed
-				pushx := sys.stage.topbound == sys.stage.botbound ||
+				pushx := sys.zmin == sys.zmax ||
 					getter.vel[0] != 0 || c.vel[0] != 0 || getter.pos[0] != getter.oldPos[0] || c.pos[0] != c.oldPos[0]
-				pushz := sys.stage.topbound != sys.stage.botbound &&
+				pushz := sys.zmin != sys.zmax &&
 					(getter.vel[2] != 0 || c.vel[2] != 0 || getter.pos[2] != getter.oldPos[2] || c.pos[2] != c.oldPos[2])
 
 				if pushx {

--- a/src/char.go
+++ b/src/char.go
@@ -2658,7 +2658,9 @@ func (c *Char) load(def string) error {
 
 	gi.constants = make(map[string]float32)
 	gi.constants["default.attack.lifetopowermul"] = 0.7
+	gi.constants["super.attack.lifetopowermul"] = 0
 	gi.constants["default.gethit.lifetopowermul"] = 0.6
+	gi.constants["super.gethit.lifetopowermul"] = 0.6
 	gi.constants["super.targetdefencemul"] = 1.5
 	gi.constants["default.lifetoguardpointsmul"] = 1.5
 	gi.constants["super.lifetoguardpointsmul"] = -0.33
@@ -5071,13 +5073,14 @@ func (c *Char) setHitdefDefault(hd *HitDef) {
 	ifnanset(&hd.down_cornerpush_veloff, hd.ground_cornerpush_veloff)
 	ifnanset(&hd.guard_cornerpush_veloff, hd.ground_cornerpush_veloff)
 	ifnanset(&hd.airguard_cornerpush_veloff, hd.ground_cornerpush_veloff)
-	ifierrset(&hd.hitgetpower,
-		int32(c.gi().constants["default.attack.lifetopowermul"]*float32(hd.hitdamage)))
 	ifierrset(&hd.guardgetpower, int32(float32(hd.hitgetpower)*0.5))
-	ifierrset(&hd.hitgivepower,
-		int32(c.gi().constants["default.gethit.lifetopowermul"]*float32(hd.hitdamage)))
 	ifierrset(&hd.guardgivepower, int32(float32(hd.hitgivepower)*0.5))
+	// Super attack behaviour
 	if hd.attr&int32(AT_AH) != 0 {
+		ifierrset(&hd.hitgetpower,
+			int32(c.gi().constants["super.attack.lifetopowermul"]*float32(hd.hitdamage)))
+		ifierrset(&hd.hitgivepower,
+			int32(c.gi().constants["super.gethit.lifetopowermul"]*float32(hd.hitdamage)))
 		ifierrset(&hd.dizzypoints,
 			int32(c.gi().constants["super.lifetodizzypointsmul"]*float32(hd.hitdamage)))
 		ifierrset(&hd.guardpoints,
@@ -5087,6 +5090,10 @@ func (c *Char) setHitdefDefault(hd *HitDef) {
 		ifierrset(&hd.guardredlife,
 			int32(c.gi().constants["super.lifetoredlifemul"]*float32(hd.guarddamage)))
 	} else {
+		ifierrset(&hd.hitgetpower,
+			int32(c.gi().constants["default.attack.lifetopowermul"]*float32(hd.hitdamage)))
+		ifierrset(&hd.hitgivepower,
+			int32(c.gi().constants["default.gethit.lifetopowermul"]*float32(hd.hitdamage)))
 		ifierrset(&hd.dizzypoints,
 			int32(c.gi().constants["default.lifetodizzypointsmul"]*float32(hd.hitdamage)))
 		ifierrset(&hd.guardpoints,

--- a/src/char.go
+++ b/src/char.go
@@ -5382,14 +5382,6 @@ func (c *Char) setFacing(f float32) {
 		if (c.facing < 0) != (f < 0) {
 			c.facing *= -1
 			c.vel[0] *= -1
-			// Flip gethitvars on x axis
-			c.ghv.xvel *= -1
-			c.ghv.xaccel *= -1
-			c.ghv.ground_velocity[0] *= -1
-			c.ghv.air_velocity[0] *= -1
-			c.ghv.down_velocity[0] *= -1
-			c.ghv.guard_velocity[0] *= -1
-			c.ghv.airguard_velocity[0] *= -1
 		}
 	}
 }
@@ -8401,7 +8393,7 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 				ghv.hitid = hd.id
 				ghv.playerNo = hd.playerNo
 				ghv.id = hd.attackerID
-				ghv.xaccel = hd.xaccel * (c.localscl / getter.localscl)
+				ghv.xaccel = hd.xaccel * (c.localscl / getter.localscl) * -byf
 				ghv.yaccel = hd.yaccel * (c.localscl / getter.localscl)
 				ghv.zaccel = hd.zaccel * (c.localscl / getter.localscl)
 				ghv.groundtype = hd.ground_type
@@ -8426,12 +8418,12 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 					ghv.slidetime = hd.guard_slidetime
 					if getter.ss.stateType == ST_A {
 						ghv.ctrltime = hd.airguard_ctrltime
-						ghv.xvel = hd.airguard_velocity[0] * (c.localscl / getter.localscl)
+						ghv.xvel = hd.airguard_velocity[0] * (c.localscl / getter.localscl) * -byf
 						ghv.yvel = hd.airguard_velocity[1] * (c.localscl / getter.localscl)
 						ghv.zvel = hd.airguard_velocity[2] * (c.localscl / getter.localscl)
 					} else {
 						ghv.ctrltime = hd.guard_ctrltime
-						ghv.xvel = hd.guard_velocity[0] * (c.localscl / getter.localscl)
+						ghv.xvel = hd.guard_velocity[0] * (c.localscl / getter.localscl) * -byf
 						// Mugen does not accept a Y component for ground guard velocity
 						// But since we're adding Z to the other parameters, let's add Y here as well to keep things consistent
 						ghv.yvel = hd.guard_velocity[1] * (c.localscl / getter.localscl)
@@ -8458,7 +8450,7 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 						// Note: ctrl time is not affected on hit in Mugen
 						// This is further proof that gethitvars don't need to be reset above
 						ghv.ctrltime = hd.air_hittime
-						ghv.xvel = hd.air_velocity[0] * (c.localscl / getter.localscl)
+						ghv.xvel = hd.air_velocity[0] * (c.localscl / getter.localscl) * -byf
 						ghv.yvel = hd.air_velocity[1] * (c.localscl / getter.localscl)
 						ghv.zvel = hd.air_velocity[2] * (c.localscl / getter.localscl)
 						ghv.fallflag = hd.air_fall
@@ -8467,7 +8459,7 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 						ghv.ctrltime = hd.down_hittime
 						ghv.fallflag = hd.ground_fall
 						if getter.pos[1] == 0 {
-							ghv.xvel = hd.down_velocity[0] * (c.localscl / getter.localscl)
+							ghv.xvel = hd.down_velocity[0] * (c.localscl / getter.localscl) * -byf
 							ghv.yvel = hd.down_velocity[1] * (c.localscl / getter.localscl)
 							ghv.zvel = hd.down_velocity[2] * (c.localscl / getter.localscl)
 							if !hd.down_bounce && ghv.yvel != 0 {
@@ -8476,13 +8468,13 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 								ghv.fall.zvelocity = float32(math.NaN())
 							}
 						} else {
-							ghv.xvel = hd.air_velocity[0] * (c.localscl / getter.localscl)
+							ghv.xvel = hd.air_velocity[0] * (c.localscl / getter.localscl) * -byf
 							ghv.yvel = hd.air_velocity[1] * (c.localscl / getter.localscl)
 							ghv.zvel = hd.air_velocity[1] * (c.localscl / getter.localscl)
 						}
 					} else {
 						ghv.ctrltime = hd.ground_hittime
-						ghv.xvel = hd.ground_velocity[0] * (c.localscl / getter.localscl)
+						ghv.xvel = hd.ground_velocity[0] * (c.localscl / getter.localscl) * -byf
 						ghv.yvel = hd.ground_velocity[1] * (c.localscl / getter.localscl)
 						ghv.zvel = hd.ground_velocity[2] * (c.localscl / getter.localscl)
 						ghv.fallflag = hd.ground_fall
@@ -8526,19 +8518,19 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 					}
 				}
 				// Save velocities regardless of statetype
-				ghv.ground_velocity[0] = hd.ground_velocity[0] * (c.localscl / getter.localscl)
+				ghv.ground_velocity[0] = hd.ground_velocity[0] * (c.localscl / getter.localscl) * -byf
 				ghv.ground_velocity[1] = hd.ground_velocity[1] * (c.localscl / getter.localscl)
 				ghv.ground_velocity[2] = hd.ground_velocity[2] * (c.localscl / getter.localscl)
-				ghv.air_velocity[0] = hd.air_velocity[0] * (c.localscl / getter.localscl)
+				ghv.air_velocity[0] = hd.air_velocity[0] * (c.localscl / getter.localscl) * -byf
 				ghv.air_velocity[1] = hd.air_velocity[1] * (c.localscl / getter.localscl)
 				ghv.air_velocity[2] = hd.air_velocity[2] * (c.localscl / getter.localscl)
-				ghv.down_velocity[0] = hd.down_velocity[0] * (c.localscl / getter.localscl)
+				ghv.down_velocity[0] = hd.down_velocity[0] * (c.localscl / getter.localscl) * -byf
 				ghv.down_velocity[1] = hd.down_velocity[1] * (c.localscl / getter.localscl)
 				ghv.down_velocity[2] = hd.down_velocity[2] * (c.localscl / getter.localscl)
-				ghv.guard_velocity[0] = hd.guard_velocity[0] * (c.localscl / getter.localscl)
+				ghv.guard_velocity[0] = hd.guard_velocity[0] * (c.localscl / getter.localscl) * -byf
 				ghv.guard_velocity[1] = hd.guard_velocity[1] * (c.localscl / getter.localscl)
 				ghv.guard_velocity[2] = hd.guard_velocity[2] * (c.localscl / getter.localscl)
-				ghv.airguard_velocity[0] = hd.airguard_velocity[0] * (c.localscl / getter.localscl)
+				ghv.airguard_velocity[0] = hd.airguard_velocity[0] * (c.localscl / getter.localscl) * -byf
 				ghv.airguard_velocity[1] = hd.airguard_velocity[1] * (c.localscl / getter.localscl)
 				ghv.airguard_velocity[2] = hd.airguard_velocity[2] * (c.localscl / getter.localscl)
 				ghv.airanimtype = hd.air_animtype
@@ -8859,15 +8851,8 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 					byf = c.facing
 				}
 			}
+			// Flip low and high hit animations when hitting enemy from behind
 			if (getter.facing < 0) == (byf < 0) {
-				// Flip X Gethitvars
-				getter.ghv.xvel *= -1
-				getter.ghv.xaccel *= -1
-				getter.ghv.ground_velocity[0] *= -1
-				getter.ghv.air_velocity[0] *= -1
-				getter.ghv.down_velocity[0] *= -1
-				getter.ghv.guard_velocity[0] *= -1
-				getter.ghv.airguard_velocity[0] *= -1
 				if getter.ghv.groundtype == 1 || getter.ghv.groundtype == 2 {
 					getter.ghv.groundtype += 3 - getter.ghv.groundtype*2
 				}

--- a/src/script.go
+++ b/src/script.go
@@ -3672,11 +3672,11 @@ func triggerFunctions(l *lua.LState) {
 		case "zvel":
 			ln = lua.LNumber(c.ghv.zvel)
 		case "xaccel":
-			ln = lua.LNumber(c.ghv.getXaccel(c))
+			ln = lua.LNumber(c.ghv.xaccel)
 		case "yaccel":
-			ln = lua.LNumber(c.ghv.getYaccel(c))
+			ln = lua.LNumber(c.ghv.yaccel)
 		case "zaccel":
-			ln = lua.LNumber(c.ghv.getZaccel(c))
+			ln = lua.LNumber(c.ghv.zaccel)
 		case "hitid", "chainid":
 			ln = lua.LNumber(c.ghv.chainId())
 		case "guarded":
@@ -3688,11 +3688,19 @@ func triggerFunctions(l *lua.LState) {
 		case "fall.damage":
 			ln = lua.LNumber(c.ghv.fall.damage)
 		case "fall.xvel":
-			ln = lua.LNumber(c.ghv.fall.xvel())
+			if math.IsNaN(float64(c.ghv.fall.xvelocity)) {
+				ln = lua.LNumber(-32760) // Winmugen behavior
+			} else {
+				ln = lua.LNumber(c.ghv.fall.xvelocity)
+			}
 		case "fall.yvel":
 			ln = lua.LNumber(c.ghv.fall.yvelocity)
 		case "fall.zvel":
-			ln = lua.LNumber(c.ghv.fall.zvelocity)
+			if math.IsNaN(float64(c.ghv.fall.zvelocity)) {
+				ln = lua.LNumber(-32760) // Winmugen behavior
+			} else {
+				ln = lua.LNumber(c.ghv.fall.zvelocity)
+			}
 		case "fall.recover":
 			ln = lua.LNumber(Btoi(c.ghv.fall.recover))
 		case "fall.time":

--- a/src/system.go
+++ b/src/system.go
@@ -977,15 +977,15 @@ func (s *System) clsnOverlap(clsn1 []float32, scl1, pos1 [2]float32, facing1 flo
 }
 
 func (s *System) newCharId() int32 {
-	// Check if next ID is already being used
-	// This is needed because helpers may be preserved between rounds
+	// Check if the next ID is already being used by a helper with "preserve"
+	// We specifically check for preserved helpers because otherwise this also detects the players from the previous match that are being replaced
 	newid := s.nextCharId
 	taken := true
 	for taken {
 		taken = false
 		for _, p := range s.chars {
 			for _, c := range p {
-				if c.id == newid && !c.csf(CSF_destroy) {
+				if c.id == newid && c.preserve != 0 && !c.csf(CSF_destroy) {
 					taken = true
 					newid++
 					break

--- a/src/system.go
+++ b/src/system.go
@@ -209,6 +209,7 @@ type System struct {
 	screenleft              float32
 	screenright             float32
 	xmin, xmax              float32
+	zmin, zmax              float32
 	winskipped              bool
 	paused, step            bool
 	roundResetFlg           bool
@@ -1661,6 +1662,8 @@ func (s *System) action() {
 		if AbsF(s.cam.minLeft-s.xmin) < 0.0001 {
 			s.xmin = s.cam.minLeft
 		}
+		s.zmin = s.stage.topbound * s.stage.localscl
+		s.zmax = s.stage.botbound * s.stage.localscl
 		s.allPalFX.step()
 		//s.bgPalFX.step()
 		s.envShake.next()


### PR DESCRIPTION
Feat:
- New common constants Super.Attack.LifeToPowerMul and Super.GetHit.LifeToPowerMul to control default power gain during super attacks
- Implements #2068 

Refactor:
- Removed several velocity functions that only did one simple operation
- Renamed bytecode's "lclscround" temp vars to what they actually do
- Adjusted some Hitdef and GetHitVar defaults to be a bit less complicated. Mostly we don't need to set things to NaN when they have specific default values
- Considerably simplified GetHitVar X velocities sign flipping

Fix:
- Fixed regression in some explods caused by an oversight in previous commit
- Fixed Z boundaries not being affected by the stage's localcoord
- Fixed player ID's sometimes not starting at the proper index