### PR TITLE
feat: Config option for tag round time scaling

### DIFF
--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -157,6 +157,7 @@ options.t_itemname = {
 			modifyGameOption('Options.Tag.Max', 4)
 			modifyGameOption('Options.Tag.Match.Wins', 2)
 			modifyGameOption('Options.Tag.LoseOnKO', false)	
+			modifyGameOption('Options.Tag.TimeScaling', 1)
 			modifyGameOption('Options.Turns.Min', 2)
 			modifyGameOption('Options.Turns.Max', 4)
 			modifyGameOption('Options.Turns.Recovery.Base', 0)

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -288,17 +288,24 @@ end
 --sets lifebar elements, round time, rounds to win
 function start.f_setRounds(roundTime, t_rounds)
 	setLifebarElements(main.lifebar)
-	--round time
+	-- Round time
 	local frames = main.timeFramesPerCount
 	local p1FramesMul = 1
 	local p2FramesMul = 1
-	if start.p[1].teamMode == 3 then --Tag
+	if start.p[1].teamMode == 3 then -- Tag
 		p1FramesMul = start.p[1].numChars
 	end
-	if start.p[2].teamMode == 3 then --Tag
+	if start.p[2].teamMode == 3 then -- Tag
 		p2FramesMul = start.p[2].numChars
 	end
-	frames = frames * math.max(p1FramesMul, p2FramesMul)
+	if (start.p[1].teamMode == 3 or start.p[2].teamMode == 3) and gameOption('Options.Tag.TimeScaling') > 0 then
+		-- Calculate the maximum team size
+		local maxTeamSize = math.max(p1FramesMul, p2FramesMul)
+		-- Apply a base multiplier for team size
+		local adjustedFrames = frames * (1 + (maxTeamSize - 1) * gameOption('Options.Tag.TimeScaling'))
+		-- Enforce a minimum threshold to avoid overly short rounds
+		frames = main.f_round(math.max(adjustedFrames, frames), 0)
+	end
 	setTimeFramesPerCount(frames)
 	if roundTime ~= nil then
 		setRoundTime(math.max(-1, roundTime * frames)) --round time predefined

--- a/src/config.go
+++ b/src/config.go
@@ -86,6 +86,7 @@ type Config struct {
 				Wins int32 `ini:"Wins"`
 			} `ini:"Match"`
 			LoseOnKO bool `ini:"LoseOnKO"`
+			TimeScaling float32 `ini:"TimeScaling"`
 		} `ini:"Tag"`
 		Turns struct {
 			Min      int `ini:"Min"`

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -77,6 +77,9 @@ Tag.Max               = 4
 Tag.Match.Wins        = 2
 ; Defeating team member ends the match
 Tag.LoseOnKO          = 0
+; Multiplier for scaling round time based on team size in Tag team mode.
+; (e.g., 1.0 for proportional scaling, 0.5 for half-rate, 0 to disable).
+Tag.TimeScaling       = 1.0
 ; Min Turns team size
 Turns.Min             = 2
 ; Max Turns team size (unlimited)


### PR DESCRIPTION
previously linear adjustment was enforced in scripts