### PR TITLE
fix: animation offset, Clsn scale, ClsnOverlap

### DIFF
--- a/src/common.go
+++ b/src/common.go
@@ -787,7 +787,7 @@ func (l *Layout) DrawAnim(r *[4]int32, x, y, scl float32, ln int16,
 		a.Draw(r, x+l.offset[0], y+l.offset[1]+float32(sys.gameHeight-240),
 			scl, scl, l.scale[0]*float32(l.facing), l.scale[0]*float32(l.facing),
 			l.scale[1]*float32(l.vfacing), 0, Rotation{l.angle, 0, 0},
-			float32(sys.gameWidth-320)/2, palfx, false, 1, false, 1, 0, 0, 0)
+			float32(sys.gameWidth-320)/2, palfx, false, 1, false, [2]float32{1, 1}, 0, 0, 0)
 	}
 }
 func (l *Layout) DrawText(x, y, scl float32, ln int16,

--- a/src/script.go
+++ b/src/script.go
@@ -3148,6 +3148,34 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LBool(sys.debugWC.canRecover()))
 		return 1
 	})
+	luaRegister(l, "clsnoverlap", func(l *lua.LState) int {
+		id := int32(numArg(l, 2))
+		var c1, c2 int32
+		// Get box 1 type
+		switch strArg(l, 1) {
+		case "clsn1":
+			c1 = 1
+		case "clsn2":
+			c1 = 2
+		case "size":
+			c1 = 3
+		default:
+			l.RaiseError("Invalid collision box type")
+		}
+		// Get box 2 type
+		switch strArg(l, 3) {
+		case "clsn1":
+			c2 = 1
+		case "clsn2":
+			c2 = 2
+		case "size":
+			c2 = 3
+		default:
+			l.RaiseError("Invalid collision box type")
+		}
+		l.Push(lua.LBool(sys.debugWC.clsnOverlapTrigger(c1, id, c2)))
+		return 1
+	})
 	luaRegister(l, "clsnvar", func(l *lua.LState) int {
 		c := strArg(l, 1)
 		idx := int(numArg(l, 2))

--- a/src/script.go
+++ b/src/script.go
@@ -2106,9 +2106,9 @@ func systemScriptInit(l *lua.LState) {
 		sys.com[sys.debugWC.playerNo] = level
 		for _, c := range sys.chars[sys.debugWC.playerNo] {
 			if level == 0 {
-				c.key = sys.debugWC.playerNo
+				c.controller = sys.debugWC.playerNo
 			} else {
-				c.key = ^sys.debugWC.playerNo
+				c.controller = ^sys.debugWC.playerNo
 			}
 		}
 		return 0

--- a/src/stage.go
+++ b/src/stage.go
@@ -234,12 +234,12 @@ func readBackGround(is IniSection, link *backGround,
 		bg.anim.srcAlpha = -1
 		bg.anim.dstAlpha = 0
 	}
-	if is.readI32ForStage("tile", &bg.anim.tile.x, &bg.anim.tile.y) {
+	if is.readI32ForStage("tile", &bg.anim.tile.xflag, &bg.anim.tile.yflag) {
 		if bg.typ == 2 {
-			bg.anim.tile.y = 0
+			bg.anim.tile.yflag = 0
 		}
-		if bg.anim.tile.x < 0 {
-			bg.anim.tile.x = math.MaxInt32
+		if bg.anim.tile.xflag < 0 {
+			bg.anim.tile.xflag = math.MaxInt32
 		}
 	}
 	if bg.typ == 2 {
@@ -249,20 +249,20 @@ func readBackGround(is IniSection, link *backGround,
 		is.ReadF32("yscalestart", &bg.yscalestart)
 		is.ReadF32("yscaledelta", &bg.yscaledelta)
 	} else {
-		is.ReadI32("tilespacing", &bg.anim.tile.sx, &bg.anim.tile.sy)
-		//bg.anim.tile.sy = bg.anim.tile.sx
+		is.ReadI32("tilespacing", &bg.anim.tile.xspacing, &bg.anim.tile.yspacing)
+		//bg.anim.tile.yspacing = bg.anim.tile.xspacing
 		if bg.actionno < 0 && len(bg.anim.frames) > 0 {
 			if spr := sff.GetSprite(
 				bg.anim.frames[0].Group, bg.anim.frames[0].Number); spr != nil {
-				bg.anim.tile.sx += int32(spr.Size[0])
-				bg.anim.tile.sy += int32(spr.Size[1])
+				bg.anim.tile.xspacing += int32(spr.Size[0])
+				bg.anim.tile.yspacing += int32(spr.Size[1])
 			}
 		} else {
-			if bg.anim.tile.sx == 0 {
-				bg.anim.tile.x = 0
+			if bg.anim.tile.xspacing == 0 {
+				bg.anim.tile.xflag = 0
 			}
-			if bg.anim.tile.sy == 0 {
-				bg.anim.tile.y = 0
+			if bg.anim.tile.yspacing == 0 {
+				bg.anim.tile.yflag = 0
 			}
 		}
 	}
@@ -451,7 +451,7 @@ func (bg backGround) draw(pos [2]float32, drawscl, bgscl, stglscl float32,
 			bg.xscale[0]*bgscl*(bg.scalestart[0]+xs)*xs3,
 			xbs*bgscl*(bg.scalestart[0]+xs)*xs3,
 			ys*ys3, xras*x/(AbsF(ys*ys3)*lscl[1]*float32(bg.anim.spr.Size[1])*bg.scalestart[1])*sclx_recip*bg.scalestart[1],
-			Rotation{}, float32(sys.gameWidth)/2, bg.palfx, true, 1, false, 1, 0, 0, 0)
+			Rotation{}, float32(sys.gameWidth)/2, bg.palfx, true, 1, false, [2]float32{1, 1}, 0, 0, 0)
 	}
 }
 

--- a/src/system.go
+++ b/src/system.go
@@ -1779,7 +1779,7 @@ func (s *System) action() {
 	if s.superanim != nil {
 		s.spritesLayer1.add(&SprData{s.superanim, &s.superpmap, s.superpos,
 			[...]float32{s.superfacing, 1}, [2]int32{-1}, 5, Rotation{}, [2]float32{},
-			false, true, s.cgi[s.superplayer].mugenver[0] != 1, 1, 1, 0, 0, [4]float32{0, 0, 0, 0}})
+			false, true, s.cgi[s.superplayer].mugenver[0] != 1, 1, [2]float32{1, 1}, 0, 0, [4]float32{0, 0, 0, 0}})
 		if s.superanim.loopend {
 			s.superanim = nil
 		}

--- a/src/system.go
+++ b/src/system.go
@@ -1165,7 +1165,7 @@ func (s *System) nextRound() {
 			p[0].posReset()
 			p[0].setCtrl(false)
 			p[0].clearState()
-			p[0].clear2()
+			p[0].clearNextRound()
 			p[0].varRangeSet(0, s.cgi[i].data.intpersistindex-1, 0)
 			p[0].fvarRangeSet(0, s.cgi[i].data.floatpersistindex-1, 0)
 			for j := range p[0].cmd {
@@ -1271,7 +1271,7 @@ func (s *System) commandUpdate() {
 			for _, c := range p {
 				if (c.helperIndex == 0 ||
 					c.helperIndex > 0 && &c.cmd[0] != &r.cmd[0]) &&
-					c.cmd[0].Input(c.key, int32(c.facing), sys.com[i], c.inputFlag) {
+					c.cmd[0].Input(c.controller, int32(c.facing), sys.com[i], c.inputFlag) {
 					hp := c.hitPause() && c.gi().constants["input.pauseonhitpause"] != 0
 					buftime := Btoi(hp && c.gi().mugenver[0] != 1)
 					if s.super > 0 {
@@ -1284,11 +1284,11 @@ func (s *System) commandUpdate() {
 						}
 					}
 					for j := range c.cmd {
-						c.cmd[j].Step(int32(c.facing), c.key < 0, hp, buftime+Btoi(hp))
+						c.cmd[j].Step(int32(c.facing), c.controller < 0, hp, buftime+Btoi(hp))
 					}
 				}
 			}
-			if r.key < 0 {
+			if r.controller < 0 {
 				cc := int32(-1)
 				// AI Scaling
 				// TODO: Balance AI Scaling
@@ -2206,7 +2206,7 @@ func (s *System) fight() (reload bool) {
 	var level [len(s.chars)]int32
 	for i, p := range s.chars {
 		if len(p) > 0 {
-			p[0].clear2()
+			p[0].clearNextRound()
 			level[i] = s.wincnt.getLevel(i)
 			if s.powerShare[i&1] && p[0].teamside != -1 {
 				pmax := Max(s.cgi[i&1].data.power, s.cgi[i].data.power)
@@ -3326,9 +3326,9 @@ func (l *Loader) loadChar(pn int) int {
 	var p *Char
 	if len(sys.chars[pn]) > 0 && cdef == sys.cgi[pn].def {
 		p = sys.chars[pn][0]
-		p.key = pn
+		p.controller = pn
 		if sys.com[pn] != 0 {
-			p.key ^= -1
+			p.controller ^= -1
 		}
 		p.clearCachedData()
 	} else {
@@ -3400,7 +3400,7 @@ func (l *Loader) loadAttachedChar(pn int) int {
 	var p *Char
 	if len(sys.chars[pn]) > 0 && cdef == sys.cgi[pn].def {
 		p = sys.chars[pn][0]
-		//p.key = -pn
+		//p.controller = -pn
 		p.clearCachedData()
 	} else {
 		p = newChar(pn, 0)


### PR DESCRIPTION
Fix:
- Fixed animation offsets being scaled incorrectly when a character uses another character's animations (such as during throws)
- Fixed chars having Clsn scale 0 in the very first frame they are created
- Fixes #2089

Feat:
- Added missing Lua version of ClsnOverlap

Refactor:
- Changed character "key" variable to "controller" (player who controls the char). It's clearer and "key" is also used in input.go for actual keys
- Simplified some "new character" functions