### PR TITLE
feat: roundsWon trigger, z-axis perspective fix

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -162,6 +162,7 @@ const (
 	OC_powermax
 	OC_canrecover
 	OC_roundstate
+	OC_roundswon
 	OC_ishelper
 	OC_numhelper
 	OC_numexplod
@@ -1840,6 +1841,8 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushF(c.rightEdge() * (c.localscl / oc.localscl))
 		case OC_roundstate:
 			sys.bcStack.PushI(sys.roundState())
+		case OC_roundswon:
+			sys.bcStack.PushI(c.roundsWon())
 		case OC_screenheight:
 			sys.bcStack.PushF(c.screenHeight())
 		case OC_screenpos_x:

--- a/src/char.go
+++ b/src/char.go
@@ -1544,10 +1544,12 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 	// Set scale
 	drawscale := [2]float32{facing * scale[0] * e.localscl, e.vfacing * scale[1] * e.localscl}
 
+	centerOffset := (e.interPos[0] - sys.cam.Pos[0])
+
 	// Apply Z axis perspective
 	if e.space == Space_stage && sys.zEnabled() {
 		zscale := sys.updateZScale(e.pos[2], e.localscl)
-		drawpos[0] *= zscale
+		drawpos[0] -= centerOffset * (1 - zscale)
 		drawpos[1] *= zscale
 		drawpos[1] += sys.posZtoY(e.interPos[2], e.localscl)
 		drawscale[0] *= zscale
@@ -2128,10 +2130,12 @@ func (p *Projectile) cueDraw(oldVer bool) {
 
 	scl := [...]float32{p.facing * p.scale[0] * p.localscl * p.zScale,
 		p.scale[1] * p.localscl * p.zScale}
+    
+	centerOffset := (p.interPos[0] - sys.cam.Pos[0])
 
 	// Apply Z axis perspective
 	if sys.zEnabled() {
-		pos[0] *= p.zScale
+		pos[0] -= centerOffset * (1 - p.zScale)
 		pos[1] *= p.zScale
 		pos[1] += sys.posZtoY(p.interPos[2], p.localscl)
 	}
@@ -4508,6 +4512,13 @@ func (c *Char) roundsExisted() int32 {
 		return sys.round - 1
 	}
 	return sys.roundsExisted[c.playerNo&1]
+}
+
+func (c *Char) roundsWon() int32 {
+	if c.teamside == -1 {
+		return 0
+	}
+	return sys.wins[c.playerNo&1]
 }
 
 // TODO: These are supposed to be affected by zoom camera shifting
@@ -8618,10 +8629,12 @@ func (c *Char) cueDraw() {
 
 		scl := [...]float32{c.facing * c.size.xscale * c.zScale * (320 / c.localcoord),
 			c.size.yscale * c.zScale * (320 / c.localcoord)}
+		
+		centerOffset := (c.interPos[0] - sys.cam.Pos[0])
 
 		// Apply Z axis perspective
 		if sys.zEnabled() {
-			pos[0] *= c.zScale
+			pos[0] -= centerOffset * (1 - c.zScale)
 			pos[1] *= c.zScale
 			pos[1] += sys.posZtoY(c.interPos[2], c.localscl)
 		}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -313,6 +313,7 @@ var triggerMap = map[string]int{
 	"roundno":           1,
 	"roundsexisted":     1,
 	"roundstate":        1,
+	"roundswon":         1,
 	"screenheight":      1,
 	"screenpos":         1,
 	"screenwidth":       1,
@@ -2999,6 +3000,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_ex_, OC_ex_roundsexisted)
 	case "roundstate":
 		out.append(OC_roundstate)
+	case "roundswon":
+		out.append(OC_roundswon)
 	case "introstate":
 		out.append(OC_ex2_, OC_ex2_introstate)
 	case "outrostate":

--- a/src/script.go
+++ b/src/script.go
@@ -4698,6 +4698,10 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.roundState()))
 		return 1
 	})
+	luaRegister(l, "roundswon", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.roundsWon()))
+		return 1
+	})
 	luaRegister(l, "screenheight", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.screenHeight()))
 		return 1


### PR DESCRIPTION
Feat: 
 - roundsWon trigger counts how many total rounds the teamside calling this trigger has won during the current match, and resets between matches
 
 Fix: 
 - Fixed a bug with z-axis perspective scaling that caused chars to be displaced from the stage’s absolute center instead of the camera’s center position