### PR TITLE
feat: invertfill in Stun and Guard bars, input buffer fix, refactoring

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1496,7 +1496,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.Push(BytecodeSF())
 			i += int(*(*int32)(unsafe.Pointer(&be[i]))) + 4
 		case OC_helperindex:
-			if c = c.getPlayerHelperIndex(sys.bcStack.Pop().ToI(), false); c != nil {
+			if c = c.getPlayerHelperIndex(sys.bcStack.Pop().ToI(), true); c != nil {
 				i += 4
 				continue
 			}
@@ -11708,13 +11708,10 @@ func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 		case modifyStageVar_shadow_intensity:
 			s.sdw.intensity = Clamp(exp[0].evalI(c), 0, 255)
 		case modifyStageVar_shadow_color:
-			// mugen 1.1 removed support for color
-			if (s.mugenver[0] != 1 || s.mugenver[1] != 1) && (s.sff.header.Ver0 != 2 || s.sff.header.Ver2 != 1) {
-				r := Clamp(exp[0].evalI(c), 0, 255)
-				g := Clamp(exp[1].evalI(c), 0, 255)
-				b := Clamp(exp[2].evalI(c), 0, 255)
-				s.sdw.color = uint32(r<<16 | g<<8 | b)
-			}
+			r := Clamp(exp[0].evalI(c), 0, 255)
+			g := Clamp(exp[1].evalI(c), 0, 255)
+			b := Clamp(exp[2].evalI(c), 0, 255)
+			s.sdw.color = uint32(r<<16 | g<<8 | b)
 		case modifyStageVar_shadow_yscale:
 			s.sdw.yscale = exp[0].evalF(c)
 		case modifyStageVar_shadow_fade_range:
@@ -11733,13 +11730,10 @@ func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 		case modifyStageVar_reflection_xshear:
 			s.reflection.xshear = exp[0].evalF(c)
 		case modifyStageVar_reflection_color:
-			// mugen 1.1 removed support for color
-			if (s.mugenver[0] != 1 || s.mugenver[1] != 1) && (s.sff.header.Ver0 != 2 || s.sff.header.Ver2 != 1) {
-				r := Clamp(exp[0].evalI(c), 0, 255)
-				g := Clamp(exp[1].evalI(c), 0, 255)
-				b := Clamp(exp[2].evalI(c), 0, 255)
-				s.reflection.color = uint32(r<<16 | g<<8 | b)
-			}
+			r := Clamp(exp[0].evalI(c), 0, 255)
+			g := Clamp(exp[1].evalI(c), 0, 255)
+			b := Clamp(exp[2].evalI(c), 0, 255)
+			s.reflection.color = uint32(r<<16 | g<<8 | b)
 		case modifyStageVar_reflection_offset:
 			s.reflection.offset[0] = exp[0].evalF(c)
 			s.reflection.offset[1] = exp[1].evalF(c)

--- a/src/char.go
+++ b/src/char.go
@@ -7464,7 +7464,7 @@ func (c *Char) actionPrepare() {
 		if c.keyctrl[0] && c.cmd != nil && (c.helperIndex == 0 || c.controller >= 0) {
 			// In Mugen, characters can perform basic actions even if they are KO
 			if !c.asf(ASF_nohardcodedkeys) {
-				if c.ctrl() && !c.inputWait() {
+				if c.ctrl() {
 					if c.scf(SCF_guard) && c.inguarddist && !c.inGuardState() && c.ss.stateType != ST_L && c.cmd[0].Buffer.B > 0 {
 						c.changeState(120, -1, -1, "") // Start guarding
 					} else if !c.asf(ASF_nojump) && c.ss.stateType == ST_S && c.cmd[0].Buffer.U > 0 &&
@@ -7618,8 +7618,7 @@ func (c *Char) actionRun() {
 	if sys.cfg.Options.AutoGuard {
 		c.setASF(ASF_autoguard)
 	}
-	if !c.inputWait() &&
-		((c.scf(SCF_ctrl) || c.ss.no == 52) &&
+	if ((c.scf(SCF_ctrl) || c.ss.no == 52) &&
 			c.ss.moveType == MT_I || c.inGuardState()) && c.cmd != nil &&
 		(c.cmd[0].Buffer.B > 0 || c.asf(ASF_autoguard)) &&
 		(c.ss.stateType == ST_S && !c.asf(ASF_nostandguard) ||
@@ -7629,10 +7628,9 @@ func (c *Char) actionRun() {
 	}
 	if !c.pauseBool {
 		if c.keyctrl[0] && c.cmd != nil {
-			if c.ctrl() && !c.inputWait() && (c.controller >= 0 || c.helperIndex == 0) {
+			if c.ctrl() && (c.controller >= 0 || c.helperIndex == 0) {
 				if !c.asf(ASF_nohardcodedkeys) {
-					if c.inguarddist && c.scf(SCF_guard) && c.cmd[0].Buffer.B > 0 &&
-						!c.inGuardState() {
+					if c.inguarddist && c.scf(SCF_guard) && !c.inGuardState() && c.cmd[0].Buffer.B > 0 {
 						c.changeState(120, -1, -1, "")
 						// In Mugen the characters *can* change to the guarding states during pauses
 						// They can still block in Ikemen despite not changing state here
@@ -8578,7 +8576,7 @@ func (cl *CharList) commandUpdate() {
 					}
 				}
 				if (c.helperIndex == 0 || c.helperIndex > 0 && &c.cmd[0] != &root.cmd[0]) &&
-					c.cmd[0].Input(c.controller, int32(c.facing), sys.com[i], c.inputFlag) {
+					c.cmd[0].Input(c.controller, int32(c.facing), sys.com[i], c.inputFlag, false) {
 					// Clear input buffers and skip the rest of the loop
 					// This used to apply only to the root, but that caused some issues with helper-based input buffers
 					if c.inputWait() || c.asf(ASF_noinput) {

--- a/src/char.go
+++ b/src/char.go
@@ -184,6 +184,7 @@ func (cr *ClsnRect) Add(clsn []float32, x, y, xs, ys, angle float32) {
 		*cr = append(*cr, rect)
 	}
 }
+
 func (cr ClsnRect) draw(trans int32) {
 	paltex := PaletteToTexture(sys.clsnSpr.Pal)
 	for _, c := range cr {
@@ -744,6 +745,7 @@ func (hd *HitDef) testAttr(attr int32) bool {
 	attr &= hd.attr
 	return attr&int32(ST_MASK) != 0 && attr&^int32(ST_MASK)&^(-1<<31) != 0
 }
+
 func (hd *HitDef) testReversalAttr(attr int32) bool {
 	attr &= hd.reversal_attr
 	return attr&int32(ST_MASK) != 0 && attr&^int32(ST_MASK)&^(-1<<31) != 0
@@ -898,6 +900,7 @@ func (ghv GetHitVar) chainId() int32 {
 	}
 	return 0
 }
+
 func (ghv GetHitVar) idMatch(id int32) bool {
 	for _, v := range ghv.hitBy {
 		if v[0] == id || v[0] == -id {
@@ -906,6 +909,7 @@ func (ghv GetHitVar) idMatch(id int32) bool {
 	}
 	return false
 }
+
 func (ghv GetHitVar) getJuggle(id, defaultJuggle int32) int32 {
 	for _, v := range ghv.hitBy {
 		if v[0] == id {
@@ -914,6 +918,7 @@ func (ghv GetHitVar) getJuggle(id, defaultJuggle int32) int32 {
 	}
 	return defaultJuggle
 }
+
 func (ghv *GetHitVar) dropId(id int32) {
 	for i, v := range ghv.hitBy {
 		if v[0] == id {
@@ -922,6 +927,7 @@ func (ghv *GetHitVar) dropId(id int32) {
 		}
 	}
 }
+
 func (ghv *GetHitVar) addId(id, juggle int32) {
 	juggle = ghv.getJuggle(id, juggle)
 	ghv.dropId(id)
@@ -1009,6 +1015,7 @@ func newAfterImage() *AfterImage {
 	ai.clear()
 	return ai
 }
+
 func (ai *AfterImage) clear() {
 	ai.time = 0
 	ai.length = 20
@@ -1032,56 +1039,67 @@ func (ai *AfterImage) clear() {
 	ai.timecount = 0
 	ai.ignorehitpause = true
 }
+
 func (ai *AfterImage) setPalColor(color int32) {
 	if len(ai.palfx) > 0 {
 		ai.palfx[0].eColor = float32(Clamp(color, 0, 256)) / 256
 	}
 }
+
 func (ai *AfterImage) setPalHueShift(huesh int32) {
 	if len(ai.palfx) > 0 {
 		ai.palfx[0].eHue = (float32(Clamp(huesh, -256, 256)) / 256)
 	}
 }
+
 func (ai *AfterImage) setPalInvertall(invertall bool) {
 	if len(ai.palfx) > 0 {
 		ai.palfx[0].eInvertall = invertall
 	}
 }
+
 func (ai *AfterImage) setPalInvertblend(invertblend int32) {
 	if len(ai.palfx) > 0 {
 		ai.palfx[0].invertblend = invertblend
 	}
 }
+
 func (ai *AfterImage) setPalBrightR(addr int32) {
 	if len(ai.palfx) > 0 {
 		ai.palfx[0].eAdd[0] = addr
 	}
 }
+
 func (ai *AfterImage) setPalBrightG(addg int32) {
 	if len(ai.palfx) > 0 {
 		ai.palfx[0].eAdd[1] = addg
 	}
 }
+
 func (ai *AfterImage) setPalBrightB(addb int32) {
 	if len(ai.palfx) > 0 {
 		ai.palfx[0].eAdd[2] = addb
 	}
 }
+
 func (ai *AfterImage) setPalContrastR(mulr int32) {
 	if len(ai.palfx) > 0 {
 		ai.palfx[0].eMul[0] = mulr
 	}
 }
+
 func (ai *AfterImage) setPalContrastG(mulg int32) {
 	if len(ai.palfx) > 0 {
 		ai.palfx[0].eMul[1] = mulg
 	}
 }
+
 func (ai *AfterImage) setPalContrastB(mulb int32) {
 	if len(ai.palfx) > 0 {
 		ai.palfx[0].eMul[2] = mulb
 	}
 }
+
 func (ai *AfterImage) setupPalFX() {
 	pb := ai.postbright
 	if ai.palfx[0].invertblend <= -2 && ai.palfx[0].eInvertall {
@@ -1101,6 +1119,7 @@ func (ai *AfterImage) setupPalFX() {
 		pb = [3]int32{}
 	}
 }
+
 func (ai *AfterImage) recAfterImg(sd *SprData, hitpause bool) {
 	if ai.time == 0 {
 		ai.reccount, ai.timegap = 0, 0
@@ -1137,6 +1156,7 @@ func (ai *AfterImage) recAfterImg(sd *SprData, hitpause bool) {
 	ai.restgap--
 	ai.timecount++
 }
+
 func (ai *AfterImage) recAndCue(sd *SprData, rec bool, hitpause bool, layer int32) {
 	if ai.time == 0 || (ai.timecount >= ai.timegap*ai.length+ai.time-1 && ai.time > 0) ||
 		ai.timegap < 1 || ai.timegap > 32767 ||
@@ -1262,15 +1282,19 @@ func (e *Explod) clear() {
 		friction:          [3]float32{1, 1, 1},
 	}
 }
+
 func (e *Explod) setX(x float32) {
 	e.pos[0], e.oldPos[0], e.newPos[0] = x, x, x
 }
+
 func (e *Explod) setY(y float32) {
 	e.pos[1], e.oldPos[1], e.newPos[1] = y, y, y
 }
+
 func (e *Explod) setZ(z float32) {
 	e.pos[2], e.oldPos[2], e.newPos[2] = z, z, z
 }
+
 func (e *Explod) setBind(bId int32) {
 	if e.space == Space_screen && (e.postype == PT_P1 || e.postype == PT_P2) {
 		return
@@ -1360,14 +1384,17 @@ func (e *Explod) setPos(c *Char) {
 		}
 	}
 }
+
 func (e *Explod) matchId(eid, pid int32) bool {
 	return e.id >= 0 && e.playerId == pid && (eid < 0 || e.id == eid)
 }
+
 func (e *Explod) setAnimElem() {
 	if e.anim != nil && e.animelem >= 1 {
 		e.anim.SetAnimElem(Clamp(e.animelem, 1, int32(len(e.anim.frames))))
 	}
 }
+
 func (e *Explod) update(oldVer bool, playerNo int) {
 	if e.anim == nil {
 		e.id = IErr
@@ -1802,6 +1829,7 @@ func (p *Projectile) paused(playerNo int) bool {
 	//}
 	return false
 }
+
 func (p *Projectile) update(playerNo int) {
 	// Check projectile removal conditions
 	if sys.tickFrame() && !p.paused(playerNo) && p.hitpause == 0 {
@@ -2035,6 +2063,7 @@ func (p *Projectile) tick(playerNo int) {
 		}
 	}
 }
+
 func (p *Projectile) cueDraw(oldVer bool, playerNo int) {
 	notpause := p.hitpause <= 0 && !p.paused(playerNo)
 	if sys.tickFrame() && p.ani != nil && notpause {
@@ -2382,6 +2411,7 @@ func newChar(n int, idx int32) (c *Char) {
 func (c *Char) warn() string {
 	return fmt.Sprintf("%v: WARNING: %v (%v) in state %v: ", sys.tickCount, c.name, c.id, c.ss.no)
 }
+
 func (c *Char) panic() {
 	if sys.workingState != &c.ss.sb {
 		sys.errLog.Panicf("%v\n%v\n%v\n%+v\n", c.gi().def, c.name,
@@ -3342,10 +3372,12 @@ func (c *Char) clearHitCount() {
 	c.uniqHitCount = 0
 	c.guardCount = 0
 }
+
 func (c *Char) clearMoveHit() {
 	c.mctime = 0
 	c.counterHit = false
 }
+
 func (c *Char) clearHitDef() {
 	c.hitdef.clear(c.localscl)
 }
@@ -3383,6 +3415,7 @@ func (c *Char) changeAnimEx(animNo int32, playerNo int, ffx string, alt bool) {
 		}
 	}
 }
+
 func (c *Char) changeAnim(animNo int32, playerNo int, ffx string) {
 	if animNo < 0 && animNo != -2 {
 		// MUGEN 1.1 exports a warning message when attempting to change anim to a negative value through ChangeAnim SCTRL,
@@ -3393,6 +3426,7 @@ func (c *Char) changeAnim(animNo int32, playerNo int, ffx string) {
 	}
 	c.changeAnimEx(animNo, playerNo, ffx, false)
 }
+
 func (c *Char) changeAnim2(animNo int32, playerNo int, ffx string) {
 	if animNo < 0 && animNo != -2 {
 		sys.appendToConsole(c.warn() + fmt.Sprintf("attempted change to negative anim (different from -2)"))
@@ -3400,6 +3434,7 @@ func (c *Char) changeAnim2(animNo int32, playerNo int, ffx string) {
 	}
 	c.changeAnimEx(animNo, playerNo, ffx, true)
 }
+
 func (c *Char) setAnimElem(e int32) {
 	if c.anim != nil {
 		c.anim.SetAnimElem(e)
@@ -3411,6 +3446,7 @@ func (c *Char) setAnimElem(e int32) {
 		}
 	}
 }
+
 func (c *Char) setCtrl(ctrl bool) {
 	if ctrl {
 		c.setSCF(SCF_ctrl)
@@ -3418,6 +3454,7 @@ func (c *Char) setCtrl(ctrl bool) {
 		c.unsetSCF(SCF_ctrl)
 	}
 }
+
 func (c *Char) setDizzy(set bool) {
 	if set {
 		c.setSCF(SCF_dizzy)
@@ -3425,6 +3462,7 @@ func (c *Char) setDizzy(set bool) {
 		c.unsetSCF(SCF_dizzy)
 	}
 }
+
 func (c *Char) setGuardBreak(set bool) {
 	if set {
 		c.setSCF(SCF_guardbreak)
@@ -3432,33 +3470,43 @@ func (c *Char) setGuardBreak(set bool) {
 		c.unsetSCF(SCF_guardbreak)
 	}
 }
+
 func (c *Char) scf(scf SystemCharFlag) bool {
 	return c.systemFlag&scf != 0
 }
+
 func (c *Char) setSCF(scf SystemCharFlag) {
 	c.systemFlag |= scf
 }
+
 func (c *Char) unsetSCF(scf SystemCharFlag) {
 	c.systemFlag &^= scf
 }
+
 func (c *Char) csf(csf CharSpecialFlag) bool {
 	return c.specialFlag&csf != 0
 }
+
 func (c *Char) setCSF(csf CharSpecialFlag) {
 	c.specialFlag |= csf
 }
+
 func (c *Char) unsetCSF(csf CharSpecialFlag) {
 	c.specialFlag &^= csf
 }
+
 func (c *Char) asf(asf AssertSpecialFlag) bool {
 	return c.assertFlag&asf != 0
 }
+
 func (c *Char) setASF(asf AssertSpecialFlag) {
 	c.assertFlag |= asf
 }
+
 func (c *Char) unsetASF(asf AssertSpecialFlag) {
 	c.assertFlag &^= asf
 }
+
 func (c *Char) parent() *Char {
 	if c.parentIndex == IErr {
 		sys.appendToConsole(c.warn() + "has no parent")
@@ -3472,6 +3520,7 @@ func (c *Char) parent() *Char {
 	}
 	return sys.chars[c.playerNo][Abs(c.parentIndex)]
 }
+
 func (c *Char) root() *Char {
 	if c.helperIndex == 0 {
 		sys.appendToConsole(c.warn() + "has no root")
@@ -3479,6 +3528,7 @@ func (c *Char) root() *Char {
 	}
 	return sys.chars[c.playerNo][0]
 }
+
 func (c *Char) helper(id int32) *Char {
 	for _, h := range sys.chars[c.playerNo][1:] {
 		if !h.csf(CSF_destroy) && (id <= 0 || id == h.helperId) {
@@ -3488,18 +3538,21 @@ func (c *Char) helper(id int32) *Char {
 	sys.appendToConsole(c.warn() + fmt.Sprintf("has no helper: %v", id))
 	return nil
 }
-func (c *Char) getPlayerHelperIndex(n int32, ex bool) *Char {
+
+func (c *Char) getPlayerHelperIndex(n int32, log bool) *Char {
 	if n <= 0 {
 		return c
 	}
-	return sys.charList.getHelperIndex(c, n, ex)
+	return sys.charList.getHelperIndex(c, n, log)
 }
+
 func (c *Char) helperByIndexExist(id BytecodeValue) BytecodeValue {
 	if id.IsSF() {
 		return BytecodeSF()
 	}
-	return BytecodeBool(c.getPlayerHelperIndex(id.ToI(), true) != nil)
+	return BytecodeBool(c.getPlayerHelperIndex(id.ToI(), false) != nil)
 }
+
 func (c *Char) target(id int32) *Char {
 	for _, tid := range c.targets {
 		if t := sys.playerID(tid); t != nil && (id < 0 || id == t.ghv.hitid) {
@@ -3511,6 +3564,7 @@ func (c *Char) target(id int32) *Char {
 	}
 	return nil
 }
+
 func (c *Char) partner(n int32, log bool) *Char {
 	n = Max(0, n)
 	if int(n) > len(sys.chars)/2-2 {
@@ -3539,6 +3593,7 @@ func (c *Char) partner(n int32, log bool) *Char {
 	}
 	return nil
 }
+
 func (c *Char) partnerV2(n int32) *Char {
 	n = Max(0, n)
 	if int(n) > len(sys.chars)/2-2 {
@@ -3553,6 +3608,7 @@ func (c *Char) partnerV2(n int32) *Char {
 	}
 	return nil
 }
+
 func (c *Char) enemy(n int32) *Char {
 	if n < 0 || n >= c.numEnemy() {
 		sys.appendToConsole(c.warn() + fmt.Sprintf("has no enemy: %v", n))
@@ -3572,7 +3628,7 @@ func (c *Char) enemy(n int32) *Char {
 
 // This is only used to simplify the redirection call
 func (c *Char) enemyNearTrigger(n int32) *Char {
-	return sys.charList.enemyNear(c, n, false, false)
+	return sys.charList.enemyNear(c, n, false, true)
 }
 
 // Get the "P2" enemy reference
@@ -3586,21 +3642,25 @@ func (c *Char) aiLevel() float32 {
 	}
 	return sys.com[c.playerNo]
 }
+
 func (c *Char) alive() bool {
 	return !c.scf(SCF_ko)
 }
+
 func (c *Char) animElemNo(time int32) BytecodeValue {
 	if c.anim != nil && time >= -c.anim.sumtime {
 		return BytecodeInt(c.anim.AnimElemNo(time))
 	}
 	return BytecodeSF()
 }
+
 func (c *Char) animElemTime(e int32) BytecodeValue {
 	if e >= 1 && c.anim != nil && int(e) <= len(c.anim.frames) {
 		return BytecodeInt(c.anim.AnimElemTime(e))
 	}
 	return BytecodeSF()
 }
+
 func (c *Char) animExist(wc *Char, anim BytecodeValue) BytecodeValue {
 	if anim.IsSF() {
 		return BytecodeSF()
@@ -3610,12 +3670,14 @@ func (c *Char) animExist(wc *Char, anim BytecodeValue) BytecodeValue {
 	}
 	return sys.chars[c.ss.sb.playerNo][0].selfAnimExist(anim)
 }
+
 func (c *Char) animTime() int32 {
 	if c.anim != nil {
 		return c.anim.AnimTime()
 	}
 	return 0
 }
+
 func (c *Char) backEdge() float32 {
 	if c.facing < 0 {
 		return c.rightEdge()
@@ -3643,15 +3705,19 @@ func (c *Char) backEdgeDist() float32 {
 	}
 	return c.pos[0] - sys.xmin/c.localscl
 }
+
 func (c *Char) bottomEdge() float32 {
 	return sys.cam.ScreenPos[1]/c.localscl + c.gameHeight()
 }
+
 func (c *Char) botBoundDist() float32 {
 	return sys.zmax/c.localscl - c.pos[2]
 }
+
 func (c *Char) canRecover() bool {
 	return c.ghv.fall_recover && c.fallTime >= c.ghv.fall_recovertime
 }
+
 func (c *Char) comboCount() int32 {
 	if c.teamside == -1 {
 		return 0
@@ -3689,6 +3755,7 @@ func (c *Char) commandByName(name string) bool {
 	i, ok := c.cmd[c.playerNo].Names[name]
 	return ok && c.command(c.playerNo, i)
 }
+
 func (c *Char) assertCommand(name string, time int32) {
 	ok := false
 	// Assert the command in every command list
@@ -3699,16 +3766,20 @@ func (c *Char) assertCommand(name string, time int32) {
 		sys.appendToConsole(c.warn() + fmt.Sprintf("attempted to assert an invalid command"))
 	}
 }
+
 func (c *Char) constp(coordinate, value float32) BytecodeValue {
 	return BytecodeFloat(c.stOgi().localcoord[0] / coordinate * value)
 }
+
 func (c *Char) ctrl() bool {
 	return c.scf(SCF_ctrl) && !c.scf(SCF_standby) &&
 		!c.scf(SCF_dizzy) && !c.scf(SCF_guardbreak)
 }
+
 func (c *Char) drawgame() bool {
 	return sys.roundState() >= 3 && sys.winTeam < 0
 }
+
 func (c *Char) frontEdge() float32 {
 	if c.facing > 0 {
 		return c.rightEdge()
@@ -3735,33 +3806,41 @@ func (c *Char) frontEdgeDist() float32 {
 	}
 	return c.pos[0] - sys.xmin/c.localscl
 }
+
 func (c *Char) gameHeight() float32 {
 	return c.screenHeight() / sys.cam.Scale
 }
+
 func (c *Char) gameWidth() float32 {
 	return c.screenWidth() / sys.cam.Scale
 }
+
 func (c *Char) getPlayerID(pn int) int32 {
 	if pn >= 1 && pn <= len(sys.chars) && len(sys.chars[pn-1]) > 0 {
 		return sys.chars[pn-1][0].id
 	}
 	return 0
 }
+
 func (c *Char) getPower() int32 {
 	if sys.cfg.Options.Team.PowerShare && c.teamside != -1 {
 		return sys.chars[c.playerNo&1][0].power
 	}
 	return sys.chars[c.playerNo][0].power
 }
+
 func (c *Char) hitDefAttr(attr int32) bool {
 	return c.ss.moveType == MT_A && c.hitdef.testAttr(attr)
 }
+
 func (c *Char) hitOver() bool {
 	return c.ghv.hittime < 0
 }
+
 func (c *Char) hitShakeOver() bool {
 	return c.ghv.hitshaketime <= 0
 }
+
 func (c *Char) isHelper(hid BytecodeValue) BytecodeValue {
 	if hid.IsSF() {
 		return BytecodeSF()
@@ -3769,9 +3848,11 @@ func (c *Char) isHelper(hid BytecodeValue) BytecodeValue {
 	id := hid.ToI()
 	return BytecodeBool(c.helperIndex != 0 && (id == math.MinInt32 || c.helperId == id))
 }
+
 func (c *Char) isHost() bool {
 	return sys.netInput != nil && sys.netInput.host
 }
+
 func (c *Char) jugglePoints(hid BytecodeValue) BytecodeValue {
 	if hid.IsSF() {
 		return BytecodeSF()
@@ -3789,45 +3870,54 @@ func (c *Char) jugglePoints(hid BytecodeValue) BytecodeValue {
 	}
 	return BytecodeInt(jp)
 }
+
 func (c *Char) leftEdge() float32 {
 	return sys.cam.ScreenPos[0] / c.localscl
 }
+
 func (c *Char) lose() bool {
 	if c.teamside == -1 {
 		return false
 	}
 	return sys.winTeam == ^c.playerNo&1
 }
+
 func (c *Char) loseKO() bool {
 	return c.lose() && sys.finishType == FT_KO
 }
+
 func (c *Char) loseTime() bool {
 	return c.lose() && sys.finishType == FT_TO
 }
+
 func (c *Char) moveContact() int32 {
 	if c.mctype != MC_Reversed {
 		return Abs(c.mctime)
 	}
 	return 0
 }
+
 func (c *Char) moveCountered() int32 {
 	if c.counterHit {
 		return Abs(c.mctime)
 	}
 	return 0
 }
+
 func (c *Char) moveGuarded() int32 {
 	if c.mctype == MC_Guarded {
 		return Abs(c.mctime)
 	}
 	return 0
 }
+
 func (c *Char) moveHit() int32 {
 	if c.mctype == MC_Hit {
 		return Abs(c.mctime)
 	}
 	return 0
 }
+
 func (c *Char) moveReversed() int32 {
 	if c.mctype == MC_Reversed {
 		return Abs(c.mctime)
@@ -3869,6 +3959,7 @@ func (c *Char) numEnemy() int32 {
 	}
 	return n
 }
+
 func (c *Char) numPlayer() int32 {
 	n := int32(0)
 	for i := 0; i < len(sys.chars)-1; i++ {
@@ -3879,6 +3970,7 @@ func (c *Char) numPlayer() int32 {
 	}
 	return n
 }
+
 func (c *Char) numExplod(eid BytecodeValue) BytecodeValue {
 	if eid.IsSF() {
 		return BytecodeSF()
@@ -3961,6 +4053,7 @@ func (c *Char) explodVar(eid BytecodeValue, idx BytecodeValue, vtype OpCode) Byt
 	}
 	return v
 }
+
 func (c *Char) projVar(pid BytecodeValue, idx BytecodeValue, flag BytecodeValue, vtype OpCode, oc *Char) BytecodeValue {
 	if pid.IsSF() {
 		return BytecodeSF()
@@ -4078,6 +4171,7 @@ func (c *Char) projVar(pid BytecodeValue, idx BytecodeValue, flag BytecodeValue,
 	}
 	return v
 }
+
 func (c *Char) numHelper(hid BytecodeValue) BytecodeValue {
 	if hid.IsSF() {
 		return BytecodeSF()
@@ -4090,12 +4184,14 @@ func (c *Char) numHelper(hid BytecodeValue) BytecodeValue {
 	}
 	return BytecodeInt(n)
 }
+
 func (c *Char) numPartner() int32 {
 	if (sys.tmode[c.playerNo&1] != TM_Simul && sys.tmode[c.playerNo&1] != TM_Tag) || c.teamside == -1 {
 		return 0
 	}
 	return sys.numSimul[c.playerNo&1] - 1
 }
+
 func (c *Char) numProj() int32 {
 	// Helpers cannot own projectiles
 	if c.helperIndex != 0 {
@@ -4109,6 +4205,7 @@ func (c *Char) numProj() int32 {
 	}
 	return n
 }
+
 func (c *Char) numProjID(pid BytecodeValue) BytecodeValue {
 	if pid.IsSF() {
 		return BytecodeSF()
@@ -4125,6 +4222,7 @@ func (c *Char) numProjID(pid BytecodeValue) BytecodeValue {
 	}
 	return BytecodeInt(n)
 }
+
 func (c *Char) numTarget(hid BytecodeValue) BytecodeValue {
 	if hid.IsSF() {
 		return BytecodeSF()
@@ -4141,6 +4239,7 @@ func (c *Char) numTarget(hid BytecodeValue) BytecodeValue {
 	}
 	return BytecodeInt(n)
 }
+
 func (c *Char) palfxvar(x int32) int32 {
 	n := int32(0)
 	if x >= 4 {
@@ -4172,6 +4271,7 @@ func (c *Char) palfxvar(x int32) int32 {
 	}
 	return n
 }
+
 func (c *Char) palfxvar2(x int32) float32 {
 	n := float32(1)
 	if x > 1 {
@@ -4200,6 +4300,7 @@ func (c *Char) pauseTime() int32 {
 	}
 	return p
 }
+
 func (c *Char) projCancelTime(pid BytecodeValue) BytecodeValue {
 	if pid.IsSF() {
 		return BytecodeSF()
@@ -4210,6 +4311,7 @@ func (c *Char) projCancelTime(pid BytecodeValue) BytecodeValue {
 	}
 	return BytecodeInt(c.gi().pctime)
 }
+
 func (c *Char) projContactTime(pid BytecodeValue) BytecodeValue {
 	if pid.IsSF() {
 		return BytecodeSF()
@@ -4220,6 +4322,7 @@ func (c *Char) projContactTime(pid BytecodeValue) BytecodeValue {
 	}
 	return BytecodeInt(c.gi().pctime)
 }
+
 func (c *Char) projGuardedTime(pid BytecodeValue) BytecodeValue {
 	if pid.IsSF() {
 		return BytecodeSF()
@@ -4230,6 +4333,7 @@ func (c *Char) projGuardedTime(pid BytecodeValue) BytecodeValue {
 	}
 	return BytecodeInt(c.gi().pctime)
 }
+
 func (c *Char) projHitTime(pid BytecodeValue) BytecodeValue {
 	if pid.IsSF() {
 		return BytecodeSF()
@@ -4240,12 +4344,15 @@ func (c *Char) projHitTime(pid BytecodeValue) BytecodeValue {
 	}
 	return BytecodeInt(c.gi().pctime)
 }
+
 func (c *Char) reversalDefAttr(attr int32) bool {
 	return c.hitdef.testReversalAttr(attr)
 }
+
 func (c *Char) rightEdge() float32 {
 	return sys.cam.ScreenPos[0]/c.localscl + c.gameWidth()
 }
+
 func (c *Char) roundsExisted() int32 {
 	if c.teamside == -1 {
 		return sys.round - 1
@@ -4268,15 +4375,18 @@ func (c *Char) screenHeight() float32 {
 	return sys.screenHeight() / (320.0 / float32(c.stOgi().localcoord[0])) /
 		((3.0 / 4.0) / (float32(sys.scrrect[3]) / float32(sys.scrrect[2])))
 }
+
 func (c *Char) screenWidth() float32 {
 	return c.stOgi().localcoord[0]
 }
+
 func (c *Char) selfAnimExist(anim BytecodeValue) BytecodeValue {
 	if anim.IsSF() {
 		return BytecodeSF()
 	}
 	return BytecodeBool(c.gi().anim.get(anim.ToI()) != nil)
 }
+
 func (c *Char) selfStatenoExist(stateno BytecodeValue) BytecodeValue {
 	if stateno.IsSF() {
 		return BytecodeSF()
@@ -4319,6 +4429,7 @@ func (c *Char) teamLeader() int {
 	}
 	return sys.teamLeader[c.playerNo&1] + 1
 }
+
 func (c *Char) teamSize() int32 {
 	if c.teamside == -1 {
 		var n int32
@@ -4334,33 +4445,42 @@ func (c *Char) teamSize() int32 {
 	}
 	return sys.numSimul[c.playerNo&1]
 }
+
 func (c *Char) time() int32 {
 	return c.ss.time
 }
+
 func (c *Char) topEdge() float32 {
 	return sys.cam.ScreenPos[1] / c.localscl
 }
+
 func (c *Char) topBoundDist() float32 {
 	return sys.zmin/c.localscl - c.pos[2]
 }
+
 func (c *Char) win() bool {
 	if c.teamside == -1 {
 		return false
 	}
 	return sys.winTeam == c.playerNo&1
 }
+
 func (c *Char) winKO() bool {
 	return c.win() && sys.finishType == FT_KO
 }
+
 func (c *Char) winTime() bool {
 	return c.win() && sys.finishType == FT_TO
 }
+
 func (c *Char) winPerfect() bool {
 	return c.win() && sys.winType[c.playerNo&1] >= WT_PNormal
 }
+
 func (c *Char) winType(wt WinType) bool {
 	return c.win() && sys.winTrigger[c.playerNo&1] == wt
 }
+
 func (c *Char) playSound(ffx string, lowpriority bool, loopCount int32, g, n, chNo, vol int32,
 	p, freqmul, ls float32, x *float32, log bool, priority int32, loopstart, loopend, startposition int, stopgh, stopcs bool) {
 	if g < 0 {
@@ -4531,6 +4651,7 @@ func (c *Char) stateChange1(no int32, pn int) bool {
 	c.stchtmp = true
 	return true
 }
+
 func (c *Char) stateChange2() bool {
 	if c.stchtmp && !c.hitPause() {
 		c.ss.sb.init(c)
@@ -4556,6 +4677,7 @@ func (c *Char) stateChange2() bool {
 	}
 	return false
 }
+
 func (c *Char) changeStateEx(no int32, pn int, anim, ctrl int32, ffx string) {
 	// This is a very specific and undocumented Mugen behavior that probably resulted from Elecbyte misinterpreting fighting games
 	// It serves very little purpose while negatively affecting some new Ikemen features like NoTurnTarget
@@ -4582,9 +4704,11 @@ func (c *Char) changeStateEx(no int32, pn int, anim, ctrl int32, ffx string) {
 		sys.changeStateNest = 0
 	}
 }
+
 func (c *Char) changeState(no, anim, ctrl int32, ffx string) {
 	c.changeStateEx(no, c.ss.sb.playerNo, anim, ctrl, ffx)
 }
+
 func (c *Char) selfState(no, anim, readplayerid, ctrl int32, ffx string) {
 	var playerno int
 	if readplayerid >= 0 {
@@ -4601,7 +4725,7 @@ func (c *Char) destroy() {
 		c.receivedDmg = 0
 		c.receivedHits = 0
 		if c.player {
-			sys.charList.p2enemyDelete(c)
+			sys.charList.p2enemyDelete(c) // Every status change that invalidates the P2 reference must run this
 		}
 		for _, tid := range c.targets {
 			if t := sys.playerID(tid); t != nil {
@@ -4809,6 +4933,7 @@ func (c *Char) newExplod() (*Explod, int) {
 	}
 	return nil, -1
 }
+
 func (c *Char) getExplods(id int32) (expls []*Explod) {
 	for i, e := range sys.explods[c.playerNo] {
 		if e.matchId(id, c.id) {
@@ -4817,6 +4942,7 @@ func (c *Char) getExplods(id int32) (expls []*Explod) {
 	}
 	return
 }
+
 func (c *Char) insertExplodEx(i int, rp [2]int32) {
 	e := &sys.explods[c.playerNo][i]
 	if e.anim == nil {
@@ -4870,9 +4996,11 @@ func (c *Char) insertExplodEx(i int, rp [2]int32) {
 		*ed = append(*ed, i)
 	}
 }
+
 func (c *Char) insertExplod(i int) {
 	c.insertExplodEx(i, [...]int32{-1, 0})
 }
+
 func (c *Char) explodBindTime(id, time int32) {
 	for i, e := range sys.explods[c.playerNo] {
 		if e.matchId(id, c.id) {
@@ -4880,6 +5008,7 @@ func (c *Char) explodBindTime(id, time int32) {
 		}
 	}
 }
+
 func (c *Char) removeExplod(id, idx int32) {
 
 	remove := func(drawlist *[]int, drop bool) {
@@ -4998,10 +5127,12 @@ func (c *Char) setX(x float32) {
 	c.oldPos[0], c.interPos[0] = x, x
 	c.setPosX(x)
 }
+
 func (c *Char) setY(y float32) {
 	c.oldPos[1], c.interPos[1] = y, y
 	c.setPosY(y)
 }
+
 func (c *Char) setZ(z float32) {
 	c.oldPos[2], c.interPos[2] = z, z
 	c.setPosZ(z)
@@ -5010,9 +5141,11 @@ func (c *Char) setZ(z float32) {
 func (c *Char) addX(x float32) {
 	c.setX(c.pos[0] + c.facing*x)
 }
+
 func (c *Char) addY(y float32) {
 	c.setY(c.pos[1] + y)
 }
+
 func (c *Char) addZ(z float32) {
 	c.setZ(c.pos[2] + z)
 }
@@ -5024,6 +5157,7 @@ func (c *Char) shadXOff(xv float32, isReflect bool) {
 		c.reflectOffset[0] = xv
 	}
 }
+
 func (c *Char) shadYOff(yv float32, isReflect bool) {
 	if !isReflect {
 		c.shadowOffset[1] = yv
@@ -5407,6 +5541,7 @@ func (c *Char) gethitAnimtype() Reaction {
 func (c *Char) isBound() bool {
 	return c.ghv.idMatch(c.bindToId)
 }
+
 func (c *Char) varGet(i int32) BytecodeValue {
 	if i >= 0 && i < int32(NumVar) {
 		return BytecodeInt(c.ivar[i])
@@ -5414,6 +5549,7 @@ func (c *Char) varGet(i int32) BytecodeValue {
 	sys.appendToConsole(c.warn() + fmt.Sprintf("var index %v out of range", i))
 	return BytecodeSF()
 }
+
 func (c *Char) fvarGet(i int32) BytecodeValue {
 	if i >= 0 && i < int32(NumFvar) {
 		return BytecodeFloat(c.fvar[i])
@@ -5421,6 +5557,7 @@ func (c *Char) fvarGet(i int32) BytecodeValue {
 	sys.appendToConsole(c.warn() + fmt.Sprintf("fvar index %v out of range", i))
 	return BytecodeSF()
 }
+
 func (c *Char) sysVarGet(i int32) BytecodeValue {
 	if i >= 0 && i < int32(NumSysVar) {
 		return BytecodeInt(c.ivar[i+int32(NumVar)])
@@ -5428,6 +5565,7 @@ func (c *Char) sysVarGet(i int32) BytecodeValue {
 	sys.appendToConsole(c.warn() + fmt.Sprintf("sysvar index %v out of range", i))
 	return BytecodeSF()
 }
+
 func (c *Char) sysFvarGet(i int32) BytecodeValue {
 	if i >= 0 && i < int32(NumSysFvar) {
 		return BytecodeFloat(c.fvar[i+int32(NumFvar)])
@@ -5435,6 +5573,7 @@ func (c *Char) sysFvarGet(i int32) BytecodeValue {
 	sys.appendToConsole(c.warn() + fmt.Sprintf("sysfvar index %v out of range", i))
 	return BytecodeSF()
 }
+
 func (c *Char) varSet(i, v int32) BytecodeValue {
 	if i >= 0 && i < int32(NumVar) {
 		c.ivar[i] = v
@@ -5443,6 +5582,7 @@ func (c *Char) varSet(i, v int32) BytecodeValue {
 	sys.appendToConsole(c.warn() + fmt.Sprintf("var index %v out of range", i))
 	return BytecodeSF()
 }
+
 func (c *Char) fvarSet(i int32, v float32) BytecodeValue {
 	if i >= 0 && i < int32(NumFvar) {
 		c.fvar[i] = v
@@ -5451,6 +5591,7 @@ func (c *Char) fvarSet(i int32, v float32) BytecodeValue {
 	sys.appendToConsole(c.warn() + fmt.Sprintf("fvar index %v out of range", i))
 	return BytecodeSF()
 }
+
 func (c *Char) sysVarSet(i, v int32) BytecodeValue {
 	if i >= 0 && i < int32(NumSysVar) {
 		c.ivar[i+int32(NumVar)] = v
@@ -5459,6 +5600,7 @@ func (c *Char) sysVarSet(i, v int32) BytecodeValue {
 	sys.appendToConsole(c.warn() + fmt.Sprintf("sysvar index %v out of range", i))
 	return BytecodeSF()
 }
+
 func (c *Char) sysFvarSet(i int32, v float32) BytecodeValue {
 	if i >= 0 && i < int32(NumSysFvar) {
 		c.fvar[i+int32(NumFvar)] = v
@@ -5467,6 +5609,7 @@ func (c *Char) sysFvarSet(i int32, v float32) BytecodeValue {
 	sys.appendToConsole(c.warn() + fmt.Sprintf("sysfvar index %v out of range", i))
 	return BytecodeSF()
 }
+
 func (c *Char) varAdd(i, v int32) BytecodeValue {
 	if i >= 0 && i < int32(NumVar) {
 		c.ivar[i] += v
@@ -5475,6 +5618,7 @@ func (c *Char) varAdd(i, v int32) BytecodeValue {
 	sys.appendToConsole(c.warn() + fmt.Sprintf("var index %v out of range", i))
 	return BytecodeSF()
 }
+
 func (c *Char) fvarAdd(i int32, v float32) BytecodeValue {
 	if i >= 0 && i < int32(NumFvar) {
 		c.fvar[i] += v
@@ -5483,6 +5627,7 @@ func (c *Char) fvarAdd(i int32, v float32) BytecodeValue {
 	sys.appendToConsole(c.warn() + fmt.Sprintf("fvar index %v out of range", i))
 	return BytecodeSF()
 }
+
 func (c *Char) sysVarAdd(i, v int32) BytecodeValue {
 	if i >= 0 && i < int32(NumSysVar) {
 		c.ivar[i+int32(NumVar)] += v
@@ -5491,6 +5636,7 @@ func (c *Char) sysVarAdd(i, v int32) BytecodeValue {
 	sys.appendToConsole(c.warn() + fmt.Sprintf("sysvar index %v out of range", i))
 	return BytecodeSF()
 }
+
 func (c *Char) sysFvarAdd(i int32, v float32) BytecodeValue {
 	if i >= 0 && i < int32(NumSysFvar) {
 		c.fvar[i+int32(NumFvar)] += v
@@ -5499,6 +5645,7 @@ func (c *Char) sysFvarAdd(i int32, v float32) BytecodeValue {
 	sys.appendToConsole(c.warn() + fmt.Sprintf("sysfvar index %v out of range", i))
 	return BytecodeSF()
 }
+
 func (c *Char) varRangeSet(s, e, v int32) {
 	if s >= 0 {
 		for i := s; i <= e && i < int32(NumVar); i++ {
@@ -5506,6 +5653,7 @@ func (c *Char) varRangeSet(s, e, v int32) {
 		}
 	}
 }
+
 func (c *Char) fvarRangeSet(s, e int32, v float32) {
 	if s >= 0 {
 		for i := s; i <= e && i < int32(NumFvar); i++ {
@@ -5513,6 +5661,7 @@ func (c *Char) fvarRangeSet(s, e int32, v float32) {
 		}
 	}
 }
+
 func (c *Char) sysVarRangeSet(s, e, v int32) {
 	if s >= 0 {
 		for i := s; i <= e && i < int32(NumSysVar); i++ {
@@ -5520,6 +5669,7 @@ func (c *Char) sysVarRangeSet(s, e, v int32) {
 		}
 	}
 }
+
 func (c *Char) sysFvarRangeSet(s, e int32, v float32) {
 	if s >= 0 {
 		for i := s; i <= e && i < int32(NumSysFvar); i++ {
@@ -5527,6 +5677,7 @@ func (c *Char) sysFvarRangeSet(s, e int32, v float32) {
 		}
 	}
 }
+
 func (c *Char) setFacing(f float32) {
 	if f != 0 {
 		if (c.facing < 0) != (f < 0) {
@@ -5535,6 +5686,7 @@ func (c *Char) setFacing(f float32) {
 		}
 	}
 }
+
 func (c *Char) getTarget(id int32) []int32 {
 	if id < 0 { // In Mugen the ID must be specifically -1
 		return c.targets
@@ -5549,6 +5701,7 @@ func (c *Char) getTarget(id int32) []int32 {
 	}
 	return tg
 }
+
 func (c *Char) targetFacing(tar []int32, f int32) {
 	tf := c.facing
 	if f < 0 {
@@ -5560,6 +5713,7 @@ func (c *Char) targetFacing(tar []int32, f int32) {
 		}
 	}
 }
+
 func (c *Char) targetBind(tar []int32, time int32, x, y, z float32) {
 	for _, tid := range tar {
 		if t := sys.playerID(tid); t != nil {
@@ -5573,6 +5727,7 @@ func (c *Char) targetBind(tar []int32, time int32, x, y, z float32) {
 		}
 	}
 }
+
 func (c *Char) bindToTarget(tar []int32, time int32, x, y, z float32, hmf HMF) {
 	if len(tar) > 0 {
 		if t := sys.playerID(tar[0]); t != nil {
@@ -5600,6 +5755,7 @@ func (c *Char) bindToTarget(tar []int32, time int32, x, y, z float32, hmf HMF) {
 		}
 	}
 }
+
 func (c *Char) targetLifeAdd(tar []int32, add int32, kill, absolute, dizzy, redlife bool) {
 	for _, tid := range tar {
 		if t := sys.playerID(tid); t != nil {
@@ -5628,6 +5784,7 @@ func (c *Char) targetLifeAdd(tar []int32, add int32, kill, absolute, dizzy, redl
 		}
 	}
 }
+
 func (c *Char) targetPowerAdd(tar []int32, power int32) {
 	for _, tid := range tar {
 		if t := sys.playerID(tid); t != nil && t.player {
@@ -5635,6 +5792,7 @@ func (c *Char) targetPowerAdd(tar []int32, power int32) {
 		}
 	}
 }
+
 func (c *Char) targetDizzyPointsAdd(tar []int32, add int32, absolute bool) {
 	for _, tid := range tar {
 		if t := sys.playerID(tid); t != nil && !t.scf(SCF_dizzy) && !t.asf(ASF_nodizzypointsdamage) {
@@ -5642,6 +5800,7 @@ func (c *Char) targetDizzyPointsAdd(tar []int32, add int32, absolute bool) {
 		}
 	}
 }
+
 func (c *Char) targetGuardPointsAdd(tar []int32, add int32, absolute bool) {
 	for _, tid := range tar {
 		if t := sys.playerID(tid); t != nil && !t.asf(ASF_noguardpointsdamage) {
@@ -5649,6 +5808,7 @@ func (c *Char) targetGuardPointsAdd(tar []int32, add int32, absolute bool) {
 		}
 	}
 }
+
 func (c *Char) targetRedLifeAdd(tar []int32, add int32, absolute bool) {
 	for _, tid := range tar {
 		if t := sys.playerID(tid); t != nil && !t.asf(ASF_noredlifedamage) {
@@ -5656,6 +5816,7 @@ func (c *Char) targetRedLifeAdd(tar []int32, add int32, absolute bool) {
 		}
 	}
 }
+
 func (c *Char) targetScoreAdd(tar []int32, s float32) {
 	for _, tid := range tar {
 		if t := sys.playerID(tid); t != nil && t.player {
@@ -5663,6 +5824,7 @@ func (c *Char) targetScoreAdd(tar []int32, s float32) {
 		}
 	}
 }
+
 func (c *Char) targetState(tar []int32, state int32) {
 	if state >= 0 {
 		pn := c.ss.sb.playerNo
@@ -5677,6 +5839,7 @@ func (c *Char) targetState(tar []int32, state int32) {
 		}
 	}
 }
+
 func (c *Char) targetVelSetX(tar []int32, x float32) {
 	for _, tid := range tar {
 		if t := sys.playerID(tid); t != nil {
@@ -5685,6 +5848,7 @@ func (c *Char) targetVelSetX(tar []int32, x float32) {
 		}
 	}
 }
+
 func (c *Char) targetVelSetY(tar []int32, y float32) {
 	for _, tid := range tar {
 		if t := sys.playerID(tid); t != nil {
@@ -5693,6 +5857,7 @@ func (c *Char) targetVelSetY(tar []int32, y float32) {
 		}
 	}
 }
+
 func (c *Char) targetVelSetZ(tar []int32, z float32) {
 	for _, tid := range tar {
 		if t := sys.playerID(tid); t != nil {
@@ -5701,6 +5866,7 @@ func (c *Char) targetVelSetZ(tar []int32, z float32) {
 		}
 	}
 }
+
 func (c *Char) targetVelAddX(tar []int32, x float32) {
 	for _, tid := range tar {
 		if t := sys.playerID(tid); t != nil {
@@ -5709,6 +5875,7 @@ func (c *Char) targetVelAddX(tar []int32, x float32) {
 		}
 	}
 }
+
 func (c *Char) targetVelAddY(tar []int32, y float32) {
 	for _, tid := range tar {
 		if t := sys.playerID(tid); t != nil {
@@ -5717,6 +5884,7 @@ func (c *Char) targetVelAddY(tar []int32, y float32) {
 		}
 	}
 }
+
 func (c *Char) targetVelAddZ(tar []int32, z float32) {
 	for _, tid := range tar {
 		if t := sys.playerID(tid); t != nil {
@@ -5725,6 +5893,7 @@ func (c *Char) targetVelAddZ(tar []int32, z float32) {
 		}
 	}
 }
+
 func (c *Char) targetDrop(excludeid int32, excludechar int32, keepone bool) {
 	var tg []int32
 	// Keep the player with this "player ID". Used with "HitOnce" attacks such as throws
@@ -5843,6 +6012,7 @@ func (c *Char) lifeAdd(add float64, kill, absolute bool) {
 	// Using LifeAdd currently does not touch the red life value
 	// This could be expanded in the future, as with TargetLifeAdd
 }
+
 func (c *Char) lifeSet(life int32) {
 	if c.alive() && sys.roundNoDamage() {
 		return
@@ -5887,6 +6057,7 @@ func (c *Char) lifeSet(life int32) {
 		c.redLife = c.life
 	}
 }
+
 func (c *Char) setPower(pow int32) {
 	// In Mugen, power cannot be changed at all after the round ends
 	// TODO: This is probably too restrictive
@@ -5899,6 +6070,7 @@ func (c *Char) setPower(pow int32) {
 		c.power = Clamp(pow, 0, c.powerMax)
 	}
 }
+
 func (c *Char) powerAdd(add int32) {
 	// Safely convert from float64 back to int32 after all calculations are done
 	int := F64toI32(float64(c.getPower()) + math.Round(float64(add)))
@@ -5917,6 +6089,7 @@ func (c *Char) powerSet(pow int32) {
 		sys.chars[c.playerNo][0].setPower(pow)
 	}
 }
+
 func (c *Char) dizzyPointsAdd(add float64, absolute bool) {
 	if add == 0 {
 		return
@@ -5928,11 +6101,13 @@ func (c *Char) dizzyPointsAdd(add float64, absolute bool) {
 	int := F64toI32(float64(c.dizzyPoints) + math.Round(add))
 	c.dizzyPointsSet(int)
 }
+
 func (c *Char) dizzyPointsSet(set int32) {
 	if sys.lifebar.stunbar && !sys.roundNoDamage() {
 		c.dizzyPoints = Clamp(set, 0, c.dizzyPointsMax)
 	}
 }
+
 func (c *Char) guardPointsAdd(add float64, absolute bool) {
 	if add == 0 {
 		return
@@ -5944,11 +6119,13 @@ func (c *Char) guardPointsAdd(add float64, absolute bool) {
 	int := F64toI32(float64(c.guardPoints) + math.Round(add))
 	c.guardPointsSet(int)
 }
+
 func (c *Char) guardPointsSet(set int32) {
 	if sys.lifebar.guardbar && !sys.roundNoDamage() {
 		c.guardPoints = Clamp(set, 0, c.guardPointsMax)
 	}
 }
+
 func (c *Char) redLifeAdd(add float64, absolute bool) {
 	if add == 0 {
 		return
@@ -5960,6 +6137,7 @@ func (c *Char) redLifeAdd(add float64, absolute bool) {
 	int := F64toI32(float64(c.redLife) + math.Round(add))
 	c.redLifeSet(int)
 }
+
 func (c *Char) redLifeSet(set int32) {
 	if !c.alive() {
 		c.redLife = 0
@@ -5967,18 +6145,21 @@ func (c *Char) redLifeSet(set int32) {
 		c.redLife = Clamp(set, c.life, c.lifeMax)
 	}
 }
+
 func (c *Char) score() float32 {
 	if c.teamside == -1 {
 		return 0
 	}
 	return sys.lifebar.sc[c.teamside].scorePoints
 }
+
 func (c *Char) scoreAdd(val float32) {
 	if c.teamside == -1 {
 		return
 	}
 	sys.lifebar.sc[c.teamside].scorePoints += val
 }
+
 func (c *Char) scoreTotal() float32 {
 	if c.teamside == -1 {
 		return 0
@@ -5992,12 +6173,14 @@ func (c *Char) scoreTotal() float32 {
 	}
 	return s
 }
+
 func (c *Char) consecutiveWins() int32 {
 	if c.teamside == -1 {
 		return 0
 	}
 	return sys.consecutiveWins[c.teamside]
 }
+
 func (c *Char) distX(opp *Char, oc *Char) float32 {
 	cpos := c.pos[0] * c.localscl
 	opos := opp.pos[0] * opp.localscl
@@ -6019,6 +6202,7 @@ func (c *Char) distX(opp *Char, oc *Char) float32 {
 	}
 	return dist
 }
+
 func (c *Char) distY(opp *Char, oc *Char) float32 {
 	cpos := c.pos[1] * c.localscl
 	opos := opp.pos[1] * opp.localscl
@@ -6092,6 +6276,7 @@ func (c *Char) rdDistX(rd *Char, oc *Char) BytecodeValue {
 	}
 	return BytecodeFloat(dist)
 }
+
 func (c *Char) rdDistY(rd *Char, oc *Char) BytecodeValue {
 	if rd == nil {
 		return BytecodeSF()
@@ -6125,6 +6310,7 @@ func (c *Char) p2BodyDistX(oc *Char) BytecodeValue {
 		return BytecodeFloat(dist)
 	}
 }
+
 func (c *Char) p2BodyDistY(oc *Char) BytecodeValue {
 	if p2 := c.p2(); p2 == nil {
 		return BytecodeSF()
@@ -6159,6 +6345,7 @@ func (c *Char) setPauseTime(pausetime, movetime int32) {
 		c.pauseMovetime--
 	}
 }
+
 func (c *Char) setSuperPauseTime(pausetime, movetime int32, unhittable bool) {
 	if ^pausetime < sys.supertime || c.playerNo != c.ss.sb.playerNo ||
 		sys.superplayer == c.playerNo {
@@ -6178,6 +6365,7 @@ func (c *Char) setSuperPauseTime(pausetime, movetime int32, unhittable bool) {
 		c.unhittableTime = pausetime + Btoi(pausetime > 0)
 	}
 }
+
 func (c *Char) getPalfx() *PalFX {
 	if c.palfx != nil {
 		return c.palfx
@@ -6194,15 +6382,19 @@ func (c *Char) getPalfx() *PalFX {
 	}
 	return c.palfx
 }
+
 func (c *Char) getPalMap() []int {
 	return c.getPalfx().remap
 }
+
 func (c *Char) pause() bool {
 	return c.acttmp <= -2
 }
+
 func (c *Char) hitPause() bool {
 	return c.hitPauseTime > 0
 }
+
 func (c *Char) angleSet(a float32) {
 	c.angle = a
 }
@@ -6243,12 +6435,14 @@ func (c *Char) makeDust(x, y, z float32) {
 		c.insertExplod(i)
 	}
 }
+
 func (c *Char) hitFallDamage() {
 	if c.ss.moveType == MT_H {
 		c.lifeAdd(-float64(c.ghv.fall_damage), c.ghv.fall_kill, false)
 		c.ghv.fall_damage = 0
 	}
 }
+
 func (c *Char) hitFallVel() {
 	if c.ss.moveType == MT_H {
 		if !math.IsNaN(float64(c.ghv.fall_xvelocity)) {
@@ -6260,6 +6454,7 @@ func (c *Char) hitFallVel() {
 		}
 	}
 }
+
 func (c *Char) hitFallSet(f int32, xv, yv, zv float32) {
 	if f >= 0 {
 		c.ghv.fallflag = f != 0
@@ -6359,6 +6554,7 @@ func (c *Char) remapSprite(src [2]int16, dst [2]int16) {
 	}
 	c.remapSpr[src[0]][src[1]] = [...]int16{dst[0], dst[1]}
 }
+
 func (c *Char) remapSpritePreset(preset string) {
 	if _, ok := c.gi().remapPreset[preset]; !ok {
 		return
@@ -6642,6 +6838,7 @@ func (c *Char) addTarget(id int32) {
 		c.targets = append(c.targets, id)
 	}
 }
+
 func (c *Char) hasTarget(id int32) bool {
 	for _, tid := range c.targets {
 		if tid == id {
@@ -6650,6 +6847,7 @@ func (c *Char) hasTarget(id int32) bool {
 	}
 	return false
 }
+
 func (c *Char) hasTargetOfHitdef(id int32) bool {
 	for _, tid := range c.hitdefTargets {
 		if tid == id {
@@ -6658,6 +6856,7 @@ func (c *Char) hasTargetOfHitdef(id int32) bool {
 	}
 	return false
 }
+
 func (c *Char) setBindTime(time int32) {
 	c.bindTime = time
 	if time == 0 {
@@ -6665,6 +6864,7 @@ func (c *Char) setBindTime(time int32) {
 		c.bindFacing = 0
 	}
 }
+
 func (c *Char) setBindToId(to *Char) {
 	if c.bindToId != to.id {
 		c.bindToId = to.id
@@ -6676,6 +6876,7 @@ func (c *Char) setBindToId(to *Char) {
 		to.setBindTime(0)
 	}
 }
+
 func (c *Char) bind() {
 	if c.bindTime == 0 {
 		if bt := sys.playerID(c.bindToId); bt != nil {
@@ -6742,6 +6943,7 @@ func (c *Char) bind() {
 		return
 	}
 }
+
 func (c *Char) trackableByCamera() bool {
 	return sys.cam.View == Fighting_View || sys.cam.View == Follow_View && c == sys.cam.FollowChar
 }
@@ -6781,11 +6983,13 @@ func (c *Char) xPlatformBound(pxmin, pxmax float32) {
 	c.setX(x)
 	c.xScreenBound()
 }
+
 func (c *Char) gethitBindClear() {
 	if c.isBound() {
 		c.setBindTime(0)
 	}
 }
+
 func (c *Char) dropTargets() {
 	if c.hitdef.reversal_attr == 0 || c.hitdef.reversal_attr == -1<<31 {
 		i := 0
@@ -6809,6 +7013,7 @@ func (c *Char) dropTargets() {
 		}
 	}
 }
+
 func (c *Char) removeTarget(pid int32) {
 	for i, t := range c.targets {
 		if t == pid {
@@ -6837,6 +7042,7 @@ func (c *Char) exitTarget() {
 func (c *Char) offsetX() float32 {
 	return float32(c.size.draw.offset[0])*c.facing + c.offset[0]/c.localscl
 }
+
 func (c *Char) offsetY() float32 {
 	return float32(c.size.draw.offset[1]) + c.offset[1]/c.localscl
 }
@@ -7625,6 +7831,7 @@ func (c *Char) actionRun() {
 	c.minus = 1
 	c.acttmp += int8(Btoi(!c.pause() && !c.hitPause())) - int8(Btoi(c.hitPause()))
 }
+
 func (c *Char) actionFinish() {
 	if c.minus < 1 || c.csf(CSF_destroy) || c.scf(SCF_disabled) {
 		return
@@ -7659,12 +7866,13 @@ func (c *Char) actionFinish() {
 	if c.alive() && c.life > 0 && !sys.roundEnd() {
 		c.unsetSCF(SCF_over_alive | SCF_over_ko)
 	}
-	if c.ss.no == 5150 { // Actual KO is not required in Mugen
+	if c.ss.no == 5150 && !c.scf(SCF_over_ko) { // Actual KO is not required in Mugen
 		c.setSCF(SCF_over_ko)
-		sys.charList.p2enemyDelete(c) // Every status change that invalidates the P2 reference must run this
+		sys.charList.p2enemyDelete(c)
 	}
 	c.minus = 1
 }
+
 func (c *Char) track() {
 	if c.trackableByCamera() {
 		min, max := c.edge[0], -c.edge[1]
@@ -7777,8 +7985,8 @@ func (c *Char) update() {
 			}
 		}
 		// Remove self from target lists of other players
-		// In Mugen, this seems to happen only after hit detection and even even if the players are paused
-		// This placement makes more sense but this difference seems partially responsible the test case in issue #1891 not working currently
+		// In Mugen, this seems to happen only after hit detection and even if the players are paused
+		// This placement makes more sense but this difference seems partially responsible for the test case in issue #1891 not working currently
 		// Also https://github.com/ikemen-engine/Ikemen-GO/issues/1592
 		if c.ss.moveType != MT_H || c.ss.no == 5150 {
 			c.exitTarget()
@@ -8280,6 +8488,7 @@ func (cl *CharList) clear() {
 	*cl = CharList{idMap: make(map[int32]*Char)}
 	sys.nextCharId = sys.cfg.Config.HelperMax
 }
+
 func (cl *CharList) add(c *Char) {
 	// Append to run order
 	cl.runOrder = append(cl.runOrder, c)
@@ -8298,6 +8507,7 @@ func (cl *CharList) add(c *Char) {
 	}
 	cl.idMap[c.id] = c
 }
+
 func (cl *CharList) replace(dc *Char, pn int, idx int32) bool {
 	var ok bool
 	// Replace run order
@@ -8321,6 +8531,7 @@ func (cl *CharList) replace(dc *Char, pn int, idx int32) bool {
 	}
 	return ok
 }
+
 func (cl *CharList) delete(dc *Char) {
 	for i, c := range cl.runOrder {
 		if c == dc {
@@ -9957,12 +10168,14 @@ func (cl *CharList) cueDraw() {
 		}
 	}
 }
+
 func (cl *CharList) get(id int32) *Char {
 	if id < 0 {
 		return nil
 	}
 	return cl.idMap[id]
 }
+
 func (cl *CharList) getIndex(id int32) *Char {
 	for j, p := range cl.runOrder {
 		if (id - 1) == int32(j) {
@@ -9971,7 +10184,8 @@ func (cl *CharList) getIndex(id int32) *Char {
 	}
 	return nil
 }
-func (cl *CharList) getHelperIndex(c *Char, id int32, ex bool) *Char {
+
+func (cl *CharList) getHelperIndex(c *Char, id int32, log bool) *Char {
 	var t []int32
 	parent := func(c *Char) *Char {
 		if c.parentIndex == IErr {
@@ -10003,7 +10217,7 @@ func (cl *CharList) getHelperIndex(c *Char, id int32, ex bool) *Char {
 			return ch
 		}
 	}
-	if !ex {
+	if log {
 		sys.appendToConsole(c.warn() + fmt.Sprintf("has no helper with index: %v", id))
 	}
 	return nil

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -1000,7 +1000,7 @@ func (sb *StunBar) step(ref int, sbr *StunBar, snd *Snd) {
 	// Multiple front elements
 	var mv float32
 	for k := range sb.front {
-		if k > mv && (1-points) >= k/100 {
+		if k > mv && points >= k/100 {
 			mv = k
 		}
 	}
@@ -1067,7 +1067,7 @@ func (sb *StunBar) draw(layerno int16, ref int, sbr *StunBar, f []*Fnt) {
 	// Multiple front elements
 	var mv float32
 	for k := range sb.front {
-		if k > mv && (1-points) >= k/100 {
+		if k > mv && points >= k/100 {
 			mv = k
 		}
 	}
@@ -1537,10 +1537,19 @@ func (ti *LifeBarTime) draw(layerno int16, f []*Fnt) {
 			timeval = int32(math.Ceil(float64(sys.time) / float64(ti.framespercount)))
 			time = fmt.Sprintf("%v", timeval)
 		}
+		// Multiple fonts according to time remaining
 		var tv int32
-		for k := range ti.counter {
-			if k > tv && timeval >= k {
-				tv = k
+		if timeval < 0 { // Infinite time. Select the highest group
+			for k := range ti.counter {
+				if k > tv {
+					tv = k
+				}
+			}
+		} else {
+			for k := range ti.counter {
+				if k > tv && timeval >= k {
+					tv = k
+				}
 			}
 		}
 		ti.counter[tv].lay.DrawText(float32(ti.pos[0])+sys.lifebarOffsetX, float32(ti.pos[1]), sys.lifebarScale, layerno,

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -155,6 +155,7 @@ func newLbText(align int32) *LbText {
 	return &LbText{font: [...]int32{-1, 0, align, 255, 255, 255},
 		palfx: newPalFX(), frgba: [...]float32{1.0, 1.0, 1.0, 1.0}}
 }
+
 func readLbText(pre string, is IniSection, str string, ln int16, f []*Fnt, align int32) *LbText {
 	txt := newLbText(align)
 	is.ReadI32(pre+"font", &txt.font[0], &txt.font[1], &txt.font[2],
@@ -301,6 +302,7 @@ func newHealthBar() *HealthBar {
 		red: make(map[int32]*AnimLayout), front: make(map[float32]*AnimLayout),
 		mid_freeze: true, mid_delay: 30, mid_mult: 1.0, mid_steps: 8.0}
 }
+
 func readHealthBar(pre string, is IniSection,
 	sff *Sff, at AnimationTable, f []*Fnt) *HealthBar {
 	hb := newHealthBar()
@@ -331,6 +333,7 @@ func readHealthBar(pre string, is IniSection,
 	hb.warn = *ReadAnimLayout(pre+"warn.", is, sff, at, 0)
 	return hb
 }
+
 func (hb *HealthBar) step(ref int, hbr *HealthBar) {
 	var life float32 = float32(sys.chars[ref][0].life) / float32(sys.chars[ref][0].lifeMax)
 	//redlife := (float32(sys.chars[ref][0].life) + float32(sys.chars[ref][0].redLife)) / float32(sys.chars[ref][0].lifeMax)
@@ -342,8 +345,11 @@ func (hb *HealthBar) step(ref int, hbr *HealthBar) {
 	} else {
 		hbr.toplife = life
 	}
+
+	// Element shifting gradient
 	hb.shift.anim.srcAlpha = int16(255 * (1 - life))
 	hb.shift.anim.dstAlpha = int16(255 * life)
+
 	if !hb.mid_freeze && getHit && !hb.gethit && len(hb.mid.anim.frames) > 0 {
 		hbr.mlifetime = hb.mid_delay
 		hbr.midlife = hbr.oldlife
@@ -373,15 +379,19 @@ func (hb *HealthBar) step(ref int, hbr *HealthBar) {
 		}
 		hbr.oldlife = life
 	}
+
 	mlmin := MaxF(hbr.midlifeMin, life)
 	if hbr.midlife < mlmin {
 		hbr.midlife += (mlmin - hbr.midlife) / 2
 	}
+
 	hb.bg0.Action()
 	hb.bg1.Action()
 	hb.bg2.Action()
 	hb.top.Action()
 	hb.mid.Action()
+
+	// Multiple front elements - red life
 	var rv int32
 	for k := range hb.red {
 		if k > rv && redVal >= k {
@@ -389,6 +399,8 @@ func (hb *HealthBar) step(ref int, hbr *HealthBar) {
 		}
 	}
 	hb.red[rv].Action()
+
+	// Multiple front elements - life
 	var fv float32
 	for k := range hb.front {
 		if k > fv && life >= k/100 {
@@ -396,9 +408,11 @@ func (hb *HealthBar) step(ref int, hbr *HealthBar) {
 		}
 	}
 	hb.front[fv].Action()
+
 	hb.shift.Action()
 	hb.warn.Action()
 }
+
 func (hb *HealthBar) reset() {
 	hb.bg0.Reset()
 	hb.bg1.Reset()
@@ -416,11 +430,13 @@ func (hb *HealthBar) reset() {
 	}
 	hb.warn.Reset()
 }
+
 func (hb *HealthBar) bgDraw(layerno int16) {
 	hb.bg0.Draw(float32(hb.pos[0])+sys.lifebarOffsetX, float32(hb.pos[1]), layerno, sys.lifebarScale)
 	hb.bg1.Draw(float32(hb.pos[0])+sys.lifebarOffsetX, float32(hb.pos[1]), layerno, sys.lifebarScale)
 	hb.bg2.Draw(float32(hb.pos[0])+sys.lifebarOffsetX, float32(hb.pos[1]), layerno, sys.lifebarScale)
 }
+
 func (hb *HealthBar) draw(layerno int16, ref int, hbr *HealthBar, f []*Fnt) {
 	life := float32(sys.chars[ref][0].life) / float32(sys.chars[ref][0].lifeMax)
 	redlife := float32(sys.chars[ref][0].redLife) / float32(sys.chars[ref][0].lifeMax)
@@ -447,6 +463,7 @@ func (hb *HealthBar) draw(layerno int16, ref int, hbr *HealthBar, f []*Fnt) {
 	}
 	mr[2] -= Min(mr[2], lr[2])
 	//rr[2] -= Min(rr[2], lr[2])
+
 	var rv int32
 	if sys.lifebar.redlifebar {
 		for k := range hb.red {
@@ -457,12 +474,16 @@ func (hb *HealthBar) draw(layerno int16, ref int, hbr *HealthBar, f []*Fnt) {
 		hb.red[rv].lay.DrawAnim(&rr, float32(hb.pos[0])+sys.lifebarOffsetX, float32(hb.pos[1]), sys.lifebarScale,
 			layerno, &hb.red[rv].anim, hb.red[rv].palfx)
 	}
+
 	hb.mid.lay.DrawAnim(&mr, float32(hb.pos[0])+sys.lifebarOffsetX, float32(hb.pos[1]), sys.lifebarScale,
 		layerno, &hb.mid.anim, hb.mid.palfx)
+
 	if hb.mid_shift {
 		hb.shift.lay.DrawAnim(&mr, float32(hb.pos[0])+sys.lifebarOffsetX, float32(hb.pos[1]), sys.lifebarScale,
 			layerno, &hb.shift.anim, hb.shift.palfx)
 	}
+
+	// Multiple front elements
 	var fv float32
 	for k := range hb.front {
 		if k > fv && life >= k/100 {
@@ -471,15 +492,19 @@ func (hb *HealthBar) draw(layerno int16, ref int, hbr *HealthBar, f []*Fnt) {
 	}
 	hb.front[fv].lay.DrawAnim(&lr, float32(hb.pos[0])+sys.lifebarOffsetX, float32(hb.pos[1]), sys.lifebarScale,
 		layerno, &hb.front[fv].anim, hb.front[fv].palfx)
+
 	hb.shift.lay.DrawAnim(&lr, float32(hb.pos[0])+sys.lifebarOffsetX, float32(hb.pos[1]), sys.lifebarScale,
 		layerno, &hb.shift.anim, hb.shift.palfx)
+
 	if hb.value.font[0] >= 0 && int(hb.value.font[0]) < len(f) && f[hb.value.font[0]] != nil {
 		text := strings.Replace(hb.value.text, "%d", fmt.Sprintf("%v", sys.chars[ref][0].life), 1)
 		text = strings.Replace(text, "%p", fmt.Sprintf("%v", math.Round(float64(life)*100)), 1)
 		hb.value.lay.DrawText(float32(hb.pos[0])+sys.lifebarOffsetX, float32(hb.pos[1]), sys.lifebarScale,
 			layerno, text, f[hb.value.font[0]], hb.value.font[1], hb.value.font[2], hb.value.palfx, hb.value.frgba)
 	}
+
 	hb.top.Draw(float32(hb.pos[0])+sys.lifebarOffsetX, float32(hb.pos[1]), layerno, sys.lifebarScale)
+
 	if life <= float32(hb.warn_range[0])/100 && life >= float32(hb.warn_range[1])/100 {
 		hb.warn.Draw(float32(hb.pos[0])+sys.lifebarOffsetX, float32(hb.pos[1]), layerno, sys.lifebarScale)
 	}
@@ -568,8 +593,11 @@ func (pb *PowerBar) step(ref int, pbr *PowerBar, snd *Snd) {
 	if pb.levelbars {
 		power = float32(pbval)/1000 - MinF(float32(level), float32(sys.chars[ref][0].powerMax)/1000-1)
 	}
+
+	// Element shifting gradient
 	pb.shift.anim.srcAlpha = int16(255 * (1 - power))
 	pb.shift.anim.dstAlpha = int16(255 * power)
+
 	pbr.midpower -= 1.0 / 144
 	if power < pbr.midpowerMin {
 		pbr.midpowerMin += (power - pbr.midpowerMin) * (1 / (12 - (power-pbr.midpowerMin)*144))
@@ -579,6 +607,7 @@ func (pb *PowerBar) step(ref int, pbr *PowerBar, snd *Snd) {
 	if pbr.midpower < pbr.midpowerMin {
 		pbr.midpower = pbr.midpowerMin
 	}
+
 	// Level sounds
 	// TODO: These probably shouldn't play when the powerbar is invisible
 	if level > pbr.prevLevel {
@@ -588,6 +617,8 @@ func (pb *PowerBar) step(ref int, pbr *PowerBar, snd *Snd) {
 		}
 	}
 	pbr.prevLevel = level
+
+	// Multiple front elements
 	var fv1 int32
 	for k := range pb.bg0 {
 		if k > fv1 && pbval >= k {
@@ -595,10 +626,13 @@ func (pb *PowerBar) step(ref int, pbr *PowerBar, snd *Snd) {
 		}
 	}
 	pb.bg0[fv1].Action()
+
 	pb.bg1.Action()
 	pb.bg2.Action()
 	pb.top.Action()
 	pb.mid.Action()
+
+	// Multiple front elements
 	var fv2 int32
 	for k := range pb.front {
 		if k > fv2 && pbval >= k {
@@ -606,6 +640,7 @@ func (pb *PowerBar) step(ref int, pbr *PowerBar, snd *Snd) {
 		}
 	}
 	pb.front[fv2].Action()
+
 	pb.shift.Action()
 }
 
@@ -624,6 +659,7 @@ func (pb *PowerBar) reset() {
 	pb.shift.anim.srcAlpha = 0
 	pb.shift.anim.dstAlpha = 255
 }
+
 func (pb *PowerBar) bgDraw(layerno int16, ref int) {
 	pbval := sys.chars[ref][0].getPower()
 	var fv int32
@@ -636,13 +672,16 @@ func (pb *PowerBar) bgDraw(layerno int16, ref int) {
 	pb.bg1.Draw(float32(pb.pos[0])+sys.lifebarOffsetX, float32(pb.pos[1]), layerno, sys.lifebarScale)
 	pb.bg2.Draw(float32(pb.pos[0])+sys.lifebarOffsetX, float32(pb.pos[1]), layerno, sys.lifebarScale)
 }
+
 func (pb *PowerBar) draw(layerno int16, ref int, pbr *PowerBar, f []*Fnt) {
 	pbval := sys.chars[ref][0].getPower()
 	power := float32(pbval) / float32(sys.chars[ref][0].powerMax)
 	level := pbval / 1000
+
 	if pb.levelbars {
 		power = float32(pbval)/1000 - MinF(float32(level), float32(sys.chars[ref][0].powerMax)/1000-1)
 	}
+
 	var MidPos = (float32(sys.gameWidth-320) / 2)
 	width := func(power float32) (r [4]int32) {
 		r = sys.scrrect
@@ -660,8 +699,11 @@ func (pb *PowerBar) draw(layerno int16, ref int, pbr *PowerBar, f []*Fnt) {
 		mr[0] += pr[2]
 	}
 	mr[2] -= Min(mr[2], pr[2])
+
 	pb.mid.lay.DrawAnim(&mr, float32(pb.pos[0])+sys.lifebarOffsetX, float32(pb.pos[1]), sys.lifebarScale,
 		layerno, &pb.mid.anim, pb.mid.palfx)
+
+	// Multiple front elements
 	var fv int32
 	for k := range pb.front {
 		if k > fv && pbval >= k {
@@ -670,6 +712,7 @@ func (pb *PowerBar) draw(layerno int16, ref int, pbr *PowerBar, f []*Fnt) {
 	}
 	pb.front[fv].lay.DrawAnim(&pr, float32(pb.pos[0])+sys.lifebarOffsetX, float32(pb.pos[1]), sys.lifebarScale,
 		layerno, &pb.front[fv].anim, pb.front[fv].palfx)
+
 	pb.shift.lay.DrawAnim(&pr, float32(pb.pos[0])+sys.lifebarOffsetX, float32(pb.pos[1]), sys.lifebarScale,
 		layerno, &pb.shift.anim, pb.shift.palfx)
 
@@ -725,13 +768,14 @@ type GuardBar struct {
 	shift       AnimLayout
 	midpower    float32
 	midpowerMin float32
-	//prevLevel   int32
+	invertfill  bool
 }
 
 func newGuardBar() (gb *GuardBar) {
 	gb = &GuardBar{front: make(map[float32]*AnimLayout)}
 	return
 }
+
 func readGuardBar(pre string, is IniSection,
 	sff *Sff, at AnimationTable, f []*Fnt) *GuardBar {
 	gb := newGuardBar()
@@ -750,20 +794,29 @@ func readGuardBar(pre string, is IniSection,
 	gb.value = *readLbText(pre+"value.", is, "%d", 0, f, 0)
 	is.ReadI32(pre+"warn.range", &gb.warn_range[0], &gb.warn_range[1])
 	gb.warn = *ReadAnimLayout(pre+"warn.", is, sff, at, 0)
+	is.ReadBool(pre+"invertfill", &gb.invertfill)
 	return gb
 }
+
 func (gb *GuardBar) step(ref int, gbr *GuardBar, snd *Snd) {
 	if !sys.lifebar.guardbar {
 		return
 	}
-	power := float32(sys.chars[ref][0].guardPoints) / float32(sys.chars[ref][0].guardPointsMax)
-	gb.shift.anim.srcAlpha = int16(255 * (1 - power))
-	gb.shift.anim.dstAlpha = int16(255 * power)
+
+	points := float32(sys.chars[ref][0].guardPoints) / float32(sys.chars[ref][0].guardPointsMax)
+	if gb.invertfill {
+		points = 1 - points
+	}
+
+	// Element shifting gradient
+	gb.shift.anim.srcAlpha = int16(255 * (1 - points))
+	gb.shift.anim.dstAlpha = int16(255 * points)
+
 	gbr.midpower -= 1.0 / 144
-	if power < gbr.midpowerMin {
-		gbr.midpowerMin += (power - gbr.midpowerMin) * (1 / (12 - (power-gbr.midpowerMin)*144))
+	if points < gbr.midpowerMin {
+		gbr.midpowerMin += (points - gbr.midpowerMin) * (1 / (12 - (points-gbr.midpowerMin)*144))
 	} else {
-		gbr.midpowerMin = power
+		gbr.midpowerMin = points
 	}
 	if gbr.midpower < gbr.midpowerMin {
 		gbr.midpower = gbr.midpowerMin
@@ -773,16 +826,20 @@ func (gb *GuardBar) step(ref int, gbr *GuardBar, snd *Snd) {
 	gb.bg2.Action()
 	gb.top.Action()
 	gb.mid.Action()
+
+	// Multiple front elements
 	var mv float32
 	for k := range gb.front {
-		if k > mv && power >= k/100 {
+		if k > mv && points >= k/100 {
 			mv = k
 		}
 	}
 	gb.front[mv].Action()
+
 	gb.shift.Action()
 	gb.warn.Action()
 }
+
 func (gb *GuardBar) reset() {
 	gb.bg0.Reset()
 	gb.bg1.Reset()
@@ -797,6 +854,7 @@ func (gb *GuardBar) reset() {
 	gb.shift.anim.dstAlpha = 255
 	gb.warn.Reset()
 }
+
 func (gb *GuardBar) bgDraw(layerno int16) {
 	if !sys.lifebar.guardbar {
 		return
@@ -805,11 +863,17 @@ func (gb *GuardBar) bgDraw(layerno int16) {
 	gb.bg1.Draw(float32(gb.pos[0])+sys.lifebarOffsetX, float32(gb.pos[1]), layerno, sys.lifebarScale)
 	gb.bg2.Draw(float32(gb.pos[0])+sys.lifebarOffsetX, float32(gb.pos[1]), layerno, sys.lifebarScale)
 }
+
 func (gb *GuardBar) draw(layerno int16, ref int, gbr *GuardBar, f []*Fnt) {
 	if !sys.lifebar.guardbar {
 		return
 	}
+
 	points := float32(sys.chars[ref][0].guardPoints) / float32(sys.chars[ref][0].guardPointsMax)
+	if gb.invertfill {
+		points = 1 - points
+	}
+
 	var MidPos = (float32(sys.gameWidth-320) / 2)
 	width := func(points float32) (r [4]int32) {
 		r = sys.scrrect
@@ -822,13 +886,17 @@ func (gb *GuardBar) draw(layerno int16, ref int, gbr *GuardBar, f []*Fnt) {
 		}
 		return
 	}
+
 	pr, mr := width(points), width(gbr.midpower)
+
 	if gb.range_x[0] < gb.range_x[1] {
 		mr[0] += pr[2]
 	}
 	mr[2] -= Min(mr[2], pr[2])
 	gb.mid.lay.DrawAnim(&mr, float32(gb.pos[0])+sys.lifebarOffsetX, float32(gb.pos[1]), sys.lifebarScale,
 		layerno, &gb.mid.anim, gb.mid.palfx)
+
+	// Multiple front elements
 	var mv float32
 	for k := range gb.front {
 		if k > mv && points >= k/100 {
@@ -837,17 +905,21 @@ func (gb *GuardBar) draw(layerno int16, ref int, gbr *GuardBar, f []*Fnt) {
 	}
 	gb.front[mv].lay.DrawAnim(&pr, float32(gb.pos[0])+sys.lifebarOffsetX, float32(gb.pos[1]), sys.lifebarScale,
 		layerno, &gb.front[mv].anim, gb.front[mv].palfx)
+
 	gb.shift.lay.DrawAnim(&pr, float32(gb.pos[0])+sys.lifebarOffsetX, float32(gb.pos[1]), sys.lifebarScale,
 		layerno, &gb.shift.anim, gb.shift.palfx)
+
 	if gb.value.font[0] >= 0 && int(gb.value.font[0]) < len(f) && f[gb.value.font[0]] != nil {
 		text := strings.Replace(gb.value.text, "%d", fmt.Sprintf("%v", sys.chars[ref][0].guardPoints), 1)
 		text = strings.Replace(text, "%p", fmt.Sprintf("%v", math.Round(float64(points)*100)), 1)
 		gb.value.lay.DrawText(float32(gb.pos[0])+sys.lifebarOffsetX, float32(gb.pos[1]), sys.lifebarScale,
 			layerno, text, f[gb.value.font[0]], gb.value.font[1], gb.value.font[2], gb.value.palfx, gb.value.frgba)
 	}
+
 	if points <= float32(gb.warn_range[0])/100 && points >= float32(gb.warn_range[1])/100 {
 		gb.warn.Draw(float32(gb.pos[0])+sys.lifebarOffsetX, float32(gb.pos[1]), layerno, sys.lifebarScale)
 	}
+
 	gb.top.Draw(float32(gb.pos[0])+sys.lifebarOffsetX, float32(gb.pos[1]), layerno, sys.lifebarScale)
 }
 
@@ -866,12 +938,14 @@ type StunBar struct {
 	shift       AnimLayout
 	midpower    float32
 	midpowerMin float32
+	invertfill  bool
 }
 
 func newStunBar() (sb *StunBar) {
 	sb = &StunBar{front: make(map[float32]*AnimLayout)}
 	return
 }
+
 func readStunBar(pre string, is IniSection,
 	sff *Sff, at AnimationTable, f []*Fnt) *StunBar {
 	sb := newStunBar()
@@ -890,15 +964,24 @@ func readStunBar(pre string, is IniSection,
 	sb.value = *readLbText(pre+"value.", is, "%d", 0, f, 0)
 	is.ReadI32(pre+"warn.range", &sb.warn_range[0], &sb.warn_range[1])
 	sb.warn = *ReadAnimLayout(pre+"warn.", is, sff, at, 0)
+	is.ReadBool(pre+"invertfill", &sb.invertfill)
 	return sb
 }
+
 func (sb *StunBar) step(ref int, sbr *StunBar, snd *Snd) {
 	if !sys.lifebar.stunbar {
 		return
 	}
-	points := 1 - float32(sys.chars[ref][0].dizzyPoints)/float32(sys.chars[ref][0].dizzyPointsMax)
-	sb.shift.anim.srcAlpha = int16(255 * points)
-	sb.shift.anim.dstAlpha = int16(255 * (1 - points))
+
+	points := float32(sys.chars[ref][0].dizzyPoints) / float32(sys.chars[ref][0].dizzyPointsMax)
+	if sb.invertfill {
+		points = 1 - points
+	}
+
+	// Element shifting gradient
+	sb.shift.anim.srcAlpha = int16(255 * (1 - points))
+	sb.shift.anim.dstAlpha = int16(255 * points)
+
 	sbr.midpower -= 1.0 / 144
 	if points < sbr.midpowerMin {
 		sbr.midpowerMin += (points - sbr.midpowerMin) * (1 / (12 - (points-sbr.midpowerMin)*144))
@@ -913,6 +996,8 @@ func (sb *StunBar) step(ref int, sbr *StunBar, snd *Snd) {
 	sb.bg2.Action()
 	sb.top.Action()
 	sb.mid.Action()
+
+	// Multiple front elements
 	var mv float32
 	for k := range sb.front {
 		if k > mv && (1-points) >= k/100 {
@@ -920,9 +1005,11 @@ func (sb *StunBar) step(ref int, sbr *StunBar, snd *Snd) {
 		}
 	}
 	sb.front[mv].Action()
+
 	sb.shift.Action()
 	sb.warn.Action()
 }
+
 func (sb *StunBar) reset() {
 	sb.bg0.Reset()
 	sb.bg1.Reset()
@@ -937,6 +1024,7 @@ func (sb *StunBar) reset() {
 	sb.shift.anim.dstAlpha = 0
 	sb.warn.Reset()
 }
+
 func (sb *StunBar) bgDraw(layerno int16) {
 	if !sys.lifebar.stunbar {
 		return
@@ -945,11 +1033,17 @@ func (sb *StunBar) bgDraw(layerno int16) {
 	sb.bg1.Draw(float32(sb.pos[0])+sys.lifebarOffsetX, float32(sb.pos[1]), layerno, sys.lifebarScale)
 	sb.bg2.Draw(float32(sb.pos[0])+sys.lifebarOffsetX, float32(sb.pos[1]), layerno, sys.lifebarScale)
 }
+
 func (sb *StunBar) draw(layerno int16, ref int, sbr *StunBar, f []*Fnt) {
 	if !sys.lifebar.stunbar {
 		return
 	}
-	points := 1 - float32(sys.chars[ref][0].dizzyPoints)/float32(sys.chars[ref][0].dizzyPointsMax)
+
+	points := float32(sys.chars[ref][0].dizzyPoints) / float32(sys.chars[ref][0].dizzyPointsMax)
+	if sb.invertfill {
+		points = 1 - points
+	}
+
 	var MidPos = (float32(sys.gameWidth-320) / 2)
 	width := func(points float32) (r [4]int32) {
 		r = sys.scrrect
@@ -969,6 +1063,8 @@ func (sb *StunBar) draw(layerno int16, ref int, sbr *StunBar, f []*Fnt) {
 	mr[2] -= Min(mr[2], pr[2])
 	sb.mid.lay.DrawAnim(&mr, float32(sb.pos[0])+sys.lifebarOffsetX, float32(sb.pos[1]), sys.lifebarScale,
 		layerno, &sb.mid.anim, sb.mid.palfx)
+
+	// Multiple front elements
 	var mv float32
 	for k := range sb.front {
 		if k > mv && (1-points) >= k/100 {
@@ -977,17 +1073,21 @@ func (sb *StunBar) draw(layerno int16, ref int, sbr *StunBar, f []*Fnt) {
 	}
 	sb.front[mv].lay.DrawAnim(&pr, float32(sb.pos[0])+sys.lifebarOffsetX, float32(sb.pos[1]), sys.lifebarScale,
 		layerno, &sb.front[mv].anim, sb.front[mv].palfx)
+
 	sb.shift.lay.DrawAnim(&pr, float32(sb.pos[0])+sys.lifebarOffsetX, float32(sb.pos[1]), sys.lifebarScale,
 		layerno, &sb.shift.anim, sb.shift.palfx)
+
 	if sb.value.font[0] >= 0 && int(sb.value.font[0]) < len(f) && f[sb.value.font[0]] != nil {
 		text := strings.Replace(sb.value.text, "%d", fmt.Sprintf("%v", sys.chars[ref][0].dizzyPoints), 1)
 		text = strings.Replace(text, "%p", fmt.Sprintf("%v", math.Round(float64(points)*100)), 1)
 		sb.value.lay.DrawText(float32(sb.pos[0])+sys.lifebarOffsetX, float32(sb.pos[1]), sys.lifebarScale,
 			layerno, text, f[sb.value.font[0]], sb.value.font[1], sb.value.font[2], sb.value.palfx, sb.value.frgba)
 	}
+
 	if points >= float32(sb.warn_range[0])/100 && points <= float32(sb.warn_range[1])/100 {
 		sb.warn.Draw(float32(sb.pos[0])+sys.lifebarOffsetX, float32(sb.pos[1]), layerno, sys.lifebarScale)
 	}
+
 	sb.top.Draw(float32(sb.pos[0])+sys.lifebarOffsetX, float32(sb.pos[1]), layerno, sys.lifebarScale)
 }
 
@@ -1087,6 +1187,7 @@ func (fa *LifeBarFace) step(ref int, far *LifeBarFace) {
 	fa.teammate_top.Action()
 	fa.teammate_ko.Action()
 }
+
 func (fa *LifeBarFace) reset() {
 	fa.bg.Reset()
 	fa.bg0.Reset()
@@ -1105,6 +1206,7 @@ func (fa *LifeBarFace) reset() {
 		fa.old_pal = [2]int32{}
 	}
 }
+
 func (fa *LifeBarFace) bgDraw(layerno int16) {
 	fa.bg.Draw(float32(fa.pos[0])+sys.lifebarOffsetX, float32(fa.pos[1]), layerno, sys.lifebarScale)
 	fa.bg0.Draw(float32(fa.pos[0])+sys.lifebarOffsetX, float32(fa.pos[1]), layerno, sys.lifebarScale)
@@ -1186,6 +1288,7 @@ type LifeBarName struct {
 func newLifeBarName() *LifeBarName {
 	return &LifeBarName{}
 }
+
 func readLifeBarName(pre string, is IniSection,
 	sff *Sff, at AnimationTable, f []*Fnt) *LifeBarName {
 	nm := newLifeBarName()
@@ -1200,19 +1303,23 @@ func readLifeBarName(pre string, is IniSection,
 	nm.top = *ReadAnimLayout(pre+"top.", is, sff, at, 0)
 	return nm
 }
+
 func (nm *LifeBarName) step() {
 	nm.bg.Action()
 	nm.teammate_bg.Action()
 	nm.top.Action()
 }
+
 func (nm *LifeBarName) reset() {
 	nm.bg.Reset()
 	nm.teammate_bg.Reset()
 	nm.top.Reset()
 }
+
 func (nm *LifeBarName) bgDraw(layerno int16) {
 	nm.bg.Draw(float32(nm.pos[0])+sys.lifebarOffsetX, float32(nm.pos[1]), layerno, sys.lifebarScale)
 }
+
 func (nm *LifeBarName) draw(layerno int16, ref int, f []*Fnt, side int) {
 	if nm.name.font[0] >= 0 && int(nm.name.font[0]) < len(f) && f[nm.name.font[0]] != nil {
 		nm.name.lay.DrawText((float32(nm.pos[0]) + sys.lifebarOffsetX), float32(nm.pos[1]), sys.lifebarScale, layerno,
@@ -1252,6 +1359,7 @@ type LifeBarWinIcon struct {
 func newLifeBarWinIcon() *LifeBarWinIcon {
 	return &LifeBarWinIcon{useiconupto: 4}
 }
+
 func readLifeBarWinIcon(pre string, is IniSection,
 	sff *Sff, at AnimationTable, f []*Fnt) *LifeBarWinIcon {
 	wi := newLifeBarWinIcon()
@@ -1272,6 +1380,7 @@ func readLifeBarWinIcon(pre string, is IniSection,
 	wi.icon[WT_Perfect] = *ReadAnimLayout(pre+"perfect.", is, sff, at, 0)
 	return wi
 }
+
 func (wi *LifeBarWinIcon) add(wt WinType) {
 	wi.wins = append(wi.wins, wt)
 	if wt >= WT_PNormal {
@@ -1284,6 +1393,7 @@ func (wi *LifeBarWinIcon) add(wt WinType) {
 	*wi.added = wi.icon[wt].anim
 	wi.added.Reset()
 }
+
 func (wi *LifeBarWinIcon) step(numwin int32) {
 	wi.bg0.Action()
 	wi.top.Action()
@@ -1301,6 +1411,7 @@ func (wi *LifeBarWinIcon) step(numwin int32) {
 		wi.addedP.Action()
 	}
 }
+
 func (wi *LifeBarWinIcon) reset() {
 	wi.bg0.Reset()
 	wi.top.Reset()
@@ -1310,7 +1421,11 @@ func (wi *LifeBarWinIcon) reset() {
 	wi.numWins = len(wi.wins)
 	wi.added, wi.addedP = nil, nil
 }
-func (wi *LifeBarWinIcon) clear() { wi.wins = nil }
+
+func (wi *LifeBarWinIcon) clear() {
+	wi.wins = nil
+}
+
 func (wi *LifeBarWinIcon) draw(layerno int16, f []*Fnt, side int) {
 	bg0num := float64(sys.lifebar.ro.match_wins[^side&1])
 	if sys.tmode[^side&1] == TM_Turns {
@@ -1374,6 +1489,7 @@ type LifeBarTime struct {
 func newLifeBarTime() *LifeBarTime {
 	return &LifeBarTime{counter: make(map[int32]*LbText), framespercount: 60}
 }
+
 func readLifeBarTime(is IniSection,
 	sff *Sff, at AnimationTable, f []*Fnt) *LifeBarTime {
 	ti := newLifeBarTime()
@@ -1397,17 +1513,21 @@ func readLifeBarTime(is IniSection,
 	is.ReadI32("framespercount", &ti.framespercount)
 	return ti
 }
+
 func (ti *LifeBarTime) step() {
 	ti.bg.Action()
 	ti.top.Action()
 }
+
 func (ti *LifeBarTime) reset() {
 	ti.bg.Reset()
 	ti.top.Reset()
 }
+
 func (ti *LifeBarTime) bgDraw(layerno int16) {
 	ti.bg.Draw(float32(ti.pos[0])+sys.lifebarOffsetX, float32(ti.pos[1]), layerno, sys.lifebarScale)
 }
+
 func (ti *LifeBarTime) draw(layerno int16, f []*Fnt) {
 	if ti.framespercount > 0 &&
 		ti.counter[0].font[0] >= 0 && int(ti.counter[0].font[0]) < len(f) && f[ti.counter[0].font[0]] != nil {
@@ -1458,6 +1578,7 @@ func newLifeBarCombo() *LifeBarCombo {
 	return &LifeBarCombo{displaytime: 90, showspeed: 8, hidespeed: 4,
 		counter_time: 7, counter_mult: 1.0 / 20}
 }
+
 func readLifeBarCombo(pre string, is IniSection,
 	sff *Sff, at AnimationTable, f []*Fnt, side int) *LifeBarCombo {
 	co := newLifeBarCombo()
@@ -1850,6 +1971,7 @@ func newLifeBarRound(snd *Snd) *LifeBarRound {
 		over_hittime: 10, over_wintime: 45, over_time: 210, fadein_time: 30,
 		fadeout_time: 30, shutter_time: 15, callfight_time: 60}
 }
+
 func readLifeBarRound(is IniSection,
 	sff *Sff, at AnimationTable, snd *Snd, f []*Fnt) *LifeBarRound {
 	ro := newLifeBarRound(snd)
@@ -2765,6 +2887,7 @@ type LifeBarRatio struct {
 func newLifeBarRatio() *LifeBarRatio {
 	return &LifeBarRatio{}
 }
+
 func readLifeBarRatio(pre string, is IniSection,
 	sff *Sff, at AnimationTable) *LifeBarRatio {
 	ra := newLifeBarRatio()
@@ -2776,19 +2899,23 @@ func readLifeBarRatio(pre string, is IniSection,
 	ra.bg = *ReadAnimLayout(pre+"bg.", is, sff, at, 0)
 	return ra
 }
+
 func (ra *LifeBarRatio) step(num int32) {
 	ra.icon[num].Action()
 	ra.bg.Action()
 }
+
 func (ra *LifeBarRatio) reset() {
 	for i := range ra.icon {
 		ra.icon[i].Reset()
 	}
 	ra.bg.Reset()
 }
+
 func (ra *LifeBarRatio) bgDraw(layerno int16) {
 	ra.bg.Draw(float32(ra.pos[0])+sys.lifebarOffsetX, float32(ra.pos[1]), layerno, sys.lifebarScale)
 }
+
 func (ra *LifeBarRatio) draw(layerno int16, num int32) {
 	ra.icon[num].Draw(float32(ra.pos[0])+sys.lifebarOffsetX,
 		float32(ra.pos[1]), layerno, sys.lifebarScale)
@@ -2807,6 +2934,7 @@ type LifeBarTimer struct {
 func newLifeBarTimer() *LifeBarTimer {
 	return &LifeBarTimer{enabled: make(map[string]bool)}
 }
+
 func readLifeBarTimer(is IniSection,
 	sff *Sff, at AnimationTable, f []*Fnt) *LifeBarTimer {
 	tr := newLifeBarTimer()
@@ -2825,19 +2953,23 @@ func readLifeBarTimer(is IniSection,
 	}
 	return tr
 }
+
 func (tr *LifeBarTimer) step() {
 	tr.bg.Action()
 	tr.top.Action()
 }
+
 func (tr *LifeBarTimer) reset() {
 	tr.bg.Reset()
 	tr.top.Reset()
 }
+
 func (tr *LifeBarTimer) bgDraw(layerno int16) {
 	if tr.active {
 		tr.bg.Draw(float32(tr.pos[0])+sys.lifebarOffsetX, float32(tr.pos[1]), layerno, sys.lifebarScale)
 	}
 }
+
 func (tr *LifeBarTimer) draw(layerno int16, f []*Fnt) {
 	if tr.active && sys.lifebar.ti.framespercount > 0 &&
 		tr.text.font[0] >= 0 && int(tr.text.font[0]) < len(f) && f[tr.text.font[0]] != nil && sys.time >= 0 {
@@ -2865,15 +2997,18 @@ func (tr *LifeBarTimer) draw(layerno int16, f []*Fnt) {
 		tr.top.Draw(float32(tr.pos[0])+sys.lifebarOffsetX, float32(tr.pos[1]), layerno, sys.lifebarScale)
 	}
 }
+
 func timeElapsed() int32 {
 	return sys.roundTime - sys.time
 }
+
 func timeRemaining() int32 {
 	if sys.time >= 0 {
 		return sys.time
 	}
 	return -1
 }
+
 func timeTotal() int32 {
 	t := sys.timerStart
 	for _, v := range sys.timerRounds {
@@ -2903,6 +3038,7 @@ type LifeBarScore struct {
 func newLifeBarScore() *LifeBarScore {
 	return &LifeBarScore{separator: [2]string{"", "."}, enabled: make(map[string]bool)}
 }
+
 func readLifeBarScore(pre string, is IniSection,
 	sff *Sff, at AnimationTable, f []*Fnt) *LifeBarScore {
 	sc := newLifeBarScore()
@@ -2927,20 +3063,24 @@ func readLifeBarScore(pre string, is IniSection,
 	}
 	return sc
 }
+
 func (sc *LifeBarScore) step() {
 	sc.bg.Action()
 	sc.top.Action()
 }
+
 func (sc *LifeBarScore) reset() {
 	sc.bg.Reset()
 	sc.top.Reset()
 	sc.scorePoints = 0
 }
+
 func (sc *LifeBarScore) bgDraw(layerno int16) {
 	if sc.active {
 		sc.bg.Draw(float32(sc.pos[0])+sys.lifebarOffsetX, float32(sc.pos[1]), layerno, sys.lifebarScale)
 	}
 }
+
 func (sc *LifeBarScore) draw(layerno int16, f []*Fnt, side int) {
 	if sc.active && sc.text.font[0] >= 0 && int(sc.text.font[0]) < len(f) && f[sc.text.font[0]] != nil {
 		text := sc.text.text
@@ -2992,6 +3132,7 @@ type LifeBarMatch struct {
 func newLifeBarMatch() *LifeBarMatch {
 	return &LifeBarMatch{enabled: make(map[string]bool)}
 }
+
 func readLifeBarMatch(is IniSection,
 	sff *Sff, at AnimationTable, f []*Fnt) *LifeBarMatch {
 	ma := newLifeBarMatch()
@@ -3010,19 +3151,23 @@ func readLifeBarMatch(is IniSection,
 	}
 	return ma
 }
+
 func (ma *LifeBarMatch) step() {
 	ma.bg.Action()
 	ma.top.Action()
 }
+
 func (ma *LifeBarMatch) reset() {
 	ma.bg.Reset()
 	ma.top.Reset()
 }
+
 func (ma *LifeBarMatch) bgDraw(layerno int16) {
 	if ma.active {
 		ma.bg.Draw(float32(ma.pos[0])+sys.lifebarOffsetX, float32(ma.pos[1]), layerno, sys.lifebarScale)
 	}
 }
+
 func (ma *LifeBarMatch) draw(layerno int16, f []*Fnt) {
 	if ma.active && ma.text.font[0] >= 0 && int(ma.text.font[0]) < len(f) && f[ma.text.font[0]] != nil {
 		text := ma.text.text
@@ -3047,6 +3192,7 @@ type LifeBarAiLevel struct {
 func newLifeBarAiLevel() *LifeBarAiLevel {
 	return &LifeBarAiLevel{separator: ".", enabled: make(map[string]bool)}
 }
+
 func readLifeBarAiLevel(pre string, is IniSection,
 	sff *Sff, at AnimationTable, f []*Fnt) *LifeBarAiLevel {
 	ai := newLifeBarAiLevel()
@@ -3067,19 +3213,23 @@ func readLifeBarAiLevel(pre string, is IniSection,
 	}
 	return ai
 }
+
 func (ai *LifeBarAiLevel) step() {
 	ai.bg.Action()
 	ai.top.Action()
 }
+
 func (ai *LifeBarAiLevel) reset() {
 	ai.bg.Reset()
 	ai.top.Reset()
 }
+
 func (ai *LifeBarAiLevel) bgDraw(layerno int16) {
 	if ai.active {
 		ai.bg.Draw(float32(ai.pos[0])+sys.lifebarOffsetX, float32(ai.pos[1]), layerno, sys.lifebarScale)
 	}
 }
+
 func (ai *LifeBarAiLevel) draw(layerno int16, f []*Fnt, ailv float32) {
 	if ai.active && ailv > 0 && ai.text.font[0] >= 0 && int(ai.text.font[0]) < len(f) && f[ai.text.font[0]] != nil {
 		text := ai.text.text
@@ -3118,6 +3268,7 @@ type LifeBarWinCount struct {
 func newLifeBarWinCount() *LifeBarWinCount {
 	return &LifeBarWinCount{enabled: make(map[string]bool)}
 }
+
 func readLifeBarWinCount(pre string, is IniSection,
 	sff *Sff, at AnimationTable, f []*Fnt) *LifeBarWinCount {
 	wc := newLifeBarWinCount()
@@ -3136,19 +3287,23 @@ func readLifeBarWinCount(pre string, is IniSection,
 	}
 	return wc
 }
+
 func (wc *LifeBarWinCount) step() {
 	wc.bg.Action()
 	wc.top.Action()
 }
+
 func (wc *LifeBarWinCount) reset() {
 	wc.bg.Reset()
 	wc.top.Reset()
 }
+
 func (wc *LifeBarWinCount) bgDraw(layerno int16) {
 	if wc.active {
 		wc.bg.Draw(float32(wc.pos[0])+sys.lifebarOffsetX, float32(wc.pos[1]), layerno, sys.lifebarScale)
 	}
 }
+
 func (wc *LifeBarWinCount) draw(layerno int16, f []*Fnt, side int) {
 	if wc.active && wc.text.font[0] >= 0 && int(wc.text.font[0]) < len(f) && f[wc.text.font[0]] != nil {
 		text := wc.text.text
@@ -3169,6 +3324,7 @@ type LifeBarMode struct {
 func newLifeBarMode() *LifeBarMode {
 	return &LifeBarMode{}
 }
+
 func readLifeBarMode(is IniSection,
 	sff *Sff, at AnimationTable, f []*Fnt) map[string]*LifeBarMode {
 	mo := make(map[string]*LifeBarMode)
@@ -3184,19 +3340,23 @@ func readLifeBarMode(is IniSection,
 	}
 	return mo
 }
+
 func (mo *LifeBarMode) step() {
 	mo.bg.Action()
 	mo.top.Action()
 }
+
 func (mo *LifeBarMode) reset() {
 	mo.bg.Reset()
 	mo.top.Reset()
 }
+
 func (mo *LifeBarMode) bgDraw(layerno int16) {
 	if sys.lifebar.mode {
 		mo.bg.Draw(float32(mo.pos[0])+sys.lifebarOffsetX, float32(mo.pos[1]), layerno, sys.lifebarScale)
 	}
 }
+
 func (mo *LifeBarMode) draw(layerno int16, f []*Fnt) {
 	if sys.lifebar.mode && mo.text.font[0] >= 0 && int(mo.text.font[0]) < len(f) && f[mo.text.font[0]] != nil {
 		mo.text.lay.DrawText(float32(mo.pos[0])+sys.lifebarOffsetX, float32(mo.pos[1]), sys.lifebarScale, layerno,
@@ -3858,6 +4018,7 @@ func loadLifebar(def string) (*Lifebar, error) {
 	l.Def = def
 	return l, nil
 }
+
 func (l *Lifebar) reloadLifebar() error {
 	lb, err := loadLifebar(l.Def)
 	if err != nil {
@@ -4113,6 +4274,7 @@ func (l *Lifebar) reset() {
 	}
 	l.textsprite = []*TextSprite{}
 }
+
 func (l *Lifebar) draw(layerno int16) {
 	if sys.postMatchFlg || sys.dialogueBarsFlg {
 		return

--- a/src/script.go
+++ b/src/script.go
@@ -773,7 +773,7 @@ func systemScriptInit(l *lua.LState) {
 		if !ok {
 			userDataError(l, 1, cl)
 		}
-		if cl.Input(int(numArg(l, 2))-1, 1, 0, 0) {
+		if cl.Input(int(numArg(l, 2))-1, 1, 0, 0, true) {
 			cl.Step(1, false, false, 0)
 		}
 		return 0

--- a/src/script.go
+++ b/src/script.go
@@ -3077,7 +3077,7 @@ func triggerFunctions(l *lua.LState) {
 		if !nilArg(l, 1) {
 			id = int32(numArg(l, 1))
 		}
-		if c := sys.debugWC.getPlayerHelperIndex(id, false); c != nil {
+		if c := sys.debugWC.getPlayerHelperIndex(id, true); c != nil {
 			sys.debugWC, ret = c, true
 		}
 		l.Push(lua.LBool(ret))


### PR DESCRIPTION
Feat:
- Previously GuardBar worked like life, with full guard points being represented by a full bar, but StunBar worked the opposite way, with full dizzy points resulting in an empty bar
- This can now be customized with the new "pX.invertfill" parameter

Fix:
- When using multiple timer fonts, the infinity value is now considered higher that 99 seconds rather than lower than 0
- Fixed 1 frame delay when (re)starting the input buffers by selectively limiting that behavior to screenpack inputs
- Fixes regression with characters being allowed to crouch longer than supposed to when a round ends
- Adjusted the way combo damage is tracked when you hit multiple enemies
- Fixes #999 
- Fixes #1201
- Fixes #2203

Refactor:
- Standardized error logging in HelperIndex redirect
- Enabled error logging in EnemyNear redirection, which was oddly disabled
- Minimized calls to "p2enemydelete" loop
- Lifted Mugen version restrictions when using ModifyStageVar to change a stage's shadow and reflection colors
- More random efforts in making code easier to read