### PR TITLE
feat: removeText, new text params, numText trigger, explod friction

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -11051,11 +11051,11 @@ const (
 	text_align
 	text_linespacing
 	text_textdelay
-	text_velocity
-	text_friction
-	text_accel
 	text_text
 	text_pos
+	text_velocity
+	text_accel
+	text_friction
 	text_scale
 	text_color
 	text_id
@@ -11115,29 +11115,29 @@ func (sc text) Run(c *Char, _ []int32) bool {
 		case text_align:
 			ts.align = exp[0].evalI(c)
 		case text_linespacing:
-			ts.lineSpacing = exp[0].evalF(c)
+			ts.lineSpacing = exp[0].evalF(c) / ts.localScale
 		case text_textdelay:
 			ts.textDelay = exp[0].evalF(c)
+		case text_pos:
+			ts.x = exp[0].evalF(c)/ts.localScale + float32(ts.offsetX)
+			if len(exp) > 1 {
+				ts.y = exp[1].evalF(c) / ts.localScale
+			}
 		case text_velocity:
 			ts.velocity[0] = exp[0].evalF(c)/ts.localScale + float32(ts.offsetX)
 				if len(exp) > 1 {
 					ts.velocity[1] = exp[1].evalF(c) / ts.localScale
-				}
-		case text_friction:
-			ts.friction[0] = exp[0].evalF(c)/ts.localScale + float32(ts.offsetX)
-				if len(exp) > 1 {
-					ts.friction[1] = exp[1].evalF(c) / ts.localScale
 				}
 		case text_accel:
 			ts.accel[0] = exp[0].evalF(c)/ts.localScale + float32(ts.offsetX)
 				if len(exp) > 1 {
 					ts.accel[1] = exp[1].evalF(c) / ts.localScale
 				}
-		case text_pos:
-			ts.x = exp[0].evalF(c)/ts.localScale + float32(ts.offsetX)
-			if len(exp) > 1 {
-				ts.y = exp[1].evalF(c) / ts.localScale
-			}
+		case text_friction:
+			ts.friction[0] = exp[0].evalF(c)/ts.localScale + float32(ts.offsetX)
+				if len(exp) > 1 {
+					ts.friction[1] = exp[1].evalF(c) / ts.localScale
+				}
 		case text_scale:
 			xscl = exp[0].evalF(c)
 			if len(exp) > 1 {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -4896,8 +4896,8 @@ const (
 	explod_random
 	explod_postype
 	explod_velocity
-	explod_accel
 	explod_friction
+	explod_accel
 	explod_scale
 	explod_bindtime
 	explod_removetime
@@ -5033,20 +5033,20 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 					e.velocity[2] = exp[2].evalF(c) * redirscale
 				}
 			}
+		case explod_friction:
+			e.friction[0] = exp[0].evalF(c)
+			if len(exp) > 1 {
+				e.friction[1] = exp[1].evalF(c)
+				if len(exp) > 2 {
+					e.friction[2] = exp[2].evalF(c)
+				}
+			}
 		case explod_accel:
 			e.accel[0] = exp[0].evalF(c) * redirscale
 			if len(exp) > 1 {
 				e.accel[1] = exp[1].evalF(c) * redirscale
 				if len(exp) > 2 {
 					e.accel[2] = exp[2].evalF(c) * redirscale
-				}
-			}
-		case explod_friction:
-			e.friction[0] = exp[0].evalF(c) * redirscale
-			if len(exp) > 1 {
-				e.friction[1] = exp[1].evalF(c) * redirscale
-				if len(exp) > 2 {
-					e.friction[2] = exp[2].evalF(c) * redirscale
 				}
 			}
 		case explod_scale:
@@ -5340,8 +5340,8 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 						e.setZ(e.offset[2])
 						e.relativePos = [3]float32{0, 0, 0}
 						e.velocity = [3]float32{0, 0, 0}
-						e.accel = [3]float32{0, 0, 0}
 						e.friction = [3]float32{1, 1, 1}
+						e.accel = [3]float32{0, 0, 0}
 						e.bindId = -2
 						if e.bindtime == 0 {
 							e.bindtime = 1
@@ -5448,29 +5448,6 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 						}
 					}
 				}
-			case explod_accel:
-				if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
-					accel := exp[0].evalF(c) * redirscale
-					eachExpl(func(e *Explod) {
-						e.accel[0] = accel
-					})
-				}
-				if len(exp) > 1 {
-					if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
-						accel := exp[1].evalF(c) * redirscale
-						eachExpl(func(e *Explod) {
-							e.accel[1] = accel
-						})
-					}
-					if len(exp) > 2 {
-						if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
-							accel := exp[2].evalF(c) * redirscale
-							eachExpl(func(e *Explod) {
-								e.accel[2] = accel
-							})
-						}
-					}
-				}
 			case explod_friction:
 				if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
 					friction := exp[0].evalF(c) * redirscale
@@ -5490,6 +5467,29 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 							friction := exp[2].evalF(c) * redirscale
 							eachExpl(func(e *Explod) {
 								e.friction[2] = friction
+							})
+						}
+					}
+				}
+			case explod_accel:
+				if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
+					accel := exp[0].evalF(c) * redirscale
+					eachExpl(func(e *Explod) {
+						e.accel[0] = accel
+					})
+				}
+				if len(exp) > 1 {
+					if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
+						accel := exp[1].evalF(c) * redirscale
+						eachExpl(func(e *Explod) {
+							e.accel[1] = accel
+						})
+					}
+					if len(exp) > 2 {
+						if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
+							accel := exp[2].evalF(c) * redirscale
+							eachExpl(func(e *Explod) {
+								e.accel[2] = accel
 							})
 						}
 					}
@@ -11054,8 +11054,8 @@ const (
 	text_text
 	text_pos
 	text_velocity
-	text_accel
 	text_friction
+	text_accel
 	text_scale
 	text_color
 	text_id
@@ -11128,15 +11128,15 @@ func (sc text) Run(c *Char, _ []int32) bool {
 				if len(exp) > 1 {
 					ts.velocity[1] = exp[1].evalF(c) / ts.localScale
 				}
+		case text_friction:
+			ts.friction[0] = exp[0].evalF(c) + float32(ts.offsetX)
+				if len(exp) > 1 {
+					ts.friction[1] = exp[1].evalF(c)
+				}
 		case text_accel:
 			ts.accel[0] = exp[0].evalF(c)/ts.localScale + float32(ts.offsetX)
 				if len(exp) > 1 {
 					ts.accel[1] = exp[1].evalF(c) / ts.localScale
-				}
-		case text_friction:
-			ts.friction[0] = exp[0].evalF(c)/ts.localScale + float32(ts.offsetX)
-				if len(exp) > 1 {
-					ts.friction[1] = exp[1].evalF(c) / ts.localScale
 				}
 		case text_scale:
 			xscl = exp[0].evalF(c)

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -11115,7 +11115,7 @@ func (sc text) Run(c *Char, _ []int32) bool {
 		case text_align:
 			ts.align = exp[0].evalI(c)
 		case text_linespacing:
-			ts.lineSpacing = exp[0].evalF(c) / ts.localScale
+			ts.lineSpacing = exp[0].evalF(c)
 		case text_textdelay:
 			ts.textDelay = exp[0].evalF(c)
 		case text_pos:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -11065,7 +11065,7 @@ const (
 func (sc text) Run(c *Char, _ []int32) bool {
 	crun := c
 	params := []interface{}{}
-	ownerID := c.id
+	ownerID := crun.id
 	ts := NewTextSprite()
 	ts.SetLocalcoord(float32(sys.scrrect[2]), float32(sys.scrrect[3]))
 	var xscl, yscl float32 = 1, 1
@@ -11157,6 +11157,7 @@ func (sc text) Run(c *Char, _ []int32) bool {
 		case text_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
+				ts.ownerid = crun.id
 			} else {
 				return false
 			}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -11181,18 +11181,28 @@ type removeText StateControllerBase
 
 const (
 	removetext_id byte = iota
+	removetext_redirectid
 )
 
 func (sc removeText) Run(c *Char, _ []int32) bool {
-	ownerID := c.id
+	crun := c
+	ownerID := crun.id
+	textID := int32(-1)
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case removetext_id:
-			idToRemove := exp[0].evalI(c)
-			sys.lifebar.RemoveText(idToRemove, ownerID)
+			textID = exp[0].evalI(c)
+		case removetext_redirectid:
+			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
+				crun = rid
+				ownerID = crun.id
+			} else {
+				return false
+			}
 		}
 		return true
 	})
+	sys.lifebar.RemoveText(textID, ownerID)
 	return false
 }
 

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5450,21 +5450,21 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				}
 			case explod_friction:
 				if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
-					friction := exp[0].evalF(c) * redirscale
+					friction := exp[0].evalF(c)
 					eachExpl(func(e *Explod) {
 						e.friction[0] = friction
 					})
 				}
 				if len(exp) > 1 {
 					if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
-						friction := exp[1].evalF(c) * redirscale
+						friction := exp[1].evalF(c)
 						eachExpl(func(e *Explod) {
 							e.friction[1] = friction
 						})
 					}
 					if len(exp) > 2 {
 						if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
-							friction := exp[2].evalF(c) * redirscale
+							friction := exp[2].evalF(c)
 							eachExpl(func(e *Explod) {
 								e.friction[2] = friction
 							})
@@ -11124,17 +11124,17 @@ func (sc text) Run(c *Char, _ []int32) bool {
 				ts.y = exp[1].evalF(c) / ts.localScale
 			}
 		case text_velocity:
-			ts.velocity[0] = exp[0].evalF(c)/ts.localScale + float32(ts.offsetX)
+			ts.velocity[0] = exp[0].evalF(c)/ts.localScale
 				if len(exp) > 1 {
 					ts.velocity[1] = exp[1].evalF(c) / ts.localScale
 				}
 		case text_friction:
-			ts.friction[0] = exp[0].evalF(c) + float32(ts.offsetX)
+			ts.friction[0] = exp[0].evalF(c)
 				if len(exp) > 1 {
 					ts.friction[1] = exp[1].evalF(c)
 				}
 		case text_accel:
-			ts.accel[0] = exp[0].evalF(c)/ts.localScale + float32(ts.offsetX)
+			ts.accel[0] = exp[0].evalF(c)/ts.localScale
 				if len(exp) > 1 {
 					ts.accel[1] = exp[1].evalF(c) / ts.localScale
 				}
@@ -11186,7 +11186,6 @@ const (
 
 func (sc removeText) Run(c *Char, _ []int32) bool {
 	crun := c
-	ownerID := crun.id
 	textID := int32(-1)
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
@@ -11195,14 +11194,13 @@ func (sc removeText) Run(c *Char, _ []int32) bool {
 		case removetext_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				ownerID = crun.id
 			} else {
 				return false
 			}
 		}
 		return true
 	})
-	sys.lifebar.RemoveText(textID, ownerID)
+	sys.lifebar.RemoveText(textID, crun.id)
 	return false
 }
 

--- a/src/char.go
+++ b/src/char.go
@@ -1133,8 +1133,8 @@ type Explod struct {
 	statehaschanged     bool
 	removetime          int32
 	velocity            [3]float32
-	accel               [3]float32
 	friction            [3]float32
+	accel               [3]float32
 	sprpriority         int32
 	layerno             int32
 	shadow              [3]int32
@@ -1503,9 +1503,9 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 			e.newPos[1] = e.pos[1] + e.velocity[1]
 			e.newPos[2] = e.pos[2] + e.velocity[2]
 			for i := range e.velocity {
-				e.velocity[i] += e.accel[i]
 				e.velocity[i] *= e.friction[i]
-				if math.Abs(float64(e.velocity[i])) < 0.1 {
+				e.velocity[i] += e.accel[i]
+				if math.Abs(float64(e.velocity[i])) < 0.1 && math.Abs(float64(e.friction[i])) > 0 {
 					e.velocity[i] = 0
 				}
 			}

--- a/src/char.go
+++ b/src/char.go
@@ -1134,6 +1134,7 @@ type Explod struct {
 	removetime          int32
 	velocity            [3]float32
 	accel               [3]float32
+	friction            [3]float32
 	sprpriority         int32
 	layerno             int32
 	shadow              [3]int32
@@ -1198,6 +1199,7 @@ func (e *Explod) clear() {
 		bindId:            -2,
 		ignorehitpause:    true,
 		interpolate_scale: [...]float32{1, 1, 0, 0},
+		friction:          [3]float32{1, 1, 1},
 	}
 }
 func (e *Explod) setX(x float32) {
@@ -1502,6 +1504,10 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 			e.newPos[2] = e.pos[2] + e.velocity[2]
 			for i := range e.velocity {
 				e.velocity[i] += e.accel[i]
+				e.velocity[i] *= e.friction[i]
+				if math.Abs(float64(e.velocity[i])) < 0.1 {
+					e.velocity[i] = 0
+				}
 			}
 			eleminterpolate := e.interpolate && e.interpolate_time[1] > 0 && e.interpolate_animelem[1] >= 0
 			if e.animfreeze || eleminterpolate {
@@ -3782,6 +3788,20 @@ func (c *Char) numExplod(eid BytecodeValue) BytecodeValue {
 	}
 	return BytecodeInt(n)
 }
+
+func (c *Char) numText(textid BytecodeValue) BytecodeValue {
+	if textid.IsSF() {
+		return BytecodeSF()
+	}
+	var id, n int32 = textid.ToI(), 0
+	for _, ts := range sys.lifebar.textsprite {
+		if ts.id == id && ts.ownerid == c.id {
+			n++
+		}
+	}
+	return BytecodeInt(n)
+}
+
 func (c *Char) explodVar(eid BytecodeValue, idx BytecodeValue, vtype OpCode) BytecodeValue {
 	if eid.IsSF() {
 		return BytecodeSF()
@@ -4510,7 +4530,7 @@ func (c *Char) destroy() {
 	}
 }
 
-func (c *Char) destroySelf(recursive, removeexplods bool) bool {
+func (c *Char) destroySelf(recursive, removeexplods, removetexts bool) bool {
 	if c.helperIndex <= 0 {
 		return false
 	}
@@ -4518,10 +4538,13 @@ func (c *Char) destroySelf(recursive, removeexplods bool) bool {
 	if removeexplods {
 		c.removeExplod(-1, -1)
 	}
+	if removetexts {
+		sys.lifebar.RemoveText(-1, c.id)
+	}
 	if recursive {
 		for _, ch := range c.children {
 			if ch != nil {
-				ch.destroySelf(recursive, removeexplods)
+				ch.destroySelf(recursive, removeexplods, removetexts)
 			}
 		}
 	}

--- a/src/char.go
+++ b/src/char.go
@@ -1505,7 +1505,7 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 			for i := range e.velocity {
 				e.velocity[i] *= e.friction[i]
 				e.velocity[i] += e.accel[i]
-				if math.Abs(float64(e.velocity[i])) < 0.1 && math.Abs(float64(e.friction[i])) != 1 {
+				if math.Abs(float64(e.velocity[i])) < 0.1 && math.Abs(float64(e.friction[i])) < 1 {
 					e.velocity[i] = 0
 				}
 			}

--- a/src/char.go
+++ b/src/char.go
@@ -1505,7 +1505,7 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 			for i := range e.velocity {
 				e.velocity[i] *= e.friction[i]
 				e.velocity[i] += e.accel[i]
-				if math.Abs(float64(e.velocity[i])) < 0.1 && math.Abs(float64(e.friction[i])) > 0 {
+				if math.Abs(float64(e.velocity[i])) < 0.1 && math.Abs(float64(e.friction[i])) != 1 {
 					e.velocity[i] = 0
 				}
 			}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -98,6 +98,7 @@ func newCompiler() *Compiler {
 		"projectile":         c.projectile,
 		"remappal":           c.remapPal,
 		"removeexplod":       c.removeExplod,
+		"removetext":         c.removeText,
 		"reversaldef":        c.reversalDef,
 		"screenbound":        c.screenBound,
 		"selfstate":          c.selfState,
@@ -278,6 +279,7 @@ var triggerMap = map[string]int{
 	"numproj":           1,
 	"numprojid":         1,
 	"numtarget":         1,
+	"numtext":           1,
 	"p1name":            1,
 	"p2bodydist":        1,
 	"p2dist":            1,
@@ -2031,6 +2033,19 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			default:
 				return bvNone(), Error(fmt.Sprint("Invalid argument: %s", c.token))
 			}
+		case "friction":
+			c.token = c.tokenizer(in)
+
+			switch c.token {
+			case "x":
+				opc = OC_ex2_explodvar_friction_x
+			case "y":
+				opc = OC_ex2_explodvar_friction_y
+			case "z":
+				opc = OC_ex2_explodvar_friction_z
+			default:
+				return bvNone(), Error(fmt.Sprint("Invalid argument: %s", c.token))
+			}
 		case "scale":
 			c.token = c.tokenizer(in)
 
@@ -2596,6 +2611,11 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 		out.append(OC_numtarget)
+	case "numtext":
+		if _, err := c.oneArg(out, in, rd, true, BytecodeInt(-1)); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_numtext)
 	case "palno":
 		out.append(OC_palno)
 	case "pos":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -4862,20 +4862,20 @@ func (c *Compiler) text(is IniSection, sc *StateControllerBase, _ int8) (StateCo
 			text_textdelay, VT_Float, 1, false); err != nil {
 			return err
 		}
-		if err := c.paramValue(is, sc, "velocity",
-			text_velocity, VT_Float, 2, false); err != nil {
+		if err := c.paramValue(is, sc, "pos",
+			text_pos, VT_Float, 2, false); err != nil {
 			return err
 		}
-		if err := c.paramValue(is, sc, "friction",
-			text_friction, VT_Float, 2, false); err != nil {
+		if err := c.paramValue(is, sc, "velocity",
+			text_velocity, VT_Float, 2, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "accel",
 			text_accel, VT_Float, 2, false); err != nil {
 			return err
 		}
-		if err := c.paramValue(is, sc, "pos",
-			text_pos, VT_Float, 2, false); err != nil {
+		if err := c.paramValue(is, sc, "friction",
+			text_friction, VT_Float, 2, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "scale",

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -740,12 +740,12 @@ func (c *Compiler) explodSub(is IniSection,
 			return err
 		}
 	}
-	if err := c.paramValue(is, sc, "accel",
-		explod_accel, VT_Float, 3, false); err != nil {
-		return err
-	}
 	if err := c.paramValue(is, sc, "friction",
 		explod_friction, VT_Float, 3, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "accel",
+		explod_accel, VT_Float, 3, false); err != nil {
 		return err
 	}
 	if err := c.paramProjection(is, sc, explod_projection); err != nil {
@@ -4870,12 +4870,12 @@ func (c *Compiler) text(is IniSection, sc *StateControllerBase, _ int8) (StateCo
 			text_velocity, VT_Float, 2, false); err != nil {
 			return err
 		}
-		if err := c.paramValue(is, sc, "accel",
-			text_accel, VT_Float, 2, false); err != nil {
-			return err
-		}
 		if err := c.paramValue(is, sc, "friction",
 			text_friction, VT_Float, 2, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "accel",
+			text_accel, VT_Float, 2, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "scale",

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -457,6 +457,10 @@ func (c *Compiler) destroySelf(is IniSection, sc *StateControllerBase, _ int8) (
 			destroySelf_removeexplods, VT_Bool, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "removetexts",
+			destroySelf_removetexts, VT_Bool, 1, false); err != nil {
+			return err
+		}
 		return nil
 	})
 	return *ret, err
@@ -738,6 +742,10 @@ func (c *Compiler) explodSub(is IniSection,
 	}
 	if err := c.paramValue(is, sc, "accel",
 		explod_accel, VT_Float, 3, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "friction",
+		explod_friction, VT_Float, 3, false); err != nil {
 		return err
 	}
 	if err := c.paramProjection(is, sc, explod_projection); err != nil {
@@ -4785,6 +4793,10 @@ func (c *Compiler) text(is IniSection, sc *StateControllerBase, _ int8) (StateCo
 			text_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "id",
+			text_id, VT_Int, 1, false); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "removetime",
 			text_removetime, VT_Int, 1, false); err != nil {
 			return err
@@ -4842,6 +4854,26 @@ func (c *Compiler) text(is IniSection, sc *StateControllerBase, _ int8) (StateCo
 			text_align, VT_Int, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "linespacing",
+			text_linespacing, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "textdelay",
+			text_textdelay, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "velocity",
+			text_velocity, VT_Float, 2, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "friction",
+			text_friction, VT_Float, 2, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "accel",
+			text_accel, VT_Float, 2, false); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "pos",
 			text_pos, VT_Float, 2, false); err != nil {
 			return err
@@ -4853,6 +4885,23 @@ func (c *Compiler) text(is IniSection, sc *StateControllerBase, _ int8) (StateCo
 		if err := c.paramValue(is, sc, "color",
 			text_color, VT_Int, 3, false); err != nil {
 			return err
+		}
+		return nil
+	})
+	return *ret, err
+}
+
+func (c *Compiler) removeText(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+	ret, err := (*removeText)(sc), c.stateSec(is, func() error {
+		b := false
+		if err := c.stateParam(is, "id", false, func(data string) error {
+			b = true
+			return c.scAdd(sc, removetext_id, data, VT_Int, 1)
+		}); err != nil {
+			return err
+		}
+		if !b {
+			sc.add(removetext_id, sc.iToExp(-1))
 		}
 		return nil
 	})

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -4893,11 +4893,11 @@ func (c *Compiler) text(is IniSection, sc *StateControllerBase, _ int8) (StateCo
 
 func (c *Compiler) removeText(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*removeText)(sc), c.stateSec(is, func() error {
-		b := false
 		if err := c.paramValue(is, sc, "redirectid",
 			removetext_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
+		b := false
 		if err := c.stateParam(is, "id", false, func(data string) error {
 			b = true
 			return c.scAdd(sc, removetext_id, data, VT_Int, 1)

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -4894,6 +4894,10 @@ func (c *Compiler) text(is IniSection, sc *StateControllerBase, _ int8) (StateCo
 func (c *Compiler) removeText(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*removeText)(sc), c.stateSec(is, func() error {
 		b := false
+		if err := c.paramValue(is, sc, "redirectid",
+			removetext_redirectid, VT_Int, 1, false); err != nil {
+			return err
+		}
 		if err := c.stateParam(is, "id", false, func(data string) error {
 			b = true
 			return c.scAdd(sc, removetext_id, data, VT_Int, 1)

--- a/src/font.go
+++ b/src/font.go
@@ -605,7 +605,7 @@ func NewTextSprite() *TextSprite {
 		layerno:    1,
 		localScale: 1,
 		offsetX:    0,
-		lineSpacing:0,
+		lineSpacing:10,
 		textDelay:  0,
 		velocity:   [2]float32{0.0, 0.0},
 		accel:      [2]float32{0.0, 0.0},

--- a/src/font.go
+++ b/src/font.go
@@ -587,8 +587,8 @@ type TextSprite struct {
 	elapsedTicks     float32
 	textDelay        float32
 	velocity         [2]float32
-	accel            [2]float32
 	friction         [2]float32
+	accel            [2]float32
 }
 
 func NewTextSprite() *TextSprite {
@@ -608,8 +608,8 @@ func NewTextSprite() *TextSprite {
 		lineSpacing:10,
 		textDelay:  0,
 		velocity:   [2]float32{0.0, 0.0},
-		accel:      [2]float32{0.0, 0.0},
 		friction:   [2]float32{1.0, 1.0},
+		accel:      [2]float32{0.0, 0.0},
 	}
 	ts.palfx.setColor(255, 255, 255)
 	return ts
@@ -641,9 +641,9 @@ func (ts *TextSprite) SetTextVel() {
 	ts.x += ts.velocity[0]
 	ts.y += ts.velocity[1]
 	for i := range ts.velocity {
-		ts.velocity[i] += ts.accel[i]
 		ts.velocity[i] *= ts.friction[i]
-		if math.Abs(float64(ts.velocity[i])) < 0.1 {
+		ts.velocity[i] += ts.accel[i]
+		if math.Abs(float64(ts.velocity[i])) < 0.1 && math.Abs(float64(ts.friction[i])) > 0 {
 			ts.velocity[i] = 0
 		}
 	}

--- a/src/font.go
+++ b/src/font.go
@@ -643,7 +643,7 @@ func (ts *TextSprite) SetTextVel() {
 	for i := range ts.velocity {
 		ts.velocity[i] *= ts.friction[i]
 		ts.velocity[i] += ts.accel[i]
-		if math.Abs(float64(ts.velocity[i])) < 0.1 && math.Abs(float64(ts.friction[i])) != 1 {
+		if math.Abs(float64(ts.velocity[i])) < 0.1 && math.Abs(float64(ts.friction[i])) < 1 {
 			ts.velocity[i] = 0
 		}
 	}

--- a/src/font.go
+++ b/src/font.go
@@ -643,7 +643,7 @@ func (ts *TextSprite) SetTextVel() {
 	for i := range ts.velocity {
 		ts.velocity[i] *= ts.friction[i]
 		ts.velocity[i] += ts.accel[i]
-		if math.Abs(float64(ts.velocity[i])) < 0.1 && math.Abs(float64(ts.friction[i])) > 0 {
+		if math.Abs(float64(ts.velocity[i])) < 0.1 && math.Abs(float64(ts.friction[i])) != 1 {
 			ts.velocity[i] = 0
 		}
 	}

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -3953,6 +3953,15 @@ func (l *Lifebar) step() {
 	}
 }
 
+func (l *Lifebar) RemoveText(id, ownerid int32) {
+    for i := len(l.textsprite) - 1; i >= 0; i-- {
+        if (id == -1 && l.textsprite[i].ownerid == ownerid) || 
+           (id != -1 && l.textsprite[i].id == id && l.textsprite[i].ownerid == ownerid) {
+            l.textsprite = append(l.textsprite[:i], l.textsprite[i+1:]...)
+        }
+    }
+}
+
 func (l *Lifebar) reset() {
 	var num [2]int
 	for ti, tm := range sys.tmode {

--- a/src/script.go
+++ b/src/script.go
@@ -3490,6 +3490,12 @@ func triggerFunctions(l *lua.LState) {
 					ln = lua.LNumber(e.accel[1])
 				case "accel z":
 					ln = lua.LNumber(e.accel[2])
+				case "friction x":
+					ln = lua.LNumber(e.friction[0])
+				case "friction y":
+					ln = lua.LNumber(e.friction[1])
+				case "friction z":
+					ln = lua.LNumber(e.friction[2])
 				case "scale x":
 					ln = lua.LNumber(e.scale[0] * e.interpolate_scale[0])
 				case "scale y":
@@ -4054,6 +4060,14 @@ func triggerFunctions(l *lua.LState) {
 			id = int32(numArg(l, 1))
 		}
 		l.Push(lua.LNumber(sys.debugWC.numTarget(BytecodeInt(id)).ToI()))
+		return 1
+	})
+	luaRegister(l, "numtext", func(*lua.LState) int {
+		id := int32(-1)
+		if l.GetTop() >= 1 {
+			id = int32(numArg(l, 1))
+		}
+		l.Push(lua.LNumber(sys.debugWC.numText(BytecodeInt(id)).ToI()))
 		return 1
 	})
 	luaRegister(l, "palfxvar", func(*lua.LState) int {


### PR DESCRIPTION
Feat:

- Text sctrl can now recognize \n and \t escape sequences.
- New text params:
    - ID – assigns an ID number to the text.
    - lineSpacing – defines the spacing between lines. defaults to 10.
    - textDelay – can be used to create a typing effect.
    - velocity: x, y
    - accel: x, y
    - friction: x, y
    
- RemoveText sctrl – declare the ID of an existing text to remove it. If nothing is declared, it will remove all texts.

- numText trigger.

- removeTexts can be used with destroySelf.

- Added friction param to explods and explodVar.