### PR TITLE
fix: modifyshadow and modifyreflection, xshear fliping sides with angleDraw; refactor

### DIFF
--- a/src/anim.go
+++ b/src/anim.go
@@ -1126,17 +1126,17 @@ func (sl ShadowList) draw(x, y, scl float32) {
 		var xshear float32
 		if s.xshear != 0 {
 			xshear = -s.xshear
-		} else if s.shadowXshear != 0 {
-			xshear = s.shadowXshear
 		} else {
-			xshear = sys.stage.sdw.xshear
+			xshear = sys.stage.sdw.xshear + s.shadowXshear 
 		}
+
 		var yscale float32
 		if s.shadowYscale != 0 {
-			yscale = s.shadowYscale
+			yscale = sys.stage.sdw.yscale * s.shadowYscale
 		} else {
 			yscale = sys.stage.sdw.yscale
 		}
+		
 		if yscale > 0 {
 			xshear = -xshear // Invert if sprite is flipped
 		}
@@ -1245,15 +1245,13 @@ func (sl ShadowList) drawReflection(x, y, scl float32) {
 		var xshear float32
 		if s.xshear != 0 {
 			xshear = -s.xshear
-		} else if s.reflectXshear != 0 {
-			xshear = s.reflectXshear
 		} else {
-			xshear = sys.stage.reflection.xshear
+			xshear = sys.stage.reflection.xshear + s.reflectXshear
 		}
 
 		var yscale float32
 		if s.reflectYscale != 0 {
-			yscale = s.reflectYscale
+			yscale = sys.stage.reflection.yscale * s.reflectYscale
 		} else {
 			yscale = sys.stage.reflection.yscale
 		}

--- a/src/anim.go
+++ b/src/anim.go
@@ -939,7 +939,6 @@ type SprData struct {
 	alpha        [2]int32
 	priority     int32
 	rot          Rotation
-	ascl         [2]float32
 	screen       bool
 	undarken     bool // Ignore SuperPause "darken"
 	oldVer       bool
@@ -961,12 +960,6 @@ func (dl *DrawList) add(sd *SprData) {
 	// Ignore if skipping the frame or adding a blank sprite
 	if sys.frameSkip || sd.isBlank() {
 		return
-	}
-	if sd.rot.angle != 0 {
-		for i, as := range sd.ascl {
-			sd.scl[i] *= as
-		}
-		sd.ascl = [...]float32{1, 1}
 	}
 	i, start := 0, 0
 	for l := len(*dl); l > 0; {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3104,13 +3104,13 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		}
 	case OC_ex_scale_x:
 		if c.csf(CSF_angledraw) {
-			sys.bcStack.PushF(c.angleScale[0])
+			sys.bcStack.PushF(c.scale[0])
 		} else {
 			sys.bcStack.PushF(1)
 		}
 	case OC_ex_scale_y:
 		if c.csf(CSF_angledraw) {
-			sys.bcStack.PushF(c.angleScale[1])
+			sys.bcStack.PushF(c.scale[1])
 		} else {
 			sys.bcStack.PushF(1)
 		}
@@ -9487,9 +9487,9 @@ func (sc angleDraw) Run(c *Char, _ []int32) bool {
 		case angleDraw_value:
 			crun.angleSet(exp[0].evalF(c))
 		case angleDraw_scale:
-			crun.angleScale[0] *= exp[0].evalF(c)
+			crun.scale[0] *= exp[0].evalF(c)
 			if len(exp) > 1 {
-				crun.angleScale[1] *= exp[1].evalF(c)
+				crun.scale[1] *= exp[1].evalF(c)
 			}
 		case angleDraw_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {

--- a/src/char.go
+++ b/src/char.go
@@ -9908,8 +9908,15 @@ func (c *Char) cueDraw() {
 				// Meaning the character's shadow offset constant is unable to offset it correctly in every stage
 				// Ikemen works differently and as you'd expect it to
 				drawZoff := sys.posZtoYoffset(c.interPos[2], c.localscl)
-				sdwYscale := sys.getYscale(c.shadowYscale, sys.stage.sdw.yscale)
-				refYscale := sys.getYscale(c.reflectYscale, sys.stage.reflection.yscale)
+				// Gets the Yscale defined by ModifyShadow/Reflection or keeps the one from the stage
+				getYscale := func(char, stage float32) float32 {
+					if char != 0 {
+						return char
+					}
+					return stage
+				}
+				sdwYscale := getYscale(c.shadowYscale, sys.stage.sdw.yscale)
+				refYscale := getYscale(c.reflectYscale, sys.stage.reflection.yscale)
 
 				sys.shadows.add(&ShadowSprite{
 					SprData:         sd,

--- a/src/script.go
+++ b/src/script.go
@@ -5757,7 +5757,7 @@ func triggerFunctions(l *lua.LState) {
 	})
 	luaRegister(l, "scaleX", func(*lua.LState) int {
 		if sys.debugWC.csf(CSF_angledraw) {
-			l.Push(lua.LNumber(sys.debugWC.angleScale[0]))
+			l.Push(lua.LNumber(sys.debugWC.scale[0]))
 		} else {
 			l.Push(lua.LNumber(1))
 		}
@@ -5765,7 +5765,7 @@ func triggerFunctions(l *lua.LState) {
 	})
 	luaRegister(l, "scaleY", func(*lua.LState) int {
 		if sys.debugWC.csf(CSF_angledraw) {
-			l.Push(lua.LNumber(sys.debugWC.angleScale[1]))
+			l.Push(lua.LNumber(sys.debugWC.scale[1]))
 		} else {
 			l.Push(lua.LNumber(1))
 		}

--- a/src/system.go
+++ b/src/system.go
@@ -926,14 +926,6 @@ func (s *System) zAxisOverlap(posz1, top1, bot1, localscl1, posz2, top2, bot2, l
 	return true
 }
 
-// Gets the Yscale defined by ModifyShadow/Reflection or keeps the one from the stage
-func (s *System) getYscale(char, stage float32) float32 {
-	if char != 0 {
-		return char
-	}
-	return stage
-}
-
 func (s *System) clsnOverlap(clsn1 [][4]float32, scl1, pos1 [2]float32, facing1 float32, angle1 float32,
 	clsn2 [][4]float32, scl2, pos2 [2]float32, facing2 float32, angle2 float32) bool {
 

--- a/src/system.go
+++ b/src/system.go
@@ -1736,7 +1736,6 @@ func (s *System) action() {
 			alpha:        [2]int32{-1},
 			priority:     5,
 			rot:          Rotation{},
-			ascl:         [2]float32{},
 			screen:       false,
 			undarken:     true,
 			oldVer:       s.cgi[s.superplayerno].mugenver[0] != 1,


### PR DESCRIPTION
Fixes:
- The yscale and xshear parameters of modifyShadow and modifyReflection are now relative to the stage.
- Fixed an issue where angleDraw caused transformSprite xshear parameter to flip sides.

Refactor:

- Removed ``ascl`` and renamed ``c.angleScale`` to ``c.scale``. ``ascl`` wasn’t used anywhere else except by the char itself, and it depended on the angle not being zero for the sprite to be scaled. It just passed the value to anim.go, and only applied it to the sprite’s scale if there was a non-zero rotation. Scale now is applied directly to the char’s scale.