### PR TITLE
fix: Truncate RenderParams X/Y before rendering

### DIFF
--- a/src/render.go
+++ b/src/render.go
@@ -276,6 +276,10 @@ func rmInitSub(rp *RenderParams) {
 		rp.rot.angle *= -1
 		rp.rot.xangle *= -1
 	}
+
+	rp.x = float32(math.Trunc(float64(rp.x)))
+	rp.y = float32(math.Trunc(float64(rp.y)))
+
 	if rp.tile.x == 0 {
 		rp.tile.sx = 0
 	} else if rp.tile.sx > 0 {


### PR DESCRIPTION
This PR eliminates a rather minor but annoying blur that occurs when running Ikemen with MSAA enabled and using low-res characters, then proceeding to move around said characters.

![image](https://github.com/user-attachments/assets/87ff6f55-8b60-468b-aa50-a912a666adb1)


The reason this happens is due to Ikemen using floating-point coordinates for X, Y, width, and height when rendering most things to the screen. This won't really be an issue to most users, but for certain edge cases it can rear its ugly head, especially if a creator's intent is to have nice sharp pixels that rely on perfectly even coordinates.

HD screenpacks suffer from a related issue when attempting to use pixel-perfect assets at certain localcoord scales like 1280x720; this fix is part of my attempts to eventually rectify this per request of the author of one such screenpack.

The strange math here is simply because I didn't want to add an extra "math32" library just to truncate these 32-bit float values.