### PR TITLE
fix:shader compilation error

### DIFF
--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -121,6 +121,8 @@ func compileShader(shaderType uint32, src string) (shader uint32) {
 			str := make([]byte, size+1)
 			gl.GetShaderInfoLog(shader, size, &l, &str[0])
 			err = Error(str[:l])
+		} else {
+			err = Error("Unknown shader compile error")
 		}
 		chk(err)
 		gl.DeleteShader(shader)
@@ -155,6 +157,8 @@ func linkProgram(params ...uint32) (program uint32) {
 			str := make([]byte, size+1)
 			gl.GetProgramInfoLog(program, size, &l, &str[0])
 			err = Error(str[:l])
+		} else {
+			err = Error("Unknown link error")
 		}
 		chk(err)
 		gl.DeleteProgram(program)

--- a/src/render_gl_darwin.go
+++ b/src/render_gl_darwin.go
@@ -122,6 +122,8 @@ func compileShader(shaderType uint32, src string) (shader uint32) {
 			str := make([]byte, size+1)
 			gl.GetShaderInfoLog(shader, size, &l, &str[0])
 			err = Error(str[:l])
+		} else {
+			err = Error("Unknown shader compile error")
 		}
 		chk(err)
 		gl.DeleteShader(shader)
@@ -150,6 +152,8 @@ func linkProgram(params ...uint32) (program uint32) {
 			str := make([]byte, size+1)
 			gl.GetProgramInfoLog(program, size, &l, &str[0])
 			err = Error(str[:l])
+		} else {
+			err = Error("Unknown link error")
 		}
 		chk(err)
 		gl.DeleteProgram(program)

--- a/src/shaders/model.frag.glsl
+++ b/src/shaders/model.frag.glsl
@@ -5,6 +5,7 @@
 #define COMPAT_TEXTURE_CUBE_LOD textureLod
 out vec4 FragColor;
 #else
+#extension GL_ARB_shader_texture_lod : enable
 #define COMPAT_VARYING varying
 #define FragColor gl_FragColor
 #define COMPAT_TEXTURE texture2D


### PR DESCRIPTION
Enable the texture lod extension in 3d model fragment shader.
Fix a problem where Ikemen go crashes without error message when INFO_LOG_LENGTH is 0.