### PR TITLE
fix: renamed topEdgeDist/bottomEdgeDist triggers for clarity

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -179,9 +179,9 @@ const (
 	OC_leftedge
 	OC_rightedge
 	OC_topedge
-	OC_topedgedist
+	OC_topbounddist
 	OC_bottomedge
-	OC_bottomedgedist
+	OC_botbounddist
 	OC_camerapos_x
 	OC_camerapos_y
 	OC_camerazoom
@@ -1510,8 +1510,8 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushI(int32(c.backEdgeDist() * (c.localscl / oc.localscl)))
 		case OC_bottomedge:
 			sys.bcStack.PushF(c.bottomEdge() * (c.localscl / oc.localscl))
-		case OC_bottomedgedist:
-			sys.bcStack.PushF(c.bottomEdgeDist() * (c.localscl / oc.localscl))
+		case OC_botbounddist:
+			sys.bcStack.PushF(c.botBoundDist() * (c.localscl / oc.localscl))
 		case OC_camerapos_x:
 			sys.bcStack.PushF(sys.cam.Pos[0] / oc.localscl)
 		case OC_camerapos_y:
@@ -1700,8 +1700,8 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushI(c.time())
 		case OC_topedge:
 			sys.bcStack.PushF(c.topEdge() * (c.localscl / oc.localscl))
-		case OC_topedgedist:
-			sys.bcStack.PushF(c.topEdgeDist() * (c.localscl / oc.localscl))
+		case OC_topbounddist:
+			sys.bcStack.PushF(c.topBoundDist() * (c.localscl / oc.localscl))
 		case OC_uniqhitcount:
 			sys.bcStack.PushI(c.uniqHitCount)
 		case OC_vel_x:

--- a/src/char.go
+++ b/src/char.go
@@ -3521,7 +3521,7 @@ func (c *Char) backEdgeDist() float32 {
 func (c *Char) bottomEdge() float32 {
 	return sys.cam.ScreenPos[1]/c.localscl + c.gameHeight()
 }
-func (c *Char) bottomEdgeDist() float32 {
+func (c *Char) botBoundDist() float32 {
 	return sys.zmax/c.localscl - c.pos[2]
 }
 func (c *Char) canRecover() bool {
@@ -4204,7 +4204,7 @@ func (c *Char) time() int32 {
 func (c *Char) topEdge() float32 {
 	return sys.cam.ScreenPos[1] / c.localscl
 }
-func (c *Char) topEdgeDist() float32 {
+func (c *Char) topBoundDist() float32 {
 	return sys.zmin/c.localscl - c.pos[2]
 }
 func (c *Char) win() bool {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -217,7 +217,7 @@ var triggerMap = map[string]int{
 	"backedgebodydist":  1,
 	"backedgedist":      1,
 	"bottomedge":        1,
-	"bottomedgedist":    1,
+	"botbounddist":      1,
 	"camerapos":         1,
 	"camerazoom":        1,
 	"canrecover":        1,
@@ -326,7 +326,7 @@ var triggerMap = map[string]int{
 	"time":              1,
 	"timemod":           1,
 	"topedge":           1,
-	"topedgedist":       1,
+	"topbounddist":      1,
 	"uniqhitcount":      1,
 	"var":               1,
 	"vel":               1,
@@ -1543,8 +1543,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		}
 	case "bottomedge":
 		out.append(OC_bottomedge)
-	case "bottomedgedist":
-		out.append(OC_bottomedgedist)
+	case "botbounddist":
+		out.append(OC_botbounddist)
 	case "camerapos":
 		c.token = c.tokenizer(in)
 		switch c.token {
@@ -3072,8 +3072,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_time)
 	case "topedge":
 		out.append(OC_topedge)
-	case "topedgedist":
-		out.append(OC_topedgedist)
+	case "topbounddist":
+		out.append(OC_topbounddist)
 	case "uniqhitcount":
 		out.append(OC_uniqhitcount)
 	case "vel":

--- a/src/script.go
+++ b/src/script.go
@@ -3128,8 +3128,8 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.debugWC.bottomEdge()))
 		return 1
 	})
-	luaRegister(l, "bottomedgedist", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.bottomEdgeDist()))
+	luaRegister(l, "botboundDist", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.botBoundDist()))
 		return 1
 	})
 	luaRegister(l, "cameraposX", func(*lua.LState) int {
@@ -4668,8 +4668,8 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.debugWC.topEdge()))
 		return 1
 	})
-	luaRegister(l, "topedgedist", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.topEdgeDist()))
+	luaRegister(l, "topBounddist", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.topBoundDist()))
 		return 1
 	})
 	luaRegister(l, "uniqhitcount", func(*lua.LState) int {


### PR DESCRIPTION
Fix:
- Renamed topEdgeDist and bottomEdgeDist triggers to topBoundDist and botBoundDist to maintain clarity and consistency with stage terms.