### PR TITLE
feat: TransformSprite, xshear for explods & projectiles, angle & xshear for BG Elements; fixes

### DIFF
--- a/src/anim.go
+++ b/src/anim.go
@@ -1021,7 +1021,7 @@ func (dl DrawList) draw(cameraX, cameraY, cameraScl float32) {
 				(sys.cam.GroundLevel()+sys.cam.Offset[1]-sys.envShake.getOffset())/cs -
 					(cameraY/cs - s.pos[1])}
 		}
-
+		// Xshear offset correction
 		xshear := -s.xshear
 		xsoffset := xshear * (float32(s.anim.spr.Size[1]) * s.scl[1] * cs)
 

--- a/src/anim.go
+++ b/src/anim.go
@@ -1022,6 +1022,9 @@ func (dl DrawList) draw(cameraX, cameraY, cameraScl float32) {
 					(cameraY/cs - s.pos[1])}
 		}
 
+		xshear := -s.xshear
+		xsoffset := xshear * (float32(s.anim.spr.Size[1]) * s.scl[1] * cs)
+
 		drawwindow := &sys.scrrect
 		// Sprite window, which can be from the Char, Explod, or Projectile
 		if s.window != [4]float32{0, 0, 0, 0} {
@@ -1042,8 +1045,6 @@ func (dl DrawList) draw(cameraX, cameraY, cameraScl float32) {
 
 			drawwindow = &window
 		}
-		xshear := -s.xshear
-		xsoffset := xshear * (float32(s.anim.spr.Size[1]) * s.scl[1] * cs)
 
 		s.anim.Draw(drawwindow, pos[0]-xsoffset, pos[1], cs, cs, s.scl[0], s.scl[0],
 			s.scl[1], xshear, s.rot, float32(sys.gameWidth)/2, s.fx, s.oldVer, s.facing,

--- a/src/anim.go
+++ b/src/anim.go
@@ -965,6 +965,7 @@ type SprData struct {
 	projection   int32
 	fLength      float32
 	window       [4]float32
+	xshear       float32
 }
 
 func (sd *SprData) isBlank() bool {
@@ -1041,9 +1042,11 @@ func (dl DrawList) draw(cameraX, cameraY, cameraScl float32) {
 
 			drawwindow = &window
 		}
+		xshear := -s.xshear
+		xsoffset := xshear * (float32(s.anim.spr.Size[1]) * s.scl[1] * cs)
 
-		s.anim.Draw(drawwindow, pos[0], pos[1], cs, cs, s.scl[0], s.scl[0],
-			s.scl[1], 0, s.rot, float32(sys.gameWidth)/2, s.fx, s.oldVer, s.facing,
+		s.anim.Draw(drawwindow, pos[0]-xsoffset, pos[1], cs, cs, s.scl[0], s.scl[0],
+			s.scl[1], xshear, s.rot, float32(sys.gameWidth)/2, s.fx, s.oldVer, s.facing,
 			s.airOffsetFix, s.projection, s.fLength, 0, false)
 
 		sys.brightness = ob
@@ -1124,7 +1127,14 @@ func (sl ShadowList) draw(x, y, scl float32) {
 		color = color&0xff*alpha<<8&0xff0000 |
 			color&0xff00*alpha>>8&0xff00 | color&0xff0000*alpha>>24&0xff
 
-		xshear := sys.stage.sdw.xshear
+		var xshear float32
+		
+		if s.xshear != 0 {
+			xshear = -s.xshear
+		} else {
+			xshear = sys.stage.sdw.xshear
+		}
+
 		if sys.stage.sdw.yscale > 0 {
 			xshear = -xshear // Invert if sprite is flipped
 		}
@@ -1215,7 +1225,14 @@ func (sl ShadowList) drawReflection(x, y, scl float32) {
 			color |= uint32(ref << 24)
 		}
 
-		xshear := sys.stage.reflection.xshear
+		var xshear float32
+		
+		if s.xshear != 0 {
+			xshear = -s.xshear
+		} else {
+			xshear = sys.stage.reflection.xshear
+		}
+
 		if sys.stage.reflection.yscale > 0 {
 			xshear = -xshear // Invert if sprite is flipped
 		}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -12924,6 +12924,7 @@ const (
 	modifyStageBG_index
 	modifyStageBG_actionno
 	modifyStageBG_alpha
+	modifyStageBG_angle
 	modifyStageBG_delta_x
 	modifyStageBG_delta_y
 	modifyStageBG_layerno
@@ -12932,9 +12933,11 @@ const (
 	modifyStageBG_spriteno
 	modifyStageBG_start_x
 	modifyStageBG_start_y
+	modifyStageBG_scalestart
 	modifyStageBG_trans
 	modifyStageBG_velocity_x
 	modifyStageBG_velocity_y
+	modifyStageBG_xshear
 )
 
 func (sc modifyStageBG) Run(c *Char, _ []int32) bool {
@@ -12987,6 +12990,11 @@ func (sc modifyStageBG) Run(c *Char, _ []int32) bool {
 						bg.anim.srcAlpha = 0
 					}
 				})
+			case modifyStageBG_angle:
+				val := exp[0].evalF(c)
+				eachBg(func(bg *backGround) {
+					bg.angle = val
+				})
 			case modifyStageBG_delta_x:
 				val := exp[0].evalF(c)
 				eachBg(func(bg *backGround) {
@@ -13032,6 +13040,13 @@ func (sc modifyStageBG) Run(c *Char, _ []int32) bool {
 				eachBg(func(bg *backGround) {
 					bg.start[1] = val
 				})
+			case modifyStageBG_scalestart:
+				sclx := exp[0].evalF(c)
+				scly := exp[1].evalF(c)
+				eachBg(func(bg *backGround) {
+					bg.scalestart[0] = sclx
+					bg.scalestart[1] = scly
+				})
 			case modifyStageBG_trans:
 				val := exp[0].evalI(c)
 				if val == 0 || val == 1 || val == 2 || val == 3 || val == 4 {
@@ -13068,6 +13083,11 @@ func (sc modifyStageBG) Run(c *Char, _ []int32) bool {
 				val := exp[0].evalF(c)
 				eachBg(func(bg *backGround) {
 					bg.bga.vel[1] = val
+				})
+			case modifyStageBG_xshear:
+				val := exp[0].evalF(c)
+				eachBg(func(bg *backGround) {
+					bg.xshear = val
 				})
 			}
 		}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -12876,6 +12876,36 @@ func (sc transformClsn) Run(c *Char, _ []int32) bool {
 	return false
 }
 
+type transformSprite StateControllerBase
+
+const (
+	transformSprite_window byte = iota
+	transformSprite_xshear
+	transformSprite_redirectid
+)
+
+func (sc transformSprite) Run(c *Char, _ []int32) bool {
+	crun := c
+	var redirscale float32 = 1.0
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
+		case transformSprite_window:
+			crun.window = [4]float32{exp[0].evalF(c) * redirscale, exp[1].evalF(c) * redirscale, exp[2].evalF(c) * redirscale, exp[3].evalF(c) * redirscale}
+		case transformSprite_xshear:
+			crun.xshear = exp[0].evalF(c)
+		case transformSprite_redirectid:
+			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
+				crun = rid
+				redirscale = c.localscl / crun.localscl
+			} else {
+				return false
+			}
+		}
+		return true
+	})
+	return false
+}
+
 type modifyStageBG StateControllerBase
 
 const (
@@ -13028,33 +13058,6 @@ func (sc modifyStageBG) Run(c *Char, _ []int32) bool {
 				eachBg(func(bg *backGround) {
 					bg.bga.vel[1] = val
 				})
-			}
-		}
-		return true
-	})
-	return false
-}
-
-type window StateControllerBase
-
-const (
-	window_ byte = iota
-	window_redirectid
-)
-
-func (sc window) Run(c *Char, _ []int32) bool {
-	crun := c
-	var redirscale float32 = 1.0
-	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
-		switch paramID {
-		case window_:
-			crun.window = [4]float32{exp[0].evalF(c) * redirscale, exp[1].evalF(c) * redirscale, exp[2].evalF(c) * redirscale, exp[3].evalF(c) * redirscale}
-		case window_redirectid:
-			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
-				crun = rid
-				redirscale = c.localscl / crun.localscl
-			} else {
-				return false
 			}
 		}
 		return true

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -823,6 +823,7 @@ const (
 	OC_ex2_projvar_pos_y
 	OC_ex2_projvar_pos_z
 	OC_ex2_projvar_projangle
+	OC_ex2_projvar_projxshear
 	OC_ex2_projvar_projanim
 	OC_ex2_projvar_projcancelanim
 	OC_ex2_projvar_projedgebound
@@ -3535,6 +3536,8 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	case OC_ex2_projvar_projscale_y:
 		fallthrough
 	case OC_ex2_projvar_projangle:
+		fallthrough
+	case OC_ex2_projvar_projxshear:
 		fallthrough
 	case OC_ex2_projvar_projsprpriority:
 		fallthrough
@@ -7120,7 +7123,8 @@ const (
 	projectile_pausemovetime
 	projectile_ownpal
 	projectile_remappal
-	projectile_window
+	projectile_projwindow
+	projectile_projxshear
 	// projectile_platform
 	// projectile_platformwidth
 	// projectile_platformheight
@@ -7286,8 +7290,10 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 			}
 		case projectile_projclsnangle:
 			p.clsnAngle = exp[0].evalF(c)
-		case projectile_window:
+		case projectile_projwindow:
 			p.window = [4]float32{exp[0].evalF(c) * redirscale, exp[1].evalF(c) * redirscale, exp[2].evalF(c) * redirscale, exp[3].evalF(c) * redirscale}
+		case projectile_projxshear:
+			p.xshear = exp[0].evalF(c)
 		// case projectile_platform:
 		// 	p.platform = exp[0].evalB(c)
 		// case projectile_platformwidth:
@@ -7657,13 +7663,18 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				eachProj(func(p *Projectile) {
 					p.clsnAngle = v1
 				})
-			case projectile_window:
+			case projectile_projwindow:
 				v1 := exp[0].evalF(c) * redirscale
 				v2 := exp[1].evalF(c) * redirscale
 				v3 := exp[2].evalF(c) * redirscale
 				v4 := exp[3].evalF(c) * redirscale
 				eachProj(func(p *Projectile) {
 					p.window = [4]float32{v1, v2, v3, v4}
+				})
+			case projectile_projxshear:
+				v1 := exp[0].evalF(c)
+				eachProj(func(p *Projectile) {
+					p.xshear = v1
 				})
 			case hitDef_attr:
 				v1 := exp[0].evalI(c)

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -799,6 +799,7 @@ const (
 	OC_ex2_explodvar_angle
 	OC_ex2_explodvar_angle_x
 	OC_ex2_explodvar_angle_y
+	OC_ex2_explodvar_xshear
 	OC_ex2_explodvar_removetime
 	OC_ex2_explodvar_pausemovetime
 	OC_ex2_explodvar_sprpriority
@@ -3423,6 +3424,8 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	case OC_ex2_explodvar_angle_y:
 		camCorrected = true // gotta do this
 		fallthrough
+	case OC_ex2_explodvar_xshear:
+		fallthrough
 		// END FALLTHROUGH (explodvar)
 	case OC_ex2_explodvar_pos_x:
 		if !camCorrected {
@@ -5456,6 +5459,7 @@ const (
 	explod_angle
 	explod_yangle
 	explod_xangle
+	explod_xshear
 	explod_projection
 	explod_focallength
 	explod_ignorehitpause
@@ -5686,6 +5690,8 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 			e.anglerot[2] = exp[0].evalF(c)
 		case explod_xangle:
 			e.anglerot[1] = exp[0].evalF(c)
+		case explod_xshear:
+			e.xshear = exp[0].evalF(c)
 		case explod_focallength:
 			e.fLength = exp[0].evalF(c)
 		case explod_ignorehitpause:
@@ -6209,6 +6215,11 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				xa := exp[0].evalF(c)
 				eachExpl(func(e *Explod) {
 					e.anglerot[1] = xa
+				})
+			case explod_xshear:
+				xs := exp[0].evalF(c)
+				eachExpl(func(e *Explod) {
+					e.xshear = xs
 				})
 			case explod_projection:
 				eachExpl(func(e *Explod) {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5173,24 +5173,38 @@ func (sc velMul) Run(c *Char, _ []int32) bool {
 type modifyShadow StateControllerBase
 
 const (
-	modifyShadow_offset byte = iota
+	modifyShadow_color byte = iota
+	modifyShadow_intensity
+	modifyShadow_offset
 	modifyShadow_window
+	modifyShadow_xshear
+	modifyShadow_yscale
 	modifyShadow_redirectid
 )
 
 func (sc modifyShadow) Run(c *Char, _ []int32) bool {
 	crun := c
-	isReflect := false
 	var redirscale float32 = 1.0
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
+		case modifyShadow_color:
+			r := Clamp(exp[0].evalI(c), 0, 255)
+			g := Clamp(exp[1].evalI(c), 0, 255)
+			b := Clamp(exp[2].evalI(c), 0, 255)
+			crun.shadowColor = [3]int32{r, g, b}
+		case modifyShadow_intensity:
+			crun.shadowIntensity = Clamp(exp[0].evalI(c), 0, 255)
 		case modifyShadow_offset:
-			crun.shadXOff(exp[0].evalF(c)*redirscale, isReflect)
+			crun.shadowOffset[0] = exp[0].evalF(c) * redirscale
 			if len(exp) > 1 {
-				crun.shadYOff(exp[1].evalF(c)*redirscale, isReflect)
+				crun.shadowOffset[1] = exp[1].evalF(c) * redirscale
 			}
 		case modifyShadow_window:
-			crun.shadWin([4]float32{exp[0].evalF(c), exp[1].evalF(c), exp[2].evalF(c), exp[3].evalF(c)}, isReflect)
+			crun.shadowWindow = [4]float32{exp[0].evalF(c), exp[1].evalF(c), exp[2].evalF(c), exp[3].evalF(c)}
+		case modifyShadow_xshear:
+			crun.shadowXshear = exp[0].evalF(c)	
+		case modifyShadow_yscale:
+			crun.shadowYscale = exp[0].evalF(c)
 		case modifyShadow_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -5207,24 +5221,38 @@ func (sc modifyShadow) Run(c *Char, _ []int32) bool {
 type modifyReflection StateControllerBase
 
 const (
-	modifyReflection_offset byte = iota
+	modifyReflection_color byte = iota
+	modifyReflection_intensity
+	modifyReflection_offset
 	modifyReflection_window
+	modifyReflection_xshear
+	modifyReflection_yscale
 	modifyReflection_redirectid
 )
 
 func (sc modifyReflection) Run(c *Char, _ []int32) bool {
 	crun := c
-	isReflect := true
 	var redirscale float32 = 1.0
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
+		case modifyReflection_color:
+			r := Clamp(exp[0].evalI(c), 0, 255)
+			g := Clamp(exp[1].evalI(c), 0, 255)
+			b := Clamp(exp[2].evalI(c), 0, 255)
+			crun.reflectColor = [3]int32{r, g, b}
+		case modifyReflection_intensity:
+			crun.reflectIntensity = Clamp(exp[0].evalI(c), 0, 255)
 		case modifyReflection_offset:
-			crun.shadXOff(exp[0].evalF(c)*redirscale, isReflect)
+			crun.reflectOffset[0] = exp[0].evalF(c) * redirscale
 			if len(exp) > 1 {
-				crun.shadYOff(exp[1].evalF(c)*redirscale, isReflect)
+				crun.reflectOffset[1] = exp[1].evalF(c) * redirscale
 			}
 		case modifyReflection_window:
-			crun.shadWin([4]float32{exp[0].evalF(c), exp[1].evalF(c), exp[2].evalF(c), exp[3].evalF(c)}, isReflect)
+			crun.reflectWindow = [4]float32{exp[0].evalF(c), exp[1].evalF(c), exp[2].evalF(c), exp[3].evalF(c)}
+		case modifyReflection_xshear:
+			crun.reflectXshear = exp[0].evalF(c)
+		case modifyReflection_yscale:
+			crun.reflectYscale = exp[0].evalF(c)
 		case modifyReflection_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid

--- a/src/char.go
+++ b/src/char.go
@@ -1208,6 +1208,7 @@ func (ai *AfterImage) recAndCue(sd *SprData, rec bool, hitpause bool, layer int3
 				projection:   img.projection,
 				fLength:      img.fLength,
 				window:       sd.window,
+				xshear:       sd.xshear,
 			})
 			// Afterimages don't cast shadows or reflections
 		}
@@ -1583,11 +1584,11 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 		undarken:     playerNo == sys.superplayerno,
 		oldVer:       oldVer,
 		facing:       facing,
-		xshear:       e.xshear,
 		airOffsetFix: [2]float32{1, 1},
 		projection:   int32(e.projection),
 		fLength:      fLength,
 		window:       ewin,
+		xshear:       e.xshear,
 	}
 	sprs.add(sd)
 
@@ -2451,6 +2452,7 @@ type Char struct {
 	vel                 [3]float32
 	facing              float32
 	window              [4]float32
+	xshear              float32
 	ivar                [NumVar + NumSysVar]int32
 	fvar                [NumFvar + NumSysFvar]float32
 	CharSystemVar
@@ -8098,8 +8100,9 @@ func (c *Char) actionPrepare() {
 		c.reflectWindow = [4]float32{}
 		c.reflectXshear = 0
 		c.reflectYscale = 0
-		// Reset Window
+		// Reset TransformSprite
 		c.window = [4]float32{}
+		c.xshear = 0
 	}
 	// Decrease unhittable timer
 	// This used to be in tick(), but Mugen Clsn display suggests it happens sooner than that
@@ -9027,6 +9030,7 @@ func (c *Char) cueDraw() {
 			airOffsetFix: airOffsetFix,
 			projection:   0,
 			fLength:      0,
+			xshear:       c.xshear,
 			window:       cwin,
 		}
 		if !c.csf(CSF_trans) {

--- a/src/char.go
+++ b/src/char.go
@@ -1814,6 +1814,7 @@ type Projectile struct {
 	aimg            AfterImage
 	palfx           *PalFX
 	window          [4]float32
+	xshear          float32
 	localscl        float32
 	parentAttackmul [4]float32
 	platform        bool
@@ -2201,6 +2202,7 @@ func (p *Projectile) cueDraw(oldVer bool) {
 			projection:   0,
 			fLength:      0,
 			window:       pwin,
+			xshear:       p.xshear,
 		}
 		p.aimg.recAndCue(sd, sys.tickNextFrame() && notpause, false, p.layerno)
 		sprs.add(sd)
@@ -4297,6 +4299,8 @@ func (c *Char) projVar(pid BytecodeValue, idx BytecodeValue, flag BytecodeValue,
 				v = BytecodeFloat(p.scale[1])
 			case OC_ex2_projvar_projangle:
 				v = BytecodeFloat(p.angle)
+			case OC_ex2_projvar_projxshear:
+				v = BytecodeFloat(p.xshear)
 			case OC_ex2_projvar_pos_x:
 				v = BytecodeFloat((p.pos[0]*p.localscl - sys.cam.Pos[0]) / oc.localscl)
 			case OC_ex2_projvar_pos_y:

--- a/src/char.go
+++ b/src/char.go
@@ -1253,6 +1253,7 @@ type Explod struct {
 	ignorehitpause bool
 	rot            Rotation
 	anglerot       [3]float32
+	xshear         float32
 	projection     Projection
 	fLength        float32
 	oldPos         [3]float32
@@ -1582,6 +1583,7 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 		undarken:     playerNo == sys.superplayerno,
 		oldVer:       oldVer,
 		facing:       facing,
+		xshear:       e.xshear,
 		airOffsetFix: [2]float32{1, 1},
 		projection:   int32(e.projection),
 		fLength:      fLength,
@@ -4177,6 +4179,8 @@ func (c *Char) explodVar(eid BytecodeValue, idx BytecodeValue, vtype OpCode) Byt
 				v = BytecodeFloat(e.anglerot[1] + e.interpolate_angle[1])
 			case OC_ex2_explodvar_angle_y:
 				v = BytecodeFloat(e.anglerot[2] + e.interpolate_angle[2])
+			case OC_ex2_explodvar_xshear:
+				v = BytecodeFloat(e.xshear)
 			case OC_ex2_explodvar_vel_x:
 				v = BytecodeFloat(e.velocity[0])
 			case OC_ex2_explodvar_vel_y:

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -3074,6 +3074,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			}
 		case "angle":
 			opc = OC_ex2_projvar_projangle
+		case "xshear":
+			opc = OC_ex2_projvar_projxshear
 		case "pos":
 			c.token = c.tokenizer(in)
 

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2286,6 +2286,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			default:
 				return bvNone(), Error(fmt.Sprint("Invalid ExplodVar angle argument: %s", c.token))
 			}
+		case "xshear":
+			opc = OC_ex2_explodvar_xshear
 		default:
 			return bvNone(), Error(fmt.Sprint("Invalid ExplodVar angle argument: %s", vname))
 		}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -185,8 +185,8 @@ func newCompiler() *Compiler {
 		"teammapset":           c.teamMapSet,
 		"text":                 c.text,
 		"transformclsn":        c.transformClsn,
+		"transformsprite":      c.transformSprite,
 		"modifystagebg":        c.modifyStageBG,
-		"window":               c.window,
 	}
 	return c
 }

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -977,6 +977,10 @@ func (c *Compiler) explod(is IniSection, sc *StateControllerBase,
 			explod_xangle, VT_Float, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "xshear",
+			explod_xshear, VT_Float, 1, false); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "focallength",
 			explod_focallength, VT_Float, 1, false); err != nil {
 			return err
@@ -1031,6 +1035,10 @@ func (c *Compiler) modifyExplod(is IniSection, sc *StateControllerBase,
 		}
 		if err := c.paramValue(is, sc, "xangle",
 			explod_xangle, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "xshear",
+			explod_xshear, VT_Float, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "focallength",

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1177,12 +1177,28 @@ func (c *Compiler) modifyShadow(is IniSection, sc *StateControllerBase, _ int8) 
 			modifyShadow_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "color",
+			modifyShadow_color, VT_Int, 3, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "intensity",
+			modifyShadow_intensity, VT_Int, 1, false); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "offset",
 			modifyShadow_offset, VT_Float, 2, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "window",
 			modifyShadow_window, VT_Float, 4, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "xshear",
+			modifyShadow_xshear, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "yscale",
+			modifyShadow_yscale, VT_Float, 1, false); err != nil {
 			return err
 		}
 		return c.posSetSub(is, sc)
@@ -1196,12 +1212,28 @@ func (c *Compiler) modifyReflection(is IniSection, sc *StateControllerBase, _ in
 			modifyReflection_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "color",
+			modifyReflection_color, VT_Int, 3, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "intensity",
+			modifyReflection_intensity, VT_Int, 1, false); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "offset",
 			modifyReflection_offset, VT_Float, 2, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "window",
 			modifyReflection_window, VT_Float, 4, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "xshear",
+			modifyReflection_xshear, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "yscale",
+			modifyReflection_yscale, VT_Float, 1, false); err != nil {
 			return err
 		}
 		return c.posSetSub(is, sc)

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -5937,6 +5937,33 @@ func (c *Compiler) transformClsn(is IniSection, sc *StateControllerBase, _ int8)
 	return *ret, err
 }
 
+func (c *Compiler) transformSprite(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+	ret, err := (*transformSprite)(sc), c.stateSec(is, func() error {
+		if err := c.paramValue(is, sc, "redirectid",
+			transformSprite_redirectid, VT_Float, 1, false); err != nil {
+			return err
+		}
+		any := false
+		if err := c.stateParam(is, "window", false, func(data string) error {
+			any = true
+			return c.scAdd(sc, transformSprite_window, data, VT_Float, 4)
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "xshear", false, func(data string) error {
+			any = true
+			return c.scAdd(sc, transformSprite_xshear, data, VT_Float, 1)
+		}); err != nil {
+			return err
+		}
+		if !any {
+			return Error("Must specify at least one TransformSprite parameter")
+		}
+		return nil
+	})
+	return *ret, err
+}
+
 func (c *Compiler) modifyStageBG(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*modifyStageBG)(sc), c.stateSec(is, func() error {
 		//if err := c.paramValue(is, sc, "redirectid",
@@ -6051,21 +6078,6 @@ func (c *Compiler) modifyStageBG(is IniSection, sc *StateControllerBase, _ int8)
 		}
 		if !any {
 			return Error("Must specify at least one ModifyStageBG parameter")
-		}
-		return nil
-	})
-	return *ret, err
-}
-
-func (c *Compiler) window(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
-	ret, err := (*window)(sc), c.stateSec(is, func() error {
-		if err := c.paramValue(is, sc, "redirectid",
-			window_redirectid, VT_Float, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "value",
-			window_, VT_Float, 4, true); err != nil {
-			return err
 		}
 		return nil
 	})

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -2287,8 +2287,12 @@ func (c *Compiler) projectileSub(is IniSection, sc *StateControllerBase, ihp int
 		projectile_projclsnangle, VT_Float, 1, false); err != nil {
 		return err
 	}
-	if err := c.paramValue(is, sc, "window",
-		projectile_window, VT_Float, 4, false); err != nil {
+	if err := c.paramValue(is, sc, "projwindow",
+		projectile_projwindow, VT_Float, 4, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "projxshear",
+		projectile_projxshear, VT_Float, 1, false); err != nil {
 		return err
 	}
 	// HitDef section

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -6037,6 +6037,12 @@ func (c *Compiler) modifyStageBG(is IniSection, sc *StateControllerBase, _ int8)
 		}); err != nil {
 			return err
 		}
+		if err := c.stateParam(is, "scalestart", false, func(data string) error {
+			any = true
+			return c.scAdd(sc, modifyStageBG_scalestart, data, VT_Float, 2)
+		}); err != nil {
+			return err
+		}
 		if err := c.stateParam(is, "trans", false, func(data string) error {
 			if len(data) == 0 {
 				return Error("trans type not specified")
@@ -6068,6 +6074,12 @@ func (c *Compiler) modifyStageBG(is IniSection, sc *StateControllerBase, _ int8)
 		}); err != nil {
 			return err
 		}
+		if err := c.stateParam(is, "angle", false, func(data string) error {
+			any = true
+			return c.scAdd(sc, modifyStageBG_angle, data, VT_Float, 1)
+		}); err != nil {
+			return err
+		}
 		if err := c.stateParam(is, "velocity.x", false, func(data string) error {
 			any = true
 			return c.scAdd(sc, modifyStageBG_velocity_x, data, VT_Float, 2)
@@ -6077,6 +6089,12 @@ func (c *Compiler) modifyStageBG(is IniSection, sc *StateControllerBase, _ int8)
 		if err := c.stateParam(is, "velocity.y", false, func(data string) error {
 			any = true
 			return c.scAdd(sc, modifyStageBG_velocity_y, data, VT_Float, 1)
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "xshear", false, func(data string) error {
+			any = true
+			return c.scAdd(sc, modifyStageBG_xshear, data, VT_Float, 1)
 		}); err != nil {
 			return err
 		}

--- a/src/script.go
+++ b/src/script.go
@@ -3694,6 +3694,8 @@ func triggerFunctions(l *lua.LState) {
 					ln = lua.LNumber(e.anglerot[1] + e.interpolate_angle[1])
 				case "angle y":
 					ln = lua.LNumber(e.anglerot[2] + e.interpolate_angle[2])
+				case "xshear":
+					ln = lua.LNumber(e.xshear)
 				case "removetime":
 					ln = lua.LNumber(e.removetime)
 				case "pausemovetime":

--- a/src/script.go
+++ b/src/script.go
@@ -4661,6 +4661,8 @@ func triggerFunctions(l *lua.LState) {
 					lv = lua.LNumber(p.scale[1])
 				case "angle":
 					lv = lua.LNumber(p.angle)
+				case "xshear":
+					lv = lua.LNumber(p.xshear)
 				case "pos x":
 					lv = lua.LNumber(p.pos[0])
 				case "pos y":

--- a/src/system.go
+++ b/src/system.go
@@ -926,6 +926,14 @@ func (s *System) zAxisOverlap(posz1, top1, bot1, localscl1, posz2, top2, bot2, l
 	return true
 }
 
+// Gets the Yscale defined by ModifyShadow/Reflection or keeps the one from the stage
+func (s *System) getYscale(char, stage float32) float32 {
+    if char != 0 {
+        return char
+    }
+    return stage
+}
+
 func (s *System) clsnOverlap(clsn1 []float32, scl1, pos1 [2]float32, facing1 float32, angle1 float32,
 	clsn2 []float32, scl2, pos2 [2]float32, facing2 float32, angle2 float32) bool {
 


### PR DESCRIPTION
Feat:
- New ModifyShadow/Reflection parameters: color, intensity, xshear, and yscale.
- Replaced Window scrl with TransformSprite, which now supports window and xshear.
```ini
[State -2, Transform]
type = TransformSprite
trigger = var(4) > 10
xshear = -.4
window = -50, -50, 100, 100
```
- Explod xshear, and explodVar xshear
- Projectile projxshear and projVar xshear.
- BG Elements xshear and angle.
- New modifyStageBG parameters: scalestart, angle, and xshear.

Fix:
- Stage window being affected by shadow/reflection yscale.
- Stage window being affected by shadow/reflection offsets.
- Stage window not adjusting correctly to different resolutions.
- Renamed projectile window parameter to projwindow.