### PR TITLE
feat: DrawPal trigger

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -208,6 +208,8 @@ const (
 	OC_numpartner
 	OC_ailevel
 	OC_palno
+	OC_drawpal_group
+	OC_drawpal_index
 	OC_hitcount
 	OC_uniqhitcount
 	OC_hitpausetime
@@ -778,6 +780,8 @@ const (
 	OC_ex2_debug_roundrestarted
 	OC_ex2_explodvar_anim
 	OC_ex2_explodvar_animelem
+	OC_ex2_explodvar_drawpal_group
+	OC_ex2_explodvar_drawpal_index
 	OC_ex2_explodvar_pos_x
 	OC_ex2_explodvar_pos_y
 	OC_ex2_explodvar_pos_z
@@ -806,6 +810,8 @@ const (
 	OC_ex2_projvar_accel_y
 	OC_ex2_projvar_accel_z
 	OC_ex2_projvar_animelem
+	OC_ex2_projvar_drawpal_group
+	OC_ex2_projvar_drawpal_index
 	OC_ex2_projvar_facing
 	OC_ex2_projvar_guardflag
 	OC_ex2_projvar_highbound
@@ -1856,6 +1862,10 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.PushI(c.gi().palno)
 			// In Winmugen a helper's PalNo is always 1
 			// That behavior has no apparent benefits and even Mugen 1.0 compatibility mode does not keep it
+		case OC_drawpal_group:
+			sys.bcStack.PushI(c.drawPal()[0])
+		case OC_drawpal_index:
+			sys.bcStack.PushI(c.drawPal()[1])
 		case OC_pos_x:
 			sys.bcStack.PushF((c.pos[0]*(c.localscl/oc.localscl) - sys.cam.Pos[0]/oc.localscl))
 		case OC_pos_y:
@@ -3349,6 +3359,10 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		fallthrough
 	case OC_ex2_explodvar_animelem:
 		fallthrough
+	case OC_ex2_explodvar_drawpal_group:
+		fallthrough
+	case OC_ex2_explodvar_drawpal_index:
+		fallthrough
 	case OC_ex2_explodvar_removetime:
 		fallthrough
 	case OC_ex2_explodvar_pausemovetime:
@@ -3491,6 +3505,10 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	case OC_ex2_projvar_projanim:
 		fallthrough
 	case OC_ex2_projvar_animelem:
+		fallthrough
+	case OC_ex2_projvar_drawpal_group:
+		fallthrough
+	case OC_ex2_projvar_drawpal_index:
 		fallthrough
 	case OC_ex2_projvar_supermovetime:
 		fallthrough

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2128,6 +2128,17 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			opc = OC_ex2_explodvar_anim
 		case "animelem":
 			opc = OC_ex2_explodvar_animelem
+		case "drawpal":
+			c.token = c.tokenizer(in)
+
+			switch c.token {
+			case "group":
+				opc = OC_ex2_explodvar_drawpal_group
+			case "index":
+				opc = OC_ex2_explodvar_drawpal_index
+			default:
+				return bvNone(), Error(fmt.Sprint("Invalid argument: %s", c.token))
+			}
 		case "removetime":
 			opc = OC_ex2_explodvar_removetime
 		case "pausemovetime":
@@ -2833,6 +2844,16 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_numtext)
 	case "palno":
 		out.append(OC_palno)
+	case "drawpal":
+		c.token = c.tokenizer(in)
+		switch c.token {
+		case "group":
+			out.append(OC_drawpal_group)
+		case "index":
+			out.append(OC_drawpal_index)
+		default:
+			return bvNone(), Error(fmt.Sprint("Invalid argument: %s", c.token))
+		}
 	case "pos":
 		c.token = c.tokenizer(in)
 		switch c.token {
@@ -3026,6 +3047,17 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			opc = OC_ex2_projvar_projanim
 		case "animelem":
 			opc = OC_ex2_projvar_animelem
+		case "drawpal":
+			c.token = c.tokenizer(in)
+
+			switch c.token {
+			case "group":
+				opc = OC_ex2_projvar_drawpal_group
+			case "index":
+				opc = OC_ex2_projvar_drawpal_index
+			default:
+				return bvNone(), Error(fmt.Sprint("Invalid argument: %s", c.token))
+			}
 		case "pausemovetime":
 			opc = OC_ex2_projvar_pausemovetime
 		case "projid":

--- a/src/script.go
+++ b/src/script.go
@@ -3708,6 +3708,10 @@ func triggerFunctions(l *lua.LState) {
 					ln = lua.LNumber(e.bindtime)
 				case "facing":
 					ln = lua.LNumber(e.facing)
+				case "drawpal group":
+					ln = lua.LNumber(sys.debugWC.explodDrawPal(id)[0])
+				case "drawpal index":
+					ln = lua.LNumber(sys.debugWC.explodDrawPal(id)[1])
 				default:
 					l.RaiseError("\nInvalid argument: %v\n", vname)
 				}
@@ -4475,6 +4479,19 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.debugWC.gi().palno))
 		return 1
 	})
+	luaRegister(l, "drawpal", func(*lua.LState) int {
+		var ln lua.LNumber
+		switch strings.ToLower(strArg(l, 1)) {
+		case "group":
+			ln = lua.LNumber(sys.debugWC.drawPal()[0])
+		case "index":
+			ln = lua.LNumber(sys.debugWC.drawPal()[1])
+		default:
+			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
+		}
+		l.Push(ln)
+		return 1
+	})
 	luaRegister(l, "parentdistX", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.rdDistX(sys.debugWC.parent(), sys.debugWC).ToI()))
 		return 1
@@ -4670,6 +4687,10 @@ func triggerFunctions(l *lua.LState) {
 				//	lv = lua.LNumber(p.hitdef.hitflag&fl != 0)
 				case "facing":
 					lv = lua.LNumber(p.facing)
+				case "drawpal group":
+					lv = lua.LNumber(sys.debugWC.projDrawPal(id)[0])
+				case "drawpal index":
+					lv = lua.LNumber(sys.debugWC.projDrawPal(id)[1])
 				default:
 					l.RaiseError("\nInvalid argument: %v\n", vname)
 				}


### PR DESCRIPTION
Feat: DrawPal trigger returns the value of the group and index of the palette being used to draw the sprites at the moment, unlike PalNo, which returns the palette selected in the character select screen. It can also be used with ExplodVar and ProjVar.

Examples(CNS):
```ini
[State -2, PowerAdd]
type = PowerAdd
trigger1 = DrawPal group = 1 && DrawPal Index = 12
value = 30
```
```ini
[State -2, Modify Explod]
type = ModifyExplod
trigger1 = ExplodVar(2000, 0, Drawpal Index) = 5
id = 2000
velocity = 7,0
```