### PR TITLE
feat: AssertSpecial NoKoFall, MoveHitSet state controller, fixes

### DIFF
--- a/data/dizzy.zss
+++ b/data/dizzy.zss
@@ -229,7 +229,7 @@ if !const(Default.Enable.Dizzy) || isHelper || teamSide = 0 {
 		# Similar to using kill = 0 in LifeAdd
 		if getHitVar(frame) && getHitVar(dizzyPoints) <= 0 {
 			dizzyPointsSet{value: 1}
-		} else if moveType = H && !inCustomState {
+		} else if (moveType = H || stateNo = const(StateDownedGetHit_gettingUp)) && !inCustomState {
 			# Change get hit properties when becoming dizzy
 			dizzySet{value: 1}
 			getHitVarSet{
@@ -244,10 +244,6 @@ if !const(Default.Enable.Dizzy) || isHelper || teamSide = 0 {
 				if anim = [const(AnimCrouchHit_light), const(AnimCrouchHit_hard)] {
 					changeAnim{value: const(AnimStandOrAirHitBack)}
 				}
-			}
-			# Use diagonal hit animation if available
-			if anim != const(AnimAirFall_hitUpDiagonal) && selfAnimExist(const(AnimAirFall_hitUpDiagonal)) {
-				changeAnim{value: const(AnimAirFall_hitUpDiagonal)}
 			}
 		}
 	}

--- a/data/training.zss
+++ b/data/training.zss
@@ -51,7 +51,11 @@ ignoreHitPause if gameMode = "training" && teamSide = 2 && !isHelper {
 		assertSpecial{flag: noRoundDisplay; flag2: noFightDisplay}
 	}
 	if roundState = 2 {
-		assertSpecial{flag: globalNoKo}
+		assertSpecial{
+			flag: globalNoKo;
+			flag2: noKoFall;
+			flag3: noKoVelocity;
+		}
 		# Life and Power recovery
 		for i = 1; player(1),numPartner + 1; 1 {
 			call TrainingRecovery($i * 2 - 1);

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3857,12 +3857,7 @@ func (sc stateDef) Run(c *Char) {
 		case stateDef_anim:
 			c.changeAnimEx(exp[1].evalI(c), c.playerNo, string(*(*[]byte)(unsafe.Pointer(&exp[0]))), false)
 		case stateDef_ctrl:
-			// in mugen fatal blow ignores statedef ctrl
-			if !c.ghv.fatal {
-				c.setCtrl(exp[0].evalB(c))
-			} else {
-				c.ghv.fatal = false
-			}
+			c.setCtrl(exp[0].evalB(c))
 		case stateDef_poweradd:
 			c.powerAdd(exp[0].evalI(c))
 		}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -12067,6 +12067,43 @@ func (sc transformClsn) Run(c *Char, _ []int32) bool {
 	return false
 }
 
+type moveHitSet StateControllerBase
+
+const (
+	moveHitSet_movehit byte = iota
+	moveHitSet_moveguarded
+	moveHitSet_movereversed
+	moveHitSet_movecountered
+	moveHitSet_redirectid
+)
+
+func (sc moveHitSet) Run(c *Char, _ []int32) bool {
+	crun := c
+	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
+		switch id {
+		case moveHitSet_movehit:
+			crun.mctype = MC_Hit
+			crun.mctime = Max(0, exp[0].evalI(c))
+		case moveHitSet_moveguarded:
+			crun.mctype = MC_Guarded
+			crun.mctime = Max(0, exp[0].evalI(c))
+		case moveHitSet_movereversed:
+			crun.mctype = MC_Reversed
+			crun.mctime = Max(0, exp[0].evalI(c))
+		case moveHitSet_movecountered:
+			crun.counterHit = exp[0].evalB(c)
+		case moveHitSet_redirectid:
+			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
+				crun = rid
+			} else {
+				return false
+			}
+		}
+		return true
+	})
+	return false
+}
+
 // StateDef data struct
 type StateBytecode struct {
 	stateType StateType

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6342,7 +6342,7 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 		hd.guardsound_channel = exp[0].evalI(c)
 	case hitDef_priority:
 		hd.priority = exp[0].evalI(c)
-		hd.bothhittype = AiuchiType(exp[1].evalI(c))
+		hd.prioritytype = TradeType(exp[1].evalI(c))
 	case hitDef_p1stateno:
 		hd.p1stateno = exp[0].evalI(c)
 	case hitDef_p2stateno:
@@ -7311,7 +7311,7 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 			case hitDef_priority:
 				eachProj(func(p *Projectile) {
 					p.hitdef.priority = exp[0].evalI(c)
-					p.hitdef.bothhittype = AiuchiType(exp[1].evalI(c))
+					p.hitdef.prioritytype = TradeType(exp[1].evalI(c))
 				})
 			case hitDef_p1stateno:
 				eachProj(func(p *Projectile) {

--- a/src/char.go
+++ b/src/char.go
@@ -811,7 +811,6 @@ type GetHitVar struct {
 	guardpower          int32
 	hitredlife          int32
 	guardredlife        int32
-	fatal               bool
 	kill                bool
 	priority            int32
 	facing              int32
@@ -7850,6 +7849,7 @@ func (c *Char) tick() {
 		} else if c.ghv.guarded &&
 			(c.ghv.damage < c.life || sys.gsf(GSF_globalnoko) || c.asf(ASF_noko) || c.asf(ASF_noguardko)) {
 			switch c.ss.stateType {
+			// All of these state changes remove ctrl from the char
 			// Guarding is not affected by P2getP1state
 			case ST_S:
 				c.selfState(150, -1, -1, 0, "")
@@ -7929,6 +7929,7 @@ func (c *Char) tick() {
 				}
 			}
 			c.setSCF(SCF_ko)
+			c.unsetSCF(SCF_ctrl) // This can be seen in Mugen when you F1 a character
 			sys.charList.p2enemyDelete(c)
 		}
 	}
@@ -8999,10 +9000,6 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 			// Hit behavior on KO
 			if ghvset && getter.ghv.damage >= getter.life {
 				if getter.ghv.kill || !getter.alive() {
-					// Set fatal flag. This removes the ability to use ctrl = 1 in a Statedef
-					if !sys.gsf(GSF_globalnoko) && !getter.asf(ASF_noko) && (!getter.ghv.guarded || !getter.asf(ASF_noguardko)) {
-						getter.ghv.fatal = true
-					}
 					// Set fall behavior
 					if !getter.asf(ASF_nokofall) {
 						getter.ghv.fallflag = true

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -3967,6 +3967,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nomakedust))
 		case "noguardko":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noguardko))
+		case "nokofall":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nokofall))
 		case "nokovelocity":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nokovelocity))
 		case "noailevel":

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -81,6 +81,7 @@ func newCompiler() *Compiler {
 		"makedust":           c.makeDust,
 		"modifyexplod":       c.modifyExplod,
 		"movehitreset":       c.moveHitReset,
+		"movehitset":         c.moveHitSet,
 		"nothitby":           c.notHitBy,
 		"null":               c.null,
 		"offset":             c.offset,

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -194,6 +194,8 @@ func (c *Compiler) assertSpecial(is IniSection, sc *StateControllerBase, _ int8)
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nomakedust)))
 			case "noguardko":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_noguardko)))
+			case "nokofall":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nokofall)))
 			case "nokovelocity":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nokovelocity)))
 			case "noailevel":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1556,16 +1556,16 @@ func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 		if err != nil {
 			return err
 		}
-		at := AT_Hit
+		at := TT_Hit
 		data = strings.TrimSpace(data)
 		if c.token == "," && len(data) > 0 {
 			switch data[0] {
 			case 'H', 'h':
-				at = AT_Hit
+				at = TT_Hit
 			case 'M', 'm':
-				at = AT_Miss
+				at = TT_Miss
 			case 'D', 'd':
-				at = AT_Dodge
+				at = TT_Dodge
 			default:
 				return Error("Invalid value: " + data)
 			}

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -5555,6 +5555,51 @@ func (c *Compiler) transformClsn(is IniSection, sc *StateControllerBase, _ int8)
 	return *ret, err
 }
 
+func (c *Compiler) moveHitSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+	ret, err := (*moveHitSet)(sc), c.stateSec(is, func() error {
+		if err := c.paramValue(is, sc, "redirectid",
+			moveHitSet_redirectid, VT_Int, 1, false); err != nil {
+			return err
+		}
+		var param bool
+		if err := c.stateParam(is, "movehit", false, func(data string) error {
+            param = true
+			return c.scAdd(sc, moveHitSet_movehit, data, VT_Int, 1)
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "moveguarded", false, func(data string) error {
+            if param {
+                return Error("Conflicting MoveHitSet parameters")
+            }
+            param = true
+			return c.scAdd(sc, moveHitSet_moveguarded, data, VT_Int, 1)
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "movereversed", false, func(data string) error {
+            if param {
+                return Error("Conflicting MoveHitSet parameters")
+            }
+            param = true
+			return c.scAdd(sc, moveHitSet_movereversed, data, VT_Int, 1)
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "movecountered", false, func(data string) error {
+            param = true // Does not conflict with others
+			return c.scAdd(sc, moveHitSet_movecountered, data, VT_Bool, 1)
+		}); err != nil {
+			return err
+		}
+		if !param {
+			return Error("No valid MoveHitSet parameters found")
+		}
+		return nil
+	})
+	return *ret, err
+}
+
 // It's just a Null... Has no effect whatsoever.
 func (c *Compiler) null(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	return nullStateController, nil

--- a/src/script.go
+++ b/src/script.go
@@ -5338,6 +5338,8 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_noko)))
 		case "noguardko":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_noguardko)))
+		case "nokofall":
+			l.Push(lua.LBool(sys.debugWC.asf(ASF_nokofall)))
 		case "nokovelocity":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_nokovelocity)))
 		case "noailevel":


### PR DESCRIPTION
Feat:
- AssertSpecial NoKoFall prevents characters from falling down when receiving a hit that depletes their remaining life. It is mostly meant for Training mode
- MoveHitSet allows changing the value of MoveHit, MoveGuarded, MoveReversed and MoveCountered

Refactor:
- The score parameter now also has an effect for ReversalDef
- Removed GetHitVar(fatal) internal variable, simplifying the code a little
- Renamed attack priority type internal names for clarity