### PR TITLE
feat: AssertSpecial CameraFreeze; fixes; refactoring

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1816,10 +1816,10 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			}
 		case OC_gametime:
 			var pfTime int32
-			if sys.netInput != nil {
-				pfTime = sys.netInput.preFightTime
-			} else if sys.fileInput != nil {
-				pfTime = sys.fileInput.pfTime
+			if sys.netConnection != nil {
+				pfTime = sys.netConnection.preFightTime
+			} else if sys.replayFile != nil {
+				pfTime = sys.replayFile.pfTime
 			} else {
 				pfTime = sys.preFightTime
 			}
@@ -11043,7 +11043,7 @@ func (sc matchRestart) Run(c *Char, _ []int32) bool {
 		}
 		return true
 	})
-	if sys.netInput == nil && sys.fileInput == nil {
+	if sys.netConnection == nil && sys.replayFile == nil {
 		if reloadFlag {
 			sys.reloadFlg = true
 		} else {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1744,7 +1744,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.Swap()
 		case OC_ailevel:
 			if !c.asf(ASF_noailevel) {
-				sys.bcStack.PushI(int32(c.aiLevel()))
+				sys.bcStack.PushI(int32(c.getAILevel()))
 			} else {
 				sys.bcStack.PushI(0)
 			}
@@ -2761,7 +2761,7 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		*i += 4
 	case OC_ex_ailevelf:
 		if !c.asf(ASF_noailevel) {
-			sys.bcStack.PushF(c.aiLevel())
+			sys.bcStack.PushF(c.getAILevel())
 		} else {
 			sys.bcStack.PushI(0)
 		}

--- a/src/camera.go
+++ b/src/camera.go
@@ -192,6 +192,9 @@ func (c *Camera) SaveRestoreTracking() {
 }
 
 func (c *Camera) Update(scl, x, y float32) {
+	if sys.gsf(GSF_camerafreeze) {
+		return
+	}
 	c.Scale = c.BaseScale() * scl
 	c.zoff = float32(c.zoffset) * c.localscl
 	if sys.stage.stageCamera.zoomanchor {

--- a/src/char.go
+++ b/src/char.go
@@ -659,8 +659,8 @@ func (hd *HitDef) clear(c *Char, localscl float32) {
 		guardsound_ffx:     "f",
 		ground_type:        HT_High,
 		air_type:           HT_Unknown,
-		air_hittime:        20, // Both default to 20. Not documented in Mugen docs
-		down_hittime:       20,
+		air_hittime:        20,
+		down_hittime:       20, // Not documented in Mugen docs
 
 		guard_pausetime:   IErr,
 		guard_shaketime:   IErr,
@@ -2284,7 +2284,7 @@ type StateState struct {
 	storeMoveType                bool
 	physics                      StateType
 	ps                           []int32
-	hitPauseExecutionToggleFlags [MaxSimul*2 + MaxAttachedChar][]bool // Flags if an sctrl runs during a hit pause on the current tick.
+	hitPauseExecutionToggleFlags [MaxPlayerNo][]bool // Flags if an sctrl runs during a hit pause on the current tick.
 	no, prevno                   int32
 	time                         int32
 	sb                           StateBytecode
@@ -2572,7 +2572,7 @@ func (c *Char) init(n int, idx int32) {
 	}
 
 	// Set controller to CPU if applicable
-	if n >= 0 && n < len(sys.com) && sys.com[n] != 0 {
+	if n >= 0 && n < len(sys.aiLevel) && sys.aiLevel[n] != 0 {
 		c.controller ^= -1
 	}
 
@@ -3609,9 +3609,9 @@ func (c *Char) parent() *Char {
 		return nil
 	}
 	if c.parentIndex < 0 {
-		sys.appendToConsole(c.warn() + "parent has been already destroyed")
+		sys.appendToConsole(c.warn() + "parent has already been destroyed")
 		if !sys.ignoreMostErrors {
-			sys.errLog.Println(c.name + " parent has been already destroyed")
+			sys.errLog.Println(c.name + " parent has already been destroyed")
 		}
 	}
 	return sys.chars[c.playerNo][Abs(c.parentIndex)]
@@ -3765,11 +3765,15 @@ func (c *Char) p2() *Char {
 	return p
 }
 
-func (c *Char) aiLevel() float32 {
+// Returns AI level as a float. Is truncated for AIlevel trigger, or not for AIlevelF
+func (c *Char) getAILevel() float32 {
 	if c.helperIndex != 0 && c.gi().mugenver[0] == 1 {
 		return 0
 	}
-	return sys.com[c.playerNo]
+	if c.playerNo >= 0 && int(c.playerNo) < len(sys.aiLevel) {
+		return sys.aiLevel[c.playerNo]
+	}
+	return 0
 }
 
 func (c *Char) alive() bool {
@@ -3905,7 +3909,7 @@ func (c *Char) assertCommand(name string, time int32) {
 		ok = c.cmd[i].Assert(name, time) || ok
 	}
 	if !ok {
-		sys.appendToConsole(c.warn() + fmt.Sprintf("attempted to assert an invalid command"))
+		sys.appendToConsole(c.warn() + fmt.Sprintf("attempted to assert an invalid command: %s", name))
 	}
 }
 
@@ -5653,12 +5657,15 @@ func (c *Char) getProjs(id int32) (projs []*Projectile) {
 func (c *Char) setHitdefDefault(hd *HitDef) {
 	hd.playerNo = c.ss.sb.playerNo
 	hd.attackerID = c.id
+
 	if !hd.isprojectile {
 		c.hitdefTargets = c.hitdefTargets[:0]
 	}
+
 	if hd.attr&^int32(ST_MASK) == 0 {
 		hd.attr = 0
 	}
+
 	if hd.hitonce < 0 {
 		if hd.attr&int32(AT_AT) != 0 {
 			hd.hitonce = 1
@@ -5666,12 +5673,14 @@ func (c *Char) setHitdefDefault(hd *HitDef) {
 			hd.hitonce = 0
 		}
 	}
+
 	// Set a parameter if it's Nan
 	ifnanset := func(dst *float32, src float32) {
 		if math.IsNaN(float64(*dst)) {
 			*dst = src
 		}
 	}
+
 	// Set a parameter if it's IErr
 	ifierrset := func(dst *int32, src int32) bool {
 		if *dst == IErr {
@@ -5683,10 +5692,19 @@ func (c *Char) setHitdefDefault(hd *HitDef) {
 
 	ifierrset(&hd.guard_pausetime, hd.pausetime)
 	ifierrset(&hd.guard_shaketime, hd.shaketime)
-	ifierrset(&hd.guard_hittime, hd.ground_hittime)
+
+	// In Mugen this one acts diferent from the documentation
+	// Ikemen characters follow the documentation since it makes more sense
+	if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
+		ifierrset(&hd.guard_hittime, hd.ground_slidetime)
+	} else {
+		ifierrset(&hd.guard_hittime, hd.ground_hittime)
+	}
+
 	ifierrset(&hd.guard_slidetime, hd.guard_hittime)
 	ifierrset(&hd.guard_ctrltime, hd.guard_slidetime)
 	ifierrset(&hd.airguard_ctrltime, hd.guard_ctrltime)
+
 	ifnanset(&hd.guard_velocity[0], hd.ground_velocity[0])
 	ifnanset(&hd.guard_velocity[2], hd.ground_velocity[2])
 	ifnanset(&hd.airguard_velocity[0], hd.air_velocity[0]*1.5)
@@ -5695,6 +5713,7 @@ func (c *Char) setHitdefDefault(hd *HitDef) {
 	ifnanset(&hd.down_velocity[0], hd.air_velocity[0])
 	ifnanset(&hd.down_velocity[1], hd.air_velocity[1])
 	ifnanset(&hd.down_velocity[2], hd.air_velocity[2])
+
 	ifierrset(&hd.fall_envshake_ampl, -4)
 	if hd.air_animtype == RA_Unknown {
 		hd.air_animtype = hd.animtype
@@ -5709,8 +5728,10 @@ func (c *Char) setHitdefDefault(hd *HitDef) {
 	if hd.air_type == HT_Unknown {
 		hd.air_type = hd.ground_type
 	}
+
 	ifierrset(&hd.forcestand, Btoi(hd.ground_velocity[1] != 0)) // Having a Y velocity causes ForceStand
 	ifierrset(&hd.forcecrouch, 0)
+
 	// Cornerpush defaults to same as respective velocities if character has Ikemenversion, instead of Mugen magic numbers
 	if hd.attr&int32(ST_A) != 0 {
 		ifnanset(&hd.ground_cornerpush_veloff, 0)
@@ -5725,6 +5746,7 @@ func (c *Char) setHitdefDefault(hd *HitDef) {
 	ifnanset(&hd.down_cornerpush_veloff, hd.ground_cornerpush_veloff)
 	ifnanset(&hd.guard_cornerpush_veloff, hd.ground_cornerpush_veloff)
 	ifnanset(&hd.airguard_cornerpush_veloff, hd.ground_cornerpush_veloff)
+
 	// Super attack behaviour
 	if hd.attr&int32(AT_AH) != 0 {
 		ifierrset(&hd.hitgetpower,
@@ -5753,8 +5775,10 @@ func (c *Char) setHitdefDefault(hd *HitDef) {
 		ifierrset(&hd.guardredlife,
 			int32(c.gi().constants["default.lifetoredlifemul"]*float32(hd.guarddamage)))
 	}
+
 	ifierrset(&hd.guardgetpower, int32(float32(hd.hitgetpower)*0.5))
 	ifierrset(&hd.guardgivepower, int32(float32(hd.hitgivepower)*0.5))
+
 	if !math.IsNaN(float64(hd.snap[0])) {
 		hd.maxdist[0], hd.mindist[0] = hd.snap[0], hd.snap[0]
 	}
@@ -5764,9 +5788,11 @@ func (c *Char) setHitdefDefault(hd *HitDef) {
 	if !math.IsNaN(float64(hd.snap[2])) {
 		hd.maxdist[2], hd.mindist[2] = hd.snap[2], hd.snap[2]
 	}
+
 	if hd.teamside == -1 {
 		hd.teamside = c.teamside + 1
 	}
+
 	if hd.p2clsncheck < 0 {
 		if hd.reversal_attr != 0 {
 			hd.p2clsncheck = 1
@@ -5774,6 +5800,7 @@ func (c *Char) setHitdefDefault(hd *HitDef) {
 			hd.p2clsncheck = 2
 		}
 	}
+
 	// In Mugen, only projectiles can use air.juggle
 	// Ikemen characters can use it to update their juggle points
 	if hd.air_juggle == IErr {
@@ -6106,7 +6133,7 @@ func (c *Char) varRangeSet(first, last, val int32) {
 				delete(c.cnsvar, k)
 				loopCount++
 				if loopCount >= MaxLoop {
-					sys.printBytecodeError(fmt.Sprintf("VarRangeSet limit reached after setting %v variables", loopCount))
+					sys.appendToConsole(c.warn() + fmt.Sprintf("VarRangeSet limit reached after setting %v variables", loopCount))
 					break
 				}
 			}
@@ -6117,7 +6144,7 @@ func (c *Char) varRangeSet(first, last, val int32) {
 			c.cnsvar[i] = val
 			loopCount++
 			if loopCount >= MaxLoop {
-				sys.printBytecodeError(fmt.Sprintf("VarRangeSet limit reached after setting %v variables", loopCount))
+				sys.appendToConsole(c.warn() + fmt.Sprintf("VarRangeSet limit reached after setting %v variables", loopCount))
 				break
 			}
 		}
@@ -6192,7 +6219,7 @@ func (c *Char) getStageBg(id int32, idx int, log bool) *backGround {
 	// Invalid index
 	if idx < 0 {
 		if log {
-			sys.appendToConsole(c.warn() + "background element index cannot be negative")
+			sys.appendToConsole(c.warn() + "stage BG element index cannot be negative")
 		}
 		return nil
 	}
@@ -7033,7 +7060,7 @@ func (c *Char) makeDust(x, y, z float32, spacing int) {
 		return
 	}
 	if spacing < 1 {
-		sys.appendToConsole(c.warn() + "Invalid MakeDust spacing")
+		sys.appendToConsole(c.warn() + "invalid MakeDust spacing")
 		spacing = 1
 	}
 	if c.dustTime >= spacing {
@@ -7252,7 +7279,7 @@ func (c *Char) mapSet(s string, Value float32, scType int32) BytecodeValue {
 		}
 	case 6:
 		if c.teamside == -1 {
-			for i := MaxSimul * 2; i < MaxSimul*2+MaxAttachedChar; i += 1 {
+			for i := MaxSimul * 2; i < MaxPlayerNo; i += 1 {
 				if len(sys.chars[i]) > 0 {
 					sys.chars[i][0].mapArray[key] = Value
 				}
@@ -7266,7 +7293,7 @@ func (c *Char) mapSet(s string, Value float32, scType int32) BytecodeValue {
 		}
 	case 7:
 		if c.teamside == -1 {
-			for i := MaxSimul * 2; i < MaxSimul*2+MaxAttachedChar; i += 1 {
+			for i := MaxSimul * 2; i < MaxPlayerNo; i += 1 {
 				if len(sys.chars[i]) > 0 {
 					sys.chars[i][0].mapArray[key] += Value
 				}
@@ -8219,15 +8246,17 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 		}
 	}
 
-	// If ReversalDef or hitting with type None, the hitResult is negative
-	if hd.reversal_attr > 0 {
-		hitResult *= -1
-	} else if getter.ss.stateType == ST_A {
-		if hd.air_type == HT_None {
+	// If using ReversalDef or hitting with type None, the hitResult is negative
+	if hitResult > 0 {
+		if hd.reversal_attr > 0 {
+			hitResult *= -1
+		} else if getter.ss.stateType == ST_A {
+			if hd.air_type == HT_None {
+				hitResult *= -1
+			}
+		} else if hd.ground_type == HT_None {
 			hitResult *= -1
 		}
-	} else if hd.ground_type == HT_None {
-		hitResult *= -1
 	}
 
 	// If any previous hit in the current frame will KO the enemy, the following ones will not prevent it
@@ -8235,14 +8264,17 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 		getter.ghv.kill = true
 	}
 
-	// Check HitOverride
+	// Check if P2 should change state
 	p2s := false
 	if !getter.stchtmp || !getter.csf(CSF_gethit) {
+		// Check HitOverride
 		c.mhv.overridden = false
 		for i, ho := range getter.ho {
+			// Check attack attributes
 			if ho.time == 0 || ho.attr&hd.attr&^int32(ST_MASK) == 0 {
 				continue
 			}
+			// Check SCA attributes
 			if isProjectile {
 				if ho.attr&hd.attr&int32(ST_MASK) == 0 {
 					continue
@@ -8252,19 +8284,21 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 					continue
 				}
 			}
+			// Miss if using p2stateno and HitOverride together
 			if !isProjectile && Abs(hitResult) == 1 &&
 				(hd.p2stateno >= 0 || hd.p1stateno >= 0) {
 				return 0
 			}
 			if ho.stateno >= 0 || ho.keepState {
+				getter.hoIdx = i
 				if ho.keepState {
 					getter.hoKeepState = true
 				}
-				getter.hoIdx = i
 				c.mhv.overridden = true
 				break
 			}
 		}
+		// Apply P2StateNo
 		if !c.mhv.overridden {
 			if Abs(hitResult) == 1 && hd.p2stateno >= 0 {
 				pn := getter.playerNo
@@ -8279,12 +8313,15 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 			}
 		}
 	}
+
 	if !isProjectile {
 		c.hitdefTargetsBuffer = append(c.hitdefTargetsBuffer, getter.id)
 		c.mhv.uniqhit = int32(len(c.hitdefTargets))
 	}
+
 	// Determine if GetHitVars should be updated
 	ghvset := !getter.csf(CSF_gethit) || !getter.stchtmp || p2s
+
 	// Variables that are set by default even if Hitdef type is "None"
 	if ghvset {
 		getter.ghv.hitid = hd.id
@@ -8302,6 +8339,7 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 		}
 		getter.sprPriority = hd.p2sprpriority
 	}
+
 	// Attacker facing
 	byf := c.facing
 	if isProjectile {
@@ -8317,6 +8355,7 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 			byf *= -1
 		}
 	}
+
 	// Getter is hit or guards the Hitdef
 	if hitResult > 0 {
 		// Stop enemy's flagged sounds. In Mugen this only happens with channel 0
@@ -9647,9 +9686,9 @@ func (c *Char) tick() {
 		}
 	}
 	if c.csf(CSF_gethit) && !c.hoKeepState {
-		c.ss.changeMoveType(MT_H)
-		// This flag prevents the previous move type from being changed twice
+		// This flag prevents prevMoveType from being changed twice
 		c.ss.storeMoveType = true
+		c.ss.changeMoveType(MT_H)
 		if c.hitPauseTime > 0 {
 			c.ss.clearHitPauseExecutionToggleFlags()
 		}
@@ -10183,7 +10222,7 @@ func (cl *CharList) commandUpdate() {
 			// The way this only allows one command to be cheated at a time may be the cause of issue #2022
 			cheat := int32(-1)
 			if root.controller < 0 {
-				if sys.roundState() == 2 && RandF32(0, sys.com[i]/2+32) > 32 { // TODO: Balance AI scaling
+				if sys.roundState() == 2 && RandF32(0, sys.aiLevel[i]/2+32) > 32 { // TODO: Balance AI scaling
 					cheat = Rand(0, int32(len(root.cmd[root.ss.sb.playerNo].Commands))-1)
 				}
 			}
@@ -10202,7 +10241,7 @@ func (cl *CharList) commandUpdate() {
 					c.autoTurn()
 				}
 				if (c.helperIndex == 0 || c.helperIndex > 0 && &c.cmd[0] != &root.cmd[0]) &&
-					c.cmd[0].Input(c.controller, int32(c.facing), sys.com[i], c.inputFlag, false) {
+					c.cmd[0].InputUpdate(c.controller, int32(c.facing), sys.aiLevel[i], c.inputFlag, false) {
 					// Clear input buffers and skip the rest of the loop
 					// This used to apply only to the root, but that caused some issues with helper-based input buffers
 					if c.inputWait() || c.asf(ASF_noinput) {

--- a/src/char.go
+++ b/src/char.go
@@ -4025,7 +4025,7 @@ func (c *Char) isHelper(id int32, idx int) bool {
 }
 
 func (c *Char) isHost() bool {
-	return sys.netInput != nil && sys.netInput.host
+	return sys.netConnection != nil && sys.netConnection.host
 }
 
 func (c *Char) jugglePoints(hid BytecodeValue) BytecodeValue {

--- a/src/char.go
+++ b/src/char.go
@@ -3993,6 +3993,15 @@ func (c *Char) isHelper(id int32, idx int) bool {
 	if c.helperIndex == 0 {
 		return false
 	}
+	// Backward compatibility
+	if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
+		// Some Mugen characters used "isHelper(-1)" even though it was meaningless there
+		// https://github.com/ikemen-engine/Ikemen-GO/issues/2415
+		if id < 0 && id != math.MinInt32 && idx == math.MinInt32 {
+			sys.appendToConsole(c.warn() + fmt.Sprintf("invalid IsHelper ID for char engine version: %v", id))
+			return false
+		}
+	}
 	// Any helper
 	if id < 0 && idx < 0 {
 		return true

--- a/src/char.go
+++ b/src/char.go
@@ -9742,7 +9742,13 @@ func (c *Char) tick() {
 			case ST_S:
 				c.changeStateEx(5000, pn, -1, 0, "")
 			case ST_C:
-				c.changeStateEx(5010, pn, -1, 0, "")
+				// Go to standing on KO
+				// Mugen does this, but does it really need to be hardcoded?
+				if c.ghv.damage >= c.life && !sys.gsf(GSF_globalnoko) && !c.asf(ASF_noko) {
+					c.changeStateEx(5000, pn, -1, 0, "")
+				} else {
+					c.changeStateEx(5010, pn, -1, 0, "")
+				}
 			default:
 				c.changeStateEx(5020, pn, -1, 0, "")
 			}

--- a/src/char.go
+++ b/src/char.go
@@ -120,6 +120,7 @@ const (
 	GSF_roundnotover
 	GSF_timerfreeze
 	// Ikemen flags
+	GSF_camerafreeze
 	GSF_roundfreeze
 	GSF_roundnotskip
 	GSF_skipfightdisplay

--- a/src/common.go
+++ b/src/common.go
@@ -25,8 +25,14 @@ func Random() int32 {
 	}
 	return sys.randseed
 }
-func Srand(s int32)             { sys.randseed = s }
-func Rand(min, max int32) int32 { return min + Random()/(IMax/(max-min+1)+1) }
+
+func Srand(s int32) {
+	sys.randseed = s
+}
+
+func Rand(min, max int32) int32 {
+	return min + Random()/(IMax/(max-min+1)+1)
+}
 
 func RandF32(min, max float32) float32 {
 	return min + float32(Random())/(float32(IMax)/(max-min+1.0)+1.0)
@@ -44,6 +50,7 @@ func RandI(x, y int32) int32 {
 	}
 	return Rand(x, y)
 }
+
 func RandF(x, y float32) float32 {
 	return x + float32(Random())*(y-x)/float32(IMax)
 }
@@ -125,6 +132,7 @@ func Cos(f float32) float32 {
 func Sin(f float32) float32 {
 	return float32(math.Sin(float64(f)))
 }
+
 func Sign(i int32) int32 {
 	if i < 0 {
 		return -1
@@ -144,38 +152,47 @@ func SignF(f float32) float32 {
 		return 0
 	}
 }
+
 func Abs(i int32) int32 {
 	if i < 0 {
 		return -i
 	}
 	return i
 }
+
 func AbsF(f float32) float32 {
 	if f < 0 {
 		return -f
 	}
 	return f
 }
+
 func Pow(x, y float32) float32 {
 	return float32(math.Pow(float64(x), float64(y)))
 }
+
 func Lerp(x, y, a float32) float32 {
 	//return float32(x + (y - x) * ClampF(a, 0, 1))
 	return float32((1-a)*x + a*y)
 }
+
 func Ceil(x float32) int32 {
 	return int32(math.Ceil(float64(x)))
 }
+
 func Floor(x float32) int32 {
 	return int32(math.Floor(float64(x)))
 }
+
 func IsFinite(f float32) bool {
 	return math.Abs(float64(f)) <= math.MaxFloat64
 }
+
 func IsNumeric(s string) bool {
 	_, err := strconv.ParseFloat(strings.TrimSpace(s), 64)
 	return err == nil
 }
+
 func Atoi(str string) int32 {
 	var n int64
 	str = strings.TrimSpace(str)
@@ -206,6 +223,7 @@ func Atoi(str string) int32 {
 	}
 	return int32(n)
 }
+
 func Atof(str string) float64 {
 	f := 0.0
 	str = strings.TrimSpace(str)
@@ -257,6 +275,7 @@ func Atof(str string) float64 {
 	}
 	return f
 }
+
 func RectRotate(x, y, w, h, cx, cy, angle float32) [][2]float32 {
 	rp := make([][2]float32, 4)
 	corners := [][2]float32{
@@ -343,12 +362,14 @@ func readDigit(d string) (int32, bool) {
 	}
 	return int32(Atof(d)), true
 }
+
 func Btoi(b bool) int32 {
 	if b {
 		return 1
 	}
 	return 0
 }
+
 func I32ToI16(i32 int32) int16 {
 	if i32 < ^int32(^uint16(0)>>1) {
 		return ^int16(^uint16(0) >> 1)
@@ -358,6 +379,7 @@ func I32ToI16(i32 int32) int16 {
 	}
 	return int16(i32)
 }
+
 func I32ToU16(i32 int32) uint16 {
 	if i32 < 0 {
 		return 0
@@ -447,6 +469,7 @@ func SplitAndTrim(str, sep string) (ss []string) {
 	}
 	return
 }
+
 func OldSprintf(f string, a ...interface{}) (s string) {
 	iIdx, lIdx, numVerbs := []int{}, []int{}, 0
 	for i := 0; i < len(f); i++ {
@@ -501,6 +524,7 @@ func OldSprintf(f string, a ...interface{}) (s string) {
 	}
 	return fmt.Sprintf(f, a...)
 }
+
 func SectionName(sec string) (string, string) {
 	if len(sec) == 0 || sec[0] != '[' {
 		return "", ""
@@ -521,6 +545,7 @@ func SectionName(sec string) (string, string) {
 	}
 	return strings.ToLower(name), sec
 }
+
 func HasExtension(file, ext string) bool {
 	match, _ := regexp.MatchString(ext, filepath.Ext(strings.ToLower(file)))
 	return match
@@ -556,11 +581,16 @@ func sliceMoveInt(array []int, srcIndex int, dstIndex int) []int {
 
 type Error string
 
-func (e Error) Error() string { return string(e) }
+func (e Error) Error() string {
+	return string(e)
+}
 
 type IniSection map[string]string
 
-func NewIniSection() IniSection { return IniSection(make(map[string]string)) }
+func NewIniSection() IniSection {
+	return IniSection(make(map[string]string))
+}
+
 func ReadIniSection(lines []string, i *int) (
 	is IniSection, name string, subname string) {
 	for ; *i < len(lines); (*i)++ {
@@ -577,6 +607,7 @@ func ReadIniSection(lines []string, i *int) (
 	is.Parse(lines, i)
 	return
 }
+
 func (is IniSection) Parse(lines []string, i *int) {
 	for ; *i < len(lines); (*i)++ {
 		if len(lines[*i]) > 0 && lines[*i][0] == '[' {
@@ -598,6 +629,7 @@ func (is IniSection) Parse(lines []string, i *int) {
 		}
 	}
 }
+
 func (is IniSection) LoadFile(name string, dirs []string,
 	load func(string) error) error {
 	str := is[name]
@@ -606,6 +638,7 @@ func (is IniSection) LoadFile(name string, dirs []string,
 	}
 	return LoadFile(&str, dirs, load)
 }
+
 func (is IniSection) ReadI32(name string, out ...*int32) bool {
 	str := is[name]
 	if len(str) == 0 {
@@ -621,6 +654,7 @@ func (is IniSection) ReadI32(name string, out ...*int32) bool {
 	}
 	return true
 }
+
 func (is IniSection) ReadF32(name string, out ...*float32) bool {
 	str := is[name]
 	if len(str) == 0 {
@@ -636,6 +670,7 @@ func (is IniSection) ReadF32(name string, out ...*float32) bool {
 	}
 	return true
 }
+
 func (is IniSection) ReadBool(name string, out ...*bool) bool {
 	str := is[name]
 	if len(str) == 0 {
@@ -651,6 +686,7 @@ func (is IniSection) ReadBool(name string, out ...*bool) bool {
 	}
 	return true
 }
+
 func (is IniSection) readI32ForStage(name string, out ...*int32) bool {
 	str := is[name]
 	if len(str) == 0 {
@@ -669,6 +705,7 @@ func (is IniSection) readI32ForStage(name string, out ...*int32) bool {
 	}
 	return true
 }
+
 func (is IniSection) readF32ForStage(name string, out ...*float32) bool {
 	str := is[name]
 	if len(str) == 0 {
@@ -687,6 +724,7 @@ func (is IniSection) readF32ForStage(name string, out ...*float32) bool {
 	}
 	return true
 }
+
 func (is IniSection) readI32CsvForStage(name string) (ary []int32) {
 	if str := is[name]; len(str) > 0 {
 		for _, s := range strings.Split(str, ",") {
@@ -700,6 +738,7 @@ func (is IniSection) readI32CsvForStage(name string) (ary []int32) {
 	}
 	return
 }
+
 func (is IniSection) readF32CsvForStage(name string) (ary []float32) {
 	if str := is[name]; len(str) > 0 {
 		for _, s := range strings.Split(str, ",") {
@@ -713,6 +752,7 @@ func (is IniSection) readF32CsvForStage(name string) (ary []float32) {
 	}
 	return
 }
+
 func (is IniSection) getText(name string) (str string, ok bool, err error) {
 	str, ok = is[name]
 	if !ok {
@@ -739,11 +779,13 @@ type Layout struct {
 func newLayout(ln int16) *Layout {
 	return &Layout{facing: 1, vfacing: 1, layerno: ln, scale: [...]float32{1, 1}}
 }
+
 func ReadLayout(pre string, is IniSection, ln int16) *Layout {
 	l := newLayout(ln)
 	l.Read(pre, is)
 	return l
 }
+
 func (l *Layout) Read(pre string, is IniSection) {
 	is.ReadF32(pre+"offset", &l.offset[0], &l.offset[1])
 	if str := is[pre+"facing"]; len(str) > 0 {
@@ -850,12 +892,14 @@ type AnimLayout struct {
 func newAnimLayout(sff *Sff, ln int16) *AnimLayout {
 	return &AnimLayout{anim: *newAnimation(sff, &sff.palList), lay: *newLayout(ln), palfx: newPalFX()}
 }
+
 func ReadAnimLayout(pre string, is IniSection,
 	sff *Sff, at AnimationTable, ln int16) *AnimLayout {
 	al := newAnimLayout(sff, ln)
 	al.Read(pre, is, at, ln)
 	return al
 }
+
 func (al *AnimLayout) Read(pre string, is IniSection, at AnimationTable,
 	ln int16) {
 	var g, n int32
@@ -875,15 +919,18 @@ func (al *AnimLayout) Read(pre string, is IniSection, at AnimationTable,
 	al.ReadAnimPalfx(pre+"palfx.", is)
 	al.lay.Read(pre, is)
 }
+
 func (al *AnimLayout) Reset() {
 	al.anim.Reset()
 }
+
 func (al *AnimLayout) Action() {
 	if al.palfx != nil {
 		al.palfx.step()
 	}
 	al.anim.Action()
 }
+
 func (al *AnimLayout) Draw(x, y float32, layerno int16, scale float32) {
 	al.lay.DrawAnim(&al.lay.window, x, y, scale, layerno, &al.anim, al.palfx)
 }
@@ -963,12 +1010,14 @@ func newAnimTextSnd(sff *Sff, ln int16) *AnimTextSnd {
 	return &AnimTextSnd{snd: [2]int32{-1},
 		anim: *newAnimLayout(sff, ln), displaytime: -2}
 }
+
 func ReadAnimTextSnd(pre string, is IniSection,
 	sff *Sff, at AnimationTable, ln int16, f []*Fnt) *AnimTextSnd {
 	ats := newAnimTextSnd(sff, ln)
 	ats.Read(pre, is, at, ln, f)
 	return ats
 }
+
 func (ats *AnimTextSnd) Read(pre string, is IniSection, at AnimationTable,
 	ln int16, f []*Fnt) {
 	is.ReadI32(pre+"snd", &ats.snd[0], &ats.snd[1])
@@ -977,14 +1026,17 @@ func (ats *AnimTextSnd) Read(pre string, is IniSection, at AnimationTable,
 	ats.anim.Read(pre, is, at, ln)
 	is.ReadI32(pre+"displaytime", &ats.displaytime)
 }
+
 func (ats *AnimTextSnd) Reset() {
 	ats.anim.Reset()
 	ats.cnt = 0
 }
+
 func (ats *AnimTextSnd) Action() {
 	ats.anim.Action()
 	ats.cnt++
 }
+
 func (ats *AnimTextSnd) Draw(x, y float32, layerno int16, f []*Fnt, scale float32) {
 	if ats.displaytime > 0 && ats.cnt > ats.displaytime {
 		return
@@ -1003,11 +1055,18 @@ func (ats *AnimTextSnd) Draw(x, y float32, layerno int16, f []*Fnt, scale float3
 	}
 }
 
-func (ats *AnimTextSnd) NoSound() bool { return ats.snd[0] < 0 }
+func (ats *AnimTextSnd) NoSound() bool {
+	return ats.snd[0] < 0
+}
+
 func (ats *AnimTextSnd) NoDisplay() bool {
 	return len(ats.anim.anim.frames) == 0 &&
 		(ats.text.font[0] < 0 || len(ats.text.text) == 0)
 }
+
+// In Mugen this returns true if the animation ends before "displaytime" is over
+// It seems like the current Ikemen behavior makes more sense however
+// https://github.com/ikemen-engine/Ikemen-GO/issues/1150
 func (ats *AnimTextSnd) End(dt int32, inf bool) bool {
 	if ats.displaytime < 0 {
 		return len(ats.anim.anim.frames) == 0 || ats.anim.anim.loopend ||

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -4494,6 +4494,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "nofallhitflag":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nofallhitflag))
 		// Ikemen global flags
+		case "camerafreeze":
+			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_camerafreeze))
 		case "globalnoko":
 			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_globalnoko))
 		case "roundnotskip":

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1414,6 +1414,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				return bvNone(), Error("Missing '(' after PlayerIndex")
 			case OC_helperindex:
 				return bvNone(), Error("Missing '(' after HelperIndex")
+			default:
+				return bvNone(), Error("Missing '('")
 			}
 		}
 		if rd {
@@ -1431,11 +1433,11 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			case OC_player:
 				return bvNone(), Error("Missing ',' after Player")
 			case OC_playerid:
-				return bvNone(), Error("Missing '(' after PlayerID")
+				return bvNone(), Error("Missing ',' after PlayerID")
 			case OC_playerindex:
-				return bvNone(), Error("Missing '(' after PlayerIndex")
+				return bvNone(), Error("Missing ',' after PlayerIndex")
 			case OC_helperindex:
-				return bvNone(), Error("Missing '(' after HelperIndex")
+				return bvNone(), Error("Missing ',' after HelperIndex")
 			default:
 				return bvNone(), Error("Missing ','")
 			}
@@ -7367,7 +7369,7 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 
 	// Initialize command list data
 	if sys.chars[pn][0].cmd == nil {
-		sys.chars[pn][0].cmd = make([]CommandList, MaxSimul*2+MaxAttachedChar)
+		sys.chars[pn][0].cmd = make([]CommandList, MaxPlayerNo)
 		b := NewInputBuffer()
 		for i := range sys.chars[pn][0].cmd {
 			sys.chars[pn][0].cmd[i] = *NewCommandList(b)

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -4564,7 +4564,7 @@ func (c *Compiler) teamMapAdd(is IniSection, sc *StateControllerBase, _ int8) (S
 func (c *Compiler) matchRestart(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*matchRestart)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "reload",
-			matchRestart_reload, VT_Bool, MaxSimul*2+MaxAttachedChar, false); err != nil {
+			matchRestart_reload, VT_Bool, MaxPlayerNo, false); err != nil {
 			return err
 		}
 		if err := c.stateParam(is, "stagedef", false, func(data string) error {

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -231,6 +231,8 @@ func (c *Compiler) assertSpecial(is IniSection, sc *StateControllerBase, _ int8)
 			case "sizepushonly":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_sizepushonly)))
 			// Ikemen global flags
+			case "camerafreeze":
+				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_camerafreeze)))
 			case "globalnoko":
 				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_globalnoko)))
 			case "roundnotskip":

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -4447,7 +4447,7 @@ func (l *Lifebar) draw(layerno int16) {
 			// LifeBarAiLevel
 			for i := range l.ai {
 				l.ai[i].bgDraw(layerno)
-				l.ai[i].draw(layerno, l.fnt[:], sys.com[sys.chars[i][0].playerNo])
+				l.ai[i].draw(layerno, l.fnt[:], sys.aiLevel[sys.chars[i][0].playerNo])
 			}
 			// LifeBarWinCount
 			for i := range l.wc {

--- a/src/script.go
+++ b/src/script.go
@@ -775,7 +775,7 @@ func systemScriptInit(l *lua.LState) {
 		if !ok {
 			userDataError(l, 1, cl)
 		}
-		if cl.Input(int(numArg(l, 2))-1, 1, 0, 0, true) {
+		if cl.InputUpdate(int(numArg(l, 2))-1, 1, 0, 0, true) {
 			cl.Step(1, false, false, 0)
 		}
 		return 0
@@ -1212,7 +1212,7 @@ func systemScriptInit(l *lua.LState) {
 						nextId++
 					}
 				}
-				for i := MaxSimul * 2; i < MaxSimul*2+MaxAttachedChar; i += 1 {
+				for i := MaxSimul * 2; i < MaxPlayerNo; i += 1 {
 					if len(sys.chars[i]) > 0 {
 						if sys.round == 1 {
 							sys.chars[i][0].id = sys.newCharId()
@@ -1531,7 +1531,7 @@ func systemScriptInit(l *lua.LState) {
 		if !nilArg(l, 1) {
 			pn = int(numArg(l, 1))
 		}
-		if pn != 0 && (pn < 1 || pn > MaxSimul*2+MaxAttachedChar) {
+		if pn != 0 && (pn < 1 || pn > MaxPlayerNo) {
 			l.RaiseError("\nInvalid player number: %v\n", pn)
 		}
 		tbl := l.NewTable()
@@ -2119,8 +2119,8 @@ func systemScriptInit(l *lua.LState) {
 		return 0
 	})
 	luaRegister(l, "resetAILevel", func(l *lua.LState) int {
-		for i := range sys.com {
-			sys.com[i] = 0
+		for i := range sys.aiLevel {
+			sys.aiLevel[i] = 0
 		}
 		return 0
 	})
@@ -2268,7 +2268,7 @@ func systemScriptInit(l *lua.LState) {
 	})
 	luaRegister(l, "setAILevel", func(*lua.LState) int {
 		level := float32(numArg(l, 1))
-		sys.com[sys.debugWC.playerNo] = level
+		sys.aiLevel[sys.debugWC.playerNo] = level
 		for _, c := range sys.chars[sys.debugWC.playerNo] {
 			if level == 0 {
 				c.controller = sys.debugWC.playerNo
@@ -2285,13 +2285,13 @@ func systemScriptInit(l *lua.LState) {
 	luaRegister(l, "setCom", func(*lua.LState) int {
 		pn := int(numArg(l, 1))
 		ailv := float32(numArg(l, 2))
-		if pn < 1 || pn > MaxSimul*2+MaxAttachedChar {
+		if pn < 1 || pn > MaxPlayerNo {
 			l.RaiseError("\nInvalid player number: %v\n", pn)
 		}
 		if ailv > 0 {
-			sys.com[pn-1] = ailv
+			sys.aiLevel[pn-1] = ailv
 		} else {
-			sys.com[pn-1] = 0
+			sys.aiLevel[pn-1] = 0
 		}
 		return 0
 	})
@@ -3142,7 +3142,7 @@ func triggerFunctions(l *lua.LState) {
 	// vanilla triggers
 	luaRegister(l, "ailevel", func(*lua.LState) int {
 		if !sys.debugWC.asf(ASF_noailevel) {
-			l.Push(lua.LNumber(sys.debugWC.aiLevel()))
+			l.Push(lua.LNumber(sys.debugWC.getAILevel()))
 		} else {
 			l.Push(lua.LNumber(0))
 		}

--- a/src/script.go
+++ b/src/script.go
@@ -5600,6 +5600,8 @@ func triggerFunctions(l *lua.LState) {
 		case "timerfreeze":
 			l.Push(lua.LBool(sys.gsf(GSF_timerfreeze)))
 		// GlobalSpecialFlag (Ikemen)
+		case "camerafreeze":
+			l.Push(lua.LBool(sys.gsf(GSF_camerafreeze)))
 		case "roundfreeze":
 			l.Push(lua.LBool(sys.gsf(GSF_roundfreeze)))
 		case "roundnotskip":

--- a/src/stage.go
+++ b/src/stage.go
@@ -787,7 +787,7 @@ type Stage struct {
 	bgct              bgcTimeLine
 	bga               bgAction
 	sdw               stageShadow
-	p                 [MaxSimul*2 + MaxAttachedChar]stagePlayer
+	p                 [MaxPlayerNo]stagePlayer
 	leftbound         float32
 	rightbound        float32
 	screenleft        int32

--- a/src/system.go
+++ b/src/system.go
@@ -504,7 +504,7 @@ func (s *System) await(fps int) bool {
 		}
 		// Begin the next frame after events have been processed. Do not clear
 		// the screen if network input is present.
-		defer gfx.BeginFrame(sys.netInput == nil)
+		defer gfx.BeginFrame(sys.netConnection == nil)
 	}
 	s.runMainThreadTask()
 	now := time.Now()
@@ -536,17 +536,17 @@ func (s *System) update() bool {
 	if s.gameTime == 0 {
 		s.preFightTime = s.frameCounter
 	}
-	if s.fileInput != nil {
+	if s.replayFile != nil {
 		if s.anyHardButton() {
 			s.await(s.cfg.Config.Framerate * 4)
 		} else {
 			s.await(s.cfg.Config.Framerate)
 		}
-		return s.fileInput.Update()
+		return s.replayFile.Update()
 	}
-	if s.netInput != nil {
+	if s.netConnection != nil {
 		s.await(s.cfg.Config.Framerate)
-		return s.netInput.Update()
+		return s.netConnection.Update()
 	}
 	return s.await(s.cfg.Config.Framerate)
 }
@@ -596,10 +596,10 @@ func (s *System) loadStart() {
 }
 
 func (s *System) synchronize() error {
-	if s.fileInput != nil {
-		s.fileInput.Synchronize()
-	} else if s.netInput != nil {
-		return s.netInput.Synchronize()
+	if s.replayFile != nil {
+		s.replayFile.Synchronize()
+	} else if s.netConnection != nil {
+		return s.netConnection.Synchronize()
 	}
 	return nil
 }
@@ -619,11 +619,11 @@ func (s *System) anyHardButton() bool {
 }
 
 func (s *System) anyButton() bool {
-	if s.fileInput != nil {
-		return s.fileInput.AnyButton()
+	if s.replayFile != nil {
+		return s.replayFile.AnyButton()
 	}
-	if s.netInput != nil {
-		return s.netInput.AnyButton()
+	if s.netConnection != nil {
+		return s.netConnection.AnyButton()
 	}
 	return s.anyHardButton()
 }
@@ -2099,7 +2099,7 @@ func (s *System) fight() (reload bool) {
 	// Reset variables
 	s.gameTime, s.paused, s.accel = 0, false, 1
 	s.aiInput = [len(s.aiInput)]AiInput{}
-	if sys.netInput != nil {
+	if sys.netConnection != nil {
 		s.clsnDisplay = false
 		s.debugDisplay = false
 		s.lifebarDisplay = true
@@ -2180,8 +2180,8 @@ func (s *System) fight() (reload bool) {
 		s.errLog.Println(err.Error())
 		s.esc = true
 	}
-	if s.netInput != nil {
-		defer s.netInput.Stop()
+	if s.netConnection != nil {
+		defer s.netConnection.Stop()
 	}
 	s.wincnt.init()
 
@@ -2565,7 +2565,7 @@ func (s *System) fight() (reload bool) {
 		if s.endMatch {
 			s.esc = true
 		} else if s.esc {
-			s.endMatch = s.netInput != nil || len(sys.cfg.Common.Lua) == 0
+			s.endMatch = s.netConnection != nil || len(sys.cfg.Common.Lua) == 0
 		}
 	}
 

--- a/src/system.go
+++ b/src/system.go
@@ -26,6 +26,7 @@ import (
 const (
 	MaxSimul        = 4
 	MaxAttachedChar = 1
+	MaxPlayerNo     = MaxSimul*2 + MaxAttachedChar
 )
 
 // sys
@@ -108,17 +109,17 @@ type System struct {
 	ffxRegexp               string
 	sel                     Select
 	keyState                map[Key]bool
-	netInput                *NetInput
-	fileInput               *FileInput
-	aiInput                 [MaxSimul*2 + MaxAttachedChar]AiInput
+	netConnection           *NetConnection
+	replayFile              *ReplayFile
+	aiInput                 [MaxPlayerNo]AiInput
 	keyConfig               []KeyConfig
 	joystickConfig          []KeyConfig
-	com                     [MaxSimul*2 + MaxAttachedChar]float32
+	aiLevel                 [MaxPlayerNo]float32
 	autolevel               bool
 	home                    int
 	gameTime                int32
 	match                   int32
-	inputRemap              [MaxSimul*2 + MaxAttachedChar]int
+	inputRemap              [MaxPlayerNo]int
 	round                   int32
 	intro                   int32
 	time                    int32
@@ -130,15 +131,15 @@ type System struct {
 	roundsExisted           [2]int32
 	draws                   int32
 	loader                  Loader
-	chars                   [MaxSimul*2 + MaxAttachedChar][]*Char
+	chars                   [MaxPlayerNo][]*Char
 	charList                CharList
-	cgi                     [MaxSimul*2 + MaxAttachedChar]CharGlobalInfo
+	cgi                     [MaxPlayerNo]CharGlobalInfo
 	tmode                   [2]TeamMode
 	numSimul, numTurns      [2]int32
 	esc                     bool
 	loadMutex               sync.Mutex
 	ignoreMostErrors        bool
-	stringPool              [MaxSimul*2 + MaxAttachedChar]StringPool
+	stringPool              [MaxPlayerNo]StringPool
 	bcStack, bcVarStack     BytecodeStack
 	bcVar                   []BytecodeValue
 	workingChar             *Char
@@ -188,7 +189,7 @@ type System struct {
 	reloadFlg               bool
 	reloadStageFlg          bool
 	reloadLifebarFlg        bool
-	reloadCharSlot          [MaxSimul*2 + MaxAttachedChar]bool
+	reloadCharSlot          [MaxPlayerNo]bool
 	shortcutScripts         map[ShortcutKey]*ShortcutScript
 	turbo                   float32
 	commandLine             chan string
@@ -211,11 +212,11 @@ type System struct {
 	fadeintime              int32
 	fadeouttime             int32
 	wintime                 int32
-	projs                   [MaxSimul*2 + MaxAttachedChar][]Projectile
-	explods                 [MaxSimul*2 + MaxAttachedChar][]Explod
-	explodsLayerN1          [MaxSimul*2 + MaxAttachedChar][]int
-	explodsLayer0           [MaxSimul*2 + MaxAttachedChar][]int
-	explodsLayer1           [MaxSimul*2 + MaxAttachedChar][]int
+	projs                   [MaxPlayerNo][]Projectile
+	explods                 [MaxPlayerNo][]Explod
+	explodsLayerN1          [MaxPlayerNo][]int
+	explodsLayer0           [MaxPlayerNo][]int
+	explodsLayer1           [MaxPlayerNo][]int
 	changeStateNest         int32
 	spritesLayerN1          DrawList
 	spritesLayerU           DrawList
@@ -1397,7 +1398,7 @@ func (s *System) action() {
 					if len(s.chars[i]) > 0 && s.chars[i][0].teamside != -1 {
 						if s.chars[i][0].alive() {
 							ko[loser] = false
-						} else if (s.tmode[i&1] == TM_Simul && s.cfg.Options.Simul.LoseOnKO && s.com[i] == 0) ||
+						} else if (s.tmode[i&1] == TM_Simul && s.cfg.Options.Simul.LoseOnKO && s.aiLevel[i] == 0) ||
 							(s.tmode[i&1] == TM_Tag && s.cfg.Options.Tag.LoseOnKO) {
 							ko[loser] = true
 							break
@@ -2413,7 +2414,7 @@ func (s *System) fight() (reload bool) {
 					tmp.RawSetString("life", lua.LNumber(p[0].life))
 					tmp.RawSetString("lifeMax", lua.LNumber(p[0].lifeMax))
 					tmp.RawSetString("winquote", lua.LNumber(p[0].winquote))
-					tmp.RawSetString("aiLevel", lua.LNumber(p[0].aiLevel()))
+					tmp.RawSetString("aiLevel", lua.LNumber(p[0].getAILevel()))
 					tmp.RawSetString("palno", lua.LNumber(p[0].gi().palno))
 					tmp.RawSetString("ratiolevel", lua.LNumber(p[0].ocd().ratioLevel))
 					tmp.RawSetString("win", lua.LBool(p[0].win()))
@@ -3366,7 +3367,7 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 		p = sys.chars[pn][0]
 		if !attached {
 			p.controller = pn
-			if sys.com[pn] != 0 {
+			if sys.aiLevel[pn] != 0 {
 				p.controller ^= -1
 			}
 		}
@@ -3388,7 +3389,7 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 		p.memberNo = -atcpn
 		p.selectNo = -atcpn
 		p.teamside = -1
-		sys.com[pn] = 8
+		sys.aiLevel[pn] = float32(sys.cfg.Options.Difficulty)
 	} else {
 		p.memberNo = memberNo
 		p.selectNo = sys.sel.selected[pn&1][memberNo][0]


### PR DESCRIPTION
Feat:
- AssertSpecial CameraFreeze. Prevents the camera from updating

Refactor:
- "guard.hittime" now (again?) correctly defaults to "ground.slidetime" for Mugen characters. Exception was added for Ikemen characters, where it will default to "ground.hittime" as documented
- Attached char difficulty no longer forced to 8
- Source code readability stuff

Fix:
- Statedef +1 no longer crashes when a comment is used in the same line
- If a player is crouching when they're KO'd, they will go into state 5000 rather than 5010, like in Mugen
- Type None hits can now also trigger a HitOverride
- Fixed couple of issues with new IsHelper syntax. Added backward compatibility check
- Fixes #2262
- Fixes #2341
- Fixes #2415
- Fixes #2417