### PR TITLE
refactor: Clsn, hit detection

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -2805,9 +2805,9 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 			case OC_ex_animelemvar_yscale:
 				sys.bcStack.PushF(f.Yscale)
 			case OC_ex_animelemvar_numclsn1:
-				sys.bcStack.PushI(int32(len(f.Clsn1()) / 4))
+				sys.bcStack.PushI(int32(len(f.Clsn1)))
 			case OC_ex_animelemvar_numclsn2:
-				sys.bcStack.PushI(int32(len(f.Clsn2()) / 4))
+				sys.bcStack.PushI(int32(len(f.Clsn2)))
 			}
 		} else {
 			sys.bcStack.Push(BytecodeSF())
@@ -3289,14 +3289,14 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		case 3: // DON'T ASK WHY BUT 0 CAUSES ERRORS, 3 DOES NOT
 			v = c.sizeBox[0]
 		case 1:
-			cf1 := c.anim.CurrentFrame().Clsn1()
-			if idx >= 0 && idx < len(cf1)/4 {
-				v = cf1[idx*4]
+			cf1 := c.anim.CurrentFrame().Clsn1
+			if cf1 != nil && idx >= 0 && idx < len(cf1) {
+				v = cf1[idx][0]
 			}
 		case 2:
-			cf2 := c.anim.CurrentFrame().Clsn2()
-			if idx >= 0 && idx < len(cf2)/4 {
-				v = cf2[idx*4]
+			cf2 := c.anim.CurrentFrame().Clsn2
+			if cf2 != nil && idx >= 0 && idx < len(cf2) {
+				v = cf2[idx][0]
 			}
 		}
 		sys.bcStack.PushF(v * (c.localscl / oc.localscl))
@@ -3308,14 +3308,14 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		case 3: // DON'T ASK WHY BUT 0 CAUSES ERRORS, 3 DOES NOT
 			v = c.sizeBox[1]
 		case 1:
-			cf1 := c.anim.CurrentFrame().Clsn1()
-			if idx >= 0 && idx < len(cf1)/4 {
-				v = cf1[idx*4+1]
+			cf1 := c.anim.CurrentFrame().Clsn1
+			if cf1 != nil && idx >= 0 && idx < len(cf1) {
+				v = cf1[idx][1]
 			}
 		case 2:
-			cf2 := c.anim.CurrentFrame().Clsn2()
-			if idx >= 0 && idx < len(cf2)/4 {
-				v = cf2[idx*4+1]
+			cf2 := c.anim.CurrentFrame().Clsn2
+			if cf2 != nil && idx >= 0 && idx < len(cf2) {
+				v = cf2[idx][1]
 			}
 		}
 		sys.bcStack.PushF(v * (c.localscl / oc.localscl))
@@ -3327,14 +3327,14 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		case 3: // DON'T ASK WHY BUT 0 CAUSES ERRORS, 3 DOES NOT
 			v = c.sizeBox[2]
 		case 1:
-			cf1 := c.anim.CurrentFrame().Clsn1()
-			if idx >= 0 && idx < len(cf1)/4 {
-				v = cf1[idx*4+2]
+			cf1 := c.anim.CurrentFrame().Clsn1
+			if cf1 != nil && idx >= 0 && idx < len(cf1) {
+				v = cf1[idx][2]
 			}
 		case 2:
-			cf2 := c.anim.CurrentFrame().Clsn2()
-			if idx >= 0 && idx < len(cf2)/4 {
-				v = cf2[idx*4+2]
+			cf2 := c.anim.CurrentFrame().Clsn2
+			if cf2 != nil && idx >= 0 && idx < len(cf2) {
+				v = cf2[idx][2]
 			}
 		}
 		sys.bcStack.PushF(v * (c.localscl / oc.localscl))
@@ -3346,14 +3346,14 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		case 3: // DON'T ASK WHY BUT 0 CAUSES ERRORS, 3 DOES NOT
 			v = c.sizeBox[3]
 		case 1:
-			cf1 := c.anim.CurrentFrame().Clsn1()
-			if idx >= 0 && idx < len(cf1)/4 {
-				v = cf1[idx*4+3]
+			cf1 := c.anim.CurrentFrame().Clsn1
+			if cf1 != nil && idx >= 0 && idx < len(cf1) {
+				v = cf1[idx][3]
 			}
 		case 2:
-			cf2 := c.anim.CurrentFrame().Clsn2()
-			if idx >= 0 && idx < len(cf2)/4 {
-				v = cf2[idx*4+3]
+			cf2 := c.anim.CurrentFrame().Clsn2
+			if cf2 != nil && idx >= 0 && idx < len(cf2) {
+				v = cf2[idx][3]
 			}
 		}
 		sys.bcStack.PushF(v * (c.localscl / oc.localscl))

--- a/src/script.go
+++ b/src/script.go
@@ -3305,14 +3305,14 @@ func triggerFunctions(l *lua.LState) {
 			case "size":
 				v = lua.LNumber(sys.debugWC.sizeBox[offset])
 			case "clsn1":
-				clsn := sys.debugWC.curFrame.Clsn1()
-				if idx >= 0 && idx < len(clsn)/4 {
-					v = lua.LNumber(clsn[idx*4+offset])
+				clsn := sys.debugWC.curFrame.Clsn1
+				if clsn != nil && idx >= 0 && idx < len(clsn) {
+					v = lua.LNumber(clsn[idx][offset])
 				}
 			case "clsn2":
-				clsn := sys.debugWC.curFrame.Clsn2()
-				if idx >= 0 && idx < len(clsn)/4 {
-					v = lua.LNumber(clsn[idx*4+offset])
+				clsn := sys.debugWC.curFrame.Clsn2
+				if clsn != nil && idx >= 0 && idx < len(clsn) {
+					v = lua.LNumber(clsn[idx][offset])
 				}
 			}
 		}
@@ -5224,9 +5224,9 @@ func triggerFunctions(l *lua.LState) {
 			case "image":
 				ln = lua.LNumber(f.Number)
 			case "numclsn1":
-				ln = lua.LNumber(len(f.Clsn1()) / 4)
+				ln = lua.LNumber(len(f.Clsn1))
 			case "numclsn2":
-				ln = lua.LNumber(len(f.Clsn2()) / 4)
+				ln = lua.LNumber(len(f.Clsn2))
 			case "time":
 				ln = lua.LNumber(f.Time)
 			case "vflip":

--- a/src/system.go
+++ b/src/system.go
@@ -934,8 +934,8 @@ func (s *System) getYscale(char, stage float32) float32 {
 	return stage
 }
 
-func (s *System) clsnOverlap(clsn1 []float32, scl1, pos1 [2]float32, facing1 float32, angle1 float32,
-	clsn2 []float32, scl2, pos2 [2]float32, facing2 float32, angle2 float32) bool {
+func (s *System) clsnOverlap(clsn1 [][4]float32, scl1, pos1 [2]float32, facing1 float32, angle1 float32,
+	clsn2 [][4]float32, scl2, pos2 [2]float32, facing2 float32, angle2 float32) bool {
 
 	// Skip function if any boxes are missing
 	if clsn1 == nil || clsn2 == nil {
@@ -953,31 +953,32 @@ func (s *System) clsnOverlap(clsn1 []float32, scl1, pos1 [2]float32, facing1 flo
 		facing2 *= -1
 		scl2[0] *= -1
 	}
+
 	// Loop through first set of boxes
-	for i := 0; i+3 < len(clsn1); i += 4 {
+	for i := 0; i < len(clsn1); i++ {
 		// Calculate positions
-		l1 := clsn1[i]
-		r1 := clsn1[i+2]
+		l1 := clsn1[i][0]
+		r1 := clsn1[i][2]
 		if facing1 < 0 {
 			l1, r1 = -r1, -l1
 		}
 		left1 := l1 * scl1[0]
 		right1 := r1 * scl1[0]
-		top1 := clsn1[i+1] * scl1[1]
-		bottom1 := clsn1[i+3] * scl1[1]
+		top1 := clsn1[i][1] * scl1[1]
+		bottom1 := clsn1[i][3] * scl1[1]
 
 		// Loop through second set of boxes
-		for j := 0; j+3 < len(clsn2); j += 4 {
+		for j := 0; j < len(clsn2); j++ {
 			// Calculate positions
-			l2 := clsn2[j]
-			r2 := clsn2[j+2]
+			l2 := clsn2[j][0]
+			r2 := clsn2[j][2]
 			if facing2 < 0 {
 				l2, r2 = -r2, -l2
 			}
 			left2 := l2 * scl2[0]
 			right2 := r2 * scl2[0]
-			top2 := clsn2[j+1] * scl2[1]
-			bottom2 := clsn2[j+3] * scl2[1]
+			top2 := clsn2[j][1] * scl2[1]
+			bottom2 := clsn2[j][3] * scl2[1]
 
 			// Check for overlap
 			if angle1 != 0 || angle2 != 0 {
@@ -994,9 +995,9 @@ func (s *System) clsnOverlap(clsn1 []float32, scl1, pos1 [2]float32, facing1 flo
 					return true
 				}
 			}
-
 		}
 	}
+
 	return false
 }
 


### PR DESCRIPTION
- Before, Clsn were stored as Clsn [][]float32. Now they are stored as Clsn1 [][4]float32 and Clsn2 [][4]float32. This makes manual Clsn index calculations no longer necessary
- Extracted 800 line anonymous function for hit detection into its own function. Player and projectile hit detections have clearer separation between them
- Minor cleanups