### PR TITLE
feat: projvar(guardflag)

### DIFF
--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -300,11 +300,11 @@ options.t_itemname = {
 	['language'] = function(t, item, cursorPosY, moveTxt)
 		if main.f_input(main.t_players, {'$F'}) then
 			changeLanguageSetting(0)
-			loadstring("LanguageName = " .. "motif.languages." .. config.Language)()
+			LanguageName = motif.languages[config.Language]
 			t.items[item].vardisplay = LanguageName or config.Language
 		elseif main.f_input(main.t_players, {'$B'}) then
 			changeLanguageSetting(-2)
-			loadstring("LanguageName = " .. "motif.languages." .. config.Language)()
+			LanguageName = motif.languages[config.Language]
 			t.items[item].vardisplay = LanguageName or config.Language
 		end
 		return true
@@ -1394,7 +1394,7 @@ options.t_vardisplay = {
 		return options.f_boolDisplay(config.KeepAspect, motif.option_info.menu_valuename_enabled, motif.option_info.menu_valuename_disabled)
 	end,
 	['language'] = function()
-		loadstring("sfs = " .. "motif.languages." .. config.Language)()
+		sfs = motif.languages[config.Language]
 		return sfs or config.Language
 	end,
 	['lifemul'] = function()

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -790,6 +790,8 @@ const (
 	OC_ex2_projvar_velmul_x
 	OC_ex2_projvar_velmul_y
 	OC_ex2_projvar_velmul_z
+	OC_ex2_projvar_guardflag
+	OC_ex2_projvar_hitflag
 	OC_ex2_hitdefvar_guardflag
 	OC_ex2_hitdefvar_hitflag
 	OC_ex2_hitdefvar_guarddamage
@@ -968,10 +970,14 @@ func (be *BytecodeExp) appendValue(bv BytecodeValue) (ok bool) {
 	}
 	return true
 }
+
+// Pushes an OpCode with an int32 operand to the top of the BytecodeExp.
 func (be *BytecodeExp) appendI32Op(op OpCode, addr int32) {
 	be.append(op)
 	be.append((*(*[4]OpCode)(unsafe.Pointer(&addr)))[:]...)
 }
+
+// Pushes an OpCode with an int64 operand to the top of the BytecodeExp.
 func (be *BytecodeExp) appendI64Op(op OpCode, addr int64) {
 	be.append(op)
 	be.append((*(*[8]OpCode)(unsafe.Pointer(&addr)))[:]...)
@@ -3252,10 +3258,16 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	case OC_ex2_projvar_pos_x:
 		fallthrough
 	case OC_ex2_projvar_pos_y:
+		fallthrough
+	case OC_ex2_projvar_guardflag:
+		fallthrough
+	case OC_ex2_projvar_hitflag:
+		flg := sys.bcStack.Pop()
 		idx := sys.bcStack.Pop()
 		id := sys.bcStack.Pop()
-		v := c.projVar(id, idx, opc, oc)
+		v := c.projVar(id, idx, flg, opc, oc)
 		sys.bcStack.Push(v)
+	// END FALLTHROUGH (projvar)
 	case OC_ex2_hitdefvar_guardflag:
 		attr := (*(*int32)(unsafe.Pointer(&be[*i])))
 		sys.bcStack.PushB(

--- a/src/char.go
+++ b/src/char.go
@@ -3826,7 +3826,11 @@ func (c *Char) projVar(pid BytecodeValue, idx BytecodeValue, flag BytecodeValue,
 	if pid.IsSF() {
 		return BytecodeSF()
 	}
+
+	// See compiler.go:ProjVar
 	var id int32 = pid.ToI()
+	if(id > 0){ id--; }
+
 	var i = idx.ToI()
 	var fl int32 = flag.ToI()
 	var v BytecodeValue

--- a/src/char.go
+++ b/src/char.go
@@ -3822,12 +3822,13 @@ func (c *Char) explodVar(eid BytecodeValue, idx BytecodeValue, vtype OpCode) Byt
 	}
 	return v
 }
-func (c *Char) projVar(pid BytecodeValue, idx BytecodeValue, vtype OpCode, oc *Char) BytecodeValue {
+func (c *Char) projVar(pid BytecodeValue, idx BytecodeValue, flag BytecodeValue, vtype OpCode, oc *Char) BytecodeValue {
 	if pid.IsSF() {
 		return BytecodeSF()
 	}
 	var id int32 = pid.ToI()
 	var i = idx.ToI()
+	var fl int32 = flag.ToI()
 	var v BytecodeValue
 	projs := c.getProjs(id)
 	if len(projs) == 0 {
@@ -3912,6 +3913,10 @@ func (c *Char) projVar(pid BytecodeValue, idx BytecodeValue, vtype OpCode, oc *C
 				v = BytecodeInt(int32(p.id))
 			case OC_ex2_projvar_teamside:
 				v = BytecodeInt(int32(p.hitdef.teamside))
+			case OC_ex2_projvar_guardflag:
+				v = BytecodeBool(p.hitdef.guardflag & fl != 0)
+			case OC_ex2_projvar_hitflag:
+				v = BytecodeBool(p.hitdef.hitflag & fl != 0)
 			}
 			break
 		}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1094,6 +1094,8 @@ func (c *Compiler) mathFunc(out *BytecodeExp, in *string, rd bool,
 	}
 	return
 }
+
+// rd means Redirect
 func (c *Compiler) expValue(out *BytecodeExp, in *string,
 	rd bool) (BytecodeValue, error) {
 	c.reverseOrder, c.norange = true, false
@@ -1192,47 +1194,44 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return nil
 		})
 	}
-	flagSub := func(opct, opc OpCode) error {
-		return eqne(func() error {
-			flg := int32(0)
-			base := c.token
-			for _, ch := range base {
-				switch ch {
-				case 'H', 'h':
-					flg |= int32(ST_S)
-				case 'L', 'l':
-					flg |= int32(ST_C)
-				case 'M', 'm':
-					flg |= int32(ST_S | ST_C)
-				case 'A', 'a':
-					flg |= int32(ST_A)
-				case 'F', 'f':
-					flg |= int32(ST_F)
-				case 'D', 'd':
-					flg |= int32(ST_D)
-				case 'P', 'p':
-					flg |= int32(ST_P)
-				default:
-					return Error("Invalid flags: " + base)
-				}
+	// Parses a flag. Returns flag and error.
+	flagSub := func() (int32, error) {
+		flg := int32(0)
+		base := c.token
+		for _, ch := range base {
+			switch ch {
+			case 'H', 'h':
+				flg |= int32(ST_S)
+			case 'L', 'l':
+				flg |= int32(ST_C)
+			case 'M', 'm':
+				flg |= int32(ST_S | ST_C)
+			case 'A', 'a':
+				flg |= int32(ST_A)
+			case 'F', 'f':
+				flg |= int32(ST_F)
+			case 'D', 'd':
+				flg |= int32(ST_D)
+			case 'P', 'p':
+				flg |= int32(ST_P)
+			default:
+				return flg, Error("Invalid flags: " + base)
 			}
-			// peek ahead to see if we have signs in the flag
-			if len(*in) > 0 {
-				switch (*in)[0] {
-				case '+':
-					// move forward
-					flg |= int32(MT_PLS)
-					*in = (*in)[1:]
-				case '-':
-					// move forward
-					flg |= int32(MT_MNS)
-					*in = (*in)[1:]
-				}
+		}
+		// peek ahead to see if we have signs in the flag
+		if len(*in) > 0 {
+			switch (*in)[0] {
+			case '+':
+				// move forward
+				flg |= int32(MT_PLS)
+				*in = (*in)[1:]
+			case '-':
+				// move forward
+				flg |= int32(MT_MNS)
+				*in = (*in)[1:]
 			}
-			out.append(opct)
-			out.appendI32Op(opc, flg)
-			return nil
-		})
+		}
+		return flg, nil
 	}
 	var be1, be2, be3 BytecodeExp
 	var bv1, bv2, bv3 BytecodeValue
@@ -2350,21 +2349,29 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		}
 		isFlag := false
 		switch param {
-		case "guardflag":
-			opc = OC_ex2_hitdefvar_guardflag
-			isFlag = true
-		case "hitflag":
-			opc = OC_ex2_hitdefvar_hitflag
-			isFlag = true
-		case "hitdamage":
-			opc = OC_ex2_hitdefvar_hitdamage
-		case "guarddamage":
-			opc = OC_ex2_hitdefvar_guarddamage
-		default:
-			return bvNone(), Error("Invalid data: " + c.token)
+			case "guardflag":
+				opc = OC_ex2_hitdefvar_guardflag
+				isFlag = true
+			case "hitflag":
+				opc = OC_ex2_hitdefvar_hitflag
+				isFlag = true
+			case "hitdamage":
+				opc = OC_ex2_hitdefvar_hitdamage
+			case "guarddamage":
+				opc = OC_ex2_hitdefvar_guarddamage
+			default:
+				return bvNone(), Error("Invalid data: " + c.token)
 		}
 		if isFlag {
-			if err := flagSub(OC_ex2_, opc); err != nil {
+			if err := eqne(func () error {
+				if flg, err := flagSub(); err != nil {
+					return err
+				} else {
+					out.append(OC_ex2_)
+					out.appendI32Op(opc, flg)
+					return nil
+				}
+			}); err != nil{
 				return bvNone(), err
 			}
 		} else {
@@ -2656,6 +2663,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		c.token = c.tokenizer(in)
 
 		vname := c.token
+		isFlag := false
 
 		switch vname {
 		case "projremove":
@@ -2787,23 +2795,51 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			opc = OC_ex2_projvar_projid
 		case "teamside":
 			opc = OC_ex2_projvar_teamside
+		case "guardflag":
+			opc = OC_ex2_projvar_guardflag
+			isFlag = true
+		case "hitflag":
+			opc = OC_ex2_projvar_hitflag
+			isFlag = true
 		default:
 			return bvNone(), Error(fmt.Sprint("Invalid argument: %s", vname))
 		}
-		c.token = c.tokenizer(in)
 
+		c.token = c.tokenizer(in)
 		if err := c.checkClosingBracket(); err != nil {
 			return bvNone(), err
 		}
 
+		bv3 := BytecodeInt(0)
+		if isFlag {
+			if err := eqne2(func (not bool) error {
+				if flg, err := flagSub(); err != nil {
+					return err
+				} else {
+					if not {
+						bv3 = BytecodeInt(^flg)
+					} else {
+						bv3 = BytecodeInt(flg)
+					}
+				}
+				return nil
+			}); err != nil{
+				return bvNone(), err
+			}
+		}
+
+		be3.appendValue(bv3)
 		be2.appendValue(bv2)
 		be1.appendValue(bv1)
+
 		if len(be2) > int(math.MaxUint8-1) {
 			be1.appendI32Op(OC_jz, int32(len(be2)+1))
 		} else {
 			be1.append(OC_jz8, OpCode(len(be2)+1))
 		}
 		be1.append(be2...)
+		be1.append(be3...)
+
 		if rd {
 			out.appendI32Op(OC_nordrun, int32(len(be1)))
 		}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2810,6 +2810,12 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 
+		// If bv1 is ever 0 Ikemen crashes.
+		// I do not know why this happens.
+		// It happened with clsnVar.
+		idx := bv1.ToI()
+		if(idx >= 0){ bv1.SetI(idx+1); }
+
 		bv3 := BytecodeInt(0)
 		if isFlag {
 			if err := eqne2(func (not bool) error {


### PR DESCRIPTION
- This PR implements guardflag and hitvar parameters for ProjVar. It is implemented in a similar way to HitDefVar's flag checking.
- HitDefVar's flag checking function was refactored for easier integration to other triggers such as ProjVar
- Rewrote some loadstring calls in favor of array notation in options.lua
- Fixed a crash that would occur when the ID parameter of ProjVar is zero