### PR TITLE
feat: Hitdefvar pausetimes, fixes

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -829,6 +829,10 @@ const (
 	OC_ex2_hitdefvar_id
 	OC_ex2_hitdefvar_sparkx
 	OC_ex2_hitdefvar_sparky
+	OC_ex2_hitdefvar_pausetime
+	OC_ex2_hitdefvar_guard_pausetime
+	OC_ex2_hitdefvar_shaketime
+	OC_ex2_hitdefvar_guard_shaketime
 	OC_ex2_hitbyattr
 )
 const (
@@ -3460,6 +3464,14 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.hitdef.sparkxy[0] * (c.localscl / oc.localscl))
 	case OC_ex2_hitdefvar_sparky:
 		sys.bcStack.PushF(c.hitdef.sparkxy[1] * (c.localscl / oc.localscl))
+	case OC_ex2_hitdefvar_pausetime:
+		sys.bcStack.PushI(c.hitdef.pausetime)
+	case OC_ex2_hitdefvar_guard_pausetime:
+		sys.bcStack.PushI(c.hitdef.guard_pausetime)
+	case OC_ex2_hitdefvar_shaketime:
+		sys.bcStack.PushI(c.hitdef.shaketime)
+	case OC_ex2_hitdefvar_guard_shaketime:
+		sys.bcStack.PushI(c.hitdef.guard_shaketime)
 	case OC_ex2_hitbyattr:
 		sys.bcStack.PushB(c.hitByAttrTrigger(*(*int32)(unsafe.Pointer(&be[*i]))))
 		*i += 4

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -495,6 +495,8 @@ const (
 	OC_ex_gethitvar_xaccel
 	OC_ex_gethitvar_yaccel
 	OC_ex_gethitvar_zaccel
+	OC_ex_gethitvar_xveladd
+	OC_ex_gethitvar_yveladd
 	OC_ex_gethitvar_chainid
 	OC_ex_gethitvar_guarded
 	OC_ex_gethitvar_isbound
@@ -2451,6 +2453,10 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.ghv.yaccel * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_zaccel:
 		sys.bcStack.PushF(c.ghv.zaccel * (c.localscl / oc.localscl))
+	case OC_ex_gethitvar_xveladd:
+		sys.bcStack.PushF(c.ghv.xveladd * (c.localscl / oc.localscl)) // Mugen has these two apparently dummied out
+	case OC_ex_gethitvar_yveladd:
+		sys.bcStack.PushF(c.ghv.yveladd * (c.localscl / oc.localscl))
 	case OC_ex_gethitvar_chainid:
 		sys.bcStack.PushI(c.ghv.chainId())
 	case OC_ex_gethitvar_guarded:
@@ -11833,8 +11839,8 @@ const (
 	getHitVarSet_attr
 	getHitVarSet_chainid
 	getHitVarSet_ctrltime
-	getHitVarSet_down_recovertime
 	getHitVarSet_down_recover
+	getHitVarSet_down_recovertime
 	getHitVarSet_fall
 	getHitVarSet_fall_damage
 	getHitVarSet_fall_envshake_ampl
@@ -11859,11 +11865,11 @@ const (
 	getHitVarSet_recovertime
 	getHitVarSet_slidetime
 	getHitVarSet_xvel
+	getHitVarSet_yvel
+	getHitVarSet_zvel
 	getHitVarSet_xaccel
 	getHitVarSet_yaccel
 	getHitVarSet_zaccel
-	getHitVarSet_yvel
-	getHitVarSet_zvel
 	getHitVarSet_redirectid
 )
 

--- a/src/char.go
+++ b/src/char.go
@@ -9125,6 +9125,7 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 			}
 		}
 		// Hitspark creation function
+		// This used to be called only when a hitspark is actually created, but with the addition of the MoveHitVar trigger it became useful to save the offset at all times
 		hitspark := func(p1, p2 *Char, animNo int32, ffx string, sparkangle float32) {
 			// This is mostly for offset in projectiles
 			off := [3]float32{pos[0], pos[1], pos[2]}
@@ -9158,52 +9159,55 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 			}
 
 			// Save hitspark position to MoveHitVar
+			// Currently it is saved even if the hit is a projectile
 			c.mhv.sparkxy[0] = off[0]
 			c.mhv.sparkxy[1] = off[1]
 
-			if e, i := c.newExplod(); e != nil {
-				e.anim = c.getAnim(animNo, ffx, true)
-				e.layerno = 1 // e.ontop = true
-				e.sprpriority = math.MinInt32
-				e.ownpal = true
-				e.relativePos = [...]float32{off[0], off[1], off[2]}
-				e.supermovetime = -1
-				e.pausemovetime = -1
-				e.localscl = 1
-				if ffx == "" || ffx == "s" {
-					e.scale = [...]float32{c.localscl, c.localscl}
-				} else if e.anim != nil {
-					e.anim.start_scale[0] *= c.localscl
-					e.anim.start_scale[1] *= c.localscl
+			if animNo >= 0 {
+				if e, i := c.newExplod(); e != nil {
+					e.anim = c.getAnim(animNo, ffx, true)
+					e.layerno = 1 // e.ontop = true
+					e.sprpriority = math.MinInt32
+					e.ownpal = true
+					e.relativePos = [...]float32{off[0], off[1], off[2]}
+					e.supermovetime = -1
+					e.pausemovetime = -1
+					e.localscl = 1
+					if ffx == "" || ffx == "s" {
+						e.scale = [...]float32{c.localscl, c.localscl}
+					} else if e.anim != nil {
+						e.anim.start_scale[0] *= c.localscl
+						e.anim.start_scale[1] *= c.localscl
+					}
+					e.setPos(p1)
+					e.anglerot[0] = sparkangle
+					c.insertExplod(i)
 				}
-				e.setPos(p1)
-				e.anglerot[0] = sparkangle
-				c.insertExplod(i)
 			}
 		}
 		// Play hit sounds and sparks
 		if Abs(hitType) == 1 {
-			if hd.sparkno >= 0 {
+			//if hd.sparkno >= 0 {
 				if hd.reversal_attr > 0 {
 					hitspark(getter, c, hd.sparkno, hd.sparkno_ffx, hd.sparkangle)
 				} else {
 					hitspark(c, getter, hd.sparkno, hd.sparkno_ffx, hd.sparkangle)
 				}
-			}
-			if hd.hitsound[0] >= 0 {
+			//}
+			if hd.hitsound[0] >= 0 && hd.hitsound[1] >= 0 {
 				vo := int32(100)
 				c.playSound(hd.hitsound_ffx, false, 0, hd.hitsound[0], hd.hitsound[1],
 					hd.hitsound_channel, vo, 0, 1, getter.localscl, &getter.pos[0], true, 0, 0, 0, 0, false, false)
 			}
 		} else {
-			if hd.guard_sparkno >= 0 {
+			//if hd.guard_sparkno >= 0 {
 				if hd.reversal_attr > 0 {
 					hitspark(getter, c, hd.guard_sparkno, hd.guard_sparkno_ffx, hd.guard_sparkangle)
 				} else {
 					hitspark(c, getter, hd.guard_sparkno, hd.guard_sparkno_ffx, hd.guard_sparkangle)
 				}
-			}
-			if hd.guardsound[0] >= 0 {
+			//}
+			if hd.guardsound[0] >= 0 && hd.guardsound[1] >= 0 {
 				vo := int32(100)
 				c.playSound(hd.guardsound_ffx, false, 0, hd.guardsound[0], hd.guardsound[1],
 					hd.guardsound_channel, vo, 0, 1, getter.localscl, &getter.pos[0], true, 0, 0, 0, 0, false, false)

--- a/src/char.go
+++ b/src/char.go
@@ -402,7 +402,7 @@ func (cv *CharVelocity) init() {
 	cv.air.gethit.airrecover.fwd = 0.0
 	cv.air.gethit.airrecover.up = -2.0
 	cv.air.gethit.airrecover.down = 1.5
-	cv.air.gethit.ko.add = [...]float32{-2, -2}
+	cv.air.gethit.ko.add = [...]float32{-2.5, -2}
 	cv.air.gethit.ko.ymin = -3
 	cv.ground.gethit.ko.xmul = 0.66
 	cv.ground.gethit.ko.add = [...]float32{-2.5, -2}
@@ -774,6 +774,8 @@ type GetHitVar struct {
 	xaccel              float32
 	yaccel              float32
 	zaccel              float32
+	xveladd             float32
+	yveladd             float32
 	hitid               int32
 	xoff                float32
 	yoff                float32
@@ -9054,9 +9056,11 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 					}
 					// Add extra velocity
 					if getter.kovelocity && !getter.asf(ASF_nokovelocity) {
+						startx := getter.ghv.xvel
+						starty := getter.ghv.yvel
 						if getter.ss.stateType == ST_A {
-							if getter.ghv.xvel < 0 {
-								getter.ghv.xvel += getter.gi().velocity.air.gethit.ko.add[0]
+							if getter.ghv.xvel != 0 {
+								getter.ghv.xvel += getter.gi().velocity.air.gethit.ko.add[0] * SignF(getter.ghv.xvel) * -1
 							}
 							if getter.ghv.yvel <= 0 {
 								getter.ghv.yvel += getter.gi().velocity.air.gethit.ko.add[1]
@@ -9068,8 +9072,8 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 							if getter.ghv.yvel == 0 {
 								getter.ghv.xvel *= getter.gi().velocity.ground.gethit.ko.xmul
 							}
-							if getter.ghv.xvel < 0 {
-								getter.ghv.xvel += getter.gi().velocity.ground.gethit.ko.add[0]
+							if getter.ghv.xvel != 0 {
+								getter.ghv.xvel += getter.gi().velocity.ground.gethit.ko.add[0] * SignF(getter.ghv.xvel) * -1
 							}
 							if getter.ghv.yvel <= 0 {
 								getter.ghv.yvel += getter.gi().velocity.ground.gethit.ko.add[1]
@@ -9078,6 +9082,10 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 								}
 							}
 						}
+						// Save difference to xveladd and yveladd
+						// Not particularly useful, but it's a trigger that was documented in Mugen and did not work
+						getter.ghv.xveladd = getter.ghv.xvel - startx
+						getter.ghv.yveladd = getter.ghv.yvel - starty
 					}
 				} else {
 					getter.ghv.damage = getter.life - 1

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2168,10 +2168,6 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		isFlag := -1
 		switch c.token {
 		// no-op triggers
-		case "xveladd":
-			bv.SetF(0)
-		case "yveladd":
-			bv.SetF(0)
 		case "fall.envshake.dir":
 			bv.SetI(0)
 		default:
@@ -2228,6 +2224,10 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				opc = OC_ex_gethitvar_yaccel
 			case "zaccel":
 				opc = OC_ex_gethitvar_zaccel
+			case "xveladd":
+				opc = OC_ex_gethitvar_xveladd
+			case "yveladd":
+				opc = OC_ex_gethitvar_yveladd
 			case "hitid", "chainid":
 				opc = OC_ex_gethitvar_chainid
 			case "guarded":

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2459,6 +2459,14 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			opc = OC_ex2_hitdefvar_sparkx
 		case "sparky":
 			opc = OC_ex2_hitdefvar_sparky
+		case "pausetime":
+			opc = OC_ex2_hitdefvar_pausetime
+		case "guard.pausetime":
+			opc = OC_ex2_hitdefvar_guard_pausetime
+		case "shaketime":
+			opc = OC_ex2_hitdefvar_shaketime
+		case "guard.shaketime":
+			opc = OC_ex2_hitdefvar_guard_shaketime
 		default:
 			return bvNone(), Error("Invalid data: " + c.token)
 		}

--- a/src/script.go
+++ b/src/script.go
@@ -3753,10 +3753,6 @@ func triggerFunctions(l *lua.LState) {
 		c := sys.debugWC
 		var ln lua.LNumber
 		switch strArg(l, 1) {
-		case "xveladd":
-			ln = lua.LNumber(0)
-		case "yveladd":
-			ln = lua.LNumber(0)
 		case "fall.envshake.dir":
 			ln = lua.LNumber(0)
 		case "animtype":
@@ -3798,7 +3794,7 @@ func triggerFunctions(l *lua.LState) {
 		case "zoff":
 			ln = lua.LNumber(c.ghv.zoff)
 		case "xvel":
-			ln = lua.LNumber(c.ghv.xvel * c.facing)
+			ln = lua.LNumber(c.ghv.xvel)
 		case "yvel":
 			ln = lua.LNumber(c.ghv.yvel)
 		case "zvel":
@@ -3809,6 +3805,10 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.ghv.yaccel)
 		case "zaccel":
 			ln = lua.LNumber(c.ghv.zaccel)
+		case "xveladd":
+			ln = lua.LNumber(c.ghv.xveladd)
+		case "yveladd":
+			ln = lua.LNumber(c.ghv.yveladd)
 		case "hitid", "chainid":
 			ln = lua.LNumber(c.ghv.chainId())
 		case "guarded":

--- a/src/script.go
+++ b/src/script.go
@@ -3744,6 +3744,14 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LNumber(c.hitdef.sparkxy[0]))
 		case "sparky":
 			l.Push(lua.LNumber(c.hitdef.sparkxy[1]))
+		case "pausetime":
+			l.Push(lua.LNumber(c.hitdef.pausetime))
+		case "guard.pausetime":
+			l.Push(lua.LNumber(c.hitdef.guard_pausetime))
+		case "shaketime":
+			l.Push(lua.LNumber(c.hitdef.shaketime))
+		case "guard.shaketime":
+			l.Push(lua.LNumber(c.hitdef.guard_shaketime))
 		default:
 			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}


### PR DESCRIPTION
Feat:
- Hitdefvar can now also return pausetime, shaketime, guard.pausetime and guard.shaketime
- New lifebar [Action] group parameter: team1.max. Defines maximum number of simultaneous messages allowed
- Added GetHitVar xveladd and yveladd, which were documented in Mugen but were also dummied out

Fix:
- Fixed spacing when lifebar action sprites and text of slightly different heights are used. Lifebar action spacing is now absolute and as defined in the lifebar's def file
- Fixes #2166 
- Requires merging https://github.com/ikemen-engine/Ikemen_GO-Elecbyte-Screenpack/pull/24 to keep default lifebars compatible

Refactor:
- Lifebar action background is now also drawn for text messages
- MoveHitVar sparkx and sparky are now saved even when the hit does not produce a hitspark
- Minor adjustment to KO velocity to make it even more accurate to Mugen