### PR TITLE
fix: crouching control, down get hit offset, AI cheating

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -6575,6 +6575,7 @@ func (c *Char) posUpdate() {
 		}
 	}
 	// Offset position when character is hit off the ground
+	// This used to be in actionPrepare(), which would be ideal, but that caused https://github.com/ikemen-engine/Ikemen-GO/issues/2188
 	if c.downHitOffset {
 		if nobind[0] {
 			c.addX(c.gi().movement.down.gethit.offset[0] * (320 / c.localcoord) / c.localscl * c.facing)
@@ -8330,10 +8331,9 @@ func (cl *CharList) commandUpdate() {
 	for i, p := range sys.chars {
 		if len(p) > 0 {
 			root := p[0]
-			cheat := int32(-1)
-			// AI cheating
-			// Select a random command to cheat for the AI
+			// Select a random command for AI cheating
 			// The way this only allows one command to be cheated at a time may be the cause of issue #2022
+			cheat := int32(-1)
 			if root.controller < 0 {
 				if sys.roundState() == 2 && RandF32(0, sys.com[i]/2+32) > 32 { // TODO: Balance AI scaling
 					cheat = Rand(0, int32(len(root.cmd[root.ss.sb.playerNo].Commands))-1)
@@ -8390,9 +8390,7 @@ func (cl *CharList) commandUpdate() {
 						cmd.Step(int32(c.facing), c.controller < 0, buffer, Btoi(buffer)+Btoi(winbuf))
 					}
 					// Enable AI cheated command
-					if cheat >= 0 {
-						c.cpucmd = cheat
-					}
+					c.cpucmd = cheat
 				}
 			}
 		}

--- a/src/common.go
+++ b/src/common.go
@@ -757,7 +757,8 @@ func (l *Layout) Read(pre string, is IniSection) {
 		l.window = sys.scrrect
 	}
 }
-func (l *Layout) DrawSprite(x, y float32, ln int16, s *Sprite, fx *PalFX, fscale float32, window *[4]int32) {
+
+func (l *Layout) DrawFaceSprite(x, y float32, ln int16, s *Sprite, fx *PalFX, fscale float32, window *[4]int32) {
 	if l.layerno == ln && s != nil {
 		// TODO: test "phantom pixel"
 		if l.facing < 0 {
@@ -774,6 +775,7 @@ func (l *Layout) DrawSprite(x, y float32, ln int16, s *Sprite, fx *PalFX, fscale
 			l.angle, fx, window)
 	}
 }
+
 func (l *Layout) DrawAnim(r *[4]int32, x, y, scl float32, ln int16,
 	a *Animation, palfx *PalFX) {
 	if l.layerno == ln {

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -1011,14 +1011,15 @@ type LifeBarFace struct {
 	teammate_scale    []float32
 	teammate_ko_hide  bool
 	numko             int32
-	old_spr, old_pal  [2]int32
+	old_spr           [2]int32
+	old_pal           [2]int32
 }
 
 func newLifeBarFace() *LifeBarFace {
 	return &LifeBarFace{face_spr: [2]int32{-1}, teammate_face_spr: [2]int32{-1}, palshare: true}
 }
-func readLifeBarFace(pre string, is IniSection,
-	sff *Sff, at AnimationTable) *LifeBarFace {
+
+func readLifeBarFace(pre string, is IniSection,	sff *Sff, at AnimationTable) *LifeBarFace {
 	fa := newLifeBarFace()
 	is.ReadI32(pre+"pos", &fa.pos[0], &fa.pos[1])
 
@@ -1050,6 +1051,7 @@ func readLifeBarFace(pre string, is IniSection,
 	is.ReadBool(pre+"teammate.ko.hide", &fa.teammate_ko_hide)
 	return fa
 }
+
 func (fa *LifeBarFace) step(ref int, far *LifeBarFace) {
 	group, number := int16(fa.face_spr[0]), int16(fa.face_spr[1])
 	if sys.chars[ref][0] != nil && sys.chars[ref][0].anim != nil {
@@ -1102,6 +1104,7 @@ func (fa *LifeBarFace) bgDraw(layerno int16) {
 	fa.bg1.Draw(float32(fa.pos[0])+sys.lifebarOffsetX, float32(fa.pos[1]), layerno, sys.lifebarScale)
 	fa.bg2.Draw(float32(fa.pos[0])+sys.lifebarOffsetX, float32(fa.pos[1]), layerno, sys.lifebarScale)
 }
+
 func (fa *LifeBarFace) draw(layerno int16, ref int, far *LifeBarFace) {
 	if far.face != nil {
 		pfx := newPalFX()
@@ -1124,7 +1127,7 @@ func (fa *LifeBarFace) draw(layerno int16, ref int, far *LifeBarFace) {
 		if ref == sys.superplayer {
 			sys.brightness = 256
 		}
-		fa.face_lay.DrawSprite((float32(fa.pos[0])+sys.lifebarOffsetX)*sys.lifebarScale, float32(fa.pos[1])*sys.lifebarScale, layerno,
+		fa.face_lay.DrawFaceSprite((float32(fa.pos[0])+sys.lifebarOffsetX)*sys.lifebarScale, float32(fa.pos[1])*sys.lifebarScale, layerno,
 			far.face, pfx, sys.cgi[ref].portraitscale*sys.lifebarPortraitScale, &fa.face_lay.window)
 		if !sys.chars[ref][0].alive() {
 			fa.ko.Draw(float32(fa.pos[0])+sys.lifebarOffsetX, float32(fa.pos[1]), layerno, sys.lifebarScale)
@@ -1148,7 +1151,7 @@ func (fa *LifeBarFace) draw(layerno int16, ref int, far *LifeBarFace) {
 				fa.teammate_bg0.Draw((x + sys.lifebarOffsetX), y, layerno, sys.lifebarScale)
 				fa.teammate_bg1.Draw((x + sys.lifebarOffsetX), y, layerno, sys.lifebarScale)
 				fa.teammate_bg2.Draw((x + sys.lifebarOffsetX), y, layerno, sys.lifebarScale)
-				fa.teammate_face_lay.DrawSprite((x+sys.lifebarOffsetX)*sys.lifebarScale, y*sys.lifebarScale, layerno,
+				fa.teammate_face_lay.DrawFaceSprite((x+sys.lifebarOffsetX)*sys.lifebarScale, y*sys.lifebarScale, layerno,
 					far.teammate_face[i], nil, far.teammate_scale[i]*sys.lifebarPortraitScale, &fa.teammate_face_lay.window)
 				if i < fa.numko {
 					fa.teammate_ko.Draw((x + sys.lifebarOffsetX), y, layerno, sys.lifebarScale)


### PR DESCRIPTION
Fixes:
- Previously, Ikemen forced characters to stand if they were in state 11 without control. At least one character was found to be severely broken by this, so the code was adjusted so that characters will keep crouching in that scenario (and cannot stand up unless control is restored)
- Fixes a Discord report:
![image](https://github.com/user-attachments/assets/8775016c-27f6-4e64-a158-d1798e7d4bb6)
- Adjusted timing at which a character will receive a position offset when hit off the ground
- Fixes #2188
- Fixed oversight that allowed a cheated command to stay permanently on when a round ended
- Fixes #2202 