### PR TITLE
fix: regressions, invisible ChangeAnim; refactoring

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -2771,7 +2771,10 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		OC_ex_animelemvar_xscale, OC_ex_animelemvar_yoffset, OC_ex_animelemvar_yscale,
 		OC_ex_animelemvar_numclsn1, OC_ex_animelemvar_numclsn2:
 		// Check for valid animation frame
-		f := c.anim.CurrentFrame()
+		var f *AnimFrame
+		if c.anim != nil {
+			f = c.anim.CurrentFrame()
+		}
 		// Handle output
 		if f != nil {
 			switch opc {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5811,6 +5811,13 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 	rp := [...]int32{-1, 0}
 	remap := false
 	ptexists := false
+
+	// Mugen chars can only modify some parameters after defining PosType
+	// Ikemen chars don't have this restriction
+	paramlock := func() bool {
+		return c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 && !ptexists
+	}
+
 	eachExpl := func(f func(e *Explod)) {
 		if idx < 0 {
 			for _, e := range expls {
@@ -5822,6 +5829,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 			f(expls[idx])
 		}
 	}
+
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
 		case explod_redirectid:
@@ -5855,15 +5863,9 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 			}
 			switch paramID {
 			case explod_postype:
-				ptexists = true // In Mugen you can only update some parameters if postype is specified
-				pt := PosType(exp[0].evalI(c))
-				eachExpl(func(e *Explod) {
-					e.postype = pt
-				})
 				// In Mugen many explod parameters are defaulted when not being modified
-				// What possibly happens in Mugen is that all parameters are read first then only applied if postype is defined
-				// Ikemen chars instead can more freely update individual parameters without affecting others
-				if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
+				// What possibly happens in Mugen is that all parameters are read first then only applied if PosType is defined
+				if paramlock() {
 					eachExpl(func(e *Explod) {
 						if e.facing*e.relativef >= 0 { // See below
 							e.relativef = 1
@@ -5879,27 +5881,39 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 						if e.bindtime == 0 {
 							e.bindtime = 1
 						}
+						e.space = Space_none
 					})
 				}
-			case explod_space:
-				sp := Space(exp[0].evalI(c))
+				// Flag PosType as found
+				// From this point onward, Mugen chars can modify more parameters (Ikemen chars always could)
+				ptexists = true
+				// Update actual PosType
+				pt := PosType(exp[0].evalI(c))
 				eachExpl(func(e *Explod) {
-					e.space = sp
+					e.postype = pt
 				})
+			case explod_space:
+				// For some reason Mugen also requires a PosType declaration to be able to modify space
+				if !paramlock() {
+					spc := Space(exp[0].evalI(c))
+					eachExpl(func(e *Explod) {
+						e.space = spc
+					})
+				}
 			case explod_facing:
-				if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
+				if !paramlock() {
 					rf := exp[0].evalF(c)
 					eachExpl(func(e *Explod) {
 						// There's a bug in Mugen 1.1 where an explod that is facing left can't be flipped
 						// https://github.com/ikemen-engine/Ikemen-GO/issues/1252
 						// Ikemen chars just work as supposed to
-						if e.facing*e.relativef >= 0 || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
+						if c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 || e.facing*e.relativef >= 0 {
 							e.relativef = rf
 						}
 					})
 				}
 			case explod_vfacing:
-				if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
+				if !paramlock() {
 					vf := exp[0].evalF(c)
 					eachExpl(func(e *Explod) {
 						// There's a bug in Mugen 1.1 where an explod that is upside down can't be flipped
@@ -5910,21 +5924,17 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 					})
 				}
 			case explod_pos:
-				if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
+				if !paramlock() {
 					pos := exp[0].evalF(c) * redirscale
 					eachExpl(func(e *Explod) {
 						e.relativePos[0] = pos
 					})
-				}
-				if len(exp) > 1 {
-					if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
+					if len(exp) > 1 {
 						pos := exp[1].evalF(c) * redirscale
 						eachExpl(func(e *Explod) {
 							e.relativePos[1] = pos
 						})
-					}
-					if len(exp) > 2 {
-						if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
+						if len(exp) > 2 {
 							pos := exp[2].evalF(c) * redirscale
 							eachExpl(func(e *Explod) {
 								e.relativePos[2] = pos
@@ -5933,23 +5943,19 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 					}
 				}
 			case explod_random:
-				if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
+				if !paramlock() {
 					rndx := (exp[0].evalF(c) / 2) * redirscale
 					rndx = RandF(-rndx, rndx)
 					eachExpl(func(e *Explod) {
 						e.relativePos[0] += rndx
 					})
-				}
-				if len(exp) > 1 {
-					if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
+					if len(exp) > 1 {
 						rndy := (exp[1].evalF(c) / 2) * redirscale
 						rndy = RandF(-rndy, rndy)
 						eachExpl(func(e *Explod) {
 							e.relativePos[1] += rndy
 						})
-					}
-					if len(exp) > 2 {
-						if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
+						if len(exp) > 2 {
 							rndz := (exp[2].evalF(c) / 2) * redirscale
 							rndz = RandF(-rndz, rndz)
 							eachExpl(func(e *Explod) {
@@ -5959,21 +5965,17 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 					}
 				}
 			case explod_velocity:
-				if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
+				if !paramlock() {
 					vel := exp[0].evalF(c) * redirscale
 					eachExpl(func(e *Explod) {
 						e.velocity[0] = vel
 					})
-				}
-				if len(exp) > 1 {
-					if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
+					if len(exp) > 1 {
 						vel := exp[1].evalF(c) * redirscale
 						eachExpl(func(e *Explod) {
 							e.velocity[1] = vel
 						})
-					}
-					if len(exp) > 2 {
-						if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
+						if len(exp) > 2 {
 							vel := exp[2].evalF(c) * redirscale
 							eachExpl(func(e *Explod) {
 								e.velocity[2] = vel
@@ -5996,21 +5998,17 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 					e.friction[2] = v3
 				})
 			case explod_accel:
-				if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
+				if !paramlock() {
 					accel := exp[0].evalF(c) * redirscale
 					eachExpl(func(e *Explod) {
 						e.accel[0] = accel
 					})
-				}
-				if len(exp) > 1 {
-					if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
+					if len(exp) > 1 {
 						accel := exp[1].evalF(c) * redirscale
 						eachExpl(func(e *Explod) {
 							e.accel[1] = accel
 						})
-					}
-					if len(exp) > 2 {
-						if ptexists || c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
+						if len(exp) > 2 {
 							accel := exp[2].evalF(c) * redirscale
 							eachExpl(func(e *Explod) {
 								e.accel[2] = accel

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -7001,12 +7001,17 @@ func (sc hitDef) Run(c *Char, _ []int32) bool {
 		sc.runSub(c, &crun.hitdef, paramID, exp)
 		return true
 	})
-	// In Winmugen, when the attr of Hitdef is set to 'Throw' and the pausetime
-	// on the attacker's side is greater than 1, it no longer executes every frame.
-	if crun.hitdef.attr&int32(AT_AT) != 0 && crun.moveContact() == 1 &&
-		c.gi().mugenver[0] != 1 && crun.hitdef.pausetime > 0 {
-		crun.hitdef.attr = 0
-		return false
+	// WinMugen compatibility
+	if c.gi().ikemenver[0] == 0 && c.gi().ikemenver[0] == 0 && c.gi().mugenver[0] != 1 { // Not crun
+		// In WinMugen, when the attr of Hitdef is set to 'Throw' and the pausetime
+		// on the attacker's side is greater than 1, it no longer executes every frame.
+		if crun.hitdef.attr&int32(AT_AT) != 0 && crun.moveContact() == 1 && crun.hitdef.pausetime > 0 {
+			crun.hitdef.attr = 0
+			return false
+		}
+		// WinMugen P1 hitpause was off by 1
+		crun.hitdef.pausetime = Clamp(crun.hitdef.pausetime, 0, crun.hitdef.pausetime - 1)
+		crun.hitdef.guard_pausetime = Clamp(crun.hitdef.guard_pausetime, 0, crun.hitdef.guard_pausetime - 1)
 	}
 	crun.setHitdefDefault(&crun.hitdef)
 	return false
@@ -7040,6 +7045,12 @@ func (sc reversalDef) Run(c *Char, _ []int32) bool {
 		}
 		return true
 	})
+	// WinMugen compatibility
+	if c.gi().ikemenver[0] == 0 && c.gi().ikemenver[0] == 0 && c.gi().mugenver[0] != 1 { // Not crun
+		// WinMugen hitpause was off by 1
+		crun.hitdef.pausetime = Clamp(crun.hitdef.pausetime, 0, crun.hitdef.pausetime - 1)
+		crun.hitdef.shaketime = Clamp(crun.hitdef.shaketime, 0, crun.hitdef.shaketime - 1)
+	}
 	crun.setHitdefDefault(&crun.hitdef)
 	return false
 }

--- a/src/char.go
+++ b/src/char.go
@@ -4810,7 +4810,8 @@ func (c *Char) playSound(ffx string, lowpriority bool, loopCount int32, g, n, ch
 }
 
 func (c *Char) autoTurn() {
-	if c.helperIndex == 0 && (c.ss.stateType == ST_S || c.ss.stateType == ST_C) && c.shouldFaceP2() {
+	if c.helperIndex == 0 && !c.asf(ASF_noautoturn) && sys.stage.autoturn &&
+		(c.ss.stateType == ST_S || c.ss.stateType == ST_C) && c.shouldFaceP2() {
 		switch c.ss.stateType {
 		case ST_S:
 			if c.animNo != 5 {
@@ -4827,12 +4828,6 @@ func (c *Char) autoTurn() {
 
 // Check if P2 enemy is behind the player and the player is allowed to face them
 func (c *Char) shouldFaceP2() bool {
-	// Turning disabled
-	if c.asf(ASF_noautoturn) || !sys.stage.autoturn {
-		return false
-	}
-
-	// Check if P2 enemy is behind the player
 	e := c.p2()
 	if e != nil && !e.asf(ASF_noturntarget) {
 		distX := c.rdDistX(e, c).ToF()
@@ -4848,7 +4843,6 @@ func (c *Char) shouldFaceP2() bool {
 			}
 		}
 	}
-
 	return false
 }
 

--- a/src/char.go
+++ b/src/char.go
@@ -10492,13 +10492,12 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 										getter.hittmp = -1
 									}
 									if !getter.csf(CSF_gethit) {
-										getter.hitPauseTime = Max(1, c.hitdef.shaketime+Btoi(c.gi().mugenver[0] == 1))
+										getter.hitPauseTime = Max(0, c.hitdef.shaketime)
 									}
 								}
 								if !c.csf(CSF_gethit) && (getter.ss.stateType == ST_A && c.hitdef.air_type != HT_None ||
 									getter.ss.stateType != ST_A && c.hitdef.ground_type != HT_None) {
-									c.hitPauseTime = Max(1, c.hitdef.pausetime+Btoi(c.gi().mugenver[0] == 1))
-									// Attacker hitpauses were off by 1 frame in Winmugen. Mugen 1.0 fixed it by compensating
+									c.hitPauseTime = Max(0, c.hitdef.pausetime)
 									// In Mugen the hitpause only actually takes effect in the next frame
 								}
 								c.uniqHitCount++
@@ -10508,7 +10507,7 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 									c.mctime = -1
 								}
 								if !c.csf(CSF_gethit) {
-									c.hitPauseTime = Max(1, c.hitdef.guard_pausetime+Btoi(c.gi().mugenver[0] == 1))
+									c.hitPauseTime = Max(0, c.hitdef.guard_pausetime)
 								}
 							}
 							if c.hitdef.hitonce > 0 {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -5454,8 +5454,7 @@ func (c *Compiler) paramValue(is IniSection, sc *StateControllerBase,
 	return nil
 }
 
-func (c *Compiler) paramPostype(is IniSection, sc *StateControllerBase,
-	id byte) error {
+func (c *Compiler) paramPostype(is IniSection, sc *StateControllerBase, id byte) error {
 	return c.stateParam(is, "postype", false, func(data string) error {
 		if len(data) == 0 {
 			return Error("postype not specified")
@@ -5486,27 +5485,26 @@ func (c *Compiler) paramPostype(is IniSection, sc *StateControllerBase,
 	})
 }
 
-func (c *Compiler) paramSpace(is IniSection, sc *StateControllerBase,
-	id byte) error {
+func (c *Compiler) paramSpace(is IniSection, sc *StateControllerBase, id byte) error {
 	return c.stateParam(is, "space", false, func(data string) error {
-		if len(data) <= 1 {
+		if len(data) == 0 {
 			return Error("space not specified")
 		}
-		var sp Space
-		if len(data) >= 2 {
-			if strings.ToLower(data[:2]) == "stage" {
-				sp = Space_stage
-			} else if strings.ToLower(data[:2]) == "screen" {
-				sp = Space_screen
-			}
+		var spc Space
+		switch strings.ToLower(data) {
+		case "stage":
+			spc = Space_stage
+		case "screen":
+			spc = Space_screen
+		default:
+			return Error("Invalid space type: " + data)
 		}
-		sc.add(id, sc.iToExp(int32(sp)))
+		sc.add(id, sc.iToExp(int32(spc)))
 		return nil
 	})
 }
 
-func (c *Compiler) paramProjection(is IniSection, sc *StateControllerBase,
-	id byte) error {
+func (c *Compiler) paramProjection(is IniSection, sc *StateControllerBase, id byte) error {
 	return c.stateParam(is, "projection", false, func(data string) error {
 		if len(data) <= 1 {
 			return Error("projection not specified")
@@ -5529,8 +5527,7 @@ func (c *Compiler) paramProjection(is IniSection, sc *StateControllerBase,
 	})
 }
 
-func (c *Compiler) paramSaveData(is IniSection, sc *StateControllerBase,
-	id byte) error {
+func (c *Compiler) paramSaveData(is IniSection, sc *StateControllerBase, id byte) error {
 	return c.stateParam(is, "savedata", false, func(data string) error {
 		if len(data) <= 1 {
 			return Error("savedata not specified")

--- a/src/script.go
+++ b/src/script.go
@@ -3305,12 +3305,12 @@ func triggerFunctions(l *lua.LState) {
 			case "size":
 				v = lua.LNumber(sys.debugWC.sizeBox[offset])
 			case "clsn1":
-				clsn := sys.debugWC.anim.CurrentFrame().Clsn1()
+				clsn := sys.debugWC.curFrame.Clsn1()
 				if idx >= 0 && idx < len(clsn)/4 {
 					v = lua.LNumber(clsn[idx*4+offset])
 				}
 			case "clsn2":
-				clsn := sys.debugWC.anim.CurrentFrame().Clsn2()
+				clsn := sys.debugWC.curFrame.Clsn2()
 				if idx >= 0 && idx < len(clsn)/4 {
 					v = lua.LNumber(clsn[idx*4+offset])
 				}


### PR DESCRIPTION
Fix:
- Fixed oversight in previous refactor that broke Explod space parameter
- AssertSpecial NoAutoTurn no longer affects StateDef facep2 (reversion). NoTurnTarget flag still does
- Fixed characters sometimes not turning towards the enemy for their win poses
- If the char uses ChangeAnim during a hitpause, they will now use an animation data backup instead of disappearing
- Fixes #1550 
- Fixes #2387 
- Fixes #2389 

Refactor:
- X and Y axes of ScreenBound movecamera parameter can now work independently. Previously the camera required characters to update both axes for it to move at all
- Refactored ModifyExplod slightly to maybe be more readable
- Moved HitDef hitpause time exceptions from char.go hit detection to bytecode.go