### PR TITLE
refactor: drawpalno, hitflags

### DIFF
--- a/data/common1.cns.zss
+++ b/data/common1.cns.zss
@@ -992,7 +992,7 @@ if roundsExisted = 0 {
 	varRangeSet{value: 0}
 	varRangeSet{fvalue: 0}
 }
-remapPal{source: 1, 1; dest: 1, ifElse(isHelper, palNo, drawPalNo)}
+remapPal{source: 1, 1; dest: 1, palNo}
 if roundNo = 1 {
 	changeState{value: 190}
 }

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -459,7 +459,6 @@ const (
 	OC_ex_roundsexisted
 	OC_ex_ishometeam
 	OC_ex_tickspersecond
-	OC_ex_drawpalno
 	OC_ex_const240p
 	OC_ex_const480p
 	OC_ex_const720p
@@ -1657,7 +1656,9 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 		case OC_numtext:
 			*sys.bcStack.Top() = c.numText(*sys.bcStack.Top())
 		case OC_palno:
-			sys.bcStack.PushI(c.palno())
+			sys.bcStack.PushI(c.gi().palno)
+			// In Winmugen a helper's PalNo is always 1
+			// That behavior has no apparent benefits and even Mugen 1.0 compatibility mode does not keep it
 		case OC_pos_x:
 			var bindVelx float32
 			if c.bindToId > 0 && !math.IsNaN(float64(c.bindPos[0])) && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
@@ -2563,8 +2564,6 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(c.dizzyPoints)
 	case OC_ex_dizzypointsmax:
 		sys.bcStack.PushI(c.dizzyPointsMax)
-	case OC_ex_drawpalno:
-		sys.bcStack.PushI(c.gi().drawpalno)
 	case OC_ex_envshakevar_time:
 		sys.bcStack.PushI(sys.envShake.time)
 	case OC_ex_envshakevar_freq:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -20,9 +20,6 @@ const (
 	ST_N
 	ST_U
 	ST_MASK = 1<<iota - 1
-	ST_D    = ST_L
-	ST_F    = ST_N
-	ST_P    = ST_U
 	ST_SCA  = ST_S | ST_C | ST_A
 )
 
@@ -54,8 +51,20 @@ const (
 	MT_H
 	MT_A
 	MT_U
-	MT_MNS = MT_I
-	MT_PLS = MT_H
+)
+
+type HitFlag int32
+
+const (
+	HF_H HitFlag = 1 << iota
+	HF_L
+	HF_A
+	HF_D
+	HF_F
+	HF_P
+	HF_MNS
+	HF_PLS
+	HF_M = HF_H | HF_L
 )
 
 type ValueType int

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -359,7 +359,6 @@ var triggerMap = map[string]int{
 	"dizzy":              1,
 	"dizzypoints":        1,
 	"dizzypointsmax":     1,
-	"drawpalno":          1,
 	"envshakevar":        1,
 	"explodvar":          1,
 	"fightscreenvar":     1,
@@ -4113,8 +4112,6 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 		out.append(OC_ex_, OC_ex_playerindexexist)
-	case "drawpalno":
-		out.append(OC_ex_, OC_ex_drawpalno)
 	case "angle":
 		out.append(OC_ex_, OC_ex_angle)
 	case "scale":

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1202,19 +1202,19 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		for _, ch := range base {
 			switch ch {
 			case 'H', 'h':
-				flg |= int32(ST_S)
+				flg |= int32(HF_H)
 			case 'L', 'l':
-				flg |= int32(ST_C)
+				flg |= int32(HF_L)
 			case 'M', 'm':
-				flg |= int32(ST_S | ST_C)
+				flg |= int32(HF_H | HF_L)
 			case 'A', 'a':
-				flg |= int32(ST_A)
+				flg |= int32(HF_A)
 			case 'F', 'f':
-				flg |= int32(ST_F)
+				flg |= int32(HF_F)
 			case 'D', 'd':
-				flg |= int32(ST_D)
+				flg |= int32(HF_D)
 			case 'P', 'p':
-				flg |= int32(ST_P)
+				flg |= int32(HF_P)
 			default:
 				return flg, Error("Invalid flags: " + base)
 			}
@@ -1224,11 +1224,11 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			switch (*in)[0] {
 			case '+':
 				// move forward
-				flg |= int32(MT_PLS)
+				flg |= int32(HF_PLS)
 				*in = (*in)[1:]
 			case '-':
 				// move forward
-				flg |= int32(MT_MNS)
+				flg |= int32(HF_MNS)
 				*in = (*in)[1:]
 			}
 		}
@@ -4217,7 +4217,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 	c.token = c.tokenizer(in)
 	return bv, nil
 }
-func (c *Compiler) renzokuEnzansihaError(in *string) error {
+func (c *Compiler) contiguousOperator(in *string) error {
 	*in = strings.TrimSpace(*in)
 	if len(*in) > 0 {
 		switch (*in)[0] {
@@ -4267,7 +4267,7 @@ func (c *Compiler) expPostNot(out *BytecodeExp, in *string) (BytecodeValue,
 					return bvNone(), Error("No comparison operator" +
 						"\n[ECID 4]\n")
 				}
-				if err := c.renzokuEnzansihaError(in); err != nil {
+				if err := c.contiguousOperator(in); err != nil {
 					return bvNone(), err
 				}
 				oldin = oldin[:len(oldin)-len(*in)]
@@ -4275,7 +4275,7 @@ func (c *Compiler) expPostNot(out *BytecodeExp, in *string) (BytecodeValue,
 					" " + *in
 			}
 		} else if opp > 0 {
-			if err := c.renzokuEnzansihaError(in); err != nil {
+			if err := c.contiguousOperator(in); err != nil {
 				return bvNone(), err
 			}
 		}

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1352,23 +1352,23 @@ func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 		for _, c := range data {
 			switch c {
 			case 'H', 'h':
-				flg |= int32(ST_S)
+				flg |= int32(HF_H)
 			case 'L', 'l':
-				flg |= int32(ST_C)
+				flg |= int32(HF_L)
 			case 'M', 'm':
-				flg |= int32(ST_S | ST_C)
+				flg |= int32(HF_H | HF_L)
 			case 'A', 'a':
-				flg |= int32(ST_A)
+				flg |= int32(HF_A)
 			case 'F', 'f':
-				flg |= int32(ST_F)
+				flg |= int32(HF_F)
 			case 'D', 'd':
-				flg |= int32(ST_D)
+				flg |= int32(HF_D)
 			case 'P', 'p':
-				flg |= int32(ST_P)
+				flg |= int32(HF_P)
 			case '-':
-				flg |= int32(MT_MNS)
+				flg |= int32(HF_MNS)
 			case '+':
-				flg |= int32(MT_PLS)
+				flg |= int32(HF_PLS)
 			}
 		}
 		sc.add(id, sc.iToExp(flg))

--- a/src/script.go
+++ b/src/script.go
@@ -3647,28 +3647,28 @@ func triggerFunctions(l *lua.LState) {
 		c := sys.debugWC
 		flagStr := func(flag int32) lua.LString {
 			str := ""
-			if flag&int32(ST_S) != 0 {
+			if flag&int32(HF_H) != 0 {
 				str += "H"
 			}
-			if flag&int32(ST_C) != 0 {
+			if flag&int32(HF_L) != 0 {
 				str += "L"
 			}
-			if flag&int32(ST_A) != 0 {
+			if flag&int32(HF_A) != 0 {
 				str += "A"
 			}
-			if flag&int32(ST_F) != 0 {
+			if flag&int32(HF_F) != 0 {
 				str += "F"
 			}
-			if flag&int32(ST_D) != 0 {
+			if flag&int32(HF_D) != 0 {
 				str += "D"
 			}
-			if flag&int32(ST_P) != 0 {
+			if flag&int32(HF_P) != 0 {
 				str += "P"
 			}
-			if flag&int32(MT_MNS) != 0 {
+			if flag&int32(HF_MNS) != 0 {
 				str += "-"
 			}
-			if flag&int32(MT_PLS) != 0 {
+			if flag&int32(HF_PLS) != 0 {
 				str += "+"
 			}
 			return lua.LString(str)


### PR DESCRIPTION
Refactor:
- The palette selection code no longer uses "drawpalno", which was a source of confusion
- Removed DrawPalNo trigger
- PalNo trigger now returns previous DrawPalNo value
- Winmugen char helpers are no longer locked to returning PalNo = 1, as that behavior adds a layer of complication to the code without benefits. That compatibility difference also does not exist in Mugen 1.0+
- Segregated hitflag bits from state types

Fix:
- Fixed issue where if you played a normal round then went into training mode, the fight call would not be skipped