### PR TITLE
feat: SoundVar(ch, valType)

### DIFF
--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -1153,7 +1153,7 @@ function start.f_playWave(ref, name, g, n, loops)
 		if main.t_selStages[ref][name .. '_wave_data'] == nil then
 			main.t_selStages[ref][name .. '_wave_data'] = getWaveData(a.dir .. a.sound, g, n, loops or -1)
 		end
-		wavePlay(main.t_selStages[ref][name .. '_wave_data'])
+		wavePlay(main.t_selStages[ref][name .. '_wave_data'], g, n)
 	else
 		local sound = start.f_getCharData(ref).sound
 		if sound == nil or sound == '' then
@@ -1162,7 +1162,7 @@ function start.f_playWave(ref, name, g, n, loops)
 		if start.f_getCharData(ref)[name .. '_wave_data'] == nil then
 			start.f_getCharData(ref)[name .. '_wave_data'] = getWaveData(start.f_getCharData(ref).dir .. sound, g, n, loops or -1)
 		end
-		wavePlay(start.f_getCharData(ref)[name .. '_wave_data'])
+		wavePlay(start.f_getCharData(ref)[name .. '_wave_data'], g, n)
 	end
 end
 

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -845,6 +845,19 @@ const (
 	OC_ex2_hitdefvar_shaketime
 	OC_ex2_hitdefvar_guard_shaketime
 	OC_ex2_hitbyattr
+	OC_ex2_soundvar_group
+	OC_ex2_soundvar_number
+	OC_ex2_soundvar_freqmul
+	OC_ex2_soundvar_isplaying
+	OC_ex2_soundvar_length
+	OC_ex2_soundvar_loopcount
+	OC_ex2_soundvar_loopstart
+	OC_ex2_soundvar_loopend
+	OC_ex2_soundvar_pan
+	OC_ex2_soundvar_position
+	OC_ex2_soundvar_priority
+	OC_ex2_soundvar_startposition
+	OC_ex2_soundvar_volumescale
 )
 const (
 	NumVar     = 60
@@ -3529,6 +3542,36 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	case OC_ex2_hitbyattr:
 		sys.bcStack.PushB(c.hitByAttrTrigger(*(*int32)(unsafe.Pointer(&be[*i]))))
 		*i += 4
+	// BEGIN FALLTHROUGH (soundvar)
+	case OC_ex2_soundvar_group:
+		fallthrough
+	case OC_ex2_soundvar_number:
+		fallthrough
+	case OC_ex2_soundvar_freqmul:
+		fallthrough
+	case OC_ex2_soundvar_isplaying:
+		fallthrough
+	case OC_ex2_soundvar_length:
+		fallthrough
+	case OC_ex2_soundvar_loopcount:
+		fallthrough
+	case OC_ex2_soundvar_loopend:
+		fallthrough
+	case OC_ex2_soundvar_loopstart:
+		fallthrough
+	case OC_ex2_soundvar_pan:
+		fallthrough
+	case OC_ex2_soundvar_position:
+		fallthrough
+	case OC_ex2_soundvar_priority:
+		fallthrough
+	case OC_ex2_soundvar_startposition:
+		fallthrough
+	case OC_ex2_soundvar_volumescale:
+		// END FALLTHROUGH (soundvar)
+		// get the channel
+		ch := sys.bcStack.Pop()
+		sys.bcStack.Push(c.soundVar(ch, opc))
 	default:
 		sys.errLog.Printf("%v\n", be[*i-1])
 		c.panic()

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -3076,25 +3076,6 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			bv1.SetI(idx + 1)
 		}
 
-		// bv3 := BytecodeInt(0)
-		// if isFlag {
-		// 	if err := eqne2(func(not bool) error {
-		// 		if flg, err := flagSub(); err != nil {
-		// 			return err
-		// 		} else {
-		// 			if not {
-		// 				bv3 = BytecodeInt(^flg)
-		// 			} else {
-		// 				bv3 = BytecodeInt(flg)
-		// 			}
-		// 		}
-		// 		return nil
-		// 	}); err != nil {
-		// 		return bvNone(), err
-		// 	}
-		// }
-
-		// be3.appendValue(bv3)
 		be2.appendValue(bv2)
 		be1.appendValue(bv1)
 
@@ -3104,7 +3085,6 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			be1.append(OC_jz8, OpCode(len(be2)+1))
 		}
 		be1.append(be2...)
-		// be1.append(be3...)
 
 		if rd {
 			out.appendI32Op(OC_nordrun, int32(len(be1)))

--- a/src/script.go
+++ b/src/script.go
@@ -4739,7 +4739,7 @@ func triggerFunctions(l *lua.LState) {
 			ch = sys.debugWC.soundChannels.Get(id)
 		}
 
-		if ch.sfx != nil {
+		if ch != nil && ch.sfx != nil {
 			switch strings.ToLower(vname) {
 			case "group":
 				lv = lua.LNumber(ch.group)


### PR DESCRIPTION
This adds a new feature to ZSS: `SoundVar(channelNo, parameter)`

Valid parameters currently are:
        group
	number
	freqmul
	isplaying
	length
	loopcount
	loopstart
	loopend
	pan
	position
	priority
	startposition
	volumescale
	

`wavePlay` Lua function was updated due to the parts needed to make the group and number feature work.

ex.
```zss

# Play a sound while attacking if one is not playing on channel 0.
if stateNo = [200,299] && Time = 1 && !SoundVar(0, IsPlaying) {
	playSnd { channel: 0; value: 5,0; volumescale: 50; }
}


if StageTime > 0 {
        # Debug output
	PrintToConsole{
		text: "0: isPlaying = %d; g,n = %d,%d, vol = %f\n1: isPlaying = %d; g,n = %d,%d, vol = %f";
		params: SoundVar(0, IsPlaying), SoundVar(0, Group), SoundVar(0, Number), SoundVar(0, VolumeScale), SoundVar(1, IsPlaying), SoundVar(1, Group), SoundVar(1, Number), SoundVar(1, VolumeScale);
	}
}
```