### PR TITLE
feat: time for ExplodVar, fix: SoundVar channel -1 not working properly

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -808,6 +808,7 @@ const (
 	OC_ex2_explodvar_removetime
 	OC_ex2_explodvar_pausemovetime
 	OC_ex2_explodvar_sprpriority
+	OC_ex2_explodvar_time
 	OC_ex2_explodvar_layerno
 	OC_ex2_explodvar_id
 	OC_ex2_explodvar_bindtime
@@ -3411,6 +3412,8 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	case OC_ex2_explodvar_id:
 		fallthrough
 	case OC_ex2_explodvar_bindtime:
+		fallthrough
+	case OC_ex2_explodvar_time:
 		fallthrough
 	case OC_ex2_explodvar_facing:
 		fallthrough

--- a/src/char.go
+++ b/src/char.go
@@ -4209,6 +4209,8 @@ func (c *Char) explodVar(eid BytecodeValue, idx BytecodeValue, vtype OpCode) Byt
 				v = BytecodeInt(e.id)
 			case OC_ex2_explodvar_bindtime:
 				v = BytecodeInt(e.bindtime)
+			case OC_ex2_explodvar_time:
+				v = BytecodeInt(e.time)
 			case OC_ex2_explodvar_facing:
 				v = BytecodeInt(int32(e.facing))
 			case OC_ex2_explodvar_drawpal_group:
@@ -4351,21 +4353,21 @@ func (c *Char) soundVar(chid BytecodeValue, vtype OpCode) BytecodeValue {
 		return BytecodeSF()
 	}
 
-	// See compiler.go:SoundVar
 	var id = chid.ToI()
-	if id > 0 {
-		id--
-	}
-
 	var ch *SoundChannel
 
 	// First, grab a channel.
 	if id >= 0 {
 		ch = c.soundChannels.Get(id)
 	} else {
-		for _, *ch = range c.soundChannels.channels {
-			if ch.sfx != nil {
-				break
+		if c != nil && c.soundChannels.channels != nil {
+			for i := 0; i < int(c.soundChannels.count()); i++ {
+				if c.soundChannels.channels[i].sfx != nil {
+					if c.soundChannels.channels[i].IsPlaying() {
+						ch = &c.soundChannels.channels[i]
+						break
+					}
+				}
 			}
 		}
 	}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2276,6 +2276,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			opc = OC_ex2_explodvar_id
 		case "bindtime":
 			opc = OC_ex2_explodvar_bindtime
+		case "time":
+			opc = OC_ex2_explodvar_time
 		case "facing":
 			opc = OC_ex2_explodvar_facing
 		case "pos":
@@ -3316,8 +3318,6 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		c.token = c.tokenizer(in)
 
 		vname := c.token
-		// isFlag := false
-
 		switch vname {
 		case "group":
 			opc = OC_ex2_soundvar_group
@@ -3352,14 +3352,6 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		c.token = c.tokenizer(in)
 		if err := c.checkClosingParenthesis(); err != nil {
 			return bvNone(), err
-		}
-
-		// If bv1 is ever 0 Ikemen crashes.
-		// I do not know why this happens.
-		// It happened with clsnVar.
-		idx := bv1.ToI()
-		if idx >= 0 {
-			bv1.SetI(idx + 1)
 		}
 
 		be2.appendValue(bv2)


### PR DESCRIPTION
Tested using the following code in KFM:

```ini
[State -2, DisplayToClipboard]
type=DisplayToClipboard
trigger1=StageTime > 1
text="SV = %d, EV = %d"
params = P2, SoundVar(-1, IsPlaying), cond(numExplod > 0, ExplodVar(-1, 0, Time), -1)
ignorehitpause = 1
```

Also it seems the offset logic is no longer necessary for SoundVar.