### PR TITLE
feat: separate Window Size from GameWidth/GameHeight, add WindowWidth and WindowHeight to config.json

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -291,6 +291,8 @@ type configSettings struct {
 	WindowCentered             bool
 	WindowIcon                 []string
 	WindowTitle                string
+	WindowWidth                int
+	WindowHeight               int
 	XinputTriggerSensitivity   float32
 	ZoomActive                 bool
 	ZoomDelay                  bool
@@ -435,6 +437,7 @@ func setupConfig() configSettings {
 	sys.windowCentered = tmp.WindowCentered
 	sys.windowMainIconLocation = tmp.WindowIcon
 	sys.windowTitle = tmp.WindowTitle
+	sys.windowSize[0], sys.windowSize[1] = tmp.WindowWidth, tmp.WindowHeight
 	sys.xinputTriggerSensitivity = tmp.XinputTriggerSensitivity
 	stoki := func(key string) int {
 		return int(StringToKey(key))

--- a/src/resources/defaultConfig.json
+++ b/src/resources/defaultConfig.json
@@ -135,6 +135,8 @@
   ],
   "WindowScaleMode": true,
   "WindowTitle": "Ikemen GO",
+  "WindowWidth": 0,
+  "WindowHeight": 0,
   "XinputTriggerSensitivity": 0.5,
   "ZoomActive": true,
   "ZoomDelay": false,

--- a/src/system.go
+++ b/src/system.go
@@ -36,6 +36,7 @@ var FPS = 60
 var sys = System{
 	randseed:          int32(time.Now().UnixNano()),
 	scrrect:           [...]int32{0, 0, 320, 240},
+	windowSize:        [...]int{0, 0},
 	gameWidth:         320,
 	gameHeight:        240,
 	keepAspect:        true,
@@ -306,6 +307,7 @@ type System struct {
 	fullscreenRefreshRate int32
 	fullscreenWidth       int32
 	fullscreenHeight      int32
+	windowSize            [2]int
 
 	// Input variables
 	controllerStickSensitivity float32

--- a/src/system_glfw.go
+++ b/src/system_glfw.go
@@ -28,12 +28,17 @@ func (s *System) newWindow(w, h int) (*Window, error) {
 		return nil, fmt.Errorf("failed to obtain primary monitor")
 	}
 
-	var mode = monitor.GetVideoMode()
-	var x, y = (mode.Width - w) / 2, (mode.Height - h) / 2
-
 	// "-windowed" overrides the configuration setting but does not change it
 	_, forceWindowed := sys.cmdFlags["-windowed"]
 	fullscreen := s.fullscreen && !forceWindowed
+
+	// Calculate window size & offset it
+	var mode = monitor.GetVideoMode()
+	var w2, h2 = w, h
+	if !fullscreen && (sys.windowSize[0] > 0 || sys.windowSize[1] > 0) {
+		w2, h2 = sys.windowSize[0], sys.windowSize[1]
+	}
+	var x, y = (mode.Width - w2) / 2, (mode.Height - h2) / 2
 
 	glfw.WindowHint(glfw.Resizable, glfw.True)
 
@@ -68,7 +73,7 @@ func (s *System) newWindow(w, h int) (*Window, error) {
 		}
 		window.SetInputMode(glfw.CursorMode, glfw.CursorHidden)
 	} else {
-		window.SetSize(w, h)
+		window.SetSize(w2, h2)
 		window.SetInputMode(glfw.CursorMode, glfw.CursorNormal)
 		if s.windowCentered {
 			window.SetPos(x, y)


### PR DESCRIPTION
Long-requested feature.

* Defaults to 0,0 (use same as GameWidth/GameHeight)
* Set either WindowWidth or WindowHeight to nonzero to activate a separate window size. The game will still be rendered at GameWidth x GameHeight resolution (but be upscaled)

Very handy for RetroPie desktop or Atari VCS style setups which may have a DE.