### PR TITLE
fix: TargetBind and Snap default facing behavior now handled differently from BindToParent/root default facing

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -9801,7 +9801,7 @@ func (sc bindToParent) Run(c *Char, _ []int32) bool {
 	crun.bindPos[0] = x
 	crun.bindPos[1] = y
 	crun.bindPos[2] = z
-	crun.setBindToId(p)
+	crun.setBindToId(p, false)
 	crun.setBindTime(time)
 	return false
 }
@@ -9849,7 +9849,7 @@ func (sc bindToRoot) Run(c *Char, _ []int32) bool {
 	crun.bindPos[0] = x
 	crun.bindPos[1] = y
 	crun.bindPos[2] = z
-	crun.setBindToId(r)
+	crun.setBindToId(r, false)
 	crun.setBindTime(time)
 	return false
 }

--- a/src/char.go
+++ b/src/char.go
@@ -5989,7 +5989,7 @@ func (c *Char) targetFacing(tar []int32, f int32) {
 func (c *Char) targetBind(tar []int32, time int32, x, y, z float32) {
 	for _, tid := range tar {
 		if t := sys.playerID(tid); t != nil {
-			t.setBindToId(c)
+			t.setBindToId(c, true)
 			t.setBindTime(time)
 			t.bindFacing = 0
 			x *= c.localscl / t.localscl
@@ -6481,6 +6481,7 @@ func (c *Char) distX(opp *Char, oc *Char) float32 {
 		if c.bindToId > 0 && !math.IsNaN(float64(c.bindPos[0])) {
 			if bt := sys.playerID(c.bindToId); bt != nil {
 				f := bt.facing
+				// We only need to correct for target binds (and snaps)
 				if AbsF(c.bindFacing) == 2 {
 					f = c.bindFacing / 2
 				}
@@ -7170,11 +7171,17 @@ func (c *Char) setBindTime(time int32) {
 	}
 }
 
-func (c *Char) setBindToId(to *Char) {
+func (c *Char) setBindToId(to *Char, isTargetBind bool) {
 	if c.bindToId != to.id {
 		c.bindToId = to.id
 	}
-	if c.bindFacing == 0 {
+	// Target binds are all we need to correct with this logic.
+	// By the time this gets to the bind() method, it's going to
+	// default to setting the facing to the same as the "bindTo"
+	// facing at that point. So as weird as it may be to default
+	// to 0 here, this behavior does seem to be what MUGEN
+	// actually does for helpers.
+	if c.bindFacing == 0 && isTargetBind {
 		c.bindFacing = to.facing * 2
 	}
 	if to.bindToId == c.id {
@@ -7215,6 +7222,7 @@ func (c *Char) bind() {
 		}
 		if !math.IsNaN(float64(c.bindPos[0])) {
 			f := bt.facing
+			// We only need to correct for target binds (and snaps)
 			if AbsF(c.bindFacing) == 2 {
 				f = c.bindFacing / 2
 			}
@@ -9522,7 +9530,7 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 				}
 				// Snap time
 				if hd.snaptime != 0 && getter.hoIdx < 0 {
-					getter.setBindToId(c)
+					getter.setBindToId(c, true)
 					getter.setBindTime(hd.snaptime + Btoi(hd.snaptime > 0 && !c.pause()))
 					getter.bindFacing = 0
 					if !math.IsNaN(float64(snap[0])) {


### PR DESCRIPTION
Default facing was broken in some instances for BindToParent/BindToRoot as discovered while working on Anakaris. Tested throw binds on Ultrarox_Clark, Warusaki3 Zangief, (WinMUGEN) and my WIP Anakaris (MUGEN 1.0 as of this writing), and helpers from Fusion's Zero (WinMUGEN) and my Anakaris (MUGEN 1.0).