### PR TITLE
feat: assertSpecial limit, separate values for depth const, disable facep2

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3960,7 +3960,7 @@ func (sc stateDef) Run(c *Char) {
 			c.layerNo = 0 // Prevent char from being forgotten in a different layer
 		case stateDef_facep2:
 			if exp[0].evalB(c) && c.rdDistX(c.p2(), c).ToF() < 0 {
-				if !c.asf(ASF_noautoturn) || !c.asf(ASF_noturntarget) || !sys.stage.autoturn {
+				if sys.stage.autoturn && !c.asf(ASF_noautoturn) && !c.asf(ASF_noturntarget) {
 					c.setFacing(-c.facing)
 				}
 			}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3960,7 +3960,7 @@ func (sc stateDef) Run(c *Char) {
 			c.layerNo = 0 // Prevent char from being forgotten in a different layer
 		case stateDef_facep2:
 			if exp[0].evalB(c) && c.rdDistX(c.p2(), c).ToF() < 0 {
-				if sys.stage.autoturn && !c.asf(ASF_noautoturn) && !c.asf(ASF_noturntarget) {
+				if sys.stage.autoturn && !c.asf(ASF_noautoturn) {
 					c.setFacing(-c.facing)
 				}
 			}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3941,6 +3941,7 @@ const (
 )
 
 func (sc stateDef) Run(c *Char) {
+	e := c.p2()
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case stateDef_hitcountpersist:
@@ -3959,7 +3960,7 @@ func (sc stateDef) Run(c *Char) {
 			c.sprPriority = exp[0].evalI(c)
 			c.layerNo = 0 // Prevent char from being forgotten in a different layer
 		case stateDef_facep2:
-			if exp[0].evalB(c) && c.rdDistX(c.p2(), c).ToF() < 0 {
+			if exp[0].evalB(c) && c.rdDistX(e, c).ToF() < 0 && !e.asf(ASF_noturntarget) {
 				if sys.stage.autoturn && !c.asf(ASF_noautoturn) {
 					c.setFacing(-c.facing)
 				}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3960,7 +3960,9 @@ func (sc stateDef) Run(c *Char) {
 			c.layerNo = 0 // Prevent char from being forgotten in a different layer
 		case stateDef_facep2:
 			if exp[0].evalB(c) && c.rdDistX(c.p2(), c).ToF() < 0 {
-				c.setFacing(-c.facing)
+				if !c.asf(ASF_noautoturn) || !c.asf(ASF_noturntarget) || !sys.stage.autoturn {
+					c.setFacing(-c.facing)
+				}
 			}
 		case stateDef_juggle:
 			c.juggle = exp[0].evalI(c)

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -289,7 +289,8 @@ const (
 	OC_const_size_shadowoffset
 	OC_const_size_draw_offset_x
 	OC_const_size_draw_offset_y
-	OC_const_size_depth
+	OC_const_size_depth_front
+	OC_const_size_depth_back
 	OC_const_size_weight
 	OC_const_size_pushfactor
 	OC_const_velocity_walk_fwd_x
@@ -2029,8 +2030,10 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.size.draw.offset[0] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_draw_offset_y:
 		sys.bcStack.PushF(c.size.draw.offset[1] * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_size_depth:
-		sys.bcStack.PushF(c.size.depth * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_size_depth_front:
+		sys.bcStack.PushF(c.size.depth[0] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_size_depth_back:
+		sys.bcStack.PushF(c.size.depth[1] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_weight:
 		sys.bcStack.PushI(c.size.weight)
 	case OC_const_size_pushfactor:
@@ -4731,7 +4734,10 @@ func (sc helper) Run(c *Char, _ []int32) bool {
 		case helper_size_shadowoffset:
 			h.size.shadowoffset = exp[0].evalF(c)
 		case helper_size_depth:
-			h.size.depth = exp[0].evalF(c)
+			h.size.depth[0] = exp[0].evalF(c)
+			if len(exp) > 1 {
+				h.size.depth[1] = exp[1].evalF(c)
+			}
 		case helper_size_weight:
 			h.size.weight = exp[0].evalI(c)
 		case helper_size_pushfactor:

--- a/src/char.go
+++ b/src/char.go
@@ -304,7 +304,7 @@ type CharSize struct {
 	draw         struct {
 		offset [2]float32
 	}
-	depth      float32 // Former depth
+	depth      [2]float32 // Former depth
 	weight     int32
 	pushfactor float32
 }
@@ -332,7 +332,7 @@ func (cs *CharSize) init() {
 	cs.mid.pos = [...]float32{-5, -60}
 	cs.shadowoffset = 0
 	cs.draw.offset = [...]float32{0, 0}
-	cs.depth = 3
+	cs.depth = [...]float32{4, 4}
 	cs.attack.depth.front = 4
 	cs.attack.depth.back = 4
 	cs.weight = 100
@@ -2865,7 +2865,8 @@ func (c *Char) load(def string) error {
 		c.size.shadowoffset *= coordRatio
 		c.size.draw.offset[0] *= coordRatio
 		c.size.draw.offset[1] *= coordRatio
-		c.size.depth *= coordRatio
+		c.size.depth[0] *= coordRatio
+		c.size.depth[1] *= coordRatio
 		c.size.attack.depth.front *= coordRatio
 		c.size.attack.depth.back *= coordRatio
 	}
@@ -3005,7 +3006,7 @@ func (c *Char) load(def string) error {
 						is.ReadF32("shadowoffset", &c.size.shadowoffset)
 						is.ReadF32("draw.offset",
 							&c.size.draw.offset[0], &c.size.draw.offset[1])
-						is.ReadF32("depth", &c.size.depth)
+						is.ReadF32("depth", &c.size.depth[0], &c.size.depth[1])
 						is.ReadF32("attack.depth", &c.size.attack.depth.front, &c.size.attack.depth.back)
 						is.ReadI32("weight", &c.size.weight)
 						is.ReadF32("pushfactor", &c.size.pushfactor)
@@ -6370,10 +6371,10 @@ func (c *Char) bodyDistY(opp *Char, oc *Char) float32 {
 }
 
 func (c *Char) bodyDistZ(opp *Char, oc *Char) float32 {
-	ctop := (c.pos[2] - c.size.depth) * c.localscl
-	cbot := (c.pos[2] + c.size.depth) * c.localscl
-	otop := (opp.pos[2] - opp.size.depth) * opp.localscl
-	obot := (opp.pos[2] + opp.size.depth) * opp.localscl
+	cbot := (c.pos[2] + c.size.depth[0]) * c.localscl
+	ctop := (c.pos[2] - c.size.depth[1]) * c.localscl
+	obot := (opp.pos[2] + opp.size.depth[0]) * opp.localscl
+	otop := (opp.pos[2] - opp.size.depth[1]) * opp.localscl
 	if cbot < otop {
 		return (otop - cbot) / oc.localscl
 	} else if ctop > obot {
@@ -7519,7 +7520,7 @@ func (c *Char) hittableByChar(ghd *HitDef, getter *Char, gst StateType, proj boo
 				getter.attrCheck(hd, c, c.ss.stateType) &&
 				c.clsnCheck(getter, 1, c.hitdef.p2clsncheck, true, false) &&
 				sys.zAxisOverlap(c.pos[2], c.hitdef.attack.depth[0], c.hitdef.attack.depth[1], c.localscl,
-					getter.pos[2], getter.size.depth, getter.size.depth, getter.localscl)
+					getter.pos[2], getter.size.depth[0], getter.size.depth[1], getter.localscl)
 		}
 	}
 
@@ -9834,7 +9835,7 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 
 					if getter.projClsnCheck(p, p.hitdef.p2clsncheck, 1) &&
 						sys.zAxisOverlap(p.pos[2], p.hitdef.attack.depth[0], p.hitdef.attack.depth[1], p.localscl,
-							getter.pos[2], getter.size.depth, getter.size.depth, getter.localscl) {
+							getter.pos[2], getter.size.depth[0], getter.size.depth[1], getter.localscl) {
 
 						if ht := hitTypeGet(c, &p.hitdef, [...]float32{p.pos[0] - c.pos[0]*(c.localscl/p.localscl),
 							p.pos[1] - c.pos[1]*(c.localscl/p.localscl), p.pos[2] - c.pos[2]*(c.localscl/p.localscl)},
@@ -9956,7 +9957,7 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 							getter.pos[2], getter.hitdef.attack.depth[0], getter.hitdef.attack.depth[1], getter.localscl)
 					} else {
 						zok = sys.zAxisOverlap(c.pos[2], c.hitdef.attack.depth[0], c.hitdef.attack.depth[1], c.localscl,
-							getter.pos[2], getter.size.depth, getter.size.depth, getter.localscl)
+							getter.pos[2], getter.size.depth[0], getter.size.depth[1], getter.localscl)
 					}
 
 					// If collision OK then get the hit type and act accordingly
@@ -10108,11 +10109,11 @@ func (cl *CharList) pushDetection(getter *Char) {
 				continue
 			}
 
-			czback := c.pos[2]*c.localscl - c.size.depth*c.localscl
-			czfront := c.pos[2]*c.localscl + c.size.depth*c.localscl
-
-			gzback := getter.pos[2]*getter.localscl - getter.size.depth*getter.localscl
-			gzfront := getter.pos[2]*getter.localscl + getter.size.depth*getter.localscl
+			czfront := c.pos[2]*c.localscl + c.size.depth[0]*c.localscl
+			czback := c.pos[2]*c.localscl - c.size.depth[1]*c.localscl
+			
+			gzfront := getter.pos[2]*getter.localscl + getter.size.depth[0]*getter.localscl
+			gzback := getter.pos[2]*getter.localscl - getter.size.depth[1]*getter.localscl
 
 			// Z axis fail
 			if gzback >= czfront || czback >= gzfront {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1810,8 +1810,10 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.append(OC_const_size_draw_offset_x)
 		case "size.draw.offset.y":
 			out.append(OC_const_size_draw_offset_y)
-		case "size.depth":
-			out.append(OC_const_size_depth)
+		case "size.depth.front":
+			out.append(OC_const_size_depth_front)
+		case "size.depth.back":
+			out.append(OC_const_size_depth_back)
 		case "size.weight":
 			out.append(OC_const_size_weight)
 		case "size.pushfactor":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -268,6 +268,31 @@ func (c *Compiler) assertSpecial(is IniSection, sc *StateControllerBase, _ int8)
 		}); err != nil {
 			return err
 		}
+		if err := c.stateParam(is, "flag4", false, func(data string) error {
+			return foo(data)
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "flag5", false, func(data string) error {
+			return foo(data)
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "flag6", false, func(data string) error {
+			return foo(data)
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "flag7", false, func(data string) error {
+			return foo(data)
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "flag8", false, func(data string) error {
+			return foo(data)
+		}); err != nil {
+			return err
+		}
 		return nil
 	})
 	return *ret, err
@@ -615,7 +640,7 @@ func (c *Compiler) helper(is IniSection, sc *StateControllerBase, _ int8) (State
 			return err
 		}
 		if err := c.paramValue(is, sc, "size.depth",
-			helper_size_depth, VT_Int, 1, false); err != nil {
+			helper_size_depth, VT_Int, 2, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "size.weight",

--- a/src/script.go
+++ b/src/script.go
@@ -3410,8 +3410,10 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.size.draw.offset[0])
 		case "size.draw.offset.y":
 			ln = lua.LNumber(c.size.draw.offset[1])
-		case "size.depth":
-			ln = lua.LNumber(c.size.depth)
+		case "size.depth.front":
+			ln = lua.LNumber(c.size.depth[0])
+		case "size.depth.back":
+			ln = lua.LNumber(c.size.depth[1])
 		case "size.weight":
 			ln = lua.LNumber(c.size.weight)
 		case "size.pushfactor":


### PR DESCRIPTION
Feat:
- Depth constant and helper's size.depth now accept two separate values instead of just one.
- Increased the assertSpecial limit to support up to 8 flags.
- NoAutoTurn, NoTurnTarget, and stage autoturn = 0 will also disable the facep2 turn