### PR TITLE
fix: KO slowdown, lifebar portrait palettes; refactor

### DIFF
--- a/data/training.zss
+++ b/data/training.zss
@@ -54,7 +54,7 @@ ignoreHitPause if gameMode = "training" && teamSide = 2 && !isHelper {
 	}
 	if roundState < 2 {
 		# Skip round and fight calls
-		assertSpecial{flag: noRoundDisplay; flag2: noFightDisplay}
+		assertSpecial{flag: skipRoundDisplay; flag2: skipFightDisplay}
 	}
 	if roundState = 2 {
 		assertSpecial{

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -2235,6 +2235,7 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushB(p8 != nil &&
 			p8.gi().nameLow == sys.stringPool[sys.workingState.playerNo].List[*(*int32)(unsafe.Pointer(&be[*i]))])
 		*i += 4
+	// StageVar
 	case OC_const_stagevar_info_name:
 		sys.bcStack.PushB(sys.stage.nameLow ==
 			sys.stringPool[sys.workingState.playerNo].List[*(*int32)(
@@ -11724,38 +11725,38 @@ const (
 
 func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 	//crun := c RedirectID is pointless when modifying a stage
-	s := *&sys.stage
+	s := sys.stage
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		// Camera group
 		case modifyStageVar_camera_autocenter:
 			s.stageCamera.autocenter = exp[0].evalB(c)
 		case modifyStageVar_camera_boundleft:
-			s.stageCamera.boundleft = int32(exp[0].evalF(c) * c.localscl / sys.stage.localscl)
+			s.stageCamera.boundleft = int32(exp[0].evalF(c) * c.localscl / s.localscl)
 		case modifyStageVar_camera_boundright:
-			s.stageCamera.boundright = int32(exp[0].evalF(c) * c.localscl / sys.stage.localscl)
+			s.stageCamera.boundright = int32(exp[0].evalF(c) * c.localscl / s.localscl)
 		case modifyStageVar_camera_boundhigh:
-			s.stageCamera.boundhigh = int32(exp[0].evalF(c) * c.localscl / sys.stage.localscl)
+			s.stageCamera.boundhigh = int32(exp[0].evalF(c) * c.localscl / s.localscl)
 		case modifyStageVar_camera_boundlow:
-			s.stageCamera.boundlow = int32(exp[0].evalF(c) * c.localscl / sys.stage.localscl)
+			s.stageCamera.boundlow = int32(exp[0].evalF(c) * c.localscl / s.localscl)
 		case modifyStageVar_camera_verticalfollow:
 			s.stageCamera.verticalfollow = exp[0].evalF(c)
 		case modifyStageVar_camera_floortension:
-			s.stageCamera.floortension = int32(exp[0].evalF(c) * c.localscl / sys.stage.localscl)
+			s.stageCamera.floortension = int32(exp[0].evalF(c) * c.localscl / s.localscl)
 		case modifyStageVar_camera_lowestcap:
 			s.stageCamera.lowestcap = exp[0].evalB(c)
 		case modifyStageVar_camera_tensionhigh:
-			s.stageCamera.tensionhigh = int32(exp[0].evalF(c) * c.localscl / sys.stage.localscl)
+			s.stageCamera.tensionhigh = int32(exp[0].evalF(c) * c.localscl / s.localscl)
 		case modifyStageVar_camera_tensionlow:
-			s.stageCamera.tensionlow = int32(exp[0].evalF(c) * c.localscl / sys.stage.localscl)
+			s.stageCamera.tensionlow = int32(exp[0].evalF(c) * c.localscl / s.localscl)
 		case modifyStageVar_camera_tension:
-			s.stageCamera.tension = int32(exp[0].evalF(c) * c.localscl / sys.stage.localscl)
+			s.stageCamera.tension = int32(exp[0].evalF(c) * c.localscl / s.localscl)
 		case modifyStageVar_camera_tensionvel:
 			s.stageCamera.tensionvel = exp[0].evalF(c)
 		case modifyStageVar_camera_cuthigh:
-			s.stageCamera.cuthigh = int32(exp[0].evalF(c) * c.localscl / sys.stage.localscl)
+			s.stageCamera.cuthigh = int32(exp[0].evalF(c) * c.localscl / s.localscl)
 		case modifyStageVar_camera_cutlow:
-			s.stageCamera.cutlow = int32(exp[0].evalF(c) * c.localscl / sys.stage.localscl)
+			s.stageCamera.cutlow = int32(exp[0].evalF(c) * c.localscl / s.localscl)
 		case modifyStageVar_camera_startzoom:
 			s.stageCamera.startzoom = exp[0].evalF(c)
 		case modifyStageVar_camera_zoomout:
@@ -11774,13 +11775,13 @@ func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 			s.stageCamera.yscrollspeed = exp[0].evalF(c)
 		// PlayerInfo group
 		case modifyStageVar_playerinfo_leftbound:
-			s.leftbound = exp[0].evalF(c) * c.localscl / sys.stage.localscl
+			s.leftbound = exp[0].evalF(c) * c.localscl / s.localscl
 		case modifyStageVar_playerinfo_rightbound:
-			s.rightbound = exp[0].evalF(c) * c.localscl / sys.stage.localscl
+			s.rightbound = exp[0].evalF(c) * c.localscl / s.localscl
 		case modifyStageVar_playerinfo_topbound:
-			s.topbound = exp[0].evalF(c) * c.localscl / sys.stage.localscl
+			s.topbound = exp[0].evalF(c) * c.localscl / s.localscl
 		case modifyStageVar_playerinfo_botbound:
-			s.botbound = exp[0].evalF(c) * c.localscl / sys.stage.localscl
+			s.botbound = exp[0].evalF(c) * c.localscl / s.localscl
 		// Scaling group
 		case modifyStageVar_scaling_topz:
 			if s.mugenver[0] != 1 { // mugen 1.0+ removed support for topz
@@ -11848,7 +11849,7 @@ func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 		}
 		return true
 	})
-	sys.stage.reload = true // Stage will have to be reloaded if it's re-selected
+	s.reload = true // Stage will have to be reloaded if it's re-selected
 	sys.cam.stageCamera = s.stageCamera
 	sys.cam.Reset() // TODO: Resetting the camera makes the zoom jitter
 	return false

--- a/src/char.go
+++ b/src/char.go
@@ -67,46 +67,46 @@ const (
 	ASF_nowalk
 	ASF_unguardable
 	// Ikemen flags
+	ASF_animatehitpause
+	ASF_animfreeze
+	ASF_autoguard
+	ASF_drawunder
+	ASF_noailevel
+	ASF_noairjump
 	ASF_nobrake
 	ASF_nocrouch
-	ASF_nostand
-	ASF_nojump
-	ASF_noairjump
-	ASF_nohardcodedkeys
-	ASF_nogetupfromliedown
-	ASF_nofastrecoverfromliedown
+	ASF_nodizzypointsdamage
+	ASF_nofacedisplay
 	ASF_nofallcount
 	ASF_nofalldefenceup
-	ASF_noturntarget
-	ASF_noinput
-	ASF_nolifebardisplay
-	ASF_nopowerbardisplay
+	ASF_nofallhitflag
+	ASF_nofastrecoverfromliedown
+	ASF_nogetupfromliedown
 	ASF_noguardbardisplay
-	ASF_nostunbardisplay
-	ASF_nofacedisplay
-	ASF_nonamedisplay
-	ASF_nowinicondisplay
-	ASF_autoguard
-	ASF_animfreeze
-	ASF_postroundinput
-	ASF_nohitdamage
 	ASF_noguarddamage
-	ASF_nodizzypointsdamage
-	ASF_noguardpointsdamage
-	ASF_noredlifedamage
-	ASF_nomakedust
 	ASF_noguardko
-	ASF_nokovelocity
-	ASF_noailevel
+	ASF_noguardpointsdamage
+	ASF_nohardcodedkeys
+	ASF_nohitdamage
+	ASF_noinput
 	ASF_nointroreset
-	ASF_sizepushonly
-	ASF_animatehitpause
-	ASF_drawunder
+	ASF_nojump
+	ASF_nokofall // In Mugen this seems hardcoded into Training mode
+	ASF_nokovelocity
+	ASF_nolifebardisplay
+	ASF_nomakedust
+	ASF_nonamedisplay
+	ASF_nopowerbardisplay
+	ASF_noredlifedamage
+	ASF_nostand
+	ASF_nostunbardisplay
+	ASF_noturntarget
+	ASF_nowinicondisplay
+	ASF_postroundinput
+	ASF_projtypecollision // TODO: Make this a parameter for normal projectiles as well?
 	ASF_runfirst
 	ASF_runlast
-	ASF_projtypecollision // TODO: Make this a parameter for normal projectiles as well?
-	ASF_nofallhitflag
-	ASF_nokofall // In Mugen this seems hardcoded into Training mode
+	ASF_sizepushonly
 )
 
 type GlobalSpecialFlag uint32
@@ -125,12 +125,12 @@ const (
 	GSF_roundnotover
 	GSF_timerfreeze
 	// Ikemen flags
-	GSF_nofightdisplay
-	GSF_nokodisplay
-	GSF_norounddisplay
-	GSF_nowindisplay
 	GSF_roundfreeze
 	GSF_roundnotskip
+	GSF_skipfightdisplay
+	GSF_skipkodisplay
+	GSF_skiprounddisplay
+	GSF_skipwindisplay
 )
 
 type PosType int32

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -4149,18 +4149,18 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		// Ikemen global flags
 		case "globalnoko":
 			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_globalnoko))
-		case "nofightdisplay":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_nofightdisplay))
-		case "nokodisplay":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_nokodisplay))
-		case "norounddisplay":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_norounddisplay))
-		case "nowindisplay":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_nowindisplay))
 		case "roundnotskip":
 			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_roundnotskip))
 		case "roundfreeze":
 			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_roundfreeze))
+		case "skipfightdisplay":
+			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_skipfightdisplay))
+		case "skipkodisplay":
+			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_skipkodisplay))
+		case "skiprounddisplay":
+			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_skiprounddisplay))
+		case "skipwindisplay":
+			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_skipwindisplay))
 		default:
 			return bvNone(), Error("Invalid data: " + c.token)
 		}

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -148,101 +148,101 @@ func (c *Compiler) assertSpecial(is IniSection, sc *StateControllerBase, _ int8)
 			case "timerfreeze":
 				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_timerfreeze)))
 			// Ikemen char flags
+			case "animatehitpause":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_animatehitpause)))
+			case "animfreeze":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_animfreeze)))
+			case "autoguard":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_autoguard)))
+			case "drawunder":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_drawunder)))
+			case "noailevel":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_noailevel)))
+			case "noairjump":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_noairjump)))
 			case "nobrake":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nobrake)))
 			case "nocrouch":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nocrouch)))
-			case "nostand":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nostand)))
-			case "nojump":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nojump)))
-			case "noairjump":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_noairjump)))
-			case "nohardcodedkeys":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nohardcodedkeys)))
-			case "nogetupfromliedown":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nogetupfromliedown)))
-			case "nofastrecoverfromliedown":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nofastrecoverfromliedown)))
+			case "nodizzypointsdamage":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nodizzypointsdamage)))
+			case "nofacedisplay":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nofacedisplay)))
 			case "nofallcount":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nofallcount)))
 			case "nofalldefenceup":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nofalldefenceup)))
-			case "noturntarget":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_noturntarget)))
-			case "noinput":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_noinput)))
-			case "nolifebardisplay":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nolifebardisplay)))
-			case "nopowerbardisplay":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nopowerbardisplay)))
+			case "nofallhitflag":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nofallhitflag)))
+			case "nofastrecoverfromliedown":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nofastrecoverfromliedown)))
+			case "nogetupfromliedown":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nogetupfromliedown)))
 			case "noguardbardisplay":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_noguardbardisplay)))
-			case "nostunbardisplay":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nostunbardisplay)))
-			case "nofacedisplay":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nofacedisplay)))
-			case "nonamedisplay":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nonamedisplay)))
-			case "nowinicondisplay":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nowinicondisplay)))
-			case "autoguard":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_autoguard)))
-			case "animfreeze":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_animfreeze)))
-			case "postroundinput":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_postroundinput)))
-			case "nohitdamage":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nohitdamage)))
 			case "noguarddamage":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_noguarddamage)))
-			case "nodizzypointsdamage":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nodizzypointsdamage)))
-			case "noguardpointsdamage":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_noguardpointsdamage)))
-			case "noredlifedamage":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_noredlifedamage)))
-			case "nomakedust":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nomakedust)))
 			case "noguardko":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_noguardko)))
+			case "noguardpointsdamage":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_noguardpointsdamage)))
+			case "nohardcodedkeys":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nohardcodedkeys)))
+			case "nohitdamage":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nohitdamage)))
+			case "noinput":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_noinput)))
+			case "nointroreset":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nointroreset)))
+			case "nojump":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nojump)))
 			case "nokofall":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nokofall)))
 			case "nokovelocity":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nokovelocity)))
-			case "noailevel":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_noailevel)))
-			case "nointroreset":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nointroreset)))
-			case "sizepushonly":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_sizepushonly)))
-			case "animatehitpause":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_animatehitpause)))
-			case "drawunder":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_drawunder)))
+			case "nolifebardisplay":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nolifebardisplay)))
+			case "nomakedust":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nomakedust)))
+			case "nonamedisplay":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nonamedisplay)))
+			case "nopowerbardisplay":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nopowerbardisplay)))
+			case "noredlifedamage":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_noredlifedamage)))
+			case "nostand":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nostand)))
+			case "nostunbardisplay":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nostunbardisplay)))
+			case "noturntarget":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_noturntarget)))
+			case "nowinicondisplay":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nowinicondisplay)))
+			case "postroundinput":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_postroundinput)))
+			case "projtypecollision":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_projtypecollision)))
 			case "runfirst":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_runfirst)))
 			case "runlast":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_runlast)))
-			case "projtypecollision":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_projtypecollision)))
-			case "nofallhitflag":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nofallhitflag)))
+			case "sizepushonly":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_sizepushonly)))
 			// Ikemen global flags
 			case "globalnoko":
 				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_globalnoko)))
-			case "nofightdisplay":
-				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_nofightdisplay)))
-			case "nokodisplay":
-				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_nokodisplay)))
-			case "norounddisplay":
-				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_norounddisplay)))
-			case "nowindisplay":
-				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_nowindisplay)))
 			case "roundnotskip":
 				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_roundnotskip)))
 			case "roundfreeze":
 				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_roundfreeze)))
+			case "skipfightdisplay":
+				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_skipfightdisplay)))
+			case "skipkodisplay":
+				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_skipkodisplay)))
+			case "skiprounddisplay":
+				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_skiprounddisplay)))
+			case "skipwindisplay":
+				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_skipwindisplay)))
 			default:
 				return Error("Invalid value: " + data)
 			}

--- a/src/image.go
+++ b/src/image.go
@@ -421,8 +421,16 @@ func (pl *PaletteList) SwapPalMap(palMap *[]int) bool {
 
 func PaletteToTexture(pal []uint32) Texture {
 	tx := gfx.newTexture(256, 1, 32, false)
-	tx.SetData(unsafe.Slice((*byte)(unsafe.Pointer(&pal[0])), len(pal)*4))
-	return tx
+
+	// Safely handle invalid palettes
+	if len(pal) == 0 {
+		sys.errLog.Printf("Invalid palette texture. Defaulting to none")
+		tx.SetData(nil)
+		return tx
+	} else {
+		tx.SetData(unsafe.Slice((*byte)(unsafe.Pointer(&pal[0])), len(pal)*4))
+		return tx
+	}
 }
 
 type SffHeader struct {
@@ -1150,7 +1158,7 @@ func (s *Sprite) CachePalette(pal []uint32) Texture {
 	// If cached texture is invalid, generate a new one and cache it
 	if !hasPalette {
 		s.PalTex = PaletteToTexture(pal)
-		s.paltemp = pal
+		s.paltemp = append([]uint32{}, pal...)
 	}
 	return s.PalTex
 }

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -2375,7 +2375,7 @@ func (ro *LifeBarRound) act() bool {
 			//	sys.introSkipped = false
 			//}
 			// Round call
-			if sys.gsf(GSF_norounddisplay) && canSkip(0) { // Skip
+			if sys.gsf(GSF_skiprounddisplay) && canSkip(0) { // Skip
 				ro.roundCallOver = true
 				ro.waitTimer[1] = 0
 			}
@@ -2465,7 +2465,7 @@ func (ro *LifeBarRound) act() bool {
 			}
 			// Skip fight call
 			// Cannot be skipped unless round call is finished or also skipped
-			if ro.roundCallOver && sys.gsf(GSF_nofightdisplay) && canSkip(1) {
+			if ro.roundCallOver && sys.gsf(GSF_skipfightdisplay) && canSkip(1) {
 				endFightCall()
 				if sys.intro > 1 {
 					sys.intro = 1 // Skip ctrl waiting time
@@ -2542,7 +2542,7 @@ func (ro *LifeBarRound) act() bool {
 				ro.waitTimer[t]--
 			}
 			// KO screen
-			if !(sys.gsf(GSF_nokodisplay) && canSkip(2)) {
+			if !(sys.gsf(GSF_skipkodisplay) && canSkip(2)) {
 				switch sys.finishType {
 				case FT_KO:
 					ro.ko_top.Action()
@@ -2565,7 +2565,7 @@ func (ro *LifeBarRound) act() bool {
 				}
 			}
 			// Winner announcement
-			if sys.intro < -(ro.over_waittime) && !(sys.gsf(GSF_nowindisplay) && canSkip(3)) {
+			if sys.intro < -(ro.over_waittime) && !(sys.gsf(GSF_skipwindisplay) && canSkip(3)) {
 				wt := sys.winTeam
 				if wt < 0 {
 					wt = 0

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -1218,6 +1218,17 @@ func (fa *LifeBarFace) bgDraw(layerno int16) {
 
 func (fa *LifeBarFace) draw(layerno int16, ref int, far *LifeBarFace) {
 	if far.face != nil {
+		// Get player current PalFX if applicable
+		pfx := newPalFX()
+		if far.palfxshare {
+			pfx = sys.chars[ref][0].getPalfx()
+		}
+
+		// Swap palette maps to get the player's current palette
+		if far.palshare {
+			sys.cgi[ref].palettedata.palList.SwapPalMap(&sys.chars[ref][0].getPalfx().remap)
+		}
+
 		// Get texture
 		far.face.Pal = nil
 		if far.face.PalTex != nil {
@@ -1226,22 +1237,16 @@ func (fa *LifeBarFace) draw(layerno int16, ref int, far *LifeBarFace) {
 			far.face.Pal = far.face.GetPal(&sys.cgi[ref].palettedata.palList)
 		}
 
-		// Palette handling
+		// Revert palette maps to initial state
 		if far.palshare {
 			sys.cgi[ref].palettedata.palList.SwapPalMap(&sys.chars[ref][0].getPalfx().remap)
-		}
-
-		// PalFX handling
-		pfx := newPalFX()
-		if far.palfxshare {
-			pfx = sys.chars[ref][0].getPalfx()
 		}
 
 		// TODO: PalFX sharing has a bug in Tag in that it uses the parameter from the char's original placement in the team
 		// For instance if player 3 tags in, they will use p3 palette options instead of p1
 		// https://github.com/ikemen-engine/Ikemen-GO/issues/2269
 
-		// Keep brightness if player initiated SuperPause
+		// Reset system brightness if player initiated SuperPause (cancel "darken" parameter)
 		ob := sys.brightness
 		if ref == sys.superplayer {
 			sys.brightness = 256
@@ -1256,7 +1261,7 @@ func (fa *LifeBarFace) draw(layerno int16, ref int, far *LifeBarFace) {
 			fa.ko.Draw(float32(fa.pos[0])+sys.lifebarOffsetX, float32(fa.pos[1]), layerno, sys.lifebarScale)
 		}
 
-		// Restore system brightness
+		// Restore original system brightness
 		sys.brightness = ob
 
 		// Turns mode teammates

--- a/src/render.go
+++ b/src/render.go
@@ -151,30 +151,24 @@ var notiling = Tiling{}
 
 // RenderParams holds the common data for all sprite rendering functions
 type RenderParams struct {
-	// Sprite texture and palette texture
-	tex    Texture
-	paltex Texture
-	// Size, position, tiling, scaling and rotation
+	tex    Texture // Sprite
+	paltex Texture // Palette
 	size     [2]uint16
-	x, y     float32
+	x, y     float32 // Position
 	tile     Tiling
-	xts, xbs float32
-	ys, vs   float32
+	xts, xbs float32 // Top and bottom X scale (as in parallax)
+	ys, vs   float32 // Y scale
 	rxadd    float32
 	xas, yas float32
 	rot      Rotation
-	// Transparency, masking and palette effects
 	tint  uint32 // Sprite tint for shadows
-	trans int32  // Mugen transparency blending
+	trans int32  // Transparency blending
 	mask  int32  // Mask for transparency
 	pfx   *PalFX
-	// Clipping
 	window *[4]int32
-	// Rotation center
-	rcx, rcy float32
-	// Perspective projection
-	projectionMode int32
-	fLength        float32
+	rcx, rcy float32 // Rotation center
+	projectionMode int32 // Perspective projection
+	fLength        float32 // Focal length
 	xOffset        float32
 	yOffset        float32
 }
@@ -407,6 +401,7 @@ func rmInitSub(rp *RenderParams) {
 func BlendReset() {
 	gfx.BlendReset()
 }
+
 func RenderSprite(rp RenderParams) {
 	if !rp.IsValid() {
 		return

--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -288,7 +288,7 @@ func (t *Texture_GL21) SetRGBPixelData(data []float32) {
 
 // Return whether texture has a valid handle
 func (t *Texture_GL21) IsValid() bool {
-	return t.handle != 0
+	return t.width != 0 && t.height != 0 && t.handle != 0
 }
 
 func (t *Texture_GL21) GetWidth() int32 {

--- a/src/render_gl_gl32.go
+++ b/src/render_gl_gl32.go
@@ -287,7 +287,7 @@ func (t *Texture_GL32) SetRGBPixelData(data []float32) {
 
 // Return whether texture has a valid handle
 func (t *Texture_GL32) IsValid() bool {
-	return t.handle != 0
+	return t.width != 0 && t.height != 0 && t.handle != 0
 }
 
 func (t *Texture_GL32) GetWidth() int32 {

--- a/src/render_kinc.go
+++ b/src/render_kinc.go
@@ -102,7 +102,7 @@ func (t *Texture) SetData(data []byte) {
 }
 
 func (t *Texture) IsValid() bool {
-	return true
+	return t.width != 0 && t.height != 0
 }
 
 // ------------------------------------------------------------------

--- a/src/script.go
+++ b/src/script.go
@@ -5540,18 +5540,18 @@ func triggerFunctions(l *lua.LState) {
 		case "timerfreeze":
 			l.Push(lua.LBool(sys.gsf(GSF_timerfreeze)))
 		// GlobalSpecialFlag (Ikemen)
-		case "nofightdisplay":
-			l.Push(lua.LBool(sys.gsf(GSF_nofightdisplay)))
-		case "nokodisplay":
-			l.Push(lua.LBool(sys.gsf(GSF_nokodisplay)))
-		case "norounddisplay":
-			l.Push(lua.LBool(sys.gsf(GSF_norounddisplay)))
-		case "nowindisplay":
-			l.Push(lua.LBool(sys.gsf(GSF_nowindisplay)))
 		case "roundfreeze":
 			l.Push(lua.LBool(sys.gsf(GSF_roundfreeze)))
 		case "roundnotskip":
 			l.Push(lua.LBool(sys.gsf(GSF_roundnotskip)))
+		case "skipfightdisplay":
+			l.Push(lua.LBool(sys.gsf(GSF_skipfightdisplay)))
+		case "skipkodisplay":
+			l.Push(lua.LBool(sys.gsf(GSF_skipkodisplay)))
+		case "skiprounddisplay":
+			l.Push(lua.LBool(sys.gsf(GSF_skiprounddisplay)))
+		case "skipwindisplay":
+			l.Push(lua.LBool(sys.gsf(GSF_skipwindisplay)))
 		// SystemCharFlag
 		case "disabled":
 			l.Push(lua.LBool(sys.debugWC.scf(SCF_disabled)))

--- a/src/system.go
+++ b/src/system.go
@@ -1625,8 +1625,8 @@ func (s *System) action() {
 				s.shuttertime++
 				// Do the actual skipping in the frame when the "shutter" effect is closed
 				if s.shuttertime == s.lifebar.ro.shutter_time {
-					// NoRoundDisplay and NoFightDisplay flags must be preserved during intro skip frame
-					skipround := (s.specialFlag&GSF_norounddisplay | s.specialFlag&GSF_nofightdisplay)
+					// SkipRoundDisplay and SkipFightDisplay flags must be preserved during intro skip frame
+					skipround := (s.specialFlag&GSF_skiprounddisplay | s.specialFlag&GSF_skipfightdisplay)
 					s.resetGblEffect()
 					s.specialFlag = skipround
 					s.fadeintime = 0

--- a/src/system.go
+++ b/src/system.go
@@ -1704,18 +1704,22 @@ func (s *System) action() {
 	explUpdate(&s.explodsLayerN1, true)
 	explUpdate(&s.explodsLayer0, true)
 	explUpdate(&s.explodsLayer1, false)
+	// Adjust game speed
 	if s.tickNextFrame() {
-		// KO slowdown
 		spd := (60 + s.cfg.Options.GameSpeed*5) / float32(s.cfg.Config.Framerate) * s.accel
+		// KO slowdown
 		s.slowtimeTrigger = 0
-		if !s.gsf(GSF_nokoslow) && s.time != 0 && s.intro < 0 && s.slowtime > 0 {
-			spd *= s.lifebar.ro.slow_speed
-			if s.slowtime < s.lifebar.ro.slow_fadetime {
-				spd += (float32(1) - s.lifebar.ro.slow_speed) * float32(s.lifebar.ro.slow_fadetime-s.slowtime) / float32(s.lifebar.ro.slow_fadetime)
+		if s.intro < 0 && s.time != 0 && s.slowtime > 0 {
+			if !s.gsf(GSF_nokoslow) {
+				spd *= s.lifebar.ro.slow_speed
+				if s.slowtime < s.lifebar.ro.slow_fadetime {
+					spd += (float32(1) - s.lifebar.ro.slow_speed) * float32(s.lifebar.ro.slow_fadetime-s.slowtime) / float32(s.lifebar.ro.slow_fadetime)
+				}
 			}
 			s.slowtimeTrigger = s.slowtime
 			s.slowtime--
 		}
+		// Outside match or while frame stepping
 		if s.postMatchFlg || s.step {
 			spd = 1
 		}


### PR DESCRIPTION
Fix:
- Fixed KO slowdown timer not decreasing if "nokoslow" flag was active, which allowed it to trigger late if the flag was then disabled
- Fixed regression in lifebar portrait palette sharing in some lifebars

Refactor:
- Renamed AssertSpecial skipfightdisplay, skipkodisplay, skiprounddisplay, skipwindisplay flags, since "no X display" usually means that X is still present but is invisible, which is not how these flags work
- Safely handle errors when an invalid palette is found before rendering, instead of crashing with out of bounds error