### PR TITLE
feat: TopBoundBodyDist and BotBoundBodyDist triggers; fixes; refactoring

### DIFF
--- a/src/anim.go
+++ b/src/anim.go
@@ -956,7 +956,7 @@ type SprData struct {
 	rot          Rotation
 	ascl         [2]float32
 	screen       bool
-	bright       bool
+	undarken     bool // Ignore SuperPause "darken"
 	oldVer       bool
 	facing       float32
 	airOffsetFix [2]float32 // posLocalscl replacement
@@ -1005,7 +1005,7 @@ func (dl DrawList) draw(cameraX, cameraY, cameraScl float32) {
 		s.anim.srcAlpha = int16(s.alpha[0])
 		s.anim.dstAlpha = int16(s.alpha[1])
 		ob := sys.brightness
-		if s.bright {
+		if s.undarken {
 			sys.brightness = 256
 		}
 		var pos [2]float32

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -9243,13 +9243,11 @@ const (
 
 func (sc makeDust) Run(c *Char, _ []int32) bool {
 	crun := c
+	spacing := int32(3) // Default spacing is 3
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case makeDust_spacing:
-			s := Max(1, exp[0].evalI(c))
-			if crun.time()%s != s-1 {
-				return false
-			}
+			spacing = exp[0].evalI(c)
 		case makeDust_pos:
 			x, y, z := exp[0].evalF(c), float32(0), float32(0)
 			if len(exp) > 1 {
@@ -9259,7 +9257,7 @@ func (sc makeDust) Run(c *Char, _ []int32) bool {
 				}
 			}
 			crun.makeDust(x-float32(crun.size.draw.offset[0]),
-				y-float32(crun.size.draw.offset[1]), z)
+				y-float32(crun.size.draw.offset[1]), z, spacing)
 		case makeDust_pos2:
 			x, y, z := exp[0].evalF(c), float32(0), float32(0)
 			if len(exp) > 1 {
@@ -9269,7 +9267,7 @@ func (sc makeDust) Run(c *Char, _ []int32) bool {
 				}
 			}
 			crun.makeDust(x-float32(crun.size.draw.offset[0]),
-				y-float32(crun.size.draw.offset[1]), z)
+				y-float32(crun.size.draw.offset[1]), z, spacing)
 		case makeDust_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6761,11 +6761,11 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 	case hitDef_down_recovertime:
 		hd.down_recovertime = exp[0].evalI(c)
 	case hitDef_attack_depth:
-		hd.attack.depth[0] = exp[0].evalF(c)
+		hd.attack_depth[0] = exp[0].evalF(c)
 		if len(exp) > 1 {
-			hd.attack.depth[1] = exp[1].evalF(c)
+			hd.attack_depth[1] = exp[1].evalF(c)
 		} else {
-			hd.attack.depth[1] = hd.attack.depth[0]
+			hd.attack_depth[1] = hd.attack_depth[0]
 		}
 	case hitDef_sparkscale:
 		hd.sparkscale[0] = exp[0].evalF(c)
@@ -7868,11 +7868,11 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 			case hitDef_attack_depth:
 				eachProj(
 					func(p *Projectile) {
-						p.hitdef.attack.depth[0] = exp[0].evalF(c)
+						p.hitdef.attack_depth[0] = exp[0].evalF(c)
 						if len(exp) > 1 {
-							p.hitdef.attack.depth[1] = exp[1].evalF(c)
+							p.hitdef.attack_depth[1] = exp[1].evalF(c)
 						} else {
-							p.hitdef.attack.depth[1] = p.hitdef.attack.depth[0]
+							p.hitdef.attack_depth[1] = p.hitdef.attack_depth[0]
 						}
 					})
 			default:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -8891,9 +8891,7 @@ func (sc superPause) Run(c *Char, _ []int32) bool {
 		sys.superanim.start_scale[1] *= crun.localscl
 		// Apply Z axis perspective
 		if sys.zEnabled() {
-			sys.superpos[0] *= crun.zScale
-			sys.superpos[1] *= crun.zScale
-			sys.superpos[1] += sys.posZtoY(crun.pos[2], crun.localscl)
+			sys.superpos = sys.drawposXYfromZ(sys.superpos, crun.localscl, crun.interPos[2], crun.zScale)
 			sys.superscale[0] *= crun.zScale
 			sys.superscale[1] *= crun.zScale
 		}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -9243,11 +9243,11 @@ const (
 
 func (sc makeDust) Run(c *Char, _ []int32) bool {
 	crun := c
-	spacing := int32(3) // Default spacing is 3
+	spacing := int(3) // Default spacing is 3
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case makeDust_spacing:
-			spacing = exp[0].evalI(c)
+			spacing = int(exp[0].evalI(c))
 		case makeDust_pos:
 			x, y, z := exp[0].evalF(c), float32(0), float32(0)
 			if len(exp) > 1 {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -190,9 +190,7 @@ const (
 	OC_leftedge
 	OC_rightedge
 	OC_topedge
-	OC_topbounddist
 	OC_bottomedge
-	OC_botbounddist
 	OC_camerapos_x
 	OC_camerapos_y
 	OC_camerazoom
@@ -871,6 +869,10 @@ const (
 	OC_ex2_systemvar_pausetime
 	OC_ex2_systemvar_slowtime
 	OC_ex2_systemvar_superpausetime
+	OC_ex2_topbounddist
+	OC_ex2_topboundbodydist
+	OC_ex2_botbounddist
+	OC_ex2_botboundbodydist
 )
 
 const (
@@ -1686,8 +1688,6 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushI(int32(c.backEdgeDist() * (c.localscl / oc.localscl)))
 		case OC_bottomedge:
 			sys.bcStack.PushF(c.bottomEdge() * (c.localscl / oc.localscl))
-		case OC_botbounddist:
-			sys.bcStack.PushF(c.botBoundDist() * (c.localscl / oc.localscl))
 		case OC_camerapos_x:
 			sys.bcStack.PushF(sys.cam.Pos[0] / oc.localscl)
 		case OC_camerapos_y:
@@ -1871,8 +1871,6 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushI(c.time())
 		case OC_topedge:
 			sys.bcStack.PushF(c.topEdge() * (c.localscl / oc.localscl))
-		case OC_topbounddist:
-			sys.bcStack.PushF(c.topBoundDist() * (c.localscl / oc.localscl))
 		case OC_uniqhitcount:
 			sys.bcStack.PushI(c.uniqHitCount)
 		case OC_vel_x:
@@ -3625,6 +3623,14 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		// get the channel
 		ch := sys.bcStack.Pop()
 		sys.bcStack.Push(c.soundVar(ch, opc))
+	case OC_ex2_botboundbodydist:
+		sys.bcStack.PushF(c.botBoundBodyDist() * (c.localscl / oc.localscl))
+	case OC_ex2_botbounddist:
+		sys.bcStack.PushF(c.botBoundDist() * (c.localscl / oc.localscl))
+	case OC_ex2_topboundbodydist:
+		sys.bcStack.PushF(c.topBoundBodyDist() * (c.localscl / oc.localscl))
+	case OC_ex2_topbounddist:
+		sys.bcStack.PushF(c.topBoundDist() * (c.localscl / oc.localscl))
 	default:
 		sys.errLog.Printf("%v\n", be[*i-1])
 		c.panic()

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -8819,8 +8819,8 @@ func (sc superPause) Run(c *Char, _ []int32) bool {
 	uh := true
 	animset := false
 	sys.superpmap.remap = nil
-	sys.superpos = [...]float32{crun.pos[0] * crun.localscl, crun.pos[1] * crun.localscl}
-	sys.superfacing = crun.facing
+	sys.superpos = [2]float32{crun.pos[0] * crun.localscl, crun.pos[1] * crun.localscl}
+	sys.superscale = [2]float32{crun.facing, 1}
 	sys.superpausebg = true
 	sys.superendcmdbuftime = 0
 	sys.superdarken = true
@@ -8875,8 +8875,8 @@ func (sc superPause) Run(c *Char, _ []int32) bool {
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
 				sys.superpmap.remap = nil
-				sys.superpos = [...]float32{crun.pos[0] * crun.localscl, crun.pos[1] * crun.localscl}
-				sys.superfacing = crun.facing
+				sys.superpos = [2]float32{crun.pos[0] * crun.localscl, crun.pos[1] * crun.localscl}
+				sys.superscale = [2]float32{crun.facing, 1}
 			} else {
 				return false
 			}
@@ -8889,6 +8889,14 @@ func (sc superPause) Run(c *Char, _ []int32) bool {
 	if sys.superanim != nil {
 		sys.superanim.start_scale[0] *= crun.localscl
 		sys.superanim.start_scale[1] *= crun.localscl
+		// Apply Z axis perspective
+		if sys.zEnabled() {
+			sys.superpos[0] *= crun.zScale
+			sys.superpos[1] *= crun.zScale
+			sys.superpos[1] += sys.posZtoY(crun.pos[2], crun.localscl)
+			sys.superscale[0] *= crun.zScale
+			sys.superscale[1] *= crun.zScale
+		}
 	}
 	crun.setSuperPauseTime(t, mt, uh)
 	return false

--- a/src/char.go
+++ b/src/char.go
@@ -1206,7 +1206,7 @@ func (ai *AfterImage) recAndCue(sd *SprData, rec bool, hitpause bool, layer int3
 				rot:          img.rot,
 				ascl:         img.ascl,
 				screen:       false,
-				bright:       sd.bright,
+				undarken:     sd.undarken,
 				oldVer:       sd.oldVer,
 				facing:       sd.facing,
 				airOffsetFix: sd.airOffsetFix,
@@ -1588,7 +1588,7 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 		rot:          rot,
 		ascl:         [...]float32{1, 1},
 		screen:       e.space == Space_screen,
-		bright:       playerNo == sys.superplayer,
+		undarken:     playerNo == sys.superplayerno,
 		oldVer:       oldVer,
 		facing:       facing,
 		airOffsetFix: [2]float32{1, 1},
@@ -2196,7 +2196,7 @@ func (p *Projectile) cueDraw(oldVer bool) {
 			rot:          Rotation{p.facing * p.angle, 0, 0},
 			ascl:         [...]float32{1, 1},
 			screen:       false,
-			bright:       p.playerno == sys.superplayer,
+			undarken:     p.playerno == sys.superplayerno,
 			oldVer:       sys.cgi[p.playerno].mugenver[0] != 1,
 			facing:       p.facing,
 			airOffsetFix: [2]float32{1, 1},
@@ -6637,10 +6637,9 @@ func (c *Char) setPauseTime(pausetime, movetime int32) {
 }
 
 func (c *Char) setSuperPauseTime(pausetime, movetime int32, unhittable bool) {
-	if ^pausetime < sys.supertimebuffer || c.playerNo != c.ss.sb.playerNo ||
-		sys.superplayer == c.playerNo {
+	if ^pausetime < sys.supertimebuffer || c.playerNo != c.ss.sb.playerNo || sys.superplayerno == c.playerNo {
 		sys.supertimebuffer = ^pausetime
-		sys.superplayer = c.playerNo
+		sys.superplayerno = c.playerNo
 		if sys.superendcmdbuftime < 0 || sys.superendcmdbuftime > pausetime {
 			sys.superendcmdbuftime = 0
 		}
@@ -8298,7 +8297,7 @@ func (c *Char) update() {
 		c.hoIdx = -1
 		c.hoKeepState = false
 		// Apply SuperPause p2defmul
-		if sys.supertimebuffer < 0 && c.teamside != sys.superplayer&1 {
+		if sys.supertimebuffer < 0 && c.teamside != sys.superplayerno&1 {
 			c.superDefenseMul *= sys.superp2defmul
 		}
 		// Update final defense
@@ -8748,7 +8747,7 @@ func (c *Char) cueDraw() {
 			rot:          Rotation{agl, 0, 0},
 			ascl:         c.angleScale,
 			screen:       false,
-			bright:       c.playerNo == sys.superplayer,
+			undarken:     c.playerNo == sys.superplayerno,
 			oldVer:       c.gi().mugenver[0] != 1,
 			facing:       c.facing,
 			airOffsetFix: airOffsetFix,

--- a/src/char.go
+++ b/src/char.go
@@ -3815,8 +3815,12 @@ func (c *Char) bottomEdge() float32 {
 	return sys.cam.ScreenPos[1]/c.localscl + c.gameHeight()
 }
 
+func (c *Char) botBoundBodyDist() float32 {
+	return c.botBoundDist() - c.depthEdge[0]
+}
+
 func (c *Char) botBoundDist() float32 {
-	return -c.depthEdge[0] + sys.zmax/c.localscl - c.pos[2]
+	return sys.zmax/c.localscl - c.pos[2]
 }
 
 func (c *Char) canRecover() bool {
@@ -4664,8 +4668,12 @@ func (c *Char) topEdge() float32 {
 	return sys.cam.ScreenPos[1] / c.localscl
 }
 
+func (c *Char) topBoundBodyDist() float32 {
+	return c.topBoundDist() - c.depthEdge[1]
+}
+
 func (c *Char) topBoundDist() float32 {
-	return c.depthEdge[1] + sys.zmin/c.localscl - c.pos[2]
+	return c.pos[2] - sys.zmin/c.localscl
 }
 
 func (c *Char) win() bool {

--- a/src/char.go
+++ b/src/char.go
@@ -1558,14 +1558,10 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 	// Set scale
 	drawscale := [2]float32{facing * scale[0] * e.localscl, e.vfacing * scale[1] * e.localscl}
 
-	centerOffset := (e.interPos[0] - sys.cam.Pos[0])
-
 	// Apply Z axis perspective
 	if e.space == Space_stage && sys.zEnabled() {
 		zscale := sys.updateZScale(e.pos[2], e.localscl)
-		drawpos[0] -= centerOffset * (1 - zscale)
-		drawpos[1] *= zscale
-		drawpos[1] += sys.posZtoY(e.interPos[2], e.localscl)
+		drawpos = sys.drawposXYfromZ(drawpos, e.localscl, e.interPos[2], zscale)
 		drawscale[0] *= zscale
 		drawscale[1] *= zscale
 	}
@@ -1605,7 +1601,7 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 		if sdwalp < 0 {
 			sdwalp = 256
 		}
-		drawZoff := sys.posZtoY(e.interPos[2], e.localscl)
+		drawZoff := sys.posZtoYoffset(e.interPos[2], e.localscl)
 		sys.shadows.add(&ShadowSprite{
 			SprData:       sd,
 			shadowColor:   sdwclr,
@@ -2168,13 +2164,9 @@ func (p *Projectile) cueDraw(oldVer bool) {
 	scl := [...]float32{p.facing * p.scale[0] * p.localscl * p.zScale,
 		p.scale[1] * p.localscl * p.zScale}
 
-	centerOffset := (p.interPos[0] - sys.cam.Pos[0])
-
 	// Apply Z axis perspective
 	if sys.zEnabled() {
-		pos[0] -= centerOffset * (1 - p.zScale)
-		pos[1] *= p.zScale
-		pos[1] += sys.posZtoY(p.interPos[2], p.localscl)
+		pos = sys.drawposXYfromZ(pos, p.localscl, p.interPos[2], p.zScale)
 	}
 
 	sprs := &sys.spritesLayer0
@@ -2209,7 +2201,7 @@ func (p *Projectile) cueDraw(oldVer bool) {
 		// Add a shadow if color is not 0
 		sdwclr := p.shadow[0]<<16 | p.shadow[1]&0xff<<8 | p.shadow[2]&0xff
 		if sdwclr != 0 {
-			drawZoff := sys.posZtoY(p.interPos[2], p.localscl)
+			drawZoff := sys.posZtoYoffset(p.interPos[2], p.localscl)
 			sys.shadows.add(&ShadowSprite{
 				SprData:       sd,
 				shadowColor:   sdwclr,
@@ -8689,14 +8681,11 @@ func (c *Char) cueDraw() {
 		scl := [...]float32{c.facing * c.size.xscale * c.zScale * (320 / c.localcoord),
 			c.size.yscale * c.zScale * (320 / c.localcoord)}
 
-		centerOffset := (c.interPos[0] - sys.cam.Pos[0])
-
 		// Apply Z axis perspective
 		if sys.zEnabled() {
-			pos[0] -= centerOffset * (1 - c.zScale)
-			pos[1] *= c.zScale
-			pos[1] += sys.posZtoY(c.interPos[2], c.localscl)
+			pos = sys.drawposXYfromZ(pos, c.localscl, c.interPos[2], c.zScale)
 		}
+
 		//if sys.zEnabled() {
 		//	ratio := float32(1.618) // Possible stage parameter?
 		//	pos[0] *= 1 + (ratio-1)*(c.zScale-1)
@@ -8791,7 +8780,7 @@ func (c *Char) cueDraw() {
 				// Mugen uses some odd math for the shadow offset here, factoring in the stage's shadow scale
 				// Meaning the character's shadow offset constant is unable to offset it correctly in every stage
 				// Ikemen works differently and as you'd expect it to
-				drawZoff := sys.posZtoY(c.interPos[2], c.localscl)
+				drawZoff := sys.posZtoYoffset(c.interPos[2], c.localscl)
 				sys.shadows.add(&ShadowSprite{
 					SprData:       sd,
 					shadowColor:   -1,

--- a/src/char.go
+++ b/src/char.go
@@ -1605,13 +1605,14 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 		if sdwalp < 0 {
 			sdwalp = 256
 		}
+		drawZoff := sys.posZtoY(e.interPos[2], e.localscl)
 		sys.shadows.add(&ShadowSprite{
 			SprData:       sd,
 			shadowColor:   sdwclr,
 			shadowAlpha:   sdwalp,
-			shadowOffset:  [2]float32{0, 0},
-			reflectOffset: [2]float32{0, 0},
-			fadeOffset:    0,
+			shadowOffset:  [2]float32{0, sys.stage.sdw.yscale*drawZoff + drawZoff},
+			reflectOffset: [2]float32{0, sys.stage.reflection.yscale*drawZoff + drawZoff},
+			fadeOffset:    drawZoff,
 		})
 	}
 	if sys.tickNextFrame() {
@@ -2206,15 +2207,16 @@ func (p *Projectile) cueDraw(oldVer bool) {
 		p.aimg.recAndCue(sd, sys.tickNextFrame() && notpause, false, p.layerno)
 		sprs.add(sd)
 		// Add a shadow if color is not 0
-		sdwclr := p.shadow[0]<<16 | p.shadow[1]&255<<8 | p.shadow[2]&255
+		sdwclr := p.shadow[0]<<16 | p.shadow[1]&0xff<<8 | p.shadow[2]&0xff
 		if sdwclr != 0 {
+			drawZoff := sys.posZtoY(p.interPos[2], p.localscl)
 			sys.shadows.add(&ShadowSprite{
 				SprData:       sd,
 				shadowColor:   sdwclr,
-				shadowAlpha:   0,
-				shadowOffset:  [2]float32{0, p.pos[2]},
-				reflectOffset: [2]float32{0, p.pos[2]},
-				fadeOffset:    0,
+				shadowAlpha:   255,
+				shadowOffset:  [2]float32{0, sys.stage.sdw.yscale*drawZoff + drawZoff},
+				reflectOffset: [2]float32{0, sys.stage.reflection.yscale*drawZoff + drawZoff},
+				fadeOffset:    drawZoff,
 			})
 		}
 	}
@@ -8803,7 +8805,7 @@ func (c *Char) cueDraw() {
 						c.reflectOffset[0] * c.localscl,
 						(c.size.shadowoffset + c.reflectOffset[1]) * c.localscl + sys.stage.reflection.yscale*drawZoff + drawZoff,
 					},
-					fadeOffset:    c.offsetY(),
+					fadeOffset:    c.offsetY() + drawZoff,
 				})
 			}
 		}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -219,6 +219,7 @@ var triggerMap = map[string]int{
 	"backedgebodydist":  1,
 	"backedgedist":      1,
 	"bottomedge":        1,
+	"botboundbodydist":  1,
 	"botbounddist":      1,
 	"camerapos":         1,
 	"camerazoom":        1,
@@ -331,6 +332,7 @@ var triggerMap = map[string]int{
 	"time":              1,
 	"timemod":           1,
 	"topedge":           1,
+	"topboundbodydist":  1,
 	"topbounddist":      1,
 	"uniqhitcount":      1,
 	"var":               1,
@@ -1554,8 +1556,10 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		}
 	case "bottomedge":
 		out.append(OC_bottomedge)
+	case "botboundbodydist":
+		out.append(OC_ex2_, OC_ex2_botboundbodydist)
 	case "botbounddist":
-		out.append(OC_botbounddist)
+		out.append(OC_ex2_, OC_ex2_botbounddist)
 	case "camerapos":
 		c.token = c.tokenizer(in)
 		switch c.token {
@@ -3315,8 +3319,10 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_time)
 	case "topedge":
 		out.append(OC_topedge)
+	case "topboundbodydist":
+		out.append(OC_ex2_, OC_ex2_topboundbodydist)
 	case "topbounddist":
-		out.append(OC_topbounddist)
+		out.append(OC_ex2_, OC_ex2_topbounddist)
 	case "uniqhitcount":
 		out.append(OC_uniqhitcount)
 	case "vel":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -3389,28 +3389,18 @@ func (c *Compiler) makeDust(is IniSection, sc *StateControllerBase, _ int8) (Sta
 			makeDust_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
-		b := false
 		if err := c.stateParam(is, "spacing", false, func(data string) error {
-			b = true
 			return c.scAdd(sc, makeDust_spacing, data, VT_Int, 1)
 		}); err != nil {
 			return err
 		}
-		if !b {
-			sc.add(makeDust_spacing, sc.iToExp(3))
-		}
-		b = false
 		if err := c.stateParam(is, "pos", false, func(data string) error {
-			b = true
-			return c.scAdd(sc, makeDust_pos, data, VT_Float, 2)
+			return c.scAdd(sc, makeDust_pos, data, VT_Float, 3)
 		}); err != nil {
 			return err
 		}
-		if !b {
-			sc.add(makeDust_pos, sc.iToExp(0))
-		}
 		if err := c.paramValue(is, sc, "pos2",
-			makeDust_pos2, VT_Float, 2, false); err != nil {
+			makeDust_pos2, VT_Float, 3, false); err != nil {
 			return err
 		}
 		return nil

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -1248,7 +1248,7 @@ func (fa *LifeBarFace) draw(layerno int16, ref int, far *LifeBarFace) {
 
 		// Reset system brightness if player initiated SuperPause (cancel "darken" parameter)
 		ob := sys.brightness
-		if ref == sys.superplayer {
+		if ref == sys.superplayerno {
 			sys.brightness = 256
 		}
 

--- a/src/script.go
+++ b/src/script.go
@@ -3215,7 +3215,11 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.debugWC.bottomEdge()))
 		return 1
 	})
-	luaRegister(l, "botboundDist", func(*lua.LState) int {
+	luaRegister(l, "botboundbodydist", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.botBoundBodyDist()))
+		return 1
+	})
+	luaRegister(l, "botbounddist", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.botBoundDist()))
 		return 1
 	})
@@ -4984,7 +4988,11 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.debugWC.topEdge()))
 		return 1
 	})
-	luaRegister(l, "topBounddist", func(*lua.LState) int {
+	luaRegister(l, "topboundbodydist", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.topBoundBodyDist()))
+		return 1
+	})
+	luaRegister(l, "topbounddist", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.topBoundDist()))
 		return 1
 	})

--- a/src/system.go
+++ b/src/system.go
@@ -858,9 +858,18 @@ func (s *System) zEnabled() bool {
 	return s.zmin != s.zmax
 }
 
-// Convert Z logic position to Y drawing position
-func (s *System) posZtoY(z, localscl float32) float32 {
-	return z * localscl * sys.stage.stageCamera.depthtoscreen
+// Convert X and Y drawing position to Z perspective
+func (s *System) drawposXYfromZ(inpos [2]float32, localscl, zpos, zscale float32) (outpos [2]float32) {
+	outpos[0] = (inpos[0] - s.cam.Pos[0]) * zscale + s.cam.Pos[0]
+	outpos[1] = inpos[1] * zscale
+	outpos[1] += s.posZtoYoffset(zpos, localscl) // "Z" position
+	return
+}
+
+// Convert Z logic position to Y drawing offset
+// This is separate from the above because shadows only need this part
+func (s *System) posZtoYoffset(zpos, localscl float32) float32 {
+	return zpos * localscl * s.stage.stageCamera.depthtoscreen
 }
 
 // Z axis check
@@ -1487,7 +1496,7 @@ func (s *System) action() {
 									s.lifebar.wi[i].add(s.winType[i])
 									if s.matchOver() {
 										// In a draw game both players go back to 0 wins
-										if winner[0] && winner[1] { // sys.winTeam < 0
+										if winner[0] == winner[1] { // sys.winTeam < 0
 											s.lifebar.wc[0].wins = 0
 											s.lifebar.wc[1].wins = 0
 										} else {

--- a/src/system.go
+++ b/src/system.go
@@ -154,12 +154,12 @@ type System struct {
 	supertimebuffer         int32
 	superpausebg            bool
 	superendcmdbuftime      int32
-	superplayer             int
+	superplayerno           int
 	superdarken             bool
 	superanim               *Animation
 	superpmap               PalFX
 	superpos                [2]float32
-	superfacing             float32
+	superscale              [2]float32
 	superp2defmul           float32
 	envcol                  [3]int32
 	envcol_time             int32
@@ -1667,20 +1667,20 @@ func (s *System) action() {
 		s.xmin = s.cam.minLeft
 	}
 	s.charList.xScreenBound()
-
+	// Superpause effect
 	if s.superanim != nil {
 		s.spritesLayer1.add(&SprData{
 			anim:         s.superanim,
 			fx:           &s.superpmap,
 			pos:          s.superpos,
-			scl:          [...]float32{s.superfacing, 1},
+			scl:          s.superscale,
 			alpha:        [2]int32{-1},
 			priority:     5,
 			rot:          Rotation{},
 			ascl:         [2]float32{},
 			screen:       false,
-			bright:       true,
-			oldVer:       s.cgi[s.superplayer].mugenver[0] != 1,
+			undarken:     true,
+			oldVer:       s.cgi[s.superplayerno].mugenver[0] != 1,
 			facing:       1,
 			airOffsetFix: [2]float32{1, 1},
 			projection:   0,
@@ -1688,7 +1688,7 @@ func (s *System) action() {
 			window:       [4]float32{0, 0, 0, 0},
 		})
 		if s.superanim.loopend {
-			s.superanim = nil
+			s.superanim = nil // Not allowed to loop
 		}
 	}
 	for i := range s.projs {

--- a/src/system.go
+++ b/src/system.go
@@ -1669,9 +1669,24 @@ func (s *System) action() {
 	s.charList.xScreenBound()
 
 	if s.superanim != nil {
-		s.spritesLayer1.add(&SprData{s.superanim, &s.superpmap, s.superpos,
-			[...]float32{s.superfacing, 1}, [2]int32{-1}, 5, Rotation{}, [2]float32{},
-			false, true, s.cgi[s.superplayer].mugenver[0] != 1, 1, [2]float32{1, 1}, 0, 0, [4]float32{0, 0, 0, 0}})
+		s.spritesLayer1.add(&SprData{
+			anim:         s.superanim,
+			fx:           &s.superpmap,
+			pos:          s.superpos,
+			scl:          [...]float32{s.superfacing, 1},
+			alpha:        [2]int32{-1},
+			priority:     5,
+			rot:          Rotation{},
+			ascl:         [2]float32{},
+			screen:       false,
+			bright:       true,
+			oldVer:       s.cgi[s.superplayer].mugenver[0] != 1,
+			facing:       1,
+			airOffsetFix: [2]float32{1, 1},
+			projection:   0,
+			fLength:      0,
+			window:       [4]float32{0, 0, 0, 0},
+		})
 		if s.superanim.loopend {
 			s.superanim = nil
 		}


### PR DESCRIPTION
Features:
- Added TopBoundBodyDist and BotBoundBodyDist triggers, which are similar to the non "body" versions but also account for the depth edge parameters

Fixes:
- Fixed shadow fading range in stages with Z axis
- Fixed explod and projectile shadow/reflection placement with Z axis
- Fixed projectile shadows not working at all (possible regression)
- Fixed superpause effect position and scale in Z axis
- Fixed perspective drawing for different localcoord chars
- Fixed physics S and C not affecting Z velocity
- Fixed MakeDust crashing when using Z coordinates
- Fixed Hitdef having a hardcoded depth of 4,4 instead of using the character's constant
- Fixes #2308

Refactor:
- Refactored MakeDust to be more like other bytecode state controllers and also work more like it does in Mugen
- Adjusted TopBoundDist and BotBoundDist triggers to be more like their X axis counterparts

