### PR TITLE
feat: Helper and Target index, StageBGVar, ModifyStageBG, other

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1496,7 +1496,9 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.Push(BytecodeSF())
 			i += int(*(*int32)(unsafe.Pointer(&be[i]))) + 4
 		case OC_target:
-			if c = c.target(sys.bcStack.Pop().ToI()); c != nil {
+			v2 := sys.bcStack.Pop().ToI()
+			v1 := sys.bcStack.Pop().ToI()
+			if c = c.target(v1, int(v2)); c != nil {
 				i += 4
 				continue
 			}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1498,7 +1498,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 		case OC_target:
 			v2 := sys.bcStack.Pop().ToI()
 			v1 := sys.bcStack.Pop().ToI()
-			if c = c.target(v1, int(v2)); c != nil {
+			if c = c.targetTrigger(v1, int(v2)); c != nil {
 				i += 4
 				continue
 			}
@@ -4036,8 +4036,8 @@ func (StateControllerBase) bToExp(i bool) (exp []BytecodeExp) {
 	return
 }
 
-func (scb *StateControllerBase) add(id byte, exp []BytecodeExp) {
-	*scb = append(*scb, id, byte(len(exp)))
+func (scb *StateControllerBase) add(paramID byte, exp []BytecodeExp) {
+	*scb = append(*scb, paramID, byte(len(exp)))
 	for _, e := range exp {
 		l := int32(len(e))
 		*scb = append(*scb, (*(*[4]byte)(unsafe.Pointer(&l)))[:]...)
@@ -4085,8 +4085,8 @@ const (
 )
 
 func (sc stateDef) Run(c *Char) {
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case stateDef_hitcountpersist:
 			if !exp[0].evalB(c) {
 				c.clearHitCount()
@@ -4162,8 +4162,8 @@ func (sc hitBy) Run(c *Char, _ []int32) bool {
 		crun.hitby[slot].playerid = pid
 		crun.hitby[slot].stack = stk
 	}
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case hitBy_time:
 			time = exp[0].evalI(c)
 		case hitBy_value:
@@ -4221,8 +4221,8 @@ func (sc notHitBy) Run(c *Char, _ []int32) bool {
 		crun.hitby[slot].playerid = pid
 		crun.hitby[slot].stack = stk
 	}
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case hitBy_time:
 			time = exp[0].evalI(c)
 		case hitBy_value:
@@ -4272,8 +4272,8 @@ const (
 
 func (sc assertSpecial) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case assertSpecial_flag:
 			crun.setASF(AssertSpecialFlag(exp[0].evalI64(c)))
 		case assertSpecial_flag_g:
@@ -4330,8 +4330,8 @@ func (sc playSnd) Run(c *Char, _ []int32) bool {
 	var p, fr float32 = 0, 1
 	x := &c.pos[0]
 	ls := c.localscl
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case playSnd_value:
 			f = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
 			g = exp[1].evalI(c)
@@ -4414,8 +4414,8 @@ func (sc changeState) Run(c *Char, _ []int32) bool {
 	var v, a, ctrl int32 = -1, -1, -1
 	ffx := ""
 	stop := true
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case changeState_value:
 			v = exp[0].evalI(c)
 		case changeState_ctrl:
@@ -4446,8 +4446,8 @@ func (sc selfState) Run(c *Char, _ []int32) bool {
 	var v, a, r, ctrl int32 = -1, -1, -1, -1
 	ffx := ""
 	stop := true
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case changeState_value:
 			v = exp[0].evalI(c)
 		case changeState_ctrl:
@@ -4496,8 +4496,8 @@ func (sc tagIn) Run(c *Char, _ []int32) bool {
 	var partnerNo int32 = -1
 	var partnerStateNo int32 = -1
 	var partnerCtrlSetting int32 = -1
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case tagIn_stateno:
 			sn := exp[0].evalI(c)
 			if sn >= 0 {
@@ -4555,8 +4555,8 @@ func (sc tagIn) Run(c *Char, _ []int32) bool {
 		crun.unsetSCF(SCF_standby)
 	}
 	// Partner
-	if partnerNo != -1 && crun.partnerV2(partnerNo) != nil {
-		partner := crun.partnerV2(partnerNo)
+	if partnerNo != -1 && crun.partnerTag(partnerNo) != nil {
+		partner := crun.partnerTag(partnerNo)
 		partner.unsetSCF(SCF_standby)
 		if partnerStateNo >= 0 {
 			partner.changeState(partnerStateNo, -1, -1, "")
@@ -4587,8 +4587,8 @@ func (sc tagOut) Run(c *Char, _ []int32) bool {
 	var tagSCF int32 = -1
 	var partnerNo int32 = -1
 	var partnerStateNo int32 = -1
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case tagOut_self:
 			tagSCF = Btoi(exp[0].evalB(c))
 		case tagOut_stateno:
@@ -4630,8 +4630,8 @@ func (sc tagOut) Run(c *Char, _ []int32) bool {
 		crun.setSCF(SCF_standby)
 		// sys.charList.p2enemyDelete(crun)
 	}
-	if partnerNo != -1 && crun.partnerV2(partnerNo) != nil {
-		partner := crun.partnerV2(partnerNo)
+	if partnerNo != -1 && crun.partnerTag(partnerNo) != nil {
+		partner := crun.partnerTag(partnerNo)
 		partner.setSCF(SCF_standby)
 		if partnerStateNo >= 0 {
 			partner.changeState(partnerStateNo, -1, -1, "")
@@ -4654,8 +4654,8 @@ func (sc destroySelf) Run(c *Char, _ []int32) bool {
 	crun := c
 	rec, rem, rtx := false, false, false
 	self := true
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case destroySelf_recursive:
 			rec = exp[0].evalB(c)
 		case destroySelf_removeexplods:
@@ -4689,8 +4689,8 @@ func (sc changeAnim) Run(c *Char, _ []int32) bool {
 	var elem int32
 	var rpid int = -1
 	setelem := false
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case changeAnim_elem:
 			elem = exp[0].evalI(c)
 			setelem = true
@@ -4728,8 +4728,8 @@ func (sc changeAnim2) Run(c *Char, _ []int32) bool {
 	var elem int32
 	var rpid int = -1
 	setelem := false
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case changeAnim_elem:
 			elem = exp[0].evalI(c)
 			setelem = true
@@ -4812,9 +4812,9 @@ func (sc helper) Run(c *Char, _ []int32) bool {
 	var extmap bool
 	var x, y, z float32 = 0, 0, 0
 	rp := [...]int32{-1, 0}
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		if h == nil {
-			if id == helper_redirectid {
+			if paramID == helper_redirectid {
 				if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 					crun = rid
 					redirscale = c.localscl / crun.localscl
@@ -4829,7 +4829,7 @@ func (sc helper) Run(c *Char, _ []int32) bool {
 		if h == nil {
 			return false
 		}
-		switch id {
+		switch paramID {
 		case helper_helpertype:
 			ht := exp[0].evalI(c)
 			switch ht {
@@ -4968,8 +4968,8 @@ const (
 
 func (sc ctrlSet) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case ctrlSet_value:
 			crun.setCtrl(exp[0].evalB(c))
 		case ctrlSet_redirectid:
@@ -4996,8 +4996,8 @@ const (
 func (sc posSet) Run(c *Char, _ []int32) bool {
 	crun := c
 	var redirscale float32 = 1.0
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case posSet_x:
 			x := sys.cam.Pos[0]/crun.localscl + exp[0].evalF(c)*redirscale
 			crun.setX(x)
@@ -5034,8 +5034,8 @@ type posAdd posSet
 func (sc posAdd) Run(c *Char, _ []int32) bool {
 	crun := c
 	var redirscale float32 = 1.0
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case posSet_x:
 			x := exp[0].evalF(c) * redirscale
 			crun.addX(x)
@@ -5072,8 +5072,8 @@ type velSet posSet
 func (sc velSet) Run(c *Char, _ []int32) bool {
 	crun := c
 	var redirscale float32 = 1.0
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case posSet_x:
 			crun.vel[0] = exp[0].evalF(c) * redirscale
 		case posSet_y:
@@ -5098,8 +5098,8 @@ type velAdd posSet
 func (sc velAdd) Run(c *Char, _ []int32) bool {
 	crun := c
 	var redirscale float32 = 1.0
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case posSet_x:
 			crun.vel[0] += exp[0].evalF(c) * redirscale
 		case posSet_y:
@@ -5123,8 +5123,8 @@ type velMul posSet
 
 func (sc velMul) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case posSet_x:
 			crun.vel[0] *= exp[0].evalF(c)
 		case posSet_y:
@@ -5152,8 +5152,8 @@ const (
 func (sc shadowOffset) Run(c *Char, _ []int32) bool {
 	crun := c
 	isReflect := false
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case shadowoffset_reflection:
 			isReflect = exp[0].evalB(c)
 		case posSet_x:
@@ -5193,9 +5193,8 @@ const (
 	palFX_redirectid
 )
 
-func (sc palFX) runSub(c *Char, pfd *PalFXDef,
-	id byte, exp []BytecodeExp) bool {
-	switch id {
+func (sc palFX) runSub(c *Char, pfd *PalFXDef, paramID byte, exp []BytecodeExp) bool {
+	switch paramID {
 	case palFX_time:
 		pfd.time = exp[0].evalI(c)
 	case palFX_color:
@@ -5272,8 +5271,8 @@ func (sc palFX) Run(c *Char, _ []int32) bool {
 	crun := c
 	doOnce := false
 	pf := newPalFX()
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		if id == palFX_redirectid {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		if paramID == palFX_redirectid {
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
 			} else {
@@ -5295,7 +5294,7 @@ func (sc palFX) Run(c *Char, _ []int32) bool {
 			}
 			doOnce = true
 		}
-		sc.runSub(c, &pf.PalFXDef, id, exp)
+		sc.runSub(c, &pf.PalFXDef, paramID, exp)
 		return true
 	})
 	return false
@@ -5305,8 +5304,8 @@ type allPalFX palFX
 
 func (sc allPalFX) Run(c *Char, _ []int32) bool {
 	sys.allPalFX.clear()
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		palFX(sc).runSub(c, &sys.allPalFX.PalFXDef, id, exp)
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		palFX(sc).runSub(c, &sys.allPalFX.PalFXDef, paramID, exp)
 		// Forcing 1.1 kind behavior
 		sys.allPalFX.invertblend = Clamp(sys.allPalFX.invertblend, 0, 1)
 		return true
@@ -5320,8 +5319,8 @@ func (sc bgPalFX) Run(c *Char, _ []int32) bool {
 	sys.bgPalFX.clear()
 	// Forcing 1.1 behavior
 	sys.bgPalFX.invertblend = -2
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		palFX(sc).runSub(c, &sys.bgPalFX.PalFXDef, id, exp)
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		palFX(sc).runSub(c, &sys.bgPalFX.PalFXDef, paramID, exp)
 		sys.bgPalFX.invertblend = -3
 		return true
 	})
@@ -5392,9 +5391,9 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 	var i int
 	//e, i := crun.newExplod()
 	rp := [...]int32{-1, 0}
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		if e == nil {
-			if id == explod_redirectid {
+			if paramID == explod_redirectid {
 				if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 					crun = rid
 					redirscale = c.localscl / crun.localscl
@@ -5418,7 +5417,7 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 				e.postype = PT_None
 			}
 		}
-		switch id {
+		switch paramID {
 		case explod_anim:
 			ffx := string(*(*[]byte)(unsafe.Pointer(&exp[0])))
 			if ffx != "" && ffx != "s" {
@@ -5611,9 +5610,9 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 			if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
 				e.palfxdef.invertblend = -2
 			}
-			palFX(sc).runSub(c, &e.palfxdef, id, exp)
+			palFX(sc).runSub(c, &e.palfxdef, paramID, exp)
 
-			explod(sc).setInterpolation(c, e, id, exp, &e.palfxdef)
+			explod(sc).setInterpolation(c, e, paramID, exp, &e.palfxdef)
 
 		}
 		return true
@@ -5632,9 +5631,8 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 	return false
 }
 
-func (sc explod) setInterpolation(c *Char, e *Explod,
-	id byte, exp []BytecodeExp, pfd *PalFXDef) bool {
-	switch id {
+func (sc explod) setInterpolation(c *Char, e *Explod, paramID byte, exp []BytecodeExp, pfd *PalFXDef) bool {
+	switch paramID {
 	case explod_interpolate_time:
 		e.interpolate_time[0] = exp[0].evalI(c)
 		if e.interpolate_time[0] < 0 {
@@ -5733,8 +5731,8 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 			f(expls[idx])
 		}
 	}
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case explod_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -5764,7 +5762,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 					}
 				})
 			}
-			switch id {
+			switch paramID {
 			case explod_postype:
 				ptexists = true // In Mugen you can only update some parameters if postype is specified
 				pt := PosType(exp[0].evalI(c))
@@ -6177,7 +6175,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 			default:
 				eachExpl(func(e *Explod) {
 					if e.ownpal {
-						palFX(sc).runSub(c, &e.palfx.PalFXDef, id, exp)
+						palFX(sc).runSub(c, &e.palfx.PalFXDef, paramID, exp)
 					}
 				})
 			}
@@ -6208,9 +6206,9 @@ func (sc gameMakeAnim) Run(c *Char, _ []int32) bool {
 	var redirscale float32 = 1.0
 	var e *Explod
 	var i int
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		if e == nil {
-			if id == gameMakeAnim_redirectid {
+			if paramID == gameMakeAnim_redirectid {
 				if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 					crun = rid
 					redirscale = c.localscl / crun.localscl
@@ -6231,7 +6229,7 @@ func (sc gameMakeAnim) Run(c *Char, _ []int32) bool {
 			}
 			e.layerno, e.sprpriority, e.ownpal = 1, math.MinInt32, true
 		}
-		switch id {
+		switch paramID {
 		case gameMakeAnim_pos:
 			e.relativePos[0] = exp[0].evalF(c) * redirscale
 			if len(exp) > 1 {
@@ -6292,9 +6290,8 @@ const (
 	afterImage_redirectid
 )
 
-func (sc afterImage) runSub(c *Char, ai *AfterImage,
-	id byte, exp []BytecodeExp) {
-	switch id {
+func (sc afterImage) runSub(c *Char, ai *AfterImage, paramID byte, exp []BytecodeExp) {
+	switch paramID {
 	case afterImage_trans:
 		ai.alpha[0] = exp[0].evalI(c)
 		ai.alpha[1] = exp[1].evalI(c)
@@ -6372,8 +6369,8 @@ func (sc afterImage) runSub(c *Char, ai *AfterImage,
 func (sc afterImage) Run(c *Char, _ []int32) bool {
 	crun := c
 	doOnce := false
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		if id == afterImage_redirectid {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		if paramID == afterImage_redirectid {
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
 			} else {
@@ -6389,7 +6386,7 @@ func (sc afterImage) Run(c *Char, _ []int32) bool {
 			crun.aimg.time = 1
 			doOnce = true
 		}
-		sc.runSub(c, &crun.aimg, id, exp)
+		sc.runSub(c, &crun.aimg, paramID, exp)
 		return true
 	})
 	crun.aimg.setupPalFX()
@@ -6405,8 +6402,8 @@ const (
 
 func (sc afterImageTime) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		if id == afterImageTime_redirectid {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		if paramID == afterImageTime_redirectid {
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
 			} else {
@@ -6416,7 +6413,7 @@ func (sc afterImageTime) Run(c *Char, _ []int32) bool {
 		if crun.aimg.timegap <= 0 {
 			return false
 		}
-		switch id {
+		switch paramID {
 		case afterImageTime_time:
 			time := exp[0].evalI(c)
 			if time == 1 {
@@ -6542,8 +6539,8 @@ const (
 )
 
 // Additions to Hitdef should ideally also be done to GetHitVarSet and ModifyProjectile
-func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
-	switch id {
+func (sc hitDef) runSub(c *Char, hd *HitDef, paramID byte, exp []BytecodeExp) bool {
+	switch paramID {
 	case hitDef_attr:
 		hd.attr = exp[0].evalI(c)
 	case hitDef_guardflag:
@@ -6883,7 +6880,7 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, id byte, exp []BytecodeExp) bool {
 			hd.guard_sparkscale[1] = exp[1].evalF(c)
 		}
 	default:
-		if !palFX(sc).runSub(c, &hd.palfx, id, exp) {
+		if !palFX(sc).runSub(c, &hd.palfx, paramID, exp) {
 			return false
 		}
 	}
@@ -6894,8 +6891,8 @@ func (sc hitDef) Run(c *Char, _ []int32) bool {
 	crun := c
 	crun.hitdef.clear(crun, crun.localscl)
 	crun.hitdef.playerNo = sys.workingState.playerNo
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		if id == hitDef_redirectid {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		if paramID == hitDef_redirectid {
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
 				crun.hitdef.clear(crun, crun.localscl)
@@ -6908,7 +6905,7 @@ func (sc hitDef) Run(c *Char, _ []int32) bool {
 		if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
 			crun.hitdef.palfx.invertblend = -2
 		}
-		sc.runSub(c, &crun.hitdef, id, exp)
+		sc.runSub(c, &crun.hitdef, paramID, exp)
 		return true
 	})
 	// In Winmugen, when the attr of Hitdef is set to 'Throw' and the pausetime
@@ -6933,8 +6930,8 @@ func (sc reversalDef) Run(c *Char, _ []int32) bool {
 	crun := c
 	crun.hitdef.clear(crun, crun.localscl)
 	crun.hitdef.playerNo = sys.workingState.playerNo
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case reversalDef_reversal_attr:
 			crun.hitdef.reversal_attr = exp[0].evalI(c)
 		case reversalDef_redirectid:
@@ -6946,7 +6943,7 @@ func (sc reversalDef) Run(c *Char, _ []int32) bool {
 				return false
 			}
 		default:
-			hitDef(sc).runSub(c, &crun.hitdef, id, exp)
+			hitDef(sc).runSub(c, &crun.hitdef, paramID, exp)
 		}
 		return true
 	})
@@ -7006,9 +7003,9 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 	op := false
 	clsnscale := false
 	rp := [...]int32{-1, 0}
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		if p == nil {
-			if id == projectile_redirectid {
+			if paramID == projectile_redirectid {
 				if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 					crun = rid
 					redirscale = c.localscl / crun.localscl
@@ -7021,7 +7018,7 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 				return false
 			}
 		}
-		switch id {
+		switch paramID {
 		case projectile_postype:
 			pt = PosType(exp[0].evalI(c))
 		case projectile_projid:
@@ -7170,8 +7167,8 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 		// case projectile_platformfence:
 		// 	p.platformFence = exp[0].evalB(c)
 		default:
-			if !hitDef(sc).runSub(c, &p.hitdef, id, exp) {
-				afterImage(sc).runSub(c, &p.aimg, id, exp)
+			if !hitDef(sc).runSub(c, &p.hitdef, paramID, exp) {
+				afterImage(sc).runSub(c, &p.aimg, paramID, exp)
 			}
 		}
 		return true
@@ -7206,8 +7203,8 @@ const (
 
 func (sc modifyHitDef) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case modifyHitDef_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -7216,7 +7213,7 @@ func (sc modifyHitDef) Run(c *Char, _ []int32) bool {
 			}
 		default:
 			if crun.hitdef.attr > 0 && crun.hitdef.reversal_attr == 0 {
-				hitDef(sc).runSub(c, &crun.hitdef, id, exp)
+				hitDef(sc).runSub(c, &crun.hitdef, paramID, exp)
 			}
 		}
 		return true
@@ -7233,8 +7230,8 @@ const (
 
 func (sc modifyReversalDef) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case modifyReversalDef_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -7247,7 +7244,7 @@ func (sc modifyReversalDef) Run(c *Char, _ []int32) bool {
 			}
 		default:
 			if crun.hitdef.reversal_attr > 0 {
-				hitDef(sc).runSub(c, &crun.hitdef, id, exp)
+				hitDef(sc).runSub(c, &crun.hitdef, paramID, exp)
 			}
 		}
 		return true
@@ -7278,8 +7275,8 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 			f(projs[mpidx])
 		}
 	}
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case modifyProjectile_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -7301,7 +7298,7 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 					return false
 				}
 			}
-			switch id {
+			switch paramID {
 			case projectile_projremove:
 				eachProj(func(p *Projectile) {
 					p.remove = exp[0].evalB(c)
@@ -7976,8 +7973,8 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 					})
 			default:
 				eachProj(func(p *Projectile) {
-					if !hitDef(sc).runSub(c, &p.hitdef, id, exp) {
-						afterImage(sc).runSub(c, &p.aimg, id, exp)
+					if !hitDef(sc).runSub(c, &p.hitdef, paramID, exp) {
+						afterImage(sc).runSub(c, &p.aimg, paramID, exp)
 					}
 				})
 			}
@@ -7999,8 +7996,8 @@ const (
 func (sc width) Run(c *Char, _ []int32) bool {
 	crun := c
 	var redirscale float32 = 1.0
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case width_player:
 			var v1, v2 float32
 			v1 = exp[0].evalF(c)
@@ -8048,8 +8045,8 @@ func (sc sprPriority) Run(c *Char, _ []int32) bool {
 	crun := c
 	v := int32(0) // Mugen uses 0 even if no value is set at all
 	l := int32(0) // Defaults to 0 so that chars are less likely to be left forgotten in a different layer
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case sprPriority_value:
 			v = exp[0].evalI(c)
 		case sprPriority_layerno:
@@ -8077,8 +8074,8 @@ const (
 
 func (sc varSet) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case varSet_:
 			exp[0].run(crun)
 		case varSet_redirectid:
@@ -8102,8 +8099,8 @@ const (
 
 func (sc turn) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case turn_:
 			crun.setFacing(-crun.facing)
 		case turn_redirectid:
@@ -8122,41 +8119,35 @@ type targetFacing StateControllerBase
 
 const (
 	targetFacing_id byte = iota
+	targetFacing_index
 	targetFacing_value
 	targetFacing_redirectid
 )
 
 func (sc targetFacing) Run(c *Char, _ []int32) bool {
 	crun := c
-	tar := crun.getTarget(-1)
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	tid, tidx := int32(-1), int(-1)
+	var value int32
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case targetFacing_id:
-			if len(tar) == 0 {
-				return false
-			}
-			tar = crun.getTarget(exp[0].evalI(c))
+			tid = exp[0].evalI(c)
+		case targetFacing_index:
+			tidx = int(exp[0].evalI(c))
 		case targetFacing_value:
-			if len(tar) == 0 {
-				return false
-			}
-			crun.targetFacing(tar, exp[0].evalI(c))
+			value = exp[0].evalI(c)
 		case targetFacing_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				tar = crun.getTarget(-1)
-				if len(tar) == 0 {
-					return false
-				}
 			} else {
 				return false
 			}
-
 		}
 		return true
 	})
-	if len(tar) == 0 {
-		return false
+	tar := crun.getTarget(tid, tidx)
+	if len(tar) > 0 && value != 0 {
+		crun.targetFacing(tar, value)
 	}
 	return false
 }
@@ -8165,6 +8156,7 @@ type targetBind StateControllerBase
 
 const (
 	targetBind_id byte = iota
+	targetBind_index
 	targetBind_time
 	targetBind_pos
 	targetBind_redirectid
@@ -8172,19 +8164,18 @@ const (
 
 func (sc targetBind) Run(c *Char, _ []int32) bool {
 	crun := c
+	tid, tidx := int32(-1), int(-1)
 	var redirscale float32 = 1.0
-	tar := crun.getTarget(-1)
-	t := int32(1)
+	time := int32(1)
 	var x, y, z float32 = 0, 0, 0
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case targetBind_id:
-			if len(tar) == 0 {
-				return false
-			}
-			tar = crun.getTarget(exp[0].evalI(c))
+			tid = exp[0].evalI(c)
+		case targetBind_index:
+			tidx = int(exp[0].evalI(c))
 		case targetBind_time:
-			t = exp[0].evalI(c)
+			time = exp[0].evalI(c)
 		case targetBind_pos:
 			x = exp[0].evalF(c) * redirscale
 			if len(exp) > 1 {
@@ -8197,48 +8188,43 @@ func (sc targetBind) Run(c *Char, _ []int32) bool {
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
 				redirscale = c.localscl / crun.localscl
-				tar = crun.getTarget(-1)
-				if len(tar) == 0 {
-					return false
-				}
 			} else {
 				return false
 			}
-
 		}
 		return true
 	})
-	if len(tar) == 0 {
-		return false
+	tar := crun.getTarget(tid, tidx)
+	if len(tar) > 0 {
+		crun.targetBind(tar, time, x, y, z)
 	}
-	crun.targetBind(tar, t, x, y, z)
 	return false
 }
 
 type bindToTarget StateControllerBase
 
 const (
-	bindToTarget_id byte = iota
-	bindToTarget_time
-	bindToTarget_pos
-	bindToTarget_posz
-	bindToTarget_redirectid
+        bindToTarget_id byte = iota
+        bindToTarget_index
+        bindToTarget_time
+        bindToTarget_pos
+        bindToTarget_posz
+        bindToTarget_redirectid
 )
 
 func (sc bindToTarget) Run(c *Char, _ []int32) bool {
 	crun := c
 	var redirscale float32 = 1.0
-	tar := crun.getTarget(-1)
-	t, x, y, z, hmf := int32(1), float32(0), float32(math.NaN()), float32(math.NaN()), HMF_F
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	tid, tidx := int32(-1), int(-1)
+	time, x, y, z, hmf := int32(1), float32(0), float32(math.NaN()), float32(math.NaN()), HMF_F
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case bindToTarget_id:
-			if len(tar) == 0 {
-				return false
-			}
-			tar = crun.getTarget(exp[0].evalI(c))
+			tid = exp[0].evalI(c)
+		case bindToTarget_index:
+			tidx = int(exp[0].evalI(c))
 		case bindToTarget_time:
-			t = exp[0].evalI(c)
+			time = exp[0].evalI(c)
 		case bindToTarget_pos:
 			x = exp[0].evalF(c) * redirscale
 			if len(exp) > 1 {
@@ -8248,76 +8234,71 @@ func (sc bindToTarget) Run(c *Char, _ []int32) bool {
 				}
 			}
 		case bindToTarget_posz:
-			z = exp[0].evalF(c) * redirscale
+				z = exp[0].evalF(c) * redirscale
 		case bindToTarget_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
 				redirscale = c.localscl / crun.localscl
-				tar = crun.getTarget(-1)
-				if len(tar) == 0 {
-					return false
-				}
 			} else {
 				return false
 			}
 		}
 		return true
 	})
-	if len(tar) == 0 {
-		return false
+	tar := crun.getTarget(tid, tidx)
+	if len(tar) > 0 {
+		crun.bindToTarget(tar, time, x, y, z, hmf)
 	}
-	crun.bindToTarget(tar, t, x, y, z, hmf)
 	return false
 }
 
 type targetLifeAdd StateControllerBase
 
 const (
-	targetLifeAdd_id byte = iota
-	targetLifeAdd_absolute
-	targetLifeAdd_kill
-	targetLifeAdd_dizzy
-	targetLifeAdd_redlife
-	targetLifeAdd_value
-	targetLifeAdd_redirectid
+        targetLifeAdd_id byte = iota
+        targetLifeAdd_index
+        targetLifeAdd_absolute
+        targetLifeAdd_kill
+        targetLifeAdd_dizzy
+        targetLifeAdd_redlife
+        targetLifeAdd_value
+        targetLifeAdd_redirectid
 )
 
 func (sc targetLifeAdd) Run(c *Char, _ []int32) bool {
 	crun := c
-	tar, a, k, d, r := crun.getTarget(-1), false, true, true, true
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	abs, kill, d, r := false, true, true, true
+	var value int32
+	tid, tidx := int32(-1), int(-1)
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case targetLifeAdd_id:
-			if len(tar) == 0 {
-				return false
-			}
-			tar = crun.getTarget(exp[0].evalI(c))
+			tid = exp[0].evalI(c)
+		case targetLifeAdd_index:
+			tidx = int(exp[0].evalI(c))
 		case targetLifeAdd_absolute:
-			a = exp[0].evalB(c)
+			abs = exp[0].evalB(c)
 		case targetLifeAdd_kill:
-			k = exp[0].evalB(c)
+			kill = exp[0].evalB(c)
 		case targetLifeAdd_dizzy:
 			d = exp[0].evalB(c)
 		case targetLifeAdd_redlife:
 			r = exp[0].evalB(c)
 		case targetLifeAdd_value:
-			if len(tar) == 0 {
-				return false
-			}
-			crun.targetLifeAdd(tar, exp[0].evalI(c), k, a, d, r)
+			value = exp[0].evalI(c)
 		case targetLifeAdd_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				tar = crun.getTarget(-1)
-				if len(tar) == 0 {
-					return false
-				}
 			} else {
 				return false
 			}
 		}
 		return true
 	})
+	tar := crun.getTarget(tid, tidx)
+	if len(tar) > 0 {
+		crun.targetLifeAdd(tar, value, kill, abs, d, r)
+	}
 	return false
 }
 
@@ -8325,38 +8306,36 @@ type targetState StateControllerBase
 
 const (
 	targetState_id byte = iota
+	targetState_index
 	targetState_value
 	targetState_redirectid
 )
 
 func (sc targetState) Run(c *Char, _ []int32) bool {
 	crun := c
-	tar := crun.getTarget(-1)
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	tid, tidx := int32(-1), int(-1)
+	vl := int32(-1)
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case targetState_id:
-			if len(tar) == 0 {
-				return false
-			}
-			tar = crun.getTarget(exp[0].evalI(c))
+			tid = exp[0].evalI(c)
+		case targetState_index:
+			tidx = int(exp[0].evalI(c))
 		case targetState_value:
-			if len(tar) == 0 {
-				return false
-			}
-			crun.targetState(tar, exp[0].evalI(c))
+			vl = exp[0].evalI(c)
 		case targetState_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				tar = crun.getTarget(-1)
-				if len(tar) == 0 {
-					return false
-				}
 			} else {
 				return false
 			}
 		}
 		return true
 	})
+	tar := crun.getTarget(tid, tidx)
+	if len(tar) > 0 {
+		crun.targetState(tar, vl)
+	}
 	return false
 }
 
@@ -8364,6 +8343,7 @@ type targetVelSet StateControllerBase
 
 const (
 	targetVelSet_id byte = iota
+	targetVelSet_index
 	targetVelSet_x
 	targetVelSet_y
 	targetVelSet_z
@@ -8373,43 +8353,46 @@ const (
 func (sc targetVelSet) Run(c *Char, _ []int32) bool {
 	crun := c
 	var redirscale float32 = 1.0
-	tar := crun.getTarget(-1)
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	tid, tidx := int32(-1), int(-1)
+	var setx, sety, setz bool
+	var velx, vely, velz float32
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case targetVelSet_id:
-			if len(tar) == 0 {
-				return false
-			}
-			tar = crun.getTarget(exp[0].evalI(c))
+			tid = exp[0].evalI(c)
+		case targetVelSet_index:
+			tidx = int(exp[0].evalI(c))
 		case targetVelSet_x:
-			if len(tar) == 0 {
-				return false
-			}
-			crun.targetVelSetX(tar, exp[0].evalF(c)*redirscale)
+			velx = exp[0].evalF(c) * redirscale
+			setx = true
 		case targetVelSet_y:
-			if len(tar) == 0 {
-				return false
-			}
-			crun.targetVelSetY(tar, exp[0].evalF(c)*redirscale)
+			vely = exp[0].evalF(c) * redirscale
+			sety = true
 		case targetVelSet_z:
-			if len(tar) == 0 {
-				return false
-			}
-			crun.targetVelSetZ(tar, exp[0].evalF(c)*redirscale)
+			velz = exp[0].evalF(c) * redirscale
+			setz = true
 		case targetVelSet_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
 				redirscale = c.localscl / crun.localscl
-				tar = crun.getTarget(-1)
-				if len(tar) == 0 {
-					return false
-				}
 			} else {
 				return false
 			}
 		}
 		return true
 	})
+	tar := crun.getTarget(tid, tidx)
+	if len(tar) > 0 {
+		if setx {
+			crun.targetVelSetX(tar, velx)
+		}
+		if sety {
+			crun.targetVelSetY(tar, vely)
+		}
+		if setz {
+			crun.targetVelSetZ(tar, velz)
+		}
+	}
 	return false
 }
 
@@ -8417,6 +8400,7 @@ type targetVelAdd StateControllerBase
 
 const (
 	targetVelAdd_id byte = iota
+	targetVelAdd_index
 	targetVelAdd_x
 	targetVelAdd_y
 	targetVelAdd_z
@@ -8426,43 +8410,46 @@ const (
 func (sc targetVelAdd) Run(c *Char, _ []int32) bool {
 	crun := c
 	var redirscale float32 = 1.0
-	tar := crun.getTarget(-1)
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	tid, tidx := int32(-1), int(-1)
+	var setx, sety, setz bool
+	var velx, vely, velz float32
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case targetVelAdd_id:
-			if len(tar) == 0 {
-				return false
-			}
-			tar = crun.getTarget(exp[0].evalI(c))
+			tid = exp[0].evalI(c)
+		case targetVelAdd_index:
+			tidx = int(exp[0].evalI(c))
 		case targetVelAdd_x:
-			if len(tar) == 0 {
-				return false
-			}
-			crun.targetVelAddX(tar, exp[0].evalF(c)*redirscale)
+			velx = exp[0].evalF(c) * redirscale
+			setx = true
 		case targetVelAdd_y:
-			if len(tar) == 0 {
-				return false
-			}
-			crun.targetVelAddY(tar, exp[0].evalF(c)*redirscale)
+			vely = exp[0].evalF(c) * redirscale
+			sety = true
 		case targetVelAdd_z:
-			if len(tar) == 0 {
-				return false
-			}
-			crun.targetVelAddZ(tar, exp[0].evalF(c)*redirscale)
+			velz = exp[0].evalF(c) * redirscale
+			setz = true
 		case targetVelAdd_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
 				redirscale = c.localscl / crun.localscl
-				tar = crun.getTarget(-1)
-				if len(tar) == 0 {
-					return false
-				}
 			} else {
 				return false
 			}
 		}
 		return true
 	})
+	tar := crun.getTarget(tid, tidx)
+	if len(tar) > 0 {
+		if setx {
+			crun.targetVelAddX(tar, velx)
+		}
+		if sety {
+			crun.targetVelAddY(tar, vely)
+		}
+		if setz {
+			crun.targetVelAddZ(tar, velz)
+		}
+	}
 	return false
 }
 
@@ -8470,38 +8457,36 @@ type targetPowerAdd StateControllerBase
 
 const (
 	targetPowerAdd_id byte = iota
+	targetPowerAdd_index
 	targetPowerAdd_value
 	targetPowerAdd_redirectid
 )
 
 func (sc targetPowerAdd) Run(c *Char, _ []int32) bool {
 	crun := c
-	tar := crun.getTarget(-1)
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	tid, tidx := int32(-1), int(-1)
+	vl := int32(0)
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case targetPowerAdd_id:
-			if len(tar) == 0 {
-				return false
-			}
-			tar = crun.getTarget(exp[0].evalI(c))
+			tid = exp[0].evalI(c)
+		case targetPowerAdd_index:
+			tidx = int(exp[0].evalI(c))
 		case targetPowerAdd_value:
-			if len(tar) == 0 {
-				return false
-			}
-			crun.targetPowerAdd(tar, exp[0].evalI(c))
+			vl = exp[0].evalI(c)
 		case targetPowerAdd_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				tar = crun.getTarget(-1)
-				if len(tar) == 0 {
-					return false
-				}
 			} else {
 				return false
 			}
 		}
 		return true
 	})
+	tar := crun.getTarget(tid, tidx)
+	if len(tar) > 0 {
+		crun.targetPowerAdd(tar, vl)
+	}
 	return false
 }
 
@@ -8515,30 +8500,26 @@ const (
 
 func (sc targetDrop) Run(c *Char, _ []int32) bool {
 	crun := c
-	tar, eid, ko := crun.getTarget(-1), int32(-1), true
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	eid, keep := int32(-1), true
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case targetDrop_excludeid:
 			eid = exp[0].evalI(c)
 		case targetDrop_keepone:
-			ko = exp[0].evalB(c)
+			keep = exp[0].evalB(c)
 		case targetDrop_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				tar = crun.getTarget(-1)
-				if len(tar) == 0 {
-					return false
-				}
 			} else {
 				return false
 			}
 		}
 		return true
 	})
-	if len(tar) == 0 {
-		return false
+	tar := crun.getTarget(-1, -1)
+	if len(tar) > 0 {
+		crun.targetDrop(eid, -1, keep)
 	}
-	crun.targetDrop(eid, -1, ko)
 	return false
 }
 
@@ -8552,22 +8533,22 @@ const (
 )
 
 func (sc lifeAdd) Run(c *Char, _ []int32) bool {
-	a, k := false, true
+	abs, kill := false, true
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case lifeAdd_absolute:
-			a = exp[0].evalB(c)
+			abs = exp[0].evalB(c)
 		case lifeAdd_kill:
-			k = exp[0].evalB(c)
+			kill = exp[0].evalB(c)
 		case lifeAdd_value:
 			v := exp[0].evalI(c)
 			// Mugen forces absolute parameter when healing characters
 			if v > 0 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
-				a = true
+				abs = true
 			}
-			crun.lifeAdd(float64(v), k, a)
-			crun.ghv.kill = k // The kill GetHitVar must currently be set here because c.lifeAdd is also used internally
+			crun.lifeAdd(float64(v), kill, abs)
+			crun.ghv.kill = kill // The kill GetHitVar must currently be set here because c.lifeAdd is also used internally
 		case lifeAdd_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -8589,8 +8570,8 @@ const (
 
 func (sc lifeSet) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case lifeSet_value:
 			crun.lifeSet(exp[0].evalI(c))
 		case lifeSet_redirectid:
@@ -8614,8 +8595,8 @@ const (
 
 func (sc powerAdd) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case powerAdd_value:
 			crun.powerAdd(exp[0].evalI(c))
 		case powerAdd_redirectid:
@@ -8639,8 +8620,8 @@ const (
 
 func (sc powerSet) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case powerSet_value:
 			crun.powerSet(exp[0].evalI(c))
 		case powerSet_redirectid:
@@ -8667,8 +8648,8 @@ const (
 func (sc hitVelSet) Run(c *Char, _ []int32) bool {
 	// Note: HitVelSet doesn't require Movetype H in Mugen
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case hitVelSet_x:
 			if exp[0].evalB(c) {
 				crun.vel[0] = crun.ghv.xvel * crun.facing
@@ -8704,8 +8685,8 @@ const (
 
 func (sc screenBound) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case screenBound_value:
 			if exp[0].evalB(c) {
 				crun.setCSF(CSF_screenbound)
@@ -8754,8 +8735,8 @@ const (
 
 func (sc posFreeze) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case posFreeze_value:
 			if exp[0].evalB(c) {
 				crun.setCSF(CSF_posfreeze)
@@ -8784,8 +8765,8 @@ const (
 
 func (sc envShake) Run(c *Char, _ []int32) bool {
 	sys.envShake.clear()
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case envShake_time:
 			sys.envShake.time = exp[0].evalI(c)
 		case envShake_ampl:
@@ -8822,8 +8803,8 @@ func (sc hitOverride) Run(c *Char, _ []int32) bool {
 	var a, s, st, t int32 = 0, 0, -1, 1
 	f := false
 	ks := false
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case hitOverride_attr:
 			a = exp[0].evalI(c)
 		case hitOverride_slot:
@@ -8875,8 +8856,8 @@ func (sc pause) Run(c *Char, _ []int32) bool {
 	crun := c
 	var t, mt int32 = 0, 0
 	sys.pausebg, sys.pauseendcmdbuftime = true, 0
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case pause_time:
 			t = exp[0].evalI(c)
 		case pause_movetime:
@@ -8927,8 +8908,8 @@ func (sc superPause) Run(c *Char, _ []int32) bool {
 	sys.superendcmdbuftime = 0
 	sys.superdarken = true
 	sys.superp2defmul = crun.gi().constants["super.targetdefencemul"]
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case superPause_time:
 			t = exp[0].evalI(c)
 		case superPause_movetime:
@@ -9012,8 +8993,8 @@ const (
 func (sc trans) Run(c *Char, _ []int32) bool {
 	crun := c
 	crun.alpha[1] = 255
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case trans_trans:
 			crun.alpha[0] = exp[0].evalI(c)
 			crun.alpha[1] = exp[1].evalI(c)
@@ -9050,8 +9031,8 @@ const (
 
 func (sc playerPush) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case playerPush_value:
 			if exp[0].evalB(c) {
 				crun.setCSF(CSF_playerpush)
@@ -9083,8 +9064,8 @@ const (
 
 func (sc stateTypeSet) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case stateTypeSet_statetype:
 			crun.ss.changeStateType(StateType(exp[0].evalI(c)))
 		case stateTypeSet_movetype:
@@ -9113,8 +9094,8 @@ const (
 
 func (sc angleDraw) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case angleDraw_value:
 			crun.angleSet(exp[0].evalF(c))
 		case angleDraw_scale:
@@ -9145,8 +9126,8 @@ const (
 func (sc angleSet) Run(c *Char, _ []int32) bool {
 	crun := c
 	v := float32(0) // Mugen uses 0 if no value is set at all
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case angleSet_value:
 			v = exp[0].evalF(c)
 		case angleSet_redirectid:
@@ -9171,8 +9152,8 @@ const (
 
 func (sc angleAdd) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case angleAdd_value:
 			crun.angleSet(crun.angle + exp[0].evalF(c))
 		case angleAdd_redirectid:
@@ -9197,8 +9178,8 @@ const (
 func (sc angleMul) Run(c *Char, _ []int32) bool {
 	crun := c
 	v := float32(0) // Mugen uses 0 if no value is set at all
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case angleMul_value:
 			v = exp[0].evalF(c)
 		case angleMul_redirectid:
@@ -9226,8 +9207,8 @@ func (sc envColor) Run(c *Char, _ []int32) bool {
 	sys.envcol = [...]int32{255, 255, 255}
 	sys.envcol_time = 1
 	sys.envcol_under = false
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case envColor_value:
 			sys.envcol[0] = exp[0].evalI(c)
 			sys.envcol[1] = exp[1].evalI(c)
@@ -9253,8 +9234,8 @@ const (
 func (sc displayToClipboard) Run(c *Char, _ []int32) bool {
 	crun := c
 	params := []interface{}{}
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case displayToClipboard_params:
 			for _, e := range exp {
 				if bv := e.run(c); bv.vtype == VT_Float {
@@ -9284,8 +9265,8 @@ type appendToClipboard displayToClipboard
 func (sc appendToClipboard) Run(c *Char, _ []int32) bool {
 	crun := c
 	params := []interface{}{}
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case displayToClipboard_params:
 			for _, e := range exp {
 				if bv := e.run(c); bv.vtype == VT_Float {
@@ -9318,8 +9299,8 @@ const (
 
 func (sc clearClipboard) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case clearClipboard_:
 			crun.clipboardText = nil
 		case clearClipboard_redirectid:
@@ -9346,8 +9327,8 @@ const (
 func (sc makeDust) Run(c *Char, _ []int32) bool {
 	crun := c
 	spacing := int(3) // Default spacing is 3
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case makeDust_spacing:
 			spacing = int(exp[0].evalI(c))
 		case makeDust_pos:
@@ -9394,8 +9375,8 @@ const (
 func (sc attackDist) Run(c *Char, _ []int32) bool {
 	crun := c
 	var redirscale float32 = 1.0
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case attackDist_x:
 			crun.attackDistX[0] = exp[0].evalF(c) * redirscale
 			if len(exp) > 1 {
@@ -9438,8 +9419,8 @@ const (
 func (sc attackMulSet) Run(c *Char, _ []int32) bool {
 	crun := c
 	base := float32(crun.gi().data.attack) * crun.ocd().attackRatio / 100
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case attackMulSet_value:
 			v := exp[0].evalF(c)
 			crun.attackMul[0] = v * base
@@ -9487,8 +9468,8 @@ func (sc defenceMulSet) Run(c *Char, _ []int32) bool {
 		mulType = 0
 	}
 
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case defenceMulSet_value:
 			val = exp[0].evalF(c)
 		case defenceMulSet_onHit:
@@ -9527,8 +9508,8 @@ const (
 
 func (sc fallEnvShake) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case fallEnvShake_:
 			if crun.ghv.fall_envshake_time > 0 {
 				sys.envShake = EnvShake{time: crun.ghv.fall_envshake_time,
@@ -9560,8 +9541,8 @@ const (
 
 func (sc hitFallDamage) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case hitFallDamage_:
 			crun.hitFallDamage()
 		case hitFallDamage_redirectid:
@@ -9585,8 +9566,8 @@ const (
 
 func (sc hitFallVel) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case hitFallVel_:
 			crun.hitFallVel()
 		case hitFallVel_redirectid:
@@ -9614,8 +9595,8 @@ const (
 func (sc hitFallSet) Run(c *Char, _ []int32) bool {
 	crun := c
 	f, xv, yv, zv := int32(-1), float32(math.NaN()), float32(math.NaN()), float32(math.NaN())
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case hitFallSet_value:
 			f = exp[0].evalI(c)
 			if len(crun.ghv.hitBy) == 0 {
@@ -9653,8 +9634,8 @@ const (
 func (sc varRangeSet) Run(c *Char, _ []int32) bool {
 	crun := c
 	var first, last int32 = 0, 0
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case varRangeSet_first:
 			first = exp[0].evalI(c)
 		case varRangeSet_last:
@@ -9697,8 +9678,8 @@ func (sc remapPal) Run(c *Char, _ []int32) bool {
 	crun := c
 	src := [...]int32{-1, 0}
 	dst := [...]int32{-1, 0} // This is the default but technically the compiler crashes if dest is not specified
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case remapPal_source:
 			src[0] = exp[0].evalI(c)
 			if len(exp) > 1 {
@@ -9731,8 +9712,8 @@ const (
 
 func (sc stopSnd) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case stopSnd_channel:
 			if ch := Min(255, exp[0].evalI(c)); ch < 0 {
 				sys.stopAllSound()
@@ -9763,8 +9744,8 @@ const (
 func (sc sndPan) Run(c *Char, _ []int32) bool {
 	crun := c
 	ch, pan, x := int32(-1), float32(0), &crun.pos[0]
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case sndPan_channel:
 			ch = exp[0].evalI(c)
 		case sndPan_pan:
@@ -9800,8 +9781,8 @@ func (sc varRandom) Run(c *Char, _ []int32) bool {
 	crun := c
 	var v int32
 	var min, max int32 = 0, 1000
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case varRandom_v:
 			v = exp[0].evalI(c)
 		case varRandom_range:
@@ -9831,8 +9812,8 @@ const (
 
 func (sc gravity) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case gravity_:
 			crun.gravity()
 		case gravity_redirectid:
@@ -9862,8 +9843,8 @@ func (sc bindToParent) Run(c *Char, _ []int32) bool {
 	p := crun.parent()
 	var x, y, z float32 = 0, 0, 0
 	var time int32 = 1
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case bindToParent_time:
 			time = exp[0].evalI(c)
 		case bindToParent_facing:
@@ -9910,8 +9891,8 @@ func (sc bindToRoot) Run(c *Char, _ []int32) bool {
 	r := crun.root()
 	var x, y, z float32 = 0, 0, 0
 	var time int32 = 1
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case bindToParent_time:
 			time = exp[0].evalI(c)
 		case bindToParent_facing:
@@ -9962,8 +9943,8 @@ func (sc removeExplod) Run(c *Char, _ []int32) bool {
 	crun := c
 	eid := int32(-1)
 	idx := int32(-1)
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case removeExplod_id:
 			eid = exp[0].evalI(c)
 		case removeExplod_index:
@@ -9992,8 +9973,8 @@ const (
 func (sc explodBindTime) Run(c *Char, _ []int32) bool {
 	crun := c
 	var eid, time int32 = -1, 0
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case explodBindTime_id:
 			eid = exp[0].evalI(c)
 		case explodBindTime_time:
@@ -10020,8 +10001,8 @@ const (
 
 func (sc moveHitReset) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case moveHitReset_:
 			crun.clearMoveHit()
 		case moveHitReset_redirectid:
@@ -10045,8 +10026,8 @@ const (
 
 func (sc hitAdd) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case hitAdd_value:
 			crun.hitAdd(exp[0].evalI(c))
 		case hitAdd_redirectid:
@@ -10071,8 +10052,8 @@ const (
 
 func (sc offset) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case offset_x:
 			crun.offset[0] = exp[0].evalF(c) * c.localscl
 		case offset_y:
@@ -10099,8 +10080,8 @@ const (
 func (sc victoryQuote) Run(c *Char, _ []int32) bool {
 	crun := c
 	var v int32 = -1
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case victoryQuote_value:
 			v = exp[0].evalI(c)
 		case victoryQuote_redirectid:
@@ -10130,8 +10111,8 @@ const (
 func (sc zoom) Run(c *Char, _ []int32) bool {
 	pos := [2]float32{0, 0}
 	t := int32(1)
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case zoom_pos:
 			pos[0] = exp[0].evalF(c) * c.localscl
 			if len(exp) > 1 {
@@ -10176,8 +10157,8 @@ func (sc forceFeedback) Run(c *Char, _ []int32) bool {
 	freq := [4]float32{128, 0, 0, 0}
 	ampl := [4]float32{128, 0, 0, 0}
 	self := true
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case forceFeedback_waveform:
 			waveform = exp[0].evalI(c)
 		case forceFeedback_time:
@@ -10231,8 +10212,8 @@ func (sc assertCommand) Run(c *Char, _ []int32) bool {
 	crun := c
 	n := ""
 	bt := int32(1)
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case assertCommand_name:
 			n = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
 		case assertCommand_buffertime:
@@ -10259,8 +10240,8 @@ const (
 
 func (sc assertInput) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case assertInput_flag:
 			crun.inputFlag |= InputBits(exp[0].evalI(c))
 		case assertInput_redirectid:
@@ -10288,8 +10269,8 @@ func (sc dialogue) Run(c *Char, _ []int32) bool {
 	crun := c
 	reset := true
 	force := false
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case dialogue_hidebars:
 			sys.dialogueBarsFlg = sys.lifebar.hidebars && exp[0].evalB(c)
 		case dialogue_force:
@@ -10322,14 +10303,14 @@ const (
 )
 
 func (sc dizzyPointsAdd) Run(c *Char, _ []int32) bool {
-	a := false
+	abs := false
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case dizzyPointsAdd_absolute:
-			a = exp[0].evalB(c)
+			abs = exp[0].evalB(c)
 		case dizzyPointsAdd_value:
-			crun.dizzyPointsAdd(float64(exp[0].evalI(c)), a)
+			crun.dizzyPointsAdd(float64(exp[0].evalI(c)), abs)
 		case dizzyPointsAdd_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -10351,8 +10332,8 @@ const (
 
 func (sc dizzyPointsSet) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case dizzyPointsSet_value:
 			crun.dizzyPointsSet(exp[0].evalI(c))
 		case dizzyPointsSet_redirectid:
@@ -10376,8 +10357,8 @@ const (
 
 func (sc dizzySet) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case dizzySet_value:
 			crun.setDizzy(exp[0].evalB(c))
 		case dizzySet_redirectid:
@@ -10401,8 +10382,8 @@ const (
 
 func (sc guardBreakSet) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case guardBreakSet_value:
 			crun.setGuardBreak(exp[0].evalB(c))
 		case guardBreakSet_redirectid:
@@ -10426,14 +10407,14 @@ const (
 )
 
 func (sc guardPointsAdd) Run(c *Char, _ []int32) bool {
-	a := false
+	abs := false
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case guardPointsAdd_absolute:
-			a = exp[0].evalB(c)
+			abs = exp[0].evalB(c)
 		case guardPointsAdd_value:
-			crun.guardPointsAdd(float64(exp[0].evalI(c)), a)
+			crun.guardPointsAdd(float64(exp[0].evalI(c)), abs)
 		case guardPointsAdd_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -10455,8 +10436,8 @@ const (
 
 func (sc guardPointsSet) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case guardPointsSet_value:
 			crun.guardPointsSet(exp[0].evalI(c))
 		case guardPointsSet_redirectid:
@@ -10492,8 +10473,8 @@ func (sc lifebarAction) Run(c *Char, _ []int32) bool {
 	var time, anim int32 = -1, -1
 	spr := [2]int32{-1, 0}
 	snd := [2]int32{-1, 0}
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case lifebarAction_top:
 			top = exp[0].evalB(c)
 		case lifebarAction_timemul:
@@ -10539,8 +10520,8 @@ func (sc loadFile) Run(c *Char, _ []int32) bool {
 	crun := c
 	var path string
 	var data SaveData
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case loadFile_path:
 			path = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
 		case loadFile_saveData:
@@ -10594,8 +10575,8 @@ func (sc mapSet) Run(c *Char, _ []int32) bool {
 	var s string
 	var value float32
 	var scType int32
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case mapSet_mapArray:
 			s = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
 		case mapSet_value:
@@ -10633,8 +10614,8 @@ const (
 func (sc matchRestart) Run(c *Char, _ []int32) bool {
 	var s string
 	reloadFlag := false
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case matchRestart_reload:
 			for i, p := range exp {
 				sys.reloadCharSlot[i] = p.evalB(c)
@@ -10693,8 +10674,8 @@ const (
 
 func (sc printToConsole) Run(c *Char, _ []int32) bool {
 	params := []interface{}{}
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case printToConsole_params:
 			for _, e := range exp {
 				if bv := e.run(c); bv.vtype == VT_Float {
@@ -10721,14 +10702,14 @@ const (
 )
 
 func (sc redLifeAdd) Run(c *Char, _ []int32) bool {
-	a := false
+	abs := false
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case redLifeAdd_absolute:
-			a = exp[0].evalB(c)
+			abs = exp[0].evalB(c)
 		case redLifeAdd_value:
-			crun.redLifeAdd(float64(exp[0].evalI(c)), a)
+			crun.redLifeAdd(float64(exp[0].evalI(c)), abs)
 		case redLifeAdd_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -10750,8 +10731,8 @@ const (
 
 func (sc redLifeSet) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case redLifeSet_value:
 			crun.redLifeSet(exp[0].evalI(c))
 		case redLifeSet_redirectid:
@@ -10779,8 +10760,8 @@ const (
 func (sc remapSprite) Run(c *Char, _ []int32) bool {
 	crun := c
 	src := [...]int16{-1, -1}
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case remapSprite_reset:
 			if exp[0].evalB(c) {
 				crun.remapSpr = make(RemapPreset)
@@ -10819,8 +10800,8 @@ const (
 )
 
 func (sc roundTimeAdd) Run(c *Char, _ []int32) bool {
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case roundTimeAdd_value:
 			if sys.roundTime != -1 {
 				sys.time = Clamp(sys.time+exp[0].evalI(c), 0, sys.roundTime)
@@ -10839,8 +10820,8 @@ const (
 )
 
 func (sc roundTimeSet) Run(c *Char, _ []int32) bool {
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case roundTimeSet_value:
 			if sys.roundTime != -1 {
 				sys.time = Clamp(exp[0].evalI(c), 0, sys.roundTime)
@@ -10863,8 +10844,8 @@ func (sc saveFile) Run(c *Char, _ []int32) bool {
 	crun := c
 	var path string
 	var data SaveData
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case saveFile_path:
 			path = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
 		case saveFile_saveData:
@@ -10912,8 +10893,8 @@ const (
 
 func (sc scoreAdd) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case scoreAdd_value:
 			crun.scoreAdd(exp[0].evalF(c))
 		case scoreAdd_redirectid:
@@ -10961,8 +10942,8 @@ func (sc modifyBGCtrl) Run(c *Char, _ []int32) bool {
 	sinadd, sinmul := [4]int32{IErr, IErr, IErr, IErr}, [4]int32{IErr, IErr, IErr, IErr}
 	sincolor, sinhue := [2]int32{IErr, IErr}, [2]int32{IErr, IErr}
 	invall, invblend, color, hue := IErr, IErr, float32(math.NaN()), float32(math.NaN())
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case modifyBGCtrl_id:
 			cid = exp[0].evalI(c)
 		case modifyBGCtrl_time:
@@ -11079,8 +11060,8 @@ func (sc modifyBgm) Run(c *Char, _ []int32) bool {
 	var volumeSet, loopStartSet, loopEndSet, posSet, freqSet = false, false, false, false, false
 	var volume, loopstart, loopend, position int = 100, 0, 0, 0
 	var freqmul float32 = 1.0
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case modifyBgm_volume:
 			volume = int(exp[0].evalI(c))
 			volumeSet = true
@@ -11162,8 +11143,8 @@ func (sc modifySnd) Run(c *Char, _ []int32) bool {
 	var p float32 = 0
 	x := &c.pos[0]
 	ls := crun.localscl
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case modifySnd_channel:
 			ch = exp[0].evalI(c)
 		case modifySnd_pan:
@@ -11315,8 +11296,8 @@ func (sc playBgm) Run(c *Char, _ []int32) bool {
 	var bgm string
 	var loop, loopcount, volume, loopstart, loopend, startposition int = 1, -1, 100, 0, 0, 0
 	var freqmul float32 = 1.0
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case playBgm_bgm:
 			bgm = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
 			// Default to stage BGM if string is stage
@@ -11374,6 +11355,7 @@ type targetDizzyPointsAdd StateControllerBase
 
 const (
 	targetDizzyPointsAdd_id byte = iota
+	targetDizzyPointsAdd_index
 	targetDizzyPointsAdd_absolute
 	targetDizzyPointsAdd_value
 	targetDizzyPointsAdd_redirectid
@@ -11381,34 +11363,32 @@ const (
 
 func (sc targetDizzyPointsAdd) Run(c *Char, _ []int32) bool {
 	crun := c
-	tar, a := crun.getTarget(-1), false
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	abs := false
+	tid, tidx := int32(-1), int(-1)
+	vl := int32(0)
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case targetDizzyPointsAdd_id:
-			if len(tar) == 0 {
-				return false
-			}
-			tar = crun.getTarget(exp[0].evalI(c))
+			tid = exp[0].evalI(c)
+		case targetDizzyPointsAdd_index:
+			tidx = int(exp[0].evalI(c))
 		case targetDizzyPointsAdd_absolute:
-			a = exp[0].evalB(c)
+			abs = exp[0].evalB(c)
 		case targetDizzyPointsAdd_value:
-			if len(tar) == 0 {
-				return false
-			}
-			crun.targetDizzyPointsAdd(tar, exp[0].evalI(c), a)
+			vl = exp[0].evalI(c)
 		case targetDizzyPointsAdd_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				tar = crun.getTarget(-1)
-				if len(tar) == 0 {
-					return false
-				}
 			} else {
 				return false
 			}
 		}
 		return true
 	})
+	tar := crun.getTarget(tid, tidx)
+	if len(tar) > 0 {
+		crun.targetDizzyPointsAdd(tar, vl, abs)
+	}
 	return false
 }
 
@@ -11416,6 +11396,7 @@ type targetGuardPointsAdd StateControllerBase
 
 const (
 	targetGuardPointsAdd_id byte = iota
+	targetGuardPointsAdd_index
 	targetGuardPointsAdd_absolute
 	targetGuardPointsAdd_value
 	targetGuardPointsAdd_redirectid
@@ -11423,34 +11404,32 @@ const (
 
 func (sc targetGuardPointsAdd) Run(c *Char, _ []int32) bool {
 	crun := c
-	tar, a := crun.getTarget(-1), false
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	abs := false
+	tid, tidx := int32(-1), int(-1)
+	vl := int32(0)
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case targetGuardPointsAdd_id:
-			if len(tar) == 0 {
-				return false
-			}
-			tar = crun.getTarget(exp[0].evalI(c))
+			tid = exp[0].evalI(c)
+		case targetGuardPointsAdd_index:
+			tidx = int(exp[0].evalI(c))
 		case targetGuardPointsAdd_absolute:
-			a = exp[0].evalB(c)
+			abs = exp[0].evalB(c)
 		case targetGuardPointsAdd_value:
-			if len(tar) == 0 {
-				return false
-			}
-			crun.targetGuardPointsAdd(tar, exp[0].evalI(c), a)
+			vl = exp[0].evalI(c)
 		case targetGuardPointsAdd_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
-				crun = rid
-				tar = crun.getTarget(-1)
-				if len(tar) == 0 {
-					return false
-				}
+					crun = rid
 			} else {
-				return false
+					return false
 			}
 		}
 		return true
 	})
+	tar := crun.getTarget(tid, tidx)
+	if len(tar) > 0 {
+		crun.targetGuardPointsAdd(tar, vl, abs)
+	}
 	return false
 }
 
@@ -11458,6 +11437,7 @@ type targetRedLifeAdd StateControllerBase
 
 const (
 	targetRedLifeAdd_id byte = iota
+	targetRedLifeAdd_index
 	targetRedLifeAdd_absolute
 	targetRedLifeAdd_value
 	targetRedLifeAdd_redirectid
@@ -11465,39 +11445,36 @@ const (
 
 func (sc targetRedLifeAdd) Run(c *Char, _ []int32) bool {
 	crun := c
-	tar, a := crun.getTarget(-1), false
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	abs := false
+	tid, tidx := int32(-1), int(-1)
+	vl := int32(0)
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case targetRedLifeAdd_id:
-			if len(tar) == 0 {
-				return false
-			}
-			tar = crun.getTarget(exp[0].evalI(c))
+			tid = exp[0].evalI(c)
+		case targetRedLifeAdd_index:
+			tidx = int(exp[0].evalI(c))
 		case targetRedLifeAdd_absolute:
-			a = exp[0].evalB(c)
+			abs = exp[0].evalB(c)
 		case targetRedLifeAdd_value:
-			if len(tar) == 0 {
-				return false
-			}
-			v := exp[0].evalI(c)
-			// Mugen forces absolute parameter when healing characters
-			if v > 0 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
-				a = true
-			}
-			crun.targetRedLifeAdd(tar, exp[0].evalI(c), a)
+			vl = exp[0].evalI(c)
 		case targetRedLifeAdd_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				tar = crun.getTarget(-1)
-				if len(tar) == 0 {
-					return false
-				}
 			} else {
 				return false
 			}
 		}
 		return true
 	})
+	// Mugen forces absolute parameter when healing characters
+	if vl > 0 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
+		abs = true
+	}
+	tar := crun.getTarget(tid, tidx)
+	if len(tar) > 0 {
+		crun.targetRedLifeAdd(tar, vl, abs)
+	}
 	return false
 }
 
@@ -11505,38 +11482,36 @@ type targetScoreAdd StateControllerBase
 
 const (
 	targetScoreAdd_id byte = iota
+	targetScoreAdd_index
 	targetScoreAdd_value
 	targetScoreAdd_redirectid
 )
 
 func (sc targetScoreAdd) Run(c *Char, _ []int32) bool {
 	crun := c
-	tar := crun.getTarget(-1)
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	tid, tidx := int32(-1), int(-1)
+	vl := float32(0)
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case targetScoreAdd_id:
-			if len(tar) == 0 {
-				return false
-			}
-			tar = crun.getTarget(exp[0].evalI(c))
+			tid = exp[0].evalI(c)
+		case targetScoreAdd_index:
+			tidx = int(exp[0].evalI(c))
 		case targetScoreAdd_value:
-			if len(tar) == 0 {
-				return false
-			}
-			crun.targetScoreAdd(tar, exp[0].evalF(c))
+			vl = exp[0].evalF(c)
 		case targetScoreAdd_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-				tar = crun.getTarget(-1)
-				if len(tar) == 0 {
-					return false
-				}
 			} else {
 				return false
 			}
 		}
 		return true
 	})
+	tar := crun.getTarget(tid, tidx)
+	if len(tar) > 0 {
+		crun.targetScoreAdd(tar, vl)
+	}
 	return false
 }
 
@@ -11572,8 +11547,8 @@ func (sc text) Run(c *Char, _ []int32) bool {
 	var xscl, yscl float32 = 1, 1
 	var fnt int = -1
 	ts.ownerid = ownerID
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case text_removetime:
 			ts.removetime = exp[0].evalI(c)
 		case text_layerno:
@@ -11689,8 +11664,8 @@ const (
 func (sc removeText) Run(c *Char, _ []int32) bool {
 	crun := c
 	textID := int32(-1)
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case removetext_id:
 			textID = exp[0].evalI(c)
 		case removetext_redirectid:
@@ -11732,8 +11707,8 @@ func (sc createPlatform) Run(schara *Char, _ []int32) bool {
 		activeTime: -1,
 	}
 
-	StateControllerBase(sc).run(schara, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(schara, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case createPlatform_id:
 			plat.id = exp[0].evalI(schara)
 		case createPlatform_name:
@@ -11835,8 +11810,8 @@ const (
 func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 	//crun := c RedirectID is pointless when modifying a stage
 	s := sys.stage
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		// Camera group
 		case modifyStageVar_camera_autocenter:
 			s.stageCamera.autocenter = exp[0].evalB(c)
@@ -11974,8 +11949,8 @@ const (
 
 func (sc cameraCtrl) Run(c *Char, _ []int32) bool {
 	//crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case cameraCtrl_view:
 			sys.cam.View = CameraView(exp[0].evalI(c))
 			if sys.cam.View == Follow_View {
@@ -12006,8 +11981,8 @@ const (
 func (sc height) Run(c *Char, _ []int32) bool {
 	crun := c
 	var redirscale float32 = 1.0
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case height_value:
 			var v1, v2 float32
 			v1 = exp[0].evalF(c)
@@ -12040,8 +12015,8 @@ const (
 func (sc depth) Run(c *Char, _ []int32) bool {
 	crun := c
 	var redirscale float32 = 1.0
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case depth_player:
 			var v1, v2 float32
 			v1 = exp[0].evalF(c)
@@ -12102,8 +12077,8 @@ const (
 // TODO: Undo all effects if a cached character is loaded
 func (sc modifyPlayer) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case modifyPlayer_lifemax:
 			lm := exp[0].evalI(c)
 			if lm < 1 {
@@ -12237,8 +12212,8 @@ const (
 func (sc getHitVarSet) Run(c *Char, _ []int32) bool {
 	crun := c
 	var redirscale float32 = 1.0
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case getHitVarSet_airtype:
 			crun.ghv.airtype = HitType(exp[0].evalI(c))
 		case getHitVarSet_animtype:
@@ -12330,8 +12305,8 @@ const (
 func (sc groundLevelOffset) Run(c *Char, _ []int32) bool {
 	crun := c
 	var redirscale float32 = 1.0
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case groundLevelOffset_value:
 			crun.groundLevel = exp[0].evalF(c) * redirscale
 		case groundLevelOffset_redirectid:
@@ -12357,8 +12332,8 @@ const (
 func (sc targetAdd) Run(c *Char, _ []int32) bool {
 	crun := c
 	var pid int32
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case targetAdd_playerid:
 			pid = exp[0].evalI(c)
 		case targetAdd_redirectid:
@@ -12412,8 +12387,8 @@ const (
 
 func (sc transformClsn) Run(c *Char, _ []int32) bool {
 	crun := c
-	StateControllerBase(sc).run(c, func(id byte, exp []BytecodeExp) bool {
-		switch id {
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
 		case transformClsn_scale:
 			crun.clsnScaleMul[0] *= exp[0].evalF(c)
 			if len(exp) > 1 {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1489,7 +1489,9 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.Push(BytecodeSF())
 			i += int(*(*int32)(unsafe.Pointer(&be[i]))) + 4
 		case OC_helper:
-			if c = c.helper(sys.bcStack.Pop().ToI()); c != nil {
+			v2 := sys.bcStack.Pop().ToI()
+			v1 := sys.bcStack.Pop().ToI()
+			if c = c.helperTrigger(v1, int(v2)); c != nil {
 				i += 4
 				continue
 			}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -847,20 +847,26 @@ const (
 	OC_ex2_projvar_velmul_x
 	OC_ex2_projvar_velmul_y
 	OC_ex2_projvar_velmul_z
-	OC_ex2_hitdefvar_guardflag
-	OC_ex2_hitdefvar_hitflag
+	OC_ex2_hitdefvar_guard_pausetime
+	OC_ex2_hitdefvar_guard_shaketime
+	OC_ex2_hitdefvar_guard_sparkno
 	OC_ex2_hitdefvar_guarddamage
+	OC_ex2_hitdefvar_guardflag
+	OC_ex2_hitdefvar_guardsound_group
+	OC_ex2_hitdefvar_guardsound_number
 	OC_ex2_hitdefvar_hitdamage
+	OC_ex2_hitdefvar_hitflag
+	OC_ex2_hitdefvar_hitsound_group
+	OC_ex2_hitdefvar_hitsound_number
+	OC_ex2_hitdefvar_id
 	OC_ex2_hitdefvar_p1stateno
 	OC_ex2_hitdefvar_p2stateno
+	OC_ex2_hitdefvar_pausetime
 	OC_ex2_hitdefvar_priority
-	OC_ex2_hitdefvar_id
+	OC_ex2_hitdefvar_shaketime
+	OC_ex2_hitdefvar_sparkno
 	OC_ex2_hitdefvar_sparkx
 	OC_ex2_hitdefvar_sparky
-	OC_ex2_hitdefvar_pausetime
-	OC_ex2_hitdefvar_guard_pausetime
-	OC_ex2_hitdefvar_shaketime
-	OC_ex2_hitdefvar_guard_shaketime
 	OC_ex2_hitbyattr
 	OC_ex2_soundvar_group
 	OC_ex2_soundvar_number
@@ -3645,6 +3651,10 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(c.hitdef.priority)
 	case OC_ex2_hitdefvar_id:
 		sys.bcStack.PushI(c.hitdef.id)
+	case OC_ex2_hitdefvar_sparkno:
+		sys.bcStack.PushI(c.hitdef.sparkno)
+	case OC_ex2_hitdefvar_guard_sparkno:
+		sys.bcStack.PushI(c.hitdef.guard_sparkno)
 	case OC_ex2_hitdefvar_sparkx:
 		sys.bcStack.PushF(c.hitdef.sparkxy[0] * (c.localscl / oc.localscl))
 	case OC_ex2_hitdefvar_sparky:
@@ -3657,6 +3667,15 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(c.hitdef.shaketime)
 	case OC_ex2_hitdefvar_guard_shaketime:
 		sys.bcStack.PushI(c.hitdef.guard_shaketime)
+	case OC_ex2_hitdefvar_hitsound_group:
+		sys.bcStack.PushI(c.hitdef.hitsound[0])
+	case OC_ex2_hitdefvar_hitsound_number:
+		sys.bcStack.PushI(c.hitdef.hitsound[1])
+	case OC_ex2_hitdefvar_guardsound_group:
+		sys.bcStack.PushI(c.hitdef.guardsound[0])
+	case OC_ex2_hitdefvar_guardsound_number:
+		sys.bcStack.PushI(c.hitdef.guardsound[1])
+	// HitByAttr
 	case OC_ex2_hitbyattr:
 		sys.bcStack.PushB(c.hitByAttrTrigger(*(*int32)(unsafe.Pointer(&be[*i]))))
 		*i += 4

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -2726,89 +2726,48 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		}
 	case OC_ex_airjumpcount:
 		sys.bcStack.PushI(c.airJumpCount)
-	case OC_ex_animelemvar_alphadest:
-		if f := c.anim.CurrentFrame(); f != nil {
-			sys.bcStack.PushI(int32(f.DstAlpha))
+	// AnimelemVar
+	case OC_ex_animelemvar_alphadest, OC_ex_animelemvar_alphasource, OC_ex_animelemvar_angle,
+		OC_ex_animelemvar_group, OC_ex_animelemvar_hflip, OC_ex_animelemvar_image,
+		OC_ex_animelemvar_time, OC_ex_animelemvar_vflip, OC_ex_animelemvar_xoffset,
+		OC_ex_animelemvar_xscale, OC_ex_animelemvar_yoffset, OC_ex_animelemvar_yscale,
+		OC_ex_animelemvar_numclsn1, OC_ex_animelemvar_numclsn2:
+		// Check for valid animation frame
+		f := c.anim.CurrentFrame()
+		// Handle output
+		if f != nil {
+			switch opc {
+			case OC_ex_animelemvar_alphadest:
+				sys.bcStack.PushI(int32(f.DstAlpha))
+			case OC_ex_animelemvar_alphasource:
+				sys.bcStack.PushI(int32(f.SrcAlpha))
+			case OC_ex_animelemvar_angle:
+				sys.bcStack.PushF(f.Angle)
+			case OC_ex_animelemvar_group:
+				sys.bcStack.PushI(int32(f.Group))
+			case OC_ex_animelemvar_hflip:
+				sys.bcStack.PushB(f.Hscale < 0)
+			case OC_ex_animelemvar_image:
+				sys.bcStack.PushI(int32(f.Number))
+			case OC_ex_animelemvar_time:
+				sys.bcStack.PushI(f.Time)
+			case OC_ex_animelemvar_vflip:
+				sys.bcStack.PushB(f.Vscale < 0)
+			case OC_ex_animelemvar_xoffset:
+				sys.bcStack.PushI(int32(f.Xoffset))
+			case OC_ex_animelemvar_xscale:
+				sys.bcStack.PushF(f.Xscale)
+			case OC_ex_animelemvar_yoffset:
+				sys.bcStack.PushI(int32(f.Yoffset))
+			case OC_ex_animelemvar_yscale:
+				sys.bcStack.PushF(f.Yscale)
+			case OC_ex_animelemvar_numclsn1:
+				sys.bcStack.PushI(int32(len(f.Clsn1()) / 4))
+			case OC_ex_animelemvar_numclsn2:
+				sys.bcStack.PushI(int32(len(f.Clsn2()) / 4))
+			}
 		} else {
-			sys.bcStack.PushI(0)
-		}
-	case OC_ex_animelemvar_angle:
-		if f := c.anim.CurrentFrame(); f != nil {
-			sys.bcStack.PushF(f.Angle)
-		} else {
-			sys.bcStack.PushI(0)
-		}
-	case OC_ex_animelemvar_alphasource:
-		if f := c.anim.CurrentFrame(); f != nil {
-			sys.bcStack.PushI(int32(f.SrcAlpha))
-		} else {
-			sys.bcStack.PushI(0)
-		}
-	case OC_ex_animelemvar_group:
-		if f := c.anim.CurrentFrame(); f != nil {
-			sys.bcStack.PushI(int32(f.Group))
-		} else {
-			sys.bcStack.PushI(-1)
-		}
-	case OC_ex_animelemvar_hflip:
-		if f := c.anim.CurrentFrame(); f != nil {
-			sys.bcStack.PushB(f.Hscale < 0)
-		} else {
-			sys.bcStack.PushI(0)
-		}
-	case OC_ex_animelemvar_image:
-		if f := c.anim.CurrentFrame(); f != nil {
-			sys.bcStack.PushI(int32(f.Number))
-		} else {
-			sys.bcStack.PushI(-1)
-		}
-	case OC_ex_animelemvar_time:
-		if f := c.anim.CurrentFrame(); f != nil {
-			sys.bcStack.PushI(f.Time)
-		} else {
-			sys.bcStack.PushI(-1)
-		}
-	case OC_ex_animelemvar_vflip:
-		if f := c.anim.CurrentFrame(); f != nil {
-			sys.bcStack.PushB(f.Vscale < 0)
-		} else {
-			sys.bcStack.PushI(0)
-		}
-	case OC_ex_animelemvar_xoffset:
-		if f := c.anim.CurrentFrame(); f != nil {
-			sys.bcStack.PushI(int32(f.Xoffset))
-		} else {
-			sys.bcStack.PushI(0)
-		}
-	case OC_ex_animelemvar_xscale:
-		if f := c.anim.CurrentFrame(); f != nil {
-			sys.bcStack.PushF(f.Xscale)
-		} else {
-			sys.bcStack.PushI(0)
-		}
-	case OC_ex_animelemvar_yoffset:
-		if f := c.anim.CurrentFrame(); f != nil {
-			sys.bcStack.PushI(int32(f.Yoffset))
-		} else {
-			sys.bcStack.PushI(0)
-		}
-	case OC_ex_animelemvar_yscale:
-		if f := c.anim.CurrentFrame(); f != nil {
-			sys.bcStack.PushF(f.Yscale)
-		} else {
-			sys.bcStack.PushI(0)
-		}
-	case OC_ex_animelemvar_numclsn1:
-		if f := c.anim.CurrentFrame(); f != nil {
-			sys.bcStack.PushI(int32(len(f.Clsn1()) / 4))
-		} else {
-			sys.bcStack.PushI(0)
-		}
-	case OC_ex_animelemvar_numclsn2:
-		if f := c.anim.CurrentFrame(); f != nil {
-			sys.bcStack.PushI(int32(len(f.Clsn2()) / 4))
-		} else {
-			sys.bcStack.PushI(0)
+			sys.bcStack.Push(BytecodeSF())
 		}
 	case OC_ex_animlength:
 		sys.bcStack.PushI(c.anim.totaltime)
@@ -2913,101 +2872,48 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushB(c.ss.sb.playerNo != c.playerNo)
 	case OC_ex_indialogue:
 		sys.bcStack.PushB(sys.dialogueFlg)
-	case OC_ex_inputtime_B:
+	// InputTime
+	case OC_ex_inputtime_B, OC_ex_inputtime_D, OC_ex_inputtime_F, OC_ex_inputtime_U, OC_ex_inputtime_L, OC_ex_inputtime_R,
+		OC_ex_inputtime_a, OC_ex_inputtime_b, OC_ex_inputtime_c, OC_ex_inputtime_x, OC_ex_inputtime_y, OC_ex_inputtime_z,
+		OC_ex_inputtime_s, OC_ex_inputtime_d, OC_ex_inputtime_w, OC_ex_inputtime_m:
+		// Check for valid inputs
 		if c.keyctrl[0] && c.cmd != nil {
-			sys.bcStack.PushI(c.cmd[0].Buffer.Bb)
+			switch opc {
+			case OC_ex_inputtime_B:
+				sys.bcStack.PushI(c.cmd[0].Buffer.Bb)
+			case OC_ex_inputtime_D:
+				sys.bcStack.PushI(c.cmd[0].Buffer.Db)
+			case OC_ex_inputtime_F:
+				sys.bcStack.PushI(c.cmd[0].Buffer.Fb)
+			case OC_ex_inputtime_U:
+				sys.bcStack.PushI(c.cmd[0].Buffer.Ub)
+			case OC_ex_inputtime_L:
+				sys.bcStack.PushI(c.cmd[0].Buffer.Lb)
+			case OC_ex_inputtime_R:
+				sys.bcStack.PushI(c.cmd[0].Buffer.Rb)
+			case OC_ex_inputtime_a:
+				sys.bcStack.PushI(c.cmd[0].Buffer.ab)
+			case OC_ex_inputtime_b:
+				sys.bcStack.PushI(c.cmd[0].Buffer.bb)
+			case OC_ex_inputtime_c:
+				sys.bcStack.PushI(c.cmd[0].Buffer.cb)
+			case OC_ex_inputtime_x:
+				sys.bcStack.PushI(c.cmd[0].Buffer.xb)
+			case OC_ex_inputtime_y:
+				sys.bcStack.PushI(c.cmd[0].Buffer.yb)
+			case OC_ex_inputtime_z:
+				sys.bcStack.PushI(c.cmd[0].Buffer.zb)
+			case OC_ex_inputtime_s:
+				sys.bcStack.PushI(c.cmd[0].Buffer.sb)
+			case OC_ex_inputtime_d:
+				sys.bcStack.PushI(c.cmd[0].Buffer.db)
+			case OC_ex_inputtime_w:
+				sys.bcStack.PushI(c.cmd[0].Buffer.wb)
+			case OC_ex_inputtime_m:
+				sys.bcStack.PushI(c.cmd[0].Buffer.mb)
+			}
 		} else {
-			sys.bcStack.PushI(0)
-		}
-	case OC_ex_inputtime_D:
-		if c.keyctrl[0] && c.cmd != nil {
-			sys.bcStack.PushI(c.cmd[0].Buffer.Db)
-		} else {
-			sys.bcStack.PushI(0)
-		}
-	case OC_ex_inputtime_F:
-		if c.keyctrl[0] && c.cmd != nil {
-			sys.bcStack.PushI(c.cmd[0].Buffer.Fb)
-		} else {
-			sys.bcStack.PushI(0)
-		}
-	case OC_ex_inputtime_U:
-		if c.keyctrl[0] && c.cmd != nil {
-			sys.bcStack.PushI(c.cmd[0].Buffer.Ub)
-		} else {
-			sys.bcStack.PushI(0)
-		}
-	case OC_ex_inputtime_L:
-		if c.keyctrl[0] && c.cmd != nil {
-			sys.bcStack.PushI(c.cmd[0].Buffer.Lb)
-		} else {
-			sys.bcStack.PushI(0)
-		}
-	case OC_ex_inputtime_R:
-		if c.keyctrl[0] && c.cmd != nil {
-			sys.bcStack.PushI(c.cmd[0].Buffer.Rb)
-		} else {
-			sys.bcStack.PushI(0)
-		}
-	case OC_ex_inputtime_a:
-		if c.keyctrl[0] && c.cmd != nil {
-			sys.bcStack.PushI(c.cmd[0].Buffer.ab)
-		} else {
-			sys.bcStack.PushI(0)
-		}
-	case OC_ex_inputtime_b:
-		if c.keyctrl[0] && c.cmd != nil {
-			sys.bcStack.PushI(c.cmd[0].Buffer.bb)
-		} else {
-			sys.bcStack.PushI(0)
-		}
-	case OC_ex_inputtime_c:
-		if c.keyctrl[0] && c.cmd != nil {
-			sys.bcStack.PushI(c.cmd[0].Buffer.cb)
-		} else {
-			sys.bcStack.PushI(0)
-		}
-	case OC_ex_inputtime_x:
-		if c.keyctrl[0] && c.cmd != nil {
-			sys.bcStack.PushI(c.cmd[0].Buffer.xb)
-		} else {
-			sys.bcStack.PushI(0)
-		}
-	case OC_ex_inputtime_y:
-		if c.keyctrl[0] && c.cmd != nil {
-			sys.bcStack.PushI(c.cmd[0].Buffer.yb)
-		} else {
-			sys.bcStack.PushI(0)
-		}
-	case OC_ex_inputtime_z:
-		if c.keyctrl[0] && c.cmd != nil {
-			sys.bcStack.PushI(c.cmd[0].Buffer.zb)
-		} else {
-			sys.bcStack.PushI(0)
-		}
-	case OC_ex_inputtime_s:
-		if c.keyctrl[0] && c.cmd != nil {
-			sys.bcStack.PushI(c.cmd[0].Buffer.sb)
-		} else {
-			sys.bcStack.PushI(0)
-		}
-	case OC_ex_inputtime_d:
-		if c.keyctrl[0] && c.cmd != nil {
-			sys.bcStack.PushI(c.cmd[0].Buffer.db)
-		} else {
-			sys.bcStack.PushI(0)
-		}
-	case OC_ex_inputtime_w:
-		if c.keyctrl[0] && c.cmd != nil {
-			sys.bcStack.PushI(c.cmd[0].Buffer.wb)
-		} else {
-			sys.bcStack.PushI(0)
-		}
-	case OC_ex_inputtime_m:
-		if c.keyctrl[0] && c.cmd != nil {
-			sys.bcStack.PushI(c.cmd[0].Buffer.mb)
-		} else {
-			sys.bcStack.PushI(0)
+			sys.bcStack.Push(BytecodeSF())
 		}
 	case OC_ex_isassertedchar:
 		sys.bcStack.PushB(c.asf(AssertSpecialFlag((*(*int64)(unsafe.Pointer(&be[*i]))))))

--- a/src/char.go
+++ b/src/char.go
@@ -3658,15 +3658,22 @@ func (c *Char) helperByIndexExist(id BytecodeValue) BytecodeValue {
 	return BytecodeBool(c.getPlayerHelperIndex(id.ToI(), false) != nil)
 }
 
-func (c *Char) target(id int32) *Char {
+func (c *Char) target(id int32, idx int) *Char {
+	// Filter targets with provided ID
+	var filteredTargets []*Char
 	for _, tid := range c.targets {
 		if t := sys.playerID(tid); t != nil && (id < 0 || id == t.ghv.hitid) {
-			return t
+			filteredTargets = append(filteredTargets, t)
 		}
 	}
-	if id != -1 {
-		sys.appendToConsole(c.warn() + fmt.Sprintf("has no target: %v", id))
+
+	// Index must be within bounds
+	if idx >= 0 && idx < len(filteredTargets) {
+		return filteredTargets[idx]
 	}
+
+	// No valid target found
+	sys.appendToConsole(c.warn() + fmt.Sprintf("has no target with hit ID %v and index %v", id, idx))
 	return nil
 }
 

--- a/src/char.go
+++ b/src/char.go
@@ -5995,6 +5995,32 @@ func (c *Char) getStageBg(id int32, idx int, log bool) *backGround {
 	return nil
 }
 
+// Get multiple stage BG elements for ModifyStageBG sctrl
+func (c *Char) getMultipleStageBg(id int32, idx int, log bool) []*backGround {
+    // Filter background elements with the specified ID
+    var filteredBg []*backGround
+    for _, bg := range sys.stage.bg {
+        if id < 0 || id == bg.id {
+            filteredBg = append(filteredBg, bg)
+            // If idx is valid and we've reached the requested index, return the single element
+            if idx >= 0 && len(filteredBg) == idx+1 {
+                return []*backGround{filteredBg[idx]}
+            }
+        }
+    }
+
+    // Return multiple instances if idx is negative
+    if idx < 0 {
+        return filteredBg
+    }
+
+    // No valid background element found
+    if log {
+        sys.appendToConsole(c.warn() + fmt.Sprintf("has no background element with ID %v and index %v", id, idx))
+    }
+    return nil
+}
+
 // Get list of targets for the Target state controllers
 func (c *Char) getTarget(id int32, idx int) []int32 {
 	// If ID and index are negative, just return all targets

--- a/src/char.go
+++ b/src/char.go
@@ -3634,13 +3634,27 @@ func (c *Char) root() *Char {
 	return sys.chars[c.playerNo][0]
 }
 
-func (c *Char) helper(id int32) *Char {
+func (c *Char) helperTrigger(id int32, idx int) *Char {
+	// Invalid index
+	if idx < 0 {
+		sys.appendToConsole(c.warn() + "helper redirection index cannot be negative")
+		return nil
+	}
+
+	// Filter helpers with the specified ID
+	var filteredHelpers []*Char
 	for _, h := range sys.chars[c.playerNo][1:] {
 		if !h.csf(CSF_destroy) && (id <= 0 || id == h.helperId) {
-			return h
+			filteredHelpers = append(filteredHelpers, h)
+			// Helper found at requested index
+			if idx >= 0 && len(filteredHelpers) == idx+1 {
+				return filteredHelpers[idx]
+			}
 		}
 	}
-	sys.appendToConsole(c.warn() + fmt.Sprintf("has no helper: %v", id))
+
+	// No valid helper found
+	sys.appendToConsole(c.warn() + fmt.Sprintf("has no helper with ID %v and index %v", id, idx))
 	return nil
 }
 
@@ -3662,11 +3676,11 @@ func (c *Char) helperByIndexExist(id BytecodeValue) BytecodeValue {
 func (c *Char) targetTrigger(id int32, idx int) *Char {
 	// Invalid index
 	if idx < 0 {
-		sys.appendToConsole(c.warn() + fmt.Sprintf("invalid target index: %v", idx))
+		sys.appendToConsole(c.warn() + "target redirection index cannot be negative")
 		return nil
 	}
 
-	// Filter targets with provided ID
+	// Filter targets with the specified ID
 	var filteredTargets []*Char
 	for _, tid := range c.targets {
 		if t := sys.playerID(tid); t != nil && (id < 0 || id == t.ghv.hitid) {

--- a/src/char.go
+++ b/src/char.go
@@ -3658,18 +3658,24 @@ func (c *Char) helperByIndexExist(id BytecodeValue) BytecodeValue {
 	return BytecodeBool(c.getPlayerHelperIndex(id.ToI(), false) != nil)
 }
 
+// Target redirection
 func (c *Char) targetTrigger(id int32, idx int) *Char {
+	// Invalid index
+	if idx < 0 {
+		sys.appendToConsole(c.warn() + fmt.Sprintf("invalid target index: %v", idx))
+		return nil
+	}
+
 	// Filter targets with provided ID
 	var filteredTargets []*Char
 	for _, tid := range c.targets {
 		if t := sys.playerID(tid); t != nil && (id < 0 || id == t.ghv.hitid) {
 			filteredTargets = append(filteredTargets, t)
+			// Target found at requested index
+			if idx >= 0 && len(filteredTargets) == idx+1 {
+				return filteredTargets[idx]
+			}
 		}
-	}
-
-	// Return target at index specified
-	if idx >= 0 && idx < len(filteredTargets) {
-		return filteredTargets[idx]
 	}
 
 	// No valid target found
@@ -5946,6 +5952,7 @@ func (c *Char) setFacing(f float32) {
 	}
 }
 
+// Get list of targets for the Target state controllers
 func (c *Char) getTarget(id int32, idx int) []int32 {
 	// If ID and index are negative, just return all targets
 	// In Mugen the ID must be specifically -1
@@ -5959,16 +5966,15 @@ func (c *Char) getTarget(id int32, idx int) []int32 {
 		if t := sys.playerID(tid); t != nil && (id < 0 || t.ghv.hitid == id) {
 			filteredTargets = append(filteredTargets, tid)
 		}
+		// Target found at requested index
+		if idx >= 0 && len(filteredTargets) == idx+1 {
+			return []int32{filteredTargets[idx]}
+		}
 	}
 
 	// If index is negative, return all targets with specified ID
 	if idx < 0 {
 		return filteredTargets
-	}
-
-	// Return target with given ID at given index
-	if idx >= 0 && idx < len(filteredTargets) {
-		return []int32{filteredTargets[idx]}
 	}
 
 	// No valid target found

--- a/src/char.go
+++ b/src/char.go
@@ -1577,7 +1577,7 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 		pos:          drawpos,
 		scl:          drawscale,
 		alpha:        alp,
-		priority:     e.sprpriority + int32(e.pos[2]*e.localscl),
+		priority:     e.sprpriority + int32(e.interPos[2]*e.localscl),
 		rot:          rot,
 		ascl:         [...]float32{1, 1},
 		screen:       e.space == Space_screen,

--- a/src/char.go
+++ b/src/char.go
@@ -5966,6 +5966,35 @@ func (c *Char) setFacing(f float32) {
 	}
 }
 
+// Get stage BG elements for StageBGVar trigger
+func (c *Char) getStageBg(id int32, idx int, log bool) *backGround {
+	// Invalid index
+	if idx < 0 {
+		if log {
+			sys.appendToConsole(c.warn() + "background element index cannot be negative")
+		}
+		return nil
+	}
+
+	// Filter background elements with the specified ID
+	var filteredBg []*backGround
+	for _, bg := range sys.stage.bg {
+		if id < 0 || id == bg.id {
+			filteredBg = append(filteredBg, bg)
+			// Background element found at requested index
+			if idx >= 0 && len(filteredBg) == idx+1 {
+				return filteredBg[idx]
+			}
+		}
+	}
+
+	// No valid background element found
+	if log {
+		sys.appendToConsole(c.warn() + fmt.Sprintf("has no background element with ID %v and index %v", id, idx))
+	}
+	return nil
+}
+
 // Get list of targets for the Target state controllers
 func (c *Char) getTarget(id int32, idx int) []int32 {
 	// If ID and index are negative, just return all targets

--- a/src/char.go
+++ b/src/char.go
@@ -5166,7 +5166,7 @@ func (c *Char) newExplod() (*Explod, int) {
 		expl.playerId = c.id
 		expl.layerno = c.layerNo
 		expl.palfx = c.getPalfx()
-		expl.palfxdef = PalFXDef{color: 1, hue: 0, mul: [...]int32{256, 256, 256}}
+		expl.palfxdef = *newPalFXDef()
 		if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
 			expl.projection = Projection_Perspective
 		} else {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -182,6 +182,7 @@ func newCompiler() *Compiler {
 		"teammapset":           c.teamMapSet,
 		"text":                 c.text,
 		"transformclsn":        c.transformClsn,
+		"modifystagebg":        c.modifyStageBG,
 	}
 	return c
 }
@@ -3274,8 +3275,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		vname := c.token
 		var opc OpCode
 		switch vname {
-		case "anim":
-			opc = OC_ex2_stagebgvar_anim
+		case "actionno":
+			opc = OC_ex2_stagebgvar_actionno
 		case "delta":
 			c.token = c.tokenizer(in)
 			switch c.token {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2495,6 +2495,10 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			opc = OC_ex2_hitdefvar_priority
 		case "id":
 			opc = OC_ex2_hitdefvar_id
+		case "sparkno":
+			opc = OC_ex2_hitdefvar_sparkno
+		case "guard.sparkno":
+			opc = OC_ex2_hitdefvar_guard_sparkno
 		case "sparkx":
 			opc = OC_ex2_hitdefvar_sparkx
 		case "sparky":
@@ -2507,6 +2511,14 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			opc = OC_ex2_hitdefvar_shaketime
 		case "guard.shaketime":
 			opc = OC_ex2_hitdefvar_guard_shaketime
+		case "hitsound.group":
+			opc = OC_ex2_hitdefvar_hitsound_group
+		case "hitsound.number":
+			opc = OC_ex2_hitdefvar_hitsound_number
+		case "guardsound.group":
+			opc = OC_ex2_hitdefvar_guardsound_group
+		case "guardsound.number":
+			opc = OC_ex2_hitdefvar_guardsound_number
 		default:
 			return bvNone(), Error("Invalid data: " + c.token)
 		}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1281,12 +1281,10 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(be2...)
 		return bvNone(), nil
 	// Redirections with 1 argument
-	case "helper", "partner", "enemy", "enemynear", "playerid", "player", "playerindex", "helperindex":
+	case "partner", "enemy", "enemynear", "playerid", "player", "playerindex", "helperindex":
 		switch c.token {
 		case "player":
 			opc = OC_player
-		case "helper":
-			opc = OC_helper
 		case "partner":
 			opc = OC_partner
 		case "enemy":
@@ -1313,8 +1311,6 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			be1.appendValue(bv1)
 		} else {
 			switch opc {
-			case OC_helper:
-				be1.appendValue(BytecodeInt(-1))
 			case OC_partner, OC_enemy, OC_enemynear:
 				be1.appendValue(BytecodeInt(0))
 			case OC_player:
@@ -1343,8 +1339,13 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(be2...)
 		return bvNone(), nil
 	// Redirections with 2 arguments
-	case "target":
-		opc = OC_target
+	case "helper", "target":
+		switch c.token {
+		case "helper":
+			opc = OC_helper
+		case "target":
+			opc = OC_target
+		}
 		c.token = c.tokenizer(in)
 		if c.token == "(" {
 			c.token = c.tokenizer(in)
@@ -1361,7 +1362,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				}
 				be1.appendValue(bv2)
 			} else {
-				// If not then default index to 0
+				// If not, default index to 0
 				be1.appendValue(BytecodeInt(0))
 			}
 			if err := c.checkClosingBracket(); err != nil {

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -5823,6 +5823,126 @@ func (c *Compiler) transformClsn(is IniSection, sc *StateControllerBase, _ int8)
 	return *ret, err
 }
 
+func (c *Compiler) modifyStageBG(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+	ret, err := (*modifyStageBG)(sc), c.stateSec(is, func() error {
+		//if err := c.paramValue(is, sc, "redirectid",
+		//	modifyStageBG_redirectid, VT_Int, 1, false); err != nil {
+		//	return err
+		//}
+		if err := c.paramValue(is, sc, "id",
+			modifyStageBG_id, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "index",
+			modifyStageBG_index, VT_Int, 1, false); err != nil {
+			return err
+		}
+		any := false
+		if err := c.stateParam(is, "actionno", false, func(data string) error {
+			any = true
+			return c.scAdd(sc, modifyStageBG_actionno, data, VT_Int, 1)
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "delta.x", false, func(data string) error {
+			any = true
+			return c.scAdd(sc, modifyStageBG_delta_x, data, VT_Float, 2)
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "delta.y", false, func(data string) error {
+			any = true
+			return c.scAdd(sc, modifyStageBG_delta_y, data, VT_Float, 1)
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "layerno", false, func(data string) error {
+			any = true
+			return c.scAdd(sc, modifyStageBG_layerno, data, VT_Float, 2)
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "pos.x", false, func(data string) error {
+			any = true
+			return c.scAdd(sc, modifyStageBG_pos_x, data, VT_Float, 2)
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "pos.y", false, func(data string) error {
+			any = true
+			return c.scAdd(sc, modifyStageBG_pos_y, data, VT_Float, 1)
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "spriteno", false, func(data string) error {
+			any = true
+			return c.scAdd(sc, modifyStageBG_spriteno, data, VT_Int, 2)
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "start.x", false, func(data string) error {
+			any = true
+			return c.scAdd(sc, modifyStageBG_start_x, data, VT_Float, 2)
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "start.y", false, func(data string) error {
+			any = true
+			return c.scAdd(sc, modifyStageBG_start_y, data, VT_Float, 1)
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "trans", false, func(data string) error {
+			if len(data) == 0 {
+				return Error("Trans type not specified")
+			}
+			any = true
+			var blend int32
+			switch strings.ToLower(data) {
+			case "none":
+				blend = 0
+			case "add":
+				blend = 1
+			case "add1":
+				blend = 2
+			case "addalpha":
+				blend = 3
+			case "sub":
+				blend = 4
+			default:
+				return Error("Invalid trans type: " + data)
+			}
+			sc.add(modifyStageBG_trans, sc.iToExp(blend))
+			return nil
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "alpha", false, func(data string) error { // Best if placed after trans
+			any = true
+			return c.scAdd(sc, modifyStageBG_alpha, data, VT_Int, 2)
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "vel.x", false, func(data string) error {
+			any = true
+			return c.scAdd(sc, modifyStageBG_vel_x, data, VT_Float, 2)
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "vel.y", false, func(data string) error {
+			any = true
+			return c.scAdd(sc, modifyStageBG_vel_y, data, VT_Float, 1)
+		}); err != nil {
+			return err
+		}
+		if !any {
+			return Error("Must specify at least one ModifyStageBG parameter")
+		}
+		return nil
+	})
+	return *ret, err
+}
+
 // It's just a Null... Has no effect whatsoever.
 func (c *Compiler) null(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	return nullStateController, nil

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -87,6 +87,7 @@ func (c *Compiler) hitBy(is IniSection, sc *StateControllerBase, _ int8) (StateC
 	})
 	return *ret, err
 }
+
 func (c *Compiler) notHitBy(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*notHitBy)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -97,6 +98,7 @@ func (c *Compiler) notHitBy(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	})
 	return *ret, err
 }
+
 func (c *Compiler) assertSpecial(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*assertSpecial)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -297,6 +299,7 @@ func (c *Compiler) assertSpecial(is IniSection, sc *StateControllerBase, _ int8)
 	})
 	return *ret, err
 }
+
 func (c *Compiler) playSnd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*playSnd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -374,6 +377,7 @@ func (c *Compiler) playSnd(is IniSection, sc *StateControllerBase, _ int8) (Stat
 	})
 	return *ret, err
 }
+
 func (c *Compiler) changeStateSub(is IniSection,
 	sc *StateControllerBase) error {
 	if err := c.paramValue(is, sc, "redirectid",
@@ -411,18 +415,21 @@ func (c *Compiler) changeStateSub(is IniSection,
 	}
 	return nil
 }
+
 func (c *Compiler) changeState(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*changeState)(sc), c.stateSec(is, func() error {
 		return c.changeStateSub(is, sc)
 	})
 	return *ret, err
 }
+
 func (c *Compiler) selfState(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*selfState)(sc), c.stateSec(is, func() error {
 		return c.changeStateSub(is, sc)
 	})
 	return *ret, err
 }
+
 func (c *Compiler) tagIn(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*tagIn)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -458,6 +465,7 @@ func (c *Compiler) tagIn(is IniSection, sc *StateControllerBase, _ int8) (StateC
 	//}
 	return *ret, err
 }
+
 func (c *Compiler) tagOut(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*tagOut)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -484,6 +492,7 @@ func (c *Compiler) tagOut(is IniSection, sc *StateControllerBase, _ int8) (State
 	//}
 	return *ret, err
 }
+
 func (c *Compiler) destroySelf(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*destroySelf)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -506,6 +515,7 @@ func (c *Compiler) destroySelf(is IniSection, sc *StateControllerBase, _ int8) (
 	})
 	return *ret, err
 }
+
 func (c *Compiler) changeAnimSub(is IniSection,
 	sc *StateControllerBase) error {
 	if err := c.paramValue(is, sc, "redirectid",
@@ -529,18 +539,21 @@ func (c *Compiler) changeAnimSub(is IniSection,
 	}
 	return nil
 }
+
 func (c *Compiler) changeAnim(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*changeAnim)(sc), c.stateSec(is, func() error {
 		return c.changeAnimSub(is, sc)
 	})
 	return *ret, err
 }
+
 func (c *Compiler) changeAnim2(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*changeAnim2)(sc), c.stateSec(is, func() error {
 		return c.changeAnimSub(is, sc)
 	})
 	return *ret, err
 }
+
 func (c *Compiler) helper(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*helper)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -725,6 +738,7 @@ func (c *Compiler) helper(is IniSection, sc *StateControllerBase, _ int8) (State
 	})
 	return *ret, err
 }
+
 func (c *Compiler) ctrlSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*ctrlSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -735,6 +749,7 @@ func (c *Compiler) ctrlSet(is IniSection, sc *StateControllerBase, _ int8) (Stat
 	})
 	return *ret, err
 }
+
 func (c *Compiler) explodSub(is IniSection,
 	sc *StateControllerBase) error {
 	if err := c.paramValue(is, sc, "remappal",
@@ -871,6 +886,7 @@ func (c *Compiler) explodSub(is IniSection,
 	}
 	return nil
 }
+
 func (c *Compiler) explodInterpolate(is IniSection,
 	sc *StateControllerBase) error {
 	if err := c.paramValue(is, sc, "interpolation.time",
@@ -919,6 +935,7 @@ func (c *Compiler) explodInterpolate(is IniSection,
 	}
 	return nil
 }
+
 func (c *Compiler) explod(is IniSection, sc *StateControllerBase,
 	ihp int8) (StateController, error) {
 	ret, err := (*explod)(sc), c.stateSec(is, func() error {
@@ -974,6 +991,7 @@ func (c *Compiler) explod(is IniSection, sc *StateControllerBase,
 	})
 	return *ret, err
 }
+
 func (c *Compiler) modifyExplod(is IniSection, sc *StateControllerBase,
 	ihp int8) (StateController, error) {
 	ret, err := (*modifyExplod)(sc), c.stateSec(is, func() error {
@@ -1030,6 +1048,7 @@ func (c *Compiler) modifyExplod(is IniSection, sc *StateControllerBase,
 	})
 	return *ret, err
 }
+
 func (c *Compiler) gameMakeAnim(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*gameMakeAnim)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -1071,6 +1090,7 @@ func (c *Compiler) gameMakeAnim(is IniSection, sc *StateControllerBase, _ int8) 
 	})
 	return *ret, err
 }
+
 func (c *Compiler) posSetSub(is IniSection,
 	sc *StateControllerBase) error {
 	if err := c.paramValue(is, sc, "x",
@@ -1087,6 +1107,7 @@ func (c *Compiler) posSetSub(is IniSection,
 	}
 	return nil
 }
+
 func (c *Compiler) posSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*posSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -1097,6 +1118,7 @@ func (c *Compiler) posSet(is IniSection, sc *StateControllerBase, _ int8) (State
 	})
 	return *ret, err
 }
+
 func (c *Compiler) posAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*posAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -1107,6 +1129,7 @@ func (c *Compiler) posAdd(is IniSection, sc *StateControllerBase, _ int8) (State
 	})
 	return *ret, err
 }
+
 func (c *Compiler) velSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*velSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -1117,6 +1140,7 @@ func (c *Compiler) velSet(is IniSection, sc *StateControllerBase, _ int8) (State
 	})
 	return *ret, err
 }
+
 func (c *Compiler) velAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*velAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -1127,6 +1151,7 @@ func (c *Compiler) velAdd(is IniSection, sc *StateControllerBase, _ int8) (State
 	})
 	return *ret, err
 }
+
 func (c *Compiler) velMul(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*velMul)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -1137,6 +1162,7 @@ func (c *Compiler) velMul(is IniSection, sc *StateControllerBase, _ int8) (State
 	})
 	return *ret, err
 }
+
 func (c *Compiler) shadowOffset(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*shadowOffset)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -1151,6 +1177,7 @@ func (c *Compiler) shadowOffset(is IniSection, sc *StateControllerBase, _ int8) 
 	})
 	return *ret, err
 }
+
 func (c *Compiler) palFXSub(is IniSection,
 	sc *StateControllerBase, prefix string) error {
 	if err := c.paramValue(is, sc, prefix+"time",
@@ -1253,6 +1280,7 @@ func (c *Compiler) palFXSub(is IniSection,
 	}
 	return nil
 }
+
 func (c *Compiler) palFX(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*palFX)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -1263,18 +1291,21 @@ func (c *Compiler) palFX(is IniSection, sc *StateControllerBase, _ int8) (StateC
 	})
 	return *ret, err
 }
+
 func (c *Compiler) allPalFX(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*allPalFX)(sc), c.stateSec(is, func() error {
 		return c.palFXSub(is, sc, "")
 	})
 	return *ret, err
 }
+
 func (c *Compiler) bgPalFX(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*bgPalFX)(sc), c.stateSec(is, func() error {
 		return c.palFXSub(is, sc, "")
 	})
 	return *ret, err
 }
+
 func (c *Compiler) afterImageSub(is IniSection,
 	sc *StateControllerBase, ihp int8, prefix string) error {
 	if err := c.paramValue(is, sc, "redirectid",
@@ -1342,6 +1373,7 @@ func (c *Compiler) afterImageSub(is IniSection,
 	}
 	return nil
 }
+
 func (c *Compiler) afterImage(is IniSection, sc *StateControllerBase,
 	ihp int8) (StateController, error) {
 	ret, err := (*afterImage)(sc), c.stateSec(is, func() error {
@@ -1349,6 +1381,7 @@ func (c *Compiler) afterImage(is IniSection, sc *StateControllerBase,
 	})
 	return *ret, err
 }
+
 func (c *Compiler) afterImageTime(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*afterImageTime)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -1377,6 +1410,7 @@ func (c *Compiler) afterImageTime(is IniSection, sc *StateControllerBase, _ int8
 	})
 	return *ret, err
 }
+
 func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 	if err := c.stateParam(is, "attr", false, func(data string) error {
 		attr, err := c.attr(data, true)
@@ -2305,6 +2339,7 @@ func (c *Compiler) width(is IniSection, sc *StateControllerBase, _ int8) (StateC
 	})
 	return *ret, err
 }
+
 func (c *Compiler) sprPriority(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*sprPriority)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -2320,6 +2355,7 @@ func (c *Compiler) sprPriority(is IniSection, sc *StateControllerBase, _ int8) (
 	})
 	return *ret, err
 }
+
 func (c *Compiler) varSetSub(is IniSection,
 	sc *StateControllerBase, rd OpCode, oc OpCode) error {
 	b, v, fv := false, false, false
@@ -2520,6 +2556,7 @@ func (c *Compiler) varSetSub(is IniSection,
 	}
 	return Error("Value parameter not specified")
 }
+
 func (c *Compiler) varSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*varSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -2530,6 +2567,7 @@ func (c *Compiler) varSet(is IniSection, sc *StateControllerBase, _ int8) (State
 	})
 	return *ret, err
 }
+
 func (c *Compiler) varAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*varSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -2540,6 +2578,7 @@ func (c *Compiler) varAdd(is IniSection, sc *StateControllerBase, _ int8) (State
 	})
 	return *ret, err
 }
+
 func (c *Compiler) parentVarSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*varSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -2550,6 +2589,7 @@ func (c *Compiler) parentVarSet(is IniSection, sc *StateControllerBase, _ int8) 
 	})
 	return *ret, err
 }
+
 func (c *Compiler) parentVarAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*varSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -2560,6 +2600,7 @@ func (c *Compiler) parentVarAdd(is IniSection, sc *StateControllerBase, _ int8) 
 	})
 	return *ret, err
 }
+
 func (c *Compiler) rootVarSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*varSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -2570,6 +2611,7 @@ func (c *Compiler) rootVarSet(is IniSection, sc *StateControllerBase, _ int8) (S
 	})
 	return *ret, err
 }
+
 func (c *Compiler) rootVarAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*varSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -2580,6 +2622,7 @@ func (c *Compiler) rootVarAdd(is IniSection, sc *StateControllerBase, _ int8) (S
 	})
 	return *ret, err
 }
+
 func (c *Compiler) turn(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*turn)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -2591,6 +2634,7 @@ func (c *Compiler) turn(is IniSection, sc *StateControllerBase, _ int8) (StateCo
 	})
 	return *ret, err
 }
+
 func (c *Compiler) targetFacing(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*targetFacing)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -2601,6 +2645,10 @@ func (c *Compiler) targetFacing(is IniSection, sc *StateControllerBase, _ int8) 
 			targetFacing_id, VT_Int, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "index",
+			targetFacing_index, VT_Int, 1, false); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "value",
 			targetFacing_value, VT_Int, 1, false); err != nil {
 			return err
@@ -2609,6 +2657,7 @@ func (c *Compiler) targetFacing(is IniSection, sc *StateControllerBase, _ int8) 
 	})
 	return *ret, err
 }
+
 func (c *Compiler) targetBind(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*targetBind)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -2617,6 +2666,10 @@ func (c *Compiler) targetBind(is IniSection, sc *StateControllerBase, _ int8) (S
 		}
 		if err := c.paramValue(is, sc, "id",
 			targetBind_id, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "index",
+			targetBind_index, VT_Int, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "time",
@@ -2631,6 +2684,7 @@ func (c *Compiler) targetBind(is IniSection, sc *StateControllerBase, _ int8) (S
 	})
 	return *ret, err
 }
+
 func (c *Compiler) bindToTarget(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*bindToTarget)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -2639,6 +2693,10 @@ func (c *Compiler) bindToTarget(is IniSection, sc *StateControllerBase, _ int8) 
 		}
 		if err := c.paramValue(is, sc, "id",
 			bindToTarget_id, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "index",
+			bindToTarget_index, VT_Int, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "time",
@@ -2687,6 +2745,7 @@ func (c *Compiler) bindToTarget(is IniSection, sc *StateControllerBase, _ int8) 
 	})
 	return *ret, err
 }
+
 func (c *Compiler) targetLifeAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*targetLifeAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -2695,6 +2754,10 @@ func (c *Compiler) targetLifeAdd(is IniSection, sc *StateControllerBase, _ int8)
 		}
 		if err := c.paramValue(is, sc, "id",
 			targetLifeAdd_id, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "index",
+			targetLifeAdd_index, VT_Int, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "absolute",
@@ -2721,6 +2784,7 @@ func (c *Compiler) targetLifeAdd(is IniSection, sc *StateControllerBase, _ int8)
 	})
 	return *ret, err
 }
+
 func (c *Compiler) targetState(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*targetState)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -2731,6 +2795,10 @@ func (c *Compiler) targetState(is IniSection, sc *StateControllerBase, _ int8) (
 			targetState_id, VT_Int, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "index",
+			targetState_index, VT_Int, 1, false); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "value",
 			targetState_value, VT_Int, 1, true); err != nil {
 			return err
@@ -2739,6 +2807,7 @@ func (c *Compiler) targetState(is IniSection, sc *StateControllerBase, _ int8) (
 	})
 	return *ret, err
 }
+
 func (c *Compiler) targetVelSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*targetVelSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -2747,6 +2816,10 @@ func (c *Compiler) targetVelSet(is IniSection, sc *StateControllerBase, _ int8) 
 		}
 		if err := c.paramValue(is, sc, "id",
 			targetVelSet_id, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "index",
+			targetVelSet_index, VT_Int, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "x",
@@ -2765,6 +2838,7 @@ func (c *Compiler) targetVelSet(is IniSection, sc *StateControllerBase, _ int8) 
 	})
 	return *ret, err
 }
+
 func (c *Compiler) targetVelAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*targetVelAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -2773,6 +2847,10 @@ func (c *Compiler) targetVelAdd(is IniSection, sc *StateControllerBase, _ int8) 
 		}
 		if err := c.paramValue(is, sc, "id",
 			targetVelAdd_id, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "index",
+			targetVelAdd_index, VT_Int, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "x",
@@ -2791,6 +2869,7 @@ func (c *Compiler) targetVelAdd(is IniSection, sc *StateControllerBase, _ int8) 
 	})
 	return *ret, err
 }
+
 func (c *Compiler) targetPowerAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*targetPowerAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -2801,6 +2880,10 @@ func (c *Compiler) targetPowerAdd(is IniSection, sc *StateControllerBase, _ int8
 			targetPowerAdd_id, VT_Int, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "index",
+			targetPowerAdd_index, VT_Int, 1, false); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "value",
 			targetPowerAdd_value, VT_Int, 1, true); err != nil {
 			return err
@@ -2809,6 +2892,7 @@ func (c *Compiler) targetPowerAdd(is IniSection, sc *StateControllerBase, _ int8
 	})
 	return *ret, err
 }
+
 func (c *Compiler) targetDrop(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*targetDrop)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -2827,6 +2911,7 @@ func (c *Compiler) targetDrop(is IniSection, sc *StateControllerBase, _ int8) (S
 	})
 	return *ret, err
 }
+
 func (c *Compiler) lifeAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*lifeAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -2849,6 +2934,7 @@ func (c *Compiler) lifeAdd(is IniSection, sc *StateControllerBase, _ int8) (Stat
 	})
 	return *ret, err
 }
+
 func (c *Compiler) lifeSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*lifeSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -2859,6 +2945,7 @@ func (c *Compiler) lifeSet(is IniSection, sc *StateControllerBase, _ int8) (Stat
 	})
 	return *ret, err
 }
+
 func (c *Compiler) powerAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*powerAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -2869,6 +2956,7 @@ func (c *Compiler) powerAdd(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	})
 	return *ret, err
 }
+
 func (c *Compiler) powerSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*powerSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -2879,6 +2967,7 @@ func (c *Compiler) powerSet(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	})
 	return *ret, err
 }
+
 func (c *Compiler) hitVelSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*hitVelSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -2901,6 +2990,7 @@ func (c *Compiler) hitVelSet(is IniSection, sc *StateControllerBase, _ int8) (St
 	})
 	return *ret, err
 }
+
 func (c *Compiler) screenBound(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*screenBound)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -2936,6 +3026,7 @@ func (c *Compiler) screenBound(is IniSection, sc *StateControllerBase, _ int8) (
 	})
 	return *ret, err
 }
+
 func (c *Compiler) posFreeze(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*posFreeze)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -2956,6 +3047,7 @@ func (c *Compiler) posFreeze(is IniSection, sc *StateControllerBase, _ int8) (St
 	})
 	return *ret, err
 }
+
 func (c *Compiler) envShake(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*envShake)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "time",
@@ -2982,6 +3074,7 @@ func (c *Compiler) envShake(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	})
 	return *ret, err
 }
+
 func (c *Compiler) hitOverride(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*hitOverride)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3022,6 +3115,7 @@ func (c *Compiler) hitOverride(is IniSection, sc *StateControllerBase, _ int8) (
 	})
 	return *ret, err
 }
+
 func (c *Compiler) pause(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*pause)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3048,6 +3142,7 @@ func (c *Compiler) pause(is IniSection, sc *StateControllerBase, _ int8) (StateC
 	})
 	return *ret, err
 }
+
 func (c *Compiler) superPause(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*superPause)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3108,6 +3203,7 @@ func (c *Compiler) superPause(is IniSection, sc *StateControllerBase, _ int8) (S
 	})
 	return *ret, err
 }
+
 func (c *Compiler) trans(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*trans)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3118,6 +3214,7 @@ func (c *Compiler) trans(is IniSection, sc *StateControllerBase, _ int8) (StateC
 	})
 	return *ret, err
 }
+
 func (c *Compiler) playerPush(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*playerPush)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3144,6 +3241,7 @@ func (c *Compiler) playerPush(is IniSection, sc *StateControllerBase, _ int8) (S
 	})
 	return *ret, err
 }
+
 func (c *Compiler) stateTypeSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*stateTypeSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3230,6 +3328,7 @@ func (c *Compiler) stateTypeSet(is IniSection, sc *StateControllerBase, _ int8) 
 	})
 	return *ret, err
 }
+
 func (c *Compiler) angleDraw(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*angleDraw)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3248,6 +3347,7 @@ func (c *Compiler) angleDraw(is IniSection, sc *StateControllerBase, _ int8) (St
 	})
 	return *ret, err
 }
+
 func (c *Compiler) angleSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*angleSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3262,6 +3362,7 @@ func (c *Compiler) angleSet(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	})
 	return *ret, err
 }
+
 func (c *Compiler) angleAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*angleAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3276,6 +3377,7 @@ func (c *Compiler) angleAdd(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	})
 	return *ret, err
 }
+
 func (c *Compiler) angleMul(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*angleMul)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3290,6 +3392,7 @@ func (c *Compiler) angleMul(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	})
 	return *ret, err
 }
+
 func (c *Compiler) envColor(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*envColor)(sc), c.stateSec(is, func() error {
 		if err := c.stateParam(is, "value", false, func(data string) error {
@@ -3317,6 +3420,7 @@ func (c *Compiler) envColor(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	})
 	return *ret, err
 }
+
 func (c *Compiler) displayToClipboardSub(is IniSection,
 	sc *StateControllerBase) error {
 	if err := c.paramValue(is, sc, "redirectid",
@@ -3360,18 +3464,21 @@ func (c *Compiler) displayToClipboardSub(is IniSection,
 	}
 	return nil
 }
+
 func (c *Compiler) displayToClipboard(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*displayToClipboard)(sc), c.stateSec(is, func() error {
 		return c.displayToClipboardSub(is, sc)
 	})
 	return *ret, err
 }
+
 func (c *Compiler) appendToClipboard(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*appendToClipboard)(sc), c.stateSec(is, func() error {
 		return c.displayToClipboardSub(is, sc)
 	})
 	return *ret, err
 }
+
 func (c *Compiler) clearClipboard(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*clearClipboard)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3383,6 +3490,7 @@ func (c *Compiler) clearClipboard(is IniSection, sc *StateControllerBase, _ int8
 	})
 	return *ret, err
 }
+
 func (c *Compiler) makeDust(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*makeDust)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3407,6 +3515,7 @@ func (c *Compiler) makeDust(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	})
 	return *ret, err
 }
+
 func (c *Compiler) attackDist(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*attackDist)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3433,6 +3542,7 @@ func (c *Compiler) attackDist(is IniSection, sc *StateControllerBase, _ int8) (S
 	})
 	return *ret, err
 }
+
 func (c *Compiler) attackMulSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*attackMulSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3477,6 +3587,7 @@ func (c *Compiler) attackMulSet(is IniSection, sc *StateControllerBase, _ int8) 
 	})
 	return *ret, err
 }
+
 func (c *Compiler) defenceMulSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*defenceMulSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(
@@ -3517,6 +3628,7 @@ func (c *Compiler) defenceMulSet(is IniSection, sc *StateControllerBase, _ int8)
 	})
 	return *ret, err
 }
+
 func (c *Compiler) fallEnvShake(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*fallEnvShake)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3528,6 +3640,7 @@ func (c *Compiler) fallEnvShake(is IniSection, sc *StateControllerBase, _ int8) 
 	})
 	return *ret, err
 }
+
 func (c *Compiler) hitFallDamage(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*hitFallDamage)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3539,6 +3652,7 @@ func (c *Compiler) hitFallDamage(is IniSection, sc *StateControllerBase, _ int8)
 	})
 	return *ret, err
 }
+
 func (c *Compiler) hitFallVel(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*hitFallVel)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3550,6 +3664,7 @@ func (c *Compiler) hitFallVel(is IniSection, sc *StateControllerBase, _ int8) (S
 	})
 	return *ret, err
 }
+
 func (c *Compiler) hitFallSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*hitFallSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3578,6 +3693,7 @@ func (c *Compiler) hitFallSet(is IniSection, sc *StateControllerBase, _ int8) (S
 	})
 	return *ret, err
 }
+
 func (c *Compiler) varRangeSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*varRangeSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3623,6 +3739,7 @@ func (c *Compiler) varRangeSet(is IniSection, sc *StateControllerBase, _ int8) (
 	})
 	return *ret, err
 }
+
 func (c *Compiler) remapPal(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*remapPal)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3641,6 +3758,7 @@ func (c *Compiler) remapPal(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	})
 	return *ret, err
 }
+
 func (c *Compiler) stopSnd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*stopSnd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3655,6 +3773,7 @@ func (c *Compiler) stopSnd(is IniSection, sc *StateControllerBase, _ int8) (Stat
 	})
 	return *ret, err
 }
+
 func (c *Compiler) sndPan(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*sndPan)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3677,6 +3796,7 @@ func (c *Compiler) sndPan(is IniSection, sc *StateControllerBase, _ int8) (State
 	})
 	return *ret, err
 }
+
 func (c *Compiler) varRandom(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*varRandom)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3695,6 +3815,7 @@ func (c *Compiler) varRandom(is IniSection, sc *StateControllerBase, _ int8) (St
 	})
 	return *ret, err
 }
+
 func (c *Compiler) gravity(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*gravity)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3706,6 +3827,7 @@ func (c *Compiler) gravity(is IniSection, sc *StateControllerBase, _ int8) (Stat
 	})
 	return *ret, err
 }
+
 func (c *Compiler) bindToParentSub(is IniSection,
 	sc *StateControllerBase) error {
 	if err := c.paramValue(is, sc, "redirectid",
@@ -3726,18 +3848,21 @@ func (c *Compiler) bindToParentSub(is IniSection,
 	}
 	return nil
 }
+
 func (c *Compiler) bindToParent(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*bindToParent)(sc), c.stateSec(is, func() error {
 		return c.bindToParentSub(is, sc)
 	})
 	return *ret, err
 }
+
 func (c *Compiler) bindToRoot(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*bindToRoot)(sc), c.stateSec(is, func() error {
 		return c.bindToParentSub(is, sc)
 	})
 	return *ret, err
 }
+
 func (c *Compiler) removeExplod(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*removeExplod)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3763,6 +3888,7 @@ func (c *Compiler) removeExplod(is IniSection, sc *StateControllerBase, _ int8) 
 	})
 	return *ret, err
 }
+
 func (c *Compiler) explodBindTime(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*explodBindTime)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3790,6 +3916,7 @@ func (c *Compiler) explodBindTime(is IniSection, sc *StateControllerBase, _ int8
 	})
 	return *ret, err
 }
+
 func (c *Compiler) moveHitReset(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*moveHitReset)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3801,6 +3928,7 @@ func (c *Compiler) moveHitReset(is IniSection, sc *StateControllerBase, _ int8) 
 	})
 	return *ret, err
 }
+
 func (c *Compiler) hitAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*hitAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3815,6 +3943,7 @@ func (c *Compiler) hitAdd(is IniSection, sc *StateControllerBase, _ int8) (State
 	})
 	return *ret, err
 }
+
 func (c *Compiler) offset(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*offset)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3833,6 +3962,7 @@ func (c *Compiler) offset(is IniSection, sc *StateControllerBase, _ int8) (State
 	})
 	return *ret, err
 }
+
 func (c *Compiler) victoryQuote(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*victoryQuote)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3847,6 +3977,7 @@ func (c *Compiler) victoryQuote(is IniSection, sc *StateControllerBase, _ int8) 
 	})
 	return *ret, err
 }
+
 func (c *Compiler) zoom(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*zoom)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "pos",
@@ -3877,6 +4008,7 @@ func (c *Compiler) zoom(is IniSection, sc *StateControllerBase, _ int8) (StateCo
 	})
 	return *ret, err
 }
+
 func (c *Compiler) forceFeedback(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*forceFeedback)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3928,6 +4060,7 @@ func (c *Compiler) forceFeedback(is IniSection, sc *StateControllerBase, _ int8)
 	})
 	return *ret, err
 }
+
 func (c *Compiler) assertInput(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*assertInput)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -3993,6 +4126,7 @@ func (c *Compiler) assertInput(is IniSection, sc *StateControllerBase, _ int8) (
 	})
 	return *ret, err
 }
+
 func (c *Compiler) dialogue(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*dialogue)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -4034,6 +4168,7 @@ func (c *Compiler) dialogue(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	})
 	return *ret, err
 }
+
 func (c *Compiler) dizzyPointsAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*dizzyPointsAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -4052,6 +4187,7 @@ func (c *Compiler) dizzyPointsAdd(is IniSection, sc *StateControllerBase, _ int8
 	})
 	return *ret, err
 }
+
 func (c *Compiler) dizzyPointsSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*dizzyPointsSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -4062,6 +4198,7 @@ func (c *Compiler) dizzyPointsSet(is IniSection, sc *StateControllerBase, _ int8
 	})
 	return *ret, err
 }
+
 func (c *Compiler) dizzySet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*dizzySet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -4072,6 +4209,7 @@ func (c *Compiler) dizzySet(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	})
 	return *ret, err
 }
+
 func (c *Compiler) guardBreakSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*guardBreakSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -4082,6 +4220,7 @@ func (c *Compiler) guardBreakSet(is IniSection, sc *StateControllerBase, _ int8)
 	})
 	return *ret, err
 }
+
 func (c *Compiler) guardPointsAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*guardPointsAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -4100,6 +4239,7 @@ func (c *Compiler) guardPointsAdd(is IniSection, sc *StateControllerBase, _ int8
 	})
 	return *ret, err
 }
+
 func (c *Compiler) guardPointsSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*guardPointsSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -4154,6 +4294,7 @@ func (c *Compiler) lifebarAction(is IniSection, sc *StateControllerBase, _ int8)
 	})
 	return *ret, err
 }
+
 func (c *Compiler) loadFile(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*loadFile)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -4245,6 +4386,7 @@ func (c *Compiler) mapSetSub(is IniSection, sc *StateControllerBase) error {
 	})
 	return err
 }
+
 func (c *Compiler) mapSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
@@ -4256,6 +4398,7 @@ func (c *Compiler) mapSet(is IniSection, sc *StateControllerBase, _ int8) (State
 
 	return *ret, err
 }
+
 func (c *Compiler) mapAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
@@ -4267,6 +4410,7 @@ func (c *Compiler) mapAdd(is IniSection, sc *StateControllerBase, _ int8) (State
 
 	return *ret, err
 }
+
 func (c *Compiler) parentMapSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
@@ -4278,6 +4422,7 @@ func (c *Compiler) parentMapSet(is IniSection, sc *StateControllerBase, _ int8) 
 
 	return *ret, err
 }
+
 func (c *Compiler) parentMapAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
@@ -4289,6 +4434,7 @@ func (c *Compiler) parentMapAdd(is IniSection, sc *StateControllerBase, _ int8) 
 
 	return *ret, err
 }
+
 func (c *Compiler) rootMapSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
@@ -4300,6 +4446,7 @@ func (c *Compiler) rootMapSet(is IniSection, sc *StateControllerBase, _ int8) (S
 
 	return *ret, err
 }
+
 func (c *Compiler) rootMapAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
@@ -4311,6 +4458,7 @@ func (c *Compiler) rootMapAdd(is IniSection, sc *StateControllerBase, _ int8) (S
 
 	return *ret, err
 }
+
 func (c *Compiler) teamMapSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
@@ -4322,6 +4470,7 @@ func (c *Compiler) teamMapSet(is IniSection, sc *StateControllerBase, _ int8) (S
 
 	return *ret, err
 }
+
 func (c *Compiler) teamMapAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
@@ -4333,6 +4482,7 @@ func (c *Compiler) teamMapAdd(is IniSection, sc *StateControllerBase, _ int8) (S
 
 	return *ret, err
 }
+
 func (c *Compiler) matchRestart(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*matchRestart)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "reload",
@@ -4424,6 +4574,7 @@ func (c *Compiler) matchRestart(is IniSection, sc *StateControllerBase, _ int8) 
 	})
 	return *ret, err
 }
+
 func (c *Compiler) playBgm(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*playBgm)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -4471,6 +4622,7 @@ func (c *Compiler) playBgm(is IniSection, sc *StateControllerBase, _ int8) (Stat
 	})
 	return *ret, err
 }
+
 func (c *Compiler) modifyBGCtrl(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*modifyBGCtrl)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -4549,6 +4701,7 @@ func (c *Compiler) modifyBGCtrl(is IniSection, sc *StateControllerBase, _ int8) 
 	})
 	return *ret, err
 }
+
 func (c *Compiler) modifySnd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*modifySnd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -4615,6 +4768,7 @@ func (c *Compiler) modifySnd(is IniSection, sc *StateControllerBase, _ int8) (St
 	})
 	return *ret, err
 }
+
 func (c *Compiler) modifyBgm(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*modifyBgm)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -4645,12 +4799,14 @@ func (c *Compiler) modifyBgm(is IniSection, sc *StateControllerBase, _ int8) (St
 	})
 	return *ret, err
 }
+
 func (c *Compiler) printToConsole(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*printToConsole)(sc), c.stateSec(is, func() error {
 		return c.displayToClipboardSub(is, sc)
 	})
 	return *ret, err
 }
+
 func (c *Compiler) redLifeAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*redLifeAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -4669,6 +4825,7 @@ func (c *Compiler) redLifeAdd(is IniSection, sc *StateControllerBase, _ int8) (S
 	})
 	return *ret, err
 }
+
 func (c *Compiler) redLifeSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*redLifeSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -4679,6 +4836,7 @@ func (c *Compiler) redLifeSet(is IniSection, sc *StateControllerBase, _ int8) (S
 	})
 	return *ret, err
 }
+
 func (c *Compiler) remapSprite(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*remapSprite)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -4710,6 +4868,7 @@ func (c *Compiler) remapSprite(is IniSection, sc *StateControllerBase, _ int8) (
 	})
 	return *ret, err
 }
+
 func (c *Compiler) roundTimeAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*roundTimeAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -4724,6 +4883,7 @@ func (c *Compiler) roundTimeAdd(is IniSection, sc *StateControllerBase, _ int8) 
 	})
 	return *ret, err
 }
+
 func (c *Compiler) roundTimeSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*roundTimeSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -4734,6 +4894,7 @@ func (c *Compiler) roundTimeSet(is IniSection, sc *StateControllerBase, _ int8) 
 	})
 	return *ret, err
 }
+
 func (c *Compiler) saveFile(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*saveFile)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -4756,6 +4917,7 @@ func (c *Compiler) saveFile(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	})
 	return *ret, err
 }
+
 func (c *Compiler) scoreAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*scoreAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -4770,6 +4932,7 @@ func (c *Compiler) scoreAdd(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	})
 	return *ret, err
 }
+
 func (c *Compiler) targetDizzyPointsAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*targetDizzyPointsAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -4792,6 +4955,7 @@ func (c *Compiler) targetDizzyPointsAdd(is IniSection, sc *StateControllerBase, 
 	})
 	return *ret, err
 }
+
 func (c *Compiler) targetGuardPointsAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*targetGuardPointsAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -4814,6 +4978,7 @@ func (c *Compiler) targetGuardPointsAdd(is IniSection, sc *StateControllerBase, 
 	})
 	return *ret, err
 }
+
 func (c *Compiler) targetRedLifeAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*targetRedLifeAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -4836,6 +5001,7 @@ func (c *Compiler) targetRedLifeAdd(is IniSection, sc *StateControllerBase, _ in
 	})
 	return *ret, err
 }
+
 func (c *Compiler) targetScoreAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*targetScoreAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -4854,6 +5020,7 @@ func (c *Compiler) targetScoreAdd(is IniSection, sc *StateControllerBase, _ int8
 	})
 	return *ret, err
 }
+
 func (c *Compiler) text(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*text)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -5053,6 +5220,7 @@ func (c *Compiler) createPlatform(is IniSection, sc *StateControllerBase, _ int8
 	})
 	return *ret, err
 }
+
 func (c *Compiler) modifyStageVar(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*modifyStageVar)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "camera.boundleft",

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1301,7 +1301,18 @@ func (c *Compiler) allPalFX(is IniSection, sc *StateControllerBase, _ int8) (Sta
 
 func (c *Compiler) bgPalFX(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*bgPalFX)(sc), c.stateSec(is, func() error {
-		return c.palFXSub(is, sc, "")
+		if err := c.paramValue(is, sc, "id",
+			bgPalFX_id, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "index",
+			bgPalFX_index, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.palFXSub(is, sc, ""); err != nil {
+			return err
+		}
+		return nil
 	})
 	return *ret, err
 }

--- a/src/image.go
+++ b/src/image.go
@@ -44,6 +44,16 @@ type PalFXDef struct {
 	ihue        [2]float32
 	itime       int32
 }
+
+func newPalFXDef() *PalFXDef {
+    return &PalFXDef{
+		color: 1,
+		icolor: [...]float32{1, 1},
+		mul: [...]int32{256, 256, 256},
+		imul: [...]int32{256, 256, 256, 256, 256, 256},
+	}
+}
+
 type PalFX struct {
 	PalFXDef
 	remap        []int
@@ -65,17 +75,22 @@ type PalFX struct {
 	eiTime       int32
 }
 
-func newPalFX() *PalFX { return &PalFX{} }
+func newPalFX() *PalFX {
+	return &PalFX{}
+}
+
 func (pf *PalFX) clear2(nt bool) {
-	pf.PalFXDef = PalFXDef{color: 1, icolor: [...]float32{1, 1}, mul: [...]int32{256, 256, 256}, imul: [...]int32{256, 256, 256, 256, 256, 256}}
+	pf.PalFXDef = *newPalFXDef()
 	pf.negType = nt
 	for i := 0; i < len(pf.sintime); i++ {
 		pf.sintime[i] = 0
 	}
 }
+
 func (pf *PalFX) clear() {
 	pf.clear2(false)
 }
+
 func (pf *PalFX) getSynFx(blending int) *PalFX {
 	if pf == nil || !pf.enable {
 		if blending == -2 && sys.allPalFX.enable {
@@ -99,6 +114,7 @@ func (pf *PalFX) getSynFx(blending int) *PalFX {
 	synth.synthesize(sys.allPalFX, blending)
 	return &synth
 }
+
 func (pf *PalFX) getFxPal(pal []uint32, neg bool) []uint32 {
 	p := pf.getSynFx(0)
 	if !p.enable {
@@ -150,6 +166,7 @@ func (pf *PalFX) getFxPal(pal []uint32, neg bool) []uint32 {
 	}
 	return sys.workpal
 }
+
 func (pf *PalFX) getFcPalFx(transNeg bool, blending int) (neg bool, grayscale float32,
 	add, mul [3]float32, invblend int32, hue float32) {
 	p := pf.getSynFx(blending)
@@ -182,6 +199,7 @@ func (pf *PalFX) getFcPalFx(transNeg bool, blending int) (neg bool, grayscale fl
 	}
 	return
 }
+
 func (pf *PalFX) sinAdd(color *[3]int32) {
 	if pf.cycletime[0] > 1 {
 		st := 2 * math.Pi * float64(pf.sintime[0])
@@ -194,6 +212,7 @@ func (pf *PalFX) sinAdd(color *[3]int32) {
 		}
 	}
 }
+
 func (pf *PalFX) sinMul(color *[3]int32) {
 	if pf.cycletime[1] > 1 {
 		st := 2 * math.Pi * float64(pf.sintime[1])
@@ -206,6 +225,7 @@ func (pf *PalFX) sinMul(color *[3]int32) {
 		}
 	}
 }
+
 func (pf *PalFX) sinColor(color *float32) {
 	if pf.cycletime[2] > 1 {
 		st := 2 * math.Pi * float64(pf.sintime[2])
@@ -218,6 +238,7 @@ func (pf *PalFX) sinColor(color *float32) {
 
 	}
 }
+
 func (pf *PalFX) sinHueshift(color *float32) {
 	if pf.cycletime[3] > 1 {
 		st := 2 * math.Pi * float64(pf.sintime[3])
@@ -230,6 +251,7 @@ func (pf *PalFX) sinHueshift(color *float32) {
 
 	}
 }
+
 func (pf *PalFX) interpolationUpdate() {
 	if pf.eiTime < pf.itime {
 		pf.eiTime++
@@ -246,6 +268,7 @@ func (pf *PalFX) interpolationUpdate() {
 	pf.eiHue = Lerp(pf.ihue[1], pf.ihue[0], t)
 	pf.eHue = pf.eiHue + pf.hue
 }
+
 func (pf *PalFX) step() {
 	pf.enable = pf.time != 0
 	if pf.enable {
@@ -281,6 +304,7 @@ func (pf *PalFX) step() {
 		}
 	}
 }
+
 func (pf *PalFX) synthesize(pfx PalFX, blending int) {
 	if blending == -2 {
 		for i, a := range pfx.eAdd {
@@ -370,6 +394,7 @@ func (pl *PaletteList) init() {
 	pl.numcols = make(map[[2]int16]int)
 	pl.PalTex = nil
 }
+
 func (pl *PaletteList) SetSource(i int, p []uint32) {
 	if i < len(pl.paletteMap) {
 		pl.paletteMap[i] = i
@@ -389,22 +414,27 @@ func (pl *PaletteList) SetSource(i int, p []uint32) {
 		pl.PalTex = append(pl.PalTex, nil)
 	}
 }
+
 func (pl *PaletteList) NewPal() (i int, p []uint32) {
 	i, p = len(pl.palettes), make([]uint32, 256)
 	pl.SetSource(i, p)
 	return
 }
+
 func (pl *PaletteList) Get(i int) []uint32 {
 	return pl.palettes[pl.paletteMap[i]]
 }
+
 func (pl *PaletteList) Remap(source int, destination int) {
 	pl.paletteMap[source] = destination
 }
+
 func (pl *PaletteList) ResetRemap() {
 	for i := range pl.paletteMap {
 		pl.paletteMap[i] = i
 	}
 }
+
 func (pl *PaletteList) GetPalMap() []int {
 	pm := make([]int, len(pl.paletteMap))
 	copy(pm, pl.paletteMap)
@@ -673,6 +703,7 @@ func (s *Sprite) shareCopy(src *Sprite) {
 	//s.paltemp = src.paltemp
 	//s.PalTex = src.PalTex
 }
+
 func (s *Sprite) GetPal(pl *PaletteList) []uint32 {
 	if len(s.Pal) > 0 || s.coldepth > 8 {
 		return s.Pal
@@ -769,6 +800,7 @@ func (s *Sprite) readPcxHeader(f *os.File, offset int64) error {
 	}
 	return nil
 }
+
 func (s *Sprite) RlePcxDecode(rle []byte) (p []byte) {
 	if len(rle) == 0 || s.rle <= 0 {
 		return rle
@@ -802,6 +834,7 @@ func (s *Sprite) RlePcxDecode(rle []byte) (p []byte) {
 	s.rle = 0
 	return
 }
+
 func (s *Sprite) read(f *os.File, sh *SffHeader, offset int64, datasize uint32,
 	nextSubheader uint32, prev *Sprite, pl *PaletteList, c00 bool) error {
 	if int64(nextSubheader) > offset {
@@ -861,6 +894,7 @@ func (s *Sprite) read(f *os.File, sh *SffHeader, offset int64, datasize uint32,
 	s.SetPxl(s.RlePcxDecode(px))
 	return nil
 }
+
 func (s *Sprite) readHeaderV2(r io.Reader, ofs *uint32, size *uint32,
 	lofs uint32, tofs uint32, link *uint16) error {
 	read := func(x interface{}) error {
@@ -910,6 +944,7 @@ func (s *Sprite) readHeaderV2(r io.Reader, ofs *uint32, size *uint32,
 	}
 	return nil
 }
+
 func (s *Sprite) Rle8Decode(rle []byte) (p []byte) {
 	if len(rle) == 0 {
 		return rle
@@ -937,6 +972,7 @@ func (s *Sprite) Rle8Decode(rle []byte) (p []byte) {
 	}
 	return
 }
+
 func (s *Sprite) Rle5Decode(rle []byte) (p []byte) {
 	if len(rle) == 0 {
 		return rle
@@ -980,6 +1016,7 @@ func (s *Sprite) Rle5Decode(rle []byte) (p []byte) {
 	}
 	return
 }
+
 func (s *Sprite) Lz5Decode(rle []byte) (p []byte) {
 	if len(rle) == 0 {
 		return rle
@@ -1056,6 +1093,7 @@ func (s *Sprite) Lz5Decode(rle []byte) (p []byte) {
 	}
 	return
 }
+
 func (s *Sprite) readV2(f *os.File, offset int64, datasize uint32) error {
 	var px []byte
 	var isRaw bool = false
@@ -1201,6 +1239,7 @@ func newSff() (s *Sff) {
 	}
 	return
 }
+
 func newPaldata() (p *Palette) {
 	p = &Palette{}
 	p.palList.init()
@@ -1223,6 +1262,7 @@ func removeSFFCache(filename string) {
 		delete(SffCache, filename)
 	}
 }
+
 func loadSff(filename string, char bool) (*Sff, error) {
 	// If this SFF is already in the cache, just return a copy
 	if cached, ok := SffCache[filename]; ok {
@@ -1374,6 +1414,7 @@ func loadSff(filename string, char bool) (*Sff, error) {
 	})
 	return s, nil
 }
+
 func preloadSff(filename string, char bool, preloadSpr map[[2]int16]bool) (*Sff, []int32, error) {
 	sff := newSff()
 	f, err := os.Open(filename)
@@ -1531,12 +1572,14 @@ func preloadSff(filename string, char bool, preloadSpr map[[2]int16]bool) (*Sff,
 	}
 	return sff, selPal, nil
 }
+
 func (s *Sff) GetSprite(g, n int16) *Sprite {
 	if g == -1 {
 		return nil
 	}
 	return s.sprites[[...]int16{g, n}]
 }
+
 func (s *Sff) getOwnPalSprite(g, n int16, pl *PaletteList) *Sprite {
 	sys.runMainThreadTask() // Generate texture
 	sp := s.GetSprite(g, n)
@@ -1548,6 +1591,7 @@ func (s *Sff) getOwnPalSprite(g, n int16, pl *PaletteList) *Sprite {
 	copy(osp.Pal, pal)
 	return &osp
 }
+
 func captureScreen() {
 	width, height := sys.window.GetSize()
 	pixdata := make([]uint8, 4*width*height)

--- a/src/script.go
+++ b/src/script.go
@@ -3036,7 +3036,7 @@ func triggerFunctions(l *lua.LState) {
 		if !nilArg(l, 2) {
 			index = int(numArg(l, 2))
 		}
-		if c := sys.debugWC.target(id, index); c != nil {
+		if c := sys.debugWC.targetTrigger(id, index); c != nil {
 			sys.debugWC, ret = c, true
 		}
 		l.Push(lua.LBool(ret))

--- a/src/script.go
+++ b/src/script.go
@@ -3751,6 +3751,10 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LNumber(c.hitdef.priority))
 		case "id":
 			l.Push(lua.LNumber(c.hitdef.id))
+		case "sparkno":
+			l.Push(lua.LNumber(c.hitdef.sparkno))
+		case "guard.sparkno":
+			l.Push(lua.LNumber(c.hitdef.guard_sparkno))
 		case "sparkx":
 			l.Push(lua.LNumber(c.hitdef.sparkxy[0]))
 		case "sparky":
@@ -3763,6 +3767,14 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LNumber(c.hitdef.shaketime))
 		case "guard.shaketime":
 			l.Push(lua.LNumber(c.hitdef.guard_shaketime))
+		case "hitsound.group":
+			l.Push(lua.LNumber(c.hitdef.hitsound[0]))
+		case "hitsound.number":
+			l.Push(lua.LNumber(c.hitdef.hitsound[1]))
+		case "guardsound.group":
+			l.Push(lua.LNumber(c.hitdef.guardsound[0]))
+		case "guardsound.number":
+			l.Push(lua.LNumber(c.hitdef.guardsound[1]))
 		default:
 			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}

--- a/src/script.go
+++ b/src/script.go
@@ -4862,6 +4862,49 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LString(s))
 		return 1
 	})
+	luaRegister(l, "stagebgvar", func(l *lua.LState) int {
+		ln := lua.LNumber(math.NaN())
+		id := int32(numArg(l, 1))
+		idx := int(numArg(l, 2))
+		vname := strArg(l, 3)
+		// Get stage background element
+		bg := sys.debugWC.getStageBg(id, idx, false)
+		// Handle returns
+		if bg != nil {
+			switch strings.ToLower(vname) {
+			case "anim":
+				ln = lua.LNumber(bg.actionno)
+			case "delta x":
+				ln = lua.LNumber(bg.delta[0])
+			case "delta y":
+				ln = lua.LNumber(bg.delta[1])
+			case "id":
+				ln = lua.LNumber(bg.id)
+			case "layerno":
+				ln = lua.LNumber(bg.layerno)
+			case "pos x":
+				ln = lua.LNumber(bg.bga.pos[0])
+			case "pos y":
+				ln = lua.LNumber(bg.bga.pos[1])
+			case "start x":
+				ln = lua.LNumber(bg.start[0])
+			case "start y":
+				ln = lua.LNumber(bg.start[1])
+			case "tile x":
+				ln = lua.LNumber(bg.anim.tile.xflag)
+			case "tile y":
+				ln = lua.LNumber(bg.anim.tile.yflag)
+			case "vel x":
+				ln = lua.LNumber(bg.bga.vel[0])
+			case "vel y":
+				ln = lua.LNumber(bg.bga.vel[1])
+			default:
+				l.RaiseError("\nInvalid argument: %v\n", vname)
+			}
+		}
+		l.Push(ln)
+		return 1
+	})
 	luaRegister(l, "stagevar", func(*lua.LState) int {
 		switch strings.ToLower(strArg(l, 1)) {
 		case "info.name":

--- a/src/script.go
+++ b/src/script.go
@@ -3014,12 +3014,18 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LBool(ret))
 		return 1
 	})
-	luaRegister(l, "helper", func(*lua.LState) int {
-		ret, id := false, int32(0)
+	luaRegister(l, "helper", func(l *lua.LState) int {
+		ret := false
+		id, index := int32(-1), 0
+		// Check if ID is provided
 		if !nilArg(l, 1) {
 			id = int32(numArg(l, 1))
 		}
-		if c := sys.debugWC.helper(id); c != nil {
+		// Check if index is provided
+		if !nilArg(l, 2) {
+			index = int(numArg(l, 2))
+		}
+		if c := sys.debugWC.helperTrigger(id, index); c != nil {
 			sys.debugWC, ret = c, true
 		}
 		l.Push(lua.LBool(ret))

--- a/src/script.go
+++ b/src/script.go
@@ -3025,12 +3025,18 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LBool(ret))
 		return 1
 	})
-	luaRegister(l, "target", func(*lua.LState) int {
-		ret, id := false, int32(-1)
+	luaRegister(l, "target", func(l *lua.LState) int {
+		ret := false
+		id, index := int32(-1), 0
+		// Check if ID is provided
 		if !nilArg(l, 1) {
 			id = int32(numArg(l, 1))
 		}
-		if c := sys.debugWC.target(id); c != nil {
+		// Check if index is provided
+		if !nilArg(l, 2) {
+			index = int(numArg(l, 2))
+		}
+		if c := sys.debugWC.target(id, index); c != nil {
 			sys.debugWC, ret = c, true
 		}
 		l.Push(lua.LBool(ret))

--- a/src/stage.go
+++ b/src/stage.go
@@ -350,6 +350,22 @@ func (bg *backGround) reset() {
 	bg.palfx.invertblend = -3
 }
 
+// Changes BG animation without changing surrounding parameters
+func (bg *backGround) changeAnim(val int32, a *Animation) {
+	// Save old
+	masktemp := bg.anim.mask
+	srcAlphatemp := bg.anim.srcAlpha
+	dstAlphatemp := bg.anim.dstAlpha
+	tiletmp := bg.anim.tile
+	// Change anim and restore old
+	bg.actionno = val
+	bg.anim = *a
+	bg.anim.tile = tiletmp
+	bg.anim.dstAlpha = dstAlphatemp
+	bg.anim.srcAlpha = srcAlphatemp
+	bg.anim.mask = masktemp
+}
+
 func (bg backGround) draw(pos [2]float32, drawscl, bgscl, stglscl float32,
 	stgscl [2]float32, shakeY float32, isStage bool) {
 
@@ -1461,22 +1477,11 @@ func (s *Stage) runBgCtrl(bgc *bgCtrl) {
 	bgc.currenttime++
 	switch bgc._type {
 	case BT_Anim:
-		a := s.at.get(bgc.v[0])
-		if a != nil {
+		if a := s.at.get(bgc.v[0]); a != nil {
 			for i := range bgc.bg {
-				masktemp := bgc.bg[i].anim.mask
-				srcAlphatemp := bgc.bg[i].anim.srcAlpha
-				dstAlphatemp := bgc.bg[i].anim.dstAlpha
-				tiletmp := bgc.bg[i].anim.tile
-				bgc.bg[i].actionno = bgc.v[0]
-				bgc.bg[i].anim = *a
-				bgc.bg[i].anim.tile = tiletmp
-				bgc.bg[i].anim.dstAlpha = dstAlphatemp
-				bgc.bg[i].anim.srcAlpha = srcAlphatemp
-				bgc.bg[i].anim.mask = masktemp
+				bgc.bg[i].changeAnim(bgc.v[0], a)
 			}
 		}
-
 		for i := range bgc.anim {
 			bgc.anim[i].toggle(bgc.v[0] != 0)
 		}

--- a/src/stage.go
+++ b/src/stage.go
@@ -67,6 +67,7 @@ type bgAction struct {
 func (bga *bgAction) clear() {
 	*bga = bgAction{}
 }
+
 func (bga *bgAction) action() {
 	for i := 0; i < 2; i++ {
 		bga.pos[i] += bga.vel[i]
@@ -129,11 +130,25 @@ type backGround struct {
 }
 
 func newBackGround(sff *Sff) *backGround {
-	return &backGround{palfx: newPalFX(), anim: *newAnimation(sff, &sff.palList), delta: [...]float32{1, 1}, zoomdelta: [...]float32{1, math.MaxFloat32},
-		xscale: [...]float32{1, 1}, rasterx: [...]float32{1, 1}, yscalestart: 100, scalestart: [...]float32{1, 1}, xbottomzoomdelta: math.MaxFloat32,
-		zoomscaledelta: [...]float32{math.MaxFloat32, math.MaxFloat32}, actionno: -1, visible: true, active: true, autoresizeparallax: false,
-		startrect: [...]int32{-32768, -32768, 65535, 65535}}
+	return &backGround{
+		palfx: newPalFX(),
+		anim: *newAnimation(sff, &sff.palList),
+		delta: [...]float32{1, 1},
+		zoomdelta: [...]float32{1, math.MaxFloat32},
+		xscale: [...]float32{1, 1},
+		rasterx: [...]float32{1, 1},
+		yscalestart: 100,
+		scalestart: [...]float32{1, 1},
+		xbottomzoomdelta: math.MaxFloat32,
+		zoomscaledelta: [...]float32{math.MaxFloat32, math.MaxFloat32},
+		actionno: -1,
+		visible: true,
+		active: true,
+		autoresizeparallax: false,
+		startrect: [...]int32{-32768, -32768, 65535, 65535},
+	}
 }
+
 func readBackGround(is IniSection, link *backGround,
 	sff *Sff, at AnimationTable, sProps StageProps) *backGround {
 	bg := newBackGround(sff)
@@ -322,6 +337,7 @@ func readBackGround(is IniSection, link *backGround,
 	}
 	return bg
 }
+
 func (bg *backGround) reset() {
 	bg.palfx.clear()
 	bg.anim.Reset()
@@ -493,8 +509,13 @@ type bgCtrl struct {
 }
 
 func newBgCtrl() *bgCtrl {
-	return &bgCtrl{looptime: -1, x: float32(math.NaN()), y: float32(math.NaN())}
+	return &bgCtrl{
+		looptime: -1,
+		x: float32(math.NaN()),
+		y: float32(math.NaN()),
+	}
 }
+
 func (bgc *bgCtrl) read(is IniSection, idx int) {
 	bgc.idx = idx
 	xy := false
@@ -601,9 +622,11 @@ func (bgc *bgCtrl) read(is IniSection, idx int) {
 	}
 	is.ReadI32("sctrlid", &bgc.sctrlid)
 }
+
 func (bgc *bgCtrl) xEnable() bool {
 	return !math.IsNaN(float64(bgc.x))
 }
+
 func (bgc *bgCtrl) yEnable() bool {
 	return !math.IsNaN(float64(bgc.y))
 }
@@ -620,6 +643,7 @@ type bgcTimeLine struct {
 func (bgct *bgcTimeLine) clear() {
 	*bgct = bgcTimeLine{}
 }
+
 func (bgct *bgcTimeLine) add(bgc *bgCtrl) {
 	if bgc.looptime >= 0 && bgc.endtime > bgc.looptime {
 		bgc.endtime = bgc.looptime
@@ -662,6 +686,7 @@ func (bgct *bgcTimeLine) add(bgc *bgCtrl) {
 		bgct.line[i] = bgctNode{bgc: []*bgCtrl{bgc}, waitTime: wtime}
 	}
 }
+
 func (bgct *bgcTimeLine) step(s *Stage) {
 	if len(bgct.line) > 0 && bgct.line[0].waitTime <= 0 {
 		for _, b := range bgct.line[0].bgc {
@@ -1357,6 +1382,7 @@ func loadStage(def string, maindef bool) (*Stage, error) {
 	s.mainstage = maindef
 	return s, nil
 }
+
 func (s *Stage) copyStageVars(src *Stage) {
 	s.stageCamera.boundleft = src.stageCamera.boundleft
 	s.stageCamera.boundright = src.stageCamera.boundright
@@ -1397,6 +1423,7 @@ func (s *Stage) copyStageVars(src *Stage) {
 	s.reflection.xshear = src.reflection.xshear
 	s.reflection.yscale = src.reflection.yscale
 }
+
 func (s *Stage) getBg(id int32) (bg []*backGround) {
 	if id >= 0 {
 		for _, b := range s.bg {
@@ -1407,6 +1434,7 @@ func (s *Stage) getBg(id int32) (bg []*backGround) {
 	}
 	return
 }
+
 func (s *Stage) get3DBg(id uint32) (nodes []*Node) {
 	if id >= 0 {
 		for _, n := range s.model.nodes {
@@ -1417,6 +1445,7 @@ func (s *Stage) get3DBg(id uint32) (nodes []*Node) {
 	}
 	return
 }
+
 func (s *Stage) get3DAnim(id uint32) (anims []*GLTFAnimation) {
 	if id >= 0 {
 		for _, a := range s.model.animations {
@@ -1427,6 +1456,7 @@ func (s *Stage) get3DAnim(id uint32) (anims []*GLTFAnimation) {
 	}
 	return
 }
+
 func (s *Stage) runBgCtrl(bgc *bgCtrl) {
 	bgc.currenttime++
 	switch bgc._type {
@@ -1594,6 +1624,7 @@ func (s *Stage) runBgCtrl(bgc *bgCtrl) {
 		}
 	}
 }
+
 func (s *Stage) action() {
 	link, zlink, paused := 0, -1, true
 	if sys.tickFrame() && (sys.supertime <= 0 || !sys.superpausebg) &&
@@ -1963,10 +1994,12 @@ func (p *GLTFAnimatableProperty) rest() {
 func (p *GLTFAnimatableProperty) restAt(v interface{}) {
 	p.restValue = v
 }
+
 func (p *GLTFAnimatableProperty) animate(v interface{}) {
 	p.isAnimated = true
 	p.animatedValue = v
 }
+
 func (p *GLTFAnimatableProperty) getValue() interface{} {
 	if p.isAnimated {
 		return p.animatedValue
@@ -2195,6 +2228,7 @@ func loadEnvironment(filepath string) (*Environment, error) {
 	}
 	return env, nil
 }
+
 func loadglTFStage(filepath string) (*Model, error) {
 	mdl := &Model{offset: [3]float32{0, 0, 0}, rotation: [3]float32{0, 0, 0}, scale: [3]float32{1, 1, 1}}
 	doc, err := gltf.Open(filepath)
@@ -3157,6 +3191,7 @@ func loadglTFStage(filepath string) (*Model, error) {
 	}
 	return mdl, nil
 }
+
 func (s *Scene) getSceneLight(n uint32, nodes []*Node) {
 	node := nodes[n]
 	for _, c := range node.childrenIndex {
@@ -3166,6 +3201,7 @@ func (s *Scene) getSceneLight(n uint32, nodes []*Node) {
 		s.lightNodes = append(s.lightNodes, n)
 	}
 }
+
 func (n *Node) getLocalTransform() (mat mgl.Mat4) {
 	mat = mgl.Ident4()
 	if n.transformChanged {
@@ -3182,6 +3218,7 @@ func (n *Node) getLocalTransform() (mat mgl.Mat4) {
 	}
 	return
 }
+
 func (n *Node) calculateWorldTransform(parentTransorm mgl.Mat4, nodes []*Node) {
 	mat := n.getLocalTransform()
 	n.worldTransform = parentTransorm.Mul4(mat)
@@ -3205,6 +3242,7 @@ func (n *Node) calculateWorldTransform(parentTransorm mgl.Mat4, nodes []*Node) {
 	}
 	return
 }
+
 func (mdl *Model) calculateTextureTransform() {
 	for _, m := range mdl.materials {
 		if index := m.textureIndex; index != nil {
@@ -3254,6 +3292,7 @@ func (mdl *Model) calculateTextureTransform() {
 		}
 	}
 }
+
 func calculateAnimationData(mdl *Model, n *Node) {
 	for _, index := range n.childrenIndex {
 		calculateAnimationData(mdl, mdl.nodes[index])
@@ -3353,6 +3392,7 @@ func calculateAnimationData(mdl *Model, n *Node) {
 		}
 	}
 }
+
 func drawNode(mdl *Model, scene *Scene, n *Node, camOffset [3]float32, drawBlended bool, unlit bool) {
 	//mat := n.getLocalTransform()
 	//model = model.Mul4(mat)
@@ -3495,6 +3535,7 @@ func drawNode(mdl *Model, scene *Scene, n *Node, camOffset [3]float32, drawBlend
 		gfx.ReleaseModelPipeline()
 	}
 }
+
 func drawNodeShadow(mdl *Model, scene *Scene, n *Node, camOffset [3]float32, drawBlended bool, lightIndex int, numLights int) {
 	//mat := n.getLocalTransform()
 	//model = model.Mul4(mat)
@@ -3564,6 +3605,7 @@ func drawNodeShadow(mdl *Model, scene *Scene, n *Node, camOffset [3]float32, dra
 		}
 	}
 }
+
 func (s *Stage) drawModel(pos [2]float32, yofs float32, scl float32, sceneNumber int) {
 	if s.model == nil || len(s.model.scenes) <= sceneNumber || !gfx.IsModelEnabled() {
 		return
@@ -3836,6 +3878,7 @@ func (s *Stage) drawModel(pos [2]float32, yofs float32, scl float32, sceneNumber
 		drawNode(s.model, scene, s.model.nodes[index], offset, true, unlit)
 	}
 }
+
 func (channel *GLTFAnimationChannel) parseAnimationPointer(m *Model, pointer string) error {
 	channel.nodeIndex = nil
 	components := strings.Split(pointer, "/")
@@ -4053,6 +4096,7 @@ func (channel *GLTFAnimationChannel) parseAnimationPointer(m *Model, pointer str
 	}
 	return nil
 }
+
 func (model *Model) calculateAnimInterpolation(interpolation GLTFAnimationInterpolation, sampler *GLTFAnimationSampler, animTime float32, prevIndex int, length int) []float32 {
 	if interpolation == InterpolationStep || prevIndex == -1 || len(model.animationTimeStamps[sampler.inputIndex]) == 1 {
 		if prevIndex == -1 {
@@ -4137,6 +4181,7 @@ func (model *Model) calculateAnimQuatInterpolation(interpolation GLTFAnimationIn
 		return newVals
 	}
 }
+
 func (anim *GLTFAnimation) toggle(enabled bool) {
 	if enabled {
 		anim.enabled = enabled
@@ -4148,6 +4193,7 @@ func (anim *GLTFAnimation) toggle(enabled bool) {
 		}
 	}
 }
+
 func (model *Model) step() {
 	for _, anim := range model.animations {
 		if anim.enabled == false {
@@ -4220,6 +4266,7 @@ func (model *Model) step() {
 		}
 	}
 }
+
 func (skin *Skin) calculateSkinMatrices(inverseGlobalTransform mgl.Mat4, nodes []*Node) {
 	matrices := make([]float32, len(skin.joints)*12*2)
 	for i, joint := range skin.joints {
@@ -4241,6 +4288,7 @@ func (skin *Skin) calculateSkinMatrices(inverseGlobalTransform mgl.Mat4, nodes [
 	}
 	skin.texture.tex.SetPixelData(matrices)
 }
+
 func (model *Model) reset() {
 	for _, anim := range model.animations {
 		anim.time = 0


### PR DESCRIPTION
Feat:
- Added sparkno, guard.sparkno, hitsound.group, hitsound.number, guardsound.group and guardsound.number to HitDefVar
- Implements #2340
- Target and Helper redirections now also accept an index argument
- "Target" family state controllers now also accept an index parameter (like ModifyExplod etc)
- StageBGVar trigger. Returns various info about the stage's BG elements
- ModifyStageBG sctrl. Allows modifying each BG element of the stage directly
- BGPalFX now also takes ID and index parameters, enabling it to affect the entire stage or only specific BG elements

Refactor:
- Simplified HitDef priority code a bit, which has always been a bit hard to troubleshoot

Fix:
- Explod layering in Z space (possible regression)