### PR TITLE
refactor: Removed DrawPalNo

### DIFF
--- a/data/common1.cns.zss
+++ b/data/common1.cns.zss
@@ -992,7 +992,7 @@ if roundsExisted = 0 {
 	varRangeSet{value: 0}
 	varRangeSet{fvalue: 0}
 }
-remapPal{source: 1, 1; dest: 1, ifElse(isHelper, palNo, drawPalNo)}
+remapPal{source: 1, 1; dest: 1, palNo}
 if roundNo = 1 {
 	changeState{value: 190}
 }

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -459,7 +459,6 @@ const (
 	OC_ex_roundsexisted
 	OC_ex_ishometeam
 	OC_ex_tickspersecond
-	OC_ex_drawpalno
 	OC_ex_const240p
 	OC_ex_const480p
 	OC_ex_const720p
@@ -2563,8 +2562,6 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(c.dizzyPoints)
 	case OC_ex_dizzypointsmax:
 		sys.bcStack.PushI(c.dizzyPointsMax)
-	case OC_ex_drawpalno:
-		sys.bcStack.PushI(c.gi().drawpalno)
 	case OC_ex_envshakevar_time:
 		sys.bcStack.PushI(sys.envShake.time)
 	case OC_ex_envshakevar_freq:

--- a/src/char.go
+++ b/src/char.go
@@ -2069,7 +2069,7 @@ type CharGlobalInfo struct {
 	palettedata      *Palette
 	snd              *Snd
 	anim             AnimationTable
-	palno, drawpalno int32
+	palno		 int32
 	pal              [MaxPalNo]string
 	palExist         [MaxPalNo]bool
 	palSelectable    [MaxPalNo]bool

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -359,7 +359,6 @@ var triggerMap = map[string]int{
 	"dizzy":              1,
 	"dizzypoints":        1,
 	"dizzypointsmax":     1,
-	"drawpalno":          1,
 	"envshakevar":        1,
 	"explodvar":          1,
 	"fightscreenvar":     1,
@@ -4113,8 +4112,6 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 		out.append(OC_ex_, OC_ex_playerindexexist)
-	case "drawpalno":
-		out.append(OC_ex_, OC_ex_drawpalno)
 	case "angle":
 		out.append(OC_ex_, OC_ex_angle)
 	case "scale":

--- a/src/system.go
+++ b/src/system.go
@@ -1175,7 +1175,7 @@ func (s *System) nextRound() {
 				s.cgi[i].palettedata.palList.ResetRemap()
 				if s.cgi[i].sff.header.Ver0 == 1 {
 					p[0].remapPal(p[0].getPalfx(),
-						[...]int32{1, 1}, [...]int32{1, s.cgi[i].drawpalno})
+						[...]int32{1, 1}, [...]int32{1, s.cgi[i].palno})
 				}
 			}
 			s.cgi[i].clearPCTime()
@@ -3554,7 +3554,7 @@ func (l *Loader) reset() {
 	l.err = nil
 	for i := range sys.cgi {
 		if sys.roundsExisted[i&1] == 0 {
-			sys.cgi[i].drawpalno = -1
+			sys.cgi[i].palno = -1
 		}
 	}
 }


### PR DESCRIPTION
Nobody seems to understand the purpose of what DrawPalNo does after the recent palette select fixes so it'll be nice to remove redundancies.

Refactor:

Removed all instances of DrawPalNo from the code and replaced its uses with PalNo when necessary.