### PR TITLE
fix: prevent array index OOB errors if not enough axes are found in JoystickState, added name to input_glfw.go output

### DIFF
--- a/src/input.go
+++ b/src/input.go
@@ -192,44 +192,58 @@ func JoystickState(joy, button int) bool {
 		if button >= len(btns) {
 			if len(btns) == 0 {
 				return false
-			} else {
+				// Prevent OOB errors #2141
+			} else if len(axes) > 0 {
 				if button == sys.joystickConfig[joy].dR {
 					return axes[0] > sys.controllerStickSensitivity
 				}
 				if button == sys.joystickConfig[joy].dL {
 					return -axes[0] > sys.controllerStickSensitivity
 				}
-				if button == sys.joystickConfig[joy].dU {
-					return -axes[1] > sys.controllerStickSensitivity
+
+				// Prevent OOB errors #2141
+				if len(axes) > 1 {
+					if button == sys.joystickConfig[joy].dU {
+						return -axes[1] > sys.controllerStickSensitivity
+					}
+					if button == sys.joystickConfig[joy].dD {
+						return axes[1] > sys.controllerStickSensitivity
+					}
 				}
-				if button == sys.joystickConfig[joy].dD {
-					return axes[1] > sys.controllerStickSensitivity
-				}
+				return false
+			} else {
 				return false
 			}
 		}
 
-		// override with axes
-		if button == sys.joystickConfig[joy].dR {
-			if axes[0] > sys.controllerStickSensitivity {
-				btns[button] = 1
+		// override with axes if they exist #2141
+		if len(axes) > 0 {
+			if button == sys.joystickConfig[joy].dR {
+				if axes[0] > sys.controllerStickSensitivity {
+					btns[button] = 1
+				}
+			}
+			if button == sys.joystickConfig[joy].dL {
+				if -axes[0] > sys.controllerStickSensitivity {
+					btns[button] = 1
+				}
+			}
+
+			// prevent OOB errors #2141
+			if len(axes) > 1 {
+				if button == sys.joystickConfig[joy].dU {
+					if -axes[1] > sys.controllerStickSensitivity {
+						btns[button] = 1
+					}
+				}
+				if button == sys.joystickConfig[joy].dD {
+					if axes[1] > sys.controllerStickSensitivity {
+						btns[button] = 1
+					}
+				}
 			}
 		}
-		if button == sys.joystickConfig[joy].dL {
-			if -axes[0] > sys.controllerStickSensitivity {
-				btns[button] = 1
-			}
-		}
-		if button == sys.joystickConfig[joy].dU {
-			if -axes[1] > sys.controllerStickSensitivity {
-				btns[button] = 1
-			}
-		}
-		if button == sys.joystickConfig[joy].dD {
-			if axes[1] > sys.controllerStickSensitivity {
-				btns[button] = 1
-			}
-		}
+
 		return btns[button] != 0
 	} else {
 		// Query axis state

--- a/src/input_glfw.go
+++ b/src/input_glfw.go
@@ -260,6 +260,7 @@ func CheckAxisForDpad(joy int, axes *[]float32, base int) string {
 	} else if -(*axes)[0] > sys.controllerStickSensitivity { // left
 		s = strconv.Itoa(1 + base)
 	}
+	// fix OOB error that can happen on erroneous joysticks
 	if len(*axes) < 2 {
 		return s
 	}
@@ -302,11 +303,11 @@ func CheckAxisForTrigger(joy int, axes *[]float32) string {
 				// do nothing
 			} else if (i == 3 || i == 4) && name == "PS4 Controller" {
 				// do nothing
-			} else if (i == 3 || i == 4) && (name == "Sony DualSense" || name == "PS5 Controller") {
+			} else if (i == 3 || i == 4) && (strings.Contains(name, "Sony DualSense") || name == "PS5 Controller") {
 				// do nothing
 			} else {
 				s = strconv.Itoa(-i*2 - 1)
-				fmt.Printf("[input_glfw.go][checkAxisForTrigger] 1.AXIS joy=%v i=%v s:%v axes[i]=%v\n", joy, i, s, (*axes)[i])
+				fmt.Printf("[input_glfw.go][checkAxisForTrigger] 1.AXIS joy=%v i=%v s:%v axes[i]=%v, name = %s\n", joy, i, s, (*axes)[i], name)
 				break
 			}
 		} else if (*axes)[i] > sys.controllerStickSensitivity {


### PR DESCRIPTION
fix:
* prevent array index OOB errors if not enough axes are found in JoystickState to address #2141
* added name to input_glfw.go output to help assist with #2146
* correction to DualSense detection (there can be others that merely start with Sony DualSense)