### PR TITLE
fix: AttackDist is reset each time the state changes, instead of every frame

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1789,21 +1789,9 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			// In Winmugen a helper's PalNo is always 1
 			// That behavior has no apparent benefits and even Mugen 1.0 compatibility mode does not keep it
 		case OC_pos_x:
-			var bindVelx float32
-			if c.bindToId > 0 && !math.IsNaN(float64(c.bindPos[0])) && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
-				if sys.playerID(c.bindToId) != nil {
-					bindVelx = c.vel[0]
-				}
-			}
-			sys.bcStack.PushF(((c.pos[0]+bindVelx)*(c.localscl/oc.localscl) - sys.cam.Pos[0]/oc.localscl))
+			sys.bcStack.PushF((c.pos[0]*(c.localscl/oc.localscl) - sys.cam.Pos[0]/oc.localscl))
 		case OC_pos_y:
-			var bindVely float32
-			if c.bindToId > 0 && !math.IsNaN(float64(c.bindPos[1])) && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
-				if sys.playerID(c.bindToId) != nil {
-					bindVely = c.vel[1]
-				}
-			}
-			sys.bcStack.PushF((c.pos[1] + bindVely - c.groundLevel - c.platformPosY) * (c.localscl / oc.localscl))
+			sys.bcStack.PushF((c.pos[1] + c.groundLevel - c.platformPosY) * (c.localscl / oc.localscl))
 		case OC_power:
 			sys.bcStack.PushI(c.getPower())
 		case OC_powermax:

--- a/src/char.go
+++ b/src/char.go
@@ -2438,6 +2438,9 @@ func (c *Char) init(n int, idx int32) {
 		facing:        1,
 		minus:         2,
 		winquote:      -1,
+		attackDistX:   [2]float32{c.size.attack.dist.width[0], c.size.attack.dist.width[1]},
+		attackDistY:   [2]float32{c.size.attack.dist.height[0], c.size.attack.dist.height[1]},
+		attackDistZ:   [2]float32{c.size.attack.dist.depth[0], c.size.attack.dist.depth[1]},
 		clsnBaseScale: [2]float32{1, 1},
 		clsnScaleMul:  [2]float32{1, 1},
 		clsnScale:     [2]float32{1, 1},
@@ -4583,6 +4586,10 @@ func (c *Char) stateChange1(no int32, pn int) bool {
 		return false
 	}
 	c.ss.no, c.ss.prevno, c.ss.time = Max(0, no), c.ss.no, 0
+	c.attackDistX = [2]float32{c.size.attack.dist.width[0], c.size.attack.dist.width[1]}
+	c.attackDistY = [2]float32{c.size.attack.dist.height[0], c.size.attack.dist.height[1]}
+	c.attackDistZ = [2]float32{c.size.attack.dist.depth[0], c.size.attack.dist.depth[1]}
+
 	// Local scale updates
 	// If the new state uses a different localcoord, some values need to be updated in the same frame
 	if newLs := 320 / sys.chars[pn][0].localcoord; c.localscl != newLs {
@@ -7525,9 +7532,6 @@ func (c *Char) actionPrepare() {
 				}
 			}
 			c.pushPriority = 0 // Reset player pushing priority
-			c.attackDistX = [2]float32{c.size.attack.dist.width[0], c.size.attack.dist.width[1]}
-			c.attackDistY = [2]float32{c.size.attack.dist.height[0], c.size.attack.dist.height[1]}
-			c.attackDistZ = [2]float32{c.size.attack.dist.depth[0], c.size.attack.dist.depth[1]}
 			// HitBy timers
 			// In Mugen this seems to happen at the end of each frame instead
 			for i, hb := range c.hitby {

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -119,7 +119,7 @@ AfterImageMax       = 128
 ; Set to a lower number to save memory (minimum 8).
 ExplodMax           = 512
 ; Maximum number of helpers allowed in total.
-; Set to a lower number to save memory (minimum 4, maximum 56).
+; Set to a lower number to save memory (minimum 4).
 HelperMax           = 56
 ; Maximum number of projectiles allowed per player.
 ; Set to a lower number to save memory (minimum 5).


### PR DESCRIPTION
- AttackDist is reset each time the state changes, instead of every frame.
- Removed unnecessary pos code during binding.
- Corrected the ini description, as there is no upper limit for HelperMax.