### PR TITLE
feat: HitDefVar ID, SparkX and SparkY, PlayerNoExist, fixes, refactor

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -636,6 +636,7 @@ const (
 	OC_ex_physics
 	OC_ex_playerno
 	OC_ex_playerindexexist
+	OC_ex_playernoexist
 	OC_ex_randomrange
 	OC_ex_ratiolevel
 	OC_ex_receiveddamage
@@ -861,8 +862,14 @@ type BytecodeValue struct {
 	v float64
 }
 
-func (bv BytecodeValue) IsNone() bool { return bv.t == VT_None }
-func (bv BytecodeValue) IsSF() bool   { return bv.t == VT_SFalse }
+func (bv BytecodeValue) IsNone() bool {
+	return bv.t == VT_None
+}
+
+func (bv BytecodeValue) IsSF() bool {
+	return bv.t == VT_SFalse
+}
+
 func (bv BytecodeValue) ToF() float32 {
 	if bv.IsSF() {
 		return 0
@@ -2839,6 +2846,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(int32(c.playerNo) + 1)
 	case OC_ex_playerindexexist:
 		*sys.bcStack.Top() = sys.playerIndexExist(*sys.bcStack.Top())
+	case OC_ex_playernoexist:
+		*sys.bcStack.Top() = sys.playerNoExist(*sys.bcStack.Top())
 	case OC_ex_randomrange:
 		v2 := sys.bcStack.Pop()
 		be.random(sys.bcStack.Top(), v2)
@@ -8394,6 +8403,8 @@ func (sc envShake) Run(c *Char, _ []int32) bool {
 			sys.envShake.time = exp[0].evalI(c)
 		case envShake_ampl:
 			sys.envShake.ampl = float32(int32(float32(exp[0].evalI(c)) * c.localscl))
+			// Because of how localscl works, the amplitude will be slightly smaller during widescreen
+			// This also happens in Mugen however
 		case envShake_freq:
 			sys.envShake.freq = MaxF(0, exp[0].evalF(c)*float32(math.Pi)/180)
 		case envShake_phase:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -2317,7 +2317,7 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_gethitvar_ground_animtype:
 		sys.bcStack.PushI(int32(c.ghv.groundanimtype))
 	case OC_ex_gethitvar_fall_animtype:
-		sys.bcStack.PushI(int32(c.ghv.fall.animtype))
+		sys.bcStack.PushI(int32(c.ghv.fall_animtype))
 	case OC_ex_gethitvar_type:
 		sys.bcStack.PushI(int32(c.ghv._type))
 	case OC_ex_gethitvar_airtype:
@@ -2369,39 +2369,39 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_gethitvar_fall:
 		sys.bcStack.PushB(c.ghv.fallflag)
 	case OC_ex_gethitvar_fall_damage:
-		sys.bcStack.PushI(c.ghv.fall.damage)
+		sys.bcStack.PushI(c.ghv.fall_damage)
 	case OC_ex_gethitvar_fall_xvel:
-		if math.IsNaN(float64(c.ghv.fall.xvelocity)) {
+		if math.IsNaN(float64(c.ghv.fall_xvelocity)) {
 			sys.bcStack.PushF(-32760) // Winmugen behavior
 		} else {
-			sys.bcStack.PushF(c.ghv.fall.xvelocity * (c.localscl / oc.localscl))
+			sys.bcStack.PushF(c.ghv.fall_xvelocity * (c.localscl / oc.localscl))
 		}
 	case OC_ex_gethitvar_fall_yvel:
-		sys.bcStack.PushF(c.ghv.fall.yvelocity * (c.localscl / oc.localscl))
+		sys.bcStack.PushF(c.ghv.fall_yvelocity * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_fall_zvel:
-		if math.IsNaN(float64(c.ghv.fall.zvelocity)) {
+		if math.IsNaN(float64(c.ghv.fall_zvelocity)) {
 			sys.bcStack.PushF(-32760) // Winmugen behavior
 		} else {
-			sys.bcStack.PushF(c.ghv.fall.zvelocity * (c.localscl / oc.localscl))
+			sys.bcStack.PushF(c.ghv.fall_zvelocity * (c.localscl / oc.localscl))
 		}
 	case OC_ex_gethitvar_fall_recover:
-		sys.bcStack.PushB(c.ghv.fall.recover)
+		sys.bcStack.PushB(c.ghv.fall_recover)
 	case OC_ex_gethitvar_fall_time:
 		sys.bcStack.PushI(c.fallTime)
 	case OC_ex_gethitvar_fall_recovertime:
-		sys.bcStack.PushI(c.ghv.fall.recovertime)
+		sys.bcStack.PushI(c.ghv.fall_recovertime)
 	case OC_ex_gethitvar_fall_kill:
-		sys.bcStack.PushB(c.ghv.fall.kill)
+		sys.bcStack.PushB(c.ghv.fall_kill)
 	case OC_ex_gethitvar_fall_envshake_time:
-		sys.bcStack.PushI(c.ghv.fall.envshake_time)
+		sys.bcStack.PushI(c.ghv.fall_envshake_time)
 	case OC_ex_gethitvar_fall_envshake_freq:
-		sys.bcStack.PushF(c.ghv.fall.envshake_freq)
+		sys.bcStack.PushF(c.ghv.fall_envshake_freq)
 	case OC_ex_gethitvar_fall_envshake_ampl:
-		sys.bcStack.PushI(int32(float32(c.ghv.fall.envshake_ampl) * (c.localscl / oc.localscl)))
+		sys.bcStack.PushI(int32(float32(c.ghv.fall_envshake_ampl) * (c.localscl / oc.localscl)))
 	case OC_ex_gethitvar_fall_envshake_phase:
-		sys.bcStack.PushF(c.ghv.fall.envshake_phase)
+		sys.bcStack.PushF(c.ghv.fall_envshake_phase)
 	case OC_ex_gethitvar_fall_envshake_mul:
-		sys.bcStack.PushF(c.ghv.fall.envshake_mul)
+		sys.bcStack.PushF(c.ghv.fall_envshake_mul)
 	case OC_ex_gethitvar_attr:
 		attr := (*(*int32)(unsafe.Pointer(&be[*i])))
 		// same as c.hitDefAttr()
@@ -2412,7 +2412,7 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_gethitvar_guardpoints:
 		sys.bcStack.PushI(c.ghv.guardpoints)
 	case OC_ex_gethitvar_id:
-		sys.bcStack.PushI(c.ghv.id)
+		sys.bcStack.PushI(c.ghv.playerId)
 	case OC_ex_gethitvar_playerno:
 		sys.bcStack.PushI(int32(c.ghv.playerNo) + 1)
 	case OC_ex_gethitvar_redlife:
@@ -2792,7 +2792,7 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_movehitvar_frame:
 		sys.bcStack.PushB(c.mhv.frame)
 	case OC_ex_movehitvar_id:
-		sys.bcStack.PushI(c.mhv.id)
+		sys.bcStack.PushI(c.mhv.playerId)
 	case OC_ex_movehitvar_overridden:
 		sys.bcStack.PushB(c.mhv.overridden)
 	case OC_ex_movehitvar_playerno:
@@ -6109,7 +6109,7 @@ const (
 	hitDef_down_cornerpush_veloff
 	hitDef_ground_hittime
 	hitDef_guard_hittime
-	hitDef_guard_dist
+	hitDef_guard_dist_x
 	hitDef_guard_dist_y
 	hitDef_guard_dist_z
 	hitDef_pausetime
@@ -6171,7 +6171,7 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 	case hitDef_air_animtype:
 		hd.air_animtype = Reaction(exp[0].evalI(c))
 	case hitDef_fall_animtype:
-		hd.fall.animtype = Reaction(exp[0].evalI(c))
+		hd.fall_animtype = Reaction(exp[0].evalI(c))
 	case hitDef_affectteam:
 		hd.affectteam = exp[0].evalI(c)
 	case hitDef_teamside:
@@ -6196,7 +6196,7 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 	case hitDef_guard_kill:
 		hd.guard_kill = exp[0].evalB(c)
 	case hitDef_fall_kill:
-		hd.fall.kill = exp[0].evalB(c)
+		hd.fall_kill = exp[0].evalB(c)
 	case hitDef_hitonce:
 		hd.hitonce = Btoi(exp[0].evalB(c))
 	case hitDef_air_juggle:
@@ -6255,17 +6255,17 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 	case hitDef_forcenofall:
 		hd.forcenofall = exp[0].evalB(c)
 	case hitDef_fall_damage:
-		hd.fall.damage = exp[0].evalI(c)
+		hd.fall_damage = exp[0].evalI(c)
 	case hitDef_fall_xvelocity:
-		hd.fall.xvelocity = exp[0].evalF(c)
+		hd.fall_xvelocity = exp[0].evalF(c)
 	case hitDef_fall_yvelocity:
-		hd.fall.yvelocity = exp[0].evalF(c)
+		hd.fall_yvelocity = exp[0].evalF(c)
 	case hitDef_fall_zvelocity:
-		hd.fall.zvelocity = exp[0].evalF(c)
+		hd.fall_zvelocity = exp[0].evalF(c)
 	case hitDef_fall_recover:
-		hd.fall.recover = exp[0].evalB(c)
+		hd.fall_recover = exp[0].evalB(c)
 	case hitDef_fall_recovertime:
-		hd.fall.recovertime = exp[0].evalI(c)
+		hd.fall_recovertime = exp[0].evalI(c)
 	case hitDef_sparkno:
 		hd.sparkno_ffx = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
 		hd.sparkno = exp[1].evalI(c)
@@ -6342,10 +6342,10 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 		hd.guard_hittime = hd.ground_hittime
 	case hitDef_guard_hittime:
 		hd.guard_hittime = exp[0].evalI(c)
-	case hitDef_guard_dist:
-		hd.guard_dist[0] = exp[0].evalI(c)
+	case hitDef_guard_dist_x:
+		hd.guard_dist_x[0] = exp[0].evalI(c)
 		if len(exp) > 1 {
-			hd.guard_dist[1] = exp[1].evalI(c)
+			hd.guard_dist_x[1] = exp[1].evalI(c)
 		}
 	case hitDef_guard_dist_y:
 		hd.guard_dist_y[0] = exp[0].evalI(c)
@@ -6436,15 +6436,15 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 	case hitDef_envshake_mul:
 		hd.envshake_mul = exp[0].evalF(c)
 	case hitDef_fall_envshake_time:
-		hd.fall.envshake_time = exp[0].evalI(c)
+		hd.fall_envshake_time = exp[0].evalI(c)
 	case hitDef_fall_envshake_ampl:
-		hd.fall.envshake_ampl = exp[0].evalI(c)
+		hd.fall_envshake_ampl = exp[0].evalI(c)
 	case hitDef_fall_envshake_freq:
-		hd.fall.envshake_freq = MaxF(0, exp[0].evalF(c))
+		hd.fall_envshake_freq = MaxF(0, exp[0].evalF(c))
 	case hitDef_fall_envshake_phase:
-		hd.fall.envshake_phase = exp[0].evalF(c)
+		hd.fall_envshake_phase = exp[0].evalF(c)
 	case hitDef_fall_envshake_mul:
-		hd.fall.envshake_mul = exp[0].evalF(c)
+		hd.fall_envshake_mul = exp[0].evalF(c)
 	case hitDef_dizzypoints:
 		hd.dizzypoints = Max(IErr+1, exp[0].evalI(c))
 	case hitDef_guardpoints:
@@ -7101,7 +7101,7 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				})
 			case hitDef_fall_animtype:
 				eachProj(func(p *Projectile) {
-					p.hitdef.fall.animtype = Reaction(exp[0].evalI(c))
+					p.hitdef.fall_animtype = Reaction(exp[0].evalI(c))
 				})
 			case hitDef_affectteam:
 				eachProj(func(p *Projectile) {
@@ -7142,7 +7142,7 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				})
 			case hitDef_fall_kill:
 				eachProj(func(p *Projectile) {
-					p.hitdef.fall.kill = exp[0].evalB(c)
+					p.hitdef.fall_kill = exp[0].evalB(c)
 				})
 			case hitDef_hitonce:
 				eachProj(func(p *Projectile) {
@@ -7239,27 +7239,27 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				})
 			case hitDef_fall_damage:
 				eachProj(func(p *Projectile) {
-					p.hitdef.fall.damage = exp[0].evalI(c)
+					p.hitdef.fall_damage = exp[0].evalI(c)
 				})
 			case hitDef_fall_xvelocity:
 				eachProj(func(p *Projectile) {
-					p.hitdef.fall.xvelocity = exp[0].evalF(c)
+					p.hitdef.fall_xvelocity = exp[0].evalF(c)
 				})
 			case hitDef_fall_yvelocity:
 				eachProj(func(p *Projectile) {
-					p.hitdef.fall.yvelocity = exp[0].evalF(c)
+					p.hitdef.fall_yvelocity = exp[0].evalF(c)
 				})
 			case hitDef_fall_zvelocity:
 				eachProj(func(p *Projectile) {
-					p.hitdef.fall.zvelocity = exp[0].evalF(c)
+					p.hitdef.fall_zvelocity = exp[0].evalF(c)
 				})
 			case hitDef_fall_recover:
 				eachProj(func(p *Projectile) {
-					p.hitdef.fall.recover = exp[0].evalB(c)
+					p.hitdef.fall_recover = exp[0].evalB(c)
 				})
 			case hitDef_fall_recovertime:
 				eachProj(func(p *Projectile) {
-					p.hitdef.fall.recovertime = exp[0].evalI(c)
+					p.hitdef.fall_recovertime = exp[0].evalI(c)
 				})
 			case hitDef_sparkno:
 				eachProj(func(p *Projectile) {
@@ -7370,11 +7370,11 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				eachProj(func(p *Projectile) {
 					p.hitdef.guard_hittime = exp[0].evalI(c)
 				})
-			case hitDef_guard_dist:
+			case hitDef_guard_dist_x:
 				eachProj(func(p *Projectile) {
-					p.hitdef.guard_dist[0] = exp[0].evalI(c)
+					p.hitdef.guard_dist_x[0] = exp[0].evalI(c)
 					if len(exp) > 1 {
-						p.hitdef.guard_dist[1] = exp[1].evalI(c)
+						p.hitdef.guard_dist_x[1] = exp[1].evalI(c)
 					}
 				})
 			case hitDef_guard_dist_y:
@@ -7505,23 +7505,23 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				})
 			case hitDef_fall_envshake_time:
 				eachProj(func(p *Projectile) {
-					p.hitdef.fall.envshake_time = exp[0].evalI(c)
+					p.hitdef.fall_envshake_time = exp[0].evalI(c)
 				})
 			case hitDef_fall_envshake_ampl:
 				eachProj(func(p *Projectile) {
-					p.hitdef.fall.envshake_ampl = exp[0].evalI(c)
+					p.hitdef.fall_envshake_ampl = exp[0].evalI(c)
 				})
 			case hitDef_fall_envshake_freq:
 				eachProj(func(p *Projectile) {
-					p.hitdef.fall.envshake_freq = MaxF(0, exp[0].evalF(c))
+					p.hitdef.fall_envshake_freq = MaxF(0, exp[0].evalF(c))
 				})
 			case hitDef_fall_envshake_phase:
 				eachProj(func(p *Projectile) {
-					p.hitdef.fall.envshake_phase = exp[0].evalF(c)
+					p.hitdef.fall_envshake_phase = exp[0].evalF(c)
 				})
 			case hitDef_fall_envshake_mul:
 				eachProj(func(p *Projectile) {
-					p.hitdef.fall.envshake_mul = exp[0].evalF(c)
+					p.hitdef.fall_envshake_mul = exp[0].evalF(c)
 				})
 			case hitDef_dizzypoints:
 				eachProj(func(p *Projectile) {
@@ -9128,14 +9128,14 @@ func (sc fallEnvShake) Run(c *Char, _ []int32) bool {
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case fallEnvShake_:
-			if crun.ghv.fall.envshake_time > 0 {
-				sys.envShake = EnvShake{time: crun.ghv.fall.envshake_time,
-					freq:  crun.ghv.fall.envshake_freq * math.Pi / 180,
-					ampl:  float32(crun.ghv.fall.envshake_ampl) * c.localscl,
-					phase: crun.ghv.fall.envshake_phase,
-					mul:   crun.ghv.fall.envshake_mul}
+			if crun.ghv.fall_envshake_time > 0 {
+				sys.envShake = EnvShake{time: crun.ghv.fall_envshake_time,
+					freq:  crun.ghv.fall_envshake_freq * math.Pi / 180,
+					ampl:  float32(crun.ghv.fall_envshake_ampl) * c.localscl,
+					phase: crun.ghv.fall_envshake_phase,
+					mul:   crun.ghv.fall_envshake_mul}
 				sys.envShake.setDefaultPhase()
-				crun.ghv.fall.envshake_time = 0
+				crun.ghv.fall_envshake_time = 0
 			}
 		case fallEnvShake_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
@@ -11780,29 +11780,29 @@ func (sc getHitVarSet) Run(c *Char, _ []int32) bool {
 		case getHitVarSet_fall:
 			crun.ghv.fallflag = exp[0].evalB(c)
 		case getHitVarSet_fall_damage:
-			crun.ghv.fall.damage = exp[0].evalI(c)
+			crun.ghv.fall_damage = exp[0].evalI(c)
 		case getHitVarSet_fall_envshake_ampl:
-			crun.ghv.fall.envshake_ampl = int32(exp[0].evalF(c) * redirscale)
+			crun.ghv.fall_envshake_ampl = int32(exp[0].evalF(c) * redirscale)
 		case getHitVarSet_fall_envshake_freq:
-			crun.ghv.fall.envshake_freq = exp[0].evalF(c)
+			crun.ghv.fall_envshake_freq = exp[0].evalF(c)
 		case getHitVarSet_fall_envshake_mul:
-			crun.ghv.fall.envshake_mul = exp[0].evalF(c)
+			crun.ghv.fall_envshake_mul = exp[0].evalF(c)
 		case getHitVarSet_fall_envshake_phase:
-			crun.ghv.fall.envshake_phase = exp[0].evalF(c)
+			crun.ghv.fall_envshake_phase = exp[0].evalF(c)
 		case getHitVarSet_fall_envshake_time:
-			crun.ghv.fall.envshake_time = exp[0].evalI(c)
+			crun.ghv.fall_envshake_time = exp[0].evalI(c)
 		case getHitVarSet_fall_kill:
-			crun.ghv.fall.kill = exp[0].evalB(c)
+			crun.ghv.fall_kill = exp[0].evalB(c)
 		case getHitVarSet_fall_recover:
-			crun.ghv.fall.recover = exp[0].evalB(c)
+			crun.ghv.fall_recover = exp[0].evalB(c)
 		case getHitVarSet_fall_recovertime:
-			crun.ghv.fall.recovertime = exp[0].evalI(c)
+			crun.ghv.fall_recovertime = exp[0].evalI(c)
 		case getHitVarSet_fall_xvel:
-			crun.ghv.fall.xvelocity = exp[0].evalF(c) * redirscale
+			crun.ghv.fall_xvelocity = exp[0].evalF(c) * redirscale
 		case getHitVarSet_fall_yvel:
-			crun.ghv.fall.yvelocity = exp[0].evalF(c) * redirscale
+			crun.ghv.fall_yvelocity = exp[0].evalF(c) * redirscale
 		case getHitVarSet_fall_zvel:
-			crun.ghv.fall.zvelocity = exp[0].evalF(c) * redirscale
+			crun.ghv.fall_zvelocity = exp[0].evalF(c) * redirscale
 		case getHitVarSet_fallcount:
 			crun.ghv.fallcount = exp[0].evalI(c)
 		case getHitVarSet_groundtype:
@@ -11814,7 +11814,7 @@ func (sc getHitVarSet) Run(c *Char, _ []int32) bool {
 		case getHitVarSet_hitshaketime:
 			crun.ghv.hitshaketime = exp[0].evalI(c)
 		case getHitVarSet_id:
-			crun.ghv.id = exp[0].evalI(c)
+			crun.ghv.playerId = exp[0].evalI(c)
 		case getHitVarSet_playerno:
 			crun.ghv.playerNo = int(exp[0].evalI(c))
 		case getHitVarSet_slidetime:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -823,6 +823,9 @@ const (
 	OC_ex2_hitdefvar_p1stateno
 	OC_ex2_hitdefvar_p2stateno
 	OC_ex2_hitdefvar_priority
+	OC_ex2_hitdefvar_id
+	OC_ex2_hitdefvar_sparkx
+	OC_ex2_hitdefvar_sparky
 	OC_ex2_hitbyattr
 )
 const (
@@ -3351,6 +3354,12 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(c.hitdef.p2stateno)
 	case OC_ex2_hitdefvar_priority:
 		sys.bcStack.PushI(c.hitdef.priority)
+	case OC_ex2_hitdefvar_id:
+		sys.bcStack.PushI(c.hitdef.id)
+	case OC_ex2_hitdefvar_sparkx:
+		sys.bcStack.PushF(c.hitdef.sparkxy[0] * (c.localscl / oc.localscl))
+	case OC_ex2_hitdefvar_sparky:
+		sys.bcStack.PushF(c.hitdef.sparkxy[1] * (c.localscl / oc.localscl))
 	case OC_ex2_hitbyattr:
 		sys.bcStack.PushB(c.hitByAttrTrigger(*(*int32)(unsafe.Pointer(&be[*i]))))
 		*i += 4

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2447,6 +2447,12 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			opc = OC_ex2_hitdefvar_p2stateno
 		case "priority":
 			opc = OC_ex2_hitdefvar_priority
+		case "id":
+			opc = OC_ex2_hitdefvar_id
+		case "sparkx":
+			opc = OC_ex2_hitdefvar_sparkx
+		case "sparky":
+			opc = OC_ex2_hitdefvar_sparky
 		default:
 			return bvNone(), Error("Invalid data: " + c.token)
 		}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -409,6 +409,7 @@ var triggerMap = map[string]int{
 	"playercount":        1,
 	"playerindexexist":   1,
 	"playerno":           1,
+	"playernoexist":      1,
 	"prevanim":           1,
 	"prevmovetype":       1,
 	"prevstatetype":      1,
@@ -4115,8 +4116,20 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		}); err != nil {
 			return bvNone(), err
 		}
+	case "playercount":
+		out.append(OC_ex_, OC_ex_playercount)
+	case "playerindexexist":
+		if _, err := c.oneArg(out, in, rd, true); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_ex_, OC_ex_playerindexexist)
 	case "playerno":
 		out.append(OC_ex_, OC_ex_playerno)
+	case "playernoexist":
+		if _, err := c.oneArg(out, in, rd, true); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_ex_, OC_ex_playernoexist)
 	case "ratiolevel":
 		out.append(OC_ex_, OC_ex_ratiolevel)
 	case "receiveddamage":
@@ -4168,13 +4181,6 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_ex_, OC_ex_timeremaining)
 	case "timetotal":
 		out.append(OC_ex_, OC_ex_timetotal)
-	case "playercount":
-		out.append(OC_ex_, OC_ex_playercount)
-	case "playerindexexist":
-		if _, err := c.oneArg(out, in, rd, true); err != nil {
-			return bvNone(), err
-		}
-		out.append(OC_ex_, OC_ex_playerindexexist)
 	case "angle":
 		out.append(OC_ex_, OC_ex_angle)
 	case "scale":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1729,12 +1729,12 @@ func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 		hitDef_guard_hittime, VT_Int, 1, false); err != nil {
 		return err
 	}
-	if err := c.paramValue(is, sc, "guard.dist",
-		hitDef_guard_dist, VT_Int, 2, false); err != nil {
+	if err := c.paramValue(is, sc, "guard.dist", // Old syntax
+		hitDef_guard_dist_x, VT_Int, 2, false); err != nil {
 		return err
 	}
-	if err := c.paramValue(is, sc, "guard.dist.width",
-		hitDef_guard_dist, VT_Int, 2, false); err != nil {
+	if err := c.paramValue(is, sc, "guard.dist.width", // New syntax
+		hitDef_guard_dist_x, VT_Int, 2, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "guard.dist.height",

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -1769,7 +1769,7 @@ type LifeBarRound struct {
 	roundCallOver      bool
 	fightCallOver      bool
 	timerActive        bool
-	wint               [WT_NumTypes * 2]LbBgTextSnd
+	winType            [WT_NumTypes * 2]LbBgTextSnd
 	fadein_time        int32
 	fadein_col         uint32
 	fadeout_time       int32
@@ -2050,24 +2050,24 @@ func readLifeBarRound(is IniSection,
 	for i := range ro.drawgame_bg {
 		ro.drawgame_bg[i] = *ReadAnimLayout(fmt.Sprintf("draw.bg%v.", i), is, sff, at, 1)
 	}
-	ro.wint[WT_Normal] = readLbBgTextSnd("p1.n.", is, sff, at, 0, f)
-	ro.wint[WT_Special] = readLbBgTextSnd("p1.s.", is, sff, at, 0, f)
-	ro.wint[WT_Hyper] = readLbBgTextSnd("p1.h.", is, sff, at, 0, f)
-	ro.wint[WT_Cheese] = readLbBgTextSnd("p1.c.", is, sff, at, 0, f)
-	ro.wint[WT_Time] = readLbBgTextSnd("p1.t.", is, sff, at, 0, f)
-	ro.wint[WT_Throw] = readLbBgTextSnd("p1.throw.", is, sff, at, 0, f)
-	ro.wint[WT_Suicide] = readLbBgTextSnd("p1.suicide.", is, sff, at, 0, f)
-	ro.wint[WT_Teammate] = readLbBgTextSnd("p1.teammate.", is, sff, at, 0, f)
-	ro.wint[WT_Perfect] = readLbBgTextSnd("p1.perfect.", is, sff, at, 0, f)
-	ro.wint[WT_Normal+WT_NumTypes] = readLbBgTextSnd("p2.n.", is, sff, at, 0, f)
-	ro.wint[WT_Special+WT_NumTypes] = readLbBgTextSnd("p2.s.", is, sff, at, 0, f)
-	ro.wint[WT_Hyper+WT_NumTypes] = readLbBgTextSnd("p2.h.", is, sff, at, 0, f)
-	ro.wint[WT_Cheese+WT_NumTypes] = readLbBgTextSnd("p2.c.", is, sff, at, 0, f)
-	ro.wint[WT_Time+WT_NumTypes] = readLbBgTextSnd("p2.t.", is, sff, at, 0, f)
-	ro.wint[WT_Throw+WT_NumTypes] = readLbBgTextSnd("p2.throw.", is, sff, at, 0, f)
-	ro.wint[WT_Suicide+WT_NumTypes] = readLbBgTextSnd("p2.suicide.", is, sff, at, 0, f)
-	ro.wint[WT_Teammate+WT_NumTypes] = readLbBgTextSnd("p2.teammate.", is, sff, at, 0, f)
-	ro.wint[WT_Perfect+WT_NumTypes] = readLbBgTextSnd("p2.perfect.", is, sff, at, 0, f)
+	ro.winType[WT_Normal] = readLbBgTextSnd("p1.n.", is, sff, at, 0, f)
+	ro.winType[WT_Special] = readLbBgTextSnd("p1.s.", is, sff, at, 0, f)
+	ro.winType[WT_Hyper] = readLbBgTextSnd("p1.h.", is, sff, at, 0, f)
+	ro.winType[WT_Cheese] = readLbBgTextSnd("p1.c.", is, sff, at, 0, f)
+	ro.winType[WT_Time] = readLbBgTextSnd("p1.t.", is, sff, at, 0, f)
+	ro.winType[WT_Throw] = readLbBgTextSnd("p1.throw.", is, sff, at, 0, f)
+	ro.winType[WT_Suicide] = readLbBgTextSnd("p1.suicide.", is, sff, at, 0, f)
+	ro.winType[WT_Teammate] = readLbBgTextSnd("p1.teammate.", is, sff, at, 0, f)
+	ro.winType[WT_Perfect] = readLbBgTextSnd("p1.perfect.", is, sff, at, 0, f)
+	ro.winType[WT_Normal+WT_NumTypes] = readLbBgTextSnd("p2.n.", is, sff, at, 0, f)
+	ro.winType[WT_Special+WT_NumTypes] = readLbBgTextSnd("p2.s.", is, sff, at, 0, f)
+	ro.winType[WT_Hyper+WT_NumTypes] = readLbBgTextSnd("p2.h.", is, sff, at, 0, f)
+	ro.winType[WT_Cheese+WT_NumTypes] = readLbBgTextSnd("p2.c.", is, sff, at, 0, f)
+	ro.winType[WT_Time+WT_NumTypes] = readLbBgTextSnd("p2.t.", is, sff, at, 0, f)
+	ro.winType[WT_Throw+WT_NumTypes] = readLbBgTextSnd("p2.throw.", is, sff, at, 0, f)
+	ro.winType[WT_Suicide+WT_NumTypes] = readLbBgTextSnd("p2.suicide.", is, sff, at, 0, f)
+	ro.winType[WT_Teammate+WT_NumTypes] = readLbBgTextSnd("p2.teammate.", is, sff, at, 0, f)
+	ro.winType[WT_Perfect+WT_NumTypes] = readLbBgTextSnd("p2.perfect.", is, sff, at, 0, f)
 	is.ReadI32("fadein.time", &ro.fadein_time)
 	var col [3]int32
 	if is.ReadI32("fadein.col", &col[0], &col[1], &col[2]) {
@@ -2363,14 +2363,14 @@ func (ro *LifeBarRound) act() bool {
 					index := sys.winType[sys.winTeam]
 					if index > WT_NumTypes {
 						if sys.winTeam == 0 {
-							ro.wint[WT_Perfect].step(ro.snd)
+							ro.winType[WT_Perfect].step(ro.snd)
 							index = index - WT_NumTypes - 1
 						} else {
-							ro.wint[WT_Perfect+WT_NumTypes].step(ro.snd)
+							ro.winType[WT_Perfect+WT_NumTypes].step(ro.snd)
 							index = index - 1
 						}
 					}
-					ro.wint[index].step(ro.snd)
+					ro.winType[index].step(ro.snd)
 				}
 			}
 		} else {
@@ -2382,6 +2382,7 @@ func (ro *LifeBarRound) act() bool {
 
 func (ro *LifeBarRound) reset() {
 	ro.current = 0
+	// Round animations
 	ro.round_default.Reset()
 	ro.round_default_top.Reset()
 	for i := range ro.round_default_bg {
@@ -2390,16 +2391,25 @@ func (ro *LifeBarRound) reset() {
 	for i := range ro.round {
 		ro.round[i].Reset()
 	}
+	// Single round animations
+	ro.round_single.Reset()
+	ro.round_single_top.Reset()
+	for i := range ro.round_single_bg {
+		ro.round_single_bg[i].Reset()
+	}
+	// Final round animations
+	ro.round_final.Reset()
 	ro.round_final_top.Reset()
 	for i := range ro.round_final_bg {
 		ro.round_final_bg[i].Reset()
 	}
-	ro.round_final.Reset()
+	// Fight call animations
 	ro.fight.Reset()
 	ro.fight_top.Reset()
 	for i := range ro.fight_bg {
 		ro.fight_bg[i].Reset()
 	}
+	// KO animations
 	ro.ko.Reset()
 	ro.ko_top.Reset()
 	for i := range ro.ko_bg {
@@ -2410,6 +2420,7 @@ func (ro *LifeBarRound) reset() {
 	for i := range ro.dko_bg {
 		ro.dko_bg[i].Reset()
 	}
+	// Time Over animations
 	ro.to.Reset()
 	ro.to_top.Reset()
 	for i := range ro.to_bg {
@@ -2459,20 +2470,22 @@ func (ro *LifeBarRound) reset() {
 			ro.win4_bg[i][j].Reset()
 		}
 	}
+	// Draw game
 	ro.drawgame.Reset()
 	ro.drawgame_top.Reset()
 	for i := range ro.drawgame_bg {
 		ro.drawgame_bg[i].Reset()
 	}
-	for i := range ro.wint {
-		ro.wint[i].reset()
+	// Win types
+	for i := range ro.winType {
+		ro.winType[i].reset()
 	}
-	ro.roundCallOver = false
-	ro.fightCallOver = false
 	// Reset action timers
 	ro.waitTimer = [4]int32{}
 	ro.waitSoundTimer = [4]int32{}
 	ro.drawTimer = [4]int32{}
+	ro.roundCallOver = false
+	ro.fightCallOver = false
 }
 
 func (ro *LifeBarRound) draw(layerno int16, f []*Fnt) {
@@ -2663,15 +2676,15 @@ func (ro *LifeBarRound) draw(layerno int16, f []*Fnt) {
 				}
 				if perfect {
 					if sys.winTeam == 0 {
-						ro.wint[WT_Perfect].bgDraw(layerno)
-						ro.wint[WT_Perfect].draw(layerno, f)
+						ro.winType[WT_Perfect].bgDraw(layerno)
+						ro.winType[WT_Perfect].draw(layerno, f)
 					} else {
-						ro.wint[WT_Perfect+WT_NumTypes].bgDraw(layerno)
-						ro.wint[WT_Perfect+WT_NumTypes].draw(layerno, f)
+						ro.winType[WT_Perfect+WT_NumTypes].bgDraw(layerno)
+						ro.winType[WT_Perfect+WT_NumTypes].draw(layerno, f)
 					}
 				}
-				ro.wint[index].bgDraw(layerno)
-				ro.wint[index].draw(layerno, f)
+				ro.winType[index].bgDraw(layerno)
+				ro.winType[index].draw(layerno, f)
 			}
 		}
 	}

--- a/src/script.go
+++ b/src/script.go
@@ -3738,6 +3738,12 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LNumber(c.hitdef.p2stateno))
 		case "priority":
 			l.Push(lua.LNumber(c.hitdef.priority))
+		case "id":
+			l.Push(lua.LNumber(c.hitdef.id))
+		case "sparkx":
+			l.Push(lua.LNumber(c.hitdef.sparkxy[0]))
+		case "sparky":
+			l.Push(lua.LNumber(c.hitdef.sparkxy[1]))
 		default:
 			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}

--- a/src/script.go
+++ b/src/script.go
@@ -3766,7 +3766,7 @@ func triggerFunctions(l *lua.LState) {
 		case "ground.animtype":
 			ln = lua.LNumber(c.ghv.groundanimtype)
 		case "fall.animtype":
-			ln = lua.LNumber(c.ghv.fall.animtype)
+			ln = lua.LNumber(c.ghv.fall_animtype)
 		case "type":
 			ln = lua.LNumber(c.ghv._type)
 		case "airtype":
@@ -3818,39 +3818,39 @@ func triggerFunctions(l *lua.LState) {
 		case "fall":
 			ln = lua.LNumber(Btoi(c.ghv.fallflag))
 		case "fall.damage":
-			ln = lua.LNumber(c.ghv.fall.damage)
+			ln = lua.LNumber(c.ghv.fall_damage)
 		case "fall.xvel":
-			if math.IsNaN(float64(c.ghv.fall.xvelocity)) {
+			if math.IsNaN(float64(c.ghv.fall_xvelocity)) {
 				ln = lua.LNumber(-32760) // Winmugen behavior
 			} else {
-				ln = lua.LNumber(c.ghv.fall.xvelocity)
+				ln = lua.LNumber(c.ghv.fall_xvelocity)
 			}
 		case "fall.yvel":
-			ln = lua.LNumber(c.ghv.fall.yvelocity)
+			ln = lua.LNumber(c.ghv.fall_yvelocity)
 		case "fall.zvel":
-			if math.IsNaN(float64(c.ghv.fall.zvelocity)) {
+			if math.IsNaN(float64(c.ghv.fall_zvelocity)) {
 				ln = lua.LNumber(-32760) // Winmugen behavior
 			} else {
-				ln = lua.LNumber(c.ghv.fall.zvelocity)
+				ln = lua.LNumber(c.ghv.fall_zvelocity)
 			}
 		case "fall.recover":
-			ln = lua.LNumber(Btoi(c.ghv.fall.recover))
+			ln = lua.LNumber(Btoi(c.ghv.fall_recover))
 		case "fall.time":
 			ln = lua.LNumber(c.fallTime)
 		case "fall.recovertime":
-			ln = lua.LNumber(c.ghv.fall.recovertime)
+			ln = lua.LNumber(c.ghv.fall_recovertime)
 		case "fall.kill":
-			ln = lua.LNumber(Btoi(c.ghv.fall.kill))
+			ln = lua.LNumber(Btoi(c.ghv.fall_kill))
 		case "fall.envshake.time":
-			ln = lua.LNumber(c.ghv.fall.envshake_time)
+			ln = lua.LNumber(c.ghv.fall_envshake_time)
 		case "fall.envshake.freq":
-			ln = lua.LNumber(c.ghv.fall.envshake_freq)
+			ln = lua.LNumber(c.ghv.fall_envshake_freq)
 		case "fall.envshake.ampl":
-			ln = lua.LNumber(c.ghv.fall.envshake_ampl)
+			ln = lua.LNumber(c.ghv.fall_envshake_ampl)
 		case "fall.envshake.phase":
-			ln = lua.LNumber(c.ghv.fall.envshake_phase)
+			ln = lua.LNumber(c.ghv.fall_envshake_phase)
 		case "fall.envshake.mul":
-			ln = lua.LNumber(c.ghv.fall.envshake_mul)
+			ln = lua.LNumber(c.ghv.fall_envshake_mul)
 		case "attr":
 			// return here, because ln is a
 			// LNumber (we have a LString)
@@ -3861,7 +3861,7 @@ func triggerFunctions(l *lua.LState) {
 		case "guardpoints":
 			ln = lua.LNumber(c.ghv.guardpoints)
 		case "id":
-			ln = lua.LNumber(c.ghv.id)
+			ln = lua.LNumber(c.ghv.playerId)
 		case "playerno":
 			ln = lua.LNumber(c.ghv.playerNo)
 		case "redlife":
@@ -4159,7 +4159,7 @@ func triggerFunctions(l *lua.LState) {
 		case "frame":
 			ln = lua.LNumber(Btoi(c.mhv.frame))
 		case "id":
-			ln = lua.LNumber(c.mhv.id)
+			ln = lua.LNumber(c.mhv.playerId)
 		case "overridden":
 			ln = lua.LNumber(Btoi(c.mhv.overridden))
 		case "playerno":

--- a/src/script.go
+++ b/src/script.go
@@ -5098,6 +5098,10 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.debugWC.finalDefense * 100))
 		return 1
 	})
+	luaRegister(l, "displayname", func(*lua.LState) int {
+		l.Push(lua.LString(sys.debugWC.gi().displayname))
+		return 1
+	})
 	luaRegister(l, "dizzy", func(*lua.LState) int {
 		l.Push(lua.LBool(sys.debugWC.scf(SCF_dizzy)))
 		return 1
@@ -5424,6 +5428,14 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(retv))
 		return 1
 	})
+	luaRegister(l, "localcoordX", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.cgi[sys.debugWC.playerNo].localcoord[0]))
+		return 1
+	})
+	luaRegister(l, "localcoordY", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.cgi[sys.debugWC.playerNo].localcoord[1]))
+		return 1
+	})
 	luaRegister(l, "map", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.mapArray[strings.ToLower(strArg(l, 1))]))
 		return 1
@@ -5471,8 +5483,8 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LString(s))
 		return 1
 	})
-	luaRegister(l, "playerno", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.playerNo + 1))
+	luaRegister(l, "playercount", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.playercount()))
 		return 1
 	})
 	luaRegister(l, "playerindex", func(*lua.LState) int {
@@ -5488,12 +5500,17 @@ func triggerFunctions(l *lua.LState) {
 			BytecodeInt(int32(numArg(l, 1)))).ToB()))
 		return 1
 	})
-	luaRegister(l, "playercount", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.playercount()))
+	luaRegister(l, "playerno", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.playerNo + 1))
 		return 1
 	})
-	// randomrange (dedicated functionality already exists in Lua)
+	luaRegister(l, "playernoexist", func(*lua.LState) int {
+		l.Push(lua.LBool(sys.playerNoExist(
+			BytecodeInt(int32(numArg(l, 1)))).ToB()))
+		return 1
+	})
 	// rad (dedicated functionality already exists in Lua)
+	// randomrange (dedicated functionality already exists in Lua)
 	luaRegister(l, "ratiolevel", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.ocd().ratioLevel))
 		return 1
@@ -5614,20 +5631,12 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.debugWC.anim.time))
 		return 1
 	})
-	luaRegister(l, "animplayerno", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.animPN) + 1)
-		return 1
-	})
 	luaRegister(l, "animtimesum", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.anim.sumtime))
 		return 1
 	})
 	luaRegister(l, "continue", func(*lua.LState) int {
 		l.Push(lua.LBool(sys.continueFlg))
-		return 1
-	})
-	luaRegister(l, "displayname", func(*lua.LState) int {
-		l.Push(lua.LString(sys.debugWC.gi().displayname))
 		return 1
 	})
 	luaRegister(l, "gameend", func(*lua.LState) int {
@@ -5656,14 +5665,6 @@ func triggerFunctions(l *lua.LState) {
 	})
 	luaRegister(l, "localcoord", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.localcoord))
-		return 1
-	})
-	luaRegister(l, "localcoordX", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.cgi[sys.debugWC.playerNo].localcoord[0]))
-		return 1
-	})
-	luaRegister(l, "localcoordY", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.cgi[sys.debugWC.playerNo].localcoord[1]))
 		return 1
 	})
 	luaRegister(l, "matchtime", func(*lua.LState) int {

--- a/src/system.go
+++ b/src/system.go
@@ -728,12 +728,26 @@ func (s *System) playerIDExist(id BytecodeValue) BytecodeValue {
 	}
 	return BytecodeBool(s.playerID(id.ToI()) != nil)
 }
-func (s *System) playerIndexExist(id BytecodeValue) BytecodeValue {
-	if id.IsSF() {
+
+func (s *System) playerIndexExist(idx BytecodeValue) BytecodeValue {
+	if idx.IsSF() {
 		return BytecodeSF()
 	}
-	return BytecodeBool(s.playerIndex(id.ToI()) != nil)
+	return BytecodeBool(s.playerIndex(idx.ToI()) != nil)
 }
+
+func (s *System) playerNoExist(no BytecodeValue) BytecodeValue {
+	if no.IsSF() {
+		return BytecodeSF()
+	}
+	exist := false
+	number := int(no.ToI() - 1)
+	if number >= 0 && number < len(sys.chars) {
+		exist = len(sys.chars[number]) > 0
+	}
+	return BytecodeBool(exist)
+}
+
 func (s *System) playercount() int32 {
 	return int32(len(s.charList.runOrder))
 }


### PR DESCRIPTION
Feat:
- Hitdefvar now supports ID, SparkX and SparkY
- PlayerNoExist trigger

Fix:
- Fixed oversight that made single round lifebar animations only play once
- Added missing localcoord conversions to projectile guard distances
- Fixed inconsistency between using AttackDist and Hitdef guard.dist in attacks that deal multiple hits

Refactor:
- Rearranged the way GetHitVars are cleared between each hit, for better clarity
- Fall GetHitVars (and Hitdef parameters) are no longer their own struct, as that spread out their code for little benefit
- Minor bytecode cleanup for readability. Renamed a couple cryptic variables. Added spacing between functions