### PR TITLE
feat: outroState trigger; fix: introState trigger

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -697,6 +697,7 @@ const (
 	OC_ex_fightscreenvar_round_over_wintime
 	OC_ex_fightscreenvar_round_slow_time
 	OC_ex_fightscreenvar_round_start_waittime
+	OC_ex_fightscreenvar_round_callfight_time
 	OC_ex_fightscreenvar_time_framespercount
 	OC_ex_groundlevel
 	OC_ex_layerno
@@ -737,6 +738,7 @@ const (
 	OC_ex2_palfxvar_all_invertall
 	OC_ex2_palfxvar_all_invertblend
 	OC_ex2_introstate
+	OC_ex2_outrostate
 	OC_ex2_continuescreen
 	OC_ex2_victoryscreen
 	OC_ex2_winscreen
@@ -2773,6 +2775,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(sys.lifebar.ro.slow_time)
 	case OC_ex_fightscreenvar_round_start_waittime:
 		sys.bcStack.PushI(sys.lifebar.ro.start_waittime)
+	case OC_ex_fightscreenvar_round_callfight_time:
+		sys.bcStack.PushI(sys.lifebar.ro.callfight_time)
 	case OC_ex_fightscreenvar_time_framespercount:
 		sys.bcStack.PushI(sys.lifebar.ti.framespercount)
 	case OC_ex_fighttime:
@@ -3179,6 +3183,8 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(sys.palfxvar(-2, 2))
 	case OC_ex2_introstate:
 		sys.bcStack.PushI(sys.introState())
+	case OC_ex2_outrostate:
+		sys.bcStack.PushI(sys.outroState())
 	case OC_ex2_continuescreen:
 		sys.bcStack.PushB(sys.continueScreenFlg)
 	case OC_ex2_victoryscreen:

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -401,6 +401,7 @@ var triggerMap = map[string]int{
 	"mugenversion":       1,
 	"numplayer":          1,
 	"offset":             1,
+	"outrostate":         1,
 	"p5name":             1,
 	"p6name":             1,
 	"p7name":             1,
@@ -2999,6 +3000,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_roundstate)
 	case "introstate":
 		out.append(OC_ex2_, OC_ex2_introstate)
+	case "outrostate":
+		out.append(OC_ex2_, OC_ex2_outrostate)
 	case "screenheight":
 		out.append(OC_screenheight)
 	case "screenpos":
@@ -3900,6 +3903,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			opc = OC_ex_fightscreenvar_round_slow_time
 		case "round.start.waittime":
 			opc = OC_ex_fightscreenvar_round_start_waittime
+		case "round.callfight.time":
+			opc = OC_ex_fightscreenvar_round_callfight_time
 		case "time.framespercount":
 			opc = OC_ex_fightscreenvar_time_framespercount
 		default:

--- a/src/script.go
+++ b/src/script.go
@@ -4698,10 +4698,6 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.roundState()))
 		return 1
 	})
-	luaRegister(l, "introstate", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.introState()))
-		return 1
-	})
 	luaRegister(l, "screenheight", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.screenHeight()))
 		return 1
@@ -5268,6 +5264,8 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LNumber(sys.lifebar.ro.slow_time))
 		case "round.start.waittime":
 			l.Push(lua.LNumber(sys.lifebar.ro.start_waittime))
+		case "round.callfight.time":
+			l.Push(lua.LNumber(sys.lifebar.ro.callfight_time))
 		case "time.framespercount":
 			l.Push(lua.LNumber(sys.lifebar.ti.framespercount))
 		default:
@@ -5397,6 +5395,10 @@ func triggerFunctions(l *lua.LState) {
 		default:
 			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}
+		return 1
+	})
+	luaRegister(l, "introstate", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.introState()))
 		return 1
 	})
 	luaRegister(l, "isasserted", func(*lua.LState) int {
@@ -5609,6 +5611,10 @@ func triggerFunctions(l *lua.LState) {
 	})
 	luaRegister(l, "offsetY", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.offset[1]))
+		return 1
+	})
+	luaRegister(l, "outrostate", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.outroState()))
 		return 1
 	})
 	luaRegister(l, "pausetime", func(*lua.LState) int {

--- a/src/system.go
+++ b/src/system.go
@@ -742,29 +742,50 @@ func (s *System) roundState() int32 {
 }
 func (s *System) introState() int32 {
 	switch {
-	// Implements discussion #1172
-	case sys.intro > sys.lifebar.ro.ctrl_time+1:
-		// roundstate = 0
+	case s.intro > s.lifebar.ro.ctrl_time+1:
+		// Pre-intro [RoundState = 0]
 		return 1
-	case sys.intro > sys.lifebar.ro.ctrl_time:
-		// characters are doing their intros
+	case s.intro == s.lifebar.ro.ctrl_time+1:
+		// Player intros [RoundState = 1]
 		return 2
-	case sys.lifebar.ro.current == 1 && sys.intro > 0:
-		// fight!
-		return 4
-	case sys.lifebar.ro.current == 0:
-		// dialogueFlg doesn't work here :(
-		for _, p := range sys.chars {
-			if len(p) > 0 && len(p[0].dialogue) > 0 {
-				return 2
-			}
-		}
-		// round <n>
+	case s.intro == s.lifebar.ro.ctrl_time:
+		// Round announcement
 		return 3
+	case s.lifebar.ro.waitTimer[1] == -1 || (s.intro > 0 && s.intro < s.lifebar.ro.ctrl_time):
+		// Fight called
+		return 4
 	default:
-		// players have gained ctrl, or not applicable
+		// Not applicable
 		return 0
 	}
+}
+func (s *System) outroState() int32 {
+	switch {
+	case s.intro >= 0:
+		// Not applicable
+		return 0
+	case s.roundOver():
+		// Round over
+		return 5
+	case s.roundWinStates():
+		// Player win states
+		return 4
+	case sys.intro < -sys.lifebar.ro.over_waittime || sys.lifebar.ro.over_waittime == 1:
+		// Players lose control, but the round has not yet entered win states
+		return 3
+	case s.intro < -s.lifebar.ro.over_hittime || sys.lifebar.ro.over_hittime == 1:
+		// Players still have control, but the match outcome can no longer be changed
+		return 2
+	case s.intro < 0:
+		// Payers can still act, allowing a possible double KO
+		return 1
+	default:
+		// Fallback case, shouldn't be reached
+		return 0
+	}
+}
+func (s *System) roundWinStates() bool {
+	return s.waitdown <= 0 || s.roundWinTime()
 }
 func (s *System) roundWinTime() bool {
 	return s.wintime < 0
@@ -1444,7 +1465,7 @@ func (s *System) action() {
 					s.wintime--
 				}
 				// Set characters into win/lose poses, update win counters
-				if s.waitdown <= 0 || s.roundWinTime() {
+				if s.roundWinStates() {
 					if s.waitdown >= 0 {
 						winner := [...]bool{!s.chars[1][0].win(), !s.chars[0][0].win()}
 						if !winner[0] || !winner[1] ||


### PR DESCRIPTION
## <a name="new_OutroState">OutroState</a> (nightly build only)

Returns the current outro state number:  
0: Not applicable  
1: Payers can still act, allowing a possible double KO  
2: Players still have control, but the match outcome can no longer be changed  
3: Players lose control, but the round has not yet entered win states  
4: Player win states  
5: Round over  

>Format:  
>OutroState  
>  
>Arguments:  
>none  
>  
>Return type:  
>int  

```ini
trigger1 = OutroState = 3
```

Fixes #2282