### PR TITLE
feat: NumStageBG trigger; fix lost camera; error and other refactors

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -74,7 +74,7 @@ const (
 	VT_Float
 	VT_Int
 	VT_Bool
-	VT_SFalse
+	VT_SFalse // Undefined
 )
 
 type OpCode byte
@@ -104,9 +104,9 @@ const (
 	OC_eq
 	OC_ne
 	OC_gt
-	OC_le
-	OC_lt
 	OC_ge
+	OC_lt
+	OC_le
 	OC_neg
 	OC_blnot
 	OC_bland
@@ -1061,11 +1061,23 @@ func (bs *BytecodeStack) PushB(b bool) {
 }
 
 func (bs BytecodeStack) Top() *BytecodeValue {
+	// This should only happen during development
+	if len(bs) == 0 {
+		panic(Error("Attempted to access the top of an empty ByteCode stack.\n"))
+	}
+
 	return &bs[len(bs)-1]
 }
 
 func (bs *BytecodeStack) Pop() (bv BytecodeValue) {
+	// This should only happen during development
+	if len(*bs) == 0 {
+		panic(Error("Attempted to pop from an empty ByteCode stack.\n"))
+	}
+
+	// Set value to what's at the top of stack. Shift stack
 	bv, *bs = *bs.Top(), (*bs)[:len(*bs)-1]
+
 	return
 }
 

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1206,11 +1206,15 @@ func (BytecodeExp) mul(v1 *BytecodeValue, v2 BytecodeValue) {
 }
 
 func (BytecodeExp) div(v1 *BytecodeValue, v2 BytecodeValue) {
-	if ValueType(Min(int32(v1.vtype), int32(v2.vtype))) == VT_Float {
-		v1.SetF(v1.ToF() / v2.ToF())
-	} else if v2.ToI() == 0 {
+	if v2.ToF() == 0 {
+		// Division by 0
 		*v1 = BytecodeSF()
+		sys.printBytecodeError("Division by 0")
+	} else if ValueType(Min(int32(v1.vtype), int32(v2.vtype))) == VT_Float {
+		// Float division
+		v1.SetF(v1.ToF() / v2.ToF())
 	} else {
+		// Int division
 		v1.SetI(v1.ToI() / v2.ToI())
 	}
 }
@@ -1218,6 +1222,7 @@ func (BytecodeExp) div(v1 *BytecodeValue, v2 BytecodeValue) {
 func (BytecodeExp) mod(v1 *BytecodeValue, v2 BytecodeValue) {
 	if v2.ToI() == 0 {
 		*v1 = BytecodeSF()
+		sys.printBytecodeError("Modulus by 0")
 	} else {
 		v1.SetI(v1.ToI() % v2.ToI())
 	}
@@ -3918,7 +3923,7 @@ func (b StateBlock) Run(c *Char, ps []int32) (changeState bool) {
 			// Safety check. Prevents a bad loop from freezing Ikemen
 			loopCount++
 			if loopCount >= 2500 {
-				sys.appendToConsole(sys.workingChar.warn() + "loop automatically stopped after 2500 iterations")
+				sys.printBytecodeError("loop automatically stopped after 2500 iterations")
 				break
 			}
 		}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -916,6 +916,7 @@ const (
 	OC_ex2_stagebgvar_tile_y
 	OC_ex2_stagebgvar_velocity_x
 	OC_ex2_stagebgvar_velocity_y
+	OC_ex2_numstagebg
 )
 
 const (
@@ -3737,6 +3738,8 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		} else {
 			sys.bcStack.Push(BytecodeSF())
 		}
+	case OC_ex2_numstagebg:
+		*sys.bcStack.Top() = c.numStageBG(*sys.bcStack.Top())
 	default:
 		sys.errLog.Printf("%v\n", be[*i-1])
 		c.panic()

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -774,8 +774,8 @@ const (
 	OC_ex2_debug_clsndisplay
 	OC_ex2_debug_debugdisplay
 	OC_ex2_debug_lifebardisplay
+	OC_ex2_debug_roundreset
 	OC_ex2_debug_wireframedisplay
-	OC_ex2_debug_roundrestarted
 	OC_ex2_drawpal_group
 	OC_ex2_drawpal_index
 	OC_ex2_explodvar_anim
@@ -3333,10 +3333,10 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushB(sys.debugDisplay)
 	case OC_ex2_debug_lifebardisplay:
 		sys.bcStack.PushB(sys.lifebarDisplay)
+	case OC_ex2_debug_roundreset:
+		sys.bcStack.PushB(sys.roundResetFlg)
 	case OC_ex2_debug_wireframedisplay:
 		sys.bcStack.PushB(sys.wireframeDisplay)
-	case OC_ex2_debug_roundrestarted:
-		sys.bcStack.PushB(sys.roundResetFlg)
 	case OC_ex2_drawpal_group:
 		sys.bcStack.PushI(c.drawPal()[0])
 	case OC_ex2_drawpal_index:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -4094,12 +4094,8 @@ func (sc stateDef) Run(c *Char) {
 			c.sprPriority = exp[0].evalI(c)
 			c.layerNo = 0 // Prevent char from being forgotten in a different layer
 		case stateDef_facep2:
-			if exp[0].evalB(c) {
-				e := c.p2()
-				if e != nil && !e.asf(ASF_noturntarget) && c.rdDistX(e, c).ToF() < 0 &&
-					!c.asf(ASF_noautoturn) && sys.stage.autoturn {
-					c.setFacing(-c.facing)
-				}
+			if exp[0].evalB(c) && c.shouldFaceP2() {
+				c.setFacing(-c.facing)
 			}
 		case stateDef_juggle:
 			c.juggle = exp[0].evalI(c)

--- a/src/char.go
+++ b/src/char.go
@@ -4799,22 +4799,46 @@ func (c *Char) playSound(ffx string, lowpriority bool, loopCount int32, g, n, ch
 }
 
 func (c *Char) autoTurn() {
-	if c.helperIndex == 0 {
-		e := c.p2()
-		if e != nil && c.rdDistX(e, c).ToF() < 0 && !e.asf(ASF_noturntarget) {
-			switch c.ss.stateType {
-			case ST_S:
-				if c.animNo != 5 {
-					c.changeAnimEx(5, c.playerNo, "", false)
-				}
-			case ST_C:
-				if c.animNo != 6 {
-					c.changeAnimEx(6, c.playerNo, "", false)
-				}
+	if c.helperIndex == 0 && (c.ss.stateType == ST_S || c.ss.stateType == ST_C) && c.shouldFaceP2() {
+		switch c.ss.stateType {
+		case ST_S:
+			if c.animNo != 5 {
+				c.changeAnimEx(5, c.playerNo, "", false)
 			}
-			c.setFacing(-c.facing)
+		case ST_C:
+			if c.animNo != 6 {
+				c.changeAnimEx(6, c.playerNo, "", false)
+			}
+		}
+		c.setFacing(-c.facing)
+	}
+}
+
+// Check if P2 enemy is behind the player and the player is allowed to face them
+func (c *Char) shouldFaceP2() bool {
+	// Turning disabled
+	if c.asf(ASF_noautoturn) || !sys.stage.autoturn {
+		return false
+	}
+
+	// Check if P2 enemy is behind the player
+	e := c.p2()
+	if e != nil && !e.asf(ASF_noturntarget) {
+		distX := c.rdDistX(e, c).ToF()
+		if sys.zEnabled() {
+			// Use a z position tie breaker when the x positions are the same
+			if distX < 0 ||
+				distX == 0 && (c.rdDistZ(e, c).ToF() < 0) == (c.pos[0] * c.facing > 0) {
+				return true
+			}
+		} else {
+			if distX < 0 {
+				return true
+			}
 		}
 	}
+
+	return false
 }
 
 func (c *Char) stateChange1(no int32, pn int) bool {
@@ -4935,8 +4959,7 @@ func (c *Char) changeStateEx(no int32, pn int, anim, ctrl int32, ffx string) {
 	// It serves very little purpose while negatively affecting some new Ikemen features like NoTurnTarget
 	// It could be removed in the future
 	// https://github.com/ikemen-engine/Ikemen-GO/issues/1755
-	if c.minus <= 0 && c.scf(SCF_ctrl) && sys.roundState() <= 2 &&
-		(c.ss.stateType == ST_S || c.ss.stateType == ST_C) && !c.asf(ASF_noautoturn) && sys.stage.autoturn {
+	if c.minus <= 0 && c.scf(SCF_ctrl) && sys.roundState() <= 2 {
 		c.autoTurn()
 	}
 	if anim != -1 {
@@ -8393,7 +8416,8 @@ func (c *Char) update() {
 				}
 			}
 			// Engine dust effects
-			if ((c.ss.moveType == MT_H && (c.ss.stateType == ST_S || c.ss.stateType == ST_C)) || c.ss.no == 52) &&
+			if sys.supertime == 0 && sys.pausetime == 0 &&
+				((c.ss.moveType == MT_H && (c.ss.stateType == ST_S || c.ss.stateType == ST_C)) || c.ss.no == 52) &&
 				c.pos[1] == 0 && (AbsF(c.pos[0]-c.dustOldPos[0]) >= 1 || AbsF(c.pos[2]-c.dustOldPos[2]) >= 1) {
 				c.makeDust(0, 0, 0, 3) // Default spacing of 3
 			}
@@ -9066,11 +9090,9 @@ func (cl *CharList) commandUpdate() {
 				}
 				// Auto turning check for the root
 				// Having this here makes B and F inputs reverse the same instant the character turns
-				if act && c.helperIndex == 0 && !c.asf(ASF_noautoturn) && sys.stage.autoturn {
-					if (c.scf(SCF_ctrl) || sys.roundState() > 2) &&
-						(c.ss.no == 0 || c.ss.no == 11 || c.ss.no == 20 || c.ss.no == 52) {
-						c.autoTurn()
-					}
+				if act && c.helperIndex == 0 && (c.scf(SCF_ctrl) || sys.roundState() > 2) &&
+					(c.ss.no == 0 || c.ss.no == 11 || c.ss.no == 20 || c.ss.no == 52) {
+					c.autoTurn()
 				}
 				if (c.helperIndex == 0 || c.helperIndex > 0 && &c.cmd[0] != &root.cmd[0]) &&
 					c.cmd[0].Input(c.controller, int32(c.facing), sys.com[i], c.inputFlag, false) {

--- a/src/char.go
+++ b/src/char.go
@@ -8373,10 +8373,12 @@ func (c *Char) track() {
 				}
 			}
 		}
-		if c.csf(CSF_movecamera_y) && !c.scf(SCF_standby) {
+		if c.csf(CSF_movecamera_y) && !c.scf(SCF_standby) && !math.IsInf(float64(c.pos[1]), 0) {
 			sys.cam.highest = MinF(c.interPos[1]*c.localscl, sys.cam.highest)
 			sys.cam.lowest = MaxF(c.interPos[1]*c.localscl, sys.cam.lowest)
 			sys.cam.Pos[1] = 0
+			// Mugen ignores characters that have infinite position
+			// https://github.com/ikemen-engine/Ikemen-GO/issues/1917
 		}
 	}
 }

--- a/src/char.go
+++ b/src/char.go
@@ -6062,6 +6062,25 @@ func (c *Char) getMultipleStageBg(id int32, idx int, log bool) []*backGround {
 	return nil
 }
 
+// For NumStageBG trigger
+func (c *Char) numStageBG(id BytecodeValue) BytecodeValue {
+	if id.IsSF() {
+		return BytecodeSF()
+	}
+
+	bid := id.ToI()
+	n := 0
+
+	// We do this instead of getMultipleStageBg because that one returns actual BG pointers
+	for _, bg := range sys.stage.bg {
+		if bid < 0 || bid == bg.id {
+			n++
+		}
+	}
+
+	return BytecodeInt(int32(n))
+}
+
 // Get list of targets for the Target state controllers
 func (c *Char) getTarget(id int32, idx int) []int32 {
 	// If ID and index are negative, just return all targets

--- a/src/common.go
+++ b/src/common.go
@@ -721,7 +721,7 @@ func (is IniSection) getText(name string) (str string, ok bool, err error) {
 	if len(str) >= 2 && str[0] == '"' && str[len(str)-1] == '"' {
 		str = str[1 : len(str)-1]
 	} else {
-		err = Error("Not enclosed in \"")
+		err = Error("String not enclosed in \"")
 	}
 	return
 }

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -284,6 +284,7 @@ var triggerMap = map[string]int{
 	"numpartner":        1,
 	"numproj":           1,
 	"numprojid":         1,
+	"numstagebg":        1,
 	"numtarget":         1,
 	"numtext":           1,
 	"p1name":            1,
@@ -2886,6 +2887,11 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 		out.append(OC_numprojid)
+	case "numstagebg":
+		if _, err := c.oneArg(out, in, rd, true, BytecodeInt(-1)); err != nil {
+			return bvNone(), err
+		}
+		out.append(OC_ex2_, OC_ex2_numstagebg)
 	case "numtarget":
 		if _, err := c.oneArg(out, in, rd, true, BytecodeInt(-1)); err != nil {
 			return bvNone(), err

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -434,7 +434,6 @@ var triggerMap = map[string]int{
 	"redlife":            1,
 	"reversaldefattr":    1,
 	"round":              1,
-	"roundrestarted":     1,
 	"roundtime":          1,
 	"runorder":           1,
 	"scale":              1,
@@ -4103,8 +4102,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.append(OC_ex2_debug_lifebardisplay)
 		case "wireframedisplay":
 			out.append(OC_ex2_debug_wireframedisplay)
-		case "roundrestarted":
-			out.append(OC_ex2_debug_roundrestarted)
+		case "roundreset":
+			out.append(OC_ex2_debug_roundreset)
 		default:
 			return bvNone(), Error("Invalid Debug trigger argument: " + c.token)
 		}
@@ -6048,7 +6047,7 @@ func (c *Compiler) stateCompile(states map[int32]StateBytecode,
 				return errmes(Error("Missing trigger1"))
 			}
 
-			/* Create trigger bytecode */
+			// Create trigger bytecode
 			var texp BytecodeExp
 			for _, e := range triggerall {
 				texp.append(e...)
@@ -7175,7 +7174,7 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 	c.playerNo = pn
 	states := make(map[int32]StateBytecode)
 
-	/* Load initial data from definition file */
+	// Load initial data from definition file
 	str, err := LoadText(def)
 	if err != nil {
 		return nil, err
@@ -7382,7 +7381,7 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 		c.cmdl.Add(*cm)
 	}
 
-	/* Compile states */
+	// Compile states
 	sys.stringPool[pn].Clear()
 	sys.cgi[pn].hitPauseToggleFlagCount = 0
 	c.funcUsed = make(map[string]bool)

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -720,7 +720,7 @@ func (c *Compiler) attr(text string, hitdef bool) (int32, error) {
 				(a < 'a' || a > 'z') {
 				return flg, nil
 			}
-			return 0, Error("Invalid value: " + string(a))
+			return 0, Error("Invalid attr value: " + string(a))
 		}
 	}
 	//hitdefflg := flg
@@ -767,7 +767,7 @@ func (c *Compiler) attr(text string, hitdef bool) (int32, error) {
 				//}
 				return flg, nil
 			}
-			return 0, Error("Invalid value: " + a)
+			return 0, Error("Invalid attr value: " + a)
 		}
 		//if i == 0 {
 		//	hitdefflg = flg
@@ -803,7 +803,7 @@ func (c *Compiler) trgAttr(in *string) (int32, error) {
 		case 'A', 'a':
 			flg |= int32(ST_A)
 		default:
-			return 0, Error("Invalid attribute value: " + att)
+			return 0, Error("Invalid attr value: " + att)
 		}
 	}
 	for len(*in) > 0 && (*in)[0] == ',' {
@@ -911,7 +911,7 @@ func (c *Compiler) intRange(in *string) (minop OpCode, maxop OpCode,
 	case "[":
 		minop = OC_ge
 	default:
-		err = Error("Missing '[' or '('")
+		err = Error("Range missing '[' or '('")
 		return
 	}
 	var intf func(in *string) (int32, error)
@@ -924,7 +924,7 @@ func (c *Compiler) intRange(in *string) (minop OpCode, maxop OpCode,
 				c.token = c.tokenizer(in)
 			}
 			if len(c.token) == 0 || c.token[0] < '0' || c.token[0] > '9' {
-				return 0, Error("Error reading number")
+				return 0, Error("Error reading range number")
 			}
 			i := Atoi(c.token)
 			if minus {
@@ -947,7 +947,7 @@ func (c *Compiler) intRange(in *string) (minop OpCode, maxop OpCode,
 		c.token = c.tokenizer(in)
 	}
 	if c.token != "," {
-		err = Error("Missing ','")
+		err = Error("Range missing ','")
 		return
 	}
 	if max, err = intf(in); err != nil {
@@ -967,7 +967,7 @@ func (c *Compiler) intRange(in *string) (minop OpCode, maxop OpCode,
 	case "]":
 		maxop = OC_le
 	default:
-		err = Error("Missing ']' or ')'")
+		err = Error("Range missing ']' or ')'")
 		return
 	}
 	c.token = c.tokenizer(in)
@@ -1190,7 +1190,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		*in = (*in)[i+1:]
 		return nil
 	}
-	eqne := func(f func() error) error {
+	eqne := func(f func() error) error { // Equal, not equal
 		not, err := c.checkEquality(in)
 		if err != nil {
 			return err
@@ -1286,7 +1286,20 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		}
 		c.token = c.tokenizer(in)
 		if c.token != "," {
-			return bvNone(), Error("Missing ','")
+			switch opc {
+			case OC_partner, OC_enemy, OC_enemynear:
+				be1.appendValue(BytecodeInt(0))
+			case OC_root:
+				return bvNone(), Error("Missing ',' after Root")
+			case OC_parent:
+				return bvNone(), Error("Missing ',' after Parent")
+			case OC_p2:
+				return bvNone(), Error("Missing ',' after P2")
+			case OC_stateowner:
+				return bvNone(), Error("Missing ',' after StateOwner")
+			default:
+				return bvNone(), Error("Missing ','")
+			}
 		}
 		c.token = c.tokenizer(in)
 		if bv2, err = c.expValue(&be2, in, true); err != nil {
@@ -1328,15 +1341,15 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		} else {
 			switch opc {
 			case OC_partner, OC_enemy, OC_enemynear:
-				be1.appendValue(BytecodeInt(0))
+				be1.appendValue(BytecodeInt(0)) // Argument is optional for these
 			case OC_player:
-				return bvNone(), Error("Missing '(' after player")
+				return bvNone(), Error("Missing '(' after Player")
 			case OC_playerid:
-				return bvNone(), Error("Missing '(' after playerid")
+				return bvNone(), Error("Missing '(' after PlayerID")
 			case OC_playerindex:
-				return bvNone(), Error("Missing '(' after playerindex")
+				return bvNone(), Error("Missing '(' after PlayerIndex")
 			case OC_helperindex:
-				return bvNone(), Error("Missing '(' after helperindex")
+				return bvNone(), Error("Missing '(' after HelperIndex")
 			}
 		}
 		if rd {
@@ -1344,7 +1357,24 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		}
 		out.append(be1...)
 		if c.token != "," {
-			return bvNone(), Error("Missing ','")
+			switch opc {
+			case OC_partner:
+				return bvNone(), Error("Missing ',' after Partner")
+			case OC_enemy:
+				return bvNone(), Error("Missing ',' after Enemy")
+			case OC_enemynear:
+				return bvNone(), Error("Missing ',' after EnemyNear")
+			case OC_player:
+				return bvNone(), Error("Missing ',' after Player")
+			case OC_playerid:
+				return bvNone(), Error("Missing '(' after PlayerID")
+			case OC_playerindex:
+				return bvNone(), Error("Missing '(' after PlayerIndex")
+			case OC_helperindex:
+				return bvNone(), Error("Missing '(' after HelperIndex")
+			default:
+				return bvNone(), Error("Missing ','")
+			}
 		}
 		c.token = c.tokenizer(in)
 		if bv2, err = c.expValue(&be2, in, true); err != nil {
@@ -1395,7 +1425,14 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		}
 		out.append(be1...)
 		if c.token != "," {
-			return bvNone(), Error("Missing ','")
+			switch opc {
+			case OC_helper:
+				return bvNone(), Error("Missing ',' after Helper")
+			case OC_target:
+				return bvNone(), Error("Missing ',' after Target")
+			default:
+				return bvNone(), Error("Missing ','")
+			}
 		}
 		c.token = c.tokenizer(in)
 		if bv2, err = c.expValue(&be2, in, true); err != nil {
@@ -1490,14 +1527,22 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 		if c.token != "," {
-			return bvNone(), Error("Missing ','")
+			if cond {
+				return bvNone(), Error("Missing ',' in Cond")
+			} else {
+				return bvNone(), Error("Missing ',' in IfElse")
+			}
 		}
 		c.token = c.tokenizer(in)
 		if bv2, err = c.expBoolOr(&be2, in); err != nil {
 			return bvNone(), err
 		}
 		if c.token != "," {
-			return bvNone(), Error("Missing ','")
+			if cond {
+				return bvNone(), Error("Missing ',' in Cond")
+			} else {
+				return bvNone(), Error("Missing ',' in IfElse")
+			}
 		}
 		c.token = c.tokenizer(in)
 		if bv3, err = c.expBoolOr(&be3, in); err != nil {
@@ -1638,7 +1683,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "y":
 			out.append(OC_camerapos_y)
 		default:
-			return bvNone(), Error("Invalid data: " + c.token)
+			return bvNone(), Error("Invalid CameraPos argument: " + c.token)
 		}
 	case "camerazoom":
 		out.append(OC_camerazoom)
@@ -1661,14 +1706,14 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		}
 		c.token = c.tokenizer(in)
 		if c.token != "," {
-			return bvNone(), Error("Missing ','")
+			return bvNone(), Error("Missing ',' in ClsnOverlap")
 		}
 		c.token = c.tokenizer(in)
 		if bv2, err = c.expBoolOr(&be2, in); err != nil {
 			return bvNone(), err
 		}
 		if c.token != "," {
-			return bvNone(), Error("Missing ','")
+			return bvNone(), Error("Missing ',' in ClsnOverlap")
 		}
 		c.token = c.tokenizer(in)
 		c2type := c.token
@@ -1716,7 +1761,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		c.token = c.tokenizer(in)
 
 		if c.token != "," {
-			return bvNone(), Error("Missing ','")
+			return bvNone(), Error("Missing ',' in ClsnVar")
 		}
 		c.token = c.tokenizer(in)
 
@@ -1736,7 +1781,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "bottom":
 			opc = OC_ex2_clsnvar_bottom
 		default:
-			return bvNone(), Error(fmt.Sprint("Invalid argument: %s", vname))
+			return bvNone(), Error(fmt.Sprint("Invalid ClsnVar argument: %s", vname))
 		}
 		c.token = c.tokenizer(in)
 
@@ -2120,14 +2165,14 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 		if c.token != "," {
-			return bvNone(), Error("Missing ','")
+			return bvNone(), Error("Missing ',' in ExplodVar")
 		}
 		c.token = c.tokenizer(in)
 		if bv2, err = c.expBoolOr(&be2, in); err != nil {
 			return bvNone(), err
 		}
 		if c.token != "," {
-			return bvNone(), Error("Missing ','")
+			return bvNone(), Error("Missing ',' in ExplodVar")
 		}
 		c.token = c.tokenizer(in)
 
@@ -2174,7 +2219,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			case "z":
 				opc = OC_ex2_explodvar_pos_z
 			default:
-				return bvNone(), Error(fmt.Sprint("Invalid argument: %s", c.token))
+				return bvNone(), Error(fmt.Sprint("Invalid ExplodVar pos argument: %s", c.token))
 			}
 		case "vel":
 			c.token = c.tokenizer(in)
@@ -2187,7 +2232,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			case "z":
 				opc = OC_ex2_explodvar_vel_z
 			default:
-				return bvNone(), Error(fmt.Sprint("Invalid argument: %s", c.token))
+				return bvNone(), Error(fmt.Sprint("Invalid ExplodVar vel argument: %s", c.token))
 			}
 		case "accel":
 			c.token = c.tokenizer(in)
@@ -2200,7 +2245,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			case "z":
 				opc = OC_ex2_explodvar_accel_z
 			default:
-				return bvNone(), Error(fmt.Sprint("Invalid argument: %s", c.token))
+				return bvNone(), Error(fmt.Sprint("Invalid ExplodVar accel argument: %s", c.token))
 			}
 		case "friction":
 			c.token = c.tokenizer(in)
@@ -2213,7 +2258,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			case "z":
 				opc = OC_ex2_explodvar_friction_z
 			default:
-				return bvNone(), Error(fmt.Sprint("Invalid argument: %s", c.token))
+				return bvNone(), Error(fmt.Sprint("Invalid ExplodVar friction argument: %s", c.token))
 			}
 		case "scale":
 			c.token = c.tokenizer(in)
@@ -2224,7 +2269,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			case "y":
 				opc = OC_ex2_explodvar_scale_y
 			default:
-				return bvNone(), Error(fmt.Sprint("Invalid argument: %s", c.token))
+				return bvNone(), Error(fmt.Sprint("Invalid ExplodVar scale argument: %s", c.token))
 			}
 		case "angle":
 			c.token = c.tokenizer(in)
@@ -2237,10 +2282,10 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			case ")":
 				opc = OC_ex2_explodvar_angle
 			default:
-				return bvNone(), Error(fmt.Sprint("Invalid argument: %s", c.token))
+				return bvNone(), Error(fmt.Sprint("Invalid ExplodVar angle argument: %s", c.token))
 			}
 		default:
-			return bvNone(), Error(fmt.Sprint("Invalid argument: %s", vname))
+			return bvNone(), Error(fmt.Sprint("Invalid ExplodVar angle argument: %s", vname))
 		}
 		if opc != OC_ex2_explodvar_angle {
 			c.token = c.tokenizer(in)
@@ -2462,7 +2507,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				opc = OC_ex_gethitvar_guardflag
 				isFlag = 2
 			default:
-				return bvNone(), Error("Invalid data: " + c.token)
+				return bvNone(), Error("Invalid GetHitVar argument: " + c.token)
 			}
 		}
 		c.token = c.tokenizer(in)
@@ -2611,7 +2656,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "guardsound.number":
 			opc = OC_ex2_hitdefvar_guardsound_number
 		default:
-			return bvNone(), Error("Invalid data: " + c.token)
+			return bvNone(), Error("Invalid HitDefVar argument: " + c.token)
 		}
 		if isFlag {
 			if err := eqne(func() error {
@@ -2647,7 +2692,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "z":
 			out.append(OC_hitvel_z)
 		default:
-			return bvNone(), Error("Invalid data: " + c.token)
+			return bvNone(), Error("Invalid HitVel argument: " + c.token)
 		}
 	case "id":
 		out.append(OC_id)
@@ -2695,7 +2740,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		trname := c.token
 		if err := eqne2(func(not bool) error {
 			if len(c.token) == 0 {
-				return Error(trname + " value is not specified")
+				return Error(trname + " trigger requires a comparison")
 			}
 			var mt MoveType
 			switch c.token[0] {
@@ -2706,7 +2751,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			case 'h':
 				mt = MT_H
 			default:
-				return Error("Invalid value: " + c.token)
+				return Error("Invalid MoveType: " + c.token)
 			}
 			if trname == "prevmovetype" {
 				out.append(OC_ex_, OC_ex_prevmovetype, OpCode(mt>>15))
@@ -2794,7 +2839,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "all.invertblend":
 			out.append(OC_ex2_palfxvar_all_invertblend)
 		default:
-			return bvNone(), Error("Invalid data: " + c.token)
+			return bvNone(), Error("Invalid PalFXVar argument: " + c.token)
 		}
 		c.token = c.tokenizer(in)
 		if err := c.checkClosingBracket(); err != nil {
@@ -2864,7 +2909,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "z":
 			out.append(OC_ex_, OC_ex_pos_z)
 		default:
-			return bvNone(), Error("Invalid data: " + c.token)
+			return bvNone(), Error("Invalid Pos argument: " + c.token)
 		}
 	case "power":
 		out.append(OC_power)
@@ -2907,14 +2952,14 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 		if c.token != "," {
-			return bvNone(), Error("Missing ','")
+			return bvNone(), Error("Missing ',' in ProjVar")
 		}
 		c.token = c.tokenizer(in)
 		if bv2, err = c.expBoolOr(&be2, in); err != nil {
 			return bvNone(), err
 		}
 		if c.token != "," {
-			return bvNone(), Error("Missing ','")
+			return bvNone(), Error("Missing ',' in ProjVar")
 		}
 		c.token = c.tokenizer(in)
 
@@ -2937,7 +2982,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			case "b":
 				opc = OC_ex2_projvar_projshadow_b
 			default:
-				return bvNone(), Error(fmt.Sprint("Invalid argument: %s", c.token))
+				return bvNone(), Error(fmt.Sprint("Invalid ProjVar shadow argument: %s", c.token))
 			}
 		case "projmisstime":
 			opc = OC_ex2_projvar_projmisstime
@@ -2966,7 +3011,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			case "z":
 				opc = OC_ex2_projvar_vel_z
 			default:
-				return bvNone(), Error(fmt.Sprint("Invalid argument: %s", c.token))
+				return bvNone(), Error(fmt.Sprint("Invalid ProjVar vel argument: %s", c.token))
 			}
 		case "velmul":
 			c.token = c.tokenizer(in)
@@ -2979,7 +3024,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			case "z":
 				opc = OC_ex2_projvar_velmul_z
 			default:
-				return bvNone(), Error(fmt.Sprint("Invalid argument: %s", c.token))
+				return bvNone(), Error(fmt.Sprint("Invalid ProjVar velmul argument: %s", c.token))
 			}
 		case "remvelocity":
 			c.token = c.tokenizer(in)
@@ -2992,7 +3037,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			case "z":
 				opc = OC_ex2_projvar_remvelocity_z
 			default:
-				return bvNone(), Error(fmt.Sprint("Invalid argument: %s", c.token))
+				return bvNone(), Error(fmt.Sprint("Invalid ProjVar remvelocity argument: %s", c.token))
 			}
 		case "accel":
 			c.token = c.tokenizer(in)
@@ -3005,7 +3050,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			case "z":
 				opc = OC_ex2_projvar_accel_z
 			default:
-				return bvNone(), Error(fmt.Sprint("Invalid argument: %s", c.token))
+				return bvNone(), Error(fmt.Sprint("Invalid ProjVar accel argument: %s", c.token))
 			}
 		case "scale":
 			c.token = c.tokenizer(in)
@@ -3016,7 +3061,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			case "y":
 				opc = OC_ex2_projvar_projscale_y
 			default:
-				return bvNone(), Error(fmt.Sprint("Invalid argument: %s", c.token))
+				return bvNone(), Error(fmt.Sprint("Invalid ProjVar scale argument: %s", c.token))
 			}
 		case "angle":
 			opc = OC_ex2_projvar_projangle
@@ -3031,7 +3076,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			case "z":
 				opc = OC_ex2_projvar_pos_z
 			default:
-				return bvNone(), Error(fmt.Sprint("Invalid argument: %s", c.token))
+				return bvNone(), Error(fmt.Sprint("Invalid ProjVar angle argument: %s", c.token))
 			}
 		case "projsprpriority":
 			opc = OC_ex2_projvar_projsprpriority
@@ -3075,7 +3120,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "facing":
 			opc = OC_ex2_projvar_facing
 		default:
-			return bvNone(), Error(fmt.Sprint("Invalid argument: %s", vname))
+			return bvNone(), Error(fmt.Sprint("Invalid ProjVar argument: %s", vname))
 		}
 
 		c.token = c.tokenizer(in)
@@ -3170,7 +3215,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "y":
 			out.append(OC_screenpos_y)
 		default:
-			return bvNone(), Error("Invalid data: " + c.token)
+			return bvNone(), Error("Invalid ScreenPos argument: " + c.token)
 		}
 	case "screenwidth":
 		out.append(OC_screenwidth)
@@ -3187,7 +3232,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 		if c.token != "," {
-			return bvNone(), Error("Missing ','")
+			return bvNone(), Error("Missing ',' in SoundVar")
 		}
 		c.token = c.tokenizer(in)
 
@@ -3222,7 +3267,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "volumescale":
 			opc = OC_ex2_soundvar_volumescale
 		default:
-			return bvNone(), Error(fmt.Sprint("Invalid argument: %s", vname))
+			return bvNone(), Error(fmt.Sprint("Invalid SoundVar argument: %s", vname))
 		}
 
 		c.token = c.tokenizer(in)
@@ -3265,7 +3310,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		trname := c.token
 		if err := eqne2(func(not bool) error {
 			if len(c.token) == 0 {
-				return Error(trname + " value is not specified")
+				return Error(trname + " trigger requires a comparison")
 			}
 			var st StateType
 			switch c.token[0] {
@@ -3278,7 +3323,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			case 'l':
 				st = ST_L
 			default:
-				return Error("Invalid value: " + c.token)
+				return Error("Invalid StateType: " + c.token)
 			}
 			if trname == "prevstatetype" {
 				out.append(OC_ex_, OC_ex_prevstatetype, OpCode(st))
@@ -3305,7 +3350,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 		if c.token != "," {
-			return bvNone(), Error("Missing ','")
+			return bvNone(), Error("Missing ',' in StageBGVar")
 		}
 		// Second argument
 		c.token = c.tokenizer(in)
@@ -3314,7 +3359,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 		if c.token != "," {
-			return bvNone(), Error("Missing ','")
+			return bvNone(), Error("Missing ',' in StageBGVar")
 		}
 		// Third argument
 		c.token = c.tokenizer(in)
@@ -3498,7 +3543,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "reflection.color.b":
 			opc = OC_const_stagevar_reflection_color_b
 		default:
-			return bvNone(), Error("Invalid data: " + svname)
+			return bvNone(), Error("Invalid StageVar argument: " + svname)
 		}
 		if isStr {
 			if err := nameSub(OC_const_, opc); err != nil {
@@ -3511,7 +3556,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 	case "teammode":
 		if err := eqne(func() error {
 			if len(c.token) == 0 {
-				return Error("teammode value is not specified")
+				return Error("TeamMode trigger requires a comparison")
 			}
 			var tm TeamMode
 			switch c.token {
@@ -3524,7 +3569,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			case "tag":
 				tm = TM_Tag
 			default:
-				return Error("Invalid value: " + c.token)
+				return Error("Invalid TeamMode: " + c.token)
 			}
 			out.append(OC_teammode, OpCode(tm))
 			return nil
@@ -3555,7 +3600,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "z":
 			out.append(OC_ex_, OC_ex_vel_z)
 		default:
-			return bvNone(), Error("Invalid data: " + c.token)
+			return bvNone(), Error("Invalid Vel argument: " + c.token)
 		}
 	case "win":
 		out.append(OC_ex_, OC_ex_win)
@@ -3573,7 +3618,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		if not, err := c.checkEquality(in); err != nil {
 			return bvNone(), err
 		} else if not && !sys.ignoreMostErrors {
-			return bvNone(), Error("animelem doesn't support '!='")
+			return bvNone(), Error("AnimElem doesn't support '!='")
 		}
 		if c.token == "-" {
 			return bvNone(), Error("'-' should not be used")
@@ -3582,7 +3627,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 		if n <= 0 {
-			return bvNone(), Error("animelem must be greater than 0")
+			return bvNone(), Error("AnimElem must be greater than 0")
 		}
 		be1.appendValue(BytecodeInt(n))
 		if rd {
@@ -3600,7 +3645,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		if not, err := c.checkEquality(in); err != nil {
 			return bvNone(), err
 		} else if not && !sys.ignoreMostErrors {
-			return bvNone(), Error("timemod doesn't support '!='")
+			return bvNone(), Error("TimeMod doesn't support '!='")
 		}
 		if c.token == "-" {
 			return bvNone(), Error("'-' should not be used")
@@ -3609,7 +3654,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 		if n <= 0 {
-			return bvNone(), Error("timemod must be greater than 0")
+			return bvNone(), Error("TimeMod must be greater than 0")
 		}
 		out.append(OC_time)
 		out.appendValue(BytecodeInt(n))
@@ -3628,7 +3673,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "z":
 			out.append(OC_ex_, OC_ex_p2dist_z)
 		default:
-			return bvNone(), Error("Invalid data: " + c.token)
+			return bvNone(), Error("Invalid P2Dist argument: " + c.token)
 		}
 	case "p2bodydist":
 		c.token = c.tokenizer(in)
@@ -3640,7 +3685,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "z":
 			out.append(OC_ex_, OC_ex_p2bodydist_z)
 		default:
-			return bvNone(), Error("Invalid data: " + c.token)
+			return bvNone(), Error("Invalid P2BodyDist argument: " + c.token)
 		}
 	case "rootdist":
 		c.token = c.tokenizer(in)
@@ -3652,7 +3697,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "z":
 			out.append(OC_ex_, OC_ex_rootdist_z)
 		default:
-			return bvNone(), Error("Invalid data: " + c.token)
+			return bvNone(), Error("Invalid RootDist argument: " + c.token)
 		}
 	case "parentdist":
 		c.token = c.tokenizer(in)
@@ -3664,7 +3709,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "z":
 			out.append(OC_ex_, OC_ex_parentdist_z)
 		default:
-			return bvNone(), Error("Invalid data: " + c.token)
+			return bvNone(), Error("Invalid ParentDist argument: " + c.token)
 		}
 	case "pi":
 		bv = BytecodeFloat(float32(math.Pi))
@@ -3690,7 +3735,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 		if c.token != "," {
-			return bvNone(), Error("Missing ','")
+			return bvNone(), Error("Missing ',' in Log")
 		}
 		c.token = c.tokenizer(in)
 		if bv2, err = c.expBoolOr(&be2, in); err != nil {
@@ -3757,7 +3802,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 		if c.token != "," {
-			return bvNone(), Error("Missing ','")
+			return bvNone(), Error("Missing ',' in Max")
 		}
 		c.token = c.tokenizer(in)
 		if bv2, err = c.expBoolOr(&be2, in); err != nil {
@@ -3787,7 +3832,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 		if c.token != "," {
-			return bvNone(), Error("Missing ','")
+			return bvNone(), Error("Missing ',' in Min")
 		}
 		c.token = c.tokenizer(in)
 		if bv2, err = c.expBoolOr(&be2, in); err != nil {
@@ -3817,7 +3862,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 		if c.token != "," {
-			return bvNone(), Error("Missing ','")
+			return bvNone(), Error("Missing ',' in RandomRange")
 		}
 		c.token = c.tokenizer(in)
 		if bv2, err = c.expBoolOr(&be2, in); err != nil {
@@ -3842,7 +3887,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 		if c.token != "," {
-			return bvNone(), Error("Missing ','")
+			return bvNone(), Error("Missing ',' in Round")
 		}
 		c.token = c.tokenizer(in)
 		if bv2, err = c.expBoolOr(&be2, in); err != nil {
@@ -3872,14 +3917,14 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 		if c.token != "," {
-			return bvNone(), Error("Missing ','")
+			return bvNone(), Error("Missing ',' in Clamp")
 		}
 		c.token = c.tokenizer(in)
 		if bv2, err = c.expBoolOr(&be2, in); err != nil {
 			return bvNone(), err
 		}
 		if c.token != "," {
-			return bvNone(), Error("Missing ','")
+			return bvNone(), Error("Missing ',' in Clamp")
 		}
 		c.token = c.tokenizer(in)
 		if bv3, err = c.expBoolOr(&be3, in); err != nil {
@@ -3911,7 +3956,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 		if c.token != "," {
-			return bvNone(), Error("Missing ','")
+			return bvNone(), Error("Missing ',' in ATan2")
 		}
 		c.token = c.tokenizer(in)
 		if bv2, err = c.expBoolOr(&be2, in); err != nil {
@@ -3956,14 +4001,14 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 		if c.token != "," {
-			return bvNone(), Error("Missing ','")
+			return bvNone(), Error("Missing ',' in Lerp")
 		}
 		c.token = c.tokenizer(in)
 		if bv2, err = c.expBoolOr(&be2, in); err != nil {
 			return bvNone(), err
 		}
 		if c.token != "," {
-			return bvNone(), Error("Missing ','")
+			return bvNone(), Error("Missing ',' in Lerp")
 		}
 		c.token = c.tokenizer(in)
 		if bv3, err = c.expBoolOr(&be3, in); err != nil {
@@ -4061,7 +4106,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "roundrestarted":
 			out.append(OC_ex2_debug_roundrestarted)
 		default:
-			return bvNone(), Error("Invalid data: " + c.token)
+			return bvNone(), Error("Invalid Debug trigger argument: " + c.token)
 		}
 		c.token = c.tokenizer(in)
 		if err := c.checkClosingBracket(); err != nil {
@@ -4391,7 +4436,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "skipwindisplay":
 			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_skipwindisplay))
 		default:
-			return bvNone(), Error("Invalid data: " + c.token)
+			return bvNone(), Error("Invalid AssertSpecial flag: " + c.token)
 		}
 		c.token = c.tokenizer(in)
 		if err := c.checkClosingBracket(); err != nil {
@@ -4463,7 +4508,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "winscreen":
 			opc = OC_ex2_motifstate_winscreen
 		default:
-			return bvNone(), Error("Invalid data: " + msname)
+			return bvNone(), Error("Invalid MotifState argument: " + msname)
 		}
 		out.append(OC_ex2_)
 		out.append(opc)
@@ -4507,7 +4552,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 	case "physics":
 		if err := eqne(func() error {
 			if len(c.token) == 0 {
-				return Error("physics value not specified")
+				return Error("Physics trigger requires a comparison")
 			}
 			var st StateType
 			switch c.token[0] {
@@ -4520,7 +4565,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			case 'n':
 				st = ST_N
 			default:
-				return Error("Invalid value: " + c.token)
+				return Error("Invalid Physics type: " + c.token)
 			}
 			out.append(OC_ex_, OC_ex_physics, OpCode(st))
 			return nil
@@ -4573,7 +4618,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			strings.ToLower(c.token))))
 		*in = strings.TrimSpace(*in)
 		if len(*in) == 0 || (!sys.ignoreMostErrors && (*in)[0] != ')') {
-			return bvNone(), Error("Missing ')' before " + c.token)
+			return bvNone(), Error("StageConst missing ')' before " + c.token)
 		}
 		*in = (*in)[1:]
 	case "stagefrontedgedist", "stagefrontedge": // Latter is deprecated
@@ -4629,7 +4674,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "z":
 			out.append(OC_ex_, OC_ex_scale_z)
 		default:
-			return bvNone(), Error("Invalid data: " + c.token)
+			return bvNone(), Error("Invalid Scale trigger argument: " + c.token)
 		}
 	case "offset":
 		c.token = c.tokenizer(in)
@@ -4639,7 +4684,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "y":
 			out.append(OC_ex_, OC_ex_offset_y)
 		default:
-			return bvNone(), Error("Invalid data: " + c.token)
+			return bvNone(), Error("Invalid Offset trigger argument: " + c.token)
 		}
 	case "alpha":
 		c.token = c.tokenizer(in)
@@ -4649,7 +4694,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "dest":
 			out.append(OC_ex_, OC_ex_alpha_d)
 		default:
-			return bvNone(), Error("Invalid data: " + c.token)
+			return bvNone(), Error("Invalid Alpha trigger argument: " + c.token)
 		}
 	case "=", "!=", ">", ">=", "<", "<=", "&", "&&", "^", "^^", "|", "||",
 		"+", "*", "**", "/", "%":
@@ -4733,14 +4778,13 @@ func (c *Compiler) contiguousOperator(in *string) error {
 			}
 			fallthrough
 		case '=', '<', '>', '|', '&', '+', '*', '/', '%', '^':
-			return Error("Invalid data: " + c.tokenizer(in))
+			return Error("Contiguous operator: " + c.tokenizer(in))
 		}
 	}
 	return nil
 }
 
-func (c *Compiler) expPostNot(out *BytecodeExp, in *string) (BytecodeValue,
-	error) {
+func (c *Compiler) expPostNot(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	bv, err := c.expValue(out, in, false)
 	if err != nil {
 		return bvNone(), err
@@ -4790,8 +4834,7 @@ func (c *Compiler) expPostNot(out *BytecodeExp, in *string) (BytecodeValue,
 	return bv, nil
 }
 
-func (c *Compiler) expPow(out *BytecodeExp, in *string) (BytecodeValue,
-	error) {
+func (c *Compiler) expPow(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	bv, err := c.expPostNot(out, in)
 	if err != nil {
 		return bvNone(), err
@@ -4823,8 +4866,7 @@ func (c *Compiler) expPow(out *BytecodeExp, in *string) (BytecodeValue,
 	return bv, nil
 }
 
-func (c *Compiler) expMldv(out *BytecodeExp, in *string) (BytecodeValue,
-	error) {
+func (c *Compiler) expMldv(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	bv, err := c.expPow(out, in)
 	if err != nil {
 		return bvNone(), err
@@ -4852,8 +4894,7 @@ func (c *Compiler) expMldv(out *BytecodeExp, in *string) (BytecodeValue,
 	}
 }
 
-func (c *Compiler) expAdsb(out *BytecodeExp, in *string) (BytecodeValue,
-	error) {
+func (c *Compiler) expAdsb(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	bv, err := c.expMldv(out, in)
 	if err != nil {
 		return bvNone(), err
@@ -4878,8 +4919,7 @@ func (c *Compiler) expAdsb(out *BytecodeExp, in *string) (BytecodeValue,
 	}
 }
 
-func (c *Compiler) expGrls(out *BytecodeExp, in *string) (BytecodeValue,
-	error) {
+func (c *Compiler) expGrls(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	bv, err := c.expAdsb(out, in)
 	if err != nil {
 		return bvNone(), err
@@ -4999,8 +5039,7 @@ func (c *Compiler) expRange(out *BytecodeExp, in *string,
 	return true, nil
 }
 
-func (c *Compiler) expEqne(out *BytecodeExp, in *string) (BytecodeValue,
-	error) {
+func (c *Compiler) expEqne(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	bv, err := c.expGrls(out, in)
 	if err != nil {
 		return bvNone(), err
@@ -5085,13 +5124,11 @@ func (c *Compiler) expOneOp(out *BytecodeExp, in *string, ef expFunc,
 	}
 }
 
-func (c *Compiler) expAnd(out *BytecodeExp, in *string) (BytecodeValue,
-	error) {
+func (c *Compiler) expAnd(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	return c.expOneOp(out, in, c.expEqne, "&", out.and, OC_and)
 }
 
-func (c *Compiler) expXor(out *BytecodeExp, in *string) (BytecodeValue,
-	error) {
+func (c *Compiler) expXor(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	return c.expOneOp(out, in, c.expAnd, "^", out.xor, OC_xor)
 }
 
@@ -5099,8 +5136,7 @@ func (c *Compiler) expOr(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	return c.expOneOp(out, in, c.expXor, "|", out.or, OC_or)
 }
 
-func (c *Compiler) expBoolAnd(out *BytecodeExp, in *string) (BytecodeValue,
-	error) {
+func (c *Compiler) expBoolAnd(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	if c.block != nil {
 		return c.expOneOp(out, in, c.expOr, "&&", out.bland, OC_bland)
 	}
@@ -5140,13 +5176,11 @@ func (c *Compiler) expBoolAnd(out *BytecodeExp, in *string) (BytecodeValue,
 	return bv, nil
 }
 
-func (c *Compiler) expBoolXor(out *BytecodeExp, in *string) (BytecodeValue,
-	error) {
+func (c *Compiler) expBoolXor(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	return c.expOneOp(out, in, c.expBoolAnd, "^^", out.blxor, OC_blxor)
 }
 
-func (c *Compiler) expBoolOr(out *BytecodeExp, in *string) (BytecodeValue,
-	error) {
+func (c *Compiler) expBoolOr(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	defer func(omp string) { c.previousOperator = omp }(c.previousOperator)
 	if c.block != nil {
 		return c.expOneOp(out, in, c.expBoolXor, "||", out.blor, OC_blor)
@@ -5209,8 +5243,7 @@ func (c *Compiler) typedExp(ef expFunc, in *string,
 	return be, nil
 }
 
-func (c *Compiler) argExpression(in *string, vt ValueType) (BytecodeExp,
-	error) {
+func (c *Compiler) argExpression(in *string, vt ValueType) (BytecodeExp, error) {
 	be, err := c.typedExp(c.expBoolOr, in, vt)
 	if err != nil {
 		return nil, err
@@ -5229,8 +5262,7 @@ func (c *Compiler) argExpression(in *string, vt ValueType) (BytecodeExp,
 	return be, nil
 }
 
-func (c *Compiler) fullExpression(in *string, vt ValueType) (BytecodeExp,
-	error) {
+func (c *Compiler) fullExpression(in *string, vt ValueType) (BytecodeExp, error) {
 	be, err := c.typedExp(c.expBoolOr, in, vt)
 	if err != nil {
 		return nil, err
@@ -5419,7 +5451,7 @@ func (c *Compiler) paramPostype(is IniSection, sc *StateControllerBase,
 	id byte) error {
 	return c.stateParam(is, "postype", false, func(data string) error {
 		if len(data) == 0 {
-			return Error("Value not specified")
+			return Error("postype not specified")
 		}
 		var pt PosType
 		if len(data) >= 2 && strings.ToLower(data[:2]) == "p2" {
@@ -5439,7 +5471,7 @@ func (c *Compiler) paramPostype(is IniSection, sc *StateControllerBase,
 			case 'n':
 				pt = PT_None
 			default:
-				return Error("Invalid value: " + data)
+				return Error("Invalid postype: " + data)
 			}
 		}
 		sc.add(id, sc.iToExp(int32(pt)))
@@ -5451,13 +5483,13 @@ func (c *Compiler) paramSpace(is IniSection, sc *StateControllerBase,
 	id byte) error {
 	return c.stateParam(is, "space", false, func(data string) error {
 		if len(data) <= 1 {
-			return Error("Value not specified")
+			return Error("space not specified")
 		}
 		var sp Space
 		if len(data) >= 2 {
-			if strings.ToLower(data[:2]) == "st" {
+			if strings.ToLower(data[:2]) == "stage" {
 				sp = Space_stage
-			} else if strings.ToLower(data[:2]) == "sc" {
+			} else if strings.ToLower(data[:2]) == "screen" {
 				sp = Space_screen
 			}
 		}
@@ -5470,7 +5502,7 @@ func (c *Compiler) paramProjection(is IniSection, sc *StateControllerBase,
 	id byte) error {
 	return c.stateParam(is, "projection", false, func(data string) error {
 		if len(data) <= 1 {
-			return Error("Value not specified")
+			return Error("projection not specified")
 		}
 		var proj Projection
 		if len(data) >= 2 {
@@ -5494,7 +5526,7 @@ func (c *Compiler) paramSaveData(is IniSection, sc *StateControllerBase,
 	id byte) error {
 	return c.stateParam(is, "savedata", false, func(data string) error {
 		if len(data) <= 1 {
-			return Error("Value not specified")
+			return Error("savedata not specified")
 		}
 		var sv SaveData
 		switch strings.ToLower(data) {
@@ -5505,7 +5537,7 @@ func (c *Compiler) paramSaveData(is IniSection, sc *StateControllerBase,
 		case "fvar":
 			sv = SaveData_fvar
 		default:
-			return Error("Invalid value: " + data)
+			return Error("Invalid savedata type: " + data)
 		}
 		sc.add(id, sc.iToExp(int32(sv)))
 		return nil
@@ -5516,7 +5548,7 @@ func (c *Compiler) paramTrans(is IniSection, sc *StateControllerBase,
 	prefix string, id byte, afterImage bool) error {
 	return c.stateParam(is, prefix+"trans", false, func(data string) error {
 		if len(data) == 0 {
-			return Error("Value not specified")
+			return Error("trans type not specified")
 		}
 		tt := TT_default
 		data = strings.ToLower(data)
@@ -5548,7 +5580,7 @@ func (c *Compiler) paramTrans(is IniSection, sc *StateControllerBase,
 				}
 			}
 			if _error && (!afterImage || !sys.ignoreMostErrors) {
-				return Error("Invalid value: " + data)
+				return Error("Invalid trans type: " + data)
 			}
 		}
 		var exp []BytecodeExp
@@ -5636,7 +5668,7 @@ func (c *Compiler) stateDef(is IniSection, sbc *StateBytecode) error {
 		sc := newStateControllerBase()
 		if err := c.stateParam(is, "type", false, func(data string) error {
 			if len(data) == 0 {
-				return Error("Value not specified")
+				return Error("statetype not specified")
 			}
 			switch strings.ToLower(data)[0] {
 			case 's':
@@ -5650,7 +5682,7 @@ func (c *Compiler) stateDef(is IniSection, sbc *StateBytecode) error {
 			case 'u':
 				sbc.stateType = ST_U
 			default:
-				return Error("Invalid value: " + data)
+				return Error("Invalid statetype: " + data)
 			}
 			return nil
 		}); err != nil {
@@ -5658,7 +5690,7 @@ func (c *Compiler) stateDef(is IniSection, sbc *StateBytecode) error {
 		}
 		if err := c.stateParam(is, "movetype", false, func(data string) error {
 			if len(data) == 0 {
-				return Error("Value not specified")
+				return Error("movetype not specified")
 			}
 			switch strings.ToLower(data)[0] {
 			case 'i':
@@ -5670,7 +5702,7 @@ func (c *Compiler) stateDef(is IniSection, sbc *StateBytecode) error {
 			case 'u':
 				sbc.moveType = MT_U
 			default:
-				return Error("Invalid value: " + data)
+				return Error("Invalid movetype: " + data)
 			}
 			return nil
 		}); err != nil {
@@ -5678,7 +5710,7 @@ func (c *Compiler) stateDef(is IniSection, sbc *StateBytecode) error {
 		}
 		if err := c.stateParam(is, "physics", false, func(data string) error {
 			if len(data) == 0 {
-				return Error("Value not specified")
+				return Error("physics not specified")
 			}
 			switch strings.ToLower(data)[0] {
 			case 's':
@@ -5692,7 +5724,7 @@ func (c *Compiler) stateDef(is IniSection, sbc *StateBytecode) error {
 			case 'u':
 				sbc.physics = ST_U
 			default:
-				return Error("Invalid value: " + data)
+				return Error("Invalid physics type: " + data)
 			}
 			return nil
 		}); err != nil {
@@ -5788,17 +5820,17 @@ func cnsStringArray(arg string) ([]string, error) {
 			}
 		}
 
-		// Do the string was closed?
+		// Was the string closed?
 		if inString != 2 {
 			if inString%2 != 0 {
-				return nil, Error("String not closed.")
+				return nil, Error("String not closed")
 			} else if inString > 2 { // Do we have more than 1 string without using ','?
-				return nil, Error("Lack of ',' separator.")
+				return nil, Error("Lack of ',' separator")
 			} else {
-				return nil, Error("Unknown string array error.")
+				return nil, Error("Unknown string array error")
 			}
 		} else if formatError {
-			return nil, Error("Wrong format on string array.")
+			return nil, Error("Wrong format on string array")
 		} else { // All's good.
 			inString = 0
 		}
@@ -5852,7 +5884,7 @@ func (c *Compiler) stateCompile(states map[int32]StateBytecode,
 	c.vars = make(map[string]uint8)
 	// Loop through state file lines
 	for ; c.i < len(c.lines); c.i++ {
-		/* Find a statedef, skipping over other lines until finding one */
+		// Find a statedef, skipping over other lines until finding one
 		// Get the current line, without comments
 		line := strings.ToLower(strings.TrimSpace(
 			strings.SplitN(c.lines[c.i], ";", 2)[0]))
@@ -6010,7 +6042,7 @@ func (c *Compiler) stateCompile(states map[int32]StateBytecode,
 
 			// Check that the sctrl has a valid type parameter
 			if scf == nil {
-				return errmes(Error("type parameter not specified"))
+				return errmes(Error("State controller type not specified"))
 			}
 			if len(trexist) == 0 || (!allUtikiri && trexist[0] == 0) {
 				return errmes(Error("Missing trigger1"))
@@ -6131,9 +6163,9 @@ func (c *Compiler) stateCompile(states map[int32]StateBytecode,
 
 func (c *Compiler) wrongClosureToken() error {
 	if c.token == "" {
-		return Error("Missing token")
+		return Error("Missing closure token")
 	}
-	return Error("Unexpected token: " + c.token)
+	return Error("Unexpected closure token: " + c.token)
 }
 
 func (c *Compiler) nextLine() (string, bool) {
@@ -6174,7 +6206,7 @@ func (c *Compiler) needToken(t string) error {
 func (c *Compiler) readString(line *string) (string, error) {
 	i := strings.Index(*line, "\"")
 	if i < 0 {
-		return "", Error("Not enclosed in \"")
+		return "", Error("String not enclosed in \"")
 	}
 	s := (*line)[:i]
 	*line = (*line)[i+1:]
@@ -6291,7 +6323,7 @@ func (c *Compiler) varNames(end string, line *string) ([]string, error) {
 			if name != "_" {
 				for _, nm := range names {
 					if nm == name {
-						return nil, Error("Duplicated name: " + name)
+						return nil, Error("Duplicate name: " + name)
 					}
 				}
 			}
@@ -6380,10 +6412,10 @@ func (c *Compiler) blockAttribSet(line *string, bl *StateBlock, sbc *StateByteco
 			continue
 		case "persistent":
 			if sbc == nil {
-				return Error("persistent cannot be used in a function")
+				return Error("Persistent cannot be used in a function")
 			}
 			if c.stateNo < 0 {
-				return Error("persistent cannot be used in a negative state")
+				return Error("Persistent cannot be used in a negative state")
 			}
 			if bl.persistentIndex >= 0 {
 				return c.wrongClosureToken()
@@ -6401,7 +6433,7 @@ func (c *Compiler) blockAttribSet(line *string, bl *StateBlock, sbc *StateByteco
 				return err
 			}
 			if bl.persistent == 1 {
-				return Error("persistent(1) is meaningless")
+				return Error("Persistent(1) is meaningless") // TODO: Do we really need to crash here?
 			}
 			if bl.persistent <= 0 {
 				bl.persistent = math.MaxInt32
@@ -6621,14 +6653,14 @@ func (c *Compiler) loopBlock(line *string, root bool, bl *StateBlock,
 		for ; i < 3; i++ {
 			if c.token == "{" {
 				if i < 2 {
-					return Error("For needs more than one expression")
+					return Error("For loop needs more than one expression")
 				} else {
 					// For only has begin/end expressions, so we stop compiling the header
 					break
 				}
 			}
 			if c.token == ";" && i < 1 {
-				return Error("Misplaced ;")
+				return Error("Misplaced ';' in for loop")
 			}
 			expr, _, err := c.readSentence(line)
 			if err != nil {
@@ -7111,7 +7143,7 @@ func (c *Compiler) stateCompileZ(states map[int32]StateBytecode,
 					if r == "_" {
 						return errmes(Error("The return value name is _"))
 					} else if _, ok := c.vars[r]; ok {
-						return errmes(Error("Duplicated name: " + r))
+						return errmes(Error("Duplicate name: " + r))
 					} else {
 						c.vars[r] = uint8(fun.numVars)
 					}

--- a/src/main.go
+++ b/src/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 var Version = "development"
-var BuildTime = ""
+var BuildTime = "" // Set automatically by GitHub Actions
 
 func init() {
 	runtime.LockOSThread()
@@ -114,7 +114,13 @@ func main() {
 		// Display error logs.
 		errorLog := createLog("Ikemen.log")
 		defer closeLog(errorLog)
+
+		// Write version and build time at the top
+		fmt.Fprintf(errorLog, "Version: %s\nBuild Time: %s\n\nError log:\n", Version, BuildTime)
+
+		// Write the rest of the log
 		fmt.Fprintln(errorLog, err)
+
 		switch err.(type) {
 		case *lua.ApiError:
 			errstr := strings.Split(err.Error(), "\n")[0]

--- a/src/script.go
+++ b/src/script.go
@@ -5270,10 +5270,10 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LBool(sys.debugDisplay))
 		case "lifebardisplay":
 			l.Push(lua.LBool(sys.lifebarDisplay))
+		case "roundreset":
+			l.Push(lua.LBool(sys.roundResetFlg))
 		case "wireframedisplay":
 			l.Push(lua.LBool(sys.wireframeDisplay))
-		case "roundrestarted":
-			l.Push(lua.LBool(sys.roundResetFlg))
 		default:
 			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}

--- a/src/script.go
+++ b/src/script.go
@@ -4311,6 +4311,14 @@ func triggerFunctions(l *lua.LState) {
 			BytecodeInt(int32(numArg(l, 1)))).ToI()))
 		return 1
 	})
+	luaRegister(l, "numstagebg", func(*lua.LState) int {
+		id := int32(-1)
+		if !nilArg(l, 1) {
+			id = int32(numArg(l, 1))
+		}
+		l.Push(lua.LNumber(sys.debugWC.numStageBG(BytecodeInt(id)).ToI()))
+		return 1
+	})
 	luaRegister(l, "numtarget", func(*lua.LState) int {
 		id := int32(-1)
 		if !nilArg(l, 1) {

--- a/src/system.go
+++ b/src/system.go
@@ -407,7 +407,7 @@ func (s *System) init(w, h int32) *lua.LState {
 	s.clsnSpr.SetPxl([]byte{0})
 	systemScriptInit(l)
 	s.shortcutScripts = make(map[ShortcutKey]*ShortcutScript)
-	// So now that we have a window we add a icon.
+	// So now that we have a window we add an icon.
 	if len(s.cfg.Config.WindowIcon) > 0 {
 		// First we initialize arrays.
 		var f = make([]io.ReadCloser, len(s.cfg.Config.WindowIcon))
@@ -450,6 +450,7 @@ func (s *System) init(w, h int32) *lua.LState {
 	}()
 	return l
 }
+
 func (s *System) shutdown() {
 	if !sys.gameEnd {
 		sys.gameEnd = true
@@ -458,6 +459,7 @@ func (s *System) shutdown() {
 	s.window.Close()
 	speaker.Close()
 }
+
 func (s *System) setWindowSize(w, h int32) {
 	s.scrrect[2], s.scrrect[3] = w, h
 	if s.scrrect[2]*3 > s.scrrect[3]*4 {
@@ -468,6 +470,7 @@ func (s *System) setWindowSize(w, h int32) {
 	s.widthScale = float32(s.scrrect[2]) / float32(s.gameWidth)
 	s.heightScale = float32(s.scrrect[3]) / float32(s.gameHeight)
 }
+
 func (s *System) eventUpdate() bool {
 	s.esc = false
 	for _, v := range s.shortcutScripts {
@@ -477,6 +480,7 @@ func (s *System) eventUpdate() bool {
 	s.gameEnd = s.window.shouldClose()
 	return !s.gameEnd
 }
+
 func (s *System) runMainThreadTask() {
 	for {
 		select {
@@ -545,6 +549,7 @@ func (s *System) update() bool {
 	}
 	return s.await(s.cfg.Config.Framerate)
 }
+
 func (s *System) tickSound() {
 	s.soundChannels.Tick()
 	if !s.noSoundFlg {
@@ -572,19 +577,23 @@ func (s *System) tickSound() {
 		s.restoreAllVolume()
 	}
 }
+
 func (s *System) resetRemapInput() {
 	for i := range s.inputRemap {
 		s.inputRemap[i] = i
 	}
 }
+
 func (s *System) loaderReset() {
 	s.round, s.wins, s.roundsExisted, s.decisiveRound = 1, [2]int32{}, [2]int32{}, [2]bool{}
 	s.loader.reset()
 }
+
 func (s *System) loadStart() {
 	s.loaderReset()
 	s.loader.runTread()
 }
+
 func (s *System) synchronize() error {
 	if s.fileInput != nil {
 		s.fileInput.Synchronize()
@@ -593,6 +602,7 @@ func (s *System) synchronize() error {
 	}
 	return nil
 }
+
 func (s *System) anyHardButton() bool {
 	for _, kc := range s.keyConfig {
 		if kc.a() || kc.b() || kc.c() || kc.x() || kc.y() || kc.z() {
@@ -606,6 +616,7 @@ func (s *System) anyHardButton() bool {
 	}
 	return false
 }
+
 func (s *System) anyButton() bool {
 	if s.fileInput != nil {
 		return s.fileInput.AnyButton()
@@ -615,9 +626,11 @@ func (s *System) anyButton() bool {
 	}
 	return s.anyHardButton()
 }
+
 func (s *System) playerID(id int32) *Char {
 	return s.charList.get(id)
 }
+
 func (s *System) playerIndex(id int32) *Char {
 	return s.charList.getIndex(id)
 }
@@ -657,6 +670,7 @@ func (s *System) playerNoExist(no BytecodeValue) BytecodeValue {
 func (s *System) playercount() int32 {
 	return int32(len(s.charList.runOrder))
 }
+
 func (s *System) palfxvar(x int32, y int32) int32 {
 	n := int32(0)
 	if x >= 4 {
@@ -692,6 +706,7 @@ func (s *System) palfxvar(x int32, y int32) int32 {
 	}
 	return n
 }
+
 func (s *System) palfxvar2(x int32, y int32) float32 {
 	n := float32(1)
 	if x > 1 {
@@ -713,12 +728,15 @@ func (s *System) palfxvar2(x int32, y int32) float32 {
 	}
 	return n * 256
 }
+
 func (s *System) screenHeight() float32 {
 	return 240
 }
+
 func (s *System) screenWidth() float32 {
 	return float32(s.gameWidth)
 }
+
 func (s *System) roundEnd() bool {
 	return s.intro < -s.lifebar.ro.over_hittime
 }
@@ -727,6 +745,7 @@ func (s *System) roundEnd() bool {
 func (s *System) roundNoDamage() bool {
 	return sys.intro < 0 && sys.intro <= -sys.lifebar.ro.over_hittime && sys.intro >= -sys.lifebar.ro.over_waittime
 }
+
 func (s *System) roundState() int32 {
 	switch {
 	case sys.intro > sys.lifebar.ro.ctrl_time+1 || sys.postMatchFlg:
@@ -741,6 +760,7 @@ func (s *System) roundState() int32 {
 		return 3
 	}
 }
+
 func (s *System) introState() int32 {
 	switch {
 	case s.intro > s.lifebar.ro.ctrl_time+1:
@@ -768,6 +788,7 @@ func (s *System) introState() int32 {
 		return 0
 	}
 }
+
 func (s *System) outroState() int32 {
 	switch {
 	case s.intro >= 0:
@@ -793,30 +814,38 @@ func (s *System) outroState() int32 {
 		return 0
 	}
 }
+
 func (s *System) roundWinStates() bool {
 	return s.waitdown <= 0 || s.roundWinTime()
 }
+
 func (s *System) roundWinTime() bool {
 	return s.wintime < 0
 }
+
 func (s *System) roundOver() bool {
 	return s.intro < -(s.lifebar.ro.over_waittime + s.lifebar.ro.over_time)
 }
+
 func (s *System) gsf(gsf GlobalSpecialFlag) bool {
 	return s.specialFlag&gsf != 0
 }
+
 func (s *System) setGSF(gsf GlobalSpecialFlag) {
 	s.specialFlag |= gsf
 }
+
 func (s *System) unsetGSF(gsf GlobalSpecialFlag) {
 	s.specialFlag &^= gsf
 }
+
 func (s *System) appendToConsole(str string) {
 	s.consoleText = append(s.consoleText, str)
 	if len(s.consoleText) > s.cfg.Debug.ConsoleRows {
 		s.consoleText = s.consoleText[len(s.consoleText)-s.cfg.Debug.ConsoleRows:]
 	}
 }
+
 func (s *System) printToConsole(pn, sn int, a ...interface{}) {
 	spl := s.stringPool[pn].List
 	if sn >= 0 && sn < len(spl) {
@@ -826,6 +855,19 @@ func (s *System) printToConsole(pn, sn int, a ...interface{}) {
 		}
 	}
 }
+
+// Print an error directly from bytecode.go
+// Printing from char.go is preferable, but not always possible
+func (s *System) printBytecodeError(str string) {
+	if s.loader.state == LS_Complete && s.workingChar != nil {
+		// Print during matches
+		s.appendToConsole(sys.workingChar.warn() + str)
+	} else if !sys.ignoreMostErrors {
+		// Print outside matches (compiling)
+		sys.errLog.Println(str)
+	}
+}
+
 func (s *System) loadTime(start time.Time, str string, shell, console bool) {
 	elapsed := time.Since(start)
 	str = fmt.Sprintf("%v; Load time: %v", str, elapsed)
@@ -984,6 +1026,7 @@ func (s *System) resetGblEffect() {
 	s.envcol_time = 0
 	s.specialFlag = 0
 }
+
 func (s *System) stopAllSound() {
 	for _, p := range s.chars {
 		for _, c := range p {
@@ -991,6 +1034,7 @@ func (s *System) stopAllSound() {
 		}
 	}
 }
+
 func (s *System) softenAllSound() {
 	for _, p := range s.chars {
 		for _, c := range p {
@@ -1010,6 +1054,7 @@ func (s *System) softenAllSound() {
 	}
 	// Don't pause motif sounds
 }
+
 func (s *System) restoreAllVolume() {
 	for _, p := range s.chars {
 		for _, c := range p {
@@ -1027,6 +1072,7 @@ func (s *System) restoreAllVolume() {
 		}
 	}
 }
+
 func (s *System) clearAllSound() {
 	s.soundChannels.StopAll()
 	s.stopAllSound()
@@ -1170,6 +1216,7 @@ func (s *System) nextRound() {
 		}
 	}
 }
+
 func (s *System) debugPaused() bool {
 	return s.paused && !s.step && s.oldTickCount < s.tickCount
 }
@@ -1214,6 +1261,7 @@ func (s *System) addFrameTime(t float32) bool {
 	s.nextAddTime = t
 	return true
 }
+
 func (s *System) resetFrameTime() {
 	s.tickCount, s.oldTickCount, s.tickCountF, s.lastTick, s.absTickCountF = 0, -1, 0, 0, 0
 	s.nextAddTime, s.oldNextAddTime = 1, 1
@@ -1264,6 +1312,7 @@ func (s *System) posReset() {
 		}
 	}
 }
+
 func (s *System) action() {
 	// Clear sprite data
 	s.spritesLayerN1 = s.spritesLayerN1[:0]
@@ -1942,6 +1991,7 @@ func (s *System) drawTop() {
 		s.debugch.draw(0x3feff)
 	}
 }
+
 func (s *System) drawDebugText() {
 	put := func(x, y *float32, txt string) {
 		for txt != "" {
@@ -2720,6 +2770,7 @@ func newSelect() *Select {
 			[...]int16{9000, 1}: true}, stageSpritePreload: make(map[[2]int16]bool),
 		cdefOverwrite: make(map[int]string)}
 }
+
 func (s *Select) GetCharNo(i int) int {
 	n := i
 	if len(s.charlist) > 0 {
@@ -2730,6 +2781,7 @@ func (s *Select) GetCharNo(i int) int {
 	}
 	return n
 }
+
 func (s *Select) GetChar(i int) *SelectChar {
 	if len(s.charlist) == 0 {
 		return nil
@@ -2737,7 +2789,9 @@ func (s *Select) GetChar(i int) *SelectChar {
 	n := s.GetCharNo(i)
 	return &s.charlist[n]
 }
+
 func (s *Select) SelectStage(n int) { s.selectedStageNo = n }
+
 func (s *Select) GetStage(n int) *SelectStage {
 	if len(s.stagelist) == 0 {
 		return nil
@@ -2748,6 +2802,7 @@ func (s *Select) GetStage(n int) *SelectStage {
 	}
 	return &s.stagelist[n-1]
 }
+
 func (s *Select) addChar(def string) {
 	var tstr string
 	tnow := time.Now()
@@ -3014,6 +3069,7 @@ func (s *Select) addChar(def string) {
 		}
 	}
 }
+
 func (s *Select) AddStage(def string) error {
 	var tstr string
 	tnow := time.Now()
@@ -3150,6 +3206,7 @@ func (s *Select) AddStage(def string) error {
 	}
 	return nil
 }
+
 func (s *Select) AddSelectedChar(tn, cn, pl int) bool {
 	m, n := 0, s.GetCharNo(cn)
 	if len(s.charlist) == 0 || len(s.charlist[n].def) == 0 {
@@ -3169,6 +3226,7 @@ func (s *Select) AddSelectedChar(tn, cn, pl int) bool {
 	sys.loadMutex.Unlock()
 	return true
 }
+
 func (s *Select) ClearSelected() {
 	sys.loadMutex.Lock()
 	s.selected = [2][][2]int{}
@@ -3276,6 +3334,8 @@ func (l *Loader) loadChar(pn int) int {
 
 	// Reuse character or create a new one
 	var p *Char
+	sys.workingChar = p // This should help compiler and bytecode stay consistent
+
 	if len(sys.chars[pn]) > 0 && cdef == sys.cgi[pn].def {
 		p = sys.chars[pn][0]
 		p.controller = pn
@@ -3451,9 +3511,15 @@ func (l *Loader) loadStage() bool {
 	}
 	return l.err == nil
 }
+
 func (l *Loader) load() {
-	defer func() { l.loadExit <- l.state }()
+	defer func() {
+		l.loadExit <- l.state
+	}()
+
 	charDone, stageDone := make([]bool, len(sys.chars)), false
+
+	// Check if all chars are loaded
 	allCharDone := func() bool {
 		for _, b := range charDone {
 			if !b {
@@ -3462,7 +3528,9 @@ func (l *Loader) load() {
 		}
 		return true
 	}
+
 	for !stageDone || !allCharDone() {
+		// Load stage
 		if !stageDone && sys.sel.selectedStageNo >= 0 {
 			if !l.loadStage() {
 				l.state = LS_Error
@@ -3470,6 +3538,7 @@ func (l *Loader) load() {
 			}
 			stageDone = true
 		}
+		// Load characters that aren't already loaded
 		for i, b := range charDone {
 			if !b {
 				result := -1
@@ -3492,8 +3561,10 @@ func (l *Loader) load() {
 				sys.tmode[i] != TM_Simul && sys.tmode[i] != TM_Tag {
 				for j := i + 2; j < len(sys.chars); j += 2 {
 					if !charDone[j] {
-						sys.chars[j], sys.cgi[j].states, charDone[j] = nil, nil, true
+						sys.chars[j] = nil
+						sys.cgi[j].states = nil
 						sys.cgi[j].hitPauseToggleFlagCount = 0
+						charDone[j] = true
 					}
 				}
 			}
@@ -3506,6 +3577,8 @@ func (l *Loader) load() {
 			return
 		}
 	}
+
+	// Flag loading state as complete
 	l.state = LS_Complete
 }
 


### PR DESCRIPTION
Feat:
- NumStageBG trigger. Returns the number of stage BG elements with the specified ID. Used to validate StageBGVar and ModifyStageBG

Fix:
- Prevent the camera from tracking characters that have infinite position
- Fixes #1917 
- Fixes #2365 

Refactor:
- Adjusted most compiler error messages to be more specific and thus make errors easier to find
- For auto turning, if both players have the same x position, their z positions will be taken into account to break the tie
- Refactored auto turning code to have less redundancy
- Hardcoded dust effects are not created during pauses, as in Mugen
- Dividing by 0 or using the modulus operator with 0 now prints an error message
- Previously, dividing a float by 0 resulted in infinity, which is true, while dividing an integer by 0 resulted in 0, which is false. Now they are both false
- Debug(roundrestarted) renamed to Debug(roundreset) to match documentation
- Version and build date added to error log
- Invalid usage of power and logarithm operators will now also print an error message
- Empty ByteCode stack errors are now identified in the crash message