### PR TITLE
fix: inguarddist and multiple enemies, other, refactor

### DIFF
--- a/data/common1.cns.zss
+++ b/data/common1.cns.zss
@@ -728,7 +728,7 @@ if mugenVersion < 1.0 {
 	explod{
 		anim: F(60 + ($vely > const240p(5)) + ($vely > const240p(14)));
 		postype: none; #p1
-		pos: pos x + cameraPos x, 0; #0, 0
+		pos: pos x + cameraPos x, 0, pos z;
 		facing: facing;
 		sprpriority: ifElse($vely <= const240p(14), -10, 10);
 	}
@@ -908,8 +908,7 @@ if time = 0 {
 		explod{
 			anim: F60;
 			postype: none;
-			pos: pos x + cameraPos x,
-			pos y - floor(vel y);
+			pos: pos x + cameraPos x, pos y - floor(vel y), pos z;
 			facing: facing;
 			sprpriority: -10
 		}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -7976,25 +7976,28 @@ func (sc width) Run(c *Char, _ []int32) bool {
 	var redirscale float32 = 1.0
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
-		case width_edge:
-			crun.setFEdge(exp[0].evalF(c) * redirscale)
-			if len(exp) > 1 {
-				crun.setBEdge(exp[1].evalF(c) * redirscale)
-			}
 		case width_player:
-			crun.setFWidth(exp[0].evalF(c) * redirscale)
+			var v1, v2 float32
+			v1 = exp[0].evalF(c)
 			if len(exp) > 1 {
-				crun.setBWidth(exp[1].evalF(c) * redirscale)
+				v2 = exp[1].evalF(c)
 			}
+			crun.setWidth(v1 * redirscale, v2 * redirscale)
+		case width_edge:
+			var v1, v2 float32
+			v1 = exp[0].evalF(c)
+			if len(exp) > 1 {
+				v2 = exp[1].evalF(c)
+			}
+			crun.setWidthEdge(v1 * redirscale, v2 * redirscale)
 		case width_value:
-			v1 := exp[0].evalF(c) * redirscale
-			crun.setFEdge(v1)
-			crun.setFWidth(v1)
+			var v1, v2 float32
+			v1 = exp[0].evalF(c)
 			if len(exp) > 1 {
-				v2 := exp[1].evalF(c) * redirscale
-				crun.setBEdge(v2)
-				crun.setBWidth(v2)
+				v2 = exp[1].evalF(c)
 			}
+			crun.setWidth(v1 * redirscale, v2 * redirscale)
+			crun.setWidthEdge(v1 * redirscale, v2 * redirscale)
 		case width_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -11981,10 +11984,12 @@ func (sc height) Run(c *Char, _ []int32) bool {
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
 		case height_value:
-			crun.setTHeight(exp[0].evalF(c) * redirscale)
+			var v1, v2 float32
+			v1 = exp[0].evalF(c)
 			if len(exp) > 1 {
-				crun.setBHeight(exp[1].evalF(c) * redirscale)
+				v2 = exp[1].evalF(c)
 			}
+			crun.setHeight(v1 * redirscale, v2 * redirscale)
 		case height_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -12012,25 +12017,28 @@ func (sc depth) Run(c *Char, _ []int32) bool {
 	var redirscale float32 = 1.0
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
-		case depth_edge:
-			crun.setFDepthEdge(exp[0].evalF(c) * redirscale)
-			if len(exp) > 1 {
-				crun.setBDepthEdge(exp[1].evalF(c) * redirscale)
-			}
 		case depth_player:
-			crun.setFDepth(exp[0].evalF(c) * redirscale)
+			var v1, v2 float32
+			v1 = exp[0].evalF(c)
 			if len(exp) > 1 {
-				crun.setBDepth(exp[1].evalF(c) * redirscale)
+				v2 = exp[1].evalF(c)
 			}
+			crun.setDepth(v1 * redirscale, v2 * redirscale)
+		case depth_edge:
+			var v1, v2 float32
+			v1 = exp[0].evalF(c)
+			if len(exp) > 1 {
+				v2 = exp[1].evalF(c)
+			}
+			crun.setDepthEdge(v1 * redirscale, v2 * redirscale)
 		case depth_value:
-			v1 := exp[0].evalF(c) * redirscale
-			crun.setFDepthEdge(v1)
-			crun.setFDepth(v1)
+			var v1, v2 float32
+			v1 = exp[0].evalF(c)
 			if len(exp) > 1 {
-				v2 := exp[1].evalF(c) * redirscale
-				crun.setBDepthEdge(v2)
-				crun.setBDepth(v2)
+				v2 = exp[1].evalF(c)
 			}
+			crun.setDepth(v1 * redirscale, v2 * redirscale)
+			crun.setDepthEdge(v1 * redirscale, v2 * redirscale)
 		case depth_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6198,6 +6198,9 @@ func (sc gameMakeAnim) Run(c *Char, _ []int32) bool {
 			e.relativePos[0] = exp[0].evalF(c) * redirscale
 			if len(exp) > 1 {
 				e.relativePos[1] = exp[1].evalF(c) * redirscale
+				if len(exp) > 2 {
+					e.relativePos[2] = exp[2].evalF(c) * redirscale
+				}
 			}
 		case gameMakeAnim_random:
 			rndx := (exp[0].evalF(c) / 2) * redirscale
@@ -6205,6 +6208,10 @@ func (sc gameMakeAnim) Run(c *Char, _ []int32) bool {
 			if len(exp) > 1 {
 				rndy := (exp[1].evalF(c) / 2) * redirscale
 				e.relativePos[1] += RandF(-rndy, rndy)
+				if len(exp) > 2 {
+					rndz := (exp[2].evalF(c) / 2) * redirscale
+					e.relativePos[2] += RandF(-rndz, rndz)
+				}
 			}
 		case gameMakeAnim_under:
 			if exp[0].evalB(c) {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3483,10 +3483,16 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	case OC_ex2_projvar_accel_y:
 		correctScale = true
 		fallthrough
+	case OC_ex2_projvar_accel_z:
+		correctScale = true
+		fallthrough
 	case OC_ex2_projvar_vel_x:
 		correctScale = true
 		fallthrough
 	case OC_ex2_projvar_vel_y:
+		correctScale = true
+		fallthrough
+	case OC_ex2_projvar_vel_z:
 		correctScale = true
 		fallthrough
 	case OC_ex2_projvar_projstagebound:
@@ -3505,6 +3511,9 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		correctScale = true
 		fallthrough
 	case OC_ex2_projvar_remvelocity_y:
+		correctScale = true
+		fallthrough
+	case OC_ex2_projvar_remvelocity_z:
 		correctScale = true
 		fallthrough
 	case OC_ex2_projvar_projremove:
@@ -3535,6 +3544,8 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		fallthrough
 	case OC_ex2_projvar_velmul_y:
 		fallthrough
+	case OC_ex2_projvar_velmul_z:
+		fallthrough
 	case OC_ex2_projvar_projscale_x:
 		fallthrough
 	case OC_ex2_projvar_projscale_y:
@@ -3560,6 +3571,8 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	case OC_ex2_projvar_pos_x:
 		fallthrough
 	case OC_ex2_projvar_pos_y:
+		fallthrough
+	case OC_ex2_projvar_pos_z:
 		fallthrough
 	case OC_ex2_projvar_facing:
 		fallthrough

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6854,20 +6854,14 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 
 func (sc hitDef) Run(c *Char, _ []int32) bool {
 	crun := c
-	crun.hitdef.clear(crun.localscl)
+	crun.hitdef.clear(crun, crun.localscl)
 	crun.hitdef.playerNo = sys.workingState.playerNo
-	crun.hitdef.sparkno = c.gi().data.sparkno
-	crun.hitdef.guard_sparkno = c.gi().data.guard.sparkno
-	crun.hitdef.hitsound_channel = c.gi().data.hitsound_channel
-	crun.hitdef.guardsound_channel = c.gi().data.guardsound_channel
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		if id == hitDef_redirectid {
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				crun.hitdef.clear(crun.localscl)
+				crun.hitdef.clear(crun, crun.localscl)
 				crun.hitdef.playerNo = sys.workingState.playerNo
-				crun.hitdef.sparkno = c.gi().data.sparkno
-				crun.hitdef.guard_sparkno = c.gi().data.guard.sparkno
 			} else {
 				return false
 			}
@@ -6899,7 +6893,7 @@ const (
 
 func (sc reversalDef) Run(c *Char, _ []int32) bool {
 	crun := c
-	crun.hitdef.clear(crun.localscl)
+	crun.hitdef.clear(crun, crun.localscl)
 	crun.hitdef.playerNo = sys.workingState.playerNo
 	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
 		switch id {
@@ -6908,7 +6902,7 @@ func (sc reversalDef) Run(c *Char, _ []int32) bool {
 		case reversalDef_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				crun.hitdef.clear(crun.localscl)
+				crun.hitdef.clear(crun, crun.localscl)
 				crun.hitdef.playerNo = sys.workingState.playerNo
 			} else {
 				return false

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -292,53 +292,71 @@ const (
 	OC_const_size_depth_back
 	OC_const_size_weight
 	OC_const_size_pushfactor
-	OC_const_velocity_walk_fwd_x
-	OC_const_velocity_walk_back_x
-	OC_const_velocity_walk_up_x
-	OC_const_velocity_walk_down_x
-	OC_const_velocity_run_fwd_x
-	OC_const_velocity_run_fwd_y
-	OC_const_velocity_run_back_x
-	OC_const_velocity_run_back_y
-	OC_const_velocity_run_up_x
-	OC_const_velocity_run_up_y
-	OC_const_velocity_run_down_x
-	OC_const_velocity_run_down_y
-	OC_const_velocity_jump_y
-	OC_const_velocity_jump_neu_x
-	OC_const_velocity_jump_back_x
-	OC_const_velocity_jump_fwd_x
-	OC_const_velocity_jump_up_x
-	OC_const_velocity_jump_down_x
-	OC_const_velocity_runjump_back_x
-	OC_const_velocity_runjump_back_y
-	OC_const_velocity_runjump_y
-	OC_const_velocity_runjump_fwd_x
-	OC_const_velocity_runjump_up_x
-	OC_const_velocity_runjump_down_x
-	OC_const_velocity_airjump_y
-	OC_const_velocity_airjump_neu_x
-	OC_const_velocity_airjump_back_x
-	OC_const_velocity_airjump_fwd_x
-	OC_const_velocity_airjump_up_x
-	OC_const_velocity_airjump_down_x
-	OC_const_velocity_air_gethit_groundrecover_x
-	OC_const_velocity_air_gethit_groundrecover_y
-	OC_const_velocity_air_gethit_airrecover_mul_x
-	OC_const_velocity_air_gethit_airrecover_mul_y
 	OC_const_velocity_air_gethit_airrecover_add_x
 	OC_const_velocity_air_gethit_airrecover_add_y
 	OC_const_velocity_air_gethit_airrecover_back
-	OC_const_velocity_air_gethit_airrecover_fwd
-	OC_const_velocity_air_gethit_airrecover_up
 	OC_const_velocity_air_gethit_airrecover_down
+	OC_const_velocity_air_gethit_airrecover_fwd
+	OC_const_velocity_air_gethit_airrecover_mul_x
+	OC_const_velocity_air_gethit_airrecover_mul_y
+	OC_const_velocity_air_gethit_airrecover_up
+	OC_const_velocity_air_gethit_groundrecover_x
+	OC_const_velocity_air_gethit_groundrecover_y
 	OC_const_velocity_air_gethit_ko_add_x
 	OC_const_velocity_air_gethit_ko_add_y
 	OC_const_velocity_air_gethit_ko_ymin
-	OC_const_velocity_ground_gethit_ko_xmul
+	OC_const_velocity_airjump_back_x
+	OC_const_velocity_airjump_down_x
+	OC_const_velocity_airjump_down_y
+	OC_const_velocity_airjump_down_z
+	OC_const_velocity_airjump_fwd_x
+	OC_const_velocity_airjump_neu_x
+	OC_const_velocity_airjump_up_x
+	OC_const_velocity_airjump_up_y
+	OC_const_velocity_airjump_up_z
+	OC_const_velocity_airjump_y
 	OC_const_velocity_ground_gethit_ko_add_x
 	OC_const_velocity_ground_gethit_ko_add_y
+	OC_const_velocity_ground_gethit_ko_xmul
 	OC_const_velocity_ground_gethit_ko_ymin
+	OC_const_velocity_jump_back_x
+	OC_const_velocity_jump_down_x
+	OC_const_velocity_jump_down_y
+	OC_const_velocity_jump_down_z
+	OC_const_velocity_jump_fwd_x
+	OC_const_velocity_jump_neu_x
+	OC_const_velocity_jump_up_x
+	OC_const_velocity_jump_up_y
+	OC_const_velocity_jump_up_z
+	OC_const_velocity_jump_y
+	OC_const_velocity_run_back_x
+	OC_const_velocity_run_back_y
+	OC_const_velocity_run_down_x
+	OC_const_velocity_run_down_y
+	OC_const_velocity_run_down_z
+	OC_const_velocity_run_fwd_x
+	OC_const_velocity_run_fwd_y
+	OC_const_velocity_run_up_x
+	OC_const_velocity_run_up_y
+	OC_const_velocity_run_up_z
+	OC_const_velocity_runjump_back_x
+	OC_const_velocity_runjump_back_y
+	OC_const_velocity_runjump_down_x
+	OC_const_velocity_runjump_down_y
+	OC_const_velocity_runjump_down_z
+	OC_const_velocity_runjump_fwd_x
+	OC_const_velocity_runjump_up_x
+	OC_const_velocity_runjump_up_y
+	OC_const_velocity_runjump_up_z
+	OC_const_velocity_runjump_y
+	OC_const_velocity_walk_back_x
+	OC_const_velocity_walk_down_x
+	OC_const_velocity_walk_down_y
+	OC_const_velocity_walk_down_z
+	OC_const_velocity_walk_fwd_x
+	OC_const_velocity_walk_up_x
+	OC_const_velocity_walk_up_y
+	OC_const_velocity_walk_up_z
 	OC_const_movement_airjump_num
 	OC_const_movement_airjump_height
 	OC_const_movement_yaccel
@@ -2051,100 +2069,136 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(c.size.weight)
 	case OC_const_size_pushfactor:
 		sys.bcStack.PushF(c.size.pushfactor)
-	case OC_const_velocity_walk_fwd_x:
-		sys.bcStack.PushF(c.gi().velocity.walk.fwd * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_walk_back_x:
-		sys.bcStack.PushF(c.gi().velocity.walk.back * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_walk_up_x:
-		sys.bcStack.PushF(c.gi().velocity.walk.up * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_walk_down_x:
-		sys.bcStack.PushF(c.gi().velocity.walk.down * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_run_fwd_x:
-		sys.bcStack.PushF(c.gi().velocity.run.fwd[0] * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_run_fwd_y:
-		sys.bcStack.PushF(c.gi().velocity.run.fwd[1] * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_run_back_x:
-		sys.bcStack.PushF(c.gi().velocity.run.back[0] * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_run_back_y:
-		sys.bcStack.PushF(c.gi().velocity.run.back[1] * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_run_up_x:
-		sys.bcStack.PushF(c.gi().velocity.run.up[0] * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_run_up_y:
-		sys.bcStack.PushF(c.gi().velocity.run.up[1] * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_run_down_x:
-		sys.bcStack.PushF(c.gi().velocity.run.down[0] * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_run_down_y:
-		sys.bcStack.PushF(c.gi().velocity.run.down[1] * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_jump_y:
-		sys.bcStack.PushF(c.gi().velocity.jump.neu[1] * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_jump_neu_x:
-		sys.bcStack.PushF(c.gi().velocity.jump.neu[0] * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_jump_back_x:
-		sys.bcStack.PushF(c.gi().velocity.jump.back * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_jump_fwd_x:
-		sys.bcStack.PushF(c.gi().velocity.jump.fwd * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_jump_up_x:
-		sys.bcStack.PushF(c.gi().velocity.jump.up * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_jump_down_x:
-		sys.bcStack.PushF(c.gi().velocity.jump.down * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_runjump_back_x:
-		sys.bcStack.PushF(c.gi().velocity.runjump.back[0] * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_runjump_back_y:
-		sys.bcStack.PushF(c.gi().velocity.runjump.back[1] * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_runjump_y:
-		sys.bcStack.PushF(c.gi().velocity.runjump.fwd[1] * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_runjump_fwd_x:
-		sys.bcStack.PushF(c.gi().velocity.runjump.fwd[0] * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_runjump_up_x:
-		sys.bcStack.PushF(c.gi().velocity.runjump.up * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_runjump_down_x:
-		sys.bcStack.PushF(c.gi().velocity.runjump.down * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_airjump_y:
-		sys.bcStack.PushF(c.gi().velocity.airjump.neu[1] * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_airjump_neu_x:
-		sys.bcStack.PushF(c.gi().velocity.airjump.neu[0] * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_airjump_back_x:
-		sys.bcStack.PushF(c.gi().velocity.airjump.back * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_airjump_fwd_x:
-		sys.bcStack.PushF(c.gi().velocity.airjump.fwd * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_airjump_up_x:
-		sys.bcStack.PushF(c.gi().velocity.airjump.up * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_airjump_down_x:
-		sys.bcStack.PushF(c.gi().velocity.airjump.down * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_air_gethit_groundrecover_x:
-		sys.bcStack.PushF(c.gi().velocity.air.gethit.groundrecover[0] * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_air_gethit_groundrecover_y:
-		sys.bcStack.PushF(c.gi().velocity.air.gethit.groundrecover[1] * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_air_gethit_airrecover_mul_x:
-		sys.bcStack.PushF(c.gi().velocity.air.gethit.airrecover.mul[0])
-	case OC_const_velocity_air_gethit_airrecover_mul_y:
-		sys.bcStack.PushF(c.gi().velocity.air.gethit.airrecover.mul[1])
 	case OC_const_velocity_air_gethit_airrecover_add_x:
 		sys.bcStack.PushF(c.gi().velocity.air.gethit.airrecover.add[0] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_air_gethit_airrecover_add_y:
 		sys.bcStack.PushF(c.gi().velocity.air.gethit.airrecover.add[1] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_air_gethit_airrecover_back:
 		sys.bcStack.PushF(c.gi().velocity.air.gethit.airrecover.back * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_air_gethit_airrecover_fwd:
-		sys.bcStack.PushF(c.gi().velocity.air.gethit.airrecover.fwd * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_air_gethit_airrecover_up:
-		sys.bcStack.PushF(c.gi().velocity.air.gethit.airrecover.up * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_air_gethit_airrecover_down:
 		sys.bcStack.PushF(c.gi().velocity.air.gethit.airrecover.down * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_air_gethit_airrecover_fwd:
+		sys.bcStack.PushF(c.gi().velocity.air.gethit.airrecover.fwd * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_air_gethit_airrecover_mul_x:
+		sys.bcStack.PushF(c.gi().velocity.air.gethit.airrecover.mul[0])
+	case OC_const_velocity_air_gethit_airrecover_mul_y:
+		sys.bcStack.PushF(c.gi().velocity.air.gethit.airrecover.mul[1])
+	case OC_const_velocity_air_gethit_airrecover_up:
+		sys.bcStack.PushF(c.gi().velocity.air.gethit.airrecover.up * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_air_gethit_groundrecover_x:
+		sys.bcStack.PushF(c.gi().velocity.air.gethit.groundrecover[0] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_air_gethit_groundrecover_y:
+		sys.bcStack.PushF(c.gi().velocity.air.gethit.groundrecover[1] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_air_gethit_ko_add_x:
 		sys.bcStack.PushF(c.gi().velocity.air.gethit.ko.add[0] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_air_gethit_ko_add_y:
 		sys.bcStack.PushF(c.gi().velocity.air.gethit.ko.add[1] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_air_gethit_ko_ymin:
 		sys.bcStack.PushF(c.gi().velocity.air.gethit.ko.ymin * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_velocity_ground_gethit_ko_xmul:
-		sys.bcStack.PushF(c.gi().velocity.ground.gethit.ko.xmul)
+	case OC_const_velocity_airjump_back_x:
+		sys.bcStack.PushF(c.gi().velocity.airjump.back * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_airjump_down_x:
+		sys.bcStack.PushF(c.gi().velocity.airjump.down[0] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_airjump_down_y:
+		sys.bcStack.PushF(c.gi().velocity.airjump.down[1] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_airjump_down_z:
+		sys.bcStack.PushF(c.gi().velocity.airjump.down[2] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_airjump_fwd_x:
+		sys.bcStack.PushF(c.gi().velocity.airjump.fwd * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_airjump_neu_x:
+		sys.bcStack.PushF(c.gi().velocity.airjump.neu[0] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_airjump_up_x:
+		sys.bcStack.PushF(c.gi().velocity.airjump.up[0] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_airjump_up_y:
+		sys.bcStack.PushF(c.gi().velocity.airjump.up[1] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_airjump_up_z:
+		sys.bcStack.PushF(c.gi().velocity.airjump.up[2] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_airjump_y:
+		sys.bcStack.PushF(c.gi().velocity.airjump.neu[1] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_ground_gethit_ko_add_x:
 		sys.bcStack.PushF(c.gi().velocity.ground.gethit.ko.add[0] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_velocity_ground_gethit_ko_add_y:
 		sys.bcStack.PushF(c.gi().velocity.ground.gethit.ko.add[1] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_ground_gethit_ko_xmul:
+		sys.bcStack.PushF(c.gi().velocity.ground.gethit.ko.xmul)
 	case OC_const_velocity_ground_gethit_ko_ymin:
 		sys.bcStack.PushF(c.gi().velocity.ground.gethit.ko.ymin * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_jump_back_x:
+		sys.bcStack.PushF(c.gi().velocity.jump.back * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_jump_down_x:
+		sys.bcStack.PushF(c.gi().velocity.jump.down[0] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_jump_down_y:
+		sys.bcStack.PushF(c.gi().velocity.jump.down[1] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_jump_down_z:
+		sys.bcStack.PushF(c.gi().velocity.jump.down[2] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_jump_fwd_x:
+		sys.bcStack.PushF(c.gi().velocity.jump.fwd * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_jump_neu_x:
+		sys.bcStack.PushF(c.gi().velocity.jump.neu[0] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_jump_up_x:
+		sys.bcStack.PushF(c.gi().velocity.jump.up[0] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_jump_up_y:
+		sys.bcStack.PushF(c.gi().velocity.jump.up[1] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_jump_up_z:
+		sys.bcStack.PushF(c.gi().velocity.jump.up[2] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_jump_y:
+		sys.bcStack.PushF(c.gi().velocity.jump.neu[1] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_run_back_x:
+		sys.bcStack.PushF(c.gi().velocity.run.back[0] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_run_back_y:
+		sys.bcStack.PushF(c.gi().velocity.run.back[1] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_run_down_x:
+		sys.bcStack.PushF(c.gi().velocity.run.down[0] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_run_down_y:
+		sys.bcStack.PushF(c.gi().velocity.run.down[1] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_run_down_z:
+		sys.bcStack.PushF(c.gi().velocity.run.down[2] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_run_fwd_x:
+		sys.bcStack.PushF(c.gi().velocity.run.fwd[0] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_run_fwd_y:
+		sys.bcStack.PushF(c.gi().velocity.run.fwd[1] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_run_up_x:
+		sys.bcStack.PushF(c.gi().velocity.run.up[0] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_run_up_y:
+		sys.bcStack.PushF(c.gi().velocity.run.up[1] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_run_up_z:
+		sys.bcStack.PushF(c.gi().velocity.run.up[2] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_runjump_back_x:
+		sys.bcStack.PushF(c.gi().velocity.runjump.back[0] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_runjump_back_y:
+		sys.bcStack.PushF(c.gi().velocity.runjump.back[1] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_runjump_down_x:
+		sys.bcStack.PushF(c.gi().velocity.runjump.down[0] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_runjump_down_y:
+		sys.bcStack.PushF(c.gi().velocity.runjump.down[1] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_runjump_down_z:
+		sys.bcStack.PushF(c.gi().velocity.runjump.down[2] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_runjump_fwd_x:
+		sys.bcStack.PushF(c.gi().velocity.runjump.fwd[0] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_runjump_up_x:
+		sys.bcStack.PushF(c.gi().velocity.runjump.up[0] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_runjump_up_y:
+		sys.bcStack.PushF(c.gi().velocity.runjump.up[1] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_runjump_up_z:
+		sys.bcStack.PushF(c.gi().velocity.runjump.up[2] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_runjump_y:
+		sys.bcStack.PushF(c.gi().velocity.runjump.fwd[1] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_walk_back_x:
+		sys.bcStack.PushF(c.gi().velocity.walk.back * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_walk_down_x:
+		sys.bcStack.PushF(c.gi().velocity.walk.down[0] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_walk_down_y:
+		sys.bcStack.PushF(c.gi().velocity.walk.down[1] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_walk_down_z:
+		sys.bcStack.PushF(c.gi().velocity.walk.down[2] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_walk_fwd_x:
+		sys.bcStack.PushF(c.gi().velocity.walk.fwd * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_walk_up_x:
+		sys.bcStack.PushF(c.gi().velocity.walk.up[0] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_walk_up_y:
+		sys.bcStack.PushF(c.gi().velocity.walk.up[1] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_velocity_walk_up_z:
+		sys.bcStack.PushF(c.gi().velocity.walk.up[2] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_movement_airjump_num:
 		sys.bcStack.PushI(c.gi().movement.airjump.num)
 	case OC_const_movement_airjump_height:

--- a/src/char.go
+++ b/src/char.go
@@ -30,25 +30,20 @@ type CharSpecialFlag uint32
 
 const (
 	CSF_angledraw CharSpecialFlag = 1 << iota
-	CSF_backdepth
-	CSF_backdepthedge
-	CSF_backedge
-	CSF_backwidth
-	CSF_bottomheight
+	CSF_depth
+	CSF_depthedge
 	CSF_destroy
-	CSF_frontdepth
-	CSF_frontdepthedge
-	CSF_frontedge
-	CSF_frontwidth
 	CSF_gethit
+	CSF_height
 	CSF_movecamera_x
 	CSF_movecamera_y
 	CSF_playerpush
 	CSF_posfreeze
 	CSF_screenbound
 	CSF_stagebound
-	CSF_topheight
 	CSF_trans
+	CSF_width
+	CSF_widthedge
 )
 
 // Flags set by AssertSpecial. They are reset together every frame
@@ -2368,7 +2363,7 @@ type CharSystemVar struct {
 	receivedHits      int32
 	cornerVelOff      float32
 	width             [2]float32
-	edge              [2]float32
+	widthEdge         [2]float32
 	height            [2]float32
 	depth             [2]float32
 	depthEdge         [2]float32
@@ -3807,7 +3802,7 @@ func (c *Char) backEdgeBodyDist() float32 {
 			offset = 1.0 / c.localscl
 		}
 	}
-	return c.backEdgeDist() - c.edge[1] - offset
+	return c.backEdgeDist() - c.widthEdge[1] - offset
 }
 
 func (c *Char) backEdgeDist() float32 {
@@ -3912,7 +3907,7 @@ func (c *Char) frontEdgeBodyDist() float32 {
 			offset = 1.0 / c.localscl
 		}
 	}
-	return c.frontEdgeDist() - c.edge[0] - offset
+	return c.frontEdgeDist() - c.widthEdge[0] - offset
 }
 
 func (c *Char) frontEdgeDist() float32 {
@@ -4833,8 +4828,8 @@ func (c *Char) stateChange1(no int32, pn int) bool {
 
 		c.width[0] *= lsRatio
 		c.width[1] *= lsRatio
-		c.edge[0] *= lsRatio
-		c.edge[1] *= lsRatio
+		c.widthEdge[0] *= lsRatio
+		c.widthEdge[1] *= lsRatio
 		c.height[0] *= lsRatio
 		c.height[1] *= lsRatio
 		c.depth[0] *= lsRatio
@@ -5704,53 +5699,53 @@ func (c *Char) baseDepthBack() float32 {
 }
 
 func (c *Char) setFEdge(fe float32) {
-	c.edge[0] = fe
-	c.setCSF(CSF_frontedge)
+	c.widthEdge[0] = fe
+	c.setCSF(CSF_widthedge)
 }
 
 func (c *Char) setBEdge(be float32) {
-	c.edge[1] = be
-	c.setCSF(CSF_backedge)
+	c.widthEdge[1] = be
+	c.setCSF(CSF_widthedge)
 }
 
 func (c *Char) setFDepthEdge(fde float32) {
 	c.depthEdge[0] = fde
-	c.setCSF(CSF_frontdepthedge)
+	c.setCSF(CSF_depthedge)
 }
 
 func (c *Char) setBDepthEdge(bde float32) {
 	c.depthEdge[1] = bde
-	c.setCSF(CSF_backdepthedge)
+	c.setCSF(CSF_depthedge)
 }
 
 func (c *Char) setFWidth(fw float32) {
 	c.width[0] = c.baseWidthFront()*((320/c.localcoord)/c.localscl) + fw
-	c.setCSF(CSF_frontwidth)
+	c.setCSF(CSF_width)
 }
 
 func (c *Char) setBWidth(bw float32) {
 	c.width[1] = c.baseWidthBack()*((320/c.localcoord)/c.localscl) + bw
-	c.setCSF(CSF_backwidth)
+	c.setCSF(CSF_width)
 }
 
 func (c *Char) setTHeight(th float32) {
 	c.height[0] = c.baseHeightTop()*((320/c.localcoord)/c.localscl) + th
-	c.setCSF(CSF_topheight)
+	c.setCSF(CSF_height)
 }
 
 func (c *Char) setBHeight(bh float32) {
 	c.height[1] = c.baseHeightBottom()*((320/c.localcoord)/c.localscl) + bh
-	c.setCSF(CSF_bottomheight)
+	c.setCSF(CSF_height)
 }
 
 func (c *Char) setFDepth(fd float32) {
 	c.depth[0] = c.baseDepthFront()*((320/c.localcoord)/c.localscl) + fd
-	c.setCSF(CSF_frontdepth)
+	c.setCSF(CSF_depth)
 }
 
 func (c *Char) setBDepth(bd float32) {
 	c.depth[1] = c.baseDepthBack()*((320/c.localcoord)/c.localscl) + bd
-	c.setCSF(CSF_backdepth)
+	c.setCSF(CSF_depth)
 }
 
 func (c *Char) updateClsnScale() {
@@ -7267,7 +7262,7 @@ func (c *Char) trackableByCamera() bool {
 func (c *Char) xScreenBound() {
 	x := c.pos[0]
 	if !sys.cam.roundstart && c.trackableByCamera() && c.csf(CSF_screenbound) && !c.scf(SCF_standby) {
-		min, max := c.edge[0], -c.edge[1]
+		min, max := c.widthEdge[0], -c.widthEdge[1]
 		if c.facing > 0 {
 			min, max = -max, -min
 		}
@@ -7291,7 +7286,7 @@ func (c *Char) zDepthBound() {
 func (c *Char) xPlatformBound(pxmin, pxmax float32) {
 	x := c.pos[0]
 	if c.ss.stateType != ST_A {
-		min, max := c.edge[0], -c.edge[1]
+		min, max := c.widthEdge[0], -c.widthEdge[1]
 		if c.facing > 0 {
 			min, max = -max, -min
 		}
@@ -7969,35 +7964,21 @@ func (c *Char) actionRun() {
 	// Reset char width and height values
 	// TODO: Some of this code could probably be integrated with the new size box
 	if !c.hitPause() {
-		if !c.csf(CSF_frontwidth) {
-			c.width[0] = c.baseWidthFront() * ((320 / c.localcoord) / c.localscl)
+		coordRatio := ((320 / c.localcoord) / c.localscl)
+		if !c.csf(CSF_width) {
+			c.width = [2]float32{c.baseWidthFront() * coordRatio, c.baseWidthBack() * coordRatio}
 		}
-		if !c.csf(CSF_backwidth) {
-			c.width[1] = c.baseWidthBack() * ((320 / c.localcoord) / c.localscl)
+		if !c.csf(CSF_widthedge) {
+			c.widthEdge = [2]float32{0, 0}
 		}
-		if !c.csf(CSF_frontedge) {
-			c.edge[0] = 0
+		if !c.csf(CSF_height) {
+			c.height = [2]float32{c.baseHeightTop() * coordRatio, c.baseHeightBottom() * coordRatio}
 		}
-		if !c.csf(CSF_backedge) {
-			c.edge[1] = 0
+		if !c.csf(CSF_depth) {
+			c.depth = [2]float32{c.baseDepthFront() * coordRatio, c.baseDepthBack() * coordRatio}
 		}
-		if !c.csf(CSF_topheight) {
-			c.height[0] = c.baseHeightTop() * ((320 / c.localcoord) / c.localscl)
-		}
-		if !c.csf(CSF_bottomheight) {
-			c.height[1] = c.baseHeightBottom() * ((320 / c.localcoord) / c.localscl)
-		}
-		if !c.csf(CSF_frontdepth) {
-			c.depth[0] = c.baseDepthFront() * ((320 / c.localcoord) / c.localscl)
-		}
-		if !c.csf(CSF_backdepth) {
-			c.depth[1] = c.baseDepthBack() * ((320 / c.localcoord) / c.localscl)
-		}
-		if !c.csf(CSF_frontdepthedge) {
-			c.depthEdge[0] = 0
-		}
-		if !c.csf(CSF_backdepthedge) {
-			c.depthEdge[1] = 0
+		if !c.csf(CSF_depthedge) {
+			c.depthEdge = [2]float32{0, 0}
 		}
 	}
 	// Update size box according to player width and height
@@ -8201,7 +8182,7 @@ func (c *Char) actionFinish() {
 
 func (c *Char) track() {
 	if c.trackableByCamera() {
-		min, max := c.edge[0], -c.edge[1]
+		min, max := c.widthEdge[0], -c.widthEdge[1]
 		if c.facing > 0 {
 			min, max = -max, -min
 		}
@@ -10369,8 +10350,8 @@ func (cl *CharList) pushDetection(getter *Char) {
 
 				getter.pushed, c.pushed = true, true
 
-				gxmin = getter.edge[0]
-				gxmax = -getter.edge[1]
+				gxmin = getter.widthEdge[0]
+				gxmax = -getter.widthEdge[1]
 				if getter.facing > 0 {
 					gxmin, gxmax = -gxmax, -gxmin
 				}
@@ -10476,7 +10457,7 @@ func (cl *CharList) pushDetection(getter *Char) {
 					getter.pos[0] = ClampF(getter.pos[0], gxmin, gxmax)
 				}
 				if c.trackableByCamera() && c.csf(CSF_screenbound) {
-					l, r := c.edge[0], -c.edge[1]
+					l, r := c.widthEdge[0], -c.widthEdge[1]
 					if c.facing > 0 {
 						l, r = -r, -l
 					}

--- a/src/char.go
+++ b/src/char.go
@@ -5698,54 +5698,37 @@ func (c *Char) baseDepthBack() float32 {
 	return float32(c.size.depth[1])
 }
 
-func (c *Char) setFEdge(fe float32) {
-	c.widthEdge[0] = fe
+func (c *Char) setWidth(fw, bw float32) {
+	coordRatio := (320/c.localcoord)/c.localscl
+	c.width[0] = c.baseWidthFront()*coordRatio + fw
+	c.width[1] = c.baseWidthBack()*coordRatio + bw
+	c.setCSF(CSF_width)
+}
+
+func (c *Char) setHeight(th, bh float32) {
+	coordRatio := (320/c.localcoord)/c.localscl
+	c.height[0] = c.baseHeightTop()*coordRatio + th
+	c.height[1] = c.baseHeightBottom()*coordRatio + bh
+	c.setCSF(CSF_height)
+}
+
+func (c *Char) setDepth(fd, bd float32) {
+	coordRatio := (320/c.localcoord)/c.localscl
+	c.depth[0] = c.baseDepthFront()*coordRatio + fd
+	c.depth[1] = c.baseDepthBack()*coordRatio + bd
+	c.setCSF(CSF_depth)
+}
+
+func (c *Char) setWidthEdge(fe, be float32) {
+	// TODO: confirm if these don't need "coordRatio"
+	c.widthEdge = [2]float32{fe, be}
 	c.setCSF(CSF_widthedge)
 }
 
-func (c *Char) setBEdge(be float32) {
-	c.widthEdge[1] = be
-	c.setCSF(CSF_widthedge)
-}
-
-func (c *Char) setFDepthEdge(fde float32) {
+func (c *Char) setDepthEdge(fde, bde float32) {
 	c.depthEdge[0] = fde
-	c.setCSF(CSF_depthedge)
-}
-
-func (c *Char) setBDepthEdge(bde float32) {
 	c.depthEdge[1] = bde
 	c.setCSF(CSF_depthedge)
-}
-
-func (c *Char) setFWidth(fw float32) {
-	c.width[0] = c.baseWidthFront()*((320/c.localcoord)/c.localscl) + fw
-	c.setCSF(CSF_width)
-}
-
-func (c *Char) setBWidth(bw float32) {
-	c.width[1] = c.baseWidthBack()*((320/c.localcoord)/c.localscl) + bw
-	c.setCSF(CSF_width)
-}
-
-func (c *Char) setTHeight(th float32) {
-	c.height[0] = c.baseHeightTop()*((320/c.localcoord)/c.localscl) + th
-	c.setCSF(CSF_height)
-}
-
-func (c *Char) setBHeight(bh float32) {
-	c.height[1] = c.baseHeightBottom()*((320/c.localcoord)/c.localscl) + bh
-	c.setCSF(CSF_height)
-}
-
-func (c *Char) setFDepth(fd float32) {
-	c.depth[0] = c.baseDepthFront()*((320/c.localcoord)/c.localscl) + fd
-	c.setCSF(CSF_depth)
-}
-
-func (c *Char) setBDepth(bd float32) {
-	c.depth[1] = c.baseDepthBack()*((320/c.localcoord)/c.localscl) + bd
-	c.setCSF(CSF_depth)
 }
 
 func (c *Char) updateClsnScale() {

--- a/src/char.go
+++ b/src/char.go
@@ -347,34 +347,34 @@ type CharVelocity struct {
 	walk struct {
 		fwd  float32
 		back float32
-		up   float32
-		down float32
+		up   [3]float32
+		down [3]float32
 	}
 	run struct {
 		fwd  [2]float32
 		back [2]float32
-		up   [2]float32
-		down [2]float32
+		up   [3]float32
+		down [3]float32
 	}
 	jump struct {
 		neu  [2]float32
 		back float32
 		fwd  float32
-		up   float32
-		down float32
+		up   [3]float32
+		down [3]float32
 	}
 	runjump struct {
 		back [2]float32
 		fwd  [2]float32
-		up   float32
-		down float32
+		up   [3]float32
+		down [3]float32
 	}
 	airjump struct {
 		neu  [2]float32
 		back float32
 		fwd  float32
-		up   float32
-		down float32
+		up   [3]float32
+		down [3]float32
 	}
 	air struct {
 		gethit struct {
@@ -3145,20 +3145,18 @@ func (c *Char) load(def string) error {
 							&gi.velocity.ground.gethit.ko.add[1])
 						is.ReadF32("ground.gethit.ko.ymin", &gi.velocity.ground.gethit.ko.ymin)
 
-						// Mugen accepts these but they are not documented
-						// Possible leftovers of Z axis implementation
-						is.ReadF32("walk.up", &gi.velocity.walk.up) // Should be "z" but Elecbyte decided on "x"
-						is.ReadF32("walk.down", &gi.velocity.walk.down)
-						is.ReadF32("run.up",
-							&gi.velocity.run.up[0], &gi.velocity.run.up[1])
-						is.ReadF32("run.down",
-							&gi.velocity.run.down[0], &gi.velocity.run.down[1]) // Z and Y?
-						is.ReadF32("jump.up", &gi.velocity.jump.up) // Mugen accepts them with this syntax, but they need "x" when retrieved with const trigger
-						is.ReadF32("jump.down", &gi.velocity.jump.down)
-						is.ReadF32("runjump.up", &gi.velocity.runjump.up)
-						is.ReadF32("runjump.down", &gi.velocity.runjump.down)
-						is.ReadF32("airjump.up", &gi.velocity.airjump.up)
-						is.ReadF32("airjump.down", &gi.velocity.airjump.down)
+						// Mugen accepts these but they are not documented. Possible leftovers of Z axis implementation
+						// In Ikemen we're making them accept 3 values each, for the 3 axes
+						is.ReadF32("walk.up", &gi.velocity.walk.up[0], &gi.velocity.walk.up[1], &gi.velocity.walk.up[2])
+						is.ReadF32("walk.down", &gi.velocity.walk.down[0], &gi.velocity.walk.down[1], &gi.velocity.walk.down[2])
+						is.ReadF32("run.up", &gi.velocity.run.up[0], &gi.velocity.run.up[1], &gi.velocity.run.up[2])
+						is.ReadF32("run.down", &gi.velocity.run.down[0], &gi.velocity.run.down[1], &gi.velocity.run.down[2])
+						is.ReadF32("jump.up", &gi.velocity.jump.up[0], &gi.velocity.jump.up[1], &gi.velocity.jump.up[2])
+						is.ReadF32("jump.down", &gi.velocity.jump.down[0], &gi.velocity.jump.down[1], &gi.velocity.jump.down[2])
+						is.ReadF32("runjump.up", &gi.velocity.runjump.up[0], &gi.velocity.runjump.up[1], &gi.velocity.runjump.up[2])
+						is.ReadF32("runjump.down", &gi.velocity.runjump.down[0], &gi.velocity.runjump.down[1], &gi.velocity.runjump.down[2])
+						is.ReadF32("airjump.up", &gi.velocity.airjump.up[0], &gi.velocity.airjump.up[1], &gi.velocity.airjump.up[2])
+						is.ReadF32("airjump.down", &gi.velocity.airjump.down[0], &gi.velocity.airjump.down[1], &gi.velocity.airjump.down[2])
 					}
 				case "movement":
 					if movement {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1824,100 +1824,136 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.append(OC_const_size_weight)
 		case "size.pushfactor":
 			out.append(OC_const_size_pushfactor)
-		case "velocity.walk.fwd.x":
-			out.append(OC_const_velocity_walk_fwd_x)
-		case "velocity.walk.back.x":
-			out.append(OC_const_velocity_walk_back_x)
-		case "velocity.walk.up.x":
-			out.append(OC_const_velocity_walk_up_x)
-		case "velocity.walk.down.x":
-			out.append(OC_const_velocity_walk_down_x)
-		case "velocity.run.fwd.x":
-			out.append(OC_const_velocity_run_fwd_x)
-		case "velocity.run.fwd.y":
-			out.append(OC_const_velocity_run_fwd_y)
-		case "velocity.run.back.x":
-			out.append(OC_const_velocity_run_back_x)
-		case "velocity.run.back.y":
-			out.append(OC_const_velocity_run_back_y)
-		case "velocity.run.up.x":
-			out.append(OC_const_velocity_run_up_x)
-		case "velocity.run.up.y":
-			out.append(OC_const_velocity_run_up_y)
-		case "velocity.run.down.x":
-			out.append(OC_const_velocity_run_down_x)
-		case "velocity.run.down.y":
-			out.append(OC_const_velocity_run_down_y)
-		case "velocity.jump.y":
-			out.append(OC_const_velocity_jump_y)
-		case "velocity.jump.neu.x":
-			out.append(OC_const_velocity_jump_neu_x)
-		case "velocity.jump.back.x":
-			out.append(OC_const_velocity_jump_back_x)
-		case "velocity.jump.fwd.x":
-			out.append(OC_const_velocity_jump_fwd_x)
-		case "velocity.jump.up.x":
-			out.append(OC_const_velocity_jump_up_x)
-		case "velocity.jump.down.x":
-			out.append(OC_const_velocity_jump_down_x)
-		case "velocity.runjump.back.x":
-			out.append(OC_const_velocity_runjump_back_x)
-		case "velocity.runjump.back.y":
-			out.append(OC_const_velocity_runjump_back_y)
-		case "velocity.runjump.y":
-			out.append(OC_const_velocity_runjump_y)
-		case "velocity.runjump.fwd.x":
-			out.append(OC_const_velocity_runjump_fwd_x)
-		case "velocity.runjump.up.x":
-			out.append(OC_const_velocity_runjump_up_x)
-		case "velocity.runjump.down.x":
-			out.append(OC_const_velocity_runjump_down_x)
-		case "velocity.airjump.y":
-			out.append(OC_const_velocity_airjump_y)
-		case "velocity.airjump.neu.x":
-			out.append(OC_const_velocity_airjump_neu_x)
-		case "velocity.airjump.back.x":
-			out.append(OC_const_velocity_airjump_back_x)
-		case "velocity.airjump.fwd.x":
-			out.append(OC_const_velocity_airjump_fwd_x)
-		case "velocity.airjump.up.x":
-			out.append(OC_const_velocity_airjump_up_x)
-		case "velocity.airjump.down.x":
-			out.append(OC_const_velocity_airjump_down_x)
-		case "velocity.air.gethit.groundrecover.x":
-			out.append(OC_const_velocity_air_gethit_groundrecover_x)
-		case "velocity.air.gethit.groundrecover.y":
-			out.append(OC_const_velocity_air_gethit_groundrecover_y)
-		case "velocity.air.gethit.airrecover.mul.x":
-			out.append(OC_const_velocity_air_gethit_airrecover_mul_x)
-		case "velocity.air.gethit.airrecover.mul.y":
-			out.append(OC_const_velocity_air_gethit_airrecover_mul_y)
 		case "velocity.air.gethit.airrecover.add.x":
 			out.append(OC_const_velocity_air_gethit_airrecover_add_x)
 		case "velocity.air.gethit.airrecover.add.y":
 			out.append(OC_const_velocity_air_gethit_airrecover_add_y)
 		case "velocity.air.gethit.airrecover.back":
 			out.append(OC_const_velocity_air_gethit_airrecover_back)
-		case "velocity.air.gethit.airrecover.fwd":
-			out.append(OC_const_velocity_air_gethit_airrecover_fwd)
-		case "velocity.air.gethit.airrecover.up":
-			out.append(OC_const_velocity_air_gethit_airrecover_up)
 		case "velocity.air.gethit.airrecover.down":
 			out.append(OC_const_velocity_air_gethit_airrecover_down)
+		case "velocity.air.gethit.airrecover.fwd":
+			out.append(OC_const_velocity_air_gethit_airrecover_fwd)
+		case "velocity.air.gethit.airrecover.mul.x":
+			out.append(OC_const_velocity_air_gethit_airrecover_mul_x)
+		case "velocity.air.gethit.airrecover.mul.y":
+			out.append(OC_const_velocity_air_gethit_airrecover_mul_y)
+		case "velocity.air.gethit.airrecover.up":
+			out.append(OC_const_velocity_air_gethit_airrecover_up)
+		case "velocity.air.gethit.groundrecover.x":
+			out.append(OC_const_velocity_air_gethit_groundrecover_x)
+		case "velocity.air.gethit.groundrecover.y":
+			out.append(OC_const_velocity_air_gethit_groundrecover_y)
 		case "velocity.air.gethit.ko.add.x":
 			out.append(OC_const_velocity_air_gethit_ko_add_x)
 		case "velocity.air.gethit.ko.add.y":
 			out.append(OC_const_velocity_air_gethit_ko_add_y)
 		case "velocity.air.gethit.ko.ymin":
 			out.append(OC_const_velocity_air_gethit_ko_ymin)
-		case "velocity.ground.gethit.ko.xmul":
-			out.append(OC_const_velocity_ground_gethit_ko_xmul)
+		case "velocity.airjump.back.x":
+			out.append(OC_const_velocity_airjump_back_x)
+		case "velocity.airjump.down.x":
+			out.append(OC_const_velocity_airjump_down_x)
+		case "velocity.airjump.down.y":
+			out.append(OC_const_velocity_airjump_down_y)
+		case "velocity.airjump.down.z":
+			out.append(OC_const_velocity_airjump_down_z)
+		case "velocity.airjump.fwd.x":
+			out.append(OC_const_velocity_airjump_fwd_x)
+		case "velocity.airjump.neu.x":
+			out.append(OC_const_velocity_airjump_neu_x)
+		case "velocity.airjump.up.x":
+			out.append(OC_const_velocity_airjump_up_x)
+		case "velocity.airjump.up.y":
+			out.append(OC_const_velocity_airjump_up_y)
+		case "velocity.airjump.up.z":
+			out.append(OC_const_velocity_airjump_up_z)
+		case "velocity.airjump.y":
+			out.append(OC_const_velocity_airjump_y)
 		case "velocity.ground.gethit.ko.add.x":
 			out.append(OC_const_velocity_ground_gethit_ko_add_x)
 		case "velocity.ground.gethit.ko.add.y":
 			out.append(OC_const_velocity_ground_gethit_ko_add_y)
+		case "velocity.ground.gethit.ko.xmul":
+			out.append(OC_const_velocity_ground_gethit_ko_xmul)
 		case "velocity.ground.gethit.ko.ymin":
 			out.append(OC_const_velocity_ground_gethit_ko_ymin)
+		case "velocity.jump.back.x":
+			out.append(OC_const_velocity_jump_back_x)
+		case "velocity.jump.down.x":
+			out.append(OC_const_velocity_jump_down_x)
+		case "velocity.jump.down.y":
+			out.append(OC_const_velocity_jump_down_y)
+		case "velocity.jump.down.z":
+			out.append(OC_const_velocity_jump_down_z)
+		case "velocity.jump.fwd.x":
+			out.append(OC_const_velocity_jump_fwd_x)
+		case "velocity.jump.neu.x":
+			out.append(OC_const_velocity_jump_neu_x)
+		case "velocity.jump.up.x":
+			out.append(OC_const_velocity_jump_up_x)
+		case "velocity.jump.up.y":
+			out.append(OC_const_velocity_jump_up_y)
+		case "velocity.jump.up.z":
+			out.append(OC_const_velocity_jump_up_z)
+		case "velocity.jump.y":
+			out.append(OC_const_velocity_jump_y)
+		case "velocity.run.back.x":
+			out.append(OC_const_velocity_run_back_x)
+		case "velocity.run.back.y":
+			out.append(OC_const_velocity_run_back_y)
+		case "velocity.run.down.x":
+			out.append(OC_const_velocity_run_down_x)
+		case "velocity.run.down.y":
+			out.append(OC_const_velocity_run_down_y)
+		case "velocity.run.down.z":
+			out.append(OC_const_velocity_run_down_z)
+		case "velocity.run.fwd.x":
+			out.append(OC_const_velocity_run_fwd_x)
+		case "velocity.run.fwd.y":
+			out.append(OC_const_velocity_run_fwd_y)
+		case "velocity.run.up.x":
+			out.append(OC_const_velocity_run_up_x)
+		case "velocity.run.up.y":
+			out.append(OC_const_velocity_run_up_y)
+		case "velocity.run.up.z":
+			out.append(OC_const_velocity_run_up_z)
+		case "velocity.runjump.back.x":
+			out.append(OC_const_velocity_runjump_back_x)
+		case "velocity.runjump.back.y":
+			out.append(OC_const_velocity_runjump_back_y)
+		case "velocity.runjump.down.x":
+			out.append(OC_const_velocity_runjump_down_x)
+		case "velocity.runjump.down.y":
+			out.append(OC_const_velocity_runjump_down_y)
+		case "velocity.runjump.down.z":
+			out.append(OC_const_velocity_runjump_down_z)
+		case "velocity.runjump.fwd.x":
+			out.append(OC_const_velocity_runjump_fwd_x)
+		case "velocity.runjump.up.x":
+			out.append(OC_const_velocity_runjump_up_x)
+		case "velocity.runjump.up.y":
+			out.append(OC_const_velocity_runjump_up_y)
+		case "velocity.runjump.up.z":
+			out.append(OC_const_velocity_runjump_up_z)
+		case "velocity.runjump.y":
+			out.append(OC_const_velocity_runjump_y)
+		case "velocity.walk.back.x":
+			out.append(OC_const_velocity_walk_back_x)
+		case "velocity.walk.down.x":
+			out.append(OC_const_velocity_walk_down_x)
+		case "velocity.walk.down.y":
+			out.append(OC_const_velocity_walk_down_y)
+		case "velocity.walk.down.z":
+			out.append(OC_const_velocity_walk_down_z)
+		case "velocity.walk.fwd.x":
+			out.append(OC_const_velocity_walk_fwd_x)
+		case "velocity.walk.up.x":
+			out.append(OC_const_velocity_walk_up_x)
+		case "velocity.walk.up.y":
+			out.append(OC_const_velocity_walk_up_y)
+		case "velocity.walk.up.z":
+			out.append(OC_const_velocity_walk_up_z)
 		case "movement.airjump.num":
 			out.append(OC_const_movement_airjump_num)
 		case "movement.airjump.height":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1037,11 +1037,11 @@ func (c *Compiler) gameMakeAnim(is IniSection, sc *StateControllerBase, _ int8) 
 			return err
 		}
 		if err := c.paramValue(is, sc, "pos",
-			gameMakeAnim_pos, VT_Float, 2, false); err != nil {
+			gameMakeAnim_pos, VT_Float, 3, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "random",
-			gameMakeAnim_random, VT_Float, 2, false); err != nil {
+			gameMakeAnim_random, VT_Float, 3, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "under",

--- a/src/script.go
+++ b/src/script.go
@@ -3422,100 +3422,118 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.size.weight)
 		case "size.pushfactor":
 			ln = lua.LNumber(c.size.pushfactor)
-		case "velocity.walk.fwd.x":
-			ln = lua.LNumber(c.gi().velocity.walk.fwd)
-		case "velocity.walk.back.x":
-			ln = lua.LNumber(c.gi().velocity.walk.back)
-		case "velocity.walk.up.x":
-			ln = lua.LNumber(c.gi().velocity.walk.up)
-		case "velocity.walk.down.x":
-			ln = lua.LNumber(c.gi().velocity.walk.down)
-		case "velocity.run.fwd.x":
-			ln = lua.LNumber(c.gi().velocity.run.fwd[0])
-		case "velocity.run.fwd.y":
-			ln = lua.LNumber(c.gi().velocity.run.fwd[1])
-		case "velocity.run.back.x":
-			ln = lua.LNumber(c.gi().velocity.run.back[0])
-		case "velocity.run.back.y":
-			ln = lua.LNumber(c.gi().velocity.run.back[1])
-		case "velocity.run.up.x":
-			ln = lua.LNumber(c.gi().velocity.run.up[0])
-		case "velocity.run.up.y":
-			ln = lua.LNumber(c.gi().velocity.run.up[1])
-		case "velocity.run.down.x":
-			ln = lua.LNumber(c.gi().velocity.run.down[0])
-		case "velocity.run.down.y":
-			ln = lua.LNumber(c.gi().velocity.run.down[1])
-		case "velocity.jump.y":
-			ln = lua.LNumber(c.gi().velocity.jump.neu[1])
-		case "velocity.jump.neu.x":
-			ln = lua.LNumber(c.gi().velocity.jump.neu[0])
-		case "velocity.jump.back.x":
-			ln = lua.LNumber(c.gi().velocity.jump.back)
-		case "velocity.jump.fwd.x":
-			ln = lua.LNumber(c.gi().velocity.jump.fwd)
-		case "velocity.jump.up.x":
-			ln = lua.LNumber(c.gi().velocity.jump.up)
-		case "velocity.jump.down.x":
-			ln = lua.LNumber(c.gi().velocity.jump.down)
-		case "velocity.runjump.back.x":
-			ln = lua.LNumber(c.gi().velocity.runjump.back[0])
-		case "velocity.runjump.back.y":
-			ln = lua.LNumber(c.gi().velocity.runjump.back[1])
-		case "velocity.runjump.y":
-			ln = lua.LNumber(c.gi().velocity.runjump.fwd[1])
-		case "velocity.runjump.fwd.x":
-			ln = lua.LNumber(c.gi().velocity.runjump.fwd[0])
-		case "velocity.runjump.up.x":
-			ln = lua.LNumber(c.gi().velocity.runjump.up)
-		case "velocity.runjump.down.x":
-			ln = lua.LNumber(c.gi().velocity.runjump.down)
-		case "velocity.airjump.y":
-			ln = lua.LNumber(c.gi().velocity.airjump.neu[1])
-		case "velocity.airjump.neu.x":
-			ln = lua.LNumber(c.gi().velocity.airjump.neu[0])
-		case "velocity.airjump.back.x":
-			ln = lua.LNumber(c.gi().velocity.airjump.back)
-		case "velocity.airjump.fwd.x":
-			ln = lua.LNumber(c.gi().velocity.airjump.fwd)
-		case "velocity.airjump.up.x":
-			ln = lua.LNumber(c.gi().velocity.airjump.up)
-		case "velocity.airjump.down.x":
-			ln = lua.LNumber(c.gi().velocity.airjump.down)
-		case "velocity.air.gethit.groundrecover.x":
-			ln = lua.LNumber(c.gi().velocity.air.gethit.groundrecover[0])
-		case "velocity.air.gethit.groundrecover.y":
-			ln = lua.LNumber(c.gi().velocity.air.gethit.groundrecover[1])
-		case "velocity.air.gethit.airrecover.mul.x":
-			ln = lua.LNumber(c.gi().velocity.air.gethit.airrecover.mul[0])
-		case "velocity.air.gethit.airrecover.mul.y":
-			ln = lua.LNumber(c.gi().velocity.air.gethit.airrecover.mul[1])
 		case "velocity.air.gethit.airrecover.add.x":
 			ln = lua.LNumber(c.gi().velocity.air.gethit.airrecover.add[0])
 		case "velocity.air.gethit.airrecover.add.y":
 			ln = lua.LNumber(c.gi().velocity.air.gethit.airrecover.add[1])
 		case "velocity.air.gethit.airrecover.back":
 			ln = lua.LNumber(c.gi().velocity.air.gethit.airrecover.back)
-		case "velocity.air.gethit.airrecover.fwd":
-			ln = lua.LNumber(c.gi().velocity.air.gethit.airrecover.fwd)
-		case "velocity.air.gethit.airrecover.up":
-			ln = lua.LNumber(c.gi().velocity.air.gethit.airrecover.up)
 		case "velocity.air.gethit.airrecover.down":
 			ln = lua.LNumber(c.gi().velocity.air.gethit.airrecover.down)
+		case "velocity.air.gethit.airrecover.fwd":
+			ln = lua.LNumber(c.gi().velocity.air.gethit.airrecover.fwd)
+		case "velocity.air.gethit.airrecover.mul.x":
+			ln = lua.LNumber(c.gi().velocity.air.gethit.airrecover.mul[0])
+		case "velocity.air.gethit.airrecover.mul.y":
+			ln = lua.LNumber(c.gi().velocity.air.gethit.airrecover.mul[1])
+		case "velocity.air.gethit.airrecover.up":
+			ln = lua.LNumber(c.gi().velocity.air.gethit.airrecover.up)
+		case "velocity.air.gethit.groundrecover.x":
+			ln = lua.LNumber(c.gi().velocity.air.gethit.groundrecover[0])
+		case "velocity.air.gethit.groundrecover.y":
+			ln = lua.LNumber(c.gi().velocity.air.gethit.groundrecover[1])
 		case "velocity.air.gethit.ko.add.x":
 			ln = lua.LNumber(c.gi().velocity.air.gethit.ko.add[0])
 		case "velocity.air.gethit.ko.add.y":
 			ln = lua.LNumber(c.gi().velocity.air.gethit.ko.add[1])
 		case "velocity.air.gethit.ko.ymin":
 			ln = lua.LNumber(c.gi().velocity.air.gethit.ko.ymin)
-		case "velocity.ground.gethit.ko.xmul":
-			ln = lua.LNumber(c.gi().velocity.ground.gethit.ko.xmul)
+		case "velocity.airjump.back.x":
+			ln = lua.LNumber(c.gi().velocity.airjump.back)
+		case "velocity.airjump.down.x":
+			ln = lua.LNumber(c.gi().velocity.airjump.down[0])
+		case "velocity.airjump.fwd.x":
+			ln = lua.LNumber(c.gi().velocity.airjump.fwd)
+		case "velocity.airjump.neu.x":
+			ln = lua.LNumber(c.gi().velocity.airjump.neu[0])
+		case "velocity.airjump.up.x":
+			ln = lua.LNumber(c.gi().velocity.airjump.up[0])
+		case "velocity.airjump.up.y":
+			ln = lua.LNumber(c.gi().velocity.airjump.up[1])
+		case "velocity.airjump.up.z":
+			ln = lua.LNumber(c.gi().velocity.airjump.up[2])
+		case "velocity.airjump.y":
+			ln = lua.LNumber(c.gi().velocity.airjump.neu[1])
 		case "velocity.ground.gethit.ko.add.x":
 			ln = lua.LNumber(c.gi().velocity.ground.gethit.ko.add[0])
 		case "velocity.ground.gethit.ko.add.y":
 			ln = lua.LNumber(c.gi().velocity.ground.gethit.ko.add[1])
+		case "velocity.ground.gethit.ko.xmul":
+			ln = lua.LNumber(c.gi().velocity.ground.gethit.ko.xmul)
 		case "velocity.ground.gethit.ko.ymin":
 			ln = lua.LNumber(c.gi().velocity.ground.gethit.ko.ymin)
+		case "velocity.jump.back.x":
+			ln = lua.LNumber(c.gi().velocity.jump.back)
+		case "velocity.jump.down.x":
+			ln = lua.LNumber(c.gi().velocity.jump.down[0])
+		case "velocity.jump.fwd.x":
+			ln = lua.LNumber(c.gi().velocity.jump.fwd)
+		case "velocity.jump.neu.x":
+			ln = lua.LNumber(c.gi().velocity.jump.neu[0])
+		case "velocity.jump.up.x":
+			ln = lua.LNumber(c.gi().velocity.jump.up[0])
+		case "velocity.jump.up.y":
+			ln = lua.LNumber(c.gi().velocity.jump.up[1])
+		case "velocity.jump.up.z":
+			ln = lua.LNumber(c.gi().velocity.jump.up[2])
+		case "velocity.jump.y":
+			ln = lua.LNumber(c.gi().velocity.jump.neu[1])
+		case "velocity.run.back.x":
+			ln = lua.LNumber(c.gi().velocity.run.back[0])
+		case "velocity.run.back.y":
+			ln = lua.LNumber(c.gi().velocity.run.back[1])
+		case "velocity.run.down.x":
+			ln = lua.LNumber(c.gi().velocity.run.down[0])
+		case "velocity.run.down.y":
+			ln = lua.LNumber(c.gi().velocity.run.down[1])
+		case "velocity.run.fwd.x":
+			ln = lua.LNumber(c.gi().velocity.run.fwd[0])
+		case "velocity.run.fwd.y":
+			ln = lua.LNumber(c.gi().velocity.run.fwd[1])
+		case "velocity.run.up.x":
+			ln = lua.LNumber(c.gi().velocity.run.up[0])
+		case "velocity.run.up.y":
+			ln = lua.LNumber(c.gi().velocity.run.up[1])
+		case "velocity.run.up.z":
+			ln = lua.LNumber(c.gi().velocity.run.up[2])
+		case "velocity.runjump.back.x":
+			ln = lua.LNumber(c.gi().velocity.runjump.back[0])
+		case "velocity.runjump.back.y":
+			ln = lua.LNumber(c.gi().velocity.runjump.back[1])
+		case "velocity.runjump.down.x":
+			ln = lua.LNumber(c.gi().velocity.runjump.down[0])
+		case "velocity.runjump.fwd.x":
+			ln = lua.LNumber(c.gi().velocity.runjump.fwd[0])
+		case "velocity.runjump.up.x":
+			ln = lua.LNumber(c.gi().velocity.runjump.up[0])
+		case "velocity.runjump.up.y":
+			ln = lua.LNumber(c.gi().velocity.runjump.up[1])
+		case "velocity.runjump.up.z":
+			ln = lua.LNumber(c.gi().velocity.runjump.up[2])
+		case "velocity.runjump.y":
+			ln = lua.LNumber(c.gi().velocity.runjump.fwd[1])
+		case "velocity.walk.back.x":
+			ln = lua.LNumber(c.gi().velocity.walk.back)
+		case "velocity.walk.down.x":
+			ln = lua.LNumber(c.gi().velocity.walk.down[0])
+		case "velocity.walk.fwd.x":
+			ln = lua.LNumber(c.gi().velocity.walk.fwd)
+		case "velocity.walk.up.x":
+			ln = lua.LNumber(c.gi().velocity.walk.up[0])
+		case "velocity.walk.up.y":
+			ln = lua.LNumber(c.gi().velocity.walk.up[1])
+		case "velocity.walk.up.z":
+			ln = lua.LNumber(c.gi().velocity.walk.up[2])
 		case "movement.airjump.num":
 			ln = lua.LNumber(c.gi().movement.airjump.num)
 		case "movement.airjump.height":


### PR DESCRIPTION
Fix:
- Added missing pos z to GameMakeAnim
- Projectile hit sparks now default to character constant values like supposed to
- Fixed crashes when some ProjVar Z component triggers were called
- Back width persisting when called before front width
- Fixed issue where inguarddist would only care about the last enemy evaluated
- Fixes #2328 

Refactor:
- The undocumented Mugen "up" and "down" velocity constants now all accept 3 values, representing the 3 axes
- Updated common1.cns.zss to use Z coordinates in explods
- Combined back/front width/height/depth flags
- Adjusted the code that determines in which axis characters should push each other
- Refactored inguarddist checks