### PR TITLE
fix: projectile localcoord yaccel, TransformClsn redirection

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6549,8 +6549,6 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 			if p == nil {
 				return false
 			}
-			p.hitdef.playerNo = sys.workingState.playerNo
-			p.hitdef.isprojectile = true
 		}
 		switch id {
 		case projectile_postype:
@@ -6724,11 +6722,6 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 	}
 	if p.aimg.time != 0 {
 		p.aimg.setupPalFX()
-	}
-	if crun.minus == -2 || crun.minus == -4 {
-		p.localscl = (320 / crun.localcoord)
-	} else {
-		p.localscl = crun.localscl
 	}
 	crun.projInit(p, pt, x, y, z, op, rp[0], rp[1], clsnscale)
 	return false

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -11838,8 +11838,9 @@ func (sc transformClsn) Run(c *Char, _ []int32) bool {
 			if len(exp) > 1 {
 				crun.clsnScaleMul[1] *= exp[1].evalF(c)
 			}
+			crun.updateClsnScale()
 		case transformClsn_angle:
-			crun.clsnAngle = exp[0].evalF(c)
+			crun.clsnAngle += exp[0].evalF(c)
 		case transformClsn_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid


### PR DESCRIPTION
- Fixed yaccel defaulting incorrectly when a projectile has a localcoord other than 320x240
- Adjusted TransformClsn code to better accept redirections
- Clsn angle is now cumulative to match scale. This should probably be revisited in the future to add flexibility
- Fixes #2087 