### PR TITLE
fix: BGMVolume restore no longer activates when it shouldn't

### DIFF
--- a/src/sound.go
+++ b/src/sound.go
@@ -259,6 +259,7 @@ func (bgm *Bgm) Open(filename string, loop, bgmVolume, bgmLoopStart, bgmLoopEnd,
 	dstFreq := beep.SampleRate(float32(sys.cfg.Sound.SampleRate) / bgm.freqmul)
 	resampler := beep.Resample(audioResampleQuality, bgm.sampleRate, dstFreq, bgm.volctrl)
 	bgm.ctrl = &beep.Ctrl{Streamer: resampler}
+	bgm.volRestore = 0 // need this to prevent paused BGM volume from overwriting the new BGM volume
 	bgm.UpdateVolume()
 	bgm.streamer.Seek(startPosition)
 	speaker.Play(bgm.ctrl)


### PR DESCRIPTION
Exactly as the description says. This fixes a bug with the "BGM Volume restore" feature on pause kicking in when it shouldn't, leading to a bug where the select screen BGM would match that of any stage that lowers the BGM.