### PR TITLE
fix: HitVel X trigger, Hitdef power; refactor: ClsnOverlap

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1590,11 +1590,12 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 		case OC_hitshakeover:
 			sys.bcStack.PushB(c.hitShakeOver())
 		case OC_hitvel_x:
-			sys.bcStack.PushF(c.hitVelX() * (c.localscl / oc.localscl))
+			// This trigger is bugged in Mugen 1.1, with its output being affected by game resolution
+			sys.bcStack.PushF(c.ghv.xvel * c.facing * (c.localscl / oc.localscl))
 		case OC_hitvel_y:
-			sys.bcStack.PushF(c.hitVelY() * (c.localscl / oc.localscl))
+			sys.bcStack.PushF(c.ghv.yvel  * (c.localscl / oc.localscl))
 		case OC_hitvel_z:
-			sys.bcStack.PushF(c.hitVelZ() * (c.localscl / oc.localscl))
+			sys.bcStack.PushF(c.ghv.zvel  * (c.localscl / oc.localscl))
 		case OC_id:
 			sys.bcStack.PushI(c.id)
 		case OC_inguarddist:
@@ -11259,13 +11260,13 @@ func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 			s.stageCamera.yscrollspeed = exp[0].evalF(c)
 		// PlayerInfo group
 		case modifyStageVar_playerinfo_leftbound:
-			s.leftbound = exp[0].evalF(c) * sys.stage.localscl / c.localscl
+			s.leftbound = exp[0].evalF(c) * c.localscl / sys.stage.localscl
 		case modifyStageVar_playerinfo_rightbound:
-			s.rightbound = exp[0].evalF(c) * sys.stage.localscl / c.localscl
+			s.rightbound = exp[0].evalF(c) * c.localscl / sys.stage.localscl
 		case modifyStageVar_playerinfo_topbound:
-			s.topbound = exp[0].evalF(c) * sys.stage.localscl / c.localscl
+			s.topbound = exp[0].evalF(c) * c.localscl / sys.stage.localscl
 		case modifyStageVar_playerinfo_botbound:
-			s.botbound = exp[0].evalF(c) * sys.stage.localscl / c.localscl
+			s.botbound = exp[0].evalF(c) * c.localscl / sys.stage.localscl
 		// Scaling group
 		case modifyStageVar_scaling_topz:
 			if s.mugenver[0] != 1 { // mugen 1.0+ removed support for topz

--- a/src/char.go
+++ b/src/char.go
@@ -3637,15 +3637,6 @@ func (c *Char) hitOver() bool {
 func (c *Char) hitShakeOver() bool {
 	return c.ghv.hitshaketime <= 0
 }
-func (c *Char) hitVelX() float32 {
-	return c.ghv.xvel
-}
-func (c *Char) hitVelY() float32 {
-	return c.ghv.yvel
-}
-func (c *Char) hitVelZ() float32 {
-	return c.ghv.zvel
-}
 func (c *Char) isHelper(hid BytecodeValue) BytecodeValue {
 	if hid.IsSF() {
 		return BytecodeSF()
@@ -5073,8 +5064,6 @@ func (c *Char) setHitdefDefault(hd *HitDef) {
 	ifnanset(&hd.down_cornerpush_veloff, hd.ground_cornerpush_veloff)
 	ifnanset(&hd.guard_cornerpush_veloff, hd.ground_cornerpush_veloff)
 	ifnanset(&hd.airguard_cornerpush_veloff, hd.ground_cornerpush_veloff)
-	ifierrset(&hd.guardgetpower, int32(float32(hd.hitgetpower)*0.5))
-	ifierrset(&hd.guardgivepower, int32(float32(hd.hitgivepower)*0.5))
 	// Super attack behaviour
 	if hd.attr&int32(AT_AH) != 0 {
 		ifierrset(&hd.hitgetpower,
@@ -5103,6 +5092,8 @@ func (c *Char) setHitdefDefault(hd *HitDef) {
 		ifierrset(&hd.guardredlife,
 			int32(c.gi().constants["default.lifetoredlifemul"]*float32(hd.guarddamage)))
 	}
+	ifierrset(&hd.guardgetpower, int32(float32(hd.hitgetpower)*0.5))
+	ifierrset(&hd.guardgivepower, int32(float32(hd.hitgivepower)*0.5))
 	if !math.IsNaN(float64(hd.snap[0])) {
 		hd.maxdist[0], hd.mindist[0] = hd.snap[0], hd.snap[0]
 	}

--- a/src/script.go
+++ b/src/script.go
@@ -3865,15 +3865,15 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "hitvelX", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.hitVelX()))
+		l.Push(lua.LNumber(sys.debugWC.ghv.xvel * sys.debugWC.facing))
 		return 1
 	})
 	luaRegister(l, "hitvelY", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.hitVelY()))
+		l.Push(lua.LNumber(sys.debugWC.ghv.yvel))
 		return 1
 	})
 	luaRegister(l, "hitvelZ", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.hitVelZ()))
+		l.Push(lua.LNumber(sys.debugWC.ghv.zvel))
 		return 1
 	})
 	luaRegister(l, "id", func(*lua.LState) int {


### PR DESCRIPTION
Fix:
- Fixed a regression caused by this old trigger not being accounted for in the previous refactor. Simplified its implementation while at it
- Fixed Hitdef resetting power on hit regression
- Fixes #2074

Refactor:
- Adjusted ClsnOverlap to check the overlap with the Clsn boxes that are currently active in the char, as opposed to the ones that will be drawn at the end of the frame like normal