### PR TITLE
feat: FightScreenState and SystemVar triggers; fixes

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -2996,7 +2996,7 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_mugenversion:
 		sys.bcStack.PushF(c.mugenVersionF())
 	case OC_ex_pausetime:
-		sys.bcStack.PushI(c.pauseTime())
+		sys.bcStack.PushI(c.pauseTimeTrigger())
 	case OC_ex_physics:
 		sys.bcStack.PushB(c.ss.physics == StateType(be[*i]))
 		*i++

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -861,7 +861,12 @@ const (
 	OC_ex2_soundvar_priority
 	OC_ex2_soundvar_startposition
 	OC_ex2_soundvar_volumescale
+	OC_ex2_fightscreenstate_fightdisplay
+	OC_ex2_fightscreenstate_kodisplay
+	OC_ex2_fightscreenstate_rounddisplay
+	OC_ex2_fightscreenstate_windisplay
 )
+
 const (
 	NumVar     = 60
 	NumSysVar  = 5
@@ -3512,6 +3517,16 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		v := c.projVar(id, idx, flg, opc, oc)
 		sys.bcStack.Push(v)
 	// END FALLTHROUGH (projvar)
+	// FightScreenState
+	case OC_ex2_fightscreenstate_fightdisplay:
+		sys.bcStack.PushB(sys.lifebar.ro.triggerFightDisplay)
+	case OC_ex2_fightscreenstate_kodisplay:
+		sys.bcStack.PushB(sys.lifebar.ro.triggerKODisplay)
+	case OC_ex2_fightscreenstate_rounddisplay:
+		sys.bcStack.PushB(sys.lifebar.ro.triggerRoundDisplay)
+	case OC_ex2_fightscreenstate_windisplay:
+		sys.bcStack.PushB(sys.lifebar.ro.triggerWinDisplay)
+	// HitDefVar
 	case OC_ex2_hitdefvar_guardflag:
 		attr := (*(*int32)(unsafe.Pointer(&be[*i])))
 		sys.bcStack.PushB(

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -865,6 +865,11 @@ const (
 	OC_ex2_fightscreenstate_kodisplay
 	OC_ex2_fightscreenstate_rounddisplay
 	OC_ex2_fightscreenstate_windisplay
+	OC_ex2_systemvar_introtime
+	OC_ex2_systemvar_outrotime
+	OC_ex2_systemvar_pausetime
+	OC_ex2_systemvar_slowtime
+	OC_ex2_systemvar_superpausetime
 )
 
 const (
@@ -3526,6 +3531,25 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushB(sys.lifebar.ro.triggerRoundDisplay)
 	case OC_ex2_fightscreenstate_windisplay:
 		sys.bcStack.PushB(sys.lifebar.ro.triggerWinDisplay)
+	// SystemVar
+	case OC_ex2_systemvar_introtime:
+		if sys.intro > 0 {
+			sys.bcStack.PushI(sys.intro)
+		} else {
+			sys.bcStack.PushI(0)
+		}
+	case OC_ex2_systemvar_outrotime:
+		if sys.intro < 0 {
+			sys.bcStack.PushI(-sys.intro)
+		} else {
+			sys.bcStack.PushI(0)
+		}
+	case OC_ex2_systemvar_pausetime:
+		sys.bcStack.PushI(sys.pausetime)
+	case OC_ex2_systemvar_slowtime:
+		sys.bcStack.PushI(sys.slowtimeTrigger)
+	case OC_ex2_systemvar_superpausetime:
+		sys.bcStack.PushI(sys.supertime)
 	// HitDefVar
 	case OC_ex2_hitdefvar_guardflag:
 		attr := (*(*int32)(unsafe.Pointer(&be[*i])))

--- a/src/char.go
+++ b/src/char.go
@@ -1428,9 +1428,9 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 		return
 	}
 	p := false
-	if sys.super > 0 {
+	if sys.supertime > 0 {
 		p = (e.supermovetime >= 0 && e.time >= e.supermovetime) || e.supermovetime < -2
-	} else if sys.pause > 0 {
+	} else if sys.pausetime > 0 {
 		p = (e.pausemovetime >= 0 && e.time >= e.pausemovetime) || e.pausemovetime < -2
 	}
 	act := !p
@@ -1824,11 +1824,11 @@ func (p *Projectile) setPos(pos [3]float32) {
 
 func (p *Projectile) paused(playerNo int) bool {
 	//if !sys.chars[playerNo][0].pause() {
-	if sys.super > 0 {
+	if sys.supertime > 0 {
 		if p.supermovetime == 0 || p.supermovetime < -1 {
 			return true
 		}
-	} else if sys.pause > 0 {
+	} else if sys.pausetime > 0 {
 		if p.pausemovetime == 0 || p.pausemovetime < -1 {
 			return true
 		}
@@ -4430,11 +4430,11 @@ func (c *Char) palfxvar2(x int32) float32 {
 
 func (c *Char) pauseTime() int32 {
 	var p int32
-	if sys.super > 0 && c.prevSuperMovetime == 0 {
-		p = sys.super
+	if sys.supertime > 0 && c.prevSuperMovetime == 0 {
+		p = sys.supertime
 	}
-	if sys.pause > 0 && c.prevPauseMovetime == 0 && p < sys.pause {
-		p = sys.pause
+	if sys.pausetime > 0 && c.prevPauseMovetime == 0 && p < sys.pausetime {
+		p = sys.pausetime
 	}
 	return p
 }
@@ -6505,9 +6505,9 @@ func (c *Char) p2BodyDistZ(oc *Char) BytecodeValue {
 }
 
 func (c *Char) setPauseTime(pausetime, movetime int32) {
-	if ^pausetime < sys.pausetime || c.playerNo != c.ss.sb.playerNo ||
+	if ^pausetime < sys.pausetimebuffer || c.playerNo != c.ss.sb.playerNo ||
 		sys.pauseplayer == c.playerNo {
-		sys.pausetime = ^pausetime
+		sys.pausetimebuffer = ^pausetime
 		sys.pauseplayer = c.playerNo
 		if sys.pauseendcmdbuftime < 0 || sys.pauseendcmdbuftime > pausetime {
 			sys.pauseendcmdbuftime = 0
@@ -6516,15 +6516,15 @@ func (c *Char) setPauseTime(pausetime, movetime int32) {
 	c.pauseMovetime = Max(0, movetime)
 	if c.pauseMovetime > pausetime {
 		c.pauseMovetime = 0
-	} else if sys.pause > 0 && c.pauseMovetime > 0 {
+	} else if sys.pausetime > 0 && c.pauseMovetime > 0 {
 		c.pauseMovetime--
 	}
 }
 
 func (c *Char) setSuperPauseTime(pausetime, movetime int32, unhittable bool) {
-	if ^pausetime < sys.supertime || c.playerNo != c.ss.sb.playerNo ||
+	if ^pausetime < sys.supertimebuffer || c.playerNo != c.ss.sb.playerNo ||
 		sys.superplayer == c.playerNo {
-		sys.supertime = ^pausetime
+		sys.supertimebuffer = ^pausetime
 		sys.superplayer = c.playerNo
 		if sys.superendcmdbuftime < 0 || sys.superendcmdbuftime > pausetime {
 			sys.superendcmdbuftime = 0
@@ -6533,7 +6533,7 @@ func (c *Char) setSuperPauseTime(pausetime, movetime int32, unhittable bool) {
 	c.superMovetime = Max(0, movetime)
 	if c.superMovetime > pausetime {
 		c.superMovetime = 0
-	} else if sys.super > 0 && c.superMovetime > 0 {
+	} else if sys.supertime > 0 && c.superMovetime > 0 {
 		c.superMovetime--
 	}
 	if unhittable {
@@ -6930,7 +6930,7 @@ func (c *Char) posUpdate() {
 	// In Ikemen, this threshold is obsolete
 	c.mhv.cornerpush = 0
 	friction := float32(0.7)
-	if c.cornerVelOff != 0 && sys.super == 0 {
+	if c.cornerVelOff != 0 && sys.supertime == 0 {
 		for _, p := range sys.chars {
 			if len(p) > 0 && p[0].ss.moveType == MT_H && p[0].ghv.playerId == c.id {
 				npos := (p[0].pos[0] + p[0].vel[0]*p[0].facing) * p[0].localscl
@@ -6999,7 +6999,7 @@ func (c *Char) posUpdate() {
 			c.gravity()
 		}
 	}
-	if sys.super == 0 {
+	if sys.supertime == 0 {
 		c.cornerVelOff *= friction
 		if AbsF(c.cornerVelOff) < 1 {
 			c.cornerVelOff = 0
@@ -7624,9 +7624,9 @@ func (c *Char) actionPrepare() {
 	}
 	c.pauseBool = false
 	if c.cmd != nil {
-		if sys.super > 0 {
+		if sys.supertime > 0 {
 			c.pauseBool = c.superMovetime == 0
-		} else if sys.pause > 0 && c.pauseMovetime == 0 {
+		} else if sys.pausetime > 0 && c.pauseMovetime == 0 {
 			c.pauseBool = true
 		}
 	}
@@ -7710,11 +7710,11 @@ func (c *Char) actionPrepare() {
 					c.ho[i].time--
 				}
 			}
-			if sys.super > 0 {
+			if sys.supertime > 0 {
 				if c.superMovetime > 0 {
 					c.superMovetime--
 				}
-			} else if sys.pause > 0 && c.pauseMovetime > 0 {
+			} else if sys.pausetime > 0 && c.pauseMovetime > 0 {
 				c.pauseMovetime--
 			}
 		}
@@ -8127,7 +8127,7 @@ func (c *Char) update() {
 				}
 			}
 			// Cancel pause move times
-			if sys.super <= 0 && sys.pause <= 0 {
+			if sys.supertime <= 0 && sys.pausetime <= 0 {
 				c.superMovetime, c.pauseMovetime = 0, 0
 			}
 			// Fall mechanics
@@ -8168,7 +8168,7 @@ func (c *Char) update() {
 		c.hoIdx = -1
 		c.hoKeepState = false
 		// Apply SuperPause p2defmul
-		if sys.supertime < 0 && c.teamside != sys.superplayer&1 {
+		if sys.supertimebuffer < 0 && c.teamside != sys.superplayer&1 {
 			c.superDefenseMul *= sys.superp2defmul
 		}
 		// Update final defense
@@ -8756,9 +8756,9 @@ func (cl *CharList) commandUpdate() {
 			// Iterate root and helpers
 			for _, c := range p {
 				act := true
-				if sys.super > 0 {
+				if sys.supertime > 0 {
 					act = c.superMovetime != 0
-				} else if sys.pause > 0 && c.pauseMovetime == 0 {
+				} else if sys.pausetime > 0 && c.pauseMovetime == 0 {
 					act = false
 				}
 				// Auto turning check for the root
@@ -8790,12 +8790,12 @@ func (cl *CharList) commandUpdate() {
 							winbuf = true
 						}
 					}
-					if sys.super > 0 {
-						if !act && sys.super <= sys.superendcmdbuftime {
+					if sys.supertime > 0 {
+						if !act && sys.supertime <= sys.superendcmdbuftime {
 							buffer = true
 						}
-					} else if sys.pause > 0 {
-						if !act && sys.pause <= sys.pauseendcmdbuftime {
+					} else if sys.pausetime > 0 {
+						if !act && sys.pausetime <= sys.pauseendcmdbuftime {
 							buffer = true
 						}
 					}
@@ -9385,10 +9385,10 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 				ghv.airguard_velocity[2] = hd.airguard_velocity[2] * scaleratio
 				ghv.priority = hd.priority
 			}
-			if sys.super > 0 {
+			if sys.supertime > 0 {
 				getter.superMovetime =
 					Max(getter.superMovetime, getter.ghv.hitshaketime)
-			} else if sys.pause > 0 {
+			} else if sys.pausetime > 0 {
 				getter.pauseMovetime =
 					Max(getter.pauseMovetime, getter.ghv.hitshaketime)
 			}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -364,6 +364,7 @@ var triggerMap = map[string]int{
 	"dizzypointsmax":     1,
 	"envshakevar":        1,
 	"explodvar":          1,
+	"fightscreenstate":   1,
 	"fightscreenvar":     1,
 	"fighttime":          1,
 	"firstattack":        1,
@@ -3868,6 +3869,29 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		if err := c.checkClosingBracket(); err != nil {
 			return bvNone(), err
 		}
+	case "fightscreenstate":
+		if err := c.checkOpeningBracket(in); err != nil {
+			return bvNone(), err
+		}
+		fssname := c.token
+		c.token = c.tokenizer(in)
+		if err := c.checkClosingBracket(); err != nil {
+			return bvNone(), err
+		}
+		switch fssname {
+		case "fightdisplay":
+			opc = OC_ex2_fightscreenstate_fightdisplay
+		case "kodisplay":
+			opc = OC_ex2_fightscreenstate_kodisplay
+		case "rounddisplay":
+			opc = OC_ex2_fightscreenstate_rounddisplay
+		case "windisplay":
+			opc = OC_ex2_fightscreenstate_windisplay
+		default:
+			return bvNone(), Error("Invalid data: " + fssname)
+		}
+		out.append(OC_ex2_)
+		out.append(opc)
 	case "fightscreenvar":
 		if err := c.checkOpeningBracket(in); err != nil {
 			return bvNone(), err

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -442,6 +442,7 @@ var triggerMap = map[string]int{
 	"stagefrontedgedist": 1,
 	"stagetime":          1,
 	"standby":            1,
+	"systemvar":          1,
 	"teamleader":         1,
 	"teamsize":           1,
 	"timeelapsed":        1,
@@ -4334,6 +4335,31 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_ex_, OC_ex_stagetime)
 	case "standby":
 		out.append(OC_ex_, OC_ex_standby)
+	case "systemvar":
+		if err := c.checkOpeningBracket(in); err != nil {
+			return bvNone(), err
+		}
+		svname := c.token
+		c.token = c.tokenizer(in)
+		if err := c.checkClosingBracket(); err != nil {
+			return bvNone(), err
+		}
+		switch svname {
+		case "introtime":
+			opc = OC_ex2_systemvar_introtime
+		case "outrotime":
+			opc = OC_ex2_systemvar_outrotime
+		case "pausetime":
+			opc = OC_ex2_systemvar_pausetime
+		case "slowtime":
+			opc = OC_ex2_systemvar_slowtime
+		case "superpausetime":
+			opc = OC_ex2_systemvar_superpausetime
+		default:
+			return bvNone(), Error("Invalid data: " + svname)
+		}
+		out.append(OC_ex2_)
+		out.append(opc)
 	case "teamleader":
 		out.append(OC_ex_, OC_ex_teamleader)
 	case "teamsize":

--- a/src/image.go
+++ b/src/image.go
@@ -509,7 +509,8 @@ func (sh *SffHeader) Read(r io.Reader, lofs *uint32, tofs *uint32) error {
 type Sprite struct {
 	Pal           []uint32
 	Tex           Texture
-	Group, Number int16
+	Group         int16 // References above 32767 will be read as negative. This is true to SFF format however
+	Number        int16
 	Size          [2]uint16
 	Offset        [2]int16
 	palidx        int
@@ -520,7 +521,7 @@ type Sprite struct {
 }
 
 func (s *Sprite) isBlank() bool {
-	return s.Tex == nil || s.Group < 0 || s.Number < 0 || s.Size[0] == 0 || s.Size[1] == 0
+	return s.Tex == nil || s.Size[0] == 0 || s.Size[1] == 0
 }
 
 func newSprite() *Sprite {
@@ -698,8 +699,7 @@ func (s *Sprite) SetRaw(data []byte, sprWidth int32, sprHeight int32, sprDepth i
 	}
 }
 
-func (s *Sprite) readHeader(r io.Reader, ofs, size *uint32,
-	link *uint16) error {
+func (s *Sprite) readHeader(r io.Reader, ofs, size *uint32,	link *uint16) error {
 	read := func(x interface{}) error {
 		return binary.Read(r, binary.LittleEndian, x)
 	}
@@ -723,6 +723,7 @@ func (s *Sprite) readHeader(r io.Reader, ofs, size *uint32,
 	}
 	return nil
 }
+
 func (s *Sprite) readPcxHeader(f *os.File, offset int64) error {
 	f.Seek(offset, 0)
 	read := func(x interface{}) error {

--- a/src/script.go
+++ b/src/script.go
@@ -5255,7 +5255,6 @@ func triggerFunctions(l *lua.LState) {
 		}
 		return 1
 	})
-
 	luaRegister(l, "fightscreenvar", func(*lua.LState) int {
 		switch strings.ToLower(strArg(l, 1)) {
 		case "info.name":
@@ -5760,6 +5759,31 @@ func triggerFunctions(l *lua.LState) {
 	})
 	luaRegister(l, "standby", func(*lua.LState) int {
 		l.Push(lua.LBool(sys.debugWC.scf(SCF_standby)))
+		return 1
+	})
+	luaRegister(l, "systemvar", func(*lua.LState) int {
+		switch strings.ToLower(strArg(l, 1)) {
+		case "introtime":
+			if sys.intro > 0 {
+				l.Push(lua.LNumber(sys.intro))
+			} else {
+				l.Push(lua.LNumber(0))
+			}
+		case "outrotime":
+			if sys.intro < 0 {
+				l.Push(lua.LNumber(-sys.intro))
+			} else {
+				l.Push(lua.LNumber(0))
+			}
+		case "pausetime":
+			l.Push(lua.LNumber(sys.pausetime))
+		case "slowtime":
+			l.Push(lua.LNumber(sys.slowtimeTrigger))
+		case "superpausetime":
+			l.Push(lua.LNumber(sys.supertime))
+		default:
+			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
+		}
 		return 1
 	})
 	luaRegister(l, "teamleader", func(*lua.LState) int {

--- a/src/script.go
+++ b/src/script.go
@@ -5633,7 +5633,7 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "pausetime", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.pauseTime()))
+		l.Push(lua.LNumber(sys.debugWC.pauseTimeTrigger()))
 		return 1
 	})
 	luaRegister(l, "physics", func(*lua.LState) int {

--- a/src/script.go
+++ b/src/script.go
@@ -5240,6 +5240,22 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.debugWC.dizzyPointsMax))
 		return 1
 	})
+	luaRegister(l, "fightscreenstate", func(*lua.LState) int {
+		switch strings.ToLower(strArg(l, 1)) {
+		case "fightdisplay":
+			l.Push(lua.LBool(sys.lifebar.ro.triggerFightDisplay))
+		case "kodisplay":
+			l.Push(lua.LBool(sys.lifebar.ro.triggerKODisplay))
+		case "rounddisplay":
+			l.Push(lua.LBool(sys.lifebar.ro.triggerFightDisplay))
+		case "windisplay":
+			l.Push(lua.LBool(sys.lifebar.ro.triggerWinDisplay))
+		default:
+			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
+		}
+		return 1
+	})
+
 	luaRegister(l, "fightscreenvar", func(*lua.LState) int {
 		switch strings.ToLower(strArg(l, 1)) {
 		case "info.name":

--- a/src/stage.go
+++ b/src/stage.go
@@ -1546,8 +1546,8 @@ func (s *Stage) runBgCtrl(bgc *bgCtrl) {
 }
 func (s *Stage) action() {
 	link, zlink, paused := 0, -1, true
-	if sys.tickFrame() && (sys.super <= 0 || !sys.superpausebg) &&
-		(sys.pause <= 0 || !sys.pausebg) {
+	if sys.tickFrame() && (sys.supertime <= 0 || !sys.superpausebg) &&
+		(sys.pausetime <= 0 || !sys.pausebg) {
 		paused = false
 		s.stageTime++
 		s.bgct.step(s)


### PR DESCRIPTION
FightScreenState:
- Allows checking if the fight screen is displaying specific screens
- Currently accepted: fightdisplay, kodisplay, rounddisplay, windisplay

SystemVar:
- Allows checking some system variables that generally don't justify having their own separate triggers
- Currently supported: introtime, outrotime, pausetime, slowtime, superpausetime

Fix:
- Fixed a regression from a previous nightly build in that Hitdef "forcenofall" was causing juggle points to not be subtracted
- Sprites with negative group or number are no longer considered blank. This was an oversight since the SFF format uses int16, meaning references above 32767 will be read as negative