### PR TITLE
feat: Simple Environment map, punctual light and shadow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,9 @@ require (
 	github.com/hajimehoshi/go-mp3 v0.3.4 // indirect
 	github.com/jfreymuth/oggvorbis v1.0.5 // indirect
 	github.com/jfreymuth/vorbis v1.0.2 // indirect
+	github.com/hajimehoshi/oto v0.7.1 // indirect
+	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
+	github.com/mdouchement/hdr v0.2.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/samhocevar/go-meltysynth v0.0.0-20230403180939-aca4a036cb16 // indirect
 	golang.org/x/image v0.19.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,11 @@ github.com/lukegb/dds v0.0.0-20190402175749-8b7170e64003 h1:6g1XsQmpC332a2qx+qkr
 github.com/lukegb/dds v0.0.0-20190402175749-8b7170e64003/go.mod h1:hOrxKmZfUO2QXaqXIlrVqNdeBIFpNBb6uBzWsP9VwDw=
 github.com/orcaman/writerseeker v0.0.0-20200621085525-1d3f536ff85e h1:s2RNOM/IGdY0Y6qfTeUKhDawdHDpK9RGBdx80qN4Ttw=
 github.com/orcaman/writerseeker v0.0.0-20200621085525-1d3f536ff85e/go.mod h1:nBdnFKj15wFbf94Rwfq4m30eAcyY9V/IyKAGQFtqkW0=
+github.com/lucasb-eyer/go-colorful v1.0.2/go.mod h1:0MS4r+7BZKSJ5mw4/S5MPN+qHFF1fYclkSPilDOKW0s=
+github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
+github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
+github.com/mdouchement/hdr v0.2.4 h1:k0ojx7smWvWw8En2BjUnb144j48gAExu5mv+ogNrkTc=
+github.com/mdouchement/hdr v0.2.4/go.mod h1:uezK2oUhYtoRLkTD0J4ryiOsu/oWLjRXx0I/92mIRmQ=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -10,11 +10,14 @@ import (
 	_ "embed" // Support for go:embed resources
 	"encoding/binary"
 	"fmt"
+	"math"
 	"runtime"
+	"strconv"
 	"unsafe"
 
 	gl "github.com/go-gl/gl/v2.1/gl"
 	glfw "github.com/go-gl/glfw/v3.3/glfw"
+	mgl "github.com/go-gl/mathgl/mgl32"
 	"golang.org/x/mobile/exp/f32"
 )
 
@@ -65,10 +68,16 @@ type ShaderProgram struct {
 	t map[string]int
 }
 
-func newShaderProgram(vert, frag, id string) (s *ShaderProgram) {
+func newShaderProgram(vert, frag, geo, id string) (s *ShaderProgram) {
 	vertObj := compileShader(gl.VERTEX_SHADER, vert)
 	fragObj := compileShader(gl.FRAGMENT_SHADER, frag)
-	prog := linkProgram(vertObj, fragObj)
+	var prog uint32
+	if len(geo) > 0 {
+		geoObj := compileShader(gl.GEOMETRY_SHADER_EXT, geo)
+		prog = linkProgram(vertObj, fragObj, geoObj)
+	} else {
+		prog = linkProgram(vertObj, fragObj)
+	}
 
 	s = &ShaderProgram{program: prog}
 	s.a = make(map[string]int32)
@@ -120,14 +129,22 @@ func compileShader(shaderType uint32, src string) (shader uint32) {
 	return
 }
 
-func linkProgram(v, f uint32) (program uint32) {
+func linkProgram(params ...uint32) (program uint32) {
 	program = gl.CreateProgram()
-	gl.AttachShader(program, v)
-	gl.AttachShader(program, f)
+	for _, param := range params {
+		gl.AttachShader(program, param)
+	}
+	if len(params) > 2 {
+		// Geometry Shader Params
+		gl.ProgramParameteriEXT(program, gl.GEOMETRY_INPUT_TYPE_EXT, gl.TRIANGLES)
+		gl.ProgramParameteriEXT(program, gl.GEOMETRY_OUTPUT_TYPE_EXT, gl.TRIANGLE_STRIP)
+		gl.ProgramParameteriEXT(program, gl.GEOMETRY_VERTICES_OUT_EXT, 3*6)
+	}
 	gl.LinkProgram(program)
 	// Mark shaders for deletion when the program is deleted
-	gl.DeleteShader(v)
-	gl.DeleteShader(f)
+	for _, param := range params {
+		gl.DeleteShader(param)
+	}
 	var ok int32
 	gl.GetProgramiv(program, gl.LINK_STATUS, &ok)
 	if ok == 0 {
@@ -182,11 +199,55 @@ func newDataTexture(width, height int32) (t *Texture) {
 		}
 	})
 	gl.BindTexture(gl.TEXTURE_2D, t.handle)
-	//gl.TexImage2D(gl.TEXTURE_2D, 0, 32, t.width, t.height, 0, 36, gl.FLOAT, unsafe.Pointer(&data[0]))
+	//gl.TexImage2D(gl.TEXTURE_2D, 0, 32, t.width, t.height, 0, 36, gl.FLOAT, nil)
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+	return
+}
+func newHDRTexture(width, height int32) (t *Texture) {
+	var h uint32
+	gl.ActiveTexture(gl.TEXTURE0)
+	gl.GenTextures(1, &h)
+	t = &Texture{width, height, 24, false, h}
+	runtime.SetFinalizer(t, func(t *Texture) {
+		sys.mainThreadTask <- func() {
+			gl.DeleteTextures(1, &t.handle)
+		}
+	})
+	gl.BindTexture(gl.TEXTURE_2D, t.handle)
+
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.MIRRORED_REPEAT)
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.MIRRORED_REPEAT)
+	return
+}
+func newCubeMapTexture(widthHeight int32, mipmap bool) (t *Texture) {
+	var h uint32
+	gl.ActiveTexture(gl.TEXTURE0)
+	gl.GenTextures(1, &h)
+	t = &Texture{widthHeight, widthHeight, 24, false, h}
+	runtime.SetFinalizer(t, func(t *Texture) {
+		sys.mainThreadTask <- func() {
+			gl.DeleteTextures(1, &t.handle)
+		}
+	})
+	gl.BindTexture(gl.TEXTURE_CUBE_MAP, t.handle)
+	for i := 0; i < 6; i++ {
+		gl.TexImage2D(uint32(gl.TEXTURE_CUBE_MAP_POSITIVE_X+i), 0, gl.RGB32F_ARB, widthHeight, widthHeight, 0, gl.RGB, gl.FLOAT, nil)
+	}
+	if mipmap {
+		gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_LINEAR)
+		gl.GenerateMipmap(gl.TEXTURE_CUBE_MAP)
+	} else {
+		gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
+	}
+
+	gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
+	gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+	gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
 	return
 }
 
@@ -231,6 +292,11 @@ func (t *Texture) SetPixelData(data []float32) {
 	gl.PixelStorei(gl.UNPACK_ALIGNMENT, 1)
 	gl.TexImage2D(gl.TEXTURE_2D, 0, gl.RGBA32F_ARB, t.width, t.height, 0, gl.RGBA, gl.FLOAT, unsafe.Pointer(&data[0]))
 }
+func (t *Texture) SetRGBPixelData(data []float32) {
+	gl.BindTexture(gl.TEXTURE_2D, t.handle)
+	gl.PixelStorei(gl.UNPACK_ALIGNMENT, 1)
+	gl.TexImage2D(gl.TEXTURE_2D, 0, gl.RGB32F_ARB, t.width, t.height, 0, gl.RGB, gl.FLOAT, unsafe.Pointer(&data[0]))
+}
 
 // Return whether texture has a valid handle
 func (t *Texture) IsValid() bool {
@@ -248,6 +314,11 @@ type Renderer struct {
 	// MSAA rendering
 	fbo_f         uint32
 	fbo_f_texture *Texture
+	// Shadow Map
+	fbo_shadow              uint32
+	fbo_shadow_texture      [4]uint32
+	fbo_shadow_cube_texture [4]uint32
+	fbo_env                 uint32
 	// Post-processing shaders
 	postVertBuffer   uint32
 	postShaderSelect []*ShaderProgram
@@ -255,9 +326,12 @@ type Renderer struct {
 	spriteShader *ShaderProgram
 	vertexBuffer uint32
 	// Shader and index data for 3D model rendering
-	modelShader       *ShaderProgram
-	stageVertexBuffer uint32
-	stageIndexBuffer  uint32
+	shadowMapShader         *ShaderProgram
+	modelShader             *ShaderProgram
+	panoramaToCubemapShader *ShaderProgram
+	cubemapFilteringShader  *ShaderProgram
+	stageVertexBuffer       uint32
+	stageIndexBuffer        uint32
 }
 
 //go:embed shaders/sprite.vert.glsl
@@ -272,11 +346,26 @@ var modelVertShader string
 //go:embed shaders/model.frag.glsl
 var modelFragShader string
 
+//go:embed shaders/shadow.vert.glsl
+var shadowVertShader string
+
+//go:embed shaders/shadow.frag.glsl
+var shadowFragShader string
+
+//go:embed shaders/shadow.geo.glsl
+var shadowGeoShader string
+
 //go:embed shaders/ident.vert.glsl
 var identVertShader string
 
 //go:embed shaders/ident.frag.glsl
 var identFragShader string
+
+//go:embed shaders/panoramaToCubemap.frag.glsl
+var panoramaToCubemapFragShader string
+
+//go:embed shaders/cubemapFiltering.frag.glsl
+var cubemapFilteringFragShader string
 
 // Render initialization.
 // Creates the default shaders, the framebuffer and enables MSAA.
@@ -302,17 +391,44 @@ func (r *Renderer) Init() {
 	gl.GenBuffers(1, &r.stageIndexBuffer)
 
 	// Sprite shader
-	r.spriteShader = newShaderProgram(vertShader, fragShader, "Main Shader")
+	r.spriteShader = newShaderProgram(vertShader, fragShader, "", "Main Shader")
 	r.spriteShader.RegisterAttributes("position", "uv")
 	r.spriteShader.RegisterUniforms("modelview", "projection", "x1x2x4x3",
 		"alpha", "tint", "mask", "neg", "gray", "add", "mult", "isFlat", "isRgba", "isTrapez", "hue")
 	r.spriteShader.RegisterTextures("pal", "tex")
 
 	// 3D model shader
-	r.modelShader = newShaderProgram(modelVertShader, modelFragShader, "Model Shader")
-	r.modelShader.RegisterAttributes("position", "uv", "vertColor", "joints_0", "joints_1", "weights_0", "weights_1", "morphTargets_0")
-	r.modelShader.RegisterUniforms("modelview", "projection", "baseColorFactor", "add", "mult", "textured", "neg", "gray", "hue", "enableAlpha", "alphaThreshold", "numJoints", "morphTargetWeight", "positionTargetCount", "uvTargetCount")
-	r.modelShader.RegisterTextures("tex", "jointMatrices")
+	r.modelShader = newShaderProgram(modelVertShader, modelFragShader, "", "Model Shader")
+	r.modelShader.RegisterAttributes("vertexId", "position", "uv", "normalIn", "tangentIn", "vertColor", "joints_0", "joints_1", "weights_0", "weights_1")
+	r.modelShader.RegisterUniforms("model", "view", "projection", "farPlane", "normalMatrix", "unlit", "baseColorFactor", "add", "mult", "useTexture", "useNormalMap", "useMetallicRoughnessMap", "neg", "gray", "hue",
+		"enableAlpha", "alphaThreshold", "numJoints", "morphTargetWeight", "morphTargetOffset", "numTargets", "numVertices",
+		"metallicRoughness", "ambientOcclusionStrength", "environmentIntensity", "mipCount",
+		"cameraPosition", "environmentRotation",
+		"lightMatrices[0]", "lightMatrices[1]", "lightMatrices[2]", "lightMatrices[3]",
+		"lights[0].direction", "lights[0].range", "lights[0].color", "lights[0].intensity", "lights[0].position", "lights[0].innerConeCos", "lights[0].outerConeCos", "lights[0].type", "lights[0].shadowBias", "lights[0].shadowMapFar",
+		"lights[1].direction", "lights[1].range", "lights[1].color", "lights[1].intensity", "lights[1].position", "lights[1].innerConeCos", "lights[1].outerConeCos", "lights[1].type", "lights[1].shadowBias", "lights[1].shadowMapFar",
+		"lights[2].direction", "lights[2].range", "lights[2].color", "lights[2].intensity", "lights[2].position", "lights[2].innerConeCos", "lights[2].outerConeCos", "lights[2].type", "lights[2].shadowBias", "lights[2].shadowMapFar",
+		"lights[3].direction", "lights[3].range", "lights[3].color", "lights[3].intensity", "lights[3].position", "lights[3].innerConeCos", "lights[3].outerConeCos", "lights[3].type", "lights[3].shadowBias", "lights[3].shadowMapFar",
+	)
+	r.modelShader.RegisterTextures("tex", "morphTargetValues", "jointMatrices", "normalMap", "metallicRoughnessMap", "ambientOcclusionMap", "lambertianEnvSampler", "GGXEnvSampler", "GGXLUT",
+		"shadowMap[0]", "shadowMap[1]", "shadowMap[2]", "shadowMap[3]",
+		"shadowCubeMap[0]", "shadowCubeMap[1]", "shadowCubeMap[2]", "shadowCubeMap[3]")
+
+	r.shadowMapShader = newShaderProgram(shadowVertShader, shadowFragShader, shadowGeoShader, "Shadow Map Shader")
+	//r.shadowMapShader = newShaderProgram(shadowVertShader, shadowFragShader, "", "Shadow Map Shader")
+	r.shadowMapShader.RegisterAttributes("vertexId", "position", "vertColor", "uv", "joints_0", "joints_1", "weights_0", "weights_1")
+	r.shadowMapShader.RegisterUniforms("model", "lightMatrices[0]", "lightMatrices[1]", "lightMatrices[2]", "lightMatrices[3]", "lightMatrices[4]", "lightMatrices[5]", "lightType", "lightPos", "farPlane", "numJoints", "morphTargetWeight", "morphTargetOffset", "numTargets", "numVertices", "enableAlpha", "alphaThreshold", "baseColorFactor", "useTexture")
+	r.shadowMapShader.RegisterTextures("morphTargetValues", "jointMatrices", "tex")
+
+	r.panoramaToCubemapShader = newShaderProgram(identVertShader, panoramaToCubemapFragShader, "", "Panorama To Cubemap Shader")
+	r.panoramaToCubemapShader.RegisterAttributes("VertCoord")
+	r.panoramaToCubemapShader.RegisterUniforms("currentFace")
+	r.panoramaToCubemapShader.RegisterTextures("panorama")
+
+	r.cubemapFilteringShader = newShaderProgram(identVertShader, cubemapFilteringFragShader, "", "Cubemap Filtering Shader")
+	r.cubemapFilteringShader.RegisterAttributes("VertCoord")
+	r.cubemapFilteringShader.RegisterUniforms("sampleCount", "distribution", "width", "currentFace", "roughness", "intensityScale", "isLUT")
+	r.cubemapFilteringShader.RegisterTextures("cubeMap")
 
 	// Compile postprocessing shaders
 
@@ -320,14 +436,14 @@ func (r *Renderer) Init() {
 	r.postShaderSelect = make([]*ShaderProgram, 1+len(sys.externalShaderList))
 
 	// Ident shader (no postprocessing)
-	r.postShaderSelect[0] = newShaderProgram(identVertShader, identFragShader, "Identity Postprocess")
+	r.postShaderSelect[0] = newShaderProgram(identVertShader, identFragShader, "", "Identity Postprocess")
 	r.postShaderSelect[0].RegisterAttributes("VertCoord")
 	r.postShaderSelect[0].RegisterUniforms("Texture", "TextureSize", "CurrentTime")
 
 	// External Shaders
 	for i := 0; i < len(sys.externalShaderList); i++ {
 		r.postShaderSelect[1+i] = newShaderProgram(sys.externalShaders[0][i],
-			sys.externalShaders[1][i], fmt.Sprintf("Postprocess Shader #%v", i+1))
+			sys.externalShaders[1][i], "", fmt.Sprintf("Postprocess Shader #%v", i+1))
 		r.postShaderSelect[1+i].RegisterUniforms("Texture", "TextureSize", "CurrentTime")
 	}
 
@@ -396,9 +512,38 @@ func (r *Renderer) Init() {
 		gl.FramebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, r.fbo_texture, 0)
 		gl.FramebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, r.rbo_depth)
 	}
+	gl.GenFramebuffersEXT(1, &r.fbo_shadow)
+	gl.ActiveTexture(gl.TEXTURE0)
+	gl.GenTextures(4, &r.fbo_shadow_texture[0])
+	gl.GenTextures(4, &r.fbo_shadow_cube_texture[0])
+
+	for i := 0; i < 4; i++ {
+		gl.BindTexture(gl.TEXTURE_2D, r.fbo_shadow_texture[i])
+
+		gl.TexImage2D(gl.TEXTURE_2D, 0, gl.DEPTH_COMPONENT, 1024, 1024, 0, gl.DEPTH_COMPONENT, gl.FLOAT, nil)
+		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
+		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
+		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+
+		gl.BindTexture(gl.TEXTURE_CUBE_MAP, r.fbo_shadow_cube_texture[i])
+		for j := 0; j < 6; j++ {
+			gl.TexImage2D(uint32(gl.TEXTURE_CUBE_MAP_POSITIVE_X+j), 0, gl.DEPTH_COMPONENT, 1024, 1024, 0, gl.DEPTH_COMPONENT, gl.FLOAT, nil)
+		}
+		gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
+		gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
+		gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+		gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+	}
+	gl.BindFramebufferEXT(gl.FRAMEBUFFER, r.fbo_shadow)
+	//gl.FramebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.TEXTURE_2D, r.fbo_shadow_texture[0], 0)
+	gl.DrawBuffer(gl.NONE)
+	gl.ReadBuffer(gl.NONE)
 	if status := gl.CheckFramebufferStatus(gl.FRAMEBUFFER); status != gl.FRAMEBUFFER_COMPLETE {
 		sys.errLog.Printf("framebuffer create failed: 0x%x", status)
 	}
+
+	gl.GenFramebuffers(1, &r.fbo_env)
 
 	gl.BindFramebuffer(gl.FRAMEBUFFER, 0)
 }
@@ -461,7 +606,7 @@ func (r *Renderer) EndFrame() {
 
 	gl.BindBuffer(gl.ARRAY_BUFFER, r.postVertBuffer)
 
-	loc := r.modelShader.a["VertCoord"]
+	loc := postShader.a["VertCoord"]
 	gl.EnableVertexAttribArray(uint32(loc))
 	gl.VertexAttribPointerWithOffset(uint32(loc), 2, gl.FLOAT, false, 0, 0)
 
@@ -494,11 +639,196 @@ func (r *Renderer) ReleasePipeline() {
 	gl.Disable(gl.BLEND)
 }
 
-func (r *Renderer) SetModelPipeline(eq BlendEquation, src, dst BlendFunc, depthTest, depthMask, doubleSided, invertFrontFace, useUV, useVertColor, useJoint0, useJoint1 bool, numVertices, vertAttrOffset uint32) {
-	gl.UseProgram(r.modelShader.program)
-
+func (r *Renderer) prepareShadowMapPipeline() {
+	gl.UseProgram(r.shadowMapShader.program)
+	gl.BindFramebufferEXT(gl.FRAMEBUFFER, r.fbo_shadow)
+	gl.Viewport(0, 0, 1024, 1024)
 	gl.Enable(gl.TEXTURE_2D)
+	gl.Disable(gl.BLEND)
+	gl.Enable(gl.DEPTH_TEST)
+	//gl.DepthFunc(gl.LESS)
+	//gl.DepthMask(true)
+
+	gl.BlendEquation(gl.FUNC_ADD)
+	gl.BlendFunc(gl.ONE, gl.ZERO)
+
+	gl.BindBuffer(gl.ARRAY_BUFFER, r.stageVertexBuffer)
+	gl.BindBuffer(gl.ELEMENT_ARRAY_BUFFER, r.stageIndexBuffer)
+}
+func (r *Renderer) setShadowMapPipeline(doubleSided, invertFrontFace, useUV, useNormal, useTangent, useVertColor, useJoint0, useJoint1 bool, numVertices, vertAttrOffset uint32) {
+	if invertFrontFace {
+		gl.FrontFace(gl.CW)
+	} else {
+		gl.FrontFace(gl.CCW)
+	}
+	if !doubleSided {
+		gl.Enable(gl.CULL_FACE)
+		gl.CullFace(gl.BACK)
+	} else {
+		gl.Disable(gl.CULL_FACE)
+	}
+
+	loc := r.shadowMapShader.a["vertexId"]
+	gl.EnableVertexAttribArray(uint32(loc))
+	gl.VertexAttribPointerWithOffset(uint32(loc), 1, gl.INT, false, 0, uintptr(vertAttrOffset))
+	offset := vertAttrOffset + 4*numVertices
+
+	loc = r.shadowMapShader.a["position"]
+	gl.EnableVertexAttribArray(uint32(loc))
+	gl.VertexAttribPointerWithOffset(uint32(loc), 3, gl.FLOAT, false, 0, uintptr(offset))
+	offset += 12 * numVertices
+	if useUV {
+		loc = r.shadowMapShader.a["uv"]
+		gl.EnableVertexAttribArray(uint32(loc))
+		gl.VertexAttribPointerWithOffset(uint32(loc), 2, gl.FLOAT, false, 0, uintptr(offset))
+		offset += 8 * numVertices
+	} else {
+		loc = r.shadowMapShader.a["uv"]
+		gl.DisableVertexAttribArray(uint32(loc))
+		gl.VertexAttrib2f(uint32(loc), 0, 0)
+	}
+	if useNormal {
+		offset += 12 * numVertices
+	}
+	if useTangent {
+		offset += 16 * numVertices
+	}
+	if useVertColor {
+		loc = r.shadowMapShader.a["vertColor"]
+		gl.EnableVertexAttribArray(uint32(loc))
+		gl.VertexAttribPointerWithOffset(uint32(loc), 4, gl.FLOAT, false, 0, uintptr(offset))
+		offset += 16 * numVertices
+	} else {
+		loc = r.shadowMapShader.a["vertColor"]
+		gl.DisableVertexAttribArray(uint32(loc))
+		gl.VertexAttrib4f(uint32(loc), 1, 1, 1, 1)
+	}
+	if useJoint0 {
+		loc = r.shadowMapShader.a["joints_0"]
+		gl.EnableVertexAttribArray(uint32(loc))
+		gl.VertexAttribPointerWithOffset(uint32(loc), 4, gl.FLOAT, false, 0, uintptr(offset))
+		offset += 16 * numVertices
+		loc = r.shadowMapShader.a["weights_0"]
+		gl.EnableVertexAttribArray(uint32(loc))
+		gl.VertexAttribPointerWithOffset(uint32(loc), 4, gl.FLOAT, false, 0, uintptr(offset))
+		offset += 16 * numVertices
+		if useJoint1 {
+			loc = r.shadowMapShader.a["joints_1"]
+			gl.EnableVertexAttribArray(uint32(loc))
+			gl.VertexAttribPointerWithOffset(uint32(loc), 4, gl.FLOAT, false, 0, uintptr(offset))
+			offset += 16 * numVertices
+			loc = r.shadowMapShader.a["weights_1"]
+			gl.EnableVertexAttribArray(uint32(loc))
+			gl.VertexAttribPointerWithOffset(uint32(loc), 4, gl.FLOAT, false, 0, uintptr(offset))
+			offset += 16 * numVertices
+		} else {
+			loc = r.shadowMapShader.a["joints_1"]
+			gl.DisableVertexAttribArray(uint32(loc))
+			gl.VertexAttrib4f(uint32(loc), 0, 0, 0, 0)
+			loc = r.shadowMapShader.a["weights_1"]
+			gl.DisableVertexAttribArray(uint32(loc))
+			gl.VertexAttrib4f(uint32(loc), 0, 0, 0, 0)
+		}
+	} else {
+		loc = r.shadowMapShader.a["joints_0"]
+		gl.DisableVertexAttribArray(uint32(loc))
+		gl.VertexAttrib4f(uint32(loc), 0, 0, 0, 0)
+		loc = r.shadowMapShader.a["weights_0"]
+		gl.DisableVertexAttribArray(uint32(loc))
+		gl.VertexAttrib4f(uint32(loc), 0, 0, 0, 0)
+		loc = r.shadowMapShader.a["joints_1"]
+		gl.DisableVertexAttribArray(uint32(loc))
+		gl.VertexAttrib4f(uint32(loc), 0, 0, 0, 0)
+		loc = r.shadowMapShader.a["weights_1"]
+		gl.DisableVertexAttribArray(uint32(loc))
+		gl.VertexAttrib4f(uint32(loc), 0, 0, 0, 0)
+	}
+}
+
+func (r *Renderer) ReleaseShadowPipeline() {
+	loc := r.modelShader.a["vertexId"]
+	gl.DisableVertexAttribArray(uint32(loc))
+	loc = r.modelShader.a["position"]
+	gl.DisableVertexAttribArray(uint32(loc))
+	loc = r.modelShader.a["uv"]
+	gl.DisableVertexAttribArray(uint32(loc))
+	loc = r.modelShader.a["vertColor"]
+	gl.DisableVertexAttribArray(uint32(loc))
+	loc = r.modelShader.a["joints_0"]
+	gl.DisableVertexAttribArray(uint32(loc))
+	loc = r.modelShader.a["weights_0"]
+	gl.DisableVertexAttribArray(uint32(loc))
+	loc = r.modelShader.a["joints_1"]
+	gl.DisableVertexAttribArray(uint32(loc))
+	loc = r.modelShader.a["weights_1"]
+	gl.DisableVertexAttribArray(uint32(loc))
+	//gl.Disable(gl.TEXTURE_2D)
+	gl.DepthMask(true)
+	gl.Disable(gl.DEPTH_TEST)
+	gl.Disable(gl.CULL_FACE)
+	gl.Disable(gl.BLEND)
+}
+func (r *Renderer) prepareModelPipeline(env *Environment) {
+	gl.UseProgram(r.modelShader.program)
+	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo)
+	gl.Viewport(0, 0, sys.scrrect[2], sys.scrrect[3])
+	gl.Clear(gl.DEPTH_BUFFER_BIT)
+	gl.Enable(gl.TEXTURE_2D)
+	gl.Enable(gl.TEXTURE_CUBE_MAP)
 	gl.Enable(gl.BLEND)
+	gl.BindBuffer(gl.ARRAY_BUFFER, r.stageVertexBuffer)
+	gl.BindBuffer(gl.ELEMENT_ARRAY_BUFFER, r.stageIndexBuffer)
+	for i := 0; i < 4; i++ {
+		loc, unit := r.modelShader.u["shadowMap["+strconv.Itoa(i)+"]"], r.modelShader.t["shadowMap["+strconv.Itoa(i)+"]"]
+		gl.ActiveTexture((uint32(gl.TEXTURE0 + unit)))
+		gl.BindTexture(gl.TEXTURE_2D, r.fbo_shadow_texture[i])
+		gl.Uniform1i(loc, int32(unit))
+		loc, unit = r.modelShader.u["shadowCubeMap["+strconv.Itoa(i)+"]"], r.modelShader.t["shadowCubeMap["+strconv.Itoa(i)+"]"]
+		gl.ActiveTexture((uint32(gl.TEXTURE0 + unit)))
+		gl.BindTexture(gl.TEXTURE_CUBE_MAP, r.fbo_shadow_cube_texture[i])
+		gl.Uniform1i(loc, int32(unit))
+	}
+	if env != nil {
+		loc, unit := r.modelShader.u["lambertianEnvSampler"], r.modelShader.t["lambertianEnvSampler"]
+		gl.ActiveTexture((uint32(gl.TEXTURE0 + unit)))
+		gl.BindTexture(gl.TEXTURE_CUBE_MAP, env.lambertianTexture.tex.handle)
+		gl.Uniform1i(loc, int32(unit))
+		loc, unit = r.modelShader.u["GGXEnvSampler"], r.modelShader.t["GGXEnvSampler"]
+		gl.ActiveTexture((uint32(gl.TEXTURE0 + unit)))
+		gl.BindTexture(gl.TEXTURE_CUBE_MAP, env.GGXTexture.tex.handle)
+		gl.Uniform1i(loc, int32(unit))
+		loc, unit = r.modelShader.u["GGXLUT"], r.modelShader.t["GGXLUT"]
+		gl.ActiveTexture((uint32(gl.TEXTURE0 + unit)))
+		gl.BindTexture(gl.TEXTURE_2D, env.GGXLUT.tex.handle)
+		gl.Uniform1i(loc, int32(unit))
+
+		loc = r.modelShader.u["environmentIntensity"]
+		gl.Uniform1f(loc, env.environmentIntensity)
+		loc = r.modelShader.u["mipCount"]
+		gl.Uniform1i(loc, env.mipmapLevels)
+		loc = r.modelShader.u["environmentRotation"]
+		rotationMatrix := mgl.Rotate3DX(math.Pi).Mul3(mgl.Rotate3DY(0.5 * math.Pi))
+		rotationM := rotationMatrix[:]
+		gl.UniformMatrix3fv(loc, 1, false, &rotationM[0])
+
+	} else {
+		loc, unit := r.modelShader.u["lambertianEnvSampler"], r.modelShader.t["lambertianEnvSampler"]
+		gl.ActiveTexture((uint32(gl.TEXTURE0 + unit)))
+		gl.BindTexture(gl.TEXTURE_CUBE_MAP, 0)
+		gl.Uniform1i(loc, int32(unit))
+		loc, unit = r.modelShader.u["GGXEnvSampler"], r.modelShader.t["GGXEnvSampler"]
+		gl.ActiveTexture((uint32(gl.TEXTURE0 + unit)))
+		gl.BindTexture(gl.TEXTURE_CUBE_MAP, 0)
+		gl.Uniform1i(loc, int32(unit))
+		loc, unit = r.modelShader.u["GGXLUT"], r.modelShader.t["GGXLUT"]
+		gl.ActiveTexture((uint32(gl.TEXTURE0 + unit)))
+		gl.BindTexture(gl.TEXTURE_2D, 0)
+		gl.Uniform1i(loc, int32(unit))
+		loc = r.modelShader.u["environmentIntensity"]
+		gl.Uniform1f(loc, 0)
+	}
+}
+func (r *Renderer) SetModelPipeline(eq BlendEquation, src, dst BlendFunc, depthTest, depthMask, doubleSided, invertFrontFace, useUV, useNormal, useTangent, useVertColor, useJoint0, useJoint1 bool, numVertices, vertAttrOffset uint32) {
 	if depthTest {
 		gl.Enable(gl.DEPTH_TEST)
 		gl.DepthFunc(gl.LESS)
@@ -521,12 +851,15 @@ func (r *Renderer) SetModelPipeline(eq BlendEquation, src, dst BlendFunc, depthT
 	gl.BlendEquation(BlendEquationLUT[eq])
 	gl.BlendFunc(BlendFunctionLUT[src], BlendFunctionLUT[dst])
 
-	gl.BindBuffer(gl.ARRAY_BUFFER, r.stageVertexBuffer)
-	gl.BindBuffer(gl.ELEMENT_ARRAY_BUFFER, r.stageIndexBuffer)
-	loc := r.modelShader.a["position"]
+	loc := r.modelShader.a["vertexId"]
 	gl.EnableVertexAttribArray(uint32(loc))
-	gl.VertexAttribPointerWithOffset(uint32(loc), 3, gl.FLOAT, false, 0, uintptr(vertAttrOffset))
-	offset := vertAttrOffset + 12*numVertices
+	gl.VertexAttribPointerWithOffset(uint32(loc), 1, gl.INT, false, 0, uintptr(vertAttrOffset))
+	offset := vertAttrOffset + 4*numVertices
+
+	loc = r.modelShader.a["position"]
+	gl.EnableVertexAttribArray(uint32(loc))
+	gl.VertexAttribPointerWithOffset(uint32(loc), 3, gl.FLOAT, false, 0, uintptr(offset))
+	offset += 12 * numVertices
 	if useUV {
 		loc = r.modelShader.a["uv"]
 		gl.EnableVertexAttribArray(uint32(loc))
@@ -535,6 +868,24 @@ func (r *Renderer) SetModelPipeline(eq BlendEquation, src, dst BlendFunc, depthT
 	} else {
 		loc = r.modelShader.a["uv"]
 		gl.VertexAttrib2f(uint32(loc), 0, 0)
+	}
+	if useNormal {
+		loc = r.modelShader.a["normalIn"]
+		gl.EnableVertexAttribArray(uint32(loc))
+		gl.VertexAttribPointerWithOffset(uint32(loc), 3, gl.FLOAT, false, 0, uintptr(offset))
+		offset += 12 * numVertices
+	} else {
+		loc = r.modelShader.a["normalIn"]
+		gl.VertexAttrib3f(uint32(loc), 0, 0, 0)
+	}
+	if useTangent {
+		loc = r.modelShader.a["tangentIn"]
+		gl.EnableVertexAttribArray(uint32(loc))
+		gl.VertexAttribPointerWithOffset(uint32(loc), 4, gl.FLOAT, false, 0, uintptr(offset))
+		offset += 16 * numVertices
+	} else {
+		loc = r.modelShader.a["tangentIn"]
+		gl.VertexAttrib4f(uint32(loc), 0, 0, 0, 0)
 	}
 	if useVertColor {
 		loc = r.modelShader.a["vertColor"]
@@ -581,7 +932,9 @@ func (r *Renderer) SetModelPipeline(eq BlendEquation, src, dst BlendFunc, depthT
 	}
 }
 func (r *Renderer) ReleaseModelPipeline() {
-	loc := r.modelShader.a["position"]
+	loc := r.modelShader.a["vertexId"]
+	gl.DisableVertexAttribArray(uint32(loc))
+	loc = r.modelShader.a["position"]
 	gl.DisableVertexAttribArray(uint32(loc))
 	loc = r.modelShader.a["uv"]
 	gl.DisableVertexAttribArray(uint32(loc))
@@ -595,33 +948,10 @@ func (r *Renderer) ReleaseModelPipeline() {
 	gl.DisableVertexAttribArray(uint32(loc))
 	loc = r.modelShader.a["weights_1"]
 	gl.DisableVertexAttribArray(uint32(loc))
-	loc = r.modelShader.a["morphTargets"]
-	gl.DisableVertexAttribArray(uint32(loc))
-	gl.DisableVertexAttribArray(uint32(loc + 1))
-	gl.DisableVertexAttribArray(uint32(loc + 2))
-	gl.DisableVertexAttribArray(uint32(loc + 3))
-	gl.DisableVertexAttribArray(uint32(loc + 4))
-	gl.DisableVertexAttribArray(uint32(loc + 5))
-	gl.DisableVertexAttribArray(uint32(loc + 6))
-	gl.DisableVertexAttribArray(uint32(loc + 7))
 	//gl.Disable(gl.TEXTURE_2D)
 	gl.DepthMask(true)
 	gl.Disable(gl.DEPTH_TEST)
 	gl.Disable(gl.CULL_FACE)
-	gl.Disable(gl.BLEND)
-}
-func (r *Renderer) SetModelMorphTarget(offsets [8]uint32, weights [8]float32, positionTargetCount, uvTargetCount int) {
-	r.SetModelUniformFv("morphTargetWeight", weights[:])
-	r.SetModelUniformI("positionTargetCount", int(positionTargetCount))
-	r.SetModelUniformI("uvTargetCount", int(uvTargetCount))
-	for i, offset := range offsets {
-		if offset != 0 {
-			loc := r.modelShader.a["morphTargets_0"] + int32(i)
-			gl.EnableVertexAttribArray(uint32(loc))
-			gl.VertexAttribPointerWithOffset(uint32(loc), 4, gl.FLOAT, false, 0, uintptr(offset))
-		}
-	}
-
 }
 
 func (r *Renderer) ReadPixels(data []uint8, width, height int) {
@@ -727,6 +1057,59 @@ func (r *Renderer) SetModelTexture(name string, t *Texture) {
 	gl.Uniform1i(loc, int32(unit))
 }
 
+func (r *Renderer) SetShadowMapUniformI(name string, val int) {
+	loc := r.shadowMapShader.u[name]
+	gl.Uniform1i(loc, int32(val))
+}
+
+func (r *Renderer) SetShadowMapUniformF(name string, values ...float32) {
+	loc := r.shadowMapShader.u[name]
+	switch len(values) {
+	case 1:
+		gl.Uniform1f(loc, values[0])
+	case 2:
+		gl.Uniform2f(loc, values[0], values[1])
+	case 3:
+		gl.Uniform3f(loc, values[0], values[1], values[2])
+	case 4:
+		gl.Uniform4f(loc, values[0], values[1], values[2], values[3])
+	}
+}
+func (r *Renderer) SetShadowMapUniformFv(name string, values []float32) {
+	loc := r.shadowMapShader.u[name]
+	switch len(values) {
+	case 2:
+		gl.Uniform2fv(loc, 1, &values[0])
+	case 3:
+		gl.Uniform3fv(loc, 1, &values[0])
+	case 4:
+		gl.Uniform4fv(loc, 1, &values[0])
+	case 8:
+		gl.Uniform4fv(loc, 2, &values[0])
+	}
+}
+func (r *Renderer) SetShadowMapUniformMatrix(name string, value []float32) {
+	loc := r.shadowMapShader.u[name]
+	gl.UniformMatrix4fv(loc, 1, false, &value[0])
+}
+
+func (r *Renderer) SetShadowMapTexture(name string, t *Texture) {
+	loc, unit := r.shadowMapShader.u[name], r.shadowMapShader.t[name]
+	gl.ActiveTexture((uint32(gl.TEXTURE0 + unit)))
+	gl.BindTexture(gl.TEXTURE_2D, t.handle)
+	gl.Uniform1i(loc, int32(unit))
+}
+
+func (r *Renderer) SetShadowFrameTexture(i uint32) {
+	gl.FramebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.TEXTURE_2D, r.fbo_shadow_texture[i], 0)
+	gl.Clear(gl.DEPTH_BUFFER_BIT)
+}
+
+func (r *Renderer) SetShadowFrameCubeTexture(i uint32) {
+	gl.FramebufferTextureEXT(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT_EXT, r.fbo_shadow_cube_texture[i], 0)
+	gl.Clear(gl.DEPTH_BUFFER_BIT)
+}
+
 func (r *Renderer) SetVertexData(values ...float32) {
 	data := f32.Bytes(binary.LittleEndian, values...)
 	gl.BindBuffer(gl.ARRAY_BUFFER, r.vertexBuffer)
@@ -749,4 +1132,107 @@ func (r *Renderer) RenderQuad() {
 }
 func (r *Renderer) RenderElements(mode PrimitiveMode, count, offset int) {
 	gl.DrawElementsWithOffset(PrimitiveModeLUT[mode], int32(count), gl.UNSIGNED_INT, uintptr(offset))
+}
+
+func (r *Renderer) RenderCubeMap(envTexture *Texture, cubeTexture *Texture, textureSize int32) {
+	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_env)
+	gl.Viewport(0, 0, textureSize, textureSize)
+	gl.UseProgram(r.panoramaToCubemapShader.program)
+	loc := r.panoramaToCubemapShader.a["VertCoord"]
+	gl.EnableVertexAttribArray(uint32(loc))
+	gl.VertexAttribPointerWithOffset(uint32(loc), 2, gl.FLOAT, false, 0, 0)
+	data := f32.Bytes(binary.LittleEndian, -1, -1, 1, -1, -1, 1, 1, 1)
+	gl.BindBuffer(gl.ARRAY_BUFFER, r.vertexBuffer)
+	gl.BufferData(gl.ARRAY_BUFFER, len(data), unsafe.Pointer(&data[0]), gl.STATIC_DRAW)
+	loc, unit := r.panoramaToCubemapShader.u["panorama"], r.panoramaToCubemapShader.t["panorama"]
+	gl.ActiveTexture((uint32(gl.TEXTURE0 + unit)))
+	gl.BindTexture(gl.TEXTURE_2D, envTexture.handle)
+	gl.Uniform1i(loc, int32(unit))
+	for i := 0; i < 6; i++ {
+		gl.FramebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, uint32(gl.TEXTURE_CUBE_MAP_POSITIVE_X+i), cubeTexture.handle, 0)
+
+		gl.Clear(gl.COLOR_BUFFER_BIT)
+		loc := r.panoramaToCubemapShader.u["currentFace"]
+		gl.Uniform1i(loc, int32(i))
+
+		gl.DrawArrays(gl.TRIANGLE_STRIP, 0, 4)
+	}
+	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo)
+	gl.BindTexture(gl.TEXTURE_CUBE_MAP, cubeTexture.handle)
+	gl.GenerateMipmap(gl.TEXTURE_CUBE_MAP)
+}
+func (r *Renderer) RenderFilteredCubeMap(distribution int32, cubeTexture *Texture, filteredTexture *Texture, textureSize, mipmapLevel, sampleCount int32, roughness float32) {
+	currentTextureSize := textureSize >> mipmapLevel
+	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_env)
+	gl.Viewport(0, 0, currentTextureSize, currentTextureSize)
+	gl.UseProgram(r.cubemapFilteringShader.program)
+	loc := r.cubemapFilteringShader.a["VertCoord"]
+	gl.EnableVertexAttribArray(uint32(loc))
+	gl.VertexAttribPointerWithOffset(uint32(loc), 2, gl.FLOAT, false, 0, 0)
+	data := f32.Bytes(binary.LittleEndian, -1, -1, 1, -1, -1, 1, 1, 1)
+	gl.BindBuffer(gl.ARRAY_BUFFER, r.vertexBuffer)
+	gl.BufferData(gl.ARRAY_BUFFER, len(data), unsafe.Pointer(&data[0]), gl.STATIC_DRAW)
+	loc, unit := r.cubemapFilteringShader.u["cubeMap"], r.cubemapFilteringShader.t["cubeMap"]
+	gl.ActiveTexture((uint32(gl.TEXTURE0 + unit)))
+	gl.BindTexture(gl.TEXTURE_CUBE_MAP, cubeTexture.handle)
+	gl.Uniform1i(loc, int32(unit))
+	loc = r.cubemapFilteringShader.u["sampleCount"]
+	gl.Uniform1i(loc, sampleCount)
+	loc = r.cubemapFilteringShader.u["distribution"]
+	gl.Uniform1i(loc, distribution)
+	loc = r.cubemapFilteringShader.u["width"]
+	gl.Uniform1i(loc, currentTextureSize)
+	loc = r.cubemapFilteringShader.u["roughness"]
+	gl.Uniform1f(loc, roughness)
+	loc = r.cubemapFilteringShader.u["intensityScale"]
+	gl.Uniform1f(loc, 1)
+	loc = r.cubemapFilteringShader.u["isLUT"]
+	gl.Uniform1i(loc, 0)
+	for i := 0; i < 6; i++ {
+		gl.FramebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, uint32(gl.TEXTURE_CUBE_MAP_POSITIVE_X+i), filteredTexture.handle, mipmapLevel)
+
+		gl.Clear(gl.COLOR_BUFFER_BIT)
+		loc := r.cubemapFilteringShader.u["currentFace"]
+		gl.Uniform1i(loc, int32(i))
+
+		gl.DrawArrays(gl.TRIANGLE_STRIP, 0, 4)
+	}
+	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo)
+}
+func (r *Renderer) RenderLUT(distribution int32, cubeTexture *Texture, lutTexture *Texture, textureSize, sampleCount int32) {
+	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_env)
+	gl.Viewport(0, 0, textureSize, textureSize)
+	gl.UseProgram(r.cubemapFilteringShader.program)
+	loc := r.cubemapFilteringShader.a["VertCoord"]
+	gl.EnableVertexAttribArray(uint32(loc))
+	gl.VertexAttribPointerWithOffset(uint32(loc), 2, gl.FLOAT, false, 0, 0)
+	data := f32.Bytes(binary.LittleEndian, -1, -1, 1, -1, -1, 1, 1, 1)
+	gl.BindBuffer(gl.ARRAY_BUFFER, r.vertexBuffer)
+	gl.BufferData(gl.ARRAY_BUFFER, len(data), unsafe.Pointer(&data[0]), gl.STATIC_DRAW)
+	loc, unit := r.cubemapFilteringShader.u["cubeMap"], r.cubemapFilteringShader.t["cubeMap"]
+	gl.ActiveTexture((uint32(gl.TEXTURE0 + unit)))
+	gl.BindTexture(gl.TEXTURE_CUBE_MAP, cubeTexture.handle)
+	gl.Uniform1i(loc, int32(unit))
+	loc = r.cubemapFilteringShader.u["sampleCount"]
+	gl.Uniform1i(loc, sampleCount)
+	loc = r.cubemapFilteringShader.u["distribution"]
+	gl.Uniform1i(loc, distribution)
+	loc = r.cubemapFilteringShader.u["width"]
+	gl.Uniform1i(loc, textureSize)
+	loc = r.cubemapFilteringShader.u["roughness"]
+	gl.Uniform1f(loc, 0)
+	loc = r.cubemapFilteringShader.u["intensityScale"]
+	gl.Uniform1f(loc, 1)
+	loc = r.cubemapFilteringShader.u["currentFace"]
+	gl.Uniform1i(loc, 0)
+	loc = r.cubemapFilteringShader.u["isLUT"]
+	gl.Uniform1i(loc, 1)
+
+	gl.BindTexture(gl.TEXTURE_2D, lutTexture.handle)
+	gl.TexImage2D(gl.TEXTURE_2D, 0, gl.RGBA32F_ARB, lutTexture.width, lutTexture.height, 0, gl.RGBA, gl.FLOAT, nil)
+
+	gl.FramebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, lutTexture.handle, 0)
+	gl.Clear(gl.COLOR_BUFFER_BIT)
+	gl.DrawArrays(gl.TRIANGLE_STRIP, 0, 4)
+	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo)
 }

--- a/src/shaders/cubemapFiltering.frag.glsl
+++ b/src/shaders/cubemapFiltering.frag.glsl
@@ -1,0 +1,400 @@
+#define MATH_PI 3.1415926535897932384626433832795
+
+#if __VERSION__ >= 130
+#define COMPAT_VARYING in
+#define COMPAT_TEXTURE_CUBE_LOD textureLod
+out vec4 FragColor;
+#else
+#extension GL_EXT_gpu_shader4 : enable
+#extension GL_ARB_shader_texture_lod : enable
+#define COMPAT_VARYING varying
+#define FragColor gl_FragColor
+#define COMPAT_TEXTURE_CUBE_LOD textureCubeLod
+#endif
+
+uniform samplerCube cubeMap;
+uniform int sampleCount;
+uniform int distribution;
+uniform int width;
+uniform int currentFace;
+uniform float roughness;
+uniform float intensityScale;
+uniform bool isLUT;
+COMPAT_VARYING vec2 texcoord;
+const int cLambertian = 0;
+const int cGGX = 1;
+const int cCharlie = 2;
+
+vec3 uvToXYZ(int face, vec2 uv)
+{
+    if(face == 0)
+        return vec3(     1.f,   uv.y,    -uv.x);
+
+    else if(face == 1)
+        return vec3(    -1.f,   uv.y,     uv.x);
+
+    else if(face == 2)
+        return vec3(   +uv.x,   -1.f,    +uv.y);
+
+    else if(face == 3)
+        return vec3(   +uv.x,    1.f,    -uv.y);
+
+    else if(face == 4)
+        return vec3(   +uv.x,   uv.y,      1.f);
+
+    else {//if(face == 5)
+        return vec3(    -uv.x,  +uv.y,     -1.f);}
+}
+
+vec2 dirToUV(vec3 dir)
+{
+    return vec2(
+            0.5f + 0.5f * atan(dir.z, dir.x) / MATH_PI,
+            1.f - acos(dir.y) / MATH_PI);
+}
+
+float saturate(float v)
+{
+    return clamp(v, 0.0f, 1.0f);
+}
+
+struct MicrofacetDistributionSample
+{
+    float pdf;
+    float cosTheta;
+    float sinTheta;
+    float phi;
+};
+
+float D_GGX(float NdotH, float roughness) {
+    float a = NdotH * roughness;
+    float k = roughness / (1.0 - NdotH * NdotH + a * a);
+    return k * k * (1.0 / MATH_PI);
+}
+
+// GGX microfacet distribution
+// https://www.cs.cornell.edu/~srm/publications/EGSR07-btdf.html
+// This implementation is based on https://bruop.github.io/ibl/,
+//  https://www.tobias-franke.eu/log/2014/03/30/notes_on_importance_sampling.html
+// and https://developer.nvidia.com/gpugems/GPUGems3/gpugems3_ch20.html
+MicrofacetDistributionSample GGX(vec2 xi, float roughness)
+{
+    MicrofacetDistributionSample ggx;
+
+    // evaluate sampling equations
+    float alpha = roughness * roughness;
+    ggx.cosTheta = saturate(sqrt((1.0 - xi.y) / (1.0 + (alpha * alpha - 1.0) * xi.y)));
+    ggx.sinTheta = sqrt(1.0 - ggx.cosTheta * ggx.cosTheta);
+    ggx.phi = 2.0 * MATH_PI * xi.x;
+
+    // evaluate GGX pdf (for half vector)
+    ggx.pdf = D_GGX(ggx.cosTheta, alpha);
+
+    // Apply the Jacobian to obtain a pdf that is parameterized by l
+    // see https://bruop.github.io/ibl/
+    // Typically you'd have the following:
+    // float pdf = D_GGX(NoH, roughness) * NoH / (4.0 * VoH);
+    // but since V = N => VoH == NoH
+    ggx.pdf /= 4.0;
+
+    return ggx;
+}
+
+MicrofacetDistributionSample Lambertian(vec2 xi, float roughness)
+{
+    MicrofacetDistributionSample lambertian;
+
+    // Cosine weighted hemisphere sampling
+    // http://www.pbr-book.org/3ed-2018/Monte_Carlo_Integration/2D_Sampling_with_Multidimensional_Transformations.html#Cosine-WeightedHemisphereSampling
+    lambertian.cosTheta = sqrt(1.0 - xi.y);
+    lambertian.sinTheta = sqrt(xi.y); // equivalent to `sqrt(1.0 - cosTheta*cosTheta)`;
+    lambertian.phi = 2.0 * MATH_PI * xi.x;
+
+    lambertian.pdf = lambertian.cosTheta / MATH_PI; // evaluation for solid angle, therefore drop the sinTheta
+
+    return lambertian;
+}
+#if __VERSION__ >= 130
+// Hammersley Points on the Hemisphere
+// CC BY 3.0 (Holger Dammertz)
+// http://holger.dammertz.org/stuff/notes_HammersleyOnHemisphere.html
+// with adapted interface
+float radicalInverse_VdC(uint bits)
+{
+    bits = (bits << 16u) | (bits >> 16u);
+    bits = ((bits & 0x55555555u) << 1u) | ((bits & 0xAAAAAAAAu) >> 1u);
+    bits = ((bits & 0x33333333u) << 2u) | ((bits & 0xCCCCCCCCu) >> 2u);
+    bits = ((bits & 0x0F0F0F0Fu) << 4u) | ((bits & 0xF0F0F0F0u) >> 4u);
+    bits = ((bits & 0x00FF00FFu) << 8u) | ((bits & 0xFF00FF00u) >> 8u);
+    return float(bits) * 2.3283064365386963e-10; // / 0x100000000
+}
+vec2 hammersley2d(int i, int N) {
+    return vec2(float(i)/float(N), radicalInverse_VdC(uint(i)));
+}
+#else
+float radicalInverse(int n, int base) {
+    float invBase = 1.0 / float(base);
+    float reversedDigits = 0.0;
+    float invBaseN = 1.0;
+    while (n > 0) {
+        int nextDigit = n % base;
+        reversedDigits = reversedDigits * base + float(nextDigit);
+        n = n / base;
+        invBaseN *= invBase;
+    }
+    return reversedDigits * invBaseN;
+}
+vec2 hammersley2d(int i, int N) {
+    return vec2(float(i)/float(N), radicalInverse(i, 2));
+}
+#endif
+// TBN generates a tangent bitangent normal coordinate frame from the normal
+// (the normal must be normalized)
+mat3 generateTBN(vec3 normal)
+{
+    vec3 bitangent = vec3(0.0, 1.0, 0.0);
+
+    float NdotUp = dot(normal, vec3(0.0, 1.0, 0.0));
+    float epsilon = 0.0000001;
+    if (1.0 - abs(NdotUp) <= epsilon)
+    {
+        // Sampling +Y or -Y, so we need a more robust bitangent.
+        if (NdotUp > 0.0)
+        {
+            bitangent = vec3(0.0, 0.0, 1.0);
+        }
+        else
+        {
+            bitangent = vec3(0.0, 0.0, -1.0);
+        }
+    }
+
+    vec3 tangent = normalize(cross(bitangent, normal));
+    bitangent = cross(normal, tangent);
+
+    return mat3(tangent, bitangent, normal);
+}
+// getImportanceSample returns an importance sample direction with pdf in the .w component
+vec4 getImportanceSample(int sampleIndex, vec3 N, float roughness)
+{
+    // generate a quasi monte carlo point in the unit square [0.1)^2
+    vec2 xi = hammersley2d(sampleIndex, sampleCount);
+
+    MicrofacetDistributionSample importanceSample;
+
+    // generate the points on the hemisphere with a fitting mapping for
+    // the distribution (e.g. lambertian uses a cosine importance)
+    if(distribution == cLambertian)
+    {
+        importanceSample = Lambertian(xi, roughness);
+    }
+    
+    else if(distribution == cGGX)
+    {
+        // Trowbridge-Reitz / GGX microfacet model (Walter et al)
+        // https://www.cs.cornell.edu/~srm/publications/EGSR07-btdf.html
+        importanceSample = GGX(xi, roughness);
+    }
+    /*
+    else if(distribution == cCharlie)
+    {
+        importanceSample = Charlie(xi, roughness);
+    }
+*/
+    // transform the hemisphere sample to the normal coordinate frame
+    // i.e. rotate the hemisphere to the normal direction
+    vec3 localSpaceDirection = normalize(vec3(
+        importanceSample.sinTheta * cos(importanceSample.phi), 
+        importanceSample.sinTheta * sin(importanceSample.phi), 
+        importanceSample.cosTheta
+    ));
+    mat3 TBN = generateTBN(N);
+    vec3 direction = TBN * localSpaceDirection;
+
+    return vec4(direction, importanceSample.pdf);
+}
+
+// Mipmap Filtered Samples (GPU Gems 3, 20.4)
+// https://developer.nvidia.com/gpugems/gpugems3/part-iii-rendering/chapter-20-gpu-based-importance-sampling
+// https://cgg.mff.cuni.cz/~jaroslav/papers/2007-sketch-fis/Final_sap_0073.pdf
+float computeLod(float pdf)
+{
+    // // Solid angle of current sample -- bigger for less likely samples
+    // float omegaS = 1.0 / (float(u_sampleCount) * pdf);
+    // // Solid angle of texel
+    // // note: the factor of 4.0 * MATH_PI 
+    // float omegaP = 4.0 * MATH_PI / (6.0 * float(width) * float(width));
+    // // Mip level is determined by the ratio of our sample's solid angle to a texel's solid angle 
+    // // note that 0.5 * log2 is equivalent to log4
+    // float lod = 0.5 * log2(omegaS / omegaP);
+
+    // babylon introduces a factor of K (=4) to the solid angle ratio
+    // this helps to avoid undersampling the environment map
+    // this does not appear in the original formulation by Jaroslav Krivanek and Mark Colbert
+    // log4(4) == 1
+    // lod += 1.0;
+
+    // We achieved good results by using the original formulation from Krivanek & Colbert adapted to cubemaps
+
+    // https://cgg.mff.cuni.cz/~jaroslav/papers/2007-sketch-fis/Final_sap_0073.pdf
+    float lod = 0.5 * log2( 6.0 * float(width) * float(width) / (float(sampleCount) * pdf));
+
+
+    return lod;
+}
+
+vec3 filterColor(vec3 N)
+{
+    vec3 color = vec3(0.f);
+    float weight = 0.0f;
+
+    for(int i = 0; i < sampleCount; ++i)
+    {
+        vec4 importanceSample = getImportanceSample(i, N, roughness);
+
+        vec3 H = vec3(importanceSample.xyz);
+        float pdf = importanceSample.w;
+
+        // mipmap filtered samples (GPU Gems 3, 20.4)
+        float lod = computeLod(pdf);
+
+        // apply the bias to the lod
+        //lod += u_lodBias;
+
+        if(distribution == cLambertian)
+        {
+            // sample lambertian at a lower resolution to avoid fireflies
+            vec3 lambertian = COMPAT_TEXTURE_CUBE_LOD(cubeMap, H, lod).rgb * intensityScale;
+
+            //// the below operations cancel each other out
+            // lambertian *= NdotH; // lamberts law
+            // lambertian /= pdf; // invert bias from importance sampling
+            // lambertian /= MATH_PI; // convert irradiance to radiance https://seblagarde.wordpress.com/2012/01/08/pi-or-not-to-pi-in-game-lighting-equation/
+
+            color += lambertian;
+        }
+        else if(distribution == cGGX || distribution == cCharlie)
+        {
+            // Note: reflect takes incident vector.
+            vec3 V = N;
+            vec3 L = normalize(reflect(-V, H));
+            float NdotL = dot(N, L);
+
+            if (NdotL > 0.0)
+            {
+                if(roughness == 0.0)
+                {
+                    // without this the roughness=0 lod is too high
+                    //lod = u_lodBias;
+                    lod = 0;
+                }
+                vec3 sampleColor = COMPAT_TEXTURE_CUBE_LOD(cubeMap, L, lod).rgb * intensityScale;
+                color += sampleColor * NdotL;
+                weight += NdotL;
+            }
+        }
+    }
+
+    if(weight != 0.0f)
+    {
+        color /= weight;
+    }
+    else
+    {
+        color /= float(sampleCount);
+    }
+
+    return color.rgb ;
+}
+
+// From the filament docs. Geometric Shadowing function
+// https://google.github.io/filament/Filament.html#toc4.4.2
+float V_SmithGGXCorrelated(float NoV, float NoL, float roughness) {
+    float a2 = pow(roughness, 4.0);
+    float GGXV = NoL * sqrt(NoV * NoV * (1.0 - a2) + a2);
+    float GGXL = NoV * sqrt(NoL * NoL * (1.0 - a2) + a2);
+    return 0.5 / (GGXV + GGXL);
+}
+
+// Compute LUT for GGX distribution.
+// See https://blog.selfshadow.com/publications/s2013-shading-course/karis/s2013_pbs_epic_notes_v2.pdf
+vec3 LUT(float NdotV, float roughness)
+{
+    // Compute spherical view vector: (sin(phi), 0, cos(phi))
+    vec3 V = vec3(sqrt(1.0 - NdotV * NdotV), 0.0, NdotV);
+
+    // The macro surface normal just points up.
+    vec3 N = vec3(0.0, 0.0, 1.0);
+
+    // To make the LUT independant from the material's F0, which is part of the Fresnel term
+    // when substituted by Schlick's approximation, we factor it out of the integral,
+    // yielding to the form: F0 * I1 + I2
+    // I1 and I2 are slighlty different in the Fresnel term, but both only depend on
+    // NoL and roughness, so they are both numerically integrated and written into two channels.
+    float A = 0.0;
+    float B = 0.0;
+    float C = 0.0;
+
+    for(int i = 0; i < sampleCount; ++i)
+    {
+        // Importance sampling, depending on the distribution.
+        vec4 importanceSample = getImportanceSample(i, N, roughness);
+        vec3 H = importanceSample.xyz;
+        // float pdf = importanceSample.w;
+        vec3 L = normalize(reflect(-V, H));
+
+        float NdotL = saturate(L.z);
+        float NdotH = saturate(H.z);
+        float VdotH = saturate(dot(V, H));
+        if (NdotL > 0.0)
+        {
+            if (distribution == cGGX)
+            {
+                // LUT for GGX distribution.
+
+                // Taken from: https://bruop.github.io/ibl
+                // Shadertoy: https://www.shadertoy.com/view/3lXXDB
+                // Terms besides V are from the GGX PDF we're dividing by.
+                float V_pdf = V_SmithGGXCorrelated(NdotV, NdotL, roughness) * VdotH * NdotL / NdotH;
+                float Fc = pow(1.0 - VdotH, 5.0);
+                A += (1.0 - Fc) * V_pdf;
+                B += Fc * V_pdf;
+                C += 0.0;
+            }
+        }
+    }
+
+    // The PDF is simply pdf(v, h) -> NDF * <nh>.
+    // To parametrize the PDF over l, use the Jacobian transform, yielding to: pdf(v, l) -> NDF * <nh> / 4<vh>
+    // Since the BRDF divide through the PDF to be normalized, the 4 can be pulled out of the integral.
+    return vec3(4.0 * A, 4.0 * B, 4.0 * 2.0 * MATH_PI * C) / float(sampleCount);
+}
+
+void main()
+{
+    vec3 color = vec3(0);
+
+    if(!isLUT){
+        vec2 newUV = texcoord ;
+
+        newUV = newUV*2.0-1.0;
+
+        vec3 scan = uvToXYZ(currentFace, newUV);
+
+        vec3 direction = normalize(scan);
+        direction.y = -direction.y;
+
+        color = filterColor(direction);
+
+        gl_FragColor.a = 1.0;
+        
+        gl_FragColor.rgb = color;
+    }else{
+        color = LUT(texcoord.x, texcoord.y);
+        gl_FragColor.rgb = color;
+        gl_FragColor.a = 1.0;
+        return;
+    }
+
+    
+}

--- a/src/shaders/model.frag.glsl
+++ b/src/shaders/model.frag.glsl
@@ -1,25 +1,363 @@
 #if __VERSION__ >= 130
 #define COMPAT_VARYING in
 #define COMPAT_TEXTURE texture
+#define COMPAT_TEXTURE_CUBE texture
+#define COMPAT_TEXTURE_CUBE_LOD textureLod
 out vec4 FragColor;
 #else
 #define COMPAT_VARYING varying
 #define FragColor gl_FragColor
 #define COMPAT_TEXTURE texture2D
+#define COMPAT_TEXTURE_CUBE textureCube
+#define COMPAT_TEXTURE_CUBE_LOD textureCubeLod
 #endif
+struct Light
+{
+    vec3 direction;
+    float range;
+
+    vec3 color;
+    float intensity;
+
+    vec3 position;
+    float innerConeCos;
+
+    float outerConeCos;
+    int type;
+
+    float shadowBias;
+    float shadowMapFar;
+};
 
 uniform sampler2D tex;
+uniform sampler2D normalMap;
+uniform sampler2D metallicRoughnessMap;
+uniform sampler2D ambientOcclusionMap;
+uniform sampler2D shadowMap[4];
+uniform samplerCube shadowCubeMap[4];
+uniform samplerCube lambertianEnvSampler;
+uniform samplerCube GGXEnvSampler;
+uniform sampler2D GGXLUT;
+uniform float environmentIntensity;
+uniform mat3 environmentRotation;
+uniform int mipCount;
+
+uniform vec3 cameraPosition;
+
 uniform vec4 baseColorFactor;
+uniform vec2 metallicRoughness;
+uniform float ambientOcclusionStrength;
+uniform bool unlit;
+
+uniform Light lights[4];
+
+
 uniform vec3 add, mult;
 uniform float gray, hue;
-uniform bool textured;
+uniform bool useTexture;
+uniform bool useNormalMap;
+uniform bool useMetallicRoughnessMap;
 uniform bool neg;
 uniform bool enableAlpha;
 uniform float alphaThreshold;
 
 COMPAT_VARYING vec2 texcoord;
 COMPAT_VARYING vec4 vColor;
+COMPAT_VARYING vec3 normal;
+COMPAT_VARYING vec3 tangent;
+COMPAT_VARYING vec3 bitangent;
+COMPAT_VARYING vec3 worldSpacePos;
+COMPAT_VARYING vec4 lightSpacePos[4];
 
+const float PI = 3.14159265358979;
+const int LightType_Directional = 0;
+const int LightType_Point = 1;
+const int LightType_Spot = 2;
+
+float clampedDot(vec3 x, vec3 y)
+{
+    return clamp(dot(x, y), 0.0, 1.0);
+}
+
+float DirectionalLightShadowCalculation(int index, vec4 lightSpacePos,float NdotL,float shadowBias)
+{
+    // perform perspective divide
+    vec3 projCoords = lightSpacePos.xyz / lightSpacePos.w;
+    // transform to [0,1] range
+    projCoords = projCoords * 0.5 + 0.5;
+    // get closest depth value from light's perspective (using [0,1] range fragPosLight as coords)
+    float closestDepth = COMPAT_TEXTURE(shadowMap[index], projCoords.xy).r; 
+    // get depth of current fragment from light's perspective
+    float currentDepth = projCoords.z;
+    // check whether current frag pos is in shadow
+    float bias = shadowBias*tan(acos(NdotL));
+    float shadow = closestDepth-currentDepth > -bias  ? 1.0 : 0;
+
+    return shadow;
+}
+
+float SpotLightShadowCalculation(int index, vec3 pointToLight, vec4 lightSpacePos,float NdotL,float farPlane,float shadowBias)
+{
+    float closestDepth = COMPAT_TEXTURE(shadowMap[index], lightSpacePos.xy).r;
+    // it is currently in linear range between [0,1]. Re-transform back to original value
+    closestDepth *= farPlane;
+    // get depth of current fragment from light's perspective
+    float currentDepth = length(pointToLight);
+    float bias = shadowBias*tan(acos(NdotL));
+    float shadow = currentDepth-closestDepth < bias  ? 1.0 : 0;
+
+    return shadow;
+}
+
+float PointLightShadowCalculation(int index, vec3 pointToLight,float NdotL,float farPlane,float shadowBias)
+{
+    float closestDepth = COMPAT_TEXTURE_CUBE(shadowCubeMap[index], -pointToLight).r;
+    // it is currently in linear range between [0,1]. Re-transform back to original value
+    closestDepth *= farPlane;
+    // now get current linear depth as the length between the fragment and light position
+    float currentDepth = length(pointToLight);
+
+    float bias = shadowBias*tan(acos(NdotL));
+
+    float shadow = currentDepth-closestDepth < bias  ? 1.0 : 0;
+
+    return shadow;
+}
+
+vec3 getNormal()
+{
+    vec2 uv_dx = dFdx(texcoord);
+    vec2 uv_dy = dFdy(texcoord);
+    if (length(uv_dx) <= 1e-2) {
+      uv_dx = vec2(1.0, 0.0);
+    }
+
+    if (length(uv_dy) <= 1e-2) {
+      uv_dy = vec2(0.0, 1.0);
+    }
+    vec3 t_ = (uv_dy.t * dFdx(worldSpacePos) - uv_dx.t * dFdy(worldSpacePos)) /
+        (uv_dx.s * uv_dy.t - uv_dy.s * uv_dx.t);
+    vec3 n, t, b, ng;
+    if(normal.x+normal.y+normal.z != 0){
+        if(tangent.x+tangent.y+tangent.z != 0){
+            t = normalize(tangent);
+            b = normalize(bitangent);
+            ng = normalize(normal);
+        }else{
+            ng = normalize(normal);
+            t = normalize(t_ - ng * dot(ng, t_));
+            b = cross(ng, t);
+        }
+    }else{
+        ng = normalize(cross(dFdx(worldSpacePos), dFdy(worldSpacePos)));
+        t = normalize(t_ - ng * dot(ng, t_));
+        b = cross(ng, t);
+    }
+    if (gl_FrontFacing == false)
+    {
+        t *= -1.0;
+        b *= -1.0;
+        ng *= -1.0;
+    }
+    if(useNormalMap){
+        return normalize(mat3(t, b, ng) * normalize(COMPAT_TEXTURE(normalMap, texcoord).xyz * 2.0 - vec3(1.0)));
+    }else{
+        return ng;
+    }
+}
+
+// https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_lights_punctual/README.md#range-property
+float getRangeAttenuation(float range, float distance)
+{
+    if (range <= 0.0)
+    {
+        // negative range means unlimited
+        return 1.0 / pow(distance, 2.0);
+    }
+    return max(min(1.0 - pow(distance / range, 4.0), 1.0), 0.0) / pow(distance, 2.0);
+}
+
+
+// https://github.com/KhronosGroup/glTF/blob/master/extensions/2.0/Khronos/KHR_lights_punctual/README.md#inner-and-outer-cone-angles
+float getSpotAttenuation(vec3 pointToLight, vec3 spotDirection, float outerConeCos, float innerConeCos)
+{
+    float actualCos = dot(normalize(spotDirection), normalize(-pointToLight));
+    if (actualCos > outerConeCos)
+    {
+        if (actualCos < innerConeCos)
+        {
+            float angularAttenuation = (actualCos - outerConeCos) / (innerConeCos - outerConeCos);
+            return angularAttenuation * angularAttenuation;
+        }
+        return 1.0;
+    }
+    return 0.0;
+}
+vec3 getLighIntensity(Light light, vec3 pointToLight)
+{
+    float rangeAttenuation = 1.0;
+    float spotAttenuation = 1.0;
+
+    if (light.type != LightType_Directional)
+    {
+        rangeAttenuation = getRangeAttenuation(light.range, length(pointToLight));
+    }
+    if (light.type == LightType_Spot)
+    {
+        spotAttenuation = getSpotAttenuation(pointToLight, light.direction, light.outerConeCos, light.innerConeCos);
+    }
+
+    return rangeAttenuation * spotAttenuation * light.intensity * light.color;
+}
+vec3 F_Schlick(vec3 f0, vec3 f90, float VdotH)
+{
+    return f0 + (f90 - f0) * pow(clamp(1.0 - VdotH, 0.0, 1.0), 5.0);
+}
+// Smith Joint GGX
+// Note: Vis = G / (4 * NdotL * NdotV)
+// see Eric Heitz. 2014. Understanding the Masking-Shadowing Function in Microfacet-Based BRDFs. Journal of Computer Graphics Techniques, 3
+// see Real-Time Rendering. Page 331 to 336.
+// see https://google.github.io/filament/Filament.md.html#materialsystem/specularbrdf/geometricshadowing(specularg)
+float V_GGX(float NdotL, float NdotV, float alphaRoughness)
+{
+    float alphaRoughnessSq = alphaRoughness * alphaRoughness;
+
+    float GGXV = NdotL * sqrt(NdotV * NdotV * (1.0 - alphaRoughnessSq) + alphaRoughnessSq);
+    float GGXL = NdotV * sqrt(NdotL * NdotL * (1.0 - alphaRoughnessSq) + alphaRoughnessSq);
+
+    float GGX = GGXV + GGXL;
+    if (GGX > 0.0)
+    {
+        return 0.5 / GGX;
+    }
+    return 0.0;
+}
+
+// The following equation(s) model the distribution of microfacet normals across the area being drawn (aka D())
+// Implementation from "Average Irregularity Representation of a Roughened Surface for Ray Reflection" by T. S. Trowbridge, and K. P. Reitz
+// Follows the distribution function recommended in the SIGGRAPH 2013 course notes from EPIC Games [1], Equation 3.
+float D_GGX(float NdotH, float alphaRoughness)
+{
+    float alphaRoughnessSq = alphaRoughness * alphaRoughness;
+    float f = (NdotH * NdotH) * (alphaRoughnessSq - 1.0) + 1.0;
+    return alphaRoughnessSq / (PI * f * f);
+}
+vec3 BRDF_lambertian(vec3 f0, vec3 f90, vec3 diffuseColor, float specularWeight, float VdotH)
+{
+    // see https://seblagarde.wordpress.com/2012/01/08/pi-or-not-to-pi-in-game-lighting-equation/
+    return (1.0 - specularWeight * F_Schlick(f0, f90, VdotH)) * (diffuseColor / PI);
+}
+vec3 BRDF_specularGGX(vec3 f0, vec3 f90, float alphaRoughness, float specularWeight, float VdotH, float NdotL, float NdotV, float NdotH)
+{
+    vec3 F = F_Schlick(f0, f90, VdotH);
+    float Vis = V_GGX(NdotL, NdotV, alphaRoughness);
+    float D = D_GGX(NdotH, alphaRoughness);
+
+    return specularWeight * F * Vis * D;
+}
+vec3 getDiffuseLight(vec3 n)
+{
+    return COMPAT_TEXTURE_CUBE(lambertianEnvSampler, environmentRotation * n).rgb * environmentIntensity;
+}
+vec4 getSpecularSample(vec3 reflection, float lod)
+{
+    return COMPAT_TEXTURE_CUBE_LOD(GGXEnvSampler, environmentRotation * reflection, lod) * environmentIntensity;
+}
+vec3 getIBLGGXFresnel(vec3 n, vec3 v, float roughness, vec3 F0, float specularWeight)
+{
+    // see https://bruop.github.io/ibl/#single_scattering_results at Single Scattering Results
+    // Roughness dependent fresnel, from Fdez-Aguera
+    float NdotV = clampedDot(n, v);
+    vec2 brdfSamplePoint = clamp(vec2(NdotV, roughness), vec2(0.0, 0.0), vec2(1.0, 1.0));
+    vec2 f_ab = COMPAT_TEXTURE(GGXLUT, brdfSamplePoint).rg;
+    vec3 Fr = max(vec3(1.0 - roughness), F0) - F0;
+    vec3 k_S = F0 + Fr * pow(1.0 - NdotV, 5.0);
+    vec3 FssEss = specularWeight * (k_S * f_ab.x + f_ab.y);
+
+    // Multiple scattering, from Fdez-Aguera
+    float Ems = (1.0 - (f_ab.x + f_ab.y));
+    vec3 F_avg = specularWeight * (F0 + (1.0 - F0) / 21.0);
+    vec3 FmsEms = Ems * FssEss * F_avg / (1.0 - F_avg * Ems);
+
+    return FssEss + FmsEms;
+}
+vec3 getIBLRadianceGGX(vec3 n, vec3 v, float roughness)
+{
+    float NdotV = clampedDot(n, v);
+    float lod = roughness * float(mipCount - 1);
+    vec3 reflection = normalize(reflect(-v, n));
+    vec4 specularSample = getSpecularSample(reflection, lod);
+
+    vec3 specularLight = specularSample.rgb;
+
+    return specularLight;
+}
+vec3 ibl(vec3 n,vec3 v,float metallic,float roughness,vec3 albedo){
+    vec3 f_diffuse = getDiffuseLight(n) * albedo.rgb;
+    vec3 f_specular_metal = getIBLRadianceGGX(n, v, roughness);
+    vec3 f_specular_dielectric = f_specular_metal;
+    vec3 f_metal_fresnel_ibl = getIBLGGXFresnel(n, v, roughness, albedo.rgb, 1.0);
+    vec3 f_metal_brdf_ibl = f_metal_fresnel_ibl * f_specular_metal;
+    vec3 f_dielectric_fresnel_ibl = getIBLGGXFresnel(n, v, roughness, vec3(0.04), 1);
+    vec3 f_dielectric_brdf_ibl = f_diffuse*(1-f_dielectric_fresnel_ibl) + f_specular_dielectric * f_dielectric_fresnel_ibl;
+
+    vec3 color = f_dielectric_brdf_ibl*(1-metallic)+f_metal_brdf_ibl*metallic;
+    return color;
+}
+vec3 pbr(vec3 worldSpacePos,vec3 v,vec3 n,vec3 albedo,float metallic,float roughness,float ao){
+	vec3 f0 = vec3(0.04)+(albedo-vec3(0.04))*metallic;
+    vec3 f90 = vec3(1.0);
+    float ior = 1.5;
+    float specularWeight = 1.0;
+    vec3 f_specular = vec3(0.0);
+    vec3 f_diffuse = vec3(0.0);
+    vec3 c_diff = albedo*(1-metallic);
+
+	for(int i = 0; i < 4; ++i) 
+    {
+        if(lights[i].color.r+lights[i].color.g+lights[i].color.b > 0){
+            vec3 pointToLight = vec3(0);
+            if(lights[i].type == LightType_Directional){
+                pointToLight = -lights[i].direction;
+            }else{
+                pointToLight = lights[i].position - worldSpacePos;
+            }
+            vec3 l = normalize(pointToLight);
+            vec3 h = normalize(l + v);
+            float NdotL = clampedDot(n, l);
+            float NdotV = clampedDot(n, v);
+            float NdotH = clampedDot(n, h);
+            float VdotH = clampedDot(v, h);
+            if (NdotL > 0.0 || NdotV > 0.0){
+                vec3 intensity = getLighIntensity(lights[i], pointToLight);
+                vec3 l_diffuse = vec3(0.0);
+                vec3 l_specular = vec3(0.0);
+                l_diffuse += intensity * NdotL *  BRDF_lambertian(f0, f90, c_diff, specularWeight, VdotH);
+                l_specular += intensity * NdotL * BRDF_specularGGX(f0, f90, roughness*roughness, specularWeight, VdotH, NdotL, NdotV, NdotH);
+                float shadow = 1;
+                if(lights[i].type == LightType_Point){
+                    shadow = PointLightShadowCalculation(i,pointToLight,NdotL,lights[i].shadowMapFar,lights[i].shadowBias);
+                }else if(lights[i].type == LightType_Directional){
+                    shadow = DirectionalLightShadowCalculation(i,lightSpacePos[i],NdotL,lights[i].shadowBias);
+                }else{
+                    shadow = SpotLightShadowCalculation(i,pointToLight,lightSpacePos[i],NdotL,lights[i].shadowMapFar,lights[i].shadowBias);
+                }
+                f_diffuse += l_diffuse * shadow;
+                f_specular += l_specular * shadow;
+            }
+        }
+    }   
+    vec3 f_ibl = vec3(0);
+    if(environmentIntensity > 0){
+        f_ibl = ibl(n,v,metallic,roughness,albedo);
+    }
+    //vec3 color = clamp(f_diffuse+f_specular+ao*f_ibl,0,1);
+    vec3 color = f_diffuse+f_specular+ao*f_ibl;
+    
+    //color = color / (color + vec3(1.0));
+    //color = pow(color, vec3(1.0/2.2));
+	return color;
+}
 vec3 hue_shift(vec3 color, float dhue) {
 	float s = sin(dhue);
 	float c = cos(dhue);
@@ -31,13 +369,30 @@ vec3 hue_shift(vec3 color, float dhue) {
 }
 
 void main(void) {
-	if(textured){
-		FragColor = COMPAT_TEXTURE(tex, texcoord) * baseColorFactor;
-	} else {
-		FragColor = baseColorFactor;
+    FragColor = vec4(1.0);
+	if(useTexture){
+		FragColor = COMPAT_TEXTURE(tex, texcoord);
+        FragColor.rgb = pow(FragColor.rgb,vec3(2.2));
 	}
-	FragColor *= vec4(pow(vColor.r, 1.0/2.2), pow(vColor.g, 1.0/2.2), pow(vColor.b, 1.0/2.2), vColor.a);
-	FragColor.rgb *= vColor.a;
+    FragColor *= baseColorFactor;
+	FragColor *= vColor;
+    if(!unlit){
+        vec3 normalF = normal;
+        if(useNormalMap){
+            normalF = getNormal();
+        }
+        vec2 metallicRoughnessF = metallicRoughness;
+        if(useMetallicRoughnessMap){
+            metallicRoughnessF = COMPAT_TEXTURE(metallicRoughnessMap, texcoord).bg;
+        }
+        float ambientOcclusion = 1;
+        if(ambientOcclusionStrength > 0){
+            ambientOcclusion = 1+ambientOcclusionStrength*(COMPAT_TEXTURE(ambientOcclusionMap, texcoord).r-1);
+        }
+        FragColor.rgb = pbr(worldSpacePos,normalize(cameraPosition - worldSpacePos),normalize(normalF),FragColor.rgb,metallicRoughnessF[0],metallicRoughnessF[1],ambientOcclusion);
+    }
+    FragColor.rgb *= vColor.a;
+    FragColor.rgb = pow(FragColor.rgb, vec3(1.0/2.2));
 	if(!enableAlpha){
 		if(FragColor.a < alphaThreshold){
 			discard;

--- a/src/shaders/model.vert.glsl
+++ b/src/shaders/model.vert.glsl
@@ -3,47 +3,59 @@
 #define COMPAT_ATTRIBUTE in
 #define COMPAT_TEXTURE texture
 #else
+#extension GL_EXT_gpu_shader4 : enable
 #define COMPAT_VARYING varying 
 #define COMPAT_ATTRIBUTE attribute 
 #define COMPAT_TEXTURE texture2D
 #endif
 
-uniform mat4 modelview, projection;
+uniform mat4 model, view, projection;
+uniform mat4 normalMatrix;
+uniform mat4 lightMatrices[4];
 uniform sampler2D jointMatrices;
+//uniform highp sampler2D morphTargetValues;
+uniform sampler2D morphTargetValues;
 uniform int numJoints;
+uniform int numTargets;
 uniform vec4 morphTargetWeight[2];
-uniform int positionTargetCount;
-uniform int uvTargetCount;
-
+uniform vec4 morphTargetOffset;
+uniform int numVertices;
+//gl_VertexID is not available in 1.2
+COMPAT_ATTRIBUTE float vertexId;
 COMPAT_ATTRIBUTE vec3 position;
+COMPAT_ATTRIBUTE vec3 normalIn;
+COMPAT_ATTRIBUTE vec4 tangentIn;
 COMPAT_ATTRIBUTE vec2 uv;
 COMPAT_ATTRIBUTE vec4 vertColor;
 COMPAT_ATTRIBUTE vec4 joints_0;
 COMPAT_ATTRIBUTE vec4 joints_1;
 COMPAT_ATTRIBUTE vec4 weights_0;
 COMPAT_ATTRIBUTE vec4 weights_1;
-//Unfortunately the current OpenGL/shader version does not support attribute array
-//attribute vec4 morphTargets[8]
-COMPAT_ATTRIBUTE vec4 morphTargets_0;
-COMPAT_ATTRIBUTE vec4 morphTargets_1;
-COMPAT_ATTRIBUTE vec4 morphTargets_2;
-COMPAT_ATTRIBUTE vec4 morphTargets_3;
-COMPAT_ATTRIBUTE vec4 morphTargets_4;
-COMPAT_ATTRIBUTE vec4 morphTargets_5;
-COMPAT_ATTRIBUTE vec4 morphTargets_6;
-COMPAT_ATTRIBUTE vec4 morphTargets_7;
+COMPAT_VARYING vec3 normal;
+COMPAT_VARYING vec3 tangent;
+COMPAT_VARYING vec3 bitangent;
 COMPAT_VARYING vec2 texcoord;
 COMPAT_VARYING vec4 vColor;
+COMPAT_VARYING vec3 worldSpacePos;
+COMPAT_VARYING vec4 lightSpacePos[4];
+
 
 mat4 getMatrixFromTexture(float index){
 	mat4 mat;
-	mat[0] = COMPAT_TEXTURE(jointMatrices,vec2(0.5/3.0,(index+0.5)/numJoints));
-	mat[1] = COMPAT_TEXTURE(jointMatrices,vec2(1.5/3.0,(index+0.5)/numJoints));
-	mat[2] = COMPAT_TEXTURE(jointMatrices,vec2(2.5/3.0,(index+0.5)/numJoints));
+	mat[0] = COMPAT_TEXTURE(jointMatrices,vec2(0.5/6.0,(index+0.5)/numJoints));
+	mat[1] = COMPAT_TEXTURE(jointMatrices,vec2(1.5/6.0,(index+0.5)/numJoints));
+	mat[2] = COMPAT_TEXTURE(jointMatrices,vec2(2.5/6.0,(index+0.5)/numJoints));
 	mat[3] = vec4(0,0,0,1);
 	return transpose(mat);
 }
-
+mat4 getNormalMatrixFromTexture(float index){
+	mat4 mat;
+	mat[0] = COMPAT_TEXTURE(jointMatrices,vec2(3.5/6.0,(index+0.5)/numJoints));
+	mat[1] = COMPAT_TEXTURE(jointMatrices,vec2(4.5/6.0,(index+0.5)/numJoints));
+	mat[2] = COMPAT_TEXTURE(jointMatrices,vec2(5.5/6.0,(index+0.5)/numJoints));
+	mat[3] = vec4(0,0,0,1);
+	return transpose(mat);
+}
 mat4 getJointMatrix(){
 	mat4 ret = mat4(0);
 	ret += weights_0.x*getMatrixFromTexture(joints_0.x);
@@ -59,82 +71,67 @@ mat4 getJointMatrix(){
 	}
 	return ret;
 }
-
+mat3 getJointNormalMatrix(){
+	mat4 ret = mat4(0);
+	ret += weights_0.x*getNormalMatrixFromTexture(joints_0.x);
+	ret += weights_0.y*getNormalMatrixFromTexture(joints_0.y);
+	ret += weights_0.z*getNormalMatrixFromTexture(joints_0.z);
+	ret += weights_0.w*getNormalMatrixFromTexture(joints_0.w);
+	ret += weights_1.x*getNormalMatrixFromTexture(joints_1.x);
+	ret += weights_1.y*getNormalMatrixFromTexture(joints_1.y);
+	ret += weights_1.z*getNormalMatrixFromTexture(joints_1.z);
+	ret += weights_1.w*getNormalMatrixFromTexture(joints_1.w);
+	if(ret == mat4(0.0)){
+		return mat3(1.0);
+	}
+	return mat3(ret);
+}
 void main(void) {
 	texcoord = uv;
 	vColor = vertColor;
 	vec4 pos = vec4(position, 1.0);
+	normal = normalIn;
+	tangent = vec3(tangentIn);
 	if(morphTargetWeight[0][0] != 0){
-		int idx = 0;
-		if(idx < positionTargetCount){
-			pos += morphTargetWeight[0][0] * morphTargets_0;
-		}else if(idx - positionTargetCount < uvTargetCount){
-			texcoord += morphTargetWeight[0][0] * vec2(morphTargets_0);
-		}else{
-			vColor += morphTargetWeight[0][0] * morphTargets_0;
+		for(int idx = 0; idx < numTargets; ++idx)
+		{
+			if(idx < morphTargetOffset[0]){
+				pos += morphTargetWeight[idx/4][idx%4] * COMPAT_TEXTURE(morphTargetValues,vec2((vertexId+0.5)/numVertices,(idx+0.5)/8));
+			}else if(idx < morphTargetOffset[1]){
+				normal += morphTargetWeight[idx/4][idx%4] * vec3(COMPAT_TEXTURE(morphTargetValues,vec2((vertexId+0.5)/numVertices,(idx+0.5)/8)));
+			}else if(idx < morphTargetOffset[2]){
+				tangent += morphTargetWeight[idx/4][idx%4] * vec3(COMPAT_TEXTURE(morphTargetValues,vec2((vertexId+0.5)/numVertices,(idx+0.5)/8)));
+			}else if(idx < morphTargetOffset[3]){
+				texcoord += morphTargetWeight[idx/4][idx%4] * vec2(COMPAT_TEXTURE(morphTargetValues,vec2((vertexId+0.5)/numVertices,(idx+0.5)/8)));
+			}else{
+				vColor += morphTargetWeight[idx/4][idx%4] * COMPAT_TEXTURE(morphTargetValues,vec2((vertexId+0.5)/numVertices,(idx+0.5)/8));
+			}
 		}
-		idx++;
-		if(idx < positionTargetCount){
-			pos += morphTargetWeight[0][1] * morphTargets_1;
-		}else if(idx - positionTargetCount < uvTargetCount){
-			texcoord += morphTargetWeight[0][1] * vec2(morphTargets_1);
-		}else{
-			vColor += morphTargetWeight[0][1] * morphTargets_1;
-		}
-		idx++;
-		if(idx < positionTargetCount){
-			pos += morphTargetWeight[0][2] * morphTargets_2;
-		}else if(idx - positionTargetCount < uvTargetCount){
-			texcoord += morphTargetWeight[0][2] * vec2(morphTargets_2);
-		}else{
-			vColor += morphTargetWeight[0][2] * morphTargets_2;
-		}
-		idx++;
-		if(idx < positionTargetCount){
-			pos += morphTargetWeight[0][3] * morphTargets_3;
-		}else if(idx - positionTargetCount < uvTargetCount){
-			texcoord += morphTargetWeight[0][3] * vec2(morphTargets_3);
-		}else{
-			vColor += morphTargetWeight[0][3] * morphTargets_3;
-		}
-		idx++;
-		if(idx < positionTargetCount){
-			pos += morphTargetWeight[1][0] * morphTargets_4;
-		}else if(idx - positionTargetCount < uvTargetCount){
-			texcoord += morphTargetWeight[1][0] * vec2(morphTargets_4);
-		}else{
-			vColor += morphTargetWeight[1][0] * morphTargets_4;
-		}
-		idx++;
-		if(idx < positionTargetCount){
-			pos += morphTargetWeight[1][1] * morphTargets_5;
-		}else if(idx - positionTargetCount < uvTargetCount){
-			texcoord += morphTargetWeight[1][1] * vec2(morphTargets_5);
-		}else{
-			vColor += morphTargetWeight[1][1] * morphTargets_5;
-		}
-		idx++;
-		if(idx < positionTargetCount){
-			pos += morphTargetWeight[1][2] * morphTargets_6;
-		}else if(idx - positionTargetCount < uvTargetCount){
-			texcoord += morphTargetWeight[1][2] * vec2(morphTargets_6);
-		}else{
-			vColor += morphTargetWeight[1][2] * morphTargets_6;
-		}
-		idx++;
-		if(idx < positionTargetCount){
-			pos += morphTargetWeight[1][3] * morphTargets_7;
-		}else if(idx - positionTargetCount < uvTargetCount){
-			texcoord += morphTargetWeight[1][3] * vec2(morphTargets_7);
-		}else{
-			vColor += morphTargetWeight[1][3] * morphTargets_7;
-		}
-		idx++;
 	}
 	if(weights_0.x+weights_0.y+weights_0.z+weights_0.w+weights_1.x+weights_1.y+weights_1.z+weights_1.w > 0){
-		mat4 tmp = getJointMatrix();
-		gl_Position = projection * (modelview * tmp * pos);
+		
+		mat4 jointMatrix = getJointMatrix();
+		mat3 jointNormalMatrix = getJointNormalMatrix();
+		vec4 tmp2 = model * jointMatrix * pos;
+		gl_Position = projection * view * tmp2;
+		worldSpacePos = vec3(tmp2);
+		for(int i = 0;i < 4;i++){
+			lightSpacePos[i] = lightMatrices[i] * tmp2;
+		}
+		normal = mat3(normalMatrix) * jointNormalMatrix * normal;
 	}else{
-		gl_Position = projection * (modelview * pos);
+		vec4 tmp2 = model * pos;
+		gl_Position = projection * view * tmp2;
+		worldSpacePos = vec3(tmp2);
+		for(int i = 0;i < 4;i++){
+			lightSpacePos[i] = lightMatrices[i] * tmp2;
+		}
+		if(normal.x+normal.y+normal.z != 0){
+			normal = normalize(mat3(normalMatrix) * normal);
+			if(tangent.x+tangent.y+tangent.z != 0){
+				tangent = normalize(vec3(model * vec4(tangent,0)));
+				bitangent = cross(normal, tangent) * tangentIn.w;
+			}
+		}
 	}
 }

--- a/src/shaders/panoramaToCubeMap.frag.glsl
+++ b/src/shaders/panoramaToCubeMap.frag.glsl
@@ -1,0 +1,65 @@
+#define MATH_PI 3.1415926535897932384626433832795
+#define MATH_INV_PI (1.0 / MATH_PI)
+#if __VERSION__ >= 130
+#define COMPAT_VARYING in
+#define COMPAT_TEXTURE texture
+out vec4 FragColor;
+#else
+#define COMPAT_VARYING varying
+#define FragColor gl_FragColor
+#define COMPAT_TEXTURE texture2D
+#endif
+
+COMPAT_VARYING vec2 texcoord;
+
+
+uniform int currentFace;
+
+uniform sampler2D panorama;
+
+vec3 uvToXYZ(int face, vec2 uv)
+{
+	if(face == 0)
+		return vec3(     1.f,   uv.y,    -uv.x);
+
+	else if(face == 1)
+		return vec3(    -1.f,   uv.y,     uv.x);
+
+	else if(face == 2)
+		return vec3(   +uv.x,   -1.f,    +uv.y);
+
+	else if(face == 3)
+		return vec3(   +uv.x,    1.f,    -uv.y);
+
+	else if(face == 4)
+		return vec3(   +uv.x,   uv.y,      1.f);
+
+	else //if(face == 5)
+	{	return vec3(    -uv.x,  +uv.y,     -1.f);}
+}
+
+vec2 dirToUV(vec3 dir)
+{
+	return vec2(
+		0.5f + 0.5f * atan(dir.z, dir.x) / MATH_PI,
+		1.f - acos(dir.y) / MATH_PI);
+}
+
+vec3 panoramaToCubeMap(int face, vec2 texCoord)
+{
+	vec2 texCoordNew = texCoord*2.0-1.0;
+	vec3 scan = uvToXYZ(face, texCoordNew);
+	vec3 direction = normalize(scan);
+	vec2 src = dirToUV(direction);
+
+	return  COMPAT_TEXTURE(panorama, src).rgb;
+}
+
+
+
+void main(void)
+{
+    FragColor = vec4(0.0, 0.0, 0.0, 1.0);
+
+	FragColor.rgb = panoramaToCubeMap(currentFace, texcoord);
+}

--- a/src/shaders/shadow.frag.glsl
+++ b/src/shaders/shadow.frag.glsl
@@ -1,0 +1,45 @@
+#if __VERSION__ >= 130
+#define COMPAT_VARYING in
+out float FragDepth;
+#define COMPAT_TEXTURE texture
+#else
+#define COMPAT_VARYING varying
+#define FragDepth gl_FragDepth
+#define COMPAT_TEXTURE texture2D
+#endif
+
+uniform sampler2D tex;
+uniform bool enableAlpha;
+uniform bool useTexture;
+uniform float alphaThreshold;
+uniform vec4 baseColorFactor;
+uniform int lightType;
+uniform vec3 lightPos;
+uniform float farPlane;
+COMPAT_VARYING vec4 FragPos;
+COMPAT_VARYING vec4 vColor0;
+COMPAT_VARYING vec2 texcoord0;
+
+const int LightType_Directional = 0;
+const int LightType_Point = 1;
+const int LightType_Spot = 2;
+void main()
+{
+    vec4 color = baseColorFactor;
+    if(useTexture){
+        color = color * COMPAT_TEXTURE(tex, texcoord0);
+    }
+    color *= vColor0;
+    if((enableAlpha && color.a <= 0) || (color.a < alphaThreshold)){
+        discard;
+    }
+    if(lightType != LightType_Directional){
+        float lightDistance = length(FragPos.xyz - lightPos);
+    
+        lightDistance = lightDistance / farPlane;
+        
+        FragDepth = lightDistance;
+    }else{
+        FragDepth = gl_FragCoord.z/gl_FragCoord.w;
+    }
+}

--- a/src/shaders/shadow.geo.glsl
+++ b/src/shaders/shadow.geo.glsl
@@ -1,0 +1,56 @@
+#if __VERSION__ >= 130
+#define COMPAT_POS_IN(i) gl_in[i].gl_Position
+
+layout(triangles) in;
+layout(triangle_strip, max_vertices = 18) out;
+in vec4 vColor[];
+in vec2 texcoord[];
+out vec4 FragPos;
+out vec4 vColor0;
+out vec2 texcoord0;
+#else
+#extension GL_EXT_geometry_shader4: enable
+#define COMPAT_POS_IN(i) gl_PositionIn[i]
+
+varying in vec4 vColor[3];
+varying in vec2 texcoord[3];
+varying out vec4 FragPos;
+varying out vec4 vColor0;
+varying out vec2 texcoord0;
+#endif
+
+uniform int lightType;
+
+uniform mat4 lightMatrices[6];
+
+const int LightType_Directional = 0;
+const int LightType_Point = 1;
+const int LightType_Spot = 2;
+void main() {
+    if(lightType == LightType_Point){
+        for(int face = 0; face < 6; ++face)
+        {
+            gl_Layer = face; // built-in variable that specifies to which face we render.
+            for(int i = 0; i < 3; ++i) // for each triangle vertex
+            {
+                FragPos = COMPAT_POS_IN(i);
+                texcoord0 = texcoord[i];
+                vColor0 = vColor[i];
+                gl_Position = lightMatrices[face] * COMPAT_POS_IN(i);
+                EmitVertex();
+            }    
+            EndPrimitive();
+        }
+    }else{
+        gl_Layer = 0;
+        for(int i = 0; i < 3; ++i) // for each triangle vertex
+        {
+            FragPos = COMPAT_POS_IN(i);
+            texcoord0 = texcoord[i];
+            vColor0 = vColor[i];
+            gl_Position = lightMatrices[0] * COMPAT_POS_IN(i);
+            EmitVertex();
+        }
+        EndPrimitive();
+    }
+} 

--- a/src/shaders/shadow.vert.glsl
+++ b/src/shaders/shadow.vert.glsl
@@ -1,0 +1,80 @@
+#if __VERSION__ >= 130
+#define COMPAT_VARYING out
+#define COMPAT_ATTRIBUTE in
+#define COMPAT_TEXTURE texture
+#else
+#extension GL_EXT_gpu_shader4 : enable
+#define COMPAT_VARYING varying 
+#define COMPAT_ATTRIBUTE attribute 
+#define COMPAT_TEXTURE texture2D
+#endif
+
+
+uniform mat4 model;
+uniform sampler2D jointMatrices;
+//uniform highp sampler2D morphTargetValues;
+uniform sampler2D morphTargetValues;
+uniform int numJoints;
+uniform int numTargets;
+uniform vec4 morphTargetWeight[2];
+uniform vec4 morphTargetOffset;
+uniform int numVertices;
+
+//gl_VertexID is not available in 1.2
+COMPAT_ATTRIBUTE float vertexId;
+COMPAT_ATTRIBUTE vec3 position;
+COMPAT_ATTRIBUTE vec4 vertColor;
+COMPAT_ATTRIBUTE vec2 uv;
+COMPAT_ATTRIBUTE vec4 joints_0;
+COMPAT_ATTRIBUTE vec4 joints_1;
+COMPAT_ATTRIBUTE vec4 weights_0;
+COMPAT_ATTRIBUTE vec4 weights_1;
+COMPAT_VARYING vec4 vColor;
+COMPAT_VARYING vec2 texcoord;
+
+
+mat4 getMatrixFromTexture(float index){
+	mat4 mat;
+	mat[0] = COMPAT_TEXTURE(jointMatrices,vec2(0.5/6.0,(index+0.5)/numJoints));
+	mat[1] = COMPAT_TEXTURE(jointMatrices,vec2(1.5/6.0,(index+0.5)/numJoints));
+	mat[2] = COMPAT_TEXTURE(jointMatrices,vec2(2.5/6.0,(index+0.5)/numJoints));
+	mat[3] = vec4(0,0,0,1);
+	return transpose(mat);
+}
+mat4 getJointMatrix(){
+	mat4 ret = mat4(0);
+	ret += weights_0.x*getMatrixFromTexture(joints_0.x);
+	ret += weights_0.y*getMatrixFromTexture(joints_0.y);
+	ret += weights_0.z*getMatrixFromTexture(joints_0.z);
+	ret += weights_0.w*getMatrixFromTexture(joints_0.w);
+	ret += weights_1.x*getMatrixFromTexture(joints_1.x);
+	ret += weights_1.y*getMatrixFromTexture(joints_1.y);
+	ret += weights_1.z*getMatrixFromTexture(joints_1.z);
+	ret += weights_1.w*getMatrixFromTexture(joints_1.w);
+	if(ret == mat4(0.0)){
+		return mat4(1.0);
+	}
+	return ret;
+}
+void main(void) {
+	texcoord = uv;
+	vColor = vertColor;
+	vec4 pos = vec4(position, 1.0);
+	if(morphTargetOffset[0] > 0){
+		for(int idx = 0; idx < numTargets; ++idx)
+		{
+			if(idx < morphTargetOffset[0]){
+				pos += morphTargetWeight[idx/4][idx%4] * COMPAT_TEXTURE(morphTargetValues,vec2((vertexId+0.5)/numVertices,(idx+0.5)/8));
+			}else if(idx >= morphTargetOffset[2] && idx < morphTargetOffset[3]){
+				texcoord += morphTargetWeight[idx/4][idx%4] * vec2(COMPAT_TEXTURE(morphTargetValues,vec2((vertexId+0.5)/numVertices,(idx+0.5)/8)));
+			}
+		}
+	}
+	if(weights_0.x+weights_0.y+weights_0.z+weights_0.w+weights_1.x+weights_1.y+weights_1.z+weights_1.w > 0){
+		
+		mat4 jointMatrix = getJointMatrix();
+		gl_Position = model * jointMatrix * pos;
+	}else{
+		gl_Position = model * pos;
+	}
+}


### PR DESCRIPTION
Add support for environment map and punctual light in 3d stage.
New stage def parameters:
```
environment: .hdr file for environment map
environmentintensity: change the environment intensity. Default is 1.0
```
New glTF custom parameters:
```
shadowMapBias: default value is 0.02
shadowMapNear: deafault value is 0.1 for point / spot light, -20 from directional light
shadowMapFar: default value is 50
shadowMapBottom: directional light only, default value is -20
shadowMapTop: directional light only, default value is 20
shadowMapLeft: directional light only, default value is -20
shadowMapRight:  directional light only, default value is 20
```