### PR TITLE
feat: stage DepthToScreen, ModifyPlayer pause parameters; refactoring

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3941,7 +3941,6 @@ const (
 )
 
 func (sc stateDef) Run(c *Char) {
-	e := c.p2()
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case stateDef_hitcountpersist:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -11874,6 +11874,9 @@ const (
 	modifyPlayer_moveguarded
 	modifyPlayer_movereversed
 	modifyPlayer_movecountered
+	modifyPlayer_hitpausetime
+	modifyPlayer_pausemovetime
+	modifyPlayer_supermovetime
 	modifyPlayer_redirectid
 )
 
@@ -11952,6 +11955,12 @@ func (sc modifyPlayer) Run(c *Char, _ []int32) bool {
 			crun.mctime = Max(0, exp[0].evalI(c))
 		case modifyPlayer_movecountered:
 			crun.counterHit = exp[0].evalB(c)
+		case modifyPlayer_hitpausetime:
+			crun.hitPauseTime = Max(0, exp[0].evalI(c))
+		case modifyPlayer_pausemovetime:
+			crun.pauseMovetime = Max(0, exp[0].evalI(c))
+		case modifyPlayer_supermovetime:
+			crun.superMovetime = Max(0, exp[0].evalI(c))
 		case modifyPlayer_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid

--- a/src/camera.go
+++ b/src/camera.go
@@ -25,6 +25,7 @@ type stageCamera struct {
 	zoffset                 int32
 	ztopscale               float32
 	zbotscale               float32
+	depthtoscreen           float32
 	topz                    float32
 	botz                    float32
 	startzoom               float32

--- a/src/char.go
+++ b/src/char.go
@@ -1541,7 +1541,7 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 		zscale := sys.updateZScale(e.pos[2], e.localscl)
 		drawpos[0] *= zscale
 		drawpos[1] *= zscale
-		drawpos[1] += e.interPos[2] * e.localscl
+		drawpos[1] += sys.posZtoY(e.interPos[2], e.localscl)
 		drawscale[0] *= zscale
 		drawscale[1] *= zscale
 	}
@@ -2109,7 +2109,7 @@ func (p *Projectile) cueDraw(oldVer bool, playerNo int) {
 	if sys.zEnabled() {
 		pos[0] *= p.zScale
 		pos[1] *= p.zScale
-		pos[1] += p.interPos[2] * p.localscl
+		pos[1] += sys.posZtoY(p.interPos[2], p.localscl)
 	}
 
 	sprs := &sys.spritesLayer0
@@ -8518,7 +8518,7 @@ func (c *Char) cueDraw() {
 		if sys.zEnabled() {
 			pos[0] *= c.zScale
 			pos[1] *= c.zScale
-			pos[1] += c.interPos[2] * c.localscl
+			pos[1] += sys.posZtoY(c.interPos[2], c.localscl)
 		}
 		//if sys.zEnabled() {
 		//	ratio := float32(1.618) // Possible stage parameter?
@@ -8600,10 +8600,10 @@ func (c *Char) cueDraw() {
 				// Mugen uses some odd math for the shadow offset here, factoring in the stage's shadow scale
 				// Meaning the character's shadow offset constant is unable to offset it correctly in every stage
 				// Ikemen works differently and as you'd expect it to
-				charposz := c.interPos[2] * c.localscl
+				drawZoff := sys.posZtoY(c.interPos[2], c.localscl)
 				sys.shadows.add(&ShadowSprite{sd, -1, sdwalp,
-					[2]float32{c.shadowOffset[0] * c.localscl, (c.size.shadowoffset+c.shadowOffset[1])*c.localscl + sys.stage.sdw.yscale*charposz + charposz}, // Shadow offset
-					[2]float32{c.reflectOffset[0] * c.localscl, (c.size.shadowoffset+c.reflectOffset[1])*c.localscl + sys.stage.reflection.yscale*charposz + charposz}, // Reflection offset
+					[2]float32{c.shadowOffset[0] * c.localscl, (c.size.shadowoffset+c.shadowOffset[1])*c.localscl + sys.stage.sdw.yscale*drawZoff + drawZoff}, // Shadow offset
+					[2]float32{c.reflectOffset[0] * c.localscl, (c.size.shadowoffset+c.reflectOffset[1])*c.localscl + sys.stage.reflection.yscale*drawZoff + drawZoff}, // Reflection offset
 					c.offsetY()}) // Fade offset
 			}
 		}

--- a/src/char.go
+++ b/src/char.go
@@ -8174,7 +8174,7 @@ func (c *Char) tick() {
 	if c.cmd == nil {
 		if c.keyctrl[0] {
 			c.cmd = make([]CommandList, len(sys.chars))
-			c.cmd[0].Buffer = NewCommandBuffer()
+			c.cmd[0].Buffer = NewInputBuffer()
 			for i := range c.cmd {
 				c.cmd[i].Buffer = c.cmd[0].Buffer
 				c.cmd[i].CopyList(sys.chars[c.playerNo][0].cmd[i])

--- a/src/char.go
+++ b/src/char.go
@@ -8589,10 +8589,13 @@ func (c *Char) cueDraw() {
 				//if sd.oldVer {
 				//	soy *= 1.5
 				//}
+				// Mugen uses some odd math for the shadow offset here, factoring in the stage's shadow scale
+				// Meaning the character's shadow offset constant is unable to offset it correctly in every stage
+				// Ikemen works differently and as you'd expect it to
 				charposz := c.interPos[2] * c.localscl
 				sys.shadows.add(&ShadowSprite{sd, -1, sdwalp,
 					[2]float32{c.shadowOffset[0] * c.localscl, (c.size.shadowoffset+c.shadowOffset[1])*c.localscl + sys.stage.sdw.yscale*charposz + charposz}, // Shadow offset
-					[2]float32{c.reflectOffset[0] * c.localscl, c.reflectOffset[1]*c.localscl + sys.stage.reflection.yscale*charposz + charposz},              // Reflection offset
+					[2]float32{c.reflectOffset[0] * c.localscl, (c.size.shadowoffset+c.reflectOffset[1])*c.localscl + sys.stage.reflection.yscale*charposz + charposz}, // Reflection offset
 					c.offsetY()}) // Fade offset
 			}
 		}

--- a/src/common.go
+++ b/src/common.go
@@ -791,8 +791,11 @@ func (l *Layout) DrawFaceSprite(x, y float32, ln int16, s *Sprite, fx *PalFX, fs
 	}
 }
 
-func (l *Layout) DrawAnim(r *[4]int32, x, y, scl float32, ln int16,
-	a *Animation, palfx *PalFX) {
+func (l *Layout) DrawAnim(r *[4]int32, x, y, scl float32, ln int16, a *Animation, palfx *PalFX) {
+	// Skip blank animations
+	if a == nil || a.isBlank() {
+		return
+	}
 	if l.layerno == ln {
 		// TODO: test "phantom pixel"
 		if l.facing < 0 {
@@ -807,6 +810,7 @@ func (l *Layout) DrawAnim(r *[4]int32, x, y, scl float32, ln int16,
 			float32(sys.gameWidth-320)/2, palfx, false, 1, false, [2]float32{1, 1}, 0, 0, 0)
 	}
 }
+
 func (l *Layout) DrawText(x, y, scl float32, ln int16,
 	text string, f *Fnt, b, a int32, palfx *PalFX, frgba [4]float32) {
 	if l.layerno == ln {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -81,7 +81,6 @@ func newCompiler() *Compiler {
 		"makedust":           c.makeDust,
 		"modifyexplod":       c.modifyExplod,
 		"movehitreset":       c.moveHitReset,
-		"movehitset":         c.moveHitSet,
 		"nothitby":           c.notHitBy,
 		"null":               c.null,
 		"offset":             c.offset,

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -6919,7 +6919,7 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 	// Initialize command list data
 	if sys.chars[pn][0].cmd == nil {
 		sys.chars[pn][0].cmd = make([]CommandList, MaxSimul*2+MaxAttachedChar)
-		b := NewCommandBuffer()
+		b := NewInputBuffer()
 		for i := range sys.chars[pn][0].cmd {
 			sys.chars[pn][0].cmd[i] = *NewCommandList(b)
 		}

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -5372,6 +5372,18 @@ func (c *Compiler) modifyPlayer(is IniSection, sc *StateControllerBase, _ int8) 
 			modifyPlayer_movecountered, VT_Bool, 1, false); err != nil { // Formerly MoveHitSet
 			return err
 		}
+		if err := c.paramValue(is, sc, "hitpausetime",
+			modifyPlayer_hitpausetime, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "pausemovetime",
+			modifyPlayer_pausemovetime, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "supermovetime",
+			modifyPlayer_supermovetime, VT_Int, 1, false); err != nil {
+			return err
+		}
 		return nil
 	})
 	return *ret, err

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -5355,6 +5355,23 @@ func (c *Compiler) modifyPlayer(is IniSection, sc *StateControllerBase, _ int8) 
 		}); err != nil {
 			return err
 		}
+
+		if err := c.paramValue(is, sc, "movehit",
+			modifyPlayer_movehit, VT_Int, 1, false); err != nil { // Formerly MoveHitSet
+			return err
+		}
+		if err := c.paramValue(is, sc, "moveguarded",
+			modifyPlayer_moveguarded, VT_Int, 1, false); err != nil { // Formerly MoveHitSet
+			return err
+		}
+		if err := c.paramValue(is, sc, "movereversed",
+			modifyPlayer_movereversed, VT_Int, 1, false); err != nil { // Formerly MoveHitSet
+			return err
+		}
+		if err := c.paramValue(is, sc, "movecountered",
+			modifyPlayer_movecountered, VT_Bool, 1, false); err != nil { // Formerly MoveHitSet
+			return err
+		}
 		return nil
 	})
 	return *ret, err
@@ -5586,51 +5603,6 @@ func (c *Compiler) transformClsn(is IniSection, sc *StateControllerBase, _ int8)
 		}
 		if !any {
 			return Error("Must specify at least one TransformClsn parameter")
-		}
-		return nil
-	})
-	return *ret, err
-}
-
-func (c *Compiler) moveHitSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
-	ret, err := (*moveHitSet)(sc), c.stateSec(is, func() error {
-		if err := c.paramValue(is, sc, "redirectid",
-			moveHitSet_redirectid, VT_Int, 1, false); err != nil {
-			return err
-		}
-		var param bool
-		if err := c.stateParam(is, "movehit", false, func(data string) error {
-			param = true
-			return c.scAdd(sc, moveHitSet_movehit, data, VT_Int, 1)
-		}); err != nil {
-			return err
-		}
-		if err := c.stateParam(is, "moveguarded", false, func(data string) error {
-			if param {
-				return Error("Conflicting MoveHitSet parameters")
-			}
-			param = true
-			return c.scAdd(sc, moveHitSet_moveguarded, data, VT_Int, 1)
-		}); err != nil {
-			return err
-		}
-		if err := c.stateParam(is, "movereversed", false, func(data string) error {
-			if param {
-				return Error("Conflicting MoveHitSet parameters")
-			}
-			param = true
-			return c.scAdd(sc, moveHitSet_movereversed, data, VT_Int, 1)
-		}); err != nil {
-			return err
-		}
-		if err := c.stateParam(is, "movecountered", false, func(data string) error {
-			param = true // Does not conflict with others
-			return c.scAdd(sc, moveHitSet_movecountered, data, VT_Bool, 1)
-		}); err != nil {
-			return err
-		}
-		if !param {
-			return Error("No valid MoveHitSet parameters found")
 		}
 		return nil
 	})

--- a/src/font.go
+++ b/src/font.go
@@ -442,8 +442,8 @@ func (f *Fnt) drawChar(
 		return 0
 	}
 
-	// in case of mismatched color depth between bank palette and
-	// sprite own palette, mugen 1.1 uses the latter, ignoring bank
+	// In case of mismatched color depth between bank palette and the sprite's own palette,
+	// Mugen 1.1 uses the latter, ignoring the bank
 	if len(f.palettes) != 0 && len(f.coldepth) > int(bank) &&
 		f.images[bt][c].img[0].coldepth != 32 &&
 		f.coldepth[bank] != f.images[bt][c].img[0].coldepth {
@@ -479,10 +479,9 @@ func (f *Fnt) Print(txt string, x, y, xscl, yscl float32, bank, align int32,
 }
 
 // DrawText prints on screen a specified text with the current font sprites
-func (f *Fnt) DrawText(txt string, x, y, xscl, yscl float32, bank, align int32,
-	window *[4]int32, palfx *PalFX) {
+func (f *Fnt) DrawText(txt string, x, y, xscl, yscl float32, bank, align int32, window *[4]int32, palfx *PalFX) {
 
-	if len(txt) == 0 {
+	if len(txt) == 0 || xscl == 0 || yscl == 0 {
 		return
 	}
 

--- a/src/image.go
+++ b/src/image.go
@@ -518,6 +518,10 @@ type Sprite struct {
 	PalTex        Texture
 }
 
+func (s *Sprite) isBlank() bool {
+	return s.Tex == nil || s.Group < 0 || s.Number < 0 || s.Size[0] == 0 || s.Size[1] == 0
+}
+
 func newSprite() *Sprite {
 	return &Sprite{palidx: -1}
 }

--- a/src/image.go
+++ b/src/image.go
@@ -410,6 +410,7 @@ func (pl *PaletteList) GetPalMap() []int {
 	copy(pm, pl.paletteMap)
 	return pm
 }
+
 func (pl *PaletteList) SwapPalMap(palMap *[]int) bool {
 	if len(*palMap) != len(pl.paletteMap) {
 		return false
@@ -669,6 +670,7 @@ func (s *Sprite) GetPal(pl *PaletteList) []uint32 {
 	}
 	return pl.Get(int(s.palidx)) //pl.palettes[pl.paletteMap[int(s.palidx)]]
 }
+
 func (s *Sprite) GetPalTex(pl *PaletteList) Texture {
 	if s.coldepth > 8 {
 		return nil
@@ -1130,8 +1132,8 @@ func (s *Sprite) readV2(f *os.File, offset int64, datasize uint32) error {
 	return nil
 }
 
-// Cache the provided palette data in a sprite. But first check if the
-// previously stored one is still valid.
+// Compare current palette to previous one and reuse if possible
+// This saves a lot of palette operations when the same player has many sprites on screen
 func (s *Sprite) CachePalette(pal []uint32) Texture {
 	hasPalette := true
 	if s.PalTex == nil || len(pal) != len(s.paltemp) {
@@ -1144,10 +1146,10 @@ func (s *Sprite) CachePalette(pal []uint32) Texture {
 			}
 		}
 	}
-	// If cached texture is invalid, generate a new one
+	// If cached texture is invalid, generate a new one and cache it
 	if !hasPalette {
 		s.PalTex = PaletteToTexture(pal)
-		s.paltemp = append([]uint32{}, pal...)
+		s.paltemp = pal
 	}
 	return s.PalTex
 }

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -421,14 +421,14 @@ func (hb *HealthBar) reset() {
 	hb.bg2.Reset()
 	hb.top.Reset()
 	hb.mid.Reset()
-	for _, v := range hb.front {
-		v.Reset()
+	for i := range hb.front {
+		hb.front[i].Reset()
 	}
 	hb.shift.Reset()
 	hb.shift.anim.srcAlpha = 0
 	hb.shift.anim.dstAlpha = 255
-	for _, v := range hb.red {
-		v.Reset()
+	for i := range hb.red {
+		hb.red[i].Reset()
 	}
 	hb.warn.Reset()
 }
@@ -647,15 +647,15 @@ func (pb *PowerBar) step(ref int, pbr *PowerBar, snd *Snd) {
 }
 
 func (pb *PowerBar) reset() {
-	for _, v := range pb.bg0 {
-		v.Reset()
+	for i := range pb.bg0 {
+		pb.bg0[i].Reset()
 	}
 	pb.bg1.Reset()
 	pb.bg2.Reset()
 	pb.top.Reset()
 	pb.mid.Reset()
-	for _, v := range pb.front {
-		v.Reset()
+	for i := range pb.front {
+		pb.front[i].Reset()
 	}
 	pb.shift.Reset()
 	pb.shift.anim.srcAlpha = 0
@@ -1018,8 +1018,8 @@ func (sb *StunBar) reset() {
 	sb.bg2.Reset()
 	sb.top.Reset()
 	sb.mid.Reset()
-	for _, v := range sb.front {
-		v.Reset()
+	for i := range sb.front {
+		sb.front[i].Reset()
 	}
 	sb.shift.Reset()
 	sb.shift.anim.srcAlpha = 255
@@ -4254,34 +4254,34 @@ func (l *Lifebar) reset() {
 			l.order[ti] = append(l.order[ti], i)
 		}
 	}
-	for _, hb := range l.hb {
-		for i := range hb {
-			hb[i].reset()
+	for i := range l.hb {
+		for j := range l.hb[i] {
+			l.hb[i][j].reset()
 		}
 	}
-	for _, pb := range l.pb {
-		for i := range pb {
-			pb[i].reset()
+	for i := range l.pb {
+		for j := range l.pb[i] {
+			l.pb[i][j].reset()
 		}
 	}
-	for _, gb := range l.gb {
-		for i := range gb {
-			gb[i].reset()
+	for i := range l.gb {
+		for j := range l.gb[i] {
+			l.gb[i][j].reset()
 		}
 	}
-	for _, sb := range l.sb {
-		for i := range sb {
-			sb[i].reset()
+	for i := range l.sb {
+		for j := range l.sb[i] {
+			l.sb[i][j].reset()
 		}
 	}
-	for _, fa := range l.fa {
-		for i := range fa {
-			fa[i].reset()
+	for i := range l.fa {
+		for j := range l.fa[i] {
+			l.fa[i][j].reset()
 		}
 	}
-	for _, nm := range l.nm {
-		for i := range nm {
-			nm[i].reset()
+	for i := range l.nm {
+		for j := range l.nm[i] {
+			l.nm[i][j].reset()
 		}
 	}
 	for i := range l.wi {

--- a/src/script.go
+++ b/src/script.go
@@ -780,7 +780,7 @@ func systemScriptInit(l *lua.LState) {
 		return 0
 	})
 	luaRegister(l, "commandNew", func(l *lua.LState) int {
-		l.Push(newUserData(l, NewCommandList(NewCommandBuffer())))
+		l.Push(newUserData(l, NewCommandList(NewInputBuffer())))
 		return 1
 	})
 	luaRegister(l, "connected", func(*lua.LState) int {

--- a/src/sound.go
+++ b/src/sound.go
@@ -765,7 +765,8 @@ func (s *SoundChannels) Play(sound *Sound, group, number, volumescale int32, pan
 	return true
 }
 func (s *SoundChannels) IsPlaying(sound *Sound) bool {
-	for _, v := range s.channels {
+	for i := range s.channels {
+		v := &s.channels[i]
 		if v.sound != nil && v.sound == sound {
 			return true
 		}
@@ -773,24 +774,28 @@ func (s *SoundChannels) IsPlaying(sound *Sound) bool {
 	return false
 }
 func (s *SoundChannels) Stop(sound *Sound) {
-	for k, v := range s.channels {
+	for i := range s.channels {
+		v := &s.channels[i]
 		if v.sound != nil && v.sound == sound {
-			s.channels[k].Stop()
+			v.Stop()
 		}
 	}
 }
+
 func (s *SoundChannels) StopAll() {
-	for k, v := range s.channels {
-		if v.sound != nil {
-			s.channels[k].Stop()
+	for i := range s.channels {
+		if s.channels[i].sound != nil {
+			s.channels[i].Stop()
 		}
 	}
 }
+
 func (s *SoundChannels) Tick() {
 	for i := range s.channels {
-		if s.channels[i].IsPlaying() {
-			if s.channels[i].streamer.Position() >= s.channels[i].sound.length && s.channels[i].sfx.loop != -1 {
-				s.channels[i].sound = nil
+		v := &s.channels[i]
+		if v.IsPlaying() {
+			if v.streamer.Position() >= v.sound.length && v.sfx.loop != -1 { // End the sound
+				v.sound = nil
 			}
 		}
 	}

--- a/src/stage.go
+++ b/src/stage.go
@@ -972,6 +972,7 @@ func loadStage(def string, maindef bool) (*Stage, error) {
 			sec[0].ReadF32("botz", &s.stageCamera.botz)
 			sec[0].ReadF32("topscale", &s.stageCamera.ztopscale)
 			sec[0].ReadF32("botscale", &s.stageCamera.zbotscale)
+			sec[0].ReadF32("depthtoscreen", &s.stageCamera.depthtoscreen)
 		}
 	}
 

--- a/src/system.go
+++ b/src/system.go
@@ -824,10 +824,14 @@ func (s *System) updateZScale(pos, localscale float32) float32 {
 	return scale
 }
 
+func (s *System) zEnabled() bool {
+	return s.zmin != s.zmax
+}
+
 // Z axis check
 // Changed to no longer check z enable constant, depends on stage now
 func (s *System) zAxisOverlap(posz1, front1, back1, localscl1, posz2, front2, back2, localscl2 float32) bool {
-	if sys.stage.topbound != sys.stage.botbound {
+	if s.zEnabled() {
 		if (posz1+front1)*localscl1 < (posz2-back2)*localscl2 ||
 			(posz1-back1)*localscl1 > (posz2+front2)*localscl2 {
 			return false
@@ -1500,9 +1504,9 @@ func (s *System) action() {
 
 	// Run "tick frame"
 	if s.tickFrame() {
+		// X axis player limits
 		s.xmin = s.cam.ScreenPos[0] + s.cam.Offset[0] + s.screenleft
-		s.xmax = s.cam.ScreenPos[0] + s.cam.Offset[0] +
-			float32(s.gameWidth)/s.cam.Scale - s.screenright
+		s.xmax = s.cam.ScreenPos[0] + s.cam.Offset[0] +	float32(s.gameWidth)/s.cam.Scale - s.screenright
 		if s.xmin > s.xmax {
 			s.xmin = (s.xmin + s.xmax) / 2
 			s.xmax = s.xmin
@@ -1513,6 +1517,7 @@ func (s *System) action() {
 		if AbsF(s.cam.minLeft-s.xmin) < 0.0001 {
 			s.xmin = s.cam.minLeft
 		}
+		// Z axis player limits
 		s.zmin = s.stage.topbound * s.stage.localscl
 		s.zmax = s.stage.botbound * s.stage.localscl
 		s.allPalFX.step()

--- a/src/system.go
+++ b/src/system.go
@@ -828,6 +828,11 @@ func (s *System) zEnabled() bool {
 	return s.zmin != s.zmax
 }
 
+// Convert Z logic position to Y drawing position
+func (s *System) posZtoY(z, localscl float32) float32 {
+	return z * localscl * sys.stage.stageCamera.depthtoscreen
+}
+
 // Z axis check
 // Changed to no longer check z enable constant, depends on stage now
 func (s *System) zAxisOverlap(posz1, front1, back1, localscl1, posz2, front2, back2, localscl2 float32) bool {


### PR DESCRIPTION
Feat:
- Stage [Scaling] group now accepts "depthtoscreen" parameter. Determines how a player's Z position affects their Y position on screen. Default 1, which means 1 pixel in Z space equates to 1 pixel in vertical screen space
- ModifyPlayer can now also alter HitPauseTime, PauseMoveTime and SuperMoveTime

Fix:
- Fixed reflections not being affected by the character's shadow offset constant

Refactor:
- Improved previous commits about skipping invalid sprites
- Renamed CommandBuffer to InputBuffer
- Helper damage percentage is once again accounted for in lifebar combo damage
- If the stage has Z movement enabled, EnemyNear and P2 redirections will also account for Z distance between players
- Refactored many loops where range was needlessly used to copy the values of entire structs. As seen on #1707 and previous Discord talks
- Removed MoveHitSet. Its features are now part of ModifyPlayer, which from here on out can be used to modify parameters that violate the normal order of things or otherwise are just not worth having a dedicated sctrl