### PR TITLE
fix: native Tag, several small refactors

### DIFF
--- a/data/tag.zss
+++ b/data/tag.zss
@@ -72,7 +72,7 @@ explod{
 # StateTagEnteringScreen
 #===============================================================================
 [StateDef const(StateTagEnteringScreen); 
-	type: S; movetype: H; physics: N;
+	type: S; movetype: I; physics: N;
 	anim: const(AnimTagEnteringScreen);
 	sprpriority: 2; ctrl: 0;
 ]
@@ -139,11 +139,13 @@ if backEdgeDist < -const240p(160) || frontEdgeDist < -const240p(160) {
 screenBound{value: 0; movecamera: 0, 0; stagebound: 0}
 assertSpecial{flag: invisible; flag2: noAutoTurn}
 
-# force standby character to always stay outside visible area
-posSet{
-	x: (player(teamLeader),pos x - player(teamLeader),screenPos x - const240p(160)) * -facing;
-	y: player(teamLeader),pos y - player(teamLeader),screenPos y - const240p(160);
+# Face towards center of screen
+if pos x * facing > 0 {
+	turn{}
 }
+
+# Force standby character to always stay outside visible area
+posSet{x: const240p(-480) * facing / min(camerazoom, 1); y: 0}
 
 # Red Life regeneration
 if life < redLife && (time % const(TagRedLifeRegenFrames)) = 0 { # every 30 frames (0.5s) by default
@@ -235,7 +237,6 @@ if !const(Default.Enable.Tag) || isHelper || teamSide = 0 {
 		map(_iksys_tagIntroFlag) := 1;
 	} else {
 		map(_iksys_tagIntroFlag) := 0;
-		screenBound{value: 0; movecamera: 0, 0}
 	}
 	map(_iksys_tagSwitchCooldown) := 0;
 } else if map(_iksys_tagActive) = 1 {
@@ -243,10 +244,6 @@ if !const(Default.Enable.Tag) || isHelper || teamSide = 0 {
 	if !alive {
 		ctrlSet{value: 0}
 		assertSpecial{flag: noailevel}
-	}
-	# fix erratic camera during intros
-	if roundState = 1 && playerNo != teamLeader {
-		screenBound{value: 0; movecamera: 0, 0}
 	}
 	# disable tag over win poses
 	if roundState = 4 {
@@ -332,5 +329,19 @@ if !const(Default.Enable.Tag) || isHelper || teamSide = 0 {
 			tagOut{}
 			tagIn{stateno: playerId($partnerId),const(StateTagJumpingIn); redirectid: $partnerId}
 		}
+	}
+}
+
+#===============================================================================
+# Global states (not halted by Pause/SuperPause, no helper limitations)
+#===============================================================================
+[StateDef +1]
+
+# fix erratic camera during intros
+if cond(isHelper, root, map(_iksys_tagActive), map(_iksys_tagActive)) {
+	if roundstate = [0, 1]
+	&& playerno != teamleader
+	&& numenemy != (numpartner + 1) {
+		screenbound{value: 0; movecamera: 0, 0; stagebound: 0}
 	}
 }

--- a/src/anim.go
+++ b/src/anim.go
@@ -670,7 +670,7 @@ func (a *Animation) Draw(window *[4]int32, x, y, xcs, ycs, xs, xbs, ys,
 	rxadd float32, rot Rotation, rcx float32, pfx *PalFX, old bool, facing float32,
 	isReflection bool, airOffsetFix [2]float32, projectionMode int32, fLength float32, color uint32) {
 	// Skip blank sprites
-	if a.spr == nil || a.spr.Tex == nil {
+	if a.spr == nil || a.spr.Tex == nil || xs == 0 || ys == 0 {
 		return
 	}
 	h, v, angle := a.drawSub1(rot.angle, facing)

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -4434,7 +4434,7 @@ func (sc tagOut) Run(c *Char, _ []int32) bool {
 	}
 	if tagSCF == 1 {
 		crun.setSCF(SCF_standby)
-		sys.charList.p2enemyDelete(crun)
+		// sys.charList.p2enemyDelete(crun)
 	}
 	if partnerNo != -1 && crun.partnerV2(partnerNo) != nil {
 		partner := crun.partnerV2(partnerNo)
@@ -4442,7 +4442,7 @@ func (sc tagOut) Run(c *Char, _ []int32) bool {
 		if partnerStateNo >= 0 {
 			partner.changeState(partnerStateNo, -1, -1, "")
 		}
-		sys.charList.p2enemyDelete(partner)
+		// sys.charList.p2enemyDelete(partner)
 	}
 	return false
 }
@@ -4640,7 +4640,7 @@ func (sc helper) Run(c *Char, _ []int32) bool {
 			ht := exp[0].evalI(c)
 			switch ht {
 			case 1:
-				h.player = true
+				h.playerFlag = true
 			case 2:
 				h.hprojectile = true // Currently unused
 			}
@@ -11854,10 +11854,15 @@ func (sc modifyPlayer) Run(c *Char, _ []int32) bool {
 			crun.guardPointsMax = gp
 			crun.guardPoints = Clamp(crun.guardPoints, 0, crun.guardPointsMax)
 		case modifyPlayer_teamside:
-			ts := int(exp[0].evalI(c))
-			if ts >= 0 && ts <= 2 {
-				ts -= 1 // Internally the teamside goes from -1 to 1
+			ts := int(exp[0].evalI(c)) - 1 // Internally the teamside starts at -1 instead of 0
+			if ts >= -1 && ts <= 1 && ts != crun.teamside {
 				crun.teamside = ts
+				// Reevaluate alliances
+				if crun.playerFlag {
+					sys.charList.enemyNearChanged = true
+				} else {
+					crun.enemyNearP2Clear()
+				}
 			}
 		case modifyPlayer_displayname:
 			dn := string(*(*[]byte)(unsafe.Pointer(&exp[0])))

--- a/src/char.go
+++ b/src/char.go
@@ -5118,7 +5118,7 @@ func (c *Char) setPosZ(z float32) {
 }
 
 func (c *Char) posReset() {
-	if c.teamside == -1 {
+	if c.teamside == -1 || c.playerNo < 0 || c.playerNo >= len(sys.stage.p) {
 		c.facing = 1
 		c.setX(0)
 		c.setY(0)

--- a/src/char.go
+++ b/src/char.go
@@ -8498,7 +8498,8 @@ func (c *Char) cueDraw() {
 }
 
 type CharList struct {
-	runOrder, drawOrder []*Char
+	runOrder            []*Char
+	drawOrder           []*Char
 	idMap               map[int32]*Char
 }
 
@@ -8558,9 +8559,17 @@ func (cl *CharList) delete(dc *Char) {
 			break
 		}
 	}
+	// You'd expect Mugen to remove the slot from the drawing order, but it does keep it open like this
+	//for i, c := range cl.drawOrder {
+	//	if c == dc {
+	//		cl.drawOrder[i] = nil
+	//		break
+	//	}
+	//}
+	// However removing it creates a more predictable drawing order
 	for i, c := range cl.drawOrder {
 		if c == dc {
-			cl.drawOrder[i] = nil
+			cl.drawOrder = append(cl.drawOrder[:i], cl.drawOrder[i+1:]...)
 			break
 		}
 	}
@@ -10179,9 +10188,21 @@ func (cl *CharList) tick() {
 	}
 }
 
+// Prepare characters for drawing
+// We once again check the movetype to minimize the difference between player sides
 func (cl *CharList) cueDraw() {
 	for _, c := range cl.drawOrder {
-		if c != nil {
+		if c != nil && c.ss.moveType == MT_A {
+			c.cueDraw()
+		}
+	}
+	for _, c := range cl.drawOrder {
+		if c != nil && c.ss.moveType == MT_I {
+			c.cueDraw()
+		}
+	}
+	for _, c := range cl.drawOrder {
+		if c != nil && c.ss.moveType == MT_H {
 			c.cueDraw()
 		}
 	}

--- a/src/char.go
+++ b/src/char.go
@@ -5192,7 +5192,7 @@ func (c *Char) hitAdd(h int32) {
 			}
 		}
 	} else if c.teamside != -1 {
-		// in mugen HitAdd increases combo count even without targets
+		// In Mugen, HitAdd can increase combo count even without targets
 		for i, p := range sys.chars {
 			if len(p) > 0 && c.teamside == ^i&1 {
 				if p[0].receivedHits != 0 || p[0].ss.moveType == MT_H {
@@ -10037,12 +10037,13 @@ func (cl *CharList) pushDetection(getter *Char) {
 				}
 
 				// Compare player weights and apply pushing factors
+				// Weight determines which player is pushed more. Factor determines how fast the player overlap is resolved
 				cfactor := float32(getter.size.weight) / float32(c.size.weight+getter.size.weight) * c.size.pushfactor * cpushed
 				gfactor := float32(c.size.weight) / float32(c.size.weight+getter.size.weight) * getter.size.pushfactor * gpushed
 
 				// Determine in which axes to push the players
-				// This needs to check both if the players have velocity or if their positions changed
-				pushx := sys.zmin == sys.zmax ||
+				// This needs to check both if the players have velocity or if their positions have changed
+				pushx := sys.zmin == sys.zmax || c.pos[2] == getter.pos[2] ||
 					getter.vel[0] != 0 || c.vel[0] != 0 || getter.pos[0] != getter.oldPos[0] || c.pos[0] != c.oldPos[0]
 				pushz := sys.zmin != sys.zmax &&
 					(getter.vel[2] != 0 || c.vel[2] != 0 || getter.pos[2] != getter.oldPos[2] || c.pos[2] != c.oldPos[2])
@@ -10117,7 +10118,6 @@ func (cl *CharList) pushDetection(getter *Char) {
 					// Clamp Z positions
 					c.zDepthBound()
 					getter.zDepthBound()
-
 				}
 
 				if getter.trackableByCamera() && getter.csf(CSF_screenbound) {

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -392,13 +392,15 @@ func (hb *HealthBar) step(ref int, hbr *HealthBar) {
 	hb.mid.Action()
 
 	// Multiple front elements - red life
-	var rv int32
-	for k := range hb.red {
-		if k > rv && redVal >= k {
-			rv = k
+	if sys.lifebar.redlifebar {
+		var rv int32
+		for k := range hb.red {
+			if k > rv && redVal >= k {
+				rv = k
+			}
 		}
+		hb.red[rv].Action()
 	}
-	hb.red[rv].Action()
 
 	// Multiple front elements - life
 	var fv float32
@@ -464,8 +466,8 @@ func (hb *HealthBar) draw(layerno int16, ref int, hbr *HealthBar, f []*Fnt) {
 	mr[2] -= Min(mr[2], lr[2])
 	//rr[2] -= Min(rr[2], lr[2])
 
-	var rv int32
 	if sys.lifebar.redlifebar {
+		var rv int32
 		for k := range hb.red {
 			if k > rv && redval >= k {
 				rv = k
@@ -1629,6 +1631,7 @@ func (co *LifeBarCombo) step(combo, damage int32, percentage float32, dizzy bool
 	co.bg.Action()
 	co.top.Action()
 
+	// Update team combo tracker
 	if combo > 0 {
 		combo = co.combo
 	} else {
@@ -1652,22 +1655,21 @@ func (co *LifeBarCombo) step(combo, damage int32, percentage float32, dizzy bool
 		co.resttime--
 	}
 
+	// Update if number of hits or total damage change
 	if combo >= 2 {
-		if co.oldhit != combo {
+		if co.oldhit != combo || co.olddmg != damage {
 			co.curhit = combo
+			co.curdmg = damage
+			co.curpct = percentage
 			co.resttime = co.displaytime
-			if co.counter_shake {
+			if co.counter_shake && co.oldhit != combo {
 				co.shaketime = co.counter_time
-			}
-			if co.olddmg != damage {
-				co.curdmg, co.olddmg = damage, damage // We probably don't need the "old" var in the current state of the code
-			}
-			if co.oldpct != percentage {
-				co.curpct, co.oldpct = percentage, percentage // We probably don't need the "old" var in the current state of the code
 			}
 		}
 	}
 	co.oldhit = combo
+	co.olddmg = damage
+	co.oldpct = percentage
 }
 
 func (co *LifeBarCombo) reset() {
@@ -1706,17 +1708,19 @@ func (co *LifeBarCombo) draw(layerno int16, f []*Fnt, side int) {
 	if co.text.font[0] >= 0 && int(co.text.font[0]) < len(f) && f[co.text.font[0]] != nil {
 		text := strings.Replace(co.text.text, "%i", fmt.Sprintf("%v", co.curhit), 1)
 		text = strings.Replace(text, "%d", fmt.Sprintf("%v", co.curdmg), 1)
-		// split float value, round to decimal place
-		s := strings.Split(fmt.Sprintf("%.[2]*[1]f", co.curpct, co.places), ".")
-		// decimal separator
+		// Truncate the percentage to avoid rounding to 100% unless the enemy is defeated
+		truncatedPct := math.Floor(float64(co.curpct) * math.Pow10(int(co.places))) / math.Pow10(int(co.places))
+		// Split float value
+		s := strings.Split(fmt.Sprintf("%.[2]*[1]f", truncatedPct, co.places), ".")
+		// Decimal separator
 		if co.places > 0 {
 			if len(s) > 1 {
 				s[0] = s[0] + co.separator + s[1]
 			}
 		}
-		// replace %p with formatted string
+		// Replace %p with formatted string
 		text = strings.Replace(text, "%p", s[0], 1)
-		// split on new line
+		// Split on new line
 		for k, v := range strings.Split(text, "\\n") {
 			if side == 1 {
 				if lt := float32(f[co.text.font[0]].TextWidth(v, co.text.font[1])) * co.text.lay.scale[0] * sys.lifebar.fnt_scale; lt > length {

--- a/src/render.go
+++ b/src/render.go
@@ -180,8 +180,8 @@ type RenderParams struct {
 }
 
 func (rp *RenderParams) IsValid() bool {
-	return rp.tex.IsValid() && IsFinite(rp.x+rp.y+rp.xts+rp.xbs+rp.ys+rp.vs+
-		rp.rxadd+rp.rot.angle+rp.rcx+rp.rcy)
+	return rp.tex.IsValid() && rp.size[0] != 0 && rp.size[1] != 0 &&
+		IsFinite(rp.x+rp.y+rp.xts+rp.xbs+rp.ys+rp.vs+rp.rxadd+rp.rot.angle+rp.rcx+rp.rcy)
 }
 
 func drawQuads(modelview mgl.Mat4, x1, y1, x2, y2, x3, y3, x4, y4 float32) {

--- a/src/stage.go
+++ b/src/stage.go
@@ -725,7 +725,7 @@ type Stage struct {
 	bgct              bgcTimeLine
 	bga               bgAction
 	sdw               stageShadow
-	p                 [8]stagePlayer
+	p                 [MaxSimul*2 + MaxAttachedChar]stagePlayer
 	leftbound         float32
 	rightbound        float32
 	screenleft        int32


### PR DESCRIPTION
Fix:
- Fixed players not pushing each other away when Z axis is enabled and their X and Z positions are exactly the same
- Placed tagged out players further away from the playable area of the screen, so AI's ignore them better
- Fixed camera shaking during Tag intros when team sizes are different
- Fixes #1347 
- Fixes #2238 (the discussion is not quite over though)
- Fixes #2256 

Refactor:
- Made two simple changes to the code to make custom builds that break the 4v4 limit easier to make
- Made player drawing order more discerning: if two players have the same sprite priority and one is attacking the other, the attacking player will always be drawn on top. Similar to player processing order but simpler
- The combo damage won't show 100% unless the enemy is defeated
- Instead of special handling for attached characters all characters obey the same rule: neutral players aren't considered enemies
- NumEnemy now also counts "standby" players
- Fixed EnemyNear and P2 checking attached characters
- Simplified when and how EnemyNear and P2 lists are cleared
- Skip drawing sprites that have scale 0