### PR TITLE
fix: revert HitDef WinMugen compatibility refactor

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -7004,17 +7004,12 @@ func (sc hitDef) Run(c *Char, _ []int32) bool {
 		sc.runSub(c, &crun.hitdef, paramID, exp)
 		return true
 	})
-	// WinMugen compatibility
-	if c.gi().ikemenver[0] == 0 && c.gi().ikemenver[0] == 0 && c.gi().mugenver[0] != 1 { // Not crun
-		// In WinMugen, when the attr of Hitdef is set to 'Throw' and the pausetime
-		// on the attacker's side is greater than 1, it no longer executes every frame.
-		if crun.hitdef.attr&int32(AT_AT) != 0 && crun.moveContact() == 1 && crun.hitdef.pausetime > 0 {
-			crun.hitdef.attr = 0
-			return false
-		}
-		// WinMugen P1 hitpause was off by 1
-		crun.hitdef.pausetime = Clamp(crun.hitdef.pausetime, 0, crun.hitdef.pausetime-1)
-		crun.hitdef.guard_pausetime = Clamp(crun.hitdef.guard_pausetime, 0, crun.hitdef.guard_pausetime-1)
+	// In WinMugen, when the attr of Hitdef is set to 'Throw' and the pausetime
+	// on the attacker's side is greater than 1, it no longer executes every frame
+	if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 && c.stWgi().mugenver[0] != 1 // Not crun
+		crun.hitdef.attr&int32(AT_AT) != 0 && crun.moveContact() == 1 && crun.hitdef.pausetime > 0 { // crun
+		crun.hitdef.attr = 0
+		return false
 	}
 	crun.setHitdefDefault(&crun.hitdef)
 	return false
@@ -7048,12 +7043,6 @@ func (sc reversalDef) Run(c *Char, _ []int32) bool {
 		}
 		return true
 	})
-	// WinMugen compatibility
-	if c.gi().ikemenver[0] == 0 && c.gi().ikemenver[0] == 0 && c.gi().mugenver[0] != 1 { // Not crun
-		// WinMugen hitpause was off by 1
-		crun.hitdef.pausetime = Clamp(crun.hitdef.pausetime, 0, crun.hitdef.pausetime-1)
-		crun.hitdef.shaketime = Clamp(crun.hitdef.shaketime, 0, crun.hitdef.shaketime-1)
-	}
 	crun.setHitdefDefault(&crun.hitdef)
 	return false
 }

--- a/src/char.go
+++ b/src/char.go
@@ -10436,6 +10436,12 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 					if zok && c.clsnCheck(getter, 1, c.hitdef.p2clsncheck, true, false) {
 						if ht := hitTypeGet(c, &c.hitdef, [3]float32{}, 0, c.attackMul); ht != 0 {
 							mvc := ht > 0 || c.hitdef.reversal_attr > 0
+
+							// Attacker hitpauses were off by 1 frame in WinMugen. Mugen 1.0 fixed it
+							// The way this should actually happen is that WinMugen chars have 1 subtracted from their hitpause in bytecode.go
+							// But because of the order that events happen in in Ikemen, it must be fixed the other way around
+							hpfix := c.gi().ikemenver[0] != 0 || c.gi().ikemenver[1] != 0 || c.gi().mugenver[0] == 1
+
 							if Abs(ht) == 1 {
 								if mvc {
 									c.mctype = MC_Hit
@@ -10504,12 +10510,12 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 										getter.hittmp = -1
 									}
 									if !getter.csf(CSF_gethit) {
-										getter.hitPauseTime = Max(0, c.hitdef.shaketime)
+										getter.hitPauseTime = Max(1, c.hitdef.shaketime+Btoi(hpfix))
 									}
 								}
 								if !c.csf(CSF_gethit) && (getter.ss.stateType == ST_A && c.hitdef.air_type != HT_None ||
 									getter.ss.stateType != ST_A && c.hitdef.ground_type != HT_None) {
-									c.hitPauseTime = Max(0, c.hitdef.pausetime)
+									c.hitPauseTime = Max(1, c.hitdef.pausetime+Btoi(hpfix))
 									// In Mugen the hitpause only actually takes effect in the next frame
 								}
 								c.uniqHitCount++
@@ -10519,7 +10525,7 @@ func (cl *CharList) hitDetection(getter *Char, proj bool) {
 									c.mctime = -1
 								}
 								if !c.csf(CSF_gethit) {
-									c.hitPauseTime = Max(0, c.hitdef.guard_pausetime)
+									c.hitPauseTime = Max(1, c.hitdef.guard_pausetime+Btoi(hpfix))
 								}
 							}
 							if c.hitdef.hitonce > 0 {


### PR DESCRIPTION
- This change is not compatible with the main branch in its current state, causing an "off by 1" error in hitpauses