### PR TITLE
feat: add ModifyBGCtrl3d to chars

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -11048,6 +11048,53 @@ func (sc modifyBGCtrl) Run(c *Char, _ []int32) bool {
 	return false
 }
 
+type modifyBGCtrl3d StateControllerBase
+
+const (
+	modifyBGCtrl3d_ctrlid byte = iota
+	modifyBGCtrl3d_time
+	modifyBGCtrl3d_value
+	modifyBGCtrl3d_redirectid
+)
+
+func (sc modifyBGCtrl3d) Run(c *Char, _ []int32) bool {
+	//crun := c
+
+	var cid int32
+	t, v := [3]int32{IErr, IErr, IErr}, [3]int32{IErr, IErr, IErr}
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
+		case modifyBGCtrl3d_ctrlid:
+			cid = exp[0].evalI(c)
+		case modifyBGCtrl3d_time:
+			t[0] = exp[0].evalI(c)
+			if len(exp) > 1 {
+				t[1] = exp[1].evalI(c)
+				if len(exp) > 2 {
+					t[2] = exp[2].evalI(c)
+				}
+			}
+		case modifyBGCtrl3d_value:
+			v[0] = exp[0].evalI(c)
+			if len(exp) > 1 {
+				v[1] = exp[1].evalI(c)
+				if len(exp) > 2 {
+					v[2] = exp[2].evalI(c)
+				}
+			}
+		case modifyBGCtrl3d_redirectid:
+			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
+				//crun = rid
+			} else {
+				return false
+			}
+		}
+		return true
+	})
+	sys.stage.modifyBGCtrl3d(uint32(cid), t, v)
+	return false
+}
+
 type modifyBgm StateControllerBase
 
 const (
@@ -11896,22 +11943,18 @@ func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 		case modifyStageVar_scaling_topz:
 			if s.mugenver[0] != 1 { // mugen 1.0+ removed support for topz
 				s.stageCamera.topz = exp[0].evalF(c)
-				shouldResetCamera = true
 			}
 		case modifyStageVar_scaling_botz:
 			if s.mugenver[0] != 1 { // mugen 1.0+ removed support for botz
 				s.stageCamera.botz = exp[0].evalF(c)
-				shouldResetCamera = true
 			}
 		case modifyStageVar_scaling_topscale:
 			if s.mugenver[0] != 1 { // mugen 1.0+ removed support for topscale
 				s.stageCamera.ztopscale = exp[0].evalF(c)
-				shouldResetCamera = true
 			}
 		case modifyStageVar_scaling_botscale:
 			if s.mugenver[0] != 1 { // mugen 1.0+ removed support for botscale
 				s.stageCamera.zbotscale = exp[0].evalF(c)
-				shouldResetCamera = true
 			}
 		// Bound group
 		case modifyStageVar_bound_screenleft:

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -149,6 +149,7 @@ func newCompiler() *Compiler {
 		"mapset":               c.mapSet,
 		"matchrestart":         c.matchRestart,
 		"modifybgctrl":         c.modifyBGCtrl,
+		"modifybgctrl3d":       c.modifyBGCtrl3d,
 		"modifybgm":            c.modifyBgm,
 		"modifyhitdef":         c.modifyHitDef,
 		"modifyplayer":         c.modifyPlayer,

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -4713,6 +4713,29 @@ func (c *Compiler) modifyBGCtrl(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
+func (c *Compiler) modifyBGCtrl3d(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+	ret, err := (*modifyBGCtrl3d)(sc), c.stateSec(is, func() error {
+		if err := c.paramValue(is, sc, "redirectid",
+			modifyBGCtrl3d_redirectid, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "id",
+			modifyBGCtrl3d_ctrlid, VT_Int, 1, true); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "time",
+			modifyBGCtrl3d_time, VT_Int, 3, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "value",
+			modifyBGCtrl3d_value, VT_Int, 3, false); err != nil {
+			return err
+		}
+		return nil
+	})
+	return *ret, err
+}
+
 func (c *Compiler) modifySnd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*modifySnd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",

--- a/src/stage.go
+++ b/src/stage.go
@@ -1875,6 +1875,39 @@ func (s *Stage) modifyBGCtrl(id int32, t, v [3]int32, x, y float32, src, dst [2]
 	}
 }
 
+func (s *Stage) modifyBGCtrl3d(id uint32, t, v [3]int32) {
+	for i := range s.bgc {
+		for j := range s.bgc[i].node {
+			if s.bgc[i].node[j].id == id {
+				if t[0] != IErr {
+					s.bgc[i].starttime = t[0]
+				}
+				if t[1] != IErr {
+					s.bgc[i].endtime = t[1]
+				}
+				if t[2] != IErr {
+					s.bgc[i].looptime = t[2]
+				}
+
+				for k := 0; k < 3; k++ {
+					if v[k] != IErr {
+						s.bgc[i].v[k] = v[k]
+					}
+				}
+				s.reload = true
+			}
+		}
+		for j := range s.bgc[i].anim {
+			if s.bgc[i].anim[j].id == id {
+				for k := 0; k < len(s.bgc[i].anim); k++ {
+					s.bgc[i].anim[k].toggle(v[0] != 0)
+				}
+				s.reload = true
+			}
+		}
+	}
+}
+
 // 3D Stage Related
 // TODO: Refactor and move this to a new file?
 type Model struct {


### PR DESCRIPTION
New feature: ModifyBGCtrl3d for character scripts.

Example (CNS):
```ini
[State -2, ModifyBGCtrl3D]
type=ModifyBGCtrl3D
trigger1 = MoveType = A && Time = 1
id = 17
time = 0
value = 1
```

Known issue: time parameter has no effect (from what I've heard, the same issue exists for 2D BGCtrls as well, which BGCtrl3D was based on).

fix: Z-axis parameters no longer reset camera in ModifyStageVar