### PR TITLE
fix: reverted depth default value to beta Mugen values, NoPowerBarDisplay, NoFaceDisplay

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -332,7 +332,7 @@ func (cs *CharSize) init() {
 	cs.mid.pos = [...]float32{-5, -60}
 	cs.shadowoffset = 0
 	cs.draw.offset = [...]float32{0, 0}
-	cs.depth = [...]float32{4, 4}
+	cs.depth = [...]float32{3, 3}
 	cs.attack.depth.front = 4
 	cs.attack.depth.back = 4
 	cs.weight = 100

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -4392,17 +4392,15 @@ func (l *Lifebar) draw(layerno int16) {
 			l.ti.bgDraw(layerno)
 			l.ti.draw(layerno, l.fnt[:])
 			// LifeBarWinIcon
-			for ti := range sys.tmode {
-				for i, v := range l.order[ti] {
-					if i == 0 && !sys.chars[v][0].asf(ASF_nowinicondisplay) {
-							l.wi[ti].draw(layerno, l.fnt[:], ti)
-					}
+			for i := range l.wi {
+				if !sys.chars[i][0].asf(ASF_nowinicondisplay) {
+						l.wi[i].draw(layerno, l.fnt[:], i)
 				}
 			}
 			// LifeBarRatio
 			for ti, tm := range sys.tmode {
 				if tm == TM_Turns {
-					if rl := sys.chars[ti][0].ocd().ratioLevel; rl > 0 {
+					if rl := sys.chars[ti][0].ocd().ratioLevel; rl > 0 && !sys.chars[ti][0].asf(ASF_nofacedisplay) {
 						l.ra[ti].bgDraw(layerno)
 						l.ra[ti].draw(layerno, rl-1)
 					}

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -4332,19 +4332,12 @@ func (l *Lifebar) draw(layerno int16) {
 				}
 			}
 			// PowerBar
-			for ti, tm := range sys.tmode {
+			for ti := range sys.tmode {
 				for i, v := range l.order[ti] {
 					index := i*2 + ti
-					if sys.cfg.Options.Team.PowerShare && (tm == TM_Simul || tm == TM_Tag) { // Draw player 1 or 2 bars
-						if i == 0 && !sys.chars[0][0].asf(ASF_nopowerbardisplay) {
-							l.pb[l.ref[ti]][index].bgDraw(layerno, index)
-							l.pb[l.ref[ti]][index].draw(layerno, index, l.pb[l.ref[ti]][index], l.fnt[:])
-						}
-					} else { // Draw everyone's bars
-						if !sys.chars[v][0].asf(ASF_nopowerbardisplay) {
-							l.pb[l.ref[ti]][index].bgDraw(layerno, index)
-							l.pb[l.ref[ti]][index].draw(layerno, v, l.pb[l.ref[ti]][v], l.fnt[:])
-						}
+					if !sys.chars[v][0].asf(ASF_nopowerbardisplay) {
+						l.pb[l.ref[ti]][index].bgDraw(layerno, index)
+						l.pb[l.ref[ti]][index].draw(layerno, v, l.pb[l.ref[ti]][v], l.fnt[:])
 					}
 				}
 			}

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -4332,12 +4332,19 @@ func (l *Lifebar) draw(layerno int16) {
 				}
 			}
 			// PowerBar
-			for ti := range sys.tmode {
+			for ti, tm := range sys.tmode {
 				for i, v := range l.order[ti] {
 					index := i*2 + ti
-					if !sys.chars[v][0].asf(ASF_nopowerbardisplay) {
-						l.pb[l.ref[ti]][index].bgDraw(layerno, index)
-						l.pb[l.ref[ti]][index].draw(layerno, v, l.pb[l.ref[ti]][v], l.fnt[:])
+					if sys.cfg.Options.Team.PowerShare && (tm == TM_Simul || tm == TM_Tag) { // Draw player 1 or 2 bars
+						if i == 0 && !sys.chars[v][0].asf(ASF_nopowerbardisplay) {
+							l.pb[l.ref[ti]][index].bgDraw(layerno, index)
+							l.pb[l.ref[ti]][index].draw(layerno, index, l.pb[l.ref[ti]][index], l.fnt[:])
+						}
+					} else { // Draw everyone's bars
+						if !sys.chars[v][0].asf(ASF_nopowerbardisplay) {
+							l.pb[l.ref[ti]][index].bgDraw(layerno, index)
+							l.pb[l.ref[ti]][index].draw(layerno, v, l.pb[l.ref[ti]][v], l.fnt[:])
+						}
 					}
 				}
 			}
@@ -4385,10 +4392,10 @@ func (l *Lifebar) draw(layerno int16) {
 			l.ti.bgDraw(layerno)
 			l.ti.draw(layerno, l.fnt[:])
 			// LifeBarWinIcon
-			for ti := range l.wi {
-				for _, v := range l.order[ti] {
-					if !sys.chars[v][0].asf(ASF_nowinicondisplay) {
-						l.wi[ti].draw(layerno, l.fnt[:], ti)
+			for ti := range sys.tmode {
+				for i, v := range l.order[ti] {
+					if i == 0 && !sys.chars[v][0].asf(ASF_nowinicondisplay) {
+							l.wi[ti].draw(layerno, l.fnt[:], ti)
 					}
 				}
 			}


### PR DESCRIPTION
Fixes:

- Changed the default values of size.depth to keep Beta Mugen default values.
- Fixed an issue with NoPowerBarDisplay, which wasn’t working correctly in simul and tag modes when TeamPowerShare was enabled. Teamside 2 couldn’t disable the power bar, while any char from teamside 1 asserting the flag would disable it for everyone.
- NoFaceDisplay now disables ratio icons too
