### PR TITLE
feat: attack/guard.dist width, height and depth

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -257,12 +257,20 @@ const (
 	OC_const_size_height_air_top
 	OC_const_size_height_air_bottom
 	OC_const_size_height_down
-	OC_const_size_attack_dist_front
-	OC_const_size_attack_dist_back
-	OC_const_size_attack_depth_back
+	OC_const_size_attack_dist_width_front
+	OC_const_size_attack_dist_width_back
+	OC_const_size_attack_dist_height_top
+	OC_const_size_attack_dist_height_bottom
+	OC_const_size_attack_dist_depth_front
+	OC_const_size_attack_dist_depth_back
 	OC_const_size_attack_depth_front
-	OC_const_size_proj_attack_dist_front
-	OC_const_size_proj_attack_dist_back
+	OC_const_size_attack_depth_back
+	OC_const_size_proj_attack_dist_width_front
+	OC_const_size_proj_attack_dist_width_back
+	OC_const_size_proj_attack_dist_height_top
+	OC_const_size_proj_attack_dist_height_bottom
+	OC_const_size_proj_attack_dist_depth_front
+	OC_const_size_proj_attack_dist_depth_back
 	OC_const_size_proj_doscale
 	OC_const_size_head_pos_x
 	OC_const_size_head_pos_y
@@ -1842,18 +1850,34 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.size.height.air[1] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_height_down:
 		sys.bcStack.PushF(c.size.height.down * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_size_attack_dist_front:
-		sys.bcStack.PushF(c.size.attack.dist.front * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_size_attack_dist_back:
-		sys.bcStack.PushF(c.size.attack.dist.back * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_size_attack_depth_back:
-		sys.bcStack.PushF(c.size.attack.depth.back * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_size_attack_dist_width_front:
+		sys.bcStack.PushF(c.size.attack.dist.width[0] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_size_attack_dist_width_back:
+		sys.bcStack.PushF(c.size.attack.dist.width[1] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_size_attack_dist_height_top:
+		sys.bcStack.PushF(c.size.attack.dist.height[0] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_size_attack_dist_height_bottom:
+		sys.bcStack.PushF(c.size.attack.dist.height[1] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_size_attack_dist_depth_front:
+		sys.bcStack.PushF(c.size.attack.dist.depth[0] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_size_attack_dist_depth_back:
+		sys.bcStack.PushF(c.size.attack.dist.depth[1] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_attack_depth_front:
 		sys.bcStack.PushF(c.size.attack.depth.front * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_size_proj_attack_dist_front:
-		sys.bcStack.PushF(c.size.proj.attack.dist.front * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_size_proj_attack_dist_back:
-		sys.bcStack.PushF(c.size.proj.attack.dist.back * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_size_attack_depth_back:
+		sys.bcStack.PushF(c.size.attack.depth.back * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_size_proj_attack_dist_width_front:
+		sys.bcStack.PushF(c.size.proj.attack.dist.width[0] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_size_proj_attack_dist_width_back:
+		sys.bcStack.PushF(c.size.proj.attack.dist.width[1] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_size_proj_attack_dist_height_top:
+		sys.bcStack.PushF(c.size.proj.attack.dist.height[0] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_size_proj_attack_dist_height_bottom:
+		sys.bcStack.PushF(c.size.proj.attack.dist.height[1] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_size_proj_attack_dist_depth_front:
+		sys.bcStack.PushF(c.size.proj.attack.dist.depth[0] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_size_proj_attack_dist_depth_back:
+		sys.bcStack.PushF(c.size.proj.attack.dist.depth[1] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_proj_doscale:
 		sys.bcStack.PushI(c.size.proj.doscale)
 	case OC_const_size_head_pos_x:
@@ -6041,6 +6065,8 @@ const (
 	hitDef_ground_hittime
 	hitDef_guard_hittime
 	hitDef_guard_dist
+	hitDef_guard_dist_y
+	hitDef_guard_dist_z
 	hitDef_pausetime
 	hitDef_guard_pausetime
 	hitDef_air_velocity
@@ -6275,6 +6301,16 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 		hd.guard_dist[0] = exp[0].evalI(c)
 		if len(exp) > 1 {
 			hd.guard_dist[1] = exp[1].evalI(c)
+		}
+	case hitDef_guard_dist_y:
+		hd.guard_dist_y[0] = exp[0].evalI(c)
+		if len(exp) > 1 {
+			hd.guard_dist_y[1] = exp[1].evalI(c)
+		}
+	case hitDef_guard_dist_z:
+		hd.guard_dist_z[0] = exp[0].evalI(c)
+		if len(exp) > 1 {
+			hd.guard_dist_z[1] = exp[1].evalI(c)
 		}
 	case hitDef_pausetime:
 		hd.pausetime = exp[0].evalI(c)
@@ -7294,6 +7330,20 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 					p.hitdef.guard_dist[0] = exp[0].evalI(c)
 					if len(exp) > 1 {
 						p.hitdef.guard_dist[1] = exp[1].evalI(c)
+					}
+				})
+			case hitDef_guard_dist_y:
+				eachProj(func(p *Projectile) {
+					p.hitdef.guard_dist_y[0] = exp[0].evalI(c)
+					if len(exp) > 1 {
+						p.hitdef.guard_dist_y[1] = exp[1].evalI(c)
+					}
+				})
+			case hitDef_guard_dist_z:
+				eachProj(func(p *Projectile) {
+					p.hitdef.guard_dist_z[0] = exp[0].evalI(c)
+					if len(exp) > 1 {
+						p.hitdef.guard_dist_z[1] = exp[1].evalI(c)
 					}
 				})
 			case hitDef_pausetime:
@@ -8888,7 +8938,9 @@ func (sc makeDust) Run(c *Char, _ []int32) bool {
 type attackDist StateControllerBase
 
 const (
-	attackDist_value byte = iota
+	attackDist_x byte = iota
+	attackDist_y
+	attackDist_z
 	attackDist_redirectid
 )
 
@@ -8897,10 +8949,20 @@ func (sc attackDist) Run(c *Char, _ []int32) bool {
 	var redirscale float32 = 1.0
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
-		case attackDist_value:
-			crun.attackDist[0] = exp[0].evalF(c) * redirscale
+		case attackDist_x:
+			crun.attackDistX[0] = exp[0].evalF(c) * redirscale
 			if len(exp) > 1 {
-				crun.attackDist[1] = exp[1].evalF(c) * redirscale
+				crun.attackDistX[1] = exp[1].evalF(c) * redirscale
+			}
+		case attackDist_y:
+			crun.attackDistY[0] = exp[0].evalF(c) * redirscale
+			if len(exp) > 1 {
+				crun.attackDistY[1] = exp[1].evalF(c) * redirscale
+			}
+		case attackDist_z:
+			crun.attackDistZ[0] = exp[0].evalF(c) * redirscale
+			if len(exp) > 1 {
+				crun.attackDistZ[1] = exp[1].evalF(c) * redirscale
 			}
 		case attackDist_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1756,18 +1756,34 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.append(OC_const_size_height_air_bottom)
 		case "size.height.down":
 			out.append(OC_const_size_height_down)
-		case "size.attack.dist", "size.attack.dist.front":
-			out.append(OC_const_size_attack_dist_front)
-		case "size.attack.dist.back":
-			out.append(OC_const_size_attack_dist_back)
-		case "size.attack.depth.back":
-			out.append(OC_const_size_attack_depth_back)
+		case "size.attack.dist", "size.attack.dist.width.front":
+			out.append(OC_const_size_attack_dist_width_front)
+		case "size.attack.dist.width.back":
+			out.append(OC_const_size_attack_dist_width_back)
+		case "size.attack.dist.height.top":
+			out.append(OC_const_size_attack_dist_height_top)
+		case "size.attack.dist.height.bottom":
+			out.append(OC_const_size_attack_dist_height_bottom)
+		case "size.attack.dist.depth.front":
+			out.append(OC_const_size_attack_dist_depth_front)
+		case "size.attack.dist.depth.back":
+			out.append(OC_const_size_attack_dist_depth_back)
 		case "size.attack.depth.front":
 			out.append(OC_const_size_attack_depth_front)
-		case "size.proj.attack.dist", "size.proj.attack.dist.front":
-			out.append(OC_const_size_proj_attack_dist_front)
-		case "size.proj.attack.dist.back":
-			out.append(OC_const_size_proj_attack_dist_back)
+		case "size.attack.depth.back":
+			out.append(OC_const_size_attack_depth_back)
+		case "size.proj.attack.dist", "size.proj.attack.dist.width.front":
+			out.append(OC_const_size_proj_attack_dist_width_front)
+		case "size.proj.attack.dist.width.back":
+			out.append(OC_const_size_proj_attack_dist_width_back)
+		case "size.proj.attack.dist.height.top":
+			out.append(OC_const_size_proj_attack_dist_height_top)
+		case "size.proj.attack.dist.height.bottom":
+			out.append(OC_const_size_proj_attack_dist_height_bottom)
+		case "size.proj.attack.dist.depth.front":
+			out.append(OC_const_size_proj_attack_dist_depth_front)
+		case "size.proj.attack.dist.depth.back":
+			out.append(OC_const_size_proj_attack_dist_depth_back)
 		case "size.proj.doscale":
 			out.append(OC_const_size_proj_doscale)
 		case "size.head.pos.x":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1731,6 +1731,18 @@ func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 		hitDef_guard_dist, VT_Int, 2, false); err != nil {
 		return err
 	}
+	if err := c.paramValue(is, sc, "guard.dist.width",
+		hitDef_guard_dist, VT_Int, 2, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "guard.dist.height",
+		hitDef_guard_dist_y, VT_Int, 2, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "guard.dist.depth",
+		hitDef_guard_dist_z, VT_Int, 2, false); err != nil {
+		return err
+	}
 	if err := c.paramValue(is, sc, "pausetime",
 		hitDef_pausetime, VT_Int, 2, false); err != nil {
 		return err
@@ -3363,7 +3375,19 @@ func (c *Compiler) attackDist(is IniSection, sc *StateControllerBase, _ int8) (S
 			return err
 		}
 		if err := c.paramValue(is, sc, "value",
-			attackDist_value, VT_Float, 2, true); err != nil {
+			attackDist_x, VT_Float, 2, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "width",
+			attackDist_x, VT_Float, 2, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "height",
+			attackDist_y, VT_Float, 2, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "depth",
+			attackDist_z, VT_Float, 2, false); err != nil {
 			return err
 		}
 		return nil

--- a/src/script.go
+++ b/src/script.go
@@ -3249,18 +3249,34 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.size.height.air[1])
 		case "size.height.down":
 			ln = lua.LNumber(c.size.height.down)
-		case "size.attack.dist", "size.attack.dist.front":
-			ln = lua.LNumber(c.size.attack.dist.front)
-		case "size.attack.dist.back":
-			ln = lua.LNumber(c.size.attack.dist.back)
-		case "size.attack.depth.back":
-			ln = lua.LNumber(c.size.attack.depth.back)
+		case "size.attack.dist", "size.attack.dist.width.front":
+			ln = lua.LNumber(c.size.attack.dist.width[0])
+		case "size.attack.dist.width.back":
+			ln = lua.LNumber(c.size.attack.dist.width[1])
+		case "size.attack.dist.height.top":
+			ln = lua.LNumber(c.size.attack.dist.height[0])
+		case "size.attack.dist.height.bottom":
+			ln = lua.LNumber(c.size.attack.dist.height[1])
+		case "size.attack.dist.depth.front":
+			ln = lua.LNumber(c.size.attack.dist.depth[0])
+		case "size.attack.dist.depth.back":
+			ln = lua.LNumber(c.size.attack.dist.depth[1])
 		case "size.attack.depth.front":
 			ln = lua.LNumber(c.size.attack.depth.front)
-		case "size.proj.attack.dist", "size.proj.attack.dist.front":
-			ln = lua.LNumber(c.size.proj.attack.dist.front)
-		case "size.proj.attack.dist.back":
-			ln = lua.LNumber(c.size.proj.attack.dist.back)
+		case "size.attack.depth.back":
+			ln = lua.LNumber(c.size.attack.depth.back)
+		case "size.proj.attack.dist", "size.proj.attack.dist.width.front":
+			ln = lua.LNumber(c.size.proj.attack.dist.width[0])
+		case "size.proj.attack.dist.width.back":
+			ln = lua.LNumber(c.size.proj.attack.dist.width[1])
+		case "size.proj.attack.dist.height.top":
+			ln = lua.LNumber(c.size.proj.attack.dist.height[0])
+		case "size.proj.attack.dist.height.bottom":
+			ln = lua.LNumber(c.size.proj.attack.dist.height[1])
+		case "size.proj.attack.dist.depth.front":
+			ln = lua.LNumber(c.size.proj.attack.dist.depth[0])
+		case "size.proj.attack.dist.depth.back":
+			ln = lua.LNumber(c.size.proj.attack.dist.depth[1])
 		case "size.proj.doscale":
 			ln = lua.LNumber(c.size.proj.doscale)
 		case "size.head.pos.x":


### PR DESCRIPTION
Feat:

- New Char Constants:

  - attack.dist.width = front, back (attack.dist.back is now the second value of attack.dist.width)
  - attack.dist.height = top, bottom
  - attack.dist.depth = front, back

- Projectile Constants:

  - proj.attack.dist.width = front, back (proj.attack.dist.back is now the second value of proj.attack.dist.width)
  - proj.attack.dist.height = top, bottom
  - proj.attack.dist.depth = front, back

Ikemen will still accept just attack.dist and proj.attack.dist for the front values of the attack.dist.width and proj.attack.dist.width.

- AttackDist New Parameters:

  - width = front, back (value parameter can still be used instead of width)
  - height = top, bottom
  - depth = front, back

- HitDef New Guard Distances:

  - guard.dist.width = front, back (guard.dist can still be used instead of guard.dist.width)
  - guard.dist.height = top, bottom
  - guard.dist.depth = front, back