### PR TITLE
fix: turns mode crashing with AttachedChars

### DIFF
--- a/src/system.go
+++ b/src/system.go
@@ -2170,7 +2170,7 @@ func (s *System) fight() (reload bool) {
 	// Initialize super meter values, and max power for teams sharing meter
 	var level [len(s.chars)]int32
 	for i, p := range s.chars {
-		if len(p) > 0 {
+		if len(p) > 0 && p[0].teamside != -1 {
 			p[0].clearNextRound()
 			level[i] = s.wincnt.getLevel(i)
 			if s.powerShare[i&1] && p[0].teamside != -1 {

--- a/src/system.go
+++ b/src/system.go
@@ -2173,7 +2173,7 @@ func (s *System) fight() (reload bool) {
 		if len(p) > 0 && p[0].teamside != -1 {
 			p[0].clearNextRound()
 			level[i] = s.wincnt.getLevel(i)
-			if s.powerShare[i&1] && p[0].teamside != -1 {
+			if s.powerShare[i&1] {
 				pmax := Max(s.cgi[i&1].data.power, s.cgi[i].data.power)
 				for j := i & 1; j < MaxSimul*2; j += 2 {
 					if len(s.chars[j]) > 0 {


### PR DESCRIPTION
Fixes a bug where having an AC in turns mode caused Ikemen to crash when checking the palettes and power of the AC