### PR TITLE
fix: Bindtime of 1 immediately after PosSets not unbinding in time

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -8363,10 +8363,18 @@ func (c *Char) tick() {
 		if c.isBound() {
 			if bt := sys.playerID(c.bindToId); bt != nil && !bt.pause() {
 				c.bindTime -= 1
+				// Fixes Binds of 1 immediately after PosSets (MUGEN 1.0/1.1 behavior)
+				if c.bindTime <= 0 {
+					c.bindToId = -1
+				}
 			}
 		} else {
 			if !c.pause() {
 				c.bindTime -= 1
+				// Fixes Binds of 1 immediately after PosSets (MUGEN 1.0/1.1 behavior)
+				if c.bindTime <= 0 {
+					c.bindToId = -1
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Please let me know if this causes any other regressions (but I haven't found any related with Anakaris).

This fixes the following situation:
```ini
[State 20000, Bind]
type = PosSet
trigger1 = 1
x = floor(root, Pos X + root, Vel X)
y = 0
ignorehitpause = 1
[State 20000, BindToRoot]
type = BindToRoot
trigger1 = 1
time = 1
pos = 0, -RootDist Y
ignorehitpause = 1
```

In MUGEN 1.0 and 1.1, this works and binds the helper to the root. In IKEMEN-Go, the bind was lasting longer than it needed to, leading to no effect from the PosSet.