### PR TITLE
fix: ShadowOffset SCTRL not working for X axis for shadows, -nomusic & -nosound cmd line opts

### DIFF
--- a/src/anim.go
+++ b/src/anim.go
@@ -1063,7 +1063,7 @@ func (sl ShadowList) draw(x, y, scl float32) {
 		}
 
 		s.anim.ShadowDraw(drawwindow,
-			sys.cam.Offset[0]-((x-s.pos[0]-xshearoff)*scl),
+			sys.cam.Offset[0]-((x-s.pos[0]-s.shadowOffset[0]-xshearoff)*scl),
 			sys.cam.GroundLevel()+sys.cam.Offset[1]-sys.envShake.getOffset()-y-
 				(s.pos[1]*sys.stage.sdw.yscale-s.shadowOffset[1]-sys.stage.sdw.offset[1])*scl,
 			scl*s.scl[0], scl*-s.scl[1],

--- a/src/char.go
+++ b/src/char.go
@@ -4290,6 +4290,10 @@ func (c *Char) playSound(ffx string, lowpriority bool, loopCount int32, g, n, ch
 	if g < 0 {
 		return
 	}
+	// Don't do anything if we have the nosound command line flag
+	if _, ok := sys.cmdFlags["-nosound"]; ok {
+		return
+	}
 	var s *Sound
 	if ffx == "" || ffx == "s" {
 		if c.gi().snd != nil {

--- a/src/sound.go
+++ b/src/sound.go
@@ -242,6 +242,14 @@ func (bgm *Bgm) Open(filename string, loop, bgmVolume, bgmLoopStart, bgmLoopEnd,
 			lc = -1
 		}
 	}
+	// Don't do anything if we have the nomusic command line flag
+	if _, ok := sys.cmdFlags["-nomusic"]; ok {
+		return
+	}
+	// Don't do anything if we have the nosound command line flag
+	if _, ok := sys.cmdFlags["-nosound"]; ok {
+		return
+	}
 	bgm.startPos = startPosition
 	// we're going to continue to use our own modified streamLooper because beep doesn't allow
 	// direct access to loop2 for dynamic modifications to loopstart, loopend, etc.


### PR DESCRIPTION
fixes:
* ShadowOffset SCTRL being broken for the X axis
* -nomusic now has an effect without having to go through Lua (fixes -nomusic not working from barebones command line)
* -nosound now has an effect without having to go through Lua (fixes -nosounds not working from barebones command line)