### PR TITLE
feat: shader stacking in options, fix: GL 3.2 shaders not stacking correctly

### DIFF
--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -1638,7 +1638,6 @@ function options.f_start()
 				options.t_itemname[path .. filename] = function(t, item, cursorPosY, moveTxt)
 					if main.f_input(main.t_players, {'pal', 's'}) then
 						sndPlay(motif.files.snd_data, motif.option_info.cursor_done_snd[1], motif.option_info.cursor_done_snd[2])
-						main.f_printTable(t)
 						for k, v in ipairs(t.items) do
 							if v.itemname == path .. filename then
 								v.selected = not v.selected
@@ -1648,11 +1647,20 @@ function options.f_start()
 									for k2, v2 in ipairs(config.ExternalShaders) do
 										if v2 == v.itemname then
 											table.remove(config.ExternalShaders, k2)
+											v.vardisplay = options.f_boolDisplay(v.selected, tostring(k2), '')
 											break
 										end
 									end
 								end
-								v.vardisplay = options.f_boolDisplay(v.selected, tostring(#config.ExternalShaders), '')
+							end
+						end
+
+						-- Need to correct ALL indices
+						for k, v in ipairs(t.items) do
+							for k2, v2 in ipairs(config.ExternalShaders) do
+								if v2 == v.itemname then
+									v.vardisplay = options.f_boolDisplay(v.selected, tostring(k2), '')
+								end
 							end
 						end
 						return true

--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -54,8 +54,8 @@ function options.f_displayRatio(value)
 end
 
 local function f_externalShaderName()
-	if #config.ExternalShaders > 0 and config.PostProcessingShader ~= 0 then
-		return config.ExternalShaders[1]:gsub('^.+/', '')
+	if #config.ExternalShaders > 0 then
+		return motif.option_info.menu_valuename_enabled
 	end
 	return motif.option_info.menu_valuename_disabled
 end
@@ -190,7 +190,7 @@ options.t_itemname = {
 			config.PanningRange = 30
 			config.Players = 4
 			--config.PngSpriteFilter = true
-			config.PostProcessingShader = 0
+			--config.PostProcessingShader = 0
 			config.QuickContinue = false
 			config.RatioAttack = {0.82, 1.0, 1.17, 1.30}
 			config.RatioLife = {0.80, 1.0, 1.17, 1.40}
@@ -981,15 +981,8 @@ options.t_itemname = {
 				main.f_warning(main.f_extractText(motif.warning_info.text_shaders_text), motif.optionbgdef)
 				return true
 			end
-			for k, v in ipairs(t.submenu[t.items[item].itemname].items) do
-				if config.ExternalShaders[1] == v.itemname then
-					v.selected = true
-				else
-					v.selected = false
-				end
-			end
 			t.submenu[t.items[item].itemname].loop()
-			t.items[item].vardisplay = f_externalShaderName()
+			t.items[item].vardisplay = options.f_boolDisplay(#config.ExternalShaders > 0, motif.option_info.menu_valuename_enabled, motif.option_info.menu_valuename_disabled)
 			options.modified = true
 			options.needReload = true
 		end
@@ -1000,7 +993,7 @@ options.t_itemname = {
 		if main.f_input(main.t_players, {'pal', 's'}) then
 			sndPlay(motif.files.snd_data, motif.option_info.cancel_snd[1], motif.option_info.cancel_snd[2])
 			config.ExternalShaders = {}
-			config.PostProcessingShader = 0
+			--config.PostProcessingShader = 0
 			options.modified = true
 			options.needReload = true
 			return false
@@ -1582,7 +1575,7 @@ options.t_vardisplay = {
 		return config.VolumeSfx .. '%'
 	end,
 	['shaders'] = function()
-		return f_externalShaderName()
+		return options.f_boolDisplay(#config.ExternalShaders > 0, motif.option_info.menu_valuename_enabled, motif.option_info.menu_valuename_disabled)
 	end,
 	['singlevsteamlife'] = function()
 		return config.Team1VS2Life .. '%'
@@ -1645,9 +1638,24 @@ function options.f_start()
 				options.t_itemname[path .. filename] = function(t, item, cursorPosY, moveTxt)
 					if main.f_input(main.t_players, {'pal', 's'}) then
 						sndPlay(motif.files.snd_data, motif.option_info.cursor_done_snd[1], motif.option_info.cursor_done_snd[2])
-						config.ExternalShaders = {path .. filename}
-						config.PostProcessingShader = 1
-						return false
+						main.f_printTable(t)
+						for k, v in ipairs(t.items) do
+							if v.itemname == path .. filename then
+								v.selected = not v.selected
+								if v.selected then
+									table.insert(config.ExternalShaders, v.itemname)
+								else
+									for k2, v2 in ipairs(config.ExternalShaders) do
+										if v2 == v.itemname then
+											table.remove(config.ExternalShaders, k2)
+											break
+										end
+									end
+								end
+								v.vardisplay = options.f_boolDisplay(v.selected, tostring(#config.ExternalShaders), '')
+							end
+						end
+						return true
 					end
 					return true
 				end
@@ -1703,14 +1711,24 @@ function options.f_start()
 			if suffix:match('_shaders_back$') and c == 'back' then
 				for k = #options.t_shaders, 1, -1 do
 					local itemname = options.t_shaders[k].path .. options.t_shaders[k].filename
+					local idx = 0
+					-- Has the shader been enabled?
+					local isSelected = false
+					for i, v in ipairs(config.ExternalShaders) do
+						if itemname == v then
+							isSelected = true
+							idx = i
+							break
+						end
+					end
 					table.insert(t_pos.items, 1, {
 						data = text:create({window = t_menuWindow}),
 						itemname = itemname,
 						displayname = options.t_shaders[k].filename,
 						paramname = 'menu_itemname_' .. suffix:gsub('back$', itemname),
 						vardata = text:create({window = t_menuWindow}),
-						vardisplay = options.f_vardisplay(c),
-						selected = false,
+						vardisplay = options.f_boolDisplay(idx > 0, tostring(idx), ''),
+						selected = isSelected,
 					})
 					table.insert(options.t_vardisplayPointers, t_pos.items[#t_pos.items])
 					--creating anim data out of appended menu items
@@ -1935,7 +1953,7 @@ function options.f_keyCfg(cfgType, controller, bgdef, skipClear)
 			local guid = getJoystickGUID(joyNum)
 
 			-- Fix the GUID so that configs are preserved between boots for macOS
-			if config[cfgType][player].GUID ~= guid then
+			if config[cfgType][player].GUID ~= guid and guid ~= '' then
 				config[cfgType][player].GUID = guid
 				options.modified = true
 			end

--- a/src/main.go
+++ b/src/main.go
@@ -261,7 +261,6 @@ type configSettings struct {
 	PauseMasterVolume          int
 	Players                    int
 	PngSpriteFilter            bool
-	PostProcessingShader       int32
 	QuickContinue              bool
 	RatioAttack                [4]float32
 	RatioLife                  [4]float32
@@ -418,7 +417,6 @@ func setupConfig() configSettings {
 	sys.pauseMasterVolume = tmp.PauseMasterVolume
 	sys.panningRange = tmp.PanningRange
 	sys.playerProjectileMax = tmp.MaxPlayerProjectile
-	sys.postProcessingShader = tmp.PostProcessingShader
 	sys.pngFilter = tmp.PngSpriteFilter
 	sys.powerShare = [...]bool{tmp.TeamPowerShare, tmp.TeamPowerShare}
 	tmp.ScreenshotFolder = strings.TrimSpace(tmp.ScreenshotFolder)

--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -591,7 +591,7 @@ func (r *Renderer_GL21) EndFrame() {
 	}
 
 	x, y, resizedWidth, resizedHeight := sys.window.GetScaledViewportSize()
-	postShader := r.postShaderSelect[sys.postProcessingShader]
+	postShader := r.postShaderSelect[len(sys.externalShaderList)]
 
 	var scaleMode int32 // GL enum
 	if sys.windowScaleMode == true {

--- a/src/render_gl_gl32.go
+++ b/src/render_gl_gl32.go
@@ -455,7 +455,7 @@ func (r *Renderer_GL32) Init() {
 		r.postShaderSelect[1+i], _ = r.newShaderProgram(sys.externalShaders[0][i],
 			sys.externalShaders[1][i], "", fmt.Sprintf("Postprocess Shader #%v", i+1), true)
 		r.postShaderSelect[1+i].RegisterAttributes("VertCoord", "TexCoord")
-		loc := r.postShaderSelect[0].a["TexCoord"]
+		loc := r.postShaderSelect[1+i].a["TexCoord"]
 		gl.VertexAttribPointer(uint32(loc), 3, gl.FLOAT, false, 5*4, gl.PtrOffset(2*4))
 		gl.EnableVertexAttribArray(uint32(loc))
 		r.postShaderSelect[1+i].RegisterUniforms("Texture_GL32", "TextureSize", "CurrentTime")

--- a/src/render_gl_gl32.go
+++ b/src/render_gl_gl32.go
@@ -589,7 +589,7 @@ func (r *Renderer_GL32) EndFrame() {
 	}
 
 	x, y, resizedWidth, resizedHeight := sys.window.GetScaledViewportSize()
-	postShader := r.postShaderSelect[sys.postProcessingShader]
+	postShader := r.postShaderSelect[len(sys.externalShaderList)]
 
 	var scaleMode int32 // GL enum
 	if sys.windowScaleMode {

--- a/src/resources/defaultConfig.json
+++ b/src/resources/defaultConfig.json
@@ -90,7 +90,6 @@
   "PauseMasterVolume": 0,
   "Players": 4,
   "PngSpriteFilter": true,
-  "PostProcessingShader": 0,
   "QuickContinue": false,
   "RatioAttack": [
     0.82,

--- a/src/system.go
+++ b/src/system.go
@@ -328,7 +328,6 @@ type System struct {
 	lifebarLocalcoord    [2]int32
 
 	// Shader Vars
-	postProcessingShader    int32
 	multisampleAntialiasing int32
 
 	// External Shader Vars
@@ -439,11 +438,6 @@ func (s *System) init(w, h int32) *lua.LState {
 				}
 			}
 		}
-	}
-
-	// Check if the shader selected is currently available.
-	if s.postProcessingShader < int32(len(s.externalShaderList)) {
-		s.postProcessingShader = 0
 	}
 
 	// Loading of external shader data.


### PR DESCRIPTION
GL 3.2 shaders now stack correctly when multiple entries are added to the config.json

Also adds the ability to stack shaders directly from options menu now. Numbers indicate the index of the shader in the stack.

Removed PostProcessingShader int variable as we can check the ExternalShaders array length.