### PR TITLE
fix: Hitdef processing; intro skip and AIR refactoring

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -2440,11 +2440,9 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		}
 	case OC_ex_animframe_angle:
 		if f := c.anim.CurrentFrame(); f != nil {
-			if len(f.Ex) > 2 && len(f.Ex[2]) > 2 { // Anim.go code could be refactored so these are easier to read
-				sys.bcStack.PushF(f.Ex[2][2])
-			} else {
-				sys.bcStack.PushF(0)
-			}
+			sys.bcStack.PushF(f.Angle)
+		} else {
+			sys.bcStack.PushI(0)
 		}
 	case OC_ex_animframe_alphasource:
 		if f := c.anim.CurrentFrame(); f != nil {
@@ -2460,7 +2458,7 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		}
 	case OC_ex_animframe_hflip:
 		if f := c.anim.CurrentFrame(); f != nil {
-			sys.bcStack.PushB(f.H < 0)
+			sys.bcStack.PushB(f.Hscale < 0)
 		} else {
 			sys.bcStack.PushI(0)
 		}
@@ -2478,37 +2476,33 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		}
 	case OC_ex_animframe_vflip:
 		if f := c.anim.CurrentFrame(); f != nil {
-			sys.bcStack.PushB(f.V < 0)
+			sys.bcStack.PushB(f.Vscale < 0)
 		} else {
 			sys.bcStack.PushI(0)
 		}
 	case OC_ex_animframe_xoffset:
 		if f := c.anim.CurrentFrame(); f != nil {
-			sys.bcStack.PushI(int32(f.X))
+			sys.bcStack.PushI(int32(f.Xoffset))
 		} else {
 			sys.bcStack.PushI(0)
 		}
 	case OC_ex_animframe_xscale:
 		if f := c.anim.CurrentFrame(); f != nil {
-			if len(f.Ex) > 2 {
-				sys.bcStack.PushF(f.Ex[2][0])
-			} else {
-				sys.bcStack.PushF(0)
-			}
+			sys.bcStack.PushF(f.Xscale)
+		} else {
+			sys.bcStack.PushI(0)
 		}
 	case OC_ex_animframe_yoffset:
 		if f := c.anim.CurrentFrame(); f != nil {
-			sys.bcStack.PushI(int32(f.Y))
+			sys.bcStack.PushI(int32(f.Yoffset))
 		} else {
 			sys.bcStack.PushI(0)
 		}
 	case OC_ex_animframe_yscale:
 		if f := c.anim.CurrentFrame(); f != nil {
-			if len(f.Ex) > 2 && len(f.Ex[2]) > 1 {
-				sys.bcStack.PushF(f.Ex[2][1])
-			} else {
-				sys.bcStack.PushF(0)
-			}
+			sys.bcStack.PushF(f.Yscale)
+		} else {
+			sys.bcStack.PushI(0)
 		}
 	case OC_ex_animframe_numclsn1:
 		if f := c.anim.CurrentFrame(); f != nil {

--- a/src/script.go
+++ b/src/script.go
@@ -1969,7 +1969,7 @@ func systemScriptInit(l *lua.LState) {
 		sys.resetGblEffect()
 		for i, p := range sys.chars {
 			if len(p) > 0 {
-				sys.playerClear(i, boolArg(l, 1))
+				sys.clearPlayerAssets(i, boolArg(l, 1))
 			}
 		}
 		return 0

--- a/src/script.go
+++ b/src/script.go
@@ -4782,11 +4782,9 @@ func triggerFunctions(l *lua.LState) {
 			return 1
 		case "angle":
 			if f := c.anim.CurrentFrame(); f != nil {
-				if len(f.Ex) > 2 && len(f.Ex[2]) > 2 {
-					l.Push(lua.LNumber(f.Ex[2][2]))
-				} else {
-					l.Push(lua.LNumber(0))
-				}
+				l.Push(lua.LNumber(f.Angle))
+			} else {
+				l.Push(lua.LNumber(0))
 			}
 			return 1
 		case "group":
@@ -4798,7 +4796,7 @@ func triggerFunctions(l *lua.LState) {
 			return 1
 		case "hflip":
 			if f := c.anim.CurrentFrame(); f != nil {
-				l.Push(lua.LBool(f.H < 0))
+				l.Push(lua.LBool(f.Hscale < 0))
 			} else {
 				l.Push(lua.LBool(false))
 			}
@@ -4833,41 +4831,37 @@ func triggerFunctions(l *lua.LState) {
 			return 1
 		case "vflip":
 			if f := c.anim.CurrentFrame(); f != nil {
-				l.Push(lua.LBool(f.V < 0))
+				l.Push(lua.LBool(f.Vscale < 0))
 			} else {
 				l.Push(lua.LBool(false))
 			}
 			return 1
 		case "xoffset":
 			if f := c.anim.CurrentFrame(); f != nil {
-				l.Push(lua.LNumber(f.X))
+				l.Push(lua.LNumber(f.Xoffset))
 			} else {
 				l.Push(lua.LNumber(0))
 			}
 			return 1
 		case "xscale":
 			if f := c.anim.CurrentFrame(); f != nil {
-				if len(f.Ex) > 2 {
-					l.Push(lua.LNumber(f.Ex[2][0]))
-				} else {
-					l.Push(lua.LNumber(0))
-				}
+				l.Push(lua.LNumber(f.Xscale))
+			} else {
+				l.Push(lua.LNumber(0))
 			}
 			return 1
 		case "yoffset":
 			if f := c.anim.CurrentFrame(); f != nil {
-				l.Push(lua.LNumber(f.Y))
+				l.Push(lua.LNumber(f.Yoffset))
 			} else {
 				l.Push(lua.LNumber(0))
 			}
 			return 1
 		case "yscale":
 			if f := c.anim.CurrentFrame(); f != nil {
-				if len(f.Ex) > 2 && len(f.Ex[2]) > 1 {
-					l.Push(lua.LNumber(f.Ex[2][0]))
-				} else {
-					l.Push(lua.LNumber(0))
-				}
+				l.Push(lua.LNumber(f.Yscale))
+			} else {
+				l.Push(lua.LNumber(0))
 			}
 			return 1
 		default:


### PR DESCRIPTION
Fix:
- Fixed a very specific scenario where having a helper with a Reversaldef active could make Ikemen skip processing player 1's Hitdef

Refactor:
- Leaving AIR scale parameters empty now leaves them at default (1) rather than 0. In addition to being more coherent with the other optional parameters, this fixes some Mugen 1.0 char sprites becoming invisible in Ikemen (as well as Mugen 1.1)
- Anim.go X scale, Y scale and angle are now explicitly named in the code rather than being part of the "Ex" array, making the code easier to read. Since "Ex" now only holds the Clsn data, it was renamed "Clsn"
- Char intros can now only be skipped if the intro flag is asserted
- Skipping the char intros now takes the game to the round call instead of the fight call
- When skipping the intro, the round number is only announced after the "shutter" effect ends