### PR TITLE
fix: helper pos param z value

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -5106,7 +5106,7 @@ func (c *Char) helperPos(pt PosType, pos [3]float32, facing int32,
 			p[0] -= pos[0]
 		}
 		p[1] = pos[1]
-		p[2] = c.pos[2]
+		p[2] = pos[2]
 		*dstFacing *= c.facing
 	case PT_Left:
 		p[0] = c.leftEdge()*(c.localscl/localscl) + pos[0]
@@ -5114,15 +5114,16 @@ func (c *Char) helperPos(pt PosType, pos [3]float32, facing int32,
 		if isProj {
 			*dstFacing *= c.facing
 		}
+		p[2] = pos[2]
 	case PT_Right:
 		p[0] = c.rightEdge()*(c.localscl/localscl) + pos[0]
 		p[1] = pos[1]
 		if isProj {
 			*dstFacing *= c.facing
 		}
-		p[2] = c.pos[2]
+		p[2] = pos[2]
 	case PT_None:
-		p = [3]float32{pos[0], pos[1], c.pos[2]}
+		p = [3]float32{pos[0], pos[1], pos[2]}
 		if isProj {
 			*dstFacing *= c.facing
 		}

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -670,7 +670,7 @@ func (c *Compiler) helper(is IniSection, sc *StateControllerBase, _ int8) (State
 			return err
 		}
 		if err := c.paramValue(is, sc, "pos",
-			helper_pos, VT_Float, 2, false); err != nil {
+			helper_pos, VT_Float, 3, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "facing",
@@ -5323,8 +5323,8 @@ func (c *Compiler) depth(is IniSection, sc *StateControllerBase, _ int8) (StateC
 		}
 		if !b {
 			if err := c.paramValue(is, sc, "value",
-				depth_value, VT_Float, 2, true); err != nil {
-				return err
+			depth_value, VT_Float, 2, true); err != nil {
+			return err
 			}
 		}
 		return nil


### PR DESCRIPTION
Fix:
- Third value of the pos parameter (z-pos) for helpers causing crashes and being ignored with different postypes