### PR TITLE
fix: ForceStageZoomout and Zoomin matching description

### DIFF
--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -174,8 +174,6 @@ options.t_itemname = {
 			modifyGameOption('Config.HelperMax', 56)
 			modifyGameOption('Config.PlayerProjectileMax', 256)
 			--modifyGameOption('Config.ZoomActive', true)
-			--modifyGameOption('Config.ForceStageZoomout', 0)
-			--modifyGameOption('Config.ForceStageZoomin', 0)
 			--modifyGameOption('Config.EscOpensMenu', true)
 			--modifyGameOption('Config.BackgroundLoading', false) --TODO: not implemented
 			--modifyGameOption('Config.FirstRun', false)
@@ -193,6 +191,8 @@ options.t_itemname = {
 			--modifyGameOption('Debug.Font', "font/debug.def")
 			--modifyGameOption('Debug.FontScale', 1.0)
 			--modifyGameOption('Debug.StartStage', "stages/stage0-720.def")
+			--modifyGameOption('Debug.ForceStageZoomout', 0)
+			--modifyGameOption('Debug.ForceStageZoomin', 0)
 			modifyGameOption('Video.RenderMode', "OpenGL 3.2")
 			modifyGameOption('Video.GameWidth', 640)
 			modifyGameOption('Video.GameHeight', 480)

--- a/src/config.go
+++ b/src/config.go
@@ -127,8 +127,6 @@ type Config struct {
 		HelperMax           int32    `ini:"HelperMax"`
 		PlayerProjectileMax int      `ini:"PlayerProjectileMax"`
 		ZoomActive          bool     `ini:"ZoomActive"`
-		ForceStageZoomout   float32  `ini:"ForceStageZoomout"`
-		ForceStageZoomin    float32  `ini:"ForceStageZoomin"`
 		EscOpensMenu        bool     `ini:"EscOpensMenu"`
 		FirstRun            bool     `ini:"FirstRun"`
 		WindowTitle         string   `ini:"WindowTitle"`
@@ -139,14 +137,16 @@ type Config struct {
 		GamepadMappings     string   `ini:"GamepadMappings"`
 	} `ini:"Config"`
 	Debug struct {
-		AllowDebugMode bool    `ini:"AllowDebugMode"`
-		AllowDebugKeys bool    `ini:"AllowDebugKeys"`
-		ClipboardRows  int     `ini:"ClipboardRows"`
-		ConsoleRows    int     `ini:"ConsoleRows"`
-		ClsnDarken     bool    `ini:"ClsnDarken"`
-		Font           string  `ini:"Font"`
-		FontScale      float32 `ini:"FontScale"`
-		StartStage     string  `ini:"StartStage"`
+		AllowDebugMode    bool    `ini:"AllowDebugMode"`
+		AllowDebugKeys    bool    `ini:"AllowDebugKeys"`
+		ClipboardRows     int     `ini:"ClipboardRows"`
+		ConsoleRows       int     `ini:"ConsoleRows"`
+		ClsnDarken        bool    `ini:"ClsnDarken"`
+		Font              string  `ini:"Font"`
+		FontScale         float32 `ini:"FontScale"`
+		StartStage        string  `ini:"StartStage"`
+		ForceStageZoomout float32 `ini:"ForceStageZoomout"`
+		ForceStageZoomin  float32 `ini:"ForceStageZoomin"`
 	} `ini:"Debug"`
 	Video struct {
 		RenderMode              string   `ini:"RenderMode"`

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -123,12 +123,6 @@ HelperMax           = 56
 PlayerProjectileMax = 256
 ; Zoom toggle (0 disables zoom for stages coded to have it).
 ZoomActive          = 1
-; Set to nonzero to force stages to have the specified zoom scale factors.
-; This option has no effect on stages that have either zoomin or zoomout
-; parameter set to a value other than the default of 1.
-; This is a debug parameter and may be removed in future versions.
-ForceStageZoomout   = 0
-ForceStageZoomin    = 0
 ; Toggles if Esc key should open Pause menu.
 EscOpensMenu        = 1
 ; Toggles match info loading during versus screen (currently not functional).
@@ -167,6 +161,12 @@ Font           = font/debug.def
 FontScale      = 0.5
 ; Default starting stage for quick versus.
 StartStage     = stages/stage0-720.def
+; Set to nonzero to force stages to have the specified zoom scale factors.
+; This option has no effect on stages that have either zoomin or zoomout
+; parameter set to a value other than the default of 1.
+; This is a debug parameter and may be removed in future versions.
+ForceStageZoomout   = 0
+ForceStageZoomin    = 0
 
 ; -------------------------------------------------------------------------------
 [Video]

--- a/src/stage.go
+++ b/src/stage.go
@@ -1052,15 +1052,15 @@ func loadStage(def string, maindef bool) (*Stage, error) {
 		sec[0].ReadF32("boundhighzoomdelta", &s.stageCamera.boundhighzoomdelta)
 		sec[0].ReadF32("verticalfollowzoomdelta", &s.stageCamera.verticalfollowzoomdelta)
 		sec[0].ReadBool("lowestcap", &s.stageCamera.lowestcap)
-		if sys.cfg.Config.ForceStageZoomin == 0 {
-			sec[0].ReadF32("zoomin", &s.stageCamera.zoomin)
-		} else {
-			s.stageCamera.zoomin = sys.cfg.Config.ForceStageZoomin
-		}
-		if sys.cfg.Config.ForceStageZoomout == 0 {
-			sec[0].ReadF32("zoomout", &s.stageCamera.zoomout)
-		} else {
-			s.stageCamera.zoomout = sys.cfg.Config.ForceStageZoomout
+		sec[0].ReadF32("zoomin", &s.stageCamera.zoomin)
+		sec[0].ReadF32("zoomout", &s.stageCamera.zoomout)
+		if s.stageCamera.zoomin == 1 && s.stageCamera.zoomout == 1 {
+			if sys.cfg.Debug.ForceStageZoomin > 0 {
+				s.stageCamera.zoomin = sys.cfg.Debug.ForceStageZoomin
+			}
+			if sys.cfg.Debug.ForceStageZoomout > 0 {
+				s.stageCamera.zoomout = sys.cfg.Debug.ForceStageZoomout
+			}
 		}
 		anchor, _, _ := sec[0].getText("zoomanchor")
 		if strings.ToLower(anchor) == "bottom" {


### PR DESCRIPTION
As per the description, this option has no effect on stages that have either the zoomin or zoomout parameter set to a value other than the default of 1. Also, it has been moved to the Debug section (again matching the Mugen description).