### PR TITLE
fix: HitBy, TargetBind; refactor Z parameters

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -908,8 +908,8 @@ const (
 	OC_ex2_stagebgvar_start_y
 	OC_ex2_stagebgvar_tile_x
 	OC_ex2_stagebgvar_tile_y
-	OC_ex2_stagebgvar_vel_x
-	OC_ex2_stagebgvar_vel_y
+	OC_ex2_stagebgvar_velocity_x
+	OC_ex2_stagebgvar_velocity_y
 )
 
 const (
@@ -3650,7 +3650,7 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		OC_ex2_stagebgvar_pos_x, OC_ex2_stagebgvar_pos_y,
 		OC_ex2_stagebgvar_start_x, OC_ex2_stagebgvar_start_y,
 		OC_ex2_stagebgvar_tile_x, OC_ex2_stagebgvar_tile_y,
-		OC_ex2_stagebgvar_vel_x, OC_ex2_stagebgvar_vel_y:
+		OC_ex2_stagebgvar_velocity_x, OC_ex2_stagebgvar_velocity_y:
 		// Common inputs
 		idx := int(sys.bcStack.Pop().ToI())
 		id := sys.bcStack.Pop().ToI()
@@ -3669,12 +3669,9 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 			case OC_ex2_stagebgvar_layerno:
 				sys.bcStack.PushI(bg.layerno)
 			case OC_ex2_stagebgvar_pos_x:
-				bg.bga.pos[0]++
 				sys.bcStack.PushF(bg.bga.pos[0] * sys.stage.localscl / oc.localscl)
-				//v = BytecodeFloat((bg.bga.pos[0]*slscl - sys.cam.Pos[0] * sys.cam.Scale) / c.localscl)
 			case OC_ex2_stagebgvar_pos_y:
 				sys.bcStack.PushF(bg.bga.pos[1] * sys.stage.localscl / oc.localscl)
-				//v = BytecodeFloat((bg.bga.pos[1]*sscale - sys.cam.GroundLevel()) / cscale)
 			case OC_ex2_stagebgvar_start_x:
 				sys.bcStack.PushF(bg.start[0] * sys.stage.localscl / oc.localscl)
 			case OC_ex2_stagebgvar_start_y:
@@ -3683,9 +3680,9 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 				sys.bcStack.PushI(bg.anim.tile.xflag)
 			case OC_ex2_stagebgvar_tile_y:
 				sys.bcStack.PushI(bg.anim.tile.yflag)
-			case OC_ex2_stagebgvar_vel_x:
+			case OC_ex2_stagebgvar_velocity_x:
 				sys.bcStack.PushF(bg.bga.vel[0] * sys.stage.localscl / oc.localscl)
-			case OC_ex2_stagebgvar_vel_y:
+			case OC_ex2_stagebgvar_velocity_y:
 				sys.bcStack.PushF(bg.bga.vel[1] * sys.stage.localscl / oc.localscl)
 			}
 		} else {
@@ -8221,7 +8218,7 @@ const (
 func (sc bindToTarget) Run(c *Char, _ []int32) bool {
 	crun := c
 	var redirscale float32 = 1.0
-	tid, tidx := int32(-1), int(-1)
+	tid, tidx := int32(-1), int(0)
 	time, x, y, z, hmf := int32(1), float32(0), float32(math.NaN()), float32(math.NaN()), HMF_F
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
@@ -12431,8 +12428,8 @@ const (
 	modifyStageBG_start_x
 	modifyStageBG_start_y
 	modifyStageBG_trans
-	modifyStageBG_vel_x
-	modifyStageBG_vel_y
+	modifyStageBG_velocity_x
+	modifyStageBG_velocity_y
 )
 
 func (sc modifyStageBG) Run(c *Char, _ []int32) bool {
@@ -12557,12 +12554,12 @@ func (sc modifyStageBG) Run(c *Char, _ []int32) bool {
 						}
 					})
 				}
-			case modifyStageBG_vel_x:
+			case modifyStageBG_velocity_x:
 				val := exp[0].evalF(c)
 				eachBg(func(bg *backGround) {
 					bg.bga.vel[0] = val
 				})
-			case modifyStageBG_vel_y:
+			case modifyStageBG_velocity_y:
 				val := exp[0].evalF(c)
 				eachBg(func(bg *backGround) {
 					bg.bga.vel[1] = val

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -2608,7 +2608,7 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_gethitvar_guarded:
 		sys.bcStack.PushB(c.ghv.guarded)
 	case OC_ex_gethitvar_isbound:
-		sys.bcStack.PushB(c.isBound())
+		sys.bcStack.PushB(c.isTargetBound())
 	case OC_ex_gethitvar_fall:
 		sys.bcStack.PushB(c.ghv.fallflag)
 	case OC_ex_gethitvar_fall_damage:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -270,16 +270,16 @@ const (
 	OC_const_size_attack_dist_width_back
 	OC_const_size_attack_dist_height_top
 	OC_const_size_attack_dist_height_bottom
-	OC_const_size_attack_dist_depth_front
-	OC_const_size_attack_dist_depth_back
-	OC_const_size_attack_depth_front
-	OC_const_size_attack_depth_back
+	OC_const_size_attack_dist_depth_top
+	OC_const_size_attack_dist_depth_bottom
+	OC_const_size_attack_depth_top
+	OC_const_size_attack_depth_bottom
 	OC_const_size_proj_attack_dist_width_front
 	OC_const_size_proj_attack_dist_width_back
 	OC_const_size_proj_attack_dist_height_top
 	OC_const_size_proj_attack_dist_height_bottom
-	OC_const_size_proj_attack_dist_depth_front
-	OC_const_size_proj_attack_dist_depth_back
+	OC_const_size_proj_attack_dist_depth_top
+	OC_const_size_proj_attack_dist_depth_bottom
 	OC_const_size_proj_doscale
 	OC_const_size_head_pos_x
 	OC_const_size_head_pos_y
@@ -288,8 +288,8 @@ const (
 	OC_const_size_shadowoffset
 	OC_const_size_draw_offset_x
 	OC_const_size_draw_offset_y
-	OC_const_size_depth_front
-	OC_const_size_depth_back
+	OC_const_size_depth_top
+	OC_const_size_depth_bottom
 	OC_const_size_weight
 	OC_const_size_pushfactor
 	OC_const_velocity_air_gethit_airrecover_add_x
@@ -2050,14 +2050,14 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.size.attack.dist.height[0] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_attack_dist_height_bottom:
 		sys.bcStack.PushF(c.size.attack.dist.height[1] * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_size_attack_dist_depth_front:
+	case OC_const_size_attack_dist_depth_top:
 		sys.bcStack.PushF(c.size.attack.dist.depth[0] * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_size_attack_dist_depth_back:
+	case OC_const_size_attack_dist_depth_bottom:
 		sys.bcStack.PushF(c.size.attack.dist.depth[1] * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_size_attack_depth_front:
-		sys.bcStack.PushF(c.size.attack.depth.front * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_size_attack_depth_back:
-		sys.bcStack.PushF(c.size.attack.depth.back * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_size_attack_depth_top:
+		sys.bcStack.PushF(c.size.attack.depth[0] * ((320 / c.localcoord) / oc.localscl))
+	case OC_const_size_attack_depth_bottom:
+		sys.bcStack.PushF(c.size.attack.depth[1] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_proj_attack_dist_width_front:
 		sys.bcStack.PushF(c.size.proj.attack.dist.width[0] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_proj_attack_dist_width_back:
@@ -2066,9 +2066,9 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.size.proj.attack.dist.height[0] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_proj_attack_dist_height_bottom:
 		sys.bcStack.PushF(c.size.proj.attack.dist.height[1] * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_size_proj_attack_dist_depth_front:
+	case OC_const_size_proj_attack_dist_depth_top:
 		sys.bcStack.PushF(c.size.proj.attack.dist.depth[0] * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_size_proj_attack_dist_depth_back:
+	case OC_const_size_proj_attack_dist_depth_bottom:
 		sys.bcStack.PushF(c.size.proj.attack.dist.depth[1] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_proj_doscale:
 		sys.bcStack.PushI(c.size.proj.doscale)
@@ -2086,9 +2086,9 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.size.draw.offset[0] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_draw_offset_y:
 		sys.bcStack.PushF(c.size.draw.offset[1] * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_size_depth_front:
+	case OC_const_size_depth_top:
 		sys.bcStack.PushF(c.size.depth[0] * ((320 / c.localcoord) / oc.localscl))
-	case OC_const_size_depth_back:
+	case OC_const_size_depth_bottom:
 		sys.bcStack.PushF(c.size.depth[1] * ((320 / c.localcoord) / oc.localscl))
 	case OC_const_size_weight:
 		sys.bcStack.PushI(c.size.weight)

--- a/src/char.go
+++ b/src/char.go
@@ -865,6 +865,7 @@ func (ghv *GetHitVar) selectiveClear(c *Char) {
 	down_recovertime := ghv.down_recovertime
 	fallcount := ghv.fallcount
 	fallflag := ghv.fallflag
+	frame := ghv.frame
 	guardcount := ghv.guardcount
 	guarddamage := ghv.guarddamage
 	guardpoints := ghv.guardpoints
@@ -885,6 +886,7 @@ func (ghv *GetHitVar) selectiveClear(c *Char) {
 	ghv.down_recovertime = down_recovertime
 	ghv.fallcount = fallcount
 	ghv.fallflag = fallflag
+	ghv.frame = frame
 	ghv.guardcount = guardcount
 	ghv.guarddamage = guarddamage
 	ghv.guardpoints = guardpoints
@@ -9647,15 +9649,14 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 				ghv.priority = hd.priority
 			}
 			if sys.supertime > 0 {
-				getter.superMovetime =
-					Max(getter.superMovetime, getter.ghv.hitshaketime)
+				getter.superMovetime = Max(getter.superMovetime, getter.ghv.hitshaketime)
 			} else if sys.pausetime > 0 {
-				getter.pauseMovetime =
-					Max(getter.pauseMovetime, getter.ghv.hitshaketime)
+				getter.pauseMovetime = Max(getter.pauseMovetime, getter.ghv.hitshaketime)
 			}
 			if !p2s && !getter.csf(CSF_gethit) {
 				getter.stchtmp = false
 			}
+			// Flag enemy as getting hit
 			getter.setCSF(CSF_gethit)
 			getter.ghv.frame = true
 			// In Mugen, having any HitOverride active allows GetHitVar Damage to exceed the remaining life
@@ -9702,8 +9703,8 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 			getter.ghv.guardpower += hd.guardgivepower
 			getter.ghv.hitdamage += getter.computeDamage(float64(hd.hitdamage), true, false, attackMul[0], c, false)
 			getter.ghv.guarddamage += getter.computeDamage(float64(hd.guarddamage), true, false, attackMul[0], c, false)
-			getter.ghv.hitredlife += getter.computeDamage(float64(hd.hitredlife), true, false, attackMul[1], c, bnd)
-			getter.ghv.guardredlife += getter.computeDamage(float64(hd.guardredlife), true, false, attackMul[1], c, bnd)
+			getter.ghv.hitredlife += getter.computeDamage(float64(hd.hitredlife), true, false, attackMul[1], c, false)
+			getter.ghv.guardredlife += getter.computeDamage(float64(hd.guardredlife), true, false, attackMul[1], c, false)
 
 			// Hit behavior on KO
 			if ghvset && getter.ghv.damage >= getter.life {

--- a/src/char.go
+++ b/src/char.go
@@ -7686,7 +7686,7 @@ func (c *Char) hitByPlayerIdCheck(getterid int32) bool {
 	return hit
 }
 
-// Check if Hitdef attributes can hit a player
+// Check if HitDef attributes can hit a player
 func (c *Char) attrCheck(getter *Char, ghd *HitDef, gstyp StateType) bool {
 
 	// Invalid attributes
@@ -7743,8 +7743,8 @@ func (c *Char) attrCheck(getter *Char, ghd *HitDef, gstyp StateType) bool {
 	attrsca := ghd.attr & int32(ST_MASK)
 	// Note: In Mugen, invincibility is checked against the enemy's actual statetype instead of the Hitdef's SCA attribute
 	// Exception for projectiles, where it respects the SCA attribute
-	// Ikemen characters work as documented. Invincibility only cares about the Hitdef's SCA attribute
-	if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
+	// Ikemen characters work as documented. Invincibility only cares about the HitDef's SCA attribute
+	if getter.stWgi().ikemenver[0] == 0 && getter.stWgi().ikemenver[1] == 0 {
 		if gstyp == ST_N { // Projectiles mostly
 			attrsca = ghd.attr & int32(ST_MASK)
 		} else {

--- a/src/char.go
+++ b/src/char.go
@@ -278,10 +278,7 @@ type CharSize struct {
 			height [2]float32
 			depth  [2]float32
 		}
-		depth struct {
-			front float32
-			back  float32
-		}
+		depth [2]float32
 	}
 	proj struct {
 		attack struct {
@@ -332,8 +329,7 @@ func (cs *CharSize) init() {
 	cs.shadowoffset = 0
 	cs.draw.offset = [...]float32{0, 0}
 	cs.depth = [...]float32{3, 3}
-	cs.attack.depth.front = 4
-	cs.attack.depth.back = 4
+	cs.attack.depth = [...]float32{4, 4}
 	cs.weight = 100
 	cs.pushfactor = 1
 }
@@ -740,7 +736,7 @@ func (hd *HitDef) clear(c *Char, localscl float32) {
 	hd.guard_sparkno = c.gi().data.guard.sparkno
 	hd.hitsound_channel = c.gi().data.hitsound_channel
 	hd.guardsound_channel = c.gi().data.guardsound_channel
-	hd.attack_depth = [2]float32{c.size.attack.depth.front, c.size.attack.depth.back}
+	hd.attack_depth = [2]float32{c.size.attack.depth[0], c.size.attack.depth[1]}
 }
 
 // When a Hitdef connects, its statetype attribute will be updated to the character's current type
@@ -2639,7 +2635,7 @@ func (c *Char) clearNextRound() {
 		alpha:           [2]int32{255, 0},
 		width:           [2]float32{c.baseWidthFront(), c.baseWidthBack()},
 		height:          [2]float32{c.baseHeightTop(), c.baseHeightBottom()},
-		depth:           [2]float32{c.baseDepthFront(), c.baseDepthBack()},
+		depth:           [2]float32{c.baseDepthTop(), c.baseDepthBottom()},
 		attackMul:       [4]float32{atk, atk, atk, atk},
 		fallDefenseMul:  1,
 		superDefenseMul: 1,
@@ -2950,8 +2946,8 @@ func (c *Char) load(def string) error {
 		c.size.draw.offset[1] *= coordRatio
 		c.size.depth[0] *= coordRatio
 		c.size.depth[1] *= coordRatio
-		c.size.attack.depth.front *= coordRatio
-		c.size.attack.depth.back *= coordRatio
+		c.size.attack.depth[0] *= coordRatio
+		c.size.attack.depth[1] *= coordRatio
 	}
 
 	gi.velocity.init()
@@ -3090,7 +3086,7 @@ func (c *Char) load(def string) error {
 						is.ReadF32("draw.offset",
 							&c.size.draw.offset[0], &c.size.draw.offset[1])
 						is.ReadF32("depth", &c.size.depth[0], &c.size.depth[1])
-						is.ReadF32("attack.depth", &c.size.attack.depth.front, &c.size.attack.depth.back)
+						is.ReadF32("attack.depth", &c.size.attack.depth[0], &c.size.attack.depth[1])
 						is.ReadI32("weight", &c.size.weight)
 						is.ReadF32("pushfactor", &c.size.pushfactor)
 					}
@@ -3843,7 +3839,7 @@ func (c *Char) bottomEdge() float32 {
 }
 
 func (c *Char) botBoundBodyDist() float32 {
-	return c.botBoundDist() - c.depthEdge[0]
+	return c.botBoundDist() - c.depthEdge[1]
 }
 
 func (c *Char) botBoundDist() float32 {
@@ -4696,7 +4692,7 @@ func (c *Char) topEdge() float32 {
 }
 
 func (c *Char) topBoundBodyDist() float32 {
-	return c.topBoundDist() - c.depthEdge[1]
+	return c.topBoundDist() - c.depthEdge[0]
 }
 
 func (c *Char) topBoundDist() float32 {
@@ -5713,11 +5709,11 @@ func (c *Char) baseHeightBottom() float32 {
 	}
 }
 
-func (c *Char) baseDepthFront() float32 {
+func (c *Char) baseDepthTop() float32 {
 	return float32(c.size.depth[0])
 }
 
-func (c *Char) baseDepthBack() float32 {
+func (c *Char) baseDepthBottom() float32 {
 	return float32(c.size.depth[1])
 }
 
@@ -5735,10 +5731,10 @@ func (c *Char) setHeight(th, bh float32) {
 	c.setCSF(CSF_height)
 }
 
-func (c *Char) setDepth(fd, bd float32) {
+func (c *Char) setDepth(td, bd float32) {
 	coordRatio := (320 / c.localcoord) / c.localscl
-	c.depth[0] = c.baseDepthFront()*coordRatio + fd
-	c.depth[1] = c.baseDepthBack()*coordRatio + bd
+	c.depth[0] = c.baseDepthTop()*coordRatio + td
+	c.depth[1] = c.baseDepthBottom()*coordRatio + bd
 	c.setCSF(CSF_depth)
 }
 
@@ -5748,8 +5744,8 @@ func (c *Char) setWidthEdge(fe, be float32) {
 	c.setCSF(CSF_widthedge)
 }
 
-func (c *Char) setDepthEdge(fde, bde float32) {
-	c.depthEdge[0] = fde
+func (c *Char) setDepthEdge(tde, bde float32) {
+	c.depthEdge[0] = tde
 	c.depthEdge[1] = bde
 	c.setCSF(CSF_depthedge)
 }
@@ -6619,10 +6615,10 @@ func (c *Char) bodyDistY(opp *Char, oc *Char) float32 {
 }
 
 func (c *Char) bodyDistZ(opp *Char, oc *Char) float32 {
-	cbot := (c.pos[2] + c.depth[0]) * c.localscl
-	ctop := (c.pos[2] - c.depth[1]) * c.localscl
-	obot := (opp.pos[2] + opp.depth[0]) * opp.localscl
-	otop := (opp.pos[2] - opp.depth[1]) * opp.localscl
+	ctop := (c.pos[2] - c.depth[0]) * c.localscl
+	cbot := (c.pos[2] + c.depth[1]) * c.localscl
+	otop := (opp.pos[2] - opp.depth[0]) * opp.localscl
+	obot := (opp.pos[2] + opp.depth[1]) * opp.localscl
 	if cbot < otop {
 		return (otop - cbot) / oc.localscl
 	} else if ctop > obot {
@@ -7354,8 +7350,9 @@ func (c *Char) xScreenBound() {
 
 func (c *Char) zDepthBound() {
 	posz := c.pos[2]
-	max, min := -c.depthEdge[0], c.depthEdge[1]
 	if c.csf(CSF_stagebound) {
+		min := c.depthEdge[0]
+		max := -c.depthEdge[1]
 		posz = ClampF(posz, min+sys.zmin/c.localscl, max+sys.zmax/c.localscl)
 	}
 	c.setPosZ(posz)
@@ -8069,7 +8066,7 @@ func (c *Char) actionRun() {
 			c.height = [2]float32{c.baseHeightTop() * coordRatio, c.baseHeightBottom() * coordRatio}
 		}
 		if !c.csf(CSF_depth) {
-			c.depth = [2]float32{c.baseDepthFront() * coordRatio, c.baseDepthBack() * coordRatio}
+			c.depth = [2]float32{c.baseDepthTop() * coordRatio, c.baseDepthBottom() * coordRatio}
 		}
 		if !c.csf(CSF_depthedge) {
 			c.depthEdge = [2]float32{0, 0}
@@ -10433,14 +10430,14 @@ func (cl *CharList) pushDetection(getter *Char) {
 				continue
 			}
 
-			czfront := c.pos[2]*c.localscl + c.depth[0]*c.localscl
-			czback := c.pos[2]*c.localscl - c.depth[1]*c.localscl
+			cztop := c.pos[2]*c.localscl - c.depth[0]*c.localscl
+			czbot := c.pos[2]*c.localscl + c.depth[1]*c.localscl
 
-			gzfront := getter.pos[2]*getter.localscl + getter.depth[0]*getter.localscl
-			gzback := getter.pos[2]*getter.localscl - getter.depth[1]*getter.localscl
+			gztop := getter.pos[2]*getter.localscl - getter.depth[0]*getter.localscl
+			gzbot := getter.pos[2]*getter.localscl + getter.depth[1]*getter.localscl
 
 			// Z axis fail
-			if gzback >= czfront || czback >= gzfront {
+			if gztop >= czbot || cztop >= gzbot {
 				continue
 			}
 
@@ -10554,21 +10551,21 @@ func (cl *CharList) pushDetection(getter *Char) {
 				if pushz {
 					if getter.pos[2] >= c.pos[2] {
 						if c.pushPriority >= getter.pushPriority {
-							//getter.pos[2] -= ((czfront - gzback) * gfactor) / getter.localscl
-							getter.pos[2] -= (czfront - gzback) / getter.localscl
+							//getter.pos[2] -= ((czbot - gztop) * gfactor) / getter.localscl
+							getter.pos[2] -= (czbot - gztop) / getter.localscl
 						}
 						if c.pushPriority <= getter.pushPriority {
-							//c.pos[2] += ((czfront - gzback) * cfactor) / c.localscl
-							c.pos[2] += (czfront - gzback) / c.localscl
+							//c.pos[2] += ((czbot - gztop) * cfactor) / c.localscl
+							c.pos[2] += (czbot - gztop) / c.localscl
 						}
 					} else if getter.pos[2] < c.pos[2] {
 						if c.pushPriority >= getter.pushPriority {
-							//getter.pos[2] -= ((gzfront - czback) * gfactor) / getter.localscl
-							getter.pos[2] -= (gzfront - czback) / getter.localscl
+							//getter.pos[2] -= ((gzbot - cztop) * gfactor) / getter.localscl
+							getter.pos[2] -= (gzbot - cztop) / getter.localscl
 						}
 						if c.pushPriority <= getter.pushPriority {
-							//c.pos[2] += ((gzfront - czback) * cfactor) / c.localscl
-							c.pos[2] += (gzfront - czback) / c.localscl
+							//c.pos[2] += ((gzbot - cztop) * cfactor) / c.localscl
+							c.pos[2] += (gzbot - cztop) / c.localscl
 						}
 					}
 					// Clamp Z positions

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -12,8 +12,9 @@ import (
 const specialSymbols = " !=<>()|&+-*/%,[]^:;{}#\"\t\r\n"
 
 type expFunc func(out *BytecodeExp, in *string) (BytecodeValue, error)
-type scFunc func(is IniSection, sc *StateControllerBase,
-	ihp int8) (StateController, error)
+
+type scFunc func(is IniSection, sc *StateControllerBase, ihp int8) (StateController, error)
+
 type Compiler struct {
 	cmdl             *CommandList
 	previousOperator string
@@ -600,6 +601,7 @@ func (*Compiler) tokenizerCS(in *string) string {
 	*in = (*in)[i:]
 	return token
 }
+
 func (*Compiler) isOperator(token string) int {
 	switch token {
 	case "", ",", ")", "]":
@@ -629,6 +631,7 @@ func (*Compiler) isOperator(token string) int {
 	}
 	return 0
 }
+
 func (c *Compiler) operator(in *string) error {
 	if len(c.previousOperator) > 0 {
 		if opp := c.isOperator(c.token); opp <= c.isOperator(c.previousOperator) {
@@ -645,6 +648,7 @@ func (c *Compiler) operator(in *string) error {
 	}
 	return nil
 }
+
 func (c *Compiler) integer2(in *string) (int32, error) {
 	istr := c.token
 	c.token = c.tokenizer(in)
@@ -664,6 +668,7 @@ func (c *Compiler) integer2(in *string) (int32, error) {
 	}
 	return i, nil
 }
+
 func (c *Compiler) number(token string) BytecodeValue {
 	f, err := strconv.ParseFloat(token, 64)
 	if err != nil && f == 0 {
@@ -685,6 +690,7 @@ func (c *Compiler) number(token string) BytecodeValue {
 	}
 	return BytecodeValue{VT_Int, f}
 }
+
 func (c *Compiler) attr(text string, hitdef bool) (int32, error) {
 	flg := int32(0)
 	att := SplitAndTrim(text, ",")
@@ -774,6 +780,7 @@ func (c *Compiler) attr(text string, hitdef bool) (int32, error) {
 	//}
 	return flg, nil
 }
+
 func (c *Compiler) trgAttr(in *string) (int32, error) {
 	flg := int32(0)
 	*in = c.token + *in
@@ -872,6 +879,7 @@ func (c *Compiler) checkClosingBracket() error {
 	}
 	return nil
 }
+
 func (c *Compiler) checkEquality(in *string) (not bool, err error) {
 	for {
 		c.token = c.tokenizer(in)
@@ -893,6 +901,7 @@ func (c *Compiler) checkEquality(in *string) (not bool, err error) {
 	c.token = c.tokenizer(in)
 	return
 }
+
 func (c *Compiler) intRange(in *string) (minop OpCode, maxop OpCode,
 	min, max int32, err error) {
 	switch c.token {
@@ -963,6 +972,7 @@ func (c *Compiler) intRange(in *string) (minop OpCode, maxop OpCode,
 	c.token = c.tokenizer(in)
 	return
 }
+
 func (c *Compiler) compareValues(_range bool, in *string) {
 	if sys.ignoreMostErrors {
 		i := 0
@@ -976,6 +986,7 @@ func (c *Compiler) compareValues(_range bool, in *string) {
 	}
 	c.token = c.tokenizer(in)
 }
+
 func (c *Compiler) evaluateComparison(out *BytecodeExp, in *string,
 	required bool) error {
 	comma := c.token == ","
@@ -1062,6 +1073,7 @@ func (c *Compiler) evaluateComparison(out *BytecodeExp, in *string,
 	c.reverseOrder = true
 	return nil
 }
+
 func (c *Compiler) oneArg(out *BytecodeExp, in *string,
 	rd, appendVal bool, defval ...BytecodeValue) (BytecodeValue, error) {
 	var be BytecodeExp
@@ -1093,6 +1105,7 @@ func (c *Compiler) oneArg(out *BytecodeExp, in *string,
 	out.append(be...)
 	return bv, nil
 }
+
 func (c *Compiler) mathFunc(out *BytecodeExp, in *string, rd bool,
 	oc OpCode, f func(*BytecodeValue)) (bv BytecodeValue, err error) {
 	var be BytecodeExp
@@ -1643,7 +1656,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "size":
 			bv1 = BytecodeInt(3)
 		default:
-			return bvNone(), Error("Invalid collision box type")
+			return bvNone(), Error("Invalid collision box type: " + c1type)
 		}
 		c.token = c.tokenizer(in)
 		if c.token != "," {
@@ -1666,7 +1679,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "size":
 			bv3 = BytecodeInt(3)
 		default:
-			return bvNone(), Error("Invalid collision box type")
+			return bvNone(), Error("Invalid collision box type: " + c2type)
 		}
 		c.token = c.tokenizer(in)
 		if err := c.checkClosingBracket(); err != nil {
@@ -3277,62 +3290,32 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		switch vname {
 		case "actionno":
 			opc = OC_ex2_stagebgvar_actionno
-		case "delta":
-			c.token = c.tokenizer(in)
-			switch c.token {
-			case "x":
-				opc = OC_ex2_stagebgvar_delta_x
-			case "y":
-				opc = OC_ex2_stagebgvar_delta_y
-			default:
-				return bvNone(), Error("Invalid StageBGVar delta argument: " + c.token)
-			}
+		case "delta.x":
+			opc = OC_ex2_stagebgvar_delta_x
+		case "delta.y":
+			opc = OC_ex2_stagebgvar_delta_y
 		case "id":
 			opc = OC_ex2_stagebgvar_id
 		case "layerno":
 			opc = OC_ex2_stagebgvar_layerno
-		case "pos":
-			c.token = c.tokenizer(in)
-			switch c.token {
-			case "x":
-				opc = OC_ex2_stagebgvar_pos_x
-			case "y":
-				opc = OC_ex2_stagebgvar_pos_y
-			default:
-				return bvNone(), Error("Invalid StageBGVar pos argument: " + c.token)
-			}
-		case "start":
-			c.token = c.tokenizer(in)
-			switch c.token {
-			case "x":
-				opc = OC_ex2_stagebgvar_start_x
-			case "y":
-				opc = OC_ex2_stagebgvar_start_y
-			default:
-				return bvNone(), Error("Invalid StageBGVar start argument: " + c.token)
-			}
-		case "tile":
-			c.token = c.tokenizer(in)
-			switch c.token {
-			case "x":
-				opc = OC_ex2_stagebgvar_tile_x
-			case "y":
-				opc = OC_ex2_stagebgvar_tile_y
-			default:
-				return bvNone(), Error("Invalid StageBGVar tile argument: " + c.token)
-			}
-		case "vel":
-			c.token = c.tokenizer(in)
-			switch c.token {
-			case "x":
-				opc = OC_ex2_stagebgvar_vel_x
-			case "y":
-				opc = OC_ex2_stagebgvar_vel_y
-			default:
-				return bvNone(), Error("Invalid StageBGVar vel argument: " + c.token)
-			}
+		case "pos.x":
+			opc = OC_ex2_stagebgvar_pos_x
+		case "pos.y":
+			opc = OC_ex2_stagebgvar_pos_y
+		case "start.x":
+			opc = OC_ex2_stagebgvar_start_x
+		case "start.y":
+			opc = OC_ex2_stagebgvar_start_y
+		case "tile.x":
+			opc = OC_ex2_stagebgvar_tile_x
+		case "tile.y":
+			opc = OC_ex2_stagebgvar_tile_y
+		case "velocity.x":
+			opc = OC_ex2_stagebgvar_velocity_x
+		case "velocity.y":
+			opc = OC_ex2_stagebgvar_velocity_y
 		default:
-			return bvNone(), Error("Invalid StageBGVar string argument: " + vname)
+			return bvNone(), Error("Invalid StageBGVar argument: " + vname)
 		}
 		c.token = c.tokenizer(in)
 		if err := c.checkClosingBracket(); err != nil {
@@ -4010,7 +3993,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "numclsn2":
 			out.append(OC_ex_animelemvar_numclsn2)
 		default:
-			return bvNone(), Error("Invalid data: " + c.token)
+			return bvNone(), Error("Invalid AnimElemVar argument: " + c.token)
 		}
 		c.token = c.tokenizer(in)
 		if err := c.checkClosingBracket(); err != nil {
@@ -4074,7 +4057,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "ampl":
 			out.append(OC_ex_envshakevar_ampl)
 		default:
-			return bvNone(), Error("Invalid data: " + c.token)
+			return bvNone(), Error("Invalid EnvShakeVar argument: " + c.token)
 		}
 		c.token = c.tokenizer(in)
 		if err := c.checkClosingBracket(); err != nil {
@@ -4099,7 +4082,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "windisplay":
 			opc = OC_ex2_fightscreenstate_windisplay
 		default:
-			return bvNone(), Error("Invalid data: " + fssname)
+			return bvNone(), Error("Invalid FightScreenState argument: " + fssname)
 		}
 		out.append(OC_ex2_)
 		out.append(opc)
@@ -4143,7 +4126,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "time.framespercount":
 			opc = OC_ex_fightscreenvar_time_framespercount
 		default:
-			return bvNone(), Error("Invalid data: " + fsvname)
+			return bvNone(), Error("Invalid FightScreenVar argument: " + fsvname)
 		}
 		if isStr {
 			if err := nameSub(OC_ex_, opc); err != nil {
@@ -4228,7 +4211,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "m":
 			out.append(OC_ex_, OC_ex_inputtime_m)
 		default:
-			return bvNone(), Error("Invalid data: " + key)
+			return bvNone(), Error("Invalid InputTime argument: " + key)
 		}
 	case "isasserted":
 		if err := c.checkOpeningBracket(in); err != nil {
@@ -4398,7 +4381,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "y":
 			out.append(OC_ex_, OC_ex_localcoord_y)
 		default:
-			return bvNone(), Error("Invalid data: " + c.token)
+			return bvNone(), Error("Invalid LocalCoord argument: " + c.token)
 		}
 	case "map":
 		if err := c.checkOpeningBracket(in); err != nil {
@@ -4476,7 +4459,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "uniqhit":
 			out.append(OC_ex_movehitvar_uniqhit)
 		default:
-			return bvNone(), Error("Invalid data: " + c.token)
+			return bvNone(), Error("Invalid MoveHitVar argument: " + c.token)
 		}
 		c.token = c.tokenizer(in)
 		if err := c.checkClosingBracket(); err != nil {
@@ -4587,7 +4570,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "superpausetime":
 			opc = OC_ex2_systemvar_superpausetime
 		default:
-			return bvNone(), Error("Invalid data: " + svname)
+			return bvNone(), Error("Invalid SystemVar argument: " + svname)
 		}
 		out.append(OC_ex2_)
 		out.append(opc)
@@ -4706,6 +4689,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 	c.token = c.tokenizer(in)
 	return bv, nil
 }
+
 func (c *Compiler) contiguousOperator(in *string) error {
 	*in = strings.TrimSpace(*in)
 	if len(*in) > 0 {
@@ -4721,6 +4705,7 @@ func (c *Compiler) contiguousOperator(in *string) error {
 	}
 	return nil
 }
+
 func (c *Compiler) expPostNot(out *BytecodeExp, in *string) (BytecodeValue,
 	error) {
 	bv, err := c.expValue(out, in, false)
@@ -4771,6 +4756,7 @@ func (c *Compiler) expPostNot(out *BytecodeExp, in *string) (BytecodeValue,
 	}
 	return bv, nil
 }
+
 func (c *Compiler) expPow(out *BytecodeExp, in *string) (BytecodeValue,
 	error) {
 	bv, err := c.expPostNot(out, in)
@@ -4803,6 +4789,7 @@ func (c *Compiler) expPow(out *BytecodeExp, in *string) (BytecodeValue,
 	}
 	return bv, nil
 }
+
 func (c *Compiler) expMldv(out *BytecodeExp, in *string) (BytecodeValue,
 	error) {
 	bv, err := c.expPow(out, in)
@@ -4831,6 +4818,7 @@ func (c *Compiler) expMldv(out *BytecodeExp, in *string) (BytecodeValue,
 		}
 	}
 }
+
 func (c *Compiler) expAdsb(out *BytecodeExp, in *string) (BytecodeValue,
 	error) {
 	bv, err := c.expMldv(out, in)
@@ -4856,6 +4844,7 @@ func (c *Compiler) expAdsb(out *BytecodeExp, in *string) (BytecodeValue,
 		}
 	}
 }
+
 func (c *Compiler) expGrls(out *BytecodeExp, in *string) (BytecodeValue,
 	error) {
 	bv, err := c.expAdsb(out, in)
@@ -4887,6 +4876,7 @@ func (c *Compiler) expGrls(out *BytecodeExp, in *string) (BytecodeValue,
 		}
 	}
 }
+
 func (c *Compiler) expRange(out *BytecodeExp, in *string,
 	bv *BytecodeValue, opc OpCode) (bool, error) {
 	open := c.token
@@ -4975,6 +4965,7 @@ func (c *Compiler) expRange(out *BytecodeExp, in *string,
 	}
 	return true, nil
 }
+
 func (c *Compiler) expEqne(out *BytecodeExp, in *string) (BytecodeValue,
 	error) {
 	bv, err := c.expGrls(out, in)
@@ -5018,6 +5009,7 @@ func (c *Compiler) expEqne(out *BytecodeExp, in *string) (BytecodeValue,
 		}
 	}
 }
+
 func (*Compiler) expOneOpSub(out *BytecodeExp, in *string, bv *BytecodeValue,
 	ef expFunc, opf func(v1 *BytecodeValue, v2 BytecodeValue),
 	opc OpCode) error {
@@ -5037,6 +5029,7 @@ func (*Compiler) expOneOpSub(out *BytecodeExp, in *string, bv *BytecodeValue,
 	}
 	return nil
 }
+
 func (c *Compiler) expOneOp(out *BytecodeExp, in *string, ef expFunc,
 	opt string, opf func(v1 *BytecodeValue, v2 BytecodeValue),
 	opc OpCode) (BytecodeValue, error) {
@@ -5058,17 +5051,21 @@ func (c *Compiler) expOneOp(out *BytecodeExp, in *string, ef expFunc,
 		}
 	}
 }
+
 func (c *Compiler) expAnd(out *BytecodeExp, in *string) (BytecodeValue,
 	error) {
 	return c.expOneOp(out, in, c.expEqne, "&", out.and, OC_and)
 }
+
 func (c *Compiler) expXor(out *BytecodeExp, in *string) (BytecodeValue,
 	error) {
 	return c.expOneOp(out, in, c.expAnd, "^", out.xor, OC_xor)
 }
+
 func (c *Compiler) expOr(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	return c.expOneOp(out, in, c.expXor, "|", out.or, OC_or)
 }
+
 func (c *Compiler) expBoolAnd(out *BytecodeExp, in *string) (BytecodeValue,
 	error) {
 	if c.block != nil {
@@ -5109,10 +5106,12 @@ func (c *Compiler) expBoolAnd(out *BytecodeExp, in *string) (BytecodeValue,
 	}
 	return bv, nil
 }
+
 func (c *Compiler) expBoolXor(out *BytecodeExp, in *string) (BytecodeValue,
 	error) {
 	return c.expOneOp(out, in, c.expBoolAnd, "^^", out.blxor, OC_blxor)
 }
+
 func (c *Compiler) expBoolOr(out *BytecodeExp, in *string) (BytecodeValue,
 	error) {
 	defer func(omp string) { c.previousOperator = omp }(c.previousOperator)
@@ -5154,6 +5153,7 @@ func (c *Compiler) expBoolOr(out *BytecodeExp, in *string) (BytecodeValue,
 	}
 	return bv, nil
 }
+
 func (c *Compiler) typedExp(ef expFunc, in *string,
 	vt ValueType) (BytecodeExp, error) {
 	c.token = c.tokenizer(in)
@@ -5175,6 +5175,7 @@ func (c *Compiler) typedExp(ef expFunc, in *string,
 	}
 	return be, nil
 }
+
 func (c *Compiler) argExpression(in *string, vt ValueType) (BytecodeExp,
 	error) {
 	be, err := c.typedExp(c.expBoolOr, in, vt)
@@ -5194,6 +5195,7 @@ func (c *Compiler) argExpression(in *string, vt ValueType) (BytecodeExp,
 	}
 	return be, nil
 }
+
 func (c *Compiler) fullExpression(in *string, vt ValueType) (BytecodeExp,
 	error) {
 	be, err := c.typedExp(c.expBoolOr, in, vt)
@@ -5205,6 +5207,7 @@ func (c *Compiler) fullExpression(in *string, vt ValueType) (BytecodeExp,
 	}
 	return be, nil
 }
+
 func (c *Compiler) parseSection(
 	sctrl func(name, data string) error) (IniSection, bool, error) {
 	is := NewIniSection()
@@ -5277,6 +5280,7 @@ func (c *Compiler) parseSection(
 	}
 	return is, !ignorehitpause, nil
 }
+
 func (c *Compiler) stateSec(is IniSection, f func() error) error {
 	if err := f(); err != nil {
 		return err
@@ -5295,6 +5299,7 @@ func (c *Compiler) stateSec(is IniSection, f func() error) error {
 	}
 	return nil
 }
+
 func (c *Compiler) stateParam(is IniSection, name string, mandatory bool, f func(string) error) error {
 	data, ok := is[name]
 	if ok {
@@ -5328,6 +5333,7 @@ func (c *Compiler) getDataPrefix(data *string, ffxDefault bool) (prefix string) 
 	}
 	return
 }
+
 func (c *Compiler) exprs(data string, vt ValueType,
 	numArg int) ([]BytecodeExp, error) {
 	bes := []BytecodeExp{}
@@ -5349,6 +5355,7 @@ func (c *Compiler) exprs(data string, vt ValueType,
 	}
 	return bes, nil
 }
+
 func (c *Compiler) scAdd(sc *StateControllerBase, id byte,
 	data string, vt ValueType, numArg int, topbe ...BytecodeExp) error {
 	bes, err := c.exprs(data, vt, numArg)
@@ -6095,6 +6102,7 @@ func (c *Compiler) wrongClosureToken() error {
 	}
 	return Error("Unexpected token: " + c.token)
 }
+
 func (c *Compiler) nextLine() (string, bool) {
 	s := <-c.linechan
 	if s == nil {
@@ -6102,6 +6110,7 @@ func (c *Compiler) nextLine() (string, bool) {
 	}
 	return *s, true
 }
+
 func (c *Compiler) scan(line *string) string {
 	for {
 		c.token = c.tokenizer(line)
@@ -6118,6 +6127,7 @@ func (c *Compiler) scan(line *string) string {
 	}
 	return c.token
 }
+
 func (c *Compiler) needToken(t string) error {
 	if c.token != t {
 		if c.token == "" {
@@ -6127,6 +6137,7 @@ func (c *Compiler) needToken(t string) error {
 	}
 	return nil
 }
+
 func (c *Compiler) readString(line *string) (string, error) {
 	i := strings.Index(*line, "\"")
 	if i < 0 {
@@ -6136,6 +6147,7 @@ func (c *Compiler) readString(line *string) (string, error) {
 	*line = (*line)[i+1:]
 	return s, nil
 }
+
 func (c *Compiler) readSentenceLine(line *string) (s string, assign bool,
 	err error) {
 	c.token = ""
@@ -6170,6 +6182,7 @@ func (c *Compiler) readSentenceLine(line *string) (s string, assign bool,
 	}
 	return
 }
+
 func (c *Compiler) readSentence(line *string) (s string, a bool, err error) {
 	if s, a, err = c.readSentenceLine(line); err != nil {
 		return
@@ -6189,6 +6202,7 @@ func (c *Compiler) readSentence(line *string) (s string, a bool, err error) {
 	}
 	return strings.TrimSpace(s), a, nil
 }
+
 func (c *Compiler) statementEnd(line *string) error {
 	c.token = c.tokenizer(line)
 	if len(c.token) > 0 && c.token[0] != '#' {
@@ -6197,6 +6211,7 @@ func (c *Compiler) statementEnd(line *string) error {
 	c.token, *line = "", ""
 	return nil
 }
+
 func (c *Compiler) readKeyValue(is IniSection, end string,
 	line *string) error {
 	name := c.scan(line)
@@ -6217,6 +6232,7 @@ func (c *Compiler) readKeyValue(is IniSection, end string,
 	is[name] = data
 	return nil
 }
+
 func (c *Compiler) varNameCheck(nm string) (err error) {
 	if (nm[0] < 'a' || nm[0] > 'z') && nm[0] != '_' {
 		return Error("Invalid name: " + nm)
@@ -6228,6 +6244,7 @@ func (c *Compiler) varNameCheck(nm string) (err error) {
 	}
 	return nil
 }
+
 func (c *Compiler) varNames(end string, line *string) ([]string, error) {
 	names, name := []string{}, c.scan(line)
 	if name != end {
@@ -6259,6 +6276,7 @@ func (c *Compiler) varNames(end string, line *string) ([]string, error) {
 	}
 	return names, nil
 }
+
 func (c *Compiler) inclNumVars(numVars *int32) error {
 	*numVars++
 	if *numVars > 256 {
@@ -6266,6 +6284,7 @@ func (c *Compiler) inclNumVars(numVars *int32) error {
 	}
 	return nil
 }
+
 func (c *Compiler) scanI32(line *string) (int32, error) {
 	t := c.scan(line)
 	if t == "" {
@@ -6277,6 +6296,7 @@ func (c *Compiler) scanI32(line *string) (int32, error) {
 	v, err := strconv.ParseInt(t, 10, 32)
 	return int32(v), err
 }
+
 func (c *Compiler) scanStateDef(line *string, constants map[string]float32) (int32, error) {
 	t := c.scan(line)
 	if t == "" {
@@ -6362,6 +6382,7 @@ func (c *Compiler) blockAttribSet(line *string, bl *StateBlock, sbc *StateByteco
 	}
 	return nil
 }
+
 func (c *Compiler) subBlock(line *string, root bool,
 	sbc *StateBytecode, numVars *int32, inheritIhp, nestedInLoop bool) (*StateBlock, error) {
 	bl := newStateBlock()
@@ -6435,6 +6456,7 @@ func (c *Compiler) subBlock(line *string, root bool,
 	}
 	return bl, nil
 }
+
 func (c *Compiler) switchBlock(line *string, bl *StateBlock,
 	sbc *StateBytecode, numVars *int32) error {
 	// In this implementation of switch, we convert the statement to an if-elseif-else chain of blocks
@@ -6535,6 +6557,7 @@ func (c *Compiler) switchBlock(line *string, bl *StateBlock,
 	}
 	return nil
 }
+
 func (c *Compiler) loopBlock(line *string, root bool, bl *StateBlock,
 	sbc *StateBytecode, numVars *int32) error {
 	bl.loopBlock = true
@@ -6609,6 +6632,7 @@ func (c *Compiler) loopBlock(line *string, root bool, bl *StateBlock,
 	}
 	return nil
 }
+
 func (c *Compiler) callFunc(line *string, root bool,
 	ctrls *[]StateController, ret []uint8) error {
 	var cf callFunction
@@ -6686,6 +6710,7 @@ func (c *Compiler) callFunc(line *string, root bool,
 	c.scan(line)
 	return nil
 }
+
 func (c *Compiler) letAssign(line *string, root bool,
 	ctrls *[]StateController, numVars *int32, names []string, endLine bool) error {
 	varis := make([]uint8, len(names))
@@ -6752,6 +6777,7 @@ func (c *Compiler) letAssign(line *string, root bool,
 	}
 	return nil
 }
+
 func (c *Compiler) stateBlock(line *string, bl *StateBlock, root bool,
 	sbc *StateBytecode, ctrls *[]StateController, numVars *int32) error {
 	c.scan(line)
@@ -6905,6 +6931,7 @@ func (c *Compiler) stateBlock(line *string, bl *StateBlock, root bool,
 	}
 	return c.wrongClosureToken()
 }
+
 func (c *Compiler) stateCompileZ(states map[int32]StateBytecode,
 	filename, src string, constants map[string]float32) error {
 	defer func(oime bool) {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1818,7 +1818,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.append(OC_const_size_air_back)
 		case "size.air.front":
 			out.append(OC_const_size_air_front)
-		case "size.height", "size.height.stand": // Latter is also accepted for consistency's sake
+		case "size.height", "size.height.stand": // Optional new syntax for consistency
 			out.append(OC_const_size_height_stand)
 		case "size.height.crouch":
 			out.append(OC_const_size_height_crouch)
@@ -1828,7 +1828,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.append(OC_const_size_height_air_bottom)
 		case "size.height.down":
 			out.append(OC_const_size_height_down)
-		case "size.attack.dist", "size.attack.dist.width.front":
+		case "size.attack.dist", "size.attack.dist.width.front": // Optional new syntax for consistency
 			out.append(OC_const_size_attack_dist_width_front)
 		case "size.attack.dist.width.back":
 			out.append(OC_const_size_attack_dist_width_back)
@@ -1836,15 +1836,15 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.append(OC_const_size_attack_dist_height_top)
 		case "size.attack.dist.height.bottom":
 			out.append(OC_const_size_attack_dist_height_bottom)
-		case "size.attack.dist.depth.front":
-			out.append(OC_const_size_attack_dist_depth_front)
-		case "size.attack.dist.depth.back":
-			out.append(OC_const_size_attack_dist_depth_back)
-		case "size.attack.depth.front":
-			out.append(OC_const_size_attack_depth_front)
-		case "size.attack.depth.back":
-			out.append(OC_const_size_attack_depth_back)
-		case "size.proj.attack.dist", "size.proj.attack.dist.width.front":
+		case "size.attack.dist.depth.top":
+			out.append(OC_const_size_attack_dist_depth_top)
+		case "size.attack.dist.depth.bottom":
+			out.append(OC_const_size_attack_dist_depth_bottom)
+		case "size.attack.depth.top":
+			out.append(OC_const_size_attack_depth_top)
+		case "size.attack.depth.bottom":
+			out.append(OC_const_size_attack_depth_bottom)
+		case "size.proj.attack.dist", "size.proj.attack.dist.width.front": // Optional new syntax for consistency
 			out.append(OC_const_size_proj_attack_dist_width_front)
 		case "size.proj.attack.dist.width.back":
 			out.append(OC_const_size_proj_attack_dist_width_back)
@@ -1852,10 +1852,10 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.append(OC_const_size_proj_attack_dist_height_top)
 		case "size.proj.attack.dist.height.bottom":
 			out.append(OC_const_size_proj_attack_dist_height_bottom)
-		case "size.proj.attack.dist.depth.front":
-			out.append(OC_const_size_proj_attack_dist_depth_front)
-		case "size.proj.attack.dist.depth.back":
-			out.append(OC_const_size_proj_attack_dist_depth_back)
+		case "size.proj.attack.dist.depth.top":
+			out.append(OC_const_size_proj_attack_dist_depth_top)
+		case "size.proj.attack.dist.depth.bottom":
+			out.append(OC_const_size_proj_attack_dist_depth_bottom)
 		case "size.proj.doscale":
 			out.append(OC_const_size_proj_doscale)
 		case "size.head.pos.x":
@@ -1872,10 +1872,10 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.append(OC_const_size_draw_offset_x)
 		case "size.draw.offset.y":
 			out.append(OC_const_size_draw_offset_y)
-		case "size.depth.front":
-			out.append(OC_const_size_depth_front)
-		case "size.depth.back":
-			out.append(OC_const_size_depth_back)
+		case "size.depth.top":
+			out.append(OC_const_size_depth_top)
+		case "size.depth.bottom":
+			out.append(OC_const_size_depth_bottom)
 		case "size.weight":
 			out.append(OC_const_size_weight)
 		case "size.pushfactor":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -5934,15 +5934,15 @@ func (c *Compiler) modifyStageBG(is IniSection, sc *StateControllerBase, _ int8)
 		}); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "vel.x", false, func(data string) error {
+		if err := c.stateParam(is, "velocity.x", false, func(data string) error {
 			any = true
-			return c.scAdd(sc, modifyStageBG_vel_x, data, VT_Float, 2)
+			return c.scAdd(sc, modifyStageBG_velocity_x, data, VT_Float, 2)
 		}); err != nil {
 			return err
 		}
-		if err := c.stateParam(is, "vel.y", false, func(data string) error {
+		if err := c.stateParam(is, "velocity.y", false, func(data string) error {
 			any = true
-			return c.scAdd(sc, modifyStageBG_vel_y, data, VT_Float, 1)
+			return c.scAdd(sc, modifyStageBG_velocity_y, data, VT_Float, 1)
 		}); err != nil {
 			return err
 		}

--- a/src/script.go
+++ b/src/script.go
@@ -3372,7 +3372,7 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.size.air.back)
 		case "size.air.front":
 			ln = lua.LNumber(c.size.air.front)
-		case "size.height", "size.height.stand":
+		case "size.height", "size.height.stand": // Optional new syntax for consistency
 			ln = lua.LNumber(c.size.height.stand)
 		case "size.height.crouch":
 			ln = lua.LNumber(c.size.height.crouch)
@@ -3382,7 +3382,7 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.size.height.air[1])
 		case "size.height.down":
 			ln = lua.LNumber(c.size.height.down)
-		case "size.attack.dist", "size.attack.dist.width.front":
+		case "size.attack.dist", "size.attack.dist.width.front": // Optional new syntax for consistency
 			ln = lua.LNumber(c.size.attack.dist.width[0])
 		case "size.attack.dist.width.back":
 			ln = lua.LNumber(c.size.attack.dist.width[1])
@@ -3390,15 +3390,15 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.size.attack.dist.height[0])
 		case "size.attack.dist.height.bottom":
 			ln = lua.LNumber(c.size.attack.dist.height[1])
-		case "size.attack.dist.depth.front":
+		case "size.attack.dist.depth.top":
 			ln = lua.LNumber(c.size.attack.dist.depth[0])
-		case "size.attack.dist.depth.back":
+		case "size.attack.dist.depth.bottom":
 			ln = lua.LNumber(c.size.attack.dist.depth[1])
-		case "size.attack.depth.front":
-			ln = lua.LNumber(c.size.attack.depth.front)
-		case "size.attack.depth.back":
-			ln = lua.LNumber(c.size.attack.depth.back)
-		case "size.proj.attack.dist", "size.proj.attack.dist.width.front":
+		case "size.attack.depth.top":
+			ln = lua.LNumber(c.size.attack.depth[0])
+		case "size.attack.depth.bottom":
+			ln = lua.LNumber(c.size.attack.depth[1])
+		case "size.proj.attack.dist", "size.proj.attack.dist.width.front": // Optional new syntax for consistency
 			ln = lua.LNumber(c.size.proj.attack.dist.width[0])
 		case "size.proj.attack.dist.width.back":
 			ln = lua.LNumber(c.size.proj.attack.dist.width[1])
@@ -3406,9 +3406,9 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.size.proj.attack.dist.height[0])
 		case "size.proj.attack.dist.height.bottom":
 			ln = lua.LNumber(c.size.proj.attack.dist.height[1])
-		case "size.proj.attack.dist.depth.front":
+		case "size.proj.attack.dist.depth.top":
 			ln = lua.LNumber(c.size.proj.attack.dist.depth[0])
-		case "size.proj.attack.dist.depth.back":
+		case "size.proj.attack.dist.depth.bottom":
 			ln = lua.LNumber(c.size.proj.attack.dist.depth[1])
 		case "size.proj.doscale":
 			ln = lua.LNumber(c.size.proj.doscale)
@@ -3426,9 +3426,9 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.size.draw.offset[0])
 		case "size.draw.offset.y":
 			ln = lua.LNumber(c.size.draw.offset[1])
-		case "size.depth.front":
+		case "size.depth.top":
 			ln = lua.LNumber(c.size.depth[0])
-		case "size.depth.back":
+		case "size.depth.bottom":
 			ln = lua.LNumber(c.size.depth[1])
 		case "size.weight":
 			ln = lua.LNumber(c.size.weight)

--- a/src/script.go
+++ b/src/script.go
@@ -3857,7 +3857,7 @@ func triggerFunctions(l *lua.LState) {
 		case "guarded":
 			ln = lua.LNumber(Btoi(c.ghv.guarded))
 		case "isbound":
-			ln = lua.LNumber(Btoi(c.isBound()))
+			ln = lua.LNumber(Btoi(c.isTargetBound()))
 		case "fall":
 			ln = lua.LNumber(Btoi(c.ghv.fallflag))
 		case "fall.damage":

--- a/src/script.go
+++ b/src/script.go
@@ -4874,29 +4874,29 @@ func triggerFunctions(l *lua.LState) {
 			switch strings.ToLower(vname) {
 			case "anim":
 				ln = lua.LNumber(bg.actionno)
-			case "delta x":
+			case "delta.x":
 				ln = lua.LNumber(bg.delta[0])
-			case "delta y":
+			case "delta.y":
 				ln = lua.LNumber(bg.delta[1])
 			case "id":
 				ln = lua.LNumber(bg.id)
 			case "layerno":
 				ln = lua.LNumber(bg.layerno)
-			case "pos x":
+			case "pos.x":
 				ln = lua.LNumber(bg.bga.pos[0])
-			case "pos y":
+			case "pos.y":
 				ln = lua.LNumber(bg.bga.pos[1])
-			case "start x":
+			case "start.x":
 				ln = lua.LNumber(bg.start[0])
-			case "start y":
+			case "start.y":
 				ln = lua.LNumber(bg.start[1])
-			case "tile x":
+			case "tile.x":
 				ln = lua.LNumber(bg.anim.tile.xflag)
-			case "tile y":
+			case "tile.y":
 				ln = lua.LNumber(bg.anim.tile.yflag)
-			case "vel x":
+			case "velocity.x":
 				ln = lua.LNumber(bg.bga.vel[0])
-			case "vel y":
+			case "velocity.y":
 				ln = lua.LNumber(bg.bga.vel[1])
 			default:
 				l.RaiseError("\nInvalid argument: %v\n", vname)

--- a/src/system.go
+++ b/src/system.go
@@ -874,10 +874,10 @@ func (s *System) posZtoYoffset(zpos, localscl float32) float32 {
 
 // Z axis check
 // Changed to no longer check z enable constant, depends on stage now
-func (s *System) zAxisOverlap(posz1, front1, back1, localscl1, posz2, front2, back2, localscl2 float32) bool {
+func (s *System) zAxisOverlap(posz1, top1, bot1, localscl1, posz2, top2, bot2, localscl2 float32) bool {
 	if s.zEnabled() {
-		if (posz1+front1)*localscl1 < (posz2-back2)*localscl2 ||
-			(posz1-back1)*localscl1 > (posz2+front2)*localscl2 {
+		if (posz1+bot1)*localscl1 < (posz2-top2)*localscl2 ||
+			(posz1-top1)*localscl1 > (posz2+bot2)*localscl2 {
 			return false
 		}
 	}


### PR DESCRIPTION
Fix:
- Fixed HitBy engine version being checked in the wrong player
- Fixes #2342 
- If a char is under TargetBind and the binder gets hit, it will SelfState to state 5050 as in Mugen
- Fixes #2347 

Refactor:
- Made StageBGVar syntax more consistent with ModifyStageBG
- Z parameters in general were reordered and renamed from considering the first parameter as "front" and second as "back", to "top" and "bottom" respectively