### PR TITLE
feat: DrawPal trigger

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -804,6 +804,8 @@ const (
 	OC_ex2_explodvar_id
 	OC_ex2_explodvar_bindtime
 	OC_ex2_explodvar_facing
+	OC_ex2_explodvar_drawpal_group
+	OC_ex2_explodvar_drawpal_index
 	OC_ex2_projvar_accel_x
 	OC_ex2_projvar_accel_y
 	OC_ex2_projvar_accel_z
@@ -3368,6 +3370,10 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	case OC_ex2_explodvar_bindtime:
 		fallthrough
 	case OC_ex2_explodvar_facing:
+		fallthrough
+	case OC_ex2_explodvar_drawpal_group:
+		fallthrough
+	case OC_ex2_explodvar_drawpal_index:
 		fallthrough
 	case OC_ex2_explodvar_scale_x:
 		fallthrough

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -810,6 +810,8 @@ const (
 	OC_ex2_projvar_accel_y
 	OC_ex2_projvar_accel_z
 	OC_ex2_projvar_animelem
+	OC_ex2_projvar_drawpal_group
+	OC_ex2_projvar_drawpal_index
 	OC_ex2_projvar_facing
 	OC_ex2_projvar_guardflag
 	OC_ex2_projvar_highbound
@@ -3519,6 +3521,10 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	case OC_ex2_projvar_pos_z:
 		fallthrough
 	case OC_ex2_projvar_facing:
+		fallthrough
+	case OC_ex2_projvar_drawpal_group:
+		fallthrough
+	case OC_ex2_projvar_drawpal_index:
 		fallthrough
 	case OC_ex2_projvar_guardflag:
 		fallthrough

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5780,6 +5780,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				eachExpl(func(e *Explod) {
 					if e.ownpal && remap {
 						crun.remapPal(e.palfx, [...]int32{1, 1}, rp)
+						crun.getExplodDrawPal(e, rp)
 					}
 				})
 			}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -208,6 +208,8 @@ const (
 	OC_numpartner
 	OC_ailevel
 	OC_palno
+	OC_drawpal_group
+	OC_drawpal_index
 	OC_hitcount
 	OC_uniqhitcount
 	OC_hitpausetime
@@ -1856,6 +1858,10 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushI(c.gi().palno)
 			// In Winmugen a helper's PalNo is always 1
 			// That behavior has no apparent benefits and even Mugen 1.0 compatibility mode does not keep it
+		case OC_drawpal_group:
+			sys.bcStack.PushI(c.drawpal[0])
+		case OC_drawpal_index:
+			sys.bcStack.PushI(c.drawpal[1])
 		case OC_pos_x:
 			sys.bcStack.PushF((c.pos[0]*(c.localscl/oc.localscl) - sys.cam.Pos[0]/oc.localscl))
 		case OC_pos_y:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -4943,6 +4943,7 @@ func (sc helper) Run(c *Char, _ []int32) bool {
 		h.localcoord = crun.localcoord
 	}
 	crun.helperInit(h, st, pt, x, y, z, f, rp, extmap)
+	crun.getHelperDrawPal(h,rp)
 	return false
 }
 
@@ -5649,6 +5650,7 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 	e.setStartParams(&e.palfxdef)
 	e.setPos(crun)
 	crun.insertExplodEx(i, rp)
+	crun.getExplodDrawPal(e, rp)
 	return false
 }
 
@@ -7214,6 +7216,7 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 		p.aimg.setupPalFX()
 	}
 	crun.projInit(p, pt, x, y, z, op, rp[0], rp[1], clsnscale)
+	crun.getProjDrawPal(p, rp[0], rp[1], op)
 	return false
 }
 

--- a/src/char.go
+++ b/src/char.go
@@ -1279,6 +1279,7 @@ type Explod struct {
 	interpolate_fLength  [2]float32
 	animNo               int32
 	interPos             [3]float32
+	drawpal              [2]int32
 }
 
 func (e *Explod) clear() {
@@ -4174,6 +4175,10 @@ func (c *Char) explodVar(eid BytecodeValue, idx BytecodeValue, vtype OpCode) Byt
 				v = BytecodeInt(e.bindtime)
 			case OC_ex2_explodvar_facing:
 				v = BytecodeInt(int32(e.facing))
+			case OC_ex2_explodvar_drawpal_group:
+				v = BytecodeInt(e.drawpal[0])
+			case OC_ex2_explodvar_drawpal_index:
+				v = BytecodeInt(e.drawpal[1])
 			}
 			break
 		}
@@ -5064,8 +5069,7 @@ func (c *Char) helperInit(h *Char, st int32, pt PosType, x, y, z float32,
 	h.setY(p[1])
 	h.setZ(p[2])
 	h.vel = [3]float32{}
-	h.drawpal[0] = c.drawpal[0]
-	h.drawpal[1] = c.drawpal[1]
+	h.drawpal = c.drawpal
 	if h.ownpal {
 		h.palfx = newPalFX()
 		if c.getPalfx().remap == nil {
@@ -5197,6 +5201,18 @@ func (c *Char) getExplods(id int32) (expls []*Explod) {
 	return
 }
 
+func (c *Char) getExplodDrawPal(e *Explod, rp [2]int32) {
+	if e.ownpal {
+		if rp == [2]int32{-1, 0} {
+			e.drawpal = c.drawpal
+		} else {
+			e.drawpal = rp
+		}
+	} else {
+		e.drawpal = c.drawpal
+	}
+}
+
 func (c *Char) insertExplodEx(i int, rp [2]int32) {
 	e := &sys.explods[c.playerNo][i]
 	if e.anim == nil {
@@ -5218,6 +5234,7 @@ func (c *Char) insertExplodEx(i int, rp [2]int32) {
 			e.palfx.remap = nil
 		}
 	}
+	c.getExplodDrawPal(e,rp)
 	if e.layerno > 0 {
 		td := &sys.explodsLayer1[c.playerNo]
 		for ii, te := range *td {
@@ -6901,8 +6918,7 @@ func (c *Char) remapPal(pfx *PalFX, src [2]int32, dst [2]int32) {
 
 	c.gi().remappedpal = [...]int32{dst[0], dst[1]}
 	// Gets the remapped palette individually
-	c.drawpal[0] = dst[0]
-	c.drawpal[1] = dst[1]
+	c.drawpal = dst
 }
 
 func (c *Char) forceRemapPal(pfx *PalFX, dst [2]int32) {

--- a/src/char.go
+++ b/src/char.go
@@ -5067,6 +5067,18 @@ func (c *Char) newHelper() (h *Char) {
 	return
 }
 
+func (c *Char) getHelperDrawPal(h *Char, rp [2]int32) {
+	if h.ownpal {
+		if rp == [2]int32{-1, 0} {
+			h.drawpal = c.drawpal
+		} else {
+			h.drawpal = rp
+		}
+	} else {
+		h.drawpal = c.drawpal
+	}
+}
+
 func (c *Char) helperInit(h *Char, st int32, pt PosType, x, y, z float32,
 	facing int32, rp [2]int32, extmap bool) {
 	p := c.helperPos(pt, [...]float32{x, y, z}, facing, &h.facing, h.localscl, false)
@@ -5074,7 +5086,6 @@ func (c *Char) helperInit(h *Char, st int32, pt PosType, x, y, z float32,
 	h.setY(p[1])
 	h.setZ(p[2])
 	h.vel = [3]float32{}
-	h.drawpal = c.drawpal
 	if h.ownpal {
 		h.palfx = newPalFX()
 		if c.getPalfx().remap == nil {
@@ -5239,7 +5250,6 @@ func (c *Char) insertExplodEx(i int, rp [2]int32) {
 			e.palfx.remap = nil
 		}
 	}
-	c.getExplodDrawPal(e,rp)
 	if e.layerno > 0 {
 		td := &sys.explodsLayer1[c.playerNo]
 		for ii, te := range *td {
@@ -5571,7 +5581,6 @@ func (c *Char) projInit(p *Projectile, pt PosType, x, y, z float32,
 		p.palfx.remap = remap
 		c.forceRemapPal(p.palfx, [...]int32{rpg, rpn})
 	}
-	c.getProjDrawPal(p, rpg, rpn, op)
 }
 
 func (c *Char) getProjs(id int32) (projs []*Projectile) {

--- a/src/char.go
+++ b/src/char.go
@@ -2404,6 +2404,7 @@ type Char struct {
 	powerMax            int32
 	dizzyPoints         int32
 	dizzyPointsMax      int32
+	drawpal             [2]int32
 	guardPoints         int32
 	guardPointsMax      int32
 	redLife             int32
@@ -5063,6 +5064,8 @@ func (c *Char) helperInit(h *Char, st int32, pt PosType, x, y, z float32,
 	h.setY(p[1])
 	h.setZ(p[2])
 	h.vel = [3]float32{}
+	h.drawpal[0] = c.drawpal[0]
+	h.drawpal[1] = c.drawpal[1]
 	if h.ownpal {
 		h.palfx = newPalFX()
 		if c.getPalfx().remap == nil {
@@ -6897,6 +6900,9 @@ func (c *Char) remapPal(pfx *PalFX, src [2]int32, dst [2]int32) {
 	}
 
 	c.gi().remappedpal = [...]int32{dst[0], dst[1]}
+	// Gets the remapped palette individually
+	c.drawpal[0] = dst[0]
+	c.drawpal[1] = dst[1]
 }
 
 func (c *Char) forceRemapPal(pfx *PalFX, dst [2]int32) {

--- a/src/char.go
+++ b/src/char.go
@@ -1821,6 +1821,7 @@ type Projectile struct {
 	remflag         bool
 	freezeflag      bool
 	contactflag     bool
+	drawpal         [2]int32
 }
 
 func newProjectile() *Projectile {
@@ -4297,6 +4298,10 @@ func (c *Char) projVar(pid BytecodeValue, idx BytecodeValue, flag BytecodeValue,
 				v = BytecodeBool(p.hitdef.hitflag&fl != 0)
 			case OC_ex2_projvar_facing:
 				v = BytecodeFloat(p.facing)
+			case OC_ex2_projvar_drawpal_group:
+				v = BytecodeInt(p.drawpal[0])
+			case OC_ex2_projvar_drawpal_index:
+				v = BytecodeInt(p.drawpal[1])
 			}
 			break
 		}
@@ -5510,6 +5515,18 @@ func (c *Char) newProj() *Projectile {
 	return p
 }
 
+func (c *Char) getProjDrawPal(p *Projectile, rpg, rpn int32, op bool) {
+	if op {
+		if [2]int32{rpg, rpn} == [2]int32{-1, 0} {
+			p.drawpal = c.drawpal
+		} else {
+			p.drawpal = [2]int32{rpg, rpn}
+		}
+	} else {
+		p.drawpal = c.drawpal
+	}
+}
+
 func (c *Char) projInit(p *Projectile, pt PosType, x, y, z float32,
 	op bool, rpg, rpn int32, clsnscale bool) {
 	pos := c.helperPos(pt, [...]float32{x, y, z}, 1, &p.facing, p.localscl, true)
@@ -5554,6 +5571,7 @@ func (c *Char) projInit(p *Projectile, pt PosType, x, y, z float32,
 		p.palfx.remap = remap
 		c.forceRemapPal(p.palfx, [...]int32{rpg, rpn})
 	}
+	c.getProjDrawPal(p, rpg, rpn, op)
 }
 
 func (c *Char) getProjs(id int32) (projs []*Projectile) {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -3063,6 +3063,17 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			isFlag = true
 		case "facing":
 			opc = OC_ex2_projvar_facing
+		case "drawpal":
+			c.token = c.tokenizer(in)
+
+			switch c.token {
+			case "group":
+				opc = OC_ex2_projvar_drawpal_group
+			case "index":
+				opc = OC_ex2_projvar_drawpal_index
+			default:
+				return bvNone(), Error(fmt.Sprint("Invalid argument: %s", c.token))
+			}
 		default:
 			return bvNone(), Error(fmt.Sprint("Invalid argument: %s", vname))
 		}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2833,6 +2833,16 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_numtext)
 	case "palno":
 		out.append(OC_palno)
+	case "drawpal":
+		c.token = c.tokenizer(in)
+		switch c.token {
+		case "group":
+			out.append(OC_drawpal_group)
+		case "index":
+			out.append(OC_drawpal_index)
+		default:
+			return bvNone(), Error("Invalid data: " + c.token)
+		}
 	case "pos":
 		c.token = c.tokenizer(in)
 		switch c.token {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2142,6 +2142,17 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			opc = OC_ex2_explodvar_bindtime
 		case "facing":
 			opc = OC_ex2_explodvar_facing
+		case "drawpal":
+			c.token = c.tokenizer(in)
+
+			switch c.token {
+			case "group":
+				opc = OC_ex2_explodvar_drawpal_group
+			case "index":
+				opc = OC_ex2_explodvar_drawpal_index
+			default:
+				return bvNone(), Error(fmt.Sprint("Invalid argument: %s", c.token))
+			}
 		case "pos":
 			c.token = c.tokenizer(in)
 

--- a/src/script.go
+++ b/src/script.go
@@ -4476,6 +4476,19 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.debugWC.gi().palno))
 		return 1
 	})
+	luaRegister(l, "drawpal", func(*lua.LState) int {
+		var ln lua.LNumber
+		switch strings.ToLower(strArg(l, 1)) {
+		case "group":
+			ln = lua.LNumber(sys.debugWC.drawpal[0])
+		case "index":
+			ln = lua.LNumber(sys.debugWC.drawpal[1])
+		default:
+			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
+		}
+		l.Push(ln)
+		return 1
+	})
 	luaRegister(l, "parentdistX", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.rdDistX(sys.debugWC.parent(), sys.debugWC).ToI()))
 		return 1

--- a/src/script.go
+++ b/src/script.go
@@ -3709,6 +3709,10 @@ func triggerFunctions(l *lua.LState) {
 					ln = lua.LNumber(e.bindtime)
 				case "facing":
 					ln = lua.LNumber(e.facing)
+				case "drawpal group":
+					ln = lua.LNumber(e.drawpal[0])
+				case "drawpal index":
+					ln = lua.LNumber(e.drawpal[1])
 				default:
 					l.RaiseError("\nInvalid argument: %v\n", vname)
 				}

--- a/src/script.go
+++ b/src/script.go
@@ -4688,6 +4688,10 @@ func triggerFunctions(l *lua.LState) {
 				//	lv = lua.LNumber(p.hitdef.hitflag&fl != 0)
 				case "facing":
 					lv = lua.LNumber(p.facing)
+				case "drawpal group":
+					lv = lua.LNumber(p.drawpal[0])
+				case "drawpal index":
+					lv = lua.LNumber(p.drawpal[1])
 				default:
 					l.RaiseError("\nInvalid argument: %v\n", vname)
 				}


### PR DESCRIPTION
Feat: DrawPal trigger returns the value of the group and index of the palette being used to draw the sprites at the moment, unlike PalNo, which returns the palette selected in the character select screen. It can be used with ExplodVar and ProjVar.

Examples(CNS):
```ini
[State -2, PowerAdd]
type = PowerAdd
trigger1 = DrawPal group = 1 && DrawPal index = 12
value = 30
```
```ini
[State -2, Modify Explod]
type = ModifyExplod
trigger1 = ExplodVar(2000, 0, drawpal index) = 5
velocity = 7,0
```