### PR TITLE
feat: config.ini common categories

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -2799,20 +2799,22 @@ func (c *Char) load(def string) error {
 	gi.constants["default.ignoredefeatedenemies"] = 1
 	gi.constants["input.pauseonhitpause"] = 1
 
-	for _, s := range sys.cfg.Common.Const {
-		if err := LoadFile(&s, []string{def, sys.motifDir, sys.lifebar.Def, "", "data/"}, func(filename string) error {
-			str, err = LoadText(filename)
-			if err != nil {
+	for _, key := range SortedKeys(sys.cfg.Common.Const) {
+		for _, v := range sys.cfg.Common.Const[key] {
+			if err := LoadFile(&v, []string{def, sys.motifDir, sys.lifebar.def, "", "data/"}, func(filename string) error {
+				str, err = LoadText(filename)
+				if err != nil {
+					return err
+				}
+				lines, i = SplitAndTrim(str, "\n"), 0
+				is, _, _ := ReadIniSection(lines, &i)
+				for key, value := range is {
+					gi.constants[key] = float32(Atof(value))
+				}
+				return nil
+			}); err != nil {
 				return err
 			}
-			lines, i = SplitAndTrim(str, "\n"), 0
-			is, _, _ := ReadIniSection(lines, &i)
-			for key, value := range is {
-				gi.constants[key] = float32(Atof(value))
-			}
-			return nil
-		}); err != nil {
-			return err
 		}
 	}
 
@@ -3189,16 +3191,18 @@ func (c *Char) load(def string) error {
 			return err
 		}
 	}
-	for _, s := range sys.cfg.Common.Air {
-		if err := LoadFile(&s, []string{def, sys.motifDir, sys.lifebar.Def, "", "data/"}, func(filename string) error {
-			txt, err := LoadText(filename)
-			if err != nil {
+	for _, key := range SortedKeys(sys.cfg.Common.Air) {
+		for _, v := range sys.cfg.Common.Air[key] {
+			if err := LoadFile(&v, []string{def, sys.motifDir, sys.lifebar.def, "", "data/"}, func(filename string) error {
+				txt, err := LoadText(filename)
+				if err != nil {
+					return err
+				}
+				str += "\n" + txt
+				return nil
+			}); err != nil {
 				return err
 			}
-			str += "\n" + txt
-			return nil
-		}); err != nil {
-			return err
 		}
 	}
 	lines, i = SplitAndTrim(str, "\n"), 0

--- a/src/common.go
+++ b/src/common.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"unicode"
@@ -997,4 +998,15 @@ func (ats *AnimTextSnd) End(dt int32, inf bool) bool {
 				ats.anim.anim.current == int32(len(ats.anim.anim.frames)-1))
 	}
 	return dt >= ats.displaytime
+}
+
+// SortedKeys returns the keys of the map sorted in ascending order.
+// It works with any map where the key is a string.
+func SortedKeys[T any](m map[string][]T) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -6804,16 +6804,18 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 			return nil, err
 		}
 	}
-	for _, s := range sys.cfg.Common.Cmd {
-		if err := LoadFile(&s, []string{def, sys.motifDir, sys.lifebar.Def, "", "data/"}, func(filename string) error {
-			txt, err := LoadText(filename)
-			if err != nil {
-				return err
+	for _, key := range SortedKeys(sys.cfg.Common.Cmd) {
+		for _, v := range sys.cfg.Common.Cmd[key] {
+			if err := LoadFile(&v, []string{def, sys.motifDir, sys.lifebar.def, "", "data/"}, func(filename string) error {
+				txt, err := LoadText(filename)
+				if err != nil {
+					return err
+				}
+				str += "\n" + txt
+				return nil
+			}); err != nil {
+				return nil, err
 			}
-			str += "\n" + txt
-			return nil
-		}); err != nil {
-			return nil, err
 		}
 	}
 	lines, i = SplitAndTrim(str, "\n"), 0
@@ -6942,10 +6944,12 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 		}
 	}
 	// Compile common states
-	for _, s := range sys.cfg.Common.States {
-		if err := c.stateCompile(states, s, []string{def, sys.motifDir, sys.lifebar.Def, "", "data/"},
-			false, constants); err != nil {
-			return nil, err
+	for _, key := range SortedKeys(sys.cfg.Common.States) {
+		for _, v := range sys.cfg.Common.States[key] {
+			if err := c.stateCompile(states, v, []string{def, sys.motifDir, sys.lifebar.def, "", "data/"},
+				false, constants); err != nil {
+				return nil, err
+			}
 		}
 	}
 	return states, nil

--- a/src/config.go
+++ b/src/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	_ "embed" // Support for go:embed resources
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -41,13 +42,13 @@ type Config struct {
 	Def     string
 	IniFile *ini.File
 	Common  struct {
-		Air     []string `ini:"Air"`
-		Cmd     []string `ini:"Cmd"`
-		Const   []string `ini:"Const"`
-		States  []string `ini:"States"`
-		Fx      []string `ini:"Fx"`
-		Modules []string `ini:"Modules"`
-		Lua     []string `ini:"Lua"`
+		Air     map[string][]string `ini:"map:^(?i)Air[0-9]*$" lua:"Air"`
+		Cmd     map[string][]string `ini:"map:^(?i)Cmd[0-9]*$" lua:"Cmd"`
+		Const   map[string][]string `ini:"map:^(?i)Const[0-9]*$" lua:"Const"`
+		States  map[string][]string `ini:"map:^(?i)States[0-9]*$" lua:"States"`
+		Fx      map[string][]string `ini:"map:^(?i)Fx[0-9]*$" lua:"Fx"`
+		Modules map[string][]string `ini:"map:^(?i)Modules[0-9]*$" lua:"Modules"`
+		Lua     map[string][]string `ini:"map:^(?i)Lua[0-9]*$" lua:"Lua"`
 	} `ini:"Common"`
 	Options struct {
 		Difficulty int     `ini:"Difficulty"`
@@ -250,7 +251,7 @@ func loadConfig(def string) (*Config, error) {
 	}
 	var c Config
 	c.Def = def
-	c.initMaps()
+	c.initStruct()
 
 	// Iterate through all sections
 	for _, section := range iniFile.Sections() {
@@ -285,11 +286,10 @@ func loadConfig(def string) (*Config, error) {
 	return &c, nil
 }
 
-// Initialize maps
-func (c *Config) initMaps() {
-	c.Keys = make(map[string]*KeysProperties)
-	c.Joystick = make(map[string]*KeysProperties)
-	c.Netplay.IP = make(map[string]string)
+// Initialize struct
+func (c *Config) initStruct() {
+	initMaps(reflect.ValueOf(c).Elem())
+	//applyDefaultsToValue(reflect.ValueOf(c).Elem())
 }
 
 // Normalize values

--- a/src/iniutils.go
+++ b/src/iniutils.go
@@ -40,7 +40,7 @@ func parseQueryPath(query string) []queryPart {
 // -------------------------------------------------------------------
 
 // findFieldByINITag recursively searches for a struct field with a matching INI tag
-func findFieldByINITag(v reflect.Value, tag string) (reflect.Value, bool) {
+func findFieldByINITag(v reflect.Value, tag string) (reflect.Value, reflect.StructField, bool) {
 	val := v
 	typ := val.Type()
 
@@ -50,17 +50,17 @@ func findFieldByINITag(v reflect.Value, tag string) (reflect.Value, bool) {
 		iniTag := field.Tag.Get("ini")
 
 		if iniTag != "" && strings.EqualFold(iniTag, tag) && field.PkgPath == "" {
-			return fVal, true
+			return fVal, field, true
 		}
 		// If the field is an embedded struct, search recursively
 		if field.Anonymous && field.Type.Kind() == reflect.Struct {
-			rv, found := findFieldByINITag(fVal, tag)
+			rv, rf, found := findFieldByINITag(fVal, tag)
 			if found {
-				return rv, true
+				return rv, rf, true
 			}
 		}
 	}
-	return reflect.Value{}, false
+	return reflect.Value{}, reflect.StructField{}, false
 }
 
 // findMapFieldWithTag searches for a map field in a struct with a specific INI tag
@@ -88,8 +88,45 @@ func findDefaultField(v reflect.Value) (reflect.Value, bool) {
 }
 
 // -------------------------------------------------------------------
-// Default Tag Applying Functions
+// Default Tag Applying and Maps initialization Functions
 // -------------------------------------------------------------------
+// initMaps traverses all fields/slices/maps of the given struct Value
+// and initializes maps if they are nil.
+func initMaps(v reflect.Value) {
+	switch v.Kind() {
+	case reflect.Ptr:
+		if !v.IsNil() {
+			initMaps(v.Elem())
+		}
+	case reflect.Struct:
+		t := v.Type()
+		for i := 0; i < v.NumField(); i++ {
+			fieldVal := v.Field(i)
+			fieldType := t.Field(i)
+
+			// Only recurse on exported fields
+			if fieldType.PkgPath != "" {
+				continue
+			}
+			initMaps(fieldVal)
+		}
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			initMaps(v.Index(i))
+		}
+	case reflect.Map:
+		// If map is nil, we "make" it
+		if v.IsNil() && v.CanSet() {
+			v.Set(reflect.MakeMap(v.Type()))
+		}
+
+		// Then we also want to recurse into each key/value pair
+		for _, key := range v.MapKeys() {
+			val := v.MapIndex(key)
+			initMaps(val)
+		}
+	}
+}
 
 // applyDefaultsToValue applies default-tagged values to any zero fields.
 // This works recursively on structs, pointers, slices, and arrays.
@@ -215,13 +252,13 @@ func isZeroValue(v reflect.Value) bool {
 // -------------------------------------------------------------------
 
 // setFieldValue assigns a value to a field based on its type
-func setFieldValue(fieldVal reflect.Value, value interface{}, keyPath string) error {
+func setFieldValue(fieldVal reflect.Value, value interface{}, defTag string, keyPath string) error {
 
-	// Set to zero-value
+	// Helper to zero-out the field
 	setNil := func(fieldVal reflect.Value) {
 		switch fieldVal.Kind() {
 		case reflect.Map:
-			// We leave maps as-is if nil, or keep the existing map if not nil
+			// do not destroy existing map
 			return
 		case reflect.Slice:
 			fieldVal.Set(reflect.MakeSlice(fieldVal.Type(), 0, 0))
@@ -242,25 +279,25 @@ func setFieldValue(fieldVal reflect.Value, value interface{}, keyPath string) er
 		}
 	}
 
+	// If "value" is literally nil, treat like empty string, but preserve maps.
 	if value == nil {
 		switch fieldVal.Kind() {
 		case reflect.Map:
-			// we leave the map as is (nil or existing)
-			return nil
+			return nil // no change
 		default:
 			setNil(fieldVal)
 			return nil
 		}
 	}
 
-	// If value is an array of strings
+	// If value is []string, handle that first
 	if arr, ok := value.([]string); ok {
 		switch fieldVal.Kind() {
 		case reflect.Slice:
 			newSlice := reflect.MakeSlice(fieldVal.Type(), 0, len(arr))
 			for _, v := range arr {
 				elem := reflect.New(fieldVal.Type().Elem()).Elem()
-				if err := setFieldValue(elem, v, keyPath); err != nil {
+				if err := setFieldValue(elem, v, defTag, keyPath); err != nil {
 					return err
 				}
 				newSlice = reflect.Append(newSlice, elem)
@@ -270,15 +307,17 @@ func setFieldValue(fieldVal reflect.Value, value interface{}, keyPath string) er
 		case reflect.Array:
 			for i := 0; i < fieldVal.Len() && i < len(arr); i++ {
 				elem := fieldVal.Index(i)
-				if err := setFieldValue(elem, arr[i], keyPath); err != nil {
+				if err := setFieldValue(elem, arr[i], defTag, keyPath); err != nil {
 					return err
 				}
 			}
 			return nil
 		default:
+			// if there's at least one element, treat arr[0] as the final string
 			if len(arr) > 0 {
-				return setFieldValue(fieldVal, arr[0], keyPath)
+				return setFieldValue(fieldVal, arr[0], defTag, keyPath)
 			}
+			// else empty => zero out
 			setNil(fieldVal)
 			return nil
 		}
@@ -291,82 +330,112 @@ func setFieldValue(fieldVal reflect.Value, value interface{}, keyPath string) er
 	}
 	trimmedValue := strings.TrimSpace(strVal)
 
-	fieldKind := fieldVal.Kind()
-	if fieldKind == reflect.Ptr {
+	// Unwrap pointer
+	if fieldVal.Kind() == reflect.Ptr {
 		if fieldVal.IsNil() {
 			fieldVal.Set(reflect.New(fieldVal.Type().Elem()))
 			applyDefaultsToValue(fieldVal)
 		}
 		fieldVal = fieldVal.Elem()
-		fieldKind = fieldVal.Kind()
 	}
 
+	// If the user explicitly gave an empty line => use the defTag if any
 	if trimmedValue == "" {
-		// If we have an empty string, set to zero-value
-		setNil(fieldVal)
-		return nil
+		if defTag == "" {
+			// If no default tag => zero out
+			setNil(fieldVal)
+			return nil
+		}
+		// If there's a default tag => parse it as if user typed it
+		trimmedValue = defTag
 	}
 
-	switch fieldKind {
+	// Now parse the final (non-empty) string
+	switch fieldVal.Kind() {
 	case reflect.Bool:
 		parsed, err := strconv.ParseBool(trimmedValue)
 		if err != nil {
 			return fmt.Errorf("failed to parse bool for '%s': %v", keyPath, err)
 		}
 		fieldVal.SetBool(parsed)
+
 	case reflect.Slice:
-		// Potentially split on commas
+		var parts []string
 		if strings.Contains(trimmedValue, ",") {
-			parts := strings.Split(trimmedValue, ",")
-			newSlice := reflect.MakeSlice(fieldVal.Type(), 0, len(parts))
-			for _, p := range parts {
-				p = strings.TrimSpace(p)
-				elem := reflect.New(fieldVal.Type().Elem()).Elem()
-				if err := setFieldValue(elem, p, keyPath); err != nil {
-					return err
-				}
-				newSlice = reflect.Append(newSlice, elem)
-			}
-			fieldVal.Set(newSlice)
-			return nil
+			parts = strings.Split(trimmedValue, ",")
 		} else {
-			newElem := reflect.New(fieldVal.Type().Elem()).Elem()
-			if err := setFieldValue(newElem, trimmedValue, keyPath); err != nil {
+			parts = []string{trimmedValue}
+		}
+		newSlice := reflect.MakeSlice(fieldVal.Type(), 0, len(parts))
+
+		for _, p := range parts {
+			elem := reflect.New(fieldVal.Type().Elem()).Elem()
+			if err := setFieldValue(elem, strings.TrimSpace(p), "", keyPath); err != nil {
 				return err
 			}
-			fieldVal.Set(reflect.Append(fieldVal, newElem))
-			return nil
+			newSlice = reflect.Append(newSlice, elem)
 		}
-	case reflect.Int32, reflect.Int, reflect.Int64:
+		fieldVal.Set(newSlice)
+
+	case reflect.Array:
+		separator := ","
+		if strings.Contains(trimmedValue, "&") {
+			separator = "&"
+		}
+		parts := strings.Split(trimmedValue, separator)
+
+		// Also parse defTag in case we do partial merges
+		defParts := []string{}
+		if defTag != "" && defTag != trimmedValue {
+			// Only parse defParts if defTag != trimmedValue, to avoid loops
+			defParts = strings.Split(defTag, ",")
+		}
+
+		// If user supplied partial => fill leftover elements from defTag (if present)
+		for i := 0; i < fieldVal.Len(); i++ {
+			var valStr string
+			if i < len(parts) && strings.TrimSpace(parts[i]) != "" {
+				// user explicitly set element i
+				valStr = strings.TrimSpace(parts[i])
+			} else if i < len(defParts) && strings.TrimSpace(defParts[i]) != "" {
+				// fallback to defTag for element i
+				valStr = strings.TrimSpace(defParts[i])
+			} else {
+				// if defTag doesn't have it => zero
+				valStr = "0"
+			}
+
+			elem := fieldVal.Index(i)
+			if err := setFieldValue(elem, valStr, "", keyPath); err != nil {
+				return err
+			}
+		}
+
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		parsed, err := strconv.ParseInt(trimmedValue, 10, 64)
 		if err != nil {
 			return fmt.Errorf("failed to parse int: %v", err)
 		}
 		fieldVal.SetInt(parsed)
+
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		parsed, err := strconv.ParseUint(trimmedValue, 10, 64)
+		if err != nil {
+			return fmt.Errorf("failed to parse uint: %v", err)
+		}
+		fieldVal.SetUint(parsed)
+
 	case reflect.Float32, reflect.Float64:
 		parsed, err := strconv.ParseFloat(trimmedValue, 64)
 		if err != nil {
 			return fmt.Errorf("failed to parse float: %v", err)
 		}
 		fieldVal.SetFloat(parsed)
+
 	case reflect.String:
-		parsed := strings.Trim(trimmedValue, "\"")
+		parsed := strings.Trim(trimmedValue, "\"") // "
 		fieldVal.SetString(parsed)
-	case reflect.Array:
-		// We also handle a possible "&" separator
-		separator := ","
-		if strings.Contains(trimmedValue, "&") {
-			separator = "&"
-		}
-		parts := strings.Split(trimmedValue, separator)
-		for i := 0; i < fieldVal.Len() && i < len(parts); i++ {
-			elem := fieldVal.Index(i)
-			valStr := strings.TrimSpace(parts[i])
-			if err := setFieldValue(elem, valStr, keyPath); err != nil {
-				continue
-			}
-		}
-		return nil
+
 	case reflect.Struct:
 		// If the struct has a default field, set its value
 		defaultField, found := findDefaultField(fieldVal)
@@ -374,13 +443,103 @@ func setFieldValue(fieldVal reflect.Value, value interface{}, keyPath string) er
 			applyDefaultsToValue(fieldVal)
 			return nil
 		}
-		err := setFieldValue(defaultField, trimmedValue, keyPath)
+		if err := setFieldValue(defaultField, trimmedValue, "", keyPath); err != nil {
+			return err
+		}
 		applyDefaultsToValue(fieldVal)
-		return err
+
 	default:
-		return fmt.Errorf("unsupported field kind: %s", fieldKind)
+		return fmt.Errorf("unsupported field kind: %s", fieldVal.Kind())
 	}
+
 	return nil
+}
+
+func assignToPatternMap(v reflect.Value, lastPartName string, value interface{}, final bool) (bool, reflect.Value, error) {
+	if v.Kind() != reflect.Struct {
+		return false, v, nil
+	}
+
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		iniTag := field.Tag.Get("ini")
+		if iniTag == "" || field.PkgPath != "" {
+			continue
+		}
+
+		if strings.HasPrefix(strings.ToLower(iniTag), "map:") {
+			pattern := iniTag[4:]
+			if pattern == "" {
+				continue
+			}
+			re, err := regexp.Compile(pattern)
+			if err != nil {
+				continue
+			}
+			if re.MatchString(lastPartName) {
+				fieldVal := v.Field(i)
+				if fieldVal.Kind() == reflect.Map && fieldVal.Type().Key().Kind() == reflect.String {
+					if fieldVal.IsNil() {
+						fieldVal.Set(reflect.MakeMap(fieldVal.Type()))
+					}
+					mapKey := reflect.ValueOf(strings.ToLower(lastPartName))
+					elemType := fieldVal.Type().Elem()
+					mapElem := fieldVal.MapIndex(mapKey)
+
+					// If we're applying a final value, we create/set a fully updated entry
+					if final {
+						var newVal reflect.Value
+						if elemType.Kind() == reflect.Ptr {
+							// If it's pointer-based, copy existing data if present
+							if mapElem.IsValid() {
+								newVal = reflect.New(elemType.Elem())
+								newVal.Elem().Set(mapElem.Elem())
+							} else {
+								newVal = reflect.New(elemType.Elem())
+							}
+						} else {
+							// Non-pointer map element
+							if mapElem.IsValid() {
+								newVal = reflect.New(elemType).Elem()
+								newVal.Set(mapElem)
+							} else {
+								newVal = reflect.New(elemType).Elem()
+							}
+						}
+						applyDefaultsToValue(newVal)
+
+						// setFieldValue takes (fieldVal, value, keyPath, lastPartName)
+						if err := setFieldValue(newVal, value, "", lastPartName); err != nil {
+							return false, v, err
+						}
+						// Store the updated element back into the map
+						fieldVal.SetMapIndex(mapKey, newVal)
+						mapElem = fieldVal.MapIndex(mapKey)
+
+					} else {
+						// Not final: just create a fresh entry if the key doesn't exist
+						if !mapElem.IsValid() {
+							var newVal reflect.Value
+							if elemType.Kind() == reflect.Ptr {
+								newVal = reflect.New(elemType.Elem())
+							} else {
+								newVal = reflect.New(elemType).Elem()
+							}
+							applyDefaultsToValue(newVal)
+							fieldVal.SetMapIndex(mapKey, newVal)
+							mapElem = fieldVal.MapIndex(mapKey)
+						} else {
+							// We still apply defaults if the mapElem is valid
+							applyDefaultsToValue(mapElem)
+						}
+					}
+					return true, mapElem, nil
+				}
+			}
+		}
+	}
+	return false, v, nil
 }
 
 // assignField assigns a value to a struct field based on query parts
@@ -404,72 +563,14 @@ func assignField(structPtr interface{}, parts []queryPart, value interface{}) er
 
 	assignDirect := func(v reflect.Value, part queryPart, value interface{}) (bool, error) {
 		if v.Kind() == reflect.Struct {
-			fieldVal, found := findFieldByINITag(v, part.name)
+			fieldVal, fieldType, found := findFieldByINITag(v, part.name)
 			if found {
-				err := setFieldValue(fieldVal, value, strings.Join(extractNames(parts), "."))
+				defTag := fieldType.Tag.Get("default") // read the struct's default tag
+				err := setFieldValue(fieldVal, value, defTag, strings.Join(extractNames(parts), "."))
 				return true, err
 			}
 		}
 		return false, nil
-	}
-
-	assignToPatternMap := func(v reflect.Value, lastPartName string, value interface{}, final bool) (bool, reflect.Value, error) {
-		if v.Kind() != reflect.Struct {
-			return false, v, nil
-		}
-
-		t := v.Type()
-		for i := 0; i < t.NumField(); i++ {
-			field := t.Field(i)
-			iniTag := field.Tag.Get("ini")
-			if iniTag == "" || field.PkgPath != "" {
-				continue
-			}
-
-			if strings.HasPrefix(strings.ToLower(iniTag), "map:") {
-				pattern := iniTag[4:]
-				if pattern == "" {
-					continue
-				}
-				re, err := regexp.Compile(pattern)
-				if err != nil {
-					continue
-				}
-				if re.MatchString(lastPartName) {
-					fieldVal := v.Field(i)
-					if fieldVal.Kind() == reflect.Map && fieldVal.Type().Key().Kind() == reflect.String {
-						if fieldVal.IsNil() {
-							fieldVal.Set(reflect.MakeMap(fieldVal.Type()))
-						}
-						mapKey := reflect.ValueOf(strings.ToLower(lastPartName))
-						elemType := fieldVal.Type().Elem()
-
-						var newVal reflect.Value
-						if elemType.Kind() == reflect.Ptr {
-							newVal = reflect.New(elemType.Elem())
-						} else {
-							newVal = reflect.New(elemType).Elem()
-						}
-						applyDefaultsToValue(newVal)
-
-						if final {
-							if err := setFieldValue(newVal, value, lastPartName); err != nil {
-								return false, v, err
-							}
-						}
-						mapElem := fieldVal.MapIndex(mapKey)
-						if !mapElem.IsValid() {
-							fieldVal.SetMapIndex(mapKey, newVal)
-							mapElem = fieldVal.MapIndex(mapKey)
-						} else {
-							applyDefaultsToValue(mapElem)
-						}
-						return true, mapElem, nil
-					}
-				}
-			}
-		}
-		return false, v, nil
 	}
 
 	for i := 0; i < len(parts); i++ {
@@ -520,7 +621,7 @@ func assignField(structPtr interface{}, parts []queryPart, value interface{}) er
 				}
 				applyDefaultsToValue(newVal)
 
-				if err := setFieldValue(newVal, value, strings.Join(extractNames(parts), ".")); err != nil {
+				if err := setFieldValue(newVal, value, "", strings.Join(extractNames(parts), ".")); err != nil {
 					return err
 				}
 				v.SetMapIndex(mapKey, newVal)
@@ -531,7 +632,7 @@ func assignField(structPtr interface{}, parts []queryPart, value interface{}) er
 		}
 
 		if v.Kind() == reflect.Struct {
-			fieldVal, found := findFieldByINITag(v, part.name)
+			fieldVal, _, found := findFieldByINITag(v, part.name)
 			if found {
 				v = fieldVal
 				continue
@@ -670,7 +771,7 @@ func updateINIFile(obj interface{}, iniFile *ini.File, query string, value strin
 		switch currentValue.Kind() {
 		case reflect.Struct:
 			// First, see if we can find a field with ini:"part.name"
-			fieldVal, found := findFieldByINITag(currentValue, part.name)
+			fieldVal, _, found := findFieldByINITag(currentValue, part.name)
 			if found {
 				// We found a direct field. We'll record its iniTag as the "section" or "subKey".
 				var structField reflect.StructField
@@ -894,7 +995,7 @@ func GetValue(structPtr interface{}, query string) (interface{}, error) {
 		switch current.Kind() {
 		case reflect.Struct:
 			// 1) Try normal ini tag
-			fieldVal, found := findFieldByINITag(current, part.name)
+			fieldVal, _, found := findFieldByINITag(current, part.name)
 			if found {
 				current = fieldVal
 			} else {
@@ -1004,3 +1105,4 @@ func SaveINI(iniFile *ini.File, filePath string) error {
 	}
 	return iniFile.SaveTo(filePath)
 }
+

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -3375,7 +3375,7 @@ func (mo *LifeBarMode) draw(layerno int16, f []*Fnt) {
 }
 
 type Lifebar struct {
-	Def        string
+	def        string
 	name       string
 	nameLow    string
 	author     string
@@ -3474,9 +3474,11 @@ func loadLifebar(def string) (*Lifebar, error) {
 	filesflg := true
 	ffx := newFightFx()
 	// Load Common FX first
-	for _, def := range sys.cfg.Common.Fx {
-		if err := loadFightFx(def); err != nil {
-			return nil, err
+	for _, key := range SortedKeys(sys.cfg.Common.Fx) {
+		for _, v := range sys.cfg.Common.Fx[key] {
+			if err := loadFightFx(v); err != nil {
+				return nil, err
+			}
 		}
 	}
 	for i < len(lines) {
@@ -4024,12 +4026,12 @@ func loadLifebar(def string) (*Lifebar, error) {
 			}
 		}
 	}
-	l.Def = def
+	l.def = def
 	return l, nil
 }
 
 func (l *Lifebar) reloadLifebar() error {
-	lb, err := loadLifebar(l.Def)
+	lb, err := loadLifebar(l.def)
 	if err != nil {
 		return err
 	}

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -2,8 +2,11 @@
 ; Configuration file for Ikemen GO
 ; -=====================================================-
 ; -------------------------------------------------------------------------------
+
 ; Common data running on characters, affecting match globally.
-; Common parameters support arrays, with values separated by commas.
+; Common parameters support arrays with comma-separated values.
+; Multiple categories can be specified by appending a unique numeric suffix to
+; their names (e.g., States0 = ..., States2 = ...).
 [Common]
 ; Common animations using character's local sprites
 Air     = data/common.air
@@ -146,27 +149,27 @@ TrainingChar        =
 ; -------------------------------------------------------------------------------
 [Debug]
 ; Set to 0 to disallow switching to debug mode by pressing Ctrl-D.
-AllowDebugMode = 1
+AllowDebugMode    = 1
 ; Set to 1 to allow debug keys.
-AllowDebugKeys = 1
+AllowDebugKeys    = 1
 ; Clipboard rows
-ClipboardRows  = 2
+ClipboardRows     = 2
 ; Console rows
-ConsoleRows    = 15
+ConsoleRows       = 15
 ; Clsn view screen darkening
-ClsnDarken     = 1
+ClsnDarken        = 1
 ; Path to debug font
-Font           = font/debug.def
+Font              = font/debug.def
 ; Debug font scale
-FontScale      = 0.5
+FontScale         = 0.5
 ; Default starting stage for quick versus.
-StartStage     = stages/stage0-720.def
+StartStage        = stages/stage0-720.def
 ; Set to nonzero to force stages to have the specified zoom scale factors.
 ; This option has no effect on stages that have either zoomin or zoomout
 ; parameter set to a value other than the default of 1.
 ; This is a debug parameter and may be removed in future versions.
-ForceStageZoomout   = 0
-ForceStageZoomin    = 0
+ForceStageZoomout = 0
+ForceStageZoomin  = 0
 
 ; -------------------------------------------------------------------------------
 [Video]

--- a/src/system.go
+++ b/src/system.go
@@ -2397,9 +2397,11 @@ func (s *System) fight() (reload bool) {
 			s.drawTop()
 		}
 		// Lua code is executed after drawing the fade effects, so that the menus are on top of them
-		for _, str := range s.cfg.Common.Lua {
-			if err := s.luaLState.DoString(str); err != nil {
-				s.luaLState.RaiseError(err.Error())
+		for _, key := range SortedKeys(sys.cfg.Common.Lua) {
+			for _, v := range sys.cfg.Common.Lua[key] {
+				if err := s.luaLState.DoString(v); err != nil {
+					s.luaLState.RaiseError(err.Error())
+				}
 			}
 		}
 		// Render debug elements


### PR DESCRIPTION
Common parameters support arrays with comma-separated values.

Multiple categories can be specified by appending a unique numeric suffix to their names (e.g., States0, States2).