### PR TITLE
fix: shadows and KO; refactor training and AnimElemVar

### DIFF
--- a/data/training.zss
+++ b/data/training.zss
@@ -8,257 +8,260 @@
 # _iksys_trainingButtonJam: 0 - none, 1-9 - a/b/c/x/y/z/s/d/w
 
 #===============================================================================
-# Functions
-#===============================================================================
-[Function TrainingRecovery(pn)]
-# Life recovery
-if player($pn),moveType = H || player($pn),dizzy {
-	mapSet{map: "_iksys_trainingLifeTimer"; value: 0; redirectid: player($pn),id}
-} else if player($pn),map(_iksys_trainingLifeTimer) >= 60 {
-	lifeSet{value: player($pn),lifeMax; redirectid: player($pn),id}
-	redLifeSet{value: player($pn),lifeMax; redirectid: player($pn),id}
-	mapSet{map: "_iksys_trainingLifeTimer"; value: 0; redirectid: player($pn),id}
-} else {
-	mapAdd{map: "_iksys_trainingLifeTimer"; value: 1; redirectid: player($pn),id}
-}
-# Power recovery
-if player($pn),ctrl = 0 {
-	mapSet{map: "_iksys_trainingPowerTimer"; value: 0; redirectid: player($pn),id}
-} else if player($pn),map(_iksys_trainingPowerTimer) >= 60 {
-	powerSet{value: player($pn),powerMax; redirectid: player($pn),id}
-	mapSet{map: "_iksys_trainingPowerTimer"; value: 0; redirectid: player($pn),id}
-} else {
-	mapAdd{map: "_iksys_trainingPowerTimer"; value: 1; redirectid: player($pn),id}
-}
-
-#===============================================================================
 # Global states (not halted by Pause/SuperPause, no helper limitations)
 #===============================================================================
 [StateDef -4]
 
-ignoreHitPause if gameMode = "training" && teamSide = 2 && !isHelper {
+ignoreHitPause if gameMode = "training" {
+	# Round start reset
 	if roundTime = 0 {
-		# Round start reset
-		map(_iksys_trainingDummyControl) := 0;
-		map(_iksys_trainingDummyMode) := 0;
-		map(_iksys_trainingGuardMode) := 0;
-		map(_iksys_trainingFallRecovery) := 0;
-		map(_iksys_trainingDistance) := 0;
-		map(_iksys_trainingButtonJam) := 0;
-		powerSet{value: player(1),powerMax; redirectid: player(1),id}
-		powerSet{value: player(2),powerMax; redirectid: player(2),id}
+		powerSet{value: powerMax}
 		map(_iksys_trainingLifeTimer) := 0;
 		map(_iksys_trainingPowerTimer) := 0;
-		map(_iksys_trainingDirection) := 0;
-		map(_iksys_trainingAirJumpNum) := 0;
 	}
+	# Life and Power recovery
+	if !isHelper {
+		# Life
+		if moveType = H || dizzy {
+			mapSet{map: "_iksys_trainingLifeTimer"; value: 0}
+		} else {
+			mapAdd{map: "_iksys_trainingLifeTimer"; value: 1}
+		}
+		if map(_iksys_trainingLifeTimer) >= 60 {
+			lifeSet{value: lifeMax}
+			redLifeSet{value: lifeMax}
+			mapSet{map: "_iksys_trainingLifeTimer"; value: 0}
+		}
+		# Power
+		if ctrl = 0 {
+			mapSet{map: "_iksys_trainingPowerTimer"; value: 0}
+		} else {
+			mapAdd{map: "_iksys_trainingPowerTimer"; value: 1}
+		}
+		if map(_iksys_trainingPowerTimer) >= 60 {
+			powerSet{value: powerMax}
+			mapSet{map: "_iksys_trainingPowerTimer"; value: 0}
+		}
+	}
+	# Disable normal KO behavior
+	assertSpecial{
+		flag: globalNoKo;
+		flag2: noKoFall;
+		flag3: noKoVelocity;
+	}
+	# Force players out of KO state
+	if stateNo = 5150 && time >= 90 && alive {
+		selfState{value: 5120}
+	}
+	# Skip round and fight calls
 	if roundState < 2 {
-		# Skip round and fight calls
 		assertSpecial{flag: skipRoundDisplay; flag2: skipFightDisplay}
 	}
-	if roundState = 2 {
-		assertSpecial{
-			flag: globalNoKo;
-			flag2: noKoFall;
-			flag3: noKoVelocity;
+	# Dummy code
+	if teamSide = 2 && !isHelper {
+		if roundTime = 0 {
+			# Round start reset
+			map(_iksys_trainingAirJumpNum) := 0;
+			map(_iksys_trainingButtonJam) := 0;
+			map(_iksys_trainingDirection) := 0;
+			map(_iksys_trainingDistance) := 0;
+			map(_iksys_trainingDummyControl) := 0;
+			map(_iksys_trainingDummyMode) := 0;
+			map(_iksys_trainingFallRecovery) := 0;
+			map(_iksys_trainingGuardMode) := 0;
 		}
-		# Life and Power recovery
-		for i = 1; player(1),numPartner + 1; 1 {
-			call TrainingRecovery($i * 2 - 1);
-		}
-		for i = 1; player(2),numPartner + 1; 1 {
-			call TrainingRecovery($i * 2);
-		}
-		# Dummy Control: Cooperative
-		if aiLevel = 0 && map(_iksys_trainingDummyControl) = 0 {
-			# Guard mode: Random
-			if map(_iksys_trainingGuardMode) = 3 {
-				if random < 500 {
+		if roundState = 2 {
+			# Dummy Control: Cooperative
+			if aiLevel = 0 && map(_iksys_trainingDummyControl) = 0 {
+				# Guard mode: Random
+				if map(_iksys_trainingGuardMode) = 3 {
+					if random < 500 {
+						assertSpecial{flag: autoGuard}
+					}
+				# Guard mode: All
+				} else if map(_iksys_trainingGuardMode) = 2 {
 					assertSpecial{flag: autoGuard}
+				# Guard mode: Auto
+				} else if map(_iksys_trainingGuardMode) = 1 {
+					if moveType = H || stateNo = const(StateDownedGetHit_gettingUp) {
+						map(_iksys_trainingAutoGuardTimer) := 15;
+					} else {
+						map(_iksys_trainingAutoGuardTimer) := (map(_iksys_trainingAutoGuardTimer) - 1);
+					}
+					if map(_iksys_trainingAutoGuardTimer) > 0 {
+						assertSpecial{flag: autoGuard}
+					}
 				}
-			# Guard mode: All
-			} else if map(_iksys_trainingGuardMode) = 2 {
-				assertSpecial{flag: autoGuard}
-			# Guard mode: Auto
-			} else if map(_iksys_trainingGuardMode) = 1 {
-				if moveType = H || stateNo = const(StateDownedGetHit_gettingUp) {
-					map(_iksys_trainingAutoGuardTimer) := 15;
-				} else {
-					map(_iksys_trainingAutoGuardTimer) := (map(_iksys_trainingAutoGuardTimer) - 1);
-				}
-				if map(_iksys_trainingAutoGuardTimer) > 0 {
-					assertSpecial{flag: autoGuard}
-				}
-			}
-			# Fall Recovery
-			if map(_iksys_trainingFallRecovery) {
-				if stateNo != [const(StateAirGetHit_fallRecoveryOnGroundStillFalling), const(StateAirGetHit_fallRecoveryInAir)] {
-					if moveType = H && stateType = A && hitFall && !getHitVar(isbound) && (pos y || vel y) {
-						# Ground recovery. Attempt only if common1 conditions are met
-						if vel y > 0 && pos y >= const(movement.air.gethit.groundrecover.ground.threshold) {
-							if map(_iksys_trainingFallRecovery) = 1 { 
+				# Fall Recovery
+				if map(_iksys_trainingFallRecovery) {
+					if stateNo != [const(StateAirGetHit_fallRecoveryOnGroundStillFalling), const(StateAirGetHit_fallRecoveryInAir)] {
+						if moveType = H && stateType = A && hitFall && !getHitVar(isbound) && (pos y || vel y) {
+							# Ground recovery. Attempt only if common1 conditions are met
+							if vel y > 0 && pos y >= const(movement.air.gethit.groundrecover.ground.threshold) {
+								if map(_iksys_trainingFallRecovery) = 1 { 
+									let rcv = 1;
+								}
+							# Air recovery. Attempt only if conditions for ground recovery are not met
+							} else if map(_iksys_trainingFallRecovery) = 2 {
 								let rcv = 1;
 							}
-						# Air recovery. Attempt only if conditions for ground recovery are not met
-						} else if map(_iksys_trainingFallRecovery) = 2 {
-							let rcv = 1;
-						}
-						# Random recovery. Attempt regardless of conditions
-						if map(_iksys_trainingFallRecovery) = 3 && random < 100 {
-							let rcv = 1;
-						}
-						if $rcv {
-							# WinMugen characters assert inputs because asserting commands directly may trigger their AI activation codes
-							if mugenVersion < 1.0 {
-								if gametime % 2 {
-									assertInput{flag: x; flag2: y; flag3: z}
-								} else {
-									assertInput{flag: a; flag2: b; flag3: c}
-								}
-							} else {
-								assertCommand{name: "recovery"; buffer.time: 2}
-								# Buffered 2 frames because asserting a command instead of inputting it has 1 frame of lag in custom fall recovery systems
+							# Random recovery. Attempt regardless of conditions
+							if map(_iksys_trainingFallRecovery) = 3 && random < 100 {
+								let rcv = 1;
 							}
-							# Random direction
-							if map(_iksys_trainingFallRecovery) = 3 {
-								if random < 333 {
-									assertInput{flag: L}
-								} else if random < 500 {
-									assertInput{flag: R}
+							if $rcv {
+								# WinMugen characters assert inputs because asserting commands directly may trigger their AI activation codes
+								if mugenVersion < 1.0 {
+									if gametime % 2 {
+										assertInput{flag: x; flag2: y; flag3: z}
+									} else {
+										assertInput{flag: a; flag2: b; flag3: c}
+									}
+								} else {
+									assertCommand{name: "recovery"; buffer.time: 2}
+									# Buffered 2 frames because asserting a command instead of inputting it has 1 frame of lag in custom fall recovery systems
 								}
-								if random < 333 {
-									assertInput{flag: U}
-								} else if random < 500 {
-									assertInput{flag: D}
+								# Random direction
+								if map(_iksys_trainingFallRecovery) = 3 {
+									if random < 333 {
+										assertInput{flag: L}
+									} else if random < 500 {
+										assertInput{flag: R}
+									}
+									if random < 333 {
+										assertInput{flag: U}
+									} else if random < 500 {
+										assertInput{flag: D}
+									}
 								}
 							}
 						}
 					}
 				}
-			}
-			# Distance
-			let dir = 0;
-			if map(_iksys_trainingDistance) != 0 {
-				# Close
-				if map(_iksys_trainingDistance) = 1 && p2BodyDist x > const240p(10) {
-					let dir = 1;
-					map(_iksys_trainingDirection) := 1;
-				# Medium
-				} else if map(_iksys_trainingDistance) = 2 {
-					if p2BodyDist x > const240p(130) {
+				# Distance
+				let dir = 0;
+				if map(_iksys_trainingDistance) != 0 {
+					# Close
+					if map(_iksys_trainingDistance) = 1 && p2BodyDist x > const240p(10) {
 						let dir = 1;
 						map(_iksys_trainingDirection) := 1;
-					} else if p2BodyDist x < const240p(80) && backEdgeBodyDist > const240p(10) {
-						let dir = -1;
-						map(_iksys_trainingDirection) := -1;
-					}
-				# Far
-				} else if map(_iksys_trainingDistance) = 3 {
-					if p2BodyDist x < const240p(260) && backEdgeBodyDist > const240p(10) {
-						let dir = -1;
-						map(_iksys_trainingDirection) := -1;
-					}
-				}
-			}
-			if map(_iksys_trainingDirection) != 0 {
-				# If adjusting position is no longer needed
-				if $dir = 0 {
-					# maintain assertion only if dummy and nearest P1 are moving in the same direction
-					if vel x * p2,vel x >= 0 || backEdgeBodyDist = 0 || p2,backEdgeBodyDist = 0 {
-						map(_iksys_trainingDirection) := 0;
-					}
-				}
-				# If dummy should move forward and player is not trying to move dummy back
-				if map(_iksys_trainingDirection) = 1 && command != "holdback" {
-					if facing = 1 {
-						for i = 0; numHelper; 1 {
-							assertInput{flag: R; redirectID: helperIndex($i), ID} # Index 0 being the root
+					# Medium
+					} else if map(_iksys_trainingDistance) = 2 {
+						if p2BodyDist x > const240p(130) {
+							let dir = 1;
+							map(_iksys_trainingDirection) := 1;
+						} else if p2BodyDist x < const240p(80) && backEdgeBodyDist > const240p(10) {
+							let dir = -1;
+							map(_iksys_trainingDirection) := -1;
 						}
-					} else {
-						for i = 0; numHelper; 1 {
-							assertInput{flag: L; redirectID: helperIndex($i), ID}
-						}
-					}
-				# If dummy should move backward and player is not trying to move dummy forward
-				} else if map(_iksys_trainingDirection) = -1 && command != "holdfwd" {
-					if facing = 1 {
-						for i = 0; numHelper; 1 {
-							assertInput{flag: L; redirectID: helperIndex($i), ID}
-						}
-					} else {
-						for i = 0; numHelper; 1 {
-							assertInput{flag: R; redirectID: helperIndex($i), ID}
+					# Far
+					} else if map(_iksys_trainingDistance) = 3 {
+						if p2BodyDist x < const240p(260) && backEdgeBodyDist > const240p(10) {
+							let dir = -1;
+							map(_iksys_trainingDirection) := -1;
 						}
 					}
 				}
-			} else {
-				# Dummy mode
-				switch map(_iksys_trainingDummyMode) {
-				# Crouch
-				case 1:
-					for i = 0; numHelper; 1 {
-						assertInput{flag: D; redirectID: helperIndex($i), ID}
+				if map(_iksys_trainingDirection) != 0 {
+					# If adjusting position is no longer needed
+					if $dir = 0 {
+						# maintain assertion only if dummy and nearest P1 are moving in the same direction
+						if vel x * p2,vel x >= 0 || backEdgeBodyDist = 0 || p2,backEdgeBodyDist = 0 {
+							map(_iksys_trainingDirection) := 0;
+						}
 					}
-				# Jump
-				case 2:
-					for i = 0; numHelper; 1 {
-						assertInput{flag: U; redirectID: helperIndex($i), ID}
+					# If dummy should move forward and player is not trying to move dummy back
+					if map(_iksys_trainingDirection) = 1 && command != "holdback" {
+						if facing = 1 {
+							for i = 0; numHelper; 1 {
+								assertInput{flag: R; redirectID: helperIndex($i), ID} # Index 0 being the root
+							}
+						} else {
+							for i = 0; numHelper; 1 {
+								assertInput{flag: L; redirectID: helperIndex($i), ID}
+							}
+						}
+					# If dummy should move backward and player is not trying to move dummy forward
+					} else if map(_iksys_trainingDirection) = -1 && command != "holdfwd" {
+						if facing = 1 {
+							for i = 0; numHelper; 1 {
+								assertInput{flag: L; redirectID: helperIndex($i), ID}
+							}
+						} else {
+							for i = 0; numHelper; 1 {
+								assertInput{flag: R; redirectID: helperIndex($i), ID}
+							}
+						}
 					}
-				# W Jump
-				case 3:
-					if vel y >= 0 {
+				} else {
+					# Dummy mode
+					switch map(_iksys_trainingDummyMode) {
+					# Crouch
+					case 1:
+						for i = 0; numHelper; 1 {
+							assertInput{flag: D; redirectID: helperIndex($i), ID}
+						}
+					# Jump
+					case 2:
 						for i = 0; numHelper; 1 {
 							assertInput{flag: U; redirectID: helperIndex($i), ID}
 						}
+					# W Jump
+					case 3:
+						if vel y >= 0 {
+							for i = 0; numHelper; 1 {
+								assertInput{flag: U; redirectID: helperIndex($i), ID}
+							}
+						}
+					default:
+						# Do nothing
 					}
-				default:
-					# Do nothing
-				}
-				# Button jam
-				if map(_iksys_trainingButtonJam) > 0 {
-					if map(_iksys_trainingButtonJamDelay) > 0 {
-						mapAdd{map: "_iksys_trainingButtonJamDelay"; value: -1}
-					} else {
-						map(_iksys_trainingButtonJamDelay) := 11;
-						switch map(_iksys_trainingButtonJam) {
-						case 1:
-							for i = 0; numHelper; 1 {
-								assertInput{flag: a; redirectID: helperIndex($i), ID}
+					# Button jam
+					if map(_iksys_trainingButtonJam) > 0 {
+						if map(_iksys_trainingButtonJamDelay) > 0 {
+							mapAdd{map: "_iksys_trainingButtonJamDelay"; value: -1}
+						} else {
+							map(_iksys_trainingButtonJamDelay) := 11;
+							switch map(_iksys_trainingButtonJam) {
+							case 1:
+								for i = 0; numHelper; 1 {
+									assertInput{flag: a; redirectID: helperIndex($i), ID}
+								}
+							case 2:
+								for i = 0; numHelper; 1 {
+									assertInput{flag: b; redirectID: helperIndex($i), ID}
+								}
+							case 3:
+								for i = 0; numHelper; 1 {
+									assertInput{flag: c; redirectID: helperIndex($i), ID}
+								}
+							case 4:
+								for i = 0; numHelper; 1 {
+									assertInput{flag: x; redirectID: helperIndex($i), ID}
+								}
+							case 5:
+								for i = 0; numHelper; 1 {
+									assertInput{flag: y; redirectID: helperIndex($i), ID}
+								}
+							case 6:
+								for i = 0; numHelper; 1 {
+									assertInput{flag: z; redirectID: helperIndex($i), ID}
+								}
+							case 7:
+								for i = 0; numHelper; 1 {
+									assertInput{flag: s; redirectID: helperIndex($i), ID}
+								}
+							case 8:
+								for i = 0; numHelper; 1 {
+									assertInput{flag: d; redirectID: helperIndex($i), ID}
+								}
+							case 9:
+								for i = 0; numHelper; 1 {
+									assertInput{flag: w; redirectID: helperIndex($i), ID}
+								}
+							default:
+								map(_iksys_trainingButtonJamDelay) := 0;
 							}
-						case 2:
-							for i = 0; numHelper; 1 {
-								assertInput{flag: b; redirectID: helperIndex($i), ID}
-							}
-						case 3:
-							for i = 0; numHelper; 1 {
-								assertInput{flag: c; redirectID: helperIndex($i), ID}
-							}
-						case 4:
-							for i = 0; numHelper; 1 {
-								assertInput{flag: x; redirectID: helperIndex($i), ID}
-							}
-						case 5:
-							for i = 0; numHelper; 1 {
-								assertInput{flag: y; redirectID: helperIndex($i), ID}
-							}
-						case 6:
-							for i = 0; numHelper; 1 {
-								assertInput{flag: z; redirectID: helperIndex($i), ID}
-							}
-						case 7:
-							for i = 0; numHelper; 1 {
-								assertInput{flag: s; redirectID: helperIndex($i), ID}
-							}
-						case 8:
-							for i = 0; numHelper; 1 {
-								assertInput{flag: d; redirectID: helperIndex($i), ID}
-							}
-						case 9:
-							for i = 0; numHelper; 1 {
-								assertInput{flag: w; redirectID: helperIndex($i), ID}
-							}
-						default:
-							map(_iksys_trainingButtonJamDelay) := 0;
 						}
 					}
 				}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -572,20 +572,20 @@ const (
 	OC_ex_gethitvar_down_recovertime
 	OC_ex_gethitvar_guardflag
 	OC_ex_ailevelf
-	OC_ex_animframe_alphadest
-	OC_ex_animframe_angle
-	OC_ex_animframe_alphasource
-	OC_ex_animframe_group
-	OC_ex_animframe_hflip
-	OC_ex_animframe_image
-	OC_ex_animframe_time
-	OC_ex_animframe_vflip
-	OC_ex_animframe_xoffset
-	OC_ex_animframe_xscale
-	OC_ex_animframe_yoffset
-	OC_ex_animframe_yscale
-	OC_ex_animframe_numclsn1
-	OC_ex_animframe_numclsn2
+	OC_ex_animelemvar_alphadest
+	OC_ex_animelemvar_angle
+	OC_ex_animelemvar_alphasource
+	OC_ex_animelemvar_group
+	OC_ex_animelemvar_hflip
+	OC_ex_animelemvar_image
+	OC_ex_animelemvar_time
+	OC_ex_animelemvar_vflip
+	OC_ex_animelemvar_xoffset
+	OC_ex_animelemvar_xscale
+	OC_ex_animelemvar_yoffset
+	OC_ex_animelemvar_yscale
+	OC_ex_animelemvar_numclsn1
+	OC_ex_animelemvar_numclsn2
 	OC_ex_animlength
 	OC_ex_animplayerno
 	OC_ex_attack
@@ -2700,85 +2700,85 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		}
 	case OC_ex_airjumpcount:
 		sys.bcStack.PushI(c.airJumpCount)
-	case OC_ex_animframe_alphadest:
+	case OC_ex_animelemvar_alphadest:
 		if f := c.anim.CurrentFrame(); f != nil {
 			sys.bcStack.PushI(int32(f.DstAlpha))
 		} else {
 			sys.bcStack.PushI(0)
 		}
-	case OC_ex_animframe_angle:
+	case OC_ex_animelemvar_angle:
 		if f := c.anim.CurrentFrame(); f != nil {
 			sys.bcStack.PushF(f.Angle)
 		} else {
 			sys.bcStack.PushI(0)
 		}
-	case OC_ex_animframe_alphasource:
+	case OC_ex_animelemvar_alphasource:
 		if f := c.anim.CurrentFrame(); f != nil {
 			sys.bcStack.PushI(int32(f.SrcAlpha))
 		} else {
 			sys.bcStack.PushI(0)
 		}
-	case OC_ex_animframe_group:
+	case OC_ex_animelemvar_group:
 		if f := c.anim.CurrentFrame(); f != nil {
 			sys.bcStack.PushI(int32(f.Group))
 		} else {
 			sys.bcStack.PushI(-1)
 		}
-	case OC_ex_animframe_hflip:
+	case OC_ex_animelemvar_hflip:
 		if f := c.anim.CurrentFrame(); f != nil {
 			sys.bcStack.PushB(f.Hscale < 0)
 		} else {
 			sys.bcStack.PushI(0)
 		}
-	case OC_ex_animframe_image:
+	case OC_ex_animelemvar_image:
 		if f := c.anim.CurrentFrame(); f != nil {
 			sys.bcStack.PushI(int32(f.Number))
 		} else {
 			sys.bcStack.PushI(-1)
 		}
-	case OC_ex_animframe_time:
+	case OC_ex_animelemvar_time:
 		if f := c.anim.CurrentFrame(); f != nil {
 			sys.bcStack.PushI(f.Time)
 		} else {
 			sys.bcStack.PushI(-1)
 		}
-	case OC_ex_animframe_vflip:
+	case OC_ex_animelemvar_vflip:
 		if f := c.anim.CurrentFrame(); f != nil {
 			sys.bcStack.PushB(f.Vscale < 0)
 		} else {
 			sys.bcStack.PushI(0)
 		}
-	case OC_ex_animframe_xoffset:
+	case OC_ex_animelemvar_xoffset:
 		if f := c.anim.CurrentFrame(); f != nil {
 			sys.bcStack.PushI(int32(f.Xoffset))
 		} else {
 			sys.bcStack.PushI(0)
 		}
-	case OC_ex_animframe_xscale:
+	case OC_ex_animelemvar_xscale:
 		if f := c.anim.CurrentFrame(); f != nil {
 			sys.bcStack.PushF(f.Xscale)
 		} else {
 			sys.bcStack.PushI(0)
 		}
-	case OC_ex_animframe_yoffset:
+	case OC_ex_animelemvar_yoffset:
 		if f := c.anim.CurrentFrame(); f != nil {
 			sys.bcStack.PushI(int32(f.Yoffset))
 		} else {
 			sys.bcStack.PushI(0)
 		}
-	case OC_ex_animframe_yscale:
+	case OC_ex_animelemvar_yscale:
 		if f := c.anim.CurrentFrame(); f != nil {
 			sys.bcStack.PushF(f.Yscale)
 		} else {
 			sys.bcStack.PushI(0)
 		}
-	case OC_ex_animframe_numclsn1:
+	case OC_ex_animelemvar_numclsn1:
 		if f := c.anim.CurrentFrame(); f != nil {
 			sys.bcStack.PushI(int32(len(f.Clsn1()) / 4))
 		} else {
 			sys.bcStack.PushI(0)
 		}
-	case OC_ex_animframe_numclsn2:
+	case OC_ex_animelemvar_numclsn2:
 		if f := c.anim.CurrentFrame(); f != nil {
 			sys.bcStack.PushI(int32(len(f.Clsn2()) / 4))
 		} else {

--- a/src/char.go
+++ b/src/char.go
@@ -2479,7 +2479,7 @@ type Char struct {
 	inputFlag       InputBits
 	pauseBool       bool
 	downHitOffset   bool
-	koEchoTime      int32
+	koEchoTimer     int32
 	groundLevel     float32
 	sizeBox         []float32
 	shadowOffset    [2]float32
@@ -8141,19 +8141,24 @@ func (c *Char) actionFinish() {
 	// Update Z scale
 	// Must be placed after posUpdate()
 	c.zScale = sys.updateZScale(c.pos[2], c.localscl)
+	// KO behavior
 	if !c.hitPause() && !c.pauseBool {
-		// Set KO flag
-		if c.life <= 0 && !sys.gsf(GSF_globalnoko) && !c.asf(ASF_noko) && (!c.ghv.guarded || !c.asf(ASF_noguardko)) {
+		if c.alive() && c.life <= 0 && !sys.gsf(GSF_globalnoko) && !c.asf(ASF_noko) && (!c.ghv.guarded || !c.asf(ASF_noguardko)) {
 			// KO sound
-			if !sys.gsf(GSF_nokosnd) && c.alive() {
-				vo := int32(100)
-				c.playSound("", false, 0, 11, 0, -1, vo, 0, 1, c.localscl, &c.pos[0], false, 0, 0, 0, 0, false, false)
+			if !sys.gsf(GSF_nokosnd) {
+				c.playSound("", false, 0, 11, 0, -1, 100, 0, 1, c.localscl, &c.pos[0], false, 0, 0, 0, 0, false, false)
 				if c.gi().data.ko.echo != 0 {
-					c.koEchoTime = 1
+					c.koEchoTimer = 1
 				}
 			}
+			// Set KO flag and force KO states if necessary
 			c.setSCF(SCF_ko)
-			c.unsetSCF(SCF_ctrl) // This can be seen in Mugen when you F1 a character
+			c.unsetSCF(SCF_ctrl) // This can be seen in Mugen when you F1 a character with ctrl && movetype = H
+			if !c.stchtmp && c.helperIndex == 0 && c.ss.moveType != MT_H {
+				c.ghv.fallflag = true
+				c.selfState(5030, -1, -1, 0, "")
+				c.ss.time = 1
+			}
 		}
 	}
 	// Over flags (char is finished for the round)
@@ -8315,15 +8320,15 @@ func (c *Char) update() {
 		}
 	}
 	// KO sound echo
-	if c.koEchoTime > 0 {
+	if c.koEchoTimer > 0 {
 		if !c.scf(SCF_ko) || sys.gsf(GSF_nokosnd) {
-			c.koEchoTime = 0
+			c.koEchoTimer = 0
 		} else {
-			if c.koEchoTime == 60 || c.koEchoTime == 120 {
-				vo := int32(100 * (240 - (c.koEchoTime + 60)) / 240)
+			if c.koEchoTimer == 60 || c.koEchoTimer == 120 {
+				vo := int32(100 * (240 - (c.koEchoTimer + 60)) / 240)
 				c.playSound("", false, 0, 11, 0, -1, vo, 0, 1, c.localscl, &c.pos[0], false, 0, 0, 0, 0, false, false)
 			}
-			c.koEchoTime++
+			c.koEchoTimer++
 		}
 	}
 }
@@ -8482,16 +8487,6 @@ func (c *Char) tick() {
 				c.cmd[0].Buffer.sb == 1 || c.cmd[0].Buffer.db == 1 ||
 				c.cmd[0].Buffer.wb == 1) { // Menu button not included
 			c.ghv.down_recovertime -= RandI(1, (c.ghv.down_recovertime+1)/2)
-		}
-		if !c.stchtmp {
-			if c.helperIndex == 0 && (c.alive() || c.ss.no == 0) && c.life <= 0 && c.ss.moveType != MT_H &&
-				!sys.gsf(GSF_globalnoko) && !c.asf(ASF_noko) && (!c.ghv.guarded || !c.asf(ASF_noguardko)) {
-				c.ghv.fallflag = true
-				c.selfState(5030, -1, -1, 0, "") // Mugen sets control to 0 here
-				c.ss.time = 1
-			} else if c.ss.no == 5150 && c.ss.time >= 90 && c.alive() {
-				c.selfState(5120, -1, -1, -1, "")
-			}
 		}
 	}
 	// Reset pushed flag

--- a/src/common.go
+++ b/src/common.go
@@ -807,7 +807,7 @@ func (l *Layout) DrawAnim(r *[4]int32, x, y, scl float32, ln int16, a *Animation
 		a.Draw(r, x+l.offset[0], y+l.offset[1]+float32(sys.gameHeight-240),
 			scl, scl, l.scale[0]*float32(l.facing), l.scale[0]*float32(l.facing),
 			l.scale[1]*float32(l.vfacing), 0, Rotation{l.angle, 0, 0},
-			float32(sys.gameWidth-320)/2, palfx, false, 1, false, [2]float32{1, 1}, 0, 0, 0)
+			float32(sys.gameWidth-320)/2, palfx, false, 1, [2]float32{1, 1}, 0, 0, 0, false)
 	}
 }
 

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -346,7 +346,7 @@ var triggerMap = map[string]int{
 	"airjumpcount":       1,
 	"alpha":              1,
 	"angle":              1,
-	"animframe":          1,
+	"animelemvar":        1,
 	"animlength":         1,
 	"animplayerno":       1,
 	"atan2":              1,
@@ -3807,40 +3807,40 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_ex_, OC_ex_ailevelf)
 	case "airjumpcount":
 		out.append(OC_ex_, OC_ex_airjumpcount)
-	case "animframe":
+	case "animelemvar":
 		if err := c.checkOpeningBracket(in); err != nil {
 			return bvNone(), err
 		}
 		out.append(OC_ex_)
 		switch c.token {
 		case "alphadest":
-			out.append(OC_ex_animframe_alphadest)
+			out.append(OC_ex_animelemvar_alphadest)
 		case "angle":
-			out.append(OC_ex_animframe_angle)
+			out.append(OC_ex_animelemvar_angle)
 		case "alphasource":
-			out.append(OC_ex_animframe_alphasource)
+			out.append(OC_ex_animelemvar_alphasource)
 		case "group":
-			out.append(OC_ex_animframe_group)
+			out.append(OC_ex_animelemvar_group)
 		case "hflip":
-			out.append(OC_ex_animframe_hflip)
+			out.append(OC_ex_animelemvar_hflip)
 		case "image":
-			out.append(OC_ex_animframe_image)
+			out.append(OC_ex_animelemvar_image)
 		case "time":
-			out.append(OC_ex_animframe_time)
+			out.append(OC_ex_animelemvar_time)
 		case "vflip":
-			out.append(OC_ex_animframe_vflip)
+			out.append(OC_ex_animelemvar_vflip)
 		case "xoffset":
-			out.append(OC_ex_animframe_xoffset)
+			out.append(OC_ex_animelemvar_xoffset)
 		case "xscale":
-			out.append(OC_ex_animframe_xscale)
+			out.append(OC_ex_animelemvar_xscale)
 		case "yoffset":
-			out.append(OC_ex_animframe_yoffset)
+			out.append(OC_ex_animelemvar_yoffset)
 		case "yscale":
-			out.append(OC_ex_animframe_yscale)
+			out.append(OC_ex_animelemvar_yscale)
 		case "numclsn1":
-			out.append(OC_ex_animframe_numclsn1)
+			out.append(OC_ex_animelemvar_numclsn1)
 		case "numclsn2":
-			out.append(OC_ex_animframe_numclsn2)
+			out.append(OC_ex_animelemvar_numclsn2)
 		default:
 			return bvNone(), Error("Invalid data: " + c.token)
 		}

--- a/src/script.go
+++ b/src/script.go
@@ -5088,9 +5088,9 @@ func triggerFunctions(l *lua.LState) {
 		}
 		return 1
 	})
-	luaRegister(l, "animframe", func(*lua.LState) int {
+	luaRegister(l, "animelemvar", func(*lua.LState) int {
 		// Because the char's animation steps at the end of each frame, before the scripts run,
-		// AnimFrame Lua version uses curFrame instead of anim.CurrentFrame()
+		// AnimElemVar Lua version uses curFrame instead of anim.CurrentFrame()
 		c := sys.debugWC
 		switch strings.ToLower(strArg(l, 1)) {
 		case "alphadest":

--- a/src/stage.go
+++ b/src/stage.go
@@ -460,7 +460,7 @@ func (bg backGround) draw(pos [2]float32, drawscl, bgscl, stglscl float32,
 			bg.xscale[0]*bgscl*(bg.scalestart[0]+xs)*xs3,
 			xbs*bgscl*(bg.scalestart[0]+xs)*xs3,
 			ys*ys3, xras*x/(AbsF(ys*ys3)*lscl[1]*float32(bg.anim.spr.Size[1])*bg.scalestart[1])*sclx_recip*bg.scalestart[1],
-			Rotation{}, float32(sys.gameWidth)/2, bg.palfx, true, 1, false, [2]float32{1, 1}, 0, 0, 0)
+			Rotation{}, float32(sys.gameWidth)/2, bg.palfx, true, 1, [2]float32{1, 1}, 0, 0, 0, false)
 	}
 }
 


### PR DESCRIPTION
Fix:
- Fixed players not being forced into KO states while crouching
- Fixed F1 button working in Training outside of roundstate 2
- Fixed xshear direction being opposite of Mugen
- Fixed shadow angles not mirroring the sprite angles
- Jumping now also affects the X offset of the shearing effect, like in Mugen
- Fixes #2333 

Refactor:
- The forced changestate from 5150 to 5120 when alive was moved to training.zss, since in Mugen it only happens in that mode
- Each player now handles their own Training mode code, instead of the dummy redirecting everything. This allows finer control and makes the code more straightforward
- Renamed AnimFrame to AnimElemVar