### PR TITLE
feat: Separate GL 3.2 builds for Win64, Linux, and LinuxARM added to build & makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,10 @@ srcFiles=src/anim.go \
 Ikemen_GO.exe: ${srcFiles}
 	cd ./build && bash ./build.sh Win64
 
+# Windows 64-bit target (GL 3.2)
+Ikemen_GO_GL32.exe: ${srcFiles}
+	cd ./build && bash ./build.sh Win64GL32
+
 # Windows 32-bit target
 Ikemen_GO_86.exe: ${srcFiles}
 	cd ./build && bash ./build.sh Win32
@@ -35,6 +39,18 @@ Ikemen_GO_86.exe: ${srcFiles}
 # Linux target
 Ikemen_GO_Linux: ${srcFiles}
 	cd ./build && ./build.sh Linux
+
+# Linux target (GL 3.2)
+Ikemen_GO_Linux_GL32: ${srcFiles}
+	cd ./build && ./build.sh LinuxGL32
+
+# Linux ARM target
+Ikemen_GO_LinuxARM: ${srcFiles}
+	cd ./build && ./build.sh LinuxARM
+
+# Linux ARM target (GL 3.2)
+Ikemen_GO_LinuxARM_GL32: ${srcFiles}
+	cd ./build && ./build.sh LinuxARMGL32
 
 # MacOS x64 target
 Ikemen_GO_MacOS: ${srcFiles}

--- a/build/build.sh
+++ b/build/build.sh
@@ -28,6 +28,10 @@ function main() {
 	
 	# Build
 	case "${targetOS}" in
+		[wW][iI][nN]64[gG][lL]32)
+			varWin64GL32
+			buildWinGL32
+		;;
 		[wW][iI][nN]64)
 			varWin64
 			buildWin
@@ -38,7 +42,15 @@ function main() {
 		;;
 		[mM][aA][cC][oO][sS])
 			varMacOS
-			build
+			buildGL32
+		;;
+		[lL][iI][nN][uU][xX][aA][rR][mM][gG][lL]32)
+			varLinuxARMGL32
+			buildGL32
+		;;
+		[lL][iI][nN][uU][xX][gG][lL]32)
+			varLinuxGL32
+			buildGL32
 		;;
 		[lL][iI][nN][uU][xX][aA][rR][mM])
 			varLinuxARM
@@ -77,6 +89,16 @@ function varWin64() {
 	binName="Ikemen_GO.exe"
 }
 
+function varWin64GL32() {
+	export GOOS=windows
+	export GOARCH=amd64
+	if [[ "${currentOS,,}" != "win64" ]]; then
+		export CC=x86_64-w64-mingw32-gcc
+		export CXX=x86_64-w64-mingw32-g++
+	fi
+	binName="Ikemen_GO_GL32.exe"
+}
+
 function varMacOS() {
 	export GOOS=darwin
 	case "${currentOS}" in
@@ -97,10 +119,21 @@ function varLinux() {
 	#export CXX=g++
 	binName="Ikemen_GO_Linux"
 }
+function varLinuxGL32() {
+	export GOOS=linux
+	#export CC=gcc
+	#export CXX=g++
+	binName="Ikemen_GO_Linux_GL32"
+}
 function varLinuxARM() {
 	export GOOS=linux
 	export GOARCH=arm64
 	binName="Ikemen_GO_LinuxARM"
+}
+function varLinuxARMGL32() {
+	export GOOS=linux
+	export GOARCH=arm64
+	binName="Ikemen_GO_LinuxARM_GL32"
 }
 
 # Build functions.
@@ -110,10 +143,22 @@ function build() {
 	go build -trimpath -v -trimpath -o ./bin/$binName ./src
 }
 
+function buildGL32() {
+	#echo "buildNormal"
+	#echo "$binName"
+	go build -tags gl32 -trimpath -v -trimpath -o ./bin/$binName ./src
+}
+
 function buildWin() {
 	#echo "buildWin"
 	#echo "$binName"
 	go build -trimpath -v -trimpath -ldflags "-H windowsgui" -o ./bin/$binName ./src
+}
+
+function buildWinGL32() {
+	#echo "buildWin"
+	#echo "$binName"
+	go build -tags "gl32" -trimpath -v -trimpath -ldflags "-H windowsgui" -o ./bin/$binName ./src
 }
 
 # Determine the target OS.

--- a/build/build_gl32.cmd
+++ b/build/build_gl32.cmd
@@ -1,0 +1,21 @@
+@echo off
+cd ..
+set CGO_ENABLED = 1
+set GOOS = windows
+
+if not exist go.mod (
+	echo Missing dependencies, please run get.cmd
+	echo.
+	pause
+	exit
+)
+if not exist bin (
+	MKDIR bin
+) 
+
+echo Building Ikemen GO...
+echo. 
+
+go build -tags gl32 -trimpath -v -ldflags -H=windowsgui -o ./bin/Ikemen_GO_GL32.exe ./src
+
+pause

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -4036,8 +4036,11 @@ function start.f_stageMusic()
 	if gamemode('demo') and motif.demo_mode.fight_playbgm == 0 then
 		return
 	end
+	-- Reset
+	local fn = bgmvar("filename")
+	local didLoadBGM = fn ~= nil and fn ~= ""
 	-- bgmusic / bgmusic.roundX / bgmusic.final
-	if roundstart() then
+	if (stagetime() > 0 and not didLoadBGM) then
 		-- only if the round is not restarted
 		if start.bgmround ~= roundno() then
 			start.bgmround = roundno()

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -4424,6 +4424,10 @@ func (c *Compiler) playBgm(is IniSection, sc *StateControllerBase, _ int8) (Stat
 			playBgm_loopcount, VT_Int, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "freqmul",
+			playBgm_freqmul, VT_Float, 1, false); err != nil {
+			return err
+		}
 		return nil
 	})
 	return *ret, err

--- a/src/input_glfw.go
+++ b/src/input_glfw.go
@@ -254,11 +254,14 @@ func (input *Input) GetJoystickIndices(guid string) []int {
 
 // From @leonkasovan's branch
 func CheckAxisForDpad(joy int, axes *[]float32, base int) string {
-	var s string
+	var s string = ""
 	if (*axes)[0] > sys.controllerStickSensitivity { // right
 		s = strconv.Itoa(2 + base)
 	} else if -(*axes)[0] > sys.controllerStickSensitivity { // left
 		s = strconv.Itoa(1 + base)
+	}
+	if len(*axes) < 2 {
+		return s
 	}
 	if (*axes)[1] > sys.controllerStickSensitivity { // down
 		s = strconv.Itoa(3 + base)

--- a/src/main.go
+++ b/src/main.go
@@ -225,7 +225,6 @@ type configSettings struct {
 	EnableModel                bool
 	EnableModelShadow          bool
 	FirstRun                   bool
-	FontShaderVer              uint
 	ForceStageZoomin           float32
 	ForceStageZoomout          float32
 	Framerate                  int32
@@ -387,11 +386,6 @@ func setupConfig() configSettings {
 	sys.enableModelShadow = tmp.EnableModelShadow
 	sys.explodMax = tmp.MaxExplod
 	sys.externalShaderList = tmp.ExternalShaders
-	// Bump up shader version for macOS only
-	if runtime.GOOS == "darwin" {
-		tmp.FontShaderVer = uint(MaxI(150, int(tmp.FontShaderVer)))
-	}
-	sys.fontShaderVer = tmp.FontShaderVer
 	// Resoluion stuff
 	sys.fullscreen = tmp.Fullscreen
 	sys.fullscreenRefreshRate = tmp.FullscreenRefreshRate

--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -21,6 +21,8 @@ import (
 	"golang.org/x/mobile/exp/f32"
 )
 
+const GL_SHADER_VER = 120 // OpenGL 2.1
+
 var InternalFormatLUT = map[int32]uint32{
 	8:  gl.LUMINANCE,
 	24: gl.RGB,

--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -1,4 +1,4 @@
-//go:build !kinc && !darwin
+//go:build !kinc && !gl32
 
 // IF YOU MAKE CHANGES TO THIS FILE, YOU MUST ALSO MAKE
 // EQUIVALENT CHANGES TO render_gl_darwin.go
@@ -1005,11 +1005,10 @@ func (r *Renderer) ReleaseModelPipeline() {
 }
 
 func (r *Renderer) ReadPixels(data []uint8, width, height int) {
-	r.EndFrame()
-	sys.window.SwapBuffers()
+	// we defer the EndFrame(), SwapBuffers(), and BeginFrame() calls that were previously below now to
+	// a single spot in order to prevent the blank screenshot bug on single digit FPS
 	gl.BindFramebuffer(gl.READ_FRAMEBUFFER, 0)
 	gl.ReadPixels(0, 0, int32(width), int32(height), gl.RGBA, gl.UNSIGNED_BYTE, unsafe.Pointer(&data[0]))
-	r.BeginFrame(false)
 }
 
 func (r *Renderer) Scissor(x, y, width, height int32) {

--- a/src/render_gl_gl32.go
+++ b/src/render_gl_gl32.go
@@ -21,6 +21,8 @@ import (
 	"golang.org/x/mobile/exp/f32"
 )
 
+const GL_SHADER_VER = 150 // OpenGL 3.2
+
 var InternalFormatLUT = map[int32]uint32{
 	8:  gl.RED,
 	24: gl.RGB,

--- a/src/render_gl_gl32.go
+++ b/src/render_gl_gl32.go
@@ -1,4 +1,4 @@
-//go:build !kinc
+//go:build !kinc && gl32
 
 // This is almost identical to render_gl.go except it uses a VAO
 // for GL 3.2 which is the minimum version that runs on modern
@@ -145,6 +145,12 @@ func linkProgram(params ...uint32) (program uint32, err error) {
 	program = gl.CreateProgram()
 	for _, param := range params {
 		gl.AttachShader(program, param)
+	}
+	if len(params) > 2 {
+		// Geometry Shader Params
+		gl.ProgramParameteri(program, gl.GEOMETRY_INPUT_TYPE, gl.TRIANGLES)
+		gl.ProgramParameteri(program, gl.GEOMETRY_OUTPUT_TYPE, gl.TRIANGLE_STRIP)
+		gl.ProgramParameteri(program, gl.GEOMETRY_VERTICES_OUT, 3*6)
 	}
 	gl.LinkProgram(program)
 	// Mark shaders for deletion when the program is deleted
@@ -1011,11 +1017,10 @@ func (r *Renderer) ReleaseModelPipeline() {
 }
 
 func (r *Renderer) ReadPixels(data []uint8, width, height int) {
-	r.EndFrame()
-	sys.window.SwapBuffers()
+	// we defer the EndFrame(), SwapBuffers(), and BeginFrame() calls that were previously below now to
+	// a single spot in order to prevent the blank screenshot bug on single digit FPS
 	gl.BindFramebuffer(gl.READ_FRAMEBUFFER, 0)
 	gl.ReadPixels(0, 0, int32(width), int32(height), gl.RGBA, gl.UNSIGNED_BYTE, unsafe.Pointer(&data[0]))
-	r.BeginFrame(false)
 }
 
 func (r *Renderer) Scissor(x, y, width, height int32) {

--- a/src/resources/defaultConfig.json
+++ b/src/resources/defaultConfig.json
@@ -46,7 +46,6 @@
   "EscOpensMenu": true,
   "ExternalShaders": [],
   "FirstRun": true,
-  "FontShaderVer": 120,
   "ForceStageZoomin": 0,
   "ForceStageZoomout": 0,
   "Framerate": 60,

--- a/src/script.go
+++ b/src/script.go
@@ -1991,7 +1991,9 @@ func systemScriptInit(l *lua.LState) {
 		return 0
 	})
 	luaRegister(l, "screenshot", func(*lua.LState) int {
-		captureScreen()
+		if !sys.isTakingScreenshot {
+			sys.isTakingScreenshot = true
+		}
 		return 0
 	})
 	luaRegister(l, "searchFile", func(l *lua.LState) int {

--- a/src/system.go
+++ b/src/system.go
@@ -74,7 +74,6 @@ var sys = System{
 	errLog:           log.New(NewLogWriter(), "", log.LstdFlags),
 	keyInput:         KeyUnknown,
 	wavChannels:      256,
-	fontShaderVer:    120,
 	//FLAC_FrameWait:          -1,
 	luaSpriteScale:       1,
 	luaPortraitScale:     1,
@@ -327,7 +326,6 @@ type System struct {
 	// Shader Vars
 	postProcessingShader    int32
 	multisampleAntialiasing int32
-	fontShaderVer           uint
 
 	// External Shader Vars
 	externalShaderList  []string

--- a/src/system_glfw.go
+++ b/src/system_glfw.go
@@ -38,7 +38,7 @@ func (s *System) newWindow(w, h int) (*Window, error) {
 	glfw.WindowHint(glfw.Resizable, glfw.True)
 
 	// only GL 3.2 needs this
-	if sys.fontShaderVer == 150 {
+	if GL_SHADER_VER == 150 {
 		glfw.WindowHint(glfw.ContextVersionMajor, 3)
 		glfw.WindowHint(glfw.ContextVersionMinor, 2)
 		glfw.WindowHint(glfw.OpenGLForwardCompatible, glfw.True)

--- a/src/system_glfw.go
+++ b/src/system_glfw.go
@@ -5,7 +5,6 @@ package main
 import (
 	"fmt"
 	"image"
-	"runtime"
 
 	glfw "github.com/go-gl/glfw/v3.3/glfw"
 )
@@ -38,8 +37,8 @@ func (s *System) newWindow(w, h int) (*Window, error) {
 
 	glfw.WindowHint(glfw.Resizable, glfw.True)
 
-	// only macOS needs this
-	if runtime.GOOS == "darwin" {
+	// only GL 3.2 needs this
+	if sys.fontShaderVer == 150 {
 		glfw.WindowHint(glfw.ContextVersionMajor, 3)
 		glfw.WindowHint(glfw.ContextVersionMinor, 2)
 		glfw.WindowHint(glfw.OpenGLForwardCompatible, glfw.True)

--- a/src/util_desktop.go
+++ b/src/util_desktop.go
@@ -44,7 +44,7 @@ func LoadFntTtf(f *Fnt, fontfile string, filename string, height int32) {
 	} else {
 		f.Size[1] = uint16(height)
 	}
-	ttf, err := glfont.LoadFont(fileDir, height, int(sys.gameWidth), int(sys.gameHeight), sys.fontShaderVer)
+	ttf, err := glfont.LoadFont(fileDir, height, int(sys.gameWidth), int(sys.gameHeight), GL_SHADER_VER)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
feat:
* Separate GL 3.2 builds for Win64, Linux, and LinuxARM added to build and makefiles. (use build_gl32.cmd for Windows or `make Ikemen_GO_Linux_GL32` for Linux or `make Ikemen_GO_LinuxARM_GL32` for Linux ARM.
* GL 3.2 context switching is done automatically depending on the build.

fix:
* freqmul parameter not being recognized for PlayBGM SCTRL
* race condition with screenshot functionality causing blank output screenshots as observed on single-digit FPS,
* corrected long-standing issue of BGM playing 1 frame of audio before character code has a chance to execute.