### PR TITLE
feat:Add option to disable 3d Model and shadow

### DIFF
--- a/data/system.base.def
+++ b/data/system.base.def
@@ -1651,7 +1651,7 @@
 	; This list is populated with shaders existing in 'external/shaders' directory
 	menu.itemname.menuvideo.shaders.empty = ""
 	menu.itemname.menuvideo.shaders.noshader = "Disable"
-	menu.itemname.menuvideo.shaders.back = "Backs"
+	menu.itemname.menuvideo.shaders.back = "Back"
 	menu.itemname.menuvideo.model = "3D Model Settings"
 	menu.itemname.menuvideo.model.enablemodel = "3D Model"
 	menu.itemname.menuvideo.model.enablshadow = "Shadow"

--- a/data/system.base.def
+++ b/data/system.base.def
@@ -1651,7 +1651,12 @@
 	; This list is populated with shaders existing in 'external/shaders' directory
 	menu.itemname.menuvideo.shaders.empty = ""
 	menu.itemname.menuvideo.shaders.noshader = "Disable"
-	menu.itemname.menuvideo.shaders.back = "Back"
+	menu.itemname.menuvideo.shaders.back = "Backs"
+	menu.itemname.menuvideo.model = "3D Model Settings"
+	menu.itemname.menuvideo.model.enablemodel = "3D Model"
+	menu.itemname.menuvideo.model.enablshadow = "Shadow"
+	menu.itemname.menuvideo.model.empty = ""
+	menu.itemname.menuvideo.model.back = "Back"
 	menu.itemname.menuvideo.empty = ""
 	menu.itemname.menuvideo.back = "Back"
 

--- a/external/script/motif.lua
+++ b/external/script/motif.lua
@@ -2039,6 +2039,11 @@ function motif.setBaseOptionInfo()
 	motif.option_info.menu_itemname_menuvideo_shaders_empty = ""
 	motif.option_info.menu_itemname_menuvideo_shaders_noshader = "Disable"
 	motif.option_info.menu_itemname_menuvideo_shaders_back = "Back"
+	motif.option_info.menu_itemname_menuvideo_model = "3D Model Settings"
+	motif.option_info.menu_itemname_menuvideo_model_enablemodel = "3D Model"
+	motif.option_info.menu_itemname_menuvideo_model_enablemodelshadow = "Shadow"
+	motif.option_info.menu_itemname_menuvideo_model_empty = ""
+	motif.option_info.menu_itemname_menuvideo_model_back = "Back"
 	motif.option_info.menu_itemname_menuvideo_empty = ""
 	motif.option_info.menu_itemname_menuvideo_back = "Back"
 
@@ -2162,6 +2167,11 @@ function motif.setBaseOptionInfo()
 		"menuvideo_shaders_empty",
 		"menuvideo_shaders_noshader",
 		"menuvideo_shaders_back",
+		"menuvideo_model",
+		"menuvideo_model_enablemodel",
+		"menuvideo_model_enablemodelshadow",
+		"menuvideo_model_empty",
+		"menuvideo_model_back",
 		"menuvideo_empty",
 		"menuvideo_back",
 		"menuaudio",

--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -216,6 +216,8 @@ options.t_itemname = {
 			config.VolumeSfx = 80
 			config.VRetrace = 1
 			config.WindowScaleMode = true
+			config.enableModel = true
+			config.enableModelShadow = true
 			--config.WavChannels = 32
 			--config.WindowCentered = true
 			--config.WindowIcon = {"external/icons/IkemenCylia.png"}
@@ -261,6 +263,8 @@ options.t_itemname = {
 			toggleVsync(config.VRetrace)
 			toggleWindowScaleMode(config.WindowScaleMode)
 			toggleKeepAspect(config.KeepAspect)
+			toggleEnableModel(config.enableModel)
+			toggleEnableModelShadow(config.enableShadow)
 			options.modified = true
 			options.needReload = true
 		end
@@ -964,6 +968,50 @@ options.t_itemname = {
 		end
 		return true
 	end,
+	--Model (submenu)
+	['model'] = function(t, item, cursorPosY, moveTxt)
+		if main.f_input(main.t_players, {'$F', '$B', 'pal', 's'}) then
+			sndPlay(motif.files.snd_data, motif.option_info.cursor_move_snd[1], motif.option_info.cursor_move_snd[2])
+			local t_pos = {}
+			local ok = false
+			t_pos.selected = true
+			t.submenu[t.items[item].itemname].loop()
+			t.items[item].vardisplay = ""
+		end
+		return true
+	end,
+	--Enable Model
+	['enablemodel'] = function(t, item, cursorPosY, moveTxt)
+		if main.f_input(main.t_players, {'$F', '$B', 'pal', 's'}) then
+			sndPlay(motif.files.snd_data, motif.option_info.cursor_move_snd[1], motif.option_info.cursor_move_snd[2])
+			if config.EnableModel == true then
+				config.EnableModel = false
+			else
+				config.EnableModel = true
+			end
+			toggleEnableModel()
+			t.items[item].vardisplay = options.f_definedDisplay(config.EnableModel, {[true] = motif.option_info.menu_valuename_enabled}, motif.option_info.menu_valuename_disabled)
+			options.modified = true
+			options.needReload = true
+		end
+		return true
+	end,
+	--Enable Model Shadow
+	['enablemodelshadow'] = function(t, item, cursorPosY, moveTxt)
+		if main.f_input(main.t_players, {'$F', '$B', 'pal', 's'}) then
+			sndPlay(motif.files.snd_data, motif.option_info.cursor_move_snd[1], motif.option_info.cursor_move_snd[2])
+			if config.EnableModelShadow == true then
+				config.EnableModelShadow = false
+			else
+				config.EnableModelShadow = true
+			end
+			toggleEnableModel()
+			t.items[item].vardisplay = options.f_definedDisplay(config.EnableModelShadow, {[true] = motif.option_info.menu_valuename_enabled}, motif.option_info.menu_valuename_disabled)
+			options.modified = true
+			options.needReload = true
+		end
+		return true
+	end,
 	--Master Volume
 	['mastervolume'] = function(t, item, cursorPosY, moveTxt)
 		if main.f_input(main.t_players, {'$F'}) and config.VolumeMaster < 200 then
@@ -1375,6 +1423,12 @@ options.t_vardisplay = {
 	['difficulty'] = function()
 		return config.Difficulty
 	end,
+	['enablemodel'] = function()
+		return options.f_definedDisplay(config.EnableModel, {[true] = motif.option_info.menu_valuename_enabled}, motif.option_info.menu_valuename_disabled)
+	end,
+	['enablemodelshadow'] = function()
+		return options.f_definedDisplay(config.EnableModelShadow, {[true] = motif.option_info.menu_valuename_enabled}, motif.option_info.menu_valuename_disabled)
+	end,
 	['explodmax'] = function()
 		return config.MaxExplod
 	end,
@@ -1429,6 +1483,9 @@ options.t_vardisplay = {
 	end,
 	['minturns'] = function()
 		return config.NumTurns[1]
+	end,
+	['model'] = function()
+		return ""
 	end,
 	['msaa'] = function()
 		return options.f_definedDisplay(config.MSAA, {[0] = motif.option_info.menu_valuename_disabled}, config.MSAA .. 'x')

--- a/src/main.go
+++ b/src/main.go
@@ -30,11 +30,15 @@ func chk(err error) {
 }
 
 // Extended version of 'chk()'
-func chkEX(err error, txt string) {
+func chkEX(err error, txt string, crash bool) bool {
 	if err != nil {
 		ShowErrorDialog(txt + err.Error())
-		panic(Error(txt + err.Error()))
+		if crash {
+			panic(Error(txt + err.Error()))
+		}
+		return true
 	}
+	return false
 }
 
 func createLog(p string) *os.File {
@@ -218,6 +222,8 @@ type configSettings struct {
 	Difficulty                 int
 	EscOpensMenu               bool
 	ExternalShaders            []string
+	EnableModel                bool
+	EnableModelShadow          bool
 	FirstRun                   bool
 	FontShaderVer              uint
 	ForceStageZoomin           float32
@@ -321,7 +327,7 @@ func setupConfig() configSettings {
 			bytes[0] == 0xef && bytes[1] == 0xbb && bytes[2] == 0xbf {
 			bytes = bytes[3:]
 		}
-		chkEX(json.Unmarshal(bytes, &tmp), "Error while loading the config file.\n")
+		chkEX(json.Unmarshal(bytes, &tmp), "Error while loading the config file.\n", true)
 	}
 	// Fix incorrect settings (default values saved into config.json)
 	switch tmp.AudioSampleRate {
@@ -377,6 +383,8 @@ func setupConfig() configSettings {
 	sys.clsnDarken = tmp.DebugClsnDarken
 	sys.consoleRows = tmp.DebugConsoleRows
 	sys.controllerStickSensitivity = tmp.ControllerStickSensitivity
+	sys.enableModel = tmp.EnableModel
+	sys.enableModelShadow = tmp.EnableModelShadow
 	sys.explodMax = tmp.MaxExplod
 	sys.externalShaderList = tmp.ExternalShaders
 	// Bump up shader version for macOS only

--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -68,22 +68,31 @@ type ShaderProgram struct {
 	t map[string]int
 }
 
-func newShaderProgram(vert, frag, geo, id string) (s *ShaderProgram) {
-	vertObj := compileShader(gl.VERTEX_SHADER, vert)
-	fragObj := compileShader(gl.FRAGMENT_SHADER, frag)
-	var prog uint32
-	if len(geo) > 0 {
-		geoObj := compileShader(gl.GEOMETRY_SHADER_EXT, geo)
-		prog = linkProgram(vertObj, fragObj, geoObj)
-	} else {
-		prog = linkProgram(vertObj, fragObj)
+func newShaderProgram(vert, frag, geo, id string, crashWhenFail bool) (s *ShaderProgram, err error) {
+	var vertObj, fragObj, geoObj, prog uint32
+	if vertObj, err = compileShader(gl.VERTEX_SHADER, vert); chkEX(err, "Shader compliation error on "+id+"\n", crashWhenFail) {
+		return nil, err
 	}
-
+	if fragObj, err = compileShader(gl.FRAGMENT_SHADER, frag); chkEX(err, "Shader compliation error on "+id+"\n", crashWhenFail) {
+		return nil, err
+	}
+	if len(geo) > 0 {
+		if geoObj, err = compileShader(gl.GEOMETRY_SHADER_EXT, geo); chkEX(err, "Shader compliation error on "+id+"\n", crashWhenFail) {
+			return nil, err
+		}
+		if prog, err = linkProgram(vertObj, fragObj, geoObj); chkEX(err, "Link program error on "+id+"\n", crashWhenFail) {
+			return nil, err
+		}
+	} else {
+		if prog, err = linkProgram(vertObj, fragObj); chkEX(err, "Link program error on "+id+"\n", crashWhenFail) {
+			return nil, err
+		}
+	}
 	s = &ShaderProgram{program: prog}
 	s.a = make(map[string]int32)
 	s.u = make(map[string]int32)
 	s.t = make(map[string]int)
-	return
+	return s, nil
 }
 func (s *ShaderProgram) RegisterAttributes(names ...string) {
 	for _, name := range names {
@@ -104,7 +113,7 @@ func (s *ShaderProgram) RegisterTextures(names ...string) {
 	}
 }
 
-func compileShader(shaderType uint32, src string) (shader uint32) {
+func compileShader(shaderType uint32, src string) (shader uint32, err error) {
 	shader = gl.CreateShader(shaderType)
 	src = "#version 120\n" + src + "\x00"
 	s, _ := gl.Strs(src)
@@ -114,7 +123,7 @@ func compileShader(shaderType uint32, src string) (shader uint32) {
 	var ok int32
 	gl.GetShaderiv(shader, gl.COMPILE_STATUS, &ok)
 	if ok == 0 {
-		var err error
+		//var err error
 		var size, l int32
 		gl.GetShaderiv(shader, gl.INFO_LOG_LENGTH, &size)
 		if size > 0 {
@@ -124,23 +133,24 @@ func compileShader(shaderType uint32, src string) (shader uint32) {
 		} else {
 			err = Error("Unknown shader compile error")
 		}
-		chk(err)
+		//chk(err)
 		gl.DeleteShader(shader)
-		panic(Error("Shader compile error"))
+		//panic(Error("Shader compile error"))
+		return 0, err
 	}
-	return
+	return shader, nil
 }
 
-func linkProgram(params ...uint32) (program uint32) {
+func linkProgram(params ...uint32) (program uint32, err error) {
 	program = gl.CreateProgram()
 	for _, param := range params {
 		gl.AttachShader(program, param)
 	}
 	if len(params) > 2 {
 		// Geometry Shader Params
-		gl.ProgramParameteriEXT(program, gl.GEOMETRY_INPUT_TYPE_EXT, gl.TRIANGLES)
-		gl.ProgramParameteriEXT(program, gl.GEOMETRY_OUTPUT_TYPE_EXT, gl.TRIANGLE_STRIP)
-		gl.ProgramParameteriEXT(program, gl.GEOMETRY_VERTICES_OUT_EXT, 3*6)
+		gl.ProgramParameteriARB(program, gl.GEOMETRY_INPUT_TYPE_ARB, gl.TRIANGLES)
+		gl.ProgramParameteriARB(program, gl.GEOMETRY_OUTPUT_TYPE_ARB, gl.TRIANGLE_STRIP)
+		gl.ProgramParameteriARB(program, gl.GEOMETRY_VERTICES_OUT_ARB, 3*6)
 	}
 	gl.LinkProgram(program)
 	// Mark shaders for deletion when the program is deleted
@@ -150,7 +160,7 @@ func linkProgram(params ...uint32) (program uint32) {
 	var ok int32
 	gl.GetProgramiv(program, gl.LINK_STATUS, &ok)
 	if ok == 0 {
-		var err error
+		//var err error
 		var size, l int32
 		gl.GetProgramiv(program, gl.INFO_LOG_LENGTH, &size)
 		if size > 0 {
@@ -160,11 +170,12 @@ func linkProgram(params ...uint32) (program uint32) {
 		} else {
 			err = Error("Unknown link error")
 		}
-		chk(err)
+		//chk(err)
 		gl.DeleteProgram(program)
-		panic(Error("Link error"))
+		//panic(Error("Link error"))
+		return 0, err
 	}
-	return
+	return program, nil
 }
 
 // ------------------------------------------------------------------
@@ -336,6 +347,9 @@ type Renderer struct {
 	cubemapFilteringShader  *ShaderProgram
 	stageVertexBuffer       uint32
 	stageIndexBuffer        uint32
+
+	enableModel  bool
+	enableShadow bool
 }
 
 //go:embed shaders/sprite.vert.glsl
@@ -371,9 +385,64 @@ var panoramaToCubeMapFragShader string
 //go:embed shaders/cubemapFiltering.frag.glsl
 var cubemapFilteringFragShader string
 
+//init 3D model shader
+func (r *Renderer) InitModelShader() error {
+	var err error
+	if r.enableShadow {
+		r.modelShader, err = newShaderProgram(modelVertShader, "#define ENABLE_SHADOW\n"+modelFragShader, "", "Model Shader", false)
+	} else {
+		r.modelShader, err = newShaderProgram(modelVertShader, modelFragShader, "", "Model Shader", false)
+	}
+	if err != nil {
+		return err
+	}
+	r.modelShader.RegisterAttributes("vertexId", "position", "uv", "normalIn", "tangentIn", "vertColor", "joints_0", "joints_1", "weights_0", "weights_1")
+	r.modelShader.RegisterUniforms("model", "view", "projection", "farPlane", "normalMatrix", "unlit", "baseColorFactor", "add", "mult", "useTexture", "useNormalMap", "useMetallicRoughnessMap", "neg", "gray", "hue",
+		"enableAlpha", "alphaThreshold", "numJoints", "morphTargetWeight", "morphTargetOffset", "numTargets", "numVertices",
+		"metallicRoughness", "ambientOcclusionStrength", "environmentIntensity", "mipCount",
+		"cameraPosition", "environmentRotation",
+		"lightMatrices[0]", "lightMatrices[1]", "lightMatrices[2]", "lightMatrices[3]",
+		"lights[0].direction", "lights[0].range", "lights[0].color", "lights[0].intensity", "lights[0].position", "lights[0].innerConeCos", "lights[0].outerConeCos", "lights[0].type", "lights[0].shadowBias", "lights[0].shadowMapFar",
+		"lights[1].direction", "lights[1].range", "lights[1].color", "lights[1].intensity", "lights[1].position", "lights[1].innerConeCos", "lights[1].outerConeCos", "lights[1].type", "lights[1].shadowBias", "lights[1].shadowMapFar",
+		"lights[2].direction", "lights[2].range", "lights[2].color", "lights[2].intensity", "lights[2].position", "lights[2].innerConeCos", "lights[2].outerConeCos", "lights[2].type", "lights[2].shadowBias", "lights[2].shadowMapFar",
+		"lights[3].direction", "lights[3].range", "lights[3].color", "lights[3].intensity", "lights[3].position", "lights[3].innerConeCos", "lights[3].outerConeCos", "lights[3].type", "lights[3].shadowBias", "lights[3].shadowMapFar",
+	)
+	r.modelShader.RegisterTextures("tex", "morphTargetValues", "jointMatrices", "normalMap", "metallicRoughnessMap", "ambientOcclusionMap", "lambertianEnvSampler", "GGXEnvSampler", "GGXLUT",
+		"shadowMap[0]", "shadowMap[1]", "shadowMap[2]", "shadowMap[3]",
+		"shadowCubeMap[0]", "shadowCubeMap[1]", "shadowCubeMap[2]", "shadowCubeMap[3]")
+
+	if r.enableShadow {
+		r.shadowMapShader, err = newShaderProgram(shadowVertShader, shadowFragShader, shadowGeoShader, "Shadow Map Shader", false)
+		if err != nil {
+			return err
+		}
+		r.shadowMapShader.RegisterAttributes("vertexId", "position", "vertColor", "uv", "joints_0", "joints_1", "weights_0", "weights_1")
+		r.shadowMapShader.RegisterUniforms("model", "lightMatrices[0]", "lightMatrices[1]", "lightMatrices[2]", "lightMatrices[3]", "lightMatrices[4]", "lightMatrices[5]", "lightType", "lightPos", "farPlane", "numJoints", "morphTargetWeight", "morphTargetOffset", "numTargets", "numVertices", "enableAlpha", "alphaThreshold", "baseColorFactor", "useTexture")
+		r.shadowMapShader.RegisterTextures("morphTargetValues", "jointMatrices", "tex")
+	}
+	r.panoramaToCubeMapShader, err = newShaderProgram(identVertShader, panoramaToCubeMapFragShader, "", "Panorama To Cubemap Shader", false)
+	if err != nil {
+		return err
+	}
+	r.panoramaToCubeMapShader.RegisterAttributes("VertCoord")
+	r.panoramaToCubeMapShader.RegisterUniforms("currentFace")
+	r.panoramaToCubeMapShader.RegisterTextures("panorama")
+
+	r.cubemapFilteringShader, err = newShaderProgram(identVertShader, cubemapFilteringFragShader, "", "Cubemap Filtering Shader", false)
+	if err != nil {
+		return err
+	}
+	r.cubemapFilteringShader.RegisterAttributes("VertCoord")
+	r.cubemapFilteringShader.RegisterUniforms("sampleCount", "distribution", "width", "currentFace", "roughness", "intensityScale", "isLUT")
+	r.cubemapFilteringShader.RegisterTextures("cubeMap")
+	return nil
+}
+
 // Render initialization.
 // Creates the default shaders, the framebuffer and enables MSAA.
 func (r *Renderer) Init() {
+	r.enableModel = sys.enableModel
+	r.enableShadow = sys.enableModelShadow
 	chk(gl.Init())
 	sys.errLog.Printf("Using OpenGL %v (%v)", gl.GetString(gl.VERSION), gl.GetString(gl.RENDERER))
 
@@ -395,44 +464,16 @@ func (r *Renderer) Init() {
 	gl.GenBuffers(1, &r.stageIndexBuffer)
 
 	// Sprite shader
-	r.spriteShader = newShaderProgram(vertShader, fragShader, "", "Main Shader")
+	r.spriteShader, _ = newShaderProgram(vertShader, fragShader, "", "Main Shader", true)
 	r.spriteShader.RegisterAttributes("position", "uv")
 	r.spriteShader.RegisterUniforms("modelview", "projection", "x1x2x4x3",
 		"alpha", "tint", "mask", "neg", "gray", "add", "mult", "isFlat", "isRgba", "isTrapez", "hue")
 	r.spriteShader.RegisterTextures("pal", "tex")
-
-	// 3D model shader
-	r.modelShader = newShaderProgram(modelVertShader, modelFragShader, "", "Model Shader")
-	r.modelShader.RegisterAttributes("vertexId", "position", "uv", "normalIn", "tangentIn", "vertColor", "joints_0", "joints_1", "weights_0", "weights_1")
-	r.modelShader.RegisterUniforms("model", "view", "projection", "farPlane", "normalMatrix", "unlit", "baseColorFactor", "add", "mult", "useTexture", "useNormalMap", "useMetallicRoughnessMap", "neg", "gray", "hue",
-		"enableAlpha", "alphaThreshold", "numJoints", "morphTargetWeight", "morphTargetOffset", "numTargets", "numVertices",
-		"metallicRoughness", "ambientOcclusionStrength", "environmentIntensity", "mipCount",
-		"cameraPosition", "environmentRotation",
-		"lightMatrices[0]", "lightMatrices[1]", "lightMatrices[2]", "lightMatrices[3]",
-		"lights[0].direction", "lights[0].range", "lights[0].color", "lights[0].intensity", "lights[0].position", "lights[0].innerConeCos", "lights[0].outerConeCos", "lights[0].type", "lights[0].shadowBias", "lights[0].shadowMapFar",
-		"lights[1].direction", "lights[1].range", "lights[1].color", "lights[1].intensity", "lights[1].position", "lights[1].innerConeCos", "lights[1].outerConeCos", "lights[1].type", "lights[1].shadowBias", "lights[1].shadowMapFar",
-		"lights[2].direction", "lights[2].range", "lights[2].color", "lights[2].intensity", "lights[2].position", "lights[2].innerConeCos", "lights[2].outerConeCos", "lights[2].type", "lights[2].shadowBias", "lights[2].shadowMapFar",
-		"lights[3].direction", "lights[3].range", "lights[3].color", "lights[3].intensity", "lights[3].position", "lights[3].innerConeCos", "lights[3].outerConeCos", "lights[3].type", "lights[3].shadowBias", "lights[3].shadowMapFar",
-	)
-	r.modelShader.RegisterTextures("tex", "morphTargetValues", "jointMatrices", "normalMap", "metallicRoughnessMap", "ambientOcclusionMap", "lambertianEnvSampler", "GGXEnvSampler", "GGXLUT",
-		"shadowMap[0]", "shadowMap[1]", "shadowMap[2]", "shadowMap[3]",
-		"shadowCubeMap[0]", "shadowCubeMap[1]", "shadowCubeMap[2]", "shadowCubeMap[3]")
-
-	r.shadowMapShader = newShaderProgram(shadowVertShader, shadowFragShader, shadowGeoShader, "Shadow Map Shader")
-	//r.shadowMapShader = newShaderProgram(shadowVertShader, shadowFragShader, "", "Shadow Map Shader")
-	r.shadowMapShader.RegisterAttributes("vertexId", "position", "vertColor", "uv", "joints_0", "joints_1", "weights_0", "weights_1")
-	r.shadowMapShader.RegisterUniforms("model", "lightMatrices[0]", "lightMatrices[1]", "lightMatrices[2]", "lightMatrices[3]", "lightMatrices[4]", "lightMatrices[5]", "lightType", "lightPos", "farPlane", "numJoints", "morphTargetWeight", "morphTargetOffset", "numTargets", "numVertices", "enableAlpha", "alphaThreshold", "baseColorFactor", "useTexture")
-	r.shadowMapShader.RegisterTextures("morphTargetValues", "jointMatrices", "tex")
-
-	r.panoramaToCubeMapShader = newShaderProgram(identVertShader, panoramaToCubeMapFragShader, "", "Panorama To Cubemap Shader")
-	r.panoramaToCubeMapShader.RegisterAttributes("VertCoord")
-	r.panoramaToCubeMapShader.RegisterUniforms("currentFace")
-	r.panoramaToCubeMapShader.RegisterTextures("panorama")
-
-	r.cubemapFilteringShader = newShaderProgram(identVertShader, cubemapFilteringFragShader, "", "Cubemap Filtering Shader")
-	r.cubemapFilteringShader.RegisterAttributes("VertCoord")
-	r.cubemapFilteringShader.RegisterUniforms("sampleCount", "distribution", "width", "currentFace", "roughness", "intensityScale", "isLUT")
-	r.cubemapFilteringShader.RegisterTextures("cubeMap")
+	if r.enableModel {
+		if err := r.InitModelShader(); err != nil {
+			r.enableModel = false
+		}
+	}
 
 	// Compile postprocessing shaders
 
@@ -440,14 +481,14 @@ func (r *Renderer) Init() {
 	r.postShaderSelect = make([]*ShaderProgram, 1+len(sys.externalShaderList))
 
 	// Ident shader (no postprocessing)
-	r.postShaderSelect[0] = newShaderProgram(identVertShader, identFragShader, "", "Identity Postprocess")
+	r.postShaderSelect[0], _ = newShaderProgram(identVertShader, identFragShader, "", "Identity Postprocess", true)
 	r.postShaderSelect[0].RegisterAttributes("VertCoord")
 	r.postShaderSelect[0].RegisterUniforms("Texture", "TextureSize", "CurrentTime")
 
 	// External Shaders
 	for i := 0; i < len(sys.externalShaderList); i++ {
-		r.postShaderSelect[1+i] = newShaderProgram(sys.externalShaders[0][i],
-			sys.externalShaders[1][i], "", fmt.Sprintf("Postprocess Shader #%v", i+1))
+		r.postShaderSelect[1+i], _ = newShaderProgram(sys.externalShaders[0][i],
+			sys.externalShaders[1][i], "", fmt.Sprintf("Postprocess Shader #%v", i+1), true)
 		r.postShaderSelect[1+i].RegisterUniforms("Texture", "TextureSize", "CurrentTime")
 	}
 
@@ -471,7 +512,6 @@ func (r *Renderer) Init() {
 
 	if sys.multisampleAntialiasing > 0 {
 		gl.TexImage2DMultisample(gl.TEXTURE_2D_MULTISAMPLE, sys.multisampleAntialiasing, gl.RGBA, sys.scrrect[2], sys.scrrect[3], true)
-
 	} else {
 		gl.TexImage2D(gl.TEXTURE_2D, 0, gl.RGBA, sys.scrrect[2], sys.scrrect[3], 0, gl.RGBA, gl.UNSIGNED_BYTE, nil)
 	}
@@ -516,38 +556,42 @@ func (r *Renderer) Init() {
 		gl.FramebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, r.fbo_texture, 0)
 		gl.FramebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, r.rbo_depth)
 	}
-	gl.GenFramebuffersEXT(1, &r.fbo_shadow)
-	gl.ActiveTexture(gl.TEXTURE0)
-	gl.GenTextures(4, &r.fbo_shadow_texture[0])
-	gl.GenTextures(4, &r.fbo_shadow_cube_texture[0])
+	if r.enableModel {
+		if r.enableShadow {
+			gl.GenFramebuffersEXT(1, &r.fbo_shadow)
+			gl.ActiveTexture(gl.TEXTURE0)
+			gl.GenTextures(4, &r.fbo_shadow_texture[0])
+			gl.GenTextures(4, &r.fbo_shadow_cube_texture[0])
 
-	for i := 0; i < 4; i++ {
-		gl.BindTexture(gl.TEXTURE_2D, r.fbo_shadow_texture[i])
+			for i := 0; i < 4; i++ {
+				gl.BindTexture(gl.TEXTURE_2D, r.fbo_shadow_texture[i])
 
-		gl.TexImage2D(gl.TEXTURE_2D, 0, gl.DEPTH_COMPONENT, 1024, 1024, 0, gl.DEPTH_COMPONENT, gl.FLOAT, nil)
-		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
-		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
-		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
-		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+				gl.TexImage2D(gl.TEXTURE_2D, 0, gl.DEPTH_COMPONENT, 1024, 1024, 0, gl.DEPTH_COMPONENT, gl.FLOAT, nil)
+				gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
+				gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
+				gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+				gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
 
-		gl.BindTexture(gl.TEXTURE_CUBE_MAP, r.fbo_shadow_cube_texture[i])
-		for j := 0; j < 6; j++ {
-			gl.TexImage2D(uint32(gl.TEXTURE_CUBE_MAP_POSITIVE_X+j), 0, gl.DEPTH_COMPONENT, 1024, 1024, 0, gl.DEPTH_COMPONENT, gl.FLOAT, nil)
+				gl.BindTexture(gl.TEXTURE_CUBE_MAP, r.fbo_shadow_cube_texture[i])
+				for j := 0; j < 6; j++ {
+					gl.TexImage2D(uint32(gl.TEXTURE_CUBE_MAP_POSITIVE_X+j), 0, gl.DEPTH_COMPONENT, 1024, 1024, 0, gl.DEPTH_COMPONENT, gl.FLOAT, nil)
+				}
+				gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
+				gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
+				gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+				gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+			}
+			gl.BindFramebufferEXT(gl.FRAMEBUFFER, r.fbo_shadow)
+			//gl.FramebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.TEXTURE_2D, r.fbo_shadow_texture[0], 0)
+			gl.DrawBuffer(gl.NONE)
+			gl.ReadBuffer(gl.NONE)
+			if status := gl.CheckFramebufferStatus(gl.FRAMEBUFFER); status != gl.FRAMEBUFFER_COMPLETE {
+				sys.errLog.Printf("framebuffer create failed: 0x%x", status)
+			}
 		}
-		gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
-		gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
-		gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
-		gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
-	}
-	gl.BindFramebufferEXT(gl.FRAMEBUFFER, r.fbo_shadow)
-	//gl.FramebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.TEXTURE_2D, r.fbo_shadow_texture[0], 0)
-	gl.DrawBuffer(gl.NONE)
-	gl.ReadBuffer(gl.NONE)
-	if status := gl.CheckFramebufferStatus(gl.FRAMEBUFFER); status != gl.FRAMEBUFFER_COMPLETE {
-		sys.errLog.Printf("framebuffer create failed: 0x%x", status)
-	}
 
-	gl.GenFramebuffers(1, &r.fbo_env)
+		gl.GenFramebuffers(1, &r.fbo_env)
+	}
 
 	gl.BindFramebuffer(gl.FRAMEBUFFER, 0)
 }
@@ -782,15 +826,17 @@ func (r *Renderer) prepareModelPipeline(env *Environment) {
 	gl.Enable(gl.BLEND)
 	gl.BindBuffer(gl.ARRAY_BUFFER, r.stageVertexBuffer)
 	gl.BindBuffer(gl.ELEMENT_ARRAY_BUFFER, r.stageIndexBuffer)
-	for i := 0; i < 4; i++ {
-		loc, unit := r.modelShader.u["shadowMap["+strconv.Itoa(i)+"]"], r.modelShader.t["shadowMap["+strconv.Itoa(i)+"]"]
-		gl.ActiveTexture((uint32(gl.TEXTURE0 + unit)))
-		gl.BindTexture(gl.TEXTURE_2D, r.fbo_shadow_texture[i])
-		gl.Uniform1i(loc, int32(unit))
-		loc, unit = r.modelShader.u["shadowCubeMap["+strconv.Itoa(i)+"]"], r.modelShader.t["shadowCubeMap["+strconv.Itoa(i)+"]"]
-		gl.ActiveTexture((uint32(gl.TEXTURE0 + unit)))
-		gl.BindTexture(gl.TEXTURE_CUBE_MAP, r.fbo_shadow_cube_texture[i])
-		gl.Uniform1i(loc, int32(unit))
+	if r.enableShadow {
+		for i := 0; i < 4; i++ {
+			loc, unit := r.modelShader.u["shadowMap["+strconv.Itoa(i)+"]"], r.modelShader.t["shadowMap["+strconv.Itoa(i)+"]"]
+			gl.ActiveTexture((uint32(gl.TEXTURE0 + unit)))
+			gl.BindTexture(gl.TEXTURE_2D, r.fbo_shadow_texture[i])
+			gl.Uniform1i(loc, int32(unit))
+			loc, unit = r.modelShader.u["shadowCubeMap["+strconv.Itoa(i)+"]"], r.modelShader.t["shadowCubeMap["+strconv.Itoa(i)+"]"]
+			gl.ActiveTexture((uint32(gl.TEXTURE0 + unit)))
+			gl.BindTexture(gl.TEXTURE_CUBE_MAP, r.fbo_shadow_cube_texture[i])
+			gl.Uniform1i(loc, int32(unit))
+		}
 	}
 	if env != nil {
 		loc, unit := r.modelShader.u["lambertianEnvSampler"], r.modelShader.t["lambertianEnvSampler"]

--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -398,7 +398,7 @@ func (r *Renderer) InitModelShader() error {
 	}
 	r.modelShader.RegisterAttributes("vertexId", "position", "uv", "normalIn", "tangentIn", "vertColor", "joints_0", "joints_1", "weights_0", "weights_1")
 	r.modelShader.RegisterUniforms("model", "view", "projection", "farPlane", "normalMatrix", "unlit", "baseColorFactor", "add", "mult", "useTexture", "useNormalMap", "useMetallicRoughnessMap", "neg", "gray", "hue",
-		"enableAlpha", "alphaThreshold", "numJoints", "morphTargetWeight", "morphTargetOffset", "numTargets", "numVertices",
+		"enableAlpha", "alphaThreshold", "numJoints", "morphTargetWeight", "morphTargetOffset", "morphTargetTextureDimension", "numTargets", "numVertices",
 		"metallicRoughness", "ambientOcclusionStrength", "environmentIntensity", "mipCount",
 		"cameraPosition", "environmentRotation",
 		"lightMatrices[0]", "lightMatrices[1]", "lightMatrices[2]", "lightMatrices[3]",

--- a/src/render_gl_darwin.go
+++ b/src/render_gl_darwin.go
@@ -394,7 +394,7 @@ func (r *Renderer) InitModelShader() error {
 	}
 	r.modelShader.RegisterAttributes("vertexId", "position", "uv", "normalIn", "tangentIn", "vertColor", "joints_0", "joints_1", "weights_0", "weights_1")
 	r.modelShader.RegisterUniforms("model", "view", "projection", "farPlane", "normalMatrix", "unlit", "baseColorFactor", "add", "mult", "useTexture", "useNormalMap", "useMetallicRoughnessMap", "neg", "gray", "hue",
-		"enableAlpha", "alphaThreshold", "numJoints", "morphTargetWeight", "morphTargetOffset", "numTargets", "numVertices",
+		"enableAlpha", "alphaThreshold", "numJoints", "morphTargetWeight", "morphTargetOffset", "morphTargetTextureDimension", "numTargets", "numVertices",
 		"metallicRoughness", "ambientOcclusionStrength", "environmentIntensity", "mipCount",
 		"cameraPosition", "environmentRotation",
 		"lightMatrices[0]", "lightMatrices[1]", "lightMatrices[2]", "lightMatrices[3]",

--- a/src/render_gl_darwin.go
+++ b/src/render_gl_darwin.go
@@ -69,22 +69,31 @@ type ShaderProgram struct {
 	t map[string]int
 }
 
-func newShaderProgram(vert, frag, geo, id string) (s *ShaderProgram) {
-	vertObj := compileShader(gl.VERTEX_SHADER, vert)
-	fragObj := compileShader(gl.FRAGMENT_SHADER, frag)
-	var prog uint32
-	if len(geo) > 0 {
-		geoObj := compileShader(gl.GEOMETRY_SHADER, geo)
-		prog = linkProgram(vertObj, fragObj, geoObj)
-	} else {
-		prog = linkProgram(vertObj, fragObj)
+func newShaderProgram(vert, frag, geo, id string, crashWhenFail bool) (s *ShaderProgram, err error) {
+	var vertObj, fragObj, geoObj, prog uint32
+	if vertObj, err = compileShader(gl.VERTEX_SHADER, vert); chkEX(err, "Shader compliation error on "+id+"\n", crashWhenFail) {
+		return nil, err
 	}
-
+	if fragObj, err = compileShader(gl.FRAGMENT_SHADER, frag); chkEX(err, "Shader compliation error on "+id+"\n", crashWhenFail) {
+		return nil, err
+	}
+	if len(geo) > 0 {
+		if geoObj, err = compileShader(gl.GEOMETRY_SHADER, geo); chkEX(err, "Shader compliation error on "+id+"\n", crashWhenFail) {
+			return nil, err
+		}
+		if prog, err = linkProgram(vertObj, fragObj, geoObj); chkEX(err, "Link program error on "+id+"\n", crashWhenFail) {
+			return nil, err
+		}
+	} else {
+		if prog, err = linkProgram(vertObj, fragObj); chkEX(err, "Link program error on "+id+"\n", crashWhenFail) {
+			return nil, err
+		}
+	}
 	s = &ShaderProgram{program: prog}
 	s.a = make(map[string]int32)
 	s.u = make(map[string]int32)
 	s.t = make(map[string]int)
-	return
+	return s, nil
 }
 func (s *ShaderProgram) RegisterAttributes(names ...string) {
 	for _, name := range names {
@@ -105,7 +114,7 @@ func (s *ShaderProgram) RegisterTextures(names ...string) {
 	}
 }
 
-func compileShader(shaderType uint32, src string) (shader uint32) {
+func compileShader(shaderType uint32, src string) (shader uint32, err error) {
 	shader = gl.CreateShader(shaderType)
 	src = "#version 150\n" + src + "\x00"
 	s, _ := gl.Strs(src)
@@ -115,7 +124,7 @@ func compileShader(shaderType uint32, src string) (shader uint32) {
 	var ok int32
 	gl.GetShaderiv(shader, gl.COMPILE_STATUS, &ok)
 	if ok == 0 {
-		var err error
+		//var err error
 		var size, l int32
 		gl.GetShaderiv(shader, gl.INFO_LOG_LENGTH, &size)
 		if size > 0 {
@@ -125,14 +134,15 @@ func compileShader(shaderType uint32, src string) (shader uint32) {
 		} else {
 			err = Error("Unknown shader compile error")
 		}
-		chk(err)
+		//chk(err)
 		gl.DeleteShader(shader)
-		panic(Error("Shader compile error"))
+		//panic(Error("Shader compile error"))
+		return 0, err
 	}
-	return
+	return shader, nil
 }
 
-func linkProgram(params ...uint32) (program uint32) {
+func linkProgram(params ...uint32) (program uint32, err error) {
 	program = gl.CreateProgram()
 	for _, param := range params {
 		gl.AttachShader(program, param)
@@ -145,7 +155,7 @@ func linkProgram(params ...uint32) (program uint32) {
 	var ok int32
 	gl.GetProgramiv(program, gl.LINK_STATUS, &ok)
 	if ok == 0 {
-		var err error
+		//var err error
 		var size, l int32
 		gl.GetProgramiv(program, gl.INFO_LOG_LENGTH, &size)
 		if size > 0 {
@@ -155,11 +165,12 @@ func linkProgram(params ...uint32) (program uint32) {
 		} else {
 			err = Error("Unknown link error")
 		}
-		chk(err)
+		//chk(err)
 		gl.DeleteProgram(program)
-		panic(Error("Link error"))
+		//panic(Error("Link error"))
+		return 0, err
 	}
-	return
+	return program, nil
 }
 
 // ------------------------------------------------------------------
@@ -332,6 +343,9 @@ type Renderer struct {
 	stageVertexBuffer       uint32
 	stageIndexBuffer        uint32
 	vao                     uint32
+
+	enableModel  bool
+	enableShadow bool
 }
 
 //go:embed shaders/sprite.vert.glsl
@@ -367,41 +381,17 @@ var panoramaToCubeMapFragShader string
 //go:embed shaders/cubemapFiltering.frag.glsl
 var cubemapFilteringFragShader string
 
-// Render initialization.
-// Creates the default shaders, the framebuffer and enables MSAA.
-func (r *Renderer) Init() {
-	chk(gl.Init())
-	sys.errLog.Printf("Using OpenGL %v (%v)", gl.GoStr(gl.GetString(gl.VERSION)), gl.GoStr(gl.GetString(gl.RENDERER)))
-
-	// Store current timestamp
-	sys.prevTimestamp = glfw.GetTime()
-
-	r.postShaderSelect = make([]*ShaderProgram, 1+len(sys.externalShaderList))
-
-	// Data buffers for rendering
-	postVertData := f32.Bytes(binary.LittleEndian, -1, -1, 1, -1, -1, 1, 1, 1)
-
-	gl.GenVertexArrays(1, &r.vao)
-	gl.BindVertexArray(r.vao)
-
-	gl.GenBuffers(1, &r.postVertBuffer)
-
-	gl.BindBuffer(gl.ARRAY_BUFFER, r.postVertBuffer)
-	gl.BufferData(gl.ARRAY_BUFFER, len(postVertData), unsafe.Pointer(&postVertData[0]), gl.STATIC_DRAW)
-
-	gl.GenBuffers(1, &r.vertexBuffer)
-	gl.GenBuffers(1, &r.stageVertexBuffer)
-	gl.GenBuffers(1, &r.stageIndexBuffer)
-
-	// Sprite shader
-	r.spriteShader = newShaderProgram(vertShader, fragShader, "", "Main Shader")
-	r.spriteShader.RegisterAttributes("position", "uv")
-	r.spriteShader.RegisterUniforms("modelview", "projection", "x1x2x4x3",
-		"alpha", "tint", "mask", "neg", "gray", "add", "mult", "isFlat", "isRgba", "isTrapez", "hue")
-	r.spriteShader.RegisterTextures("pal", "tex")
-
-	// 3D model shader
-	r.modelShader = newShaderProgram(modelVertShader, modelFragShader, "", "Model Shader")
+//init 3D model shader
+func (r *Renderer) InitModelShader() error {
+	var err error
+	if r.enableShadow {
+		r.modelShader, err = newShaderProgram(modelVertShader, "#define ENABLE_SHADOW\n"+modelFragShader, "", "Model Shader", false)
+	} else {
+		r.modelShader, err = newShaderProgram(modelVertShader, modelFragShader, "", "Model Shader", false)
+	}
+	if err != nil {
+		return err
+	}
 	r.modelShader.RegisterAttributes("vertexId", "position", "uv", "normalIn", "tangentIn", "vertColor", "joints_0", "joints_1", "weights_0", "weights_1")
 	r.modelShader.RegisterUniforms("model", "view", "projection", "farPlane", "normalMatrix", "unlit", "baseColorFactor", "add", "mult", "useTexture", "useNormalMap", "useMetallicRoughnessMap", "neg", "gray", "hue",
 		"enableAlpha", "alphaThreshold", "numJoints", "morphTargetWeight", "morphTargetOffset", "numTargets", "numVertices",
@@ -417,21 +407,74 @@ func (r *Renderer) Init() {
 		"shadowMap[0]", "shadowMap[1]", "shadowMap[2]", "shadowMap[3]",
 		"shadowCubeMap[0]", "shadowCubeMap[1]", "shadowCubeMap[2]", "shadowCubeMap[3]")
 
-	r.shadowMapShader = newShaderProgram(shadowVertShader, shadowFragShader, shadowGeoShader, "Shadow Map Shader")
-	//r.shadowMapShader = newShaderProgram(shadowVertShader, shadowFragShader, "", "Shadow Map Shader")
-	r.shadowMapShader.RegisterAttributes("vertexId", "position", "vertColor", "uv", "joints_0", "joints_1", "weights_0", "weights_1")
-	r.shadowMapShader.RegisterUniforms("model", "lightMatrices[0]", "lightMatrices[1]", "lightMatrices[2]", "lightMatrices[3]", "lightMatrices[4]", "lightMatrices[5]", "lightType", "lightPos", "farPlane", "numJoints", "morphTargetWeight", "morphTargetOffset", "numTargets", "numVertices", "enableAlpha", "alphaThreshold", "baseColorFactor", "useTexture")
-	r.shadowMapShader.RegisterTextures("morphTargetValues", "jointMatrices", "tex")
-
-	r.panoramaToCubeMapShader = newShaderProgram(identVertShader, panoramaToCubeMapFragShader, "", "Panorama To Cubemap Shader")
+	if r.enableShadow {
+		r.shadowMapShader, err = newShaderProgram(shadowVertShader, shadowFragShader, shadowGeoShader, "Shadow Map Shader", false)
+		if err != nil {
+			return err
+		}
+		r.shadowMapShader.RegisterAttributes("vertexId", "position", "vertColor", "uv", "joints_0", "joints_1", "weights_0", "weights_1")
+		r.shadowMapShader.RegisterUniforms("model", "lightMatrices[0]", "lightMatrices[1]", "lightMatrices[2]", "lightMatrices[3]", "lightMatrices[4]", "lightMatrices[5]", "lightType", "lightPos", "farPlane", "numJoints", "morphTargetWeight", "morphTargetOffset", "numTargets", "numVertices", "enableAlpha", "alphaThreshold", "baseColorFactor", "useTexture")
+		r.shadowMapShader.RegisterTextures("morphTargetValues", "jointMatrices", "tex")
+	}
+	r.panoramaToCubeMapShader, err = newShaderProgram(identVertShader, panoramaToCubeMapFragShader, "", "Panorama To Cubemap Shader", false)
+	if err != nil {
+		return err
+	}
 	r.panoramaToCubeMapShader.RegisterAttributes("VertCoord")
 	r.panoramaToCubeMapShader.RegisterUniforms("currentFace")
 	r.panoramaToCubeMapShader.RegisterTextures("panorama")
 
-	r.cubemapFilteringShader = newShaderProgram(identVertShader, cubemapFilteringFragShader, "", "Cubemap Filtering Shader")
+	r.cubemapFilteringShader, err = newShaderProgram(identVertShader, cubemapFilteringFragShader, "", "Cubemap Filtering Shader", false)
+	if err != nil {
+		return err
+	}
 	r.cubemapFilteringShader.RegisterAttributes("VertCoord")
 	r.cubemapFilteringShader.RegisterUniforms("sampleCount", "distribution", "width", "currentFace", "roughness", "intensityScale", "isLUT")
 	r.cubemapFilteringShader.RegisterTextures("cubeMap")
+	return nil
+}
+
+// Render initialization.
+// Creates the default shaders, the framebuffer and enables MSAA.
+func (r *Renderer) Init() {
+	chk(gl.Init())
+	sys.errLog.Printf("Using OpenGL %v (%v)", gl.GoStr(gl.GetString(gl.VERSION)), gl.GoStr(gl.GetString(gl.RENDERER)))
+
+	// Store current timestamp
+	sys.prevTimestamp = glfw.GetTime()
+
+	r.postShaderSelect = make([]*ShaderProgram, 1+len(sys.externalShaderList))
+
+	// Data buffers for rendering
+	postVertData := f32.Bytes(binary.LittleEndian, -1, -1, 1, -1, -1, 1, 1, 1)
+
+	r.enableModel = sys.enableModel
+	r.enableShadow = sys.enableModelShadow
+
+	gl.GenVertexArrays(1, &r.vao)
+	gl.BindVertexArray(r.vao)
+
+	gl.GenBuffers(1, &r.postVertBuffer)
+
+	gl.BindBuffer(gl.ARRAY_BUFFER, r.postVertBuffer)
+	gl.BufferData(gl.ARRAY_BUFFER, len(postVertData), unsafe.Pointer(&postVertData[0]), gl.STATIC_DRAW)
+
+	gl.GenBuffers(1, &r.vertexBuffer)
+	gl.GenBuffers(1, &r.stageVertexBuffer)
+	gl.GenBuffers(1, &r.stageIndexBuffer)
+
+	// Sprite shader
+	r.spriteShader, _ = newShaderProgram(vertShader, fragShader, "", "Main Shader", true)
+	r.spriteShader.RegisterAttributes("position", "uv")
+	r.spriteShader.RegisterUniforms("modelview", "projection", "x1x2x4x3",
+		"alpha", "tint", "mask", "neg", "gray", "add", "mult", "isFlat", "isRgba", "isTrapez", "hue")
+	r.spriteShader.RegisterTextures("pal", "tex")
+
+	if r.enableModel {
+		if err := r.InitModelShader(); err != nil {
+			r.enableModel = false
+		}
+	}
 
 	// Compile postprocessing shaders
 
@@ -439,14 +482,14 @@ func (r *Renderer) Init() {
 	r.postShaderSelect = make([]*ShaderProgram, 1+len(sys.externalShaderList))
 
 	// Ident shader (no postprocessing)
-	r.postShaderSelect[0] = newShaderProgram(identVertShader, identFragShader, "", "Identity Postprocess")
+	r.postShaderSelect[0], _ = newShaderProgram(identVertShader, identFragShader, "", "Identity Postprocess", true)
 	r.postShaderSelect[0].RegisterAttributes("VertCoord", "TexCoord")
 	r.postShaderSelect[0].RegisterUniforms("Texture", "TextureSize", "CurrentTime")
 
 	// External Shaders
 	for i := 0; i < len(sys.externalShaderList); i++ {
-		r.postShaderSelect[1+i] = newShaderProgram(sys.externalShaders[0][i],
-			sys.externalShaders[1][i], "", fmt.Sprintf("Postprocess Shader #%v", i+1))
+		r.postShaderSelect[1+i], _ = newShaderProgram(sys.externalShaders[0][i],
+			sys.externalShaders[1][i], "", fmt.Sprintf("Postprocess Shader #%v", i+1), true)
 		r.postShaderSelect[1+i].RegisterAttributes("VertCoord", "TexCoord")
 		loc := r.postShaderSelect[0].a["TexCoord"]
 		gl.VertexAttribPointer(uint32(loc), 3, gl.FLOAT, false, 5*4, gl.PtrOffset(2*4))
@@ -519,39 +562,42 @@ func (r *Renderer) Init() {
 		gl.FramebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, r.fbo_texture, 0)
 		gl.FramebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, r.rbo_depth)
 	}
-	gl.GenFramebuffers(1, &r.fbo_shadow)
-	gl.ActiveTexture(gl.TEXTURE0)
-	gl.GenTextures(4, &r.fbo_shadow_texture[0])
-	gl.GenTextures(4, &r.fbo_shadow_cube_texture[0])
 
-	for i := 0; i < 4; i++ {
-		gl.BindTexture(gl.TEXTURE_2D, r.fbo_shadow_texture[i])
+	if r.enableModel {
+		if r.enableShadow {
+			gl.GenFramebuffers(1, &r.fbo_shadow)
+			gl.ActiveTexture(gl.TEXTURE0)
+			gl.GenTextures(4, &r.fbo_shadow_texture[0])
+			gl.GenTextures(4, &r.fbo_shadow_cube_texture[0])
 
-		gl.TexImage2D(gl.TEXTURE_2D, 0, gl.DEPTH_COMPONENT, 1024, 1024, 0, gl.DEPTH_COMPONENT, gl.FLOAT, nil)
-		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
-		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
-		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
-		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+			for i := 0; i < 4; i++ {
+				gl.BindTexture(gl.TEXTURE_2D, r.fbo_shadow_texture[i])
 
-		gl.BindTexture(gl.TEXTURE_CUBE_MAP, r.fbo_shadow_cube_texture[i])
-		for j := 0; j < 6; j++ {
-			gl.TexImage2D(uint32(gl.TEXTURE_CUBE_MAP_POSITIVE_X+j), 0, gl.DEPTH_COMPONENT, 1024, 1024, 0, gl.DEPTH_COMPONENT, gl.FLOAT, nil)
+				gl.TexImage2D(gl.TEXTURE_2D, 0, gl.DEPTH_COMPONENT, 1024, 1024, 0, gl.DEPTH_COMPONENT, gl.FLOAT, nil)
+				gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
+				gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
+				gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+				gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+
+				gl.BindTexture(gl.TEXTURE_CUBE_MAP, r.fbo_shadow_cube_texture[i])
+				for j := 0; j < 6; j++ {
+					gl.TexImage2D(uint32(gl.TEXTURE_CUBE_MAP_POSITIVE_X+j), 0, gl.DEPTH_COMPONENT, 1024, 1024, 0, gl.DEPTH_COMPONENT, gl.FLOAT, nil)
+				}
+				gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
+				gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
+				gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+				gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+			}
+			gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_shadow)
+			//gl.FramebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.TEXTURE_2D, r.fbo_shadow_texture[0], 0)
+			gl.DrawBuffer(gl.NONE)
+			gl.ReadBuffer(gl.NONE)
+			if status := gl.CheckFramebufferStatus(gl.FRAMEBUFFER); status != gl.FRAMEBUFFER_COMPLETE {
+				sys.errLog.Printf("framebuffer create failed: 0x%x", status)
+			}
 		}
-		gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
-		gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
-		gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
-		gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+		gl.GenFramebuffers(1, &r.fbo_env)
 	}
-	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_shadow)
-	//gl.FramebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.TEXTURE_2D, r.fbo_shadow_texture[0], 0)
-	gl.DrawBuffer(gl.NONE)
-	gl.ReadBuffer(gl.NONE)
-	if status := gl.CheckFramebufferStatus(gl.FRAMEBUFFER); status != gl.FRAMEBUFFER_COMPLETE {
-		sys.errLog.Printf("framebuffer create failed: 0x%x", status)
-	}
-
-	gl.GenFramebuffers(1, &r.fbo_env)
-
 	gl.BindFramebuffer(gl.FRAMEBUFFER, 0)
 }
 
@@ -789,15 +835,17 @@ func (r *Renderer) prepareModelPipeline(env *Environment) {
 	gl.Enable(gl.BLEND)
 	gl.BindBuffer(gl.ARRAY_BUFFER, r.stageVertexBuffer)
 	gl.BindBuffer(gl.ELEMENT_ARRAY_BUFFER, r.stageIndexBuffer)
-	for i := 0; i < 4; i++ {
-		loc, unit := r.modelShader.u["shadowMap["+strconv.Itoa(i)+"]"], r.modelShader.t["shadowMap["+strconv.Itoa(i)+"]"]
-		gl.ActiveTexture((uint32(gl.TEXTURE0 + unit)))
-		gl.BindTexture(gl.TEXTURE_2D, r.fbo_shadow_texture[i])
-		gl.Uniform1i(loc, int32(unit))
-		loc, unit = r.modelShader.u["shadowCubeMap["+strconv.Itoa(i)+"]"], r.modelShader.t["shadowCubeMap["+strconv.Itoa(i)+"]"]
-		gl.ActiveTexture((uint32(gl.TEXTURE0 + unit)))
-		gl.BindTexture(gl.TEXTURE_CUBE_MAP, r.fbo_shadow_cube_texture[i])
-		gl.Uniform1i(loc, int32(unit))
+	if r.enableShadow {
+		for i := 0; i < 4; i++ {
+			loc, unit := r.modelShader.u["shadowMap["+strconv.Itoa(i)+"]"], r.modelShader.t["shadowMap["+strconv.Itoa(i)+"]"]
+			gl.ActiveTexture((uint32(gl.TEXTURE0 + unit)))
+			gl.BindTexture(gl.TEXTURE_2D, r.fbo_shadow_texture[i])
+			gl.Uniform1i(loc, int32(unit))
+			loc, unit = r.modelShader.u["shadowCubeMap["+strconv.Itoa(i)+"]"], r.modelShader.t["shadowCubeMap["+strconv.Itoa(i)+"]"]
+			gl.ActiveTexture((uint32(gl.TEXTURE0 + unit)))
+			gl.BindTexture(gl.TEXTURE_CUBE_MAP, r.fbo_shadow_cube_texture[i])
+			gl.Uniform1i(loc, int32(unit))
+		}
 	}
 	if env != nil {
 		loc, unit := r.modelShader.u["lambertianEnvSampler"], r.modelShader.t["lambertianEnvSampler"]

--- a/src/resources/defaultConfig.json
+++ b/src/resources/defaultConfig.json
@@ -41,6 +41,8 @@
   "DebugKeys": true,
   "DebugMode": true,
   "Difficulty": 5,
+  "EnableModel": true,
+  "EnableModelShadow": true,
   "EscOpensMenu": true,
   "ExternalShaders": [],
   "FirstRun": true,

--- a/src/script.go
+++ b/src/script.go
@@ -2894,6 +2894,22 @@ func systemScriptInit(l *lua.LState) {
 		sys.window.SetSwapInterval(sys.vRetrace)
 		return 0
 	})
+	luaRegister(l, "toggleEnableModel", func(*lua.LState) int {
+		if l.GetTop() >= 1 {
+			sys.enableModel = boolArg(l, 1)
+		} else {
+			sys.enableModel = !sys.enableModel
+		}
+		return 0
+	})
+	luaRegister(l, "toggleEnableModelShadow", func(*lua.LState) int {
+		if l.GetTop() >= 1 {
+			sys.enableModelShadow = boolArg(l, 1)
+		} else {
+			sys.enableModelShadow = !sys.enableModel
+		}
+		return 0
+	})
 	luaRegister(l, "updateVolume", func(l *lua.LState) int {
 		if l.GetTop() >= 1 {
 			sys.bgm.bgmVolume = int(Min(int32(numArg(l, 1)), int32(sys.maxBgmVolume)))

--- a/src/shaders/model.vert.glsl
+++ b/src/shaders/model.vert.glsl
@@ -17,6 +17,7 @@ uniform sampler2D jointMatrices;
 uniform sampler2D morphTargetValues;
 uniform int numJoints;
 uniform int numTargets;
+uniform int morphTargetTextureDimension;
 uniform vec4 morphTargetWeight[2];
 uniform vec4 morphTargetOffset;
 uniform int numVertices;
@@ -95,16 +96,18 @@ void main(void) {
 	if(morphTargetWeight[0][0] != 0){
 		for(int idx = 0; idx < numTargets; ++idx)
 		{
+			float i = idx*numVertices+vertexId;
+			vec2 xy = vec2((i+0.5)/morphTargetTextureDimension-floor(i/morphTargetTextureDimension),(floor(i/morphTargetTextureDimension)+0.5)/morphTargetTextureDimension);
 			if(idx < morphTargetOffset[0]){
-				pos += morphTargetWeight[idx/4][idx%4] * COMPAT_TEXTURE(morphTargetValues,vec2((vertexId+0.5)/numVertices,(idx+0.5)/8));
+				pos += morphTargetWeight[idx/4][idx%4] * COMPAT_TEXTURE(morphTargetValues,xy);
 			}else if(idx < morphTargetOffset[1]){
-				normal += morphTargetWeight[idx/4][idx%4] * vec3(COMPAT_TEXTURE(morphTargetValues,vec2((vertexId+0.5)/numVertices,(idx+0.5)/8)));
+				normal += morphTargetWeight[idx/4][idx%4] * vec3(COMPAT_TEXTURE(morphTargetValues,xy));
 			}else if(idx < morphTargetOffset[2]){
-				tangent += morphTargetWeight[idx/4][idx%4] * vec3(COMPAT_TEXTURE(morphTargetValues,vec2((vertexId+0.5)/numVertices,(idx+0.5)/8)));
+				tangent += morphTargetWeight[idx/4][idx%4] * vec3(COMPAT_TEXTURE(morphTargetValues,xy));
 			}else if(idx < morphTargetOffset[3]){
-				texcoord += morphTargetWeight[idx/4][idx%4] * vec2(COMPAT_TEXTURE(morphTargetValues,vec2((vertexId+0.5)/numVertices,(idx+0.5)/8)));
+				texcoord += morphTargetWeight[idx/4][idx%4] * vec2(COMPAT_TEXTURE(morphTargetValues,xy));
 			}else{
-				vColor += morphTargetWeight[idx/4][idx%4] * COMPAT_TEXTURE(morphTargetValues,vec2((vertexId+0.5)/numVertices,(idx+0.5)/8));
+				vColor += morphTargetWeight[idx/4][idx%4] * COMPAT_TEXTURE(morphTargetValues,xy);
 			}
 		}
 	}

--- a/src/stage.go
+++ b/src/stage.go
@@ -2646,7 +2646,8 @@ func loadglTFStage(filepath string) (*Model, error) {
 				}
 				primitive.morphTargetTexture = &GLTFTexture{}
 				sys.mainThreadTask <- func() {
-					primitive.morphTargetTexture.tex = newDataTexture(int32(primitive.numVertices), 8)
+					dimension := int(math.Ceil(math.Pow(float64(8*primitive.numVertices), 0.5)))
+					primitive.morphTargetTexture.tex = newDataTexture(int32(dimension), int32(dimension))
 					//primitive.morphTargetTexture.tex.SetPixelData(targetBuffer)
 				}
 			}
@@ -2990,8 +2991,9 @@ func calculateAnimationData(mdl *Model, n *Node) {
 			p.morphTargetCount = uint32(count)
 			if len(targetBuffer) > int(8*4*p.numVertices) {
 				targetBuffer = targetBuffer[:8*4*p.numVertices]
-			} else if len(targetBuffer) < int(8*4*p.numVertices) {
-				targetBuffer = append(targetBuffer, make([]float32, int(8*4*p.numVertices)-len(targetBuffer))...)
+			}
+			if len(targetBuffer) < int(4*p.morphTargetTexture.tex.width*p.morphTargetTexture.tex.width) {
+				targetBuffer = append(targetBuffer, make([]float32, int(4*p.morphTargetTexture.tex.width*p.morphTargetTexture.tex.width)-len(targetBuffer))...)
 			}
 			p.morphTargetTexture.tex.SetPixelData(targetBuffer)
 		} else {
@@ -3074,6 +3076,7 @@ func drawNode(mdl *Model, scene *Scene, n *Node, camOffset [3]float32, drawBlend
 				gfx.SetModelUniformI("numTargets", int(Min(int32(p.morphTargetCount), 8)))
 				gfx.SetModelTexture("morphTargetValues", p.morphTargetTexture.tex)
 				gfx.SetModelUniformFv("morphTargetWeight", p.morphTargetWeight[:])
+				gfx.SetModelUniformI("morphTargetTextureDimension", int(p.morphTargetTexture.tex.width))
 			} else {
 				gfx.SetModelUniformFv("morphTargetWeight", make([]float32, 8))
 			}

--- a/src/system.go
+++ b/src/system.go
@@ -91,6 +91,8 @@ var sys = System{
 	panningRange:         30,
 	windowCentered:       true,
 	audioSampleRate:      44100,
+	enableModel:          true,
+	enableModelShadow:    true,
 }
 
 type TeamMode int32
@@ -337,9 +339,11 @@ type System struct {
 	windowMainIconLocation []string
 
 	// Rendering
-	borderless bool
-	vRetrace   int
-	pngFilter  bool // Controls the GL_TEXTURE_MAG_FILTER on 32bit sprites
+	borderless        bool
+	vRetrace          int
+	pngFilter         bool // Controls the GL_TEXTURE_MAG_FILTER on 32bit sprites
+	enableModel       bool // Controls the GL_TEXTURE_MAG_FILTER on 32bit sprites
+	enableModelShadow bool // Controls the GL_TEXTURE_MAG_FILTER on 32bit sprites
 
 	gameMode          string
 	frameCounter      int32


### PR DESCRIPTION
Allow user disable 3D model / shadows under Video settings.
3D model shader compilation errors no longer crash the engine.
Fix #2101 
Fix the problem where morph target animation is not working properly on primitive with too many vertices