### PR TITLE
feat: ProjVar time; Tag refactoring; other fixes

### DIFF
--- a/data/action.zss
+++ b/data/action.zss
@@ -3,9 +3,9 @@
 #===============================================================================
 [StateDef -4]
 
-if !const(Default.Enable.Action) || isHelper || teamSide = 0 {
+ignoreHitPause if !const(Default.Enable.Action) || isHelper || teamSide = 0 {
 	# Do nothing, global code disabled locally or executed by helper or stage
-} else ignoreHitPause if roundState >= 2 {
+} else if roundState >= 2 {
 	# First Attack
 	let ret = call IkSys_FirstAttack();
 	if $ret {

--- a/data/dizzy.zss
+++ b/data/dizzy.zss
@@ -199,7 +199,7 @@ if !dizzy || time > 300 {
 
 if !const(Default.Enable.Dizzy) || isHelper || teamSide = 0 {
 	# Do nothing, global code disabled locally or executed by helper/stage
-} else if roundTime = 0 {
+} else if roundState = 0 {
 	# Initialize points and variables
 	dizzyPointsSet{value: dizzyPointsMax}
 	map(_iksys_dizzyPointsTimer) := 0;

--- a/data/functions.zss
+++ b/data/functions.zss
@@ -224,9 +224,9 @@ ignoreHitPause{
 #===============================================================================
 [StateDef -4]
 
-if teamSide = 0 {
+ignoreHitPause if teamSide = 0 {
 	# Do nothing, global code executed by stage
-} else if roundTime = 0 {
+} else if roundState = 0 {
 	map(_iksys_firstAttackFlag) := 0;
 	map(_iksys_counterHitFlag) := 0;
 	map(_iksys_technicalFlag) := 0;
@@ -249,7 +249,7 @@ if teamSide = 0 {
 	map(_iksys_receivedDamageFlag) := 0;
 	map(_iksys_receivedDamageCurr) := 0;
 	map(_iksys_receivedDamageRet) := 0;
-} else ignoreHitPause if roundState >= 2 {
+} else if roundState >= 2 {
 	call IkSys_FirstAttack();
 	call IkSys_CounterHit();
 	call IkSys_Technical();

--- a/data/guardbreak.zss
+++ b/data/guardbreak.zss
@@ -144,7 +144,7 @@ if time >= 60 {
 
 if !const(Default.Enable.GuardBreak) || isHelper || teamSide = 0 {
 	# Do nothing, global code disabled locally or executed by helper/stage
-} else if roundTime = 0 {
+} else if roundState = 0 {
 	# Initialize points and variables
 	guardPointsSet{value: guardPointsMax}
 	map(_iksys_guardPointsTimer) := 0;

--- a/data/score.zss
+++ b/data/score.zss
@@ -3,9 +3,9 @@
 #===============================================================================
 [StateDef -4]
 
-if !const(Default.Enable.Score) || teamSide = 0 {
+ignoreHitPause if !const(Default.Enable.Score) || teamSide = 0 {
 	# do nothing, global code disabled locally or executed by stage
-} else if roundTime = 0 {
+} else if roundState = 0 {
 	map(_iksys_scoreTimeVitalFlag) := 0;
 } else if roundState = 4 && !isHelper {
 	# score: time vital bonus
@@ -43,7 +43,7 @@ if !const(Default.Enable.Score) || teamSide = 0 {
 			map(_iksys_scoreTimeVitalFlag) := 1;
 		}
 	}
-} else ignoreHitPause if roundState >= 2 {
+} else if roundState >= 2 {
 	# score: first attack bonus
 	if !isHelper {
 		let ret = call IkSys_FirstAttack();

--- a/data/tag.zss
+++ b/data/tag.zss
@@ -78,7 +78,6 @@ explod{
 ]
 
 screenBound{value: 0; movecamera: 1, 1; stagebound: 0}
-assertSpecial{flag: noTurnTarget}
 
 if time = 0 {
 	if facing != player(teamLeader),facing {
@@ -116,6 +115,7 @@ if backEdgeDist >= 0 && (floor(map(_iksys_tagSwitchDist)) <= 0 || p2BodyDist X <
 ]
 
 screenBound{value: 0; movecamera: 0, 0; stagebound: 0}
+assertSpecial{flag: noTurnTarget}
 
 if time = 0 {
 	turn{}
@@ -137,7 +137,7 @@ if backEdgeDist < -const240p(160) || frontEdgeDist < -const240p(160) {
 ]
 
 screenBound{value: 0; movecamera: 0, 0; stagebound: 0}
-assertSpecial{flag: invisible; flag2: noAutoTurn}
+assertSpecial{flag: invisible; flag2: noTurnTarget}
 
 # Face towards center of screen
 if pos x * facing > 0 {
@@ -166,7 +166,6 @@ if roundState = 3 {
 	playerPush{value: 0}
 } else {
 	screenBound{value: 0; movecamera: 1, 1; stagebound: 0}
-	assertSpecial{flag: noTurnTarget}
 }
 
 # the character cannot be hit until he has fully entered the stage
@@ -193,12 +192,12 @@ if time = 0 {
 		call TagSwitchExplod();
 	}
 	if roundState = 2 {
-		velSet{x: const240p(4); y: -const240p(8.75)}
+		velSet{x: const240p(4.0); y: -const240p(10.0)}
 	} else {
-		velSet{x: const240p(8.0 - 0.75 * (playerno - teamside)); y: -const240p(8.75)}
+		velSet{x: const240p(8.0 - 0.75 * (playerno - teamside)); y: -const240p(10.0)}
 	}
 } else {
-	gravity{}
+	velAdd{y: const240p(0.5)}
 	if vel y > 0 && pos y >= 0 {
 		velSet{x: 0; y: 0}
 		selfState{value: const(StateTagLanding)}
@@ -220,6 +219,31 @@ if time = 0 {
 
 if animTime >= 0 {
 	selfState{value: const(StateStand); ctrl: 1}
+}
+
+#===============================================================================
+# Global states (not halted by Pause/SuperPause, no helper limitations)
+#===============================================================================
+[StateDef -4]
+
+# Make players (any mode) only turn towards enemy Tag team leader
+# This benefits assist systems more than it does this native Tag code
+ignoreHitPause if roundState = 2 && !isHelper {
+	# Disable turning for player
+	if p2, teamMode = Tag && p2, playerNo != p2, teamLeader ||
+		p2, time <= 0 && p2, prevStateNo = p2, const(StateTagWaitingOutside) { # Run order fix
+		assertSpecial{flag: noAutoTurn}
+	}
+	# Disable turning towards enemy
+	# We use redirections here so that the flags are asserted as soon as possible
+	if numEnemy > 0 && enemy, teamMode = Tag {
+		for i = 0; numEnemy - 1; 1 {
+			if enemy($i), playerNo != enemy($i), teamLeader ||
+				enemy($i), time <= 0 && enemy($i), prevStateNo = enemy($i), const(StateTagWaitingOutside) { # Run order fix
+				assertSpecial{flag: noTurnTarget; redirectID: enemy($i), ID}
+			}
+		}
+	}
 }
 
 #===============================================================================

--- a/data/tag.zss
+++ b/data/tag.zss
@@ -229,7 +229,7 @@ if animTime >= 0 {
 
 if !const(Default.Enable.Tag) || isHelper || teamSide = 0 {
 	# do nothing, global code disabled locally or executed by helper/stage
-} else if roundTime = 0 && teamMode = Tag {
+} else if roundState = 0 && teamMode = Tag {
 	map(_iksys_tagActive) := 1;
 	map(_iksys_tagLastId) := 0;
 	map(_iksys_tagPartnerId) := 0;

--- a/data/training.zss
+++ b/data/training.zss
@@ -14,7 +14,7 @@
 
 ignoreHitPause if gameMode = "training" {
 	# Round start reset
-	if roundTime = 0 {
+	if roundState = 0 {
 		powerSet{value: powerMax}
 		map(_iksys_trainingLifeTimer) := 0;
 		map(_iksys_trainingPowerTimer) := 0;
@@ -59,7 +59,7 @@ ignoreHitPause if gameMode = "training" {
 	}
 	# Dummy code
 	if teamSide = 2 && !isHelper {
-		if roundTime = 0 {
+		if roundState = 0 {
 			# Round start reset
 			map(_iksys_trainingAirJumpNum) := 0;
 			map(_iksys_trainingButtonJam) := 0;

--- a/src/anim.go
+++ b/src/anim.go
@@ -634,7 +634,9 @@ func (a *Animation) alpha() int32 {
 		return -2
 	}
 	sa = byte(int32(sa) * sys.brightness >> 8)
-	if sa < 5 && da == 255 {
+	// Mugen sprites disappear a bit earlier than this
+	// However that makes subtle interpolated blending noticeably jump
+	if sa < 1 && da == 255 {
 		return 0
 	}
 	if sa == 255 && da == 255 {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3105,13 +3105,13 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		}
 	case OC_ex_scale_x:
 		if c.csf(CSF_angledraw) {
-			sys.bcStack.PushF(c.scale[0])
+			sys.bcStack.PushF(c.angleDrawScale[0])
 		} else {
 			sys.bcStack.PushF(1)
 		}
 	case OC_ex_scale_y:
 		if c.csf(CSF_angledraw) {
-			sys.bcStack.PushF(c.scale[1])
+			sys.bcStack.PushF(c.angleDrawScale[1])
 		} else {
 			sys.bcStack.PushF(1)
 		}
@@ -9490,9 +9490,9 @@ func (sc angleDraw) Run(c *Char, _ []int32) bool {
 		case angleDraw_value:
 			crun.angleSet(exp[0].evalF(c))
 		case angleDraw_scale:
-			crun.scale[0] *= exp[0].evalF(c)
+			crun.angleDrawScale[0] *= exp[0].evalF(c)
 			if len(exp) > 1 {
-				crun.scale[1] *= exp[1].evalF(c)
+				crun.angleDrawScale[1] *= exp[1].evalF(c)
 			}
 		case angleDraw_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -783,36 +783,36 @@ const (
 	OC_ex2_debug_wireframedisplay
 	OC_ex2_drawpal_group
 	OC_ex2_drawpal_index
-	OC_ex2_explodvar_anim
-	OC_ex2_explodvar_animelem
-	OC_ex2_explodvar_drawpal_group
-	OC_ex2_explodvar_drawpal_index
-	OC_ex2_explodvar_pos_x
-	OC_ex2_explodvar_pos_y
-	OC_ex2_explodvar_pos_z
-	OC_ex2_explodvar_scale_x
-	OC_ex2_explodvar_scale_y
-	OC_ex2_explodvar_vel_x
-	OC_ex2_explodvar_vel_y
-	OC_ex2_explodvar_vel_z
 	OC_ex2_explodvar_accel_x
 	OC_ex2_explodvar_accel_y
 	OC_ex2_explodvar_accel_z
-	OC_ex2_explodvar_friction_x
-	OC_ex2_explodvar_friction_y
-	OC_ex2_explodvar_friction_z
 	OC_ex2_explodvar_angle
 	OC_ex2_explodvar_angle_x
 	OC_ex2_explodvar_angle_y
-	OC_ex2_explodvar_xshear
-	OC_ex2_explodvar_removetime
+	OC_ex2_explodvar_anim
+	OC_ex2_explodvar_animelem
+	OC_ex2_explodvar_bindtime
+	OC_ex2_explodvar_drawpal_group
+	OC_ex2_explodvar_drawpal_index
+	OC_ex2_explodvar_facing
+	OC_ex2_explodvar_friction_x
+	OC_ex2_explodvar_friction_y
+	OC_ex2_explodvar_friction_z
+	OC_ex2_explodvar_id
+	OC_ex2_explodvar_layerno
 	OC_ex2_explodvar_pausemovetime
+	OC_ex2_explodvar_pos_x
+	OC_ex2_explodvar_pos_y
+	OC_ex2_explodvar_pos_z
+	OC_ex2_explodvar_removetime
+	OC_ex2_explodvar_scale_x
+	OC_ex2_explodvar_scale_y
 	OC_ex2_explodvar_sprpriority
 	OC_ex2_explodvar_time
-	OC_ex2_explodvar_layerno
-	OC_ex2_explodvar_id
-	OC_ex2_explodvar_bindtime
-	OC_ex2_explodvar_facing
+	OC_ex2_explodvar_vel_x
+	OC_ex2_explodvar_vel_y
+	OC_ex2_explodvar_vel_z
+	OC_ex2_explodvar_xshear
 	OC_ex2_projvar_accel_x
 	OC_ex2_projvar_accel_y
 	OC_ex2_projvar_accel_z
@@ -829,7 +829,6 @@ const (
 	OC_ex2_projvar_pos_y
 	OC_ex2_projvar_pos_z
 	OC_ex2_projvar_projangle
-	OC_ex2_projvar_projxshear
 	OC_ex2_projvar_projanim
 	OC_ex2_projvar_projcancelanim
 	OC_ex2_projvar_projedgebound
@@ -850,11 +849,13 @@ const (
 	OC_ex2_projvar_projshadow_r
 	OC_ex2_projvar_projsprpriority
 	OC_ex2_projvar_projstagebound
+	OC_ex2_projvar_projxshear
 	OC_ex2_projvar_remvelocity_x
 	OC_ex2_projvar_remvelocity_y
 	OC_ex2_projvar_remvelocity_z
 	OC_ex2_projvar_supermovetime
 	OC_ex2_projvar_teamside
+	OC_ex2_projvar_time
 	OC_ex2_projvar_vel_x
 	OC_ex2_projvar_vel_y
 	OC_ex2_projvar_vel_z
@@ -3569,6 +3570,8 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	case OC_ex2_projvar_pos_z:
 		fallthrough
 	case OC_ex2_projvar_facing:
+		fallthrough
+	case OC_ex2_projvar_time:
 		fallthrough
 	case OC_ex2_projvar_guardflag:
 		fallthrough

--- a/src/char.go
+++ b/src/char.go
@@ -7494,6 +7494,7 @@ func (c *Char) posUpdate() {
 			}
 		}
 	}
+
 	// Check if character is bound
 	nobind := [...]bool{c.bindTime == 0 || math.IsNaN(float64(c.bindPos[0])),
 		c.bindTime == 0 || math.IsNaN(float64(c.bindPos[1])),
@@ -7503,6 +7504,7 @@ func (c *Char) posUpdate() {
 			c.oldPos[i], c.interPos[i] = c.pos[i], c.pos[i]
 		}
 	}
+
 	// Offset position when character is hit off the ground
 	// This used to be in actionPrepare(), which would be ideal, but that caused https://github.com/ikemen-engine/Ikemen-GO/issues/2188
 	if c.downHitOffset {
@@ -7514,12 +7516,13 @@ func (c *Char) posUpdate() {
 		}
 		c.downHitOffset = false
 	}
+
+	// Apply velocity
 	if c.csf(CSF_posfreeze) {
 		if nobind[0] {
 			c.setPosX(c.oldPos[0] + c.mhv.cornerpush) // PosFreeze does not disable cornerpush in Mugen
 		}
 	} else {
-		// Apply velocity
 		if nobind[0] {
 			c.setPosX(c.oldPos[0] + c.vel[0]*c.facing + c.mhv.cornerpush)
 		}
@@ -7529,30 +7532,34 @@ func (c *Char) posUpdate() {
 		if nobind[2] {
 			c.setPosZ(c.oldPos[2] + c.vel[2])
 		}
-		// Apply physics types
-		switch c.ss.physics {
-		case ST_S:
-			c.vel[0] *= c.gi().movement.stand.friction
-			if AbsF(c.vel[0]) < 1 {
-				c.vel[0] = 0
-			}
-			c.vel[2] *= c.gi().movement.stand.friction
-			if AbsF(c.vel[2]) < 1 {
-				c.vel[2] = 0
-			}
-		case ST_C:
-			c.vel[0] *= c.gi().movement.crouch.friction
-			c.vel[2] *= c.gi().movement.crouch.friction
-		case ST_A:
-			c.gravity()
-		}
 	}
+
+	// Apply physics types
+	switch c.ss.physics {
+	case ST_S:
+		c.vel[0] *= c.gi().movement.stand.friction
+		if AbsF(c.vel[0]) < 1 {
+			c.vel[0] = 0
+		}
+		c.vel[2] *= c.gi().movement.stand.friction
+		if AbsF(c.vel[2]) < 1 {
+			c.vel[2] = 0
+		}
+	case ST_C:
+		c.vel[0] *= c.gi().movement.crouch.friction
+		c.vel[2] *= c.gi().movement.crouch.friction
+	case ST_A:
+		c.gravity()
+	}
+
+	// Apply friction to corner push
 	if sys.supertime == 0 {
 		c.cornerVelOff *= friction
 		if AbsF(c.cornerVelOff) < 1 {
 			c.cornerVelOff = 0
 		}
 	}
+
 	c.bindPosAdd = [...]float32{0, 0, 0}
 }
 

--- a/src/char.go
+++ b/src/char.go
@@ -1822,6 +1822,7 @@ type Projectile struct {
 	remflag         bool
 	freezeflag      bool
 	contactflag     bool
+	time            int32
 }
 
 func newProjectile() *Projectile {
@@ -2106,6 +2107,7 @@ func (p *Projectile) tick() {
 	}
 	if !p.paused(p.playerno) {
 		if p.hitpause <= 0 {
+			p.time++ // Only used in ProjVar currently
 			if p.removetime > 0 {
 				p.removetime--
 			}
@@ -4185,52 +4187,52 @@ func (c *Char) explodVar(eid BytecodeValue, idx BytecodeValue, vtype OpCode) Byt
 			switch vtype {
 			case OC_ex2_explodvar_anim:
 				v = BytecodeInt(e.animNo)
-			case OC_ex2_explodvar_animelem:
-				v = BytecodeInt(e.anim.current + 1)
-			case OC_ex2_explodvar_pos_x:
-				v = BytecodeFloat(e.pos[0] + e.offset[0] + e.relativePos[0] + e.interpolate_pos[0])
-			case OC_ex2_explodvar_pos_y:
-				v = BytecodeFloat(e.pos[1] + e.offset[1] + e.relativePos[1] + e.interpolate_pos[1])
-			case OC_ex2_explodvar_pos_z:
-				v = BytecodeFloat(e.pos[2] + e.offset[2] + e.relativePos[2] + e.interpolate_pos[2])
-			case OC_ex2_explodvar_scale_x:
-				v = BytecodeFloat(e.scale[0] * e.interpolate_scale[0])
-			case OC_ex2_explodvar_scale_y:
-				v = BytecodeFloat(e.scale[1] * e.interpolate_scale[1])
 			case OC_ex2_explodvar_angle:
 				v = BytecodeFloat(e.anglerot[0] + e.interpolate_angle[0])
 			case OC_ex2_explodvar_angle_x:
 				v = BytecodeFloat(e.anglerot[1] + e.interpolate_angle[1])
 			case OC_ex2_explodvar_angle_y:
 				v = BytecodeFloat(e.anglerot[2] + e.interpolate_angle[2])
-			case OC_ex2_explodvar_xshear:
-				v = BytecodeFloat(e.xshear)
+			case OC_ex2_explodvar_animelem:
+				v = BytecodeInt(e.anim.current + 1)
+			case OC_ex2_explodvar_bindtime:
+				v = BytecodeInt(e.bindtime)
+			case OC_ex2_explodvar_drawpal_group:
+				v = BytecodeInt(c.explodDrawPal(e)[0])
+			case OC_ex2_explodvar_drawpal_index:
+				v = BytecodeInt(c.explodDrawPal(e)[1])
+			case OC_ex2_explodvar_facing:
+				v = BytecodeInt(int32(e.facing))
+			case OC_ex2_explodvar_id:
+				v = BytecodeInt(e.id)
+			case OC_ex2_explodvar_layerno:
+				v = BytecodeInt(e.layerno)
+			case OC_ex2_explodvar_pausemovetime:
+				v = BytecodeInt(e.pausemovetime)
+			case OC_ex2_explodvar_pos_x:
+				v = BytecodeFloat(e.pos[0] + e.offset[0] + e.relativePos[0] + e.interpolate_pos[0])
+			case OC_ex2_explodvar_pos_y:
+				v = BytecodeFloat(e.pos[1] + e.offset[1] + e.relativePos[1] + e.interpolate_pos[1])
+			case OC_ex2_explodvar_pos_z:
+				v = BytecodeFloat(e.pos[2] + e.offset[2] + e.relativePos[2] + e.interpolate_pos[2])
+			case OC_ex2_explodvar_removetime:
+				v = BytecodeInt(e.removetime)
+			case OC_ex2_explodvar_scale_x:
+				v = BytecodeFloat(e.scale[0] * e.interpolate_scale[0])
+			case OC_ex2_explodvar_scale_y:
+				v = BytecodeFloat(e.scale[1] * e.interpolate_scale[1])
+			case OC_ex2_explodvar_sprpriority:
+				v = BytecodeInt(e.sprpriority)
+			case OC_ex2_explodvar_time:
+				v = BytecodeInt(e.time)
 			case OC_ex2_explodvar_vel_x:
 				v = BytecodeFloat(e.velocity[0])
 			case OC_ex2_explodvar_vel_y:
 				v = BytecodeFloat(e.velocity[1])
 			case OC_ex2_explodvar_vel_z:
 				v = BytecodeFloat(e.velocity[2])
-			case OC_ex2_explodvar_removetime:
-				v = BytecodeInt(e.removetime)
-			case OC_ex2_explodvar_pausemovetime:
-				v = BytecodeInt(e.pausemovetime)
-			case OC_ex2_explodvar_sprpriority:
-				v = BytecodeInt(e.sprpriority)
-			case OC_ex2_explodvar_layerno:
-				v = BytecodeInt(e.layerno)
-			case OC_ex2_explodvar_id:
-				v = BytecodeInt(e.id)
-			case OC_ex2_explodvar_bindtime:
-				v = BytecodeInt(e.bindtime)
-			case OC_ex2_explodvar_time:
-				v = BytecodeInt(e.time)
-			case OC_ex2_explodvar_facing:
-				v = BytecodeInt(int32(e.facing))
-			case OC_ex2_explodvar_drawpal_group:
-				v = BytecodeInt(c.explodDrawPal(e)[0])
-			case OC_ex2_explodvar_drawpal_index:
-				v = BytecodeInt(c.explodDrawPal(e)[1])
+			case OC_ex2_explodvar_xshear:
+				v = BytecodeFloat(e.xshear)
 			}
 			break
 		}
@@ -4259,30 +4261,92 @@ func (c *Char) projVar(pid BytecodeValue, idx BytecodeValue, flag BytecodeValue,
 	for n, p := range projs {
 		if i == int32(n) {
 			switch vtype {
-			case OC_ex2_projvar_projremove:
-				v = BytecodeBool(p.remove)
-			case OC_ex2_projvar_projremovetime:
-				v = BytecodeInt(p.removetime)
-			case OC_ex2_projvar_projshadow_r:
-				v = BytecodeInt(p.shadow[0])
-			case OC_ex2_projvar_projshadow_g:
-				v = BytecodeInt(p.shadow[1])
-			case OC_ex2_projvar_projshadow_b:
-				v = BytecodeInt(p.shadow[2])
-			case OC_ex2_projvar_projmisstime:
-				v = BytecodeInt(p.curmisstime)
+			case OC_ex2_projvar_accel_x:
+				v = BytecodeFloat(p.accel[0] * p.localscl)
+			case OC_ex2_projvar_accel_y:
+				v = BytecodeFloat(p.accel[1] * p.localscl)
+			case OC_ex2_projvar_accel_z:
+				v = BytecodeFloat(p.accel[2] * p.localscl)
+			case OC_ex2_projvar_animelem:
+				v = BytecodeInt(p.ani.current + 1)
+			case OC_ex2_projvar_drawpal_group:
+				v = BytecodeInt(c.projDrawPal(p)[0])
+			case OC_ex2_projvar_drawpal_index:
+				v = BytecodeInt(c.projDrawPal(p)[1])
+			case OC_ex2_projvar_facing:
+				v = BytecodeFloat(p.facing)
+			case OC_ex2_projvar_guardflag:
+				v = BytecodeBool(p.hitdef.guardflag&fl != 0)
+			case OC_ex2_projvar_highbound:
+				v = BytecodeInt(int32(float32(p.heightbound[1]) * p.localscl / oc.localscl))
+			case OC_ex2_projvar_hitflag:
+				v = BytecodeBool(p.hitdef.hitflag&fl != 0)
+			case OC_ex2_projvar_lowbound:
+				v = BytecodeInt(int32(float32(p.heightbound[0]) * p.localscl / oc.localscl))
+			case OC_ex2_projvar_pausemovetime:
+				v = BytecodeInt(p.pausemovetime)
+			case OC_ex2_projvar_pos_x:
+				v = BytecodeFloat((p.pos[0]*p.localscl - sys.cam.Pos[0]) / oc.localscl)
+			case OC_ex2_projvar_pos_y:
+				v = BytecodeFloat(p.pos[1] * p.localscl / oc.localscl)
+			case OC_ex2_projvar_pos_z:
+				v = BytecodeFloat(p.pos[2] * p.localscl / oc.localscl)
+			case OC_ex2_projvar_projanim:
+				v = BytecodeInt(p.anim)
+			case OC_ex2_projvar_projangle:
+				v = BytecodeFloat(p.angle)
+			case OC_ex2_projvar_projcancelanim:
+				v = BytecodeInt(p.cancelanim)
+			case OC_ex2_projvar_projedgebound:
+				v = BytecodeInt(int32(float32(p.edgebound) * p.localscl / oc.localscl))
+			case OC_ex2_projvar_projhitanim:
+				v = BytecodeInt(p.hitanim)
 			case OC_ex2_projvar_projhits:
 				v = BytecodeInt(p.hits)
 			case OC_ex2_projvar_projhitsmax:
 				v = BytecodeInt(p.totalhits)
+			case OC_ex2_projvar_projid:
+				v = BytecodeInt(int32(p.id))
+			case OC_ex2_projvar_projlayerno:
+				v = BytecodeInt(p.layerno)
+			case OC_ex2_projvar_projmisstime:
+				v = BytecodeInt(p.curmisstime)
 			case OC_ex2_projvar_projpriority:
 				v = BytecodeInt(p.priority)
-			case OC_ex2_projvar_projhitanim:
-				v = BytecodeInt(p.hitanim)
+			case OC_ex2_projvar_projremove:
+				v = BytecodeBool(p.remove)
 			case OC_ex2_projvar_projremanim:
 				v = BytecodeInt(p.remanim)
-			case OC_ex2_projvar_projcancelanim:
-				v = BytecodeInt(p.cancelanim)
+			case OC_ex2_projvar_projremovetime:
+				v = BytecodeInt(p.removetime)
+			case OC_ex2_projvar_projscale_x:
+				v = BytecodeFloat(p.scale[0])
+			case OC_ex2_projvar_projscale_y:
+				v = BytecodeFloat(p.scale[1])
+			case OC_ex2_projvar_projshadow_b:
+				v = BytecodeInt(p.shadow[2])
+			case OC_ex2_projvar_projshadow_g:
+				v = BytecodeInt(p.shadow[1])
+			case OC_ex2_projvar_projshadow_r:
+				v = BytecodeInt(p.shadow[0])
+			case OC_ex2_projvar_projsprpriority:
+				v = BytecodeInt(p.sprpriority)
+			case OC_ex2_projvar_projstagebound:
+				v = BytecodeInt(int32(float32(p.stagebound) * p.localscl / oc.localscl))
+			case OC_ex2_projvar_projxshear:
+				v = BytecodeFloat(p.xshear)
+			case OC_ex2_projvar_remvelocity_x:
+				v = BytecodeFloat(p.remvelocity[0] * p.localscl / oc.localscl)
+			case OC_ex2_projvar_remvelocity_y:
+				v = BytecodeFloat(p.remvelocity[1] * p.localscl / oc.localscl)
+			case OC_ex2_projvar_remvelocity_z:
+				v = BytecodeFloat(p.remvelocity[2] * p.localscl / oc.localscl)
+			case OC_ex2_projvar_supermovetime:
+				v = BytecodeInt(p.supermovetime)
+			case OC_ex2_projvar_teamside:
+				v = BytecodeInt(int32(p.hitdef.teamside))
+			case OC_ex2_projvar_time:
+				v = BytecodeInt(p.time)
 			case OC_ex2_projvar_vel_x:
 				v = BytecodeFloat(p.velocity[0] * p.localscl / oc.localscl)
 			case OC_ex2_projvar_vel_y:
@@ -4295,66 +4359,6 @@ func (c *Char) projVar(pid BytecodeValue, idx BytecodeValue, flag BytecodeValue,
 				v = BytecodeFloat(p.velmul[1])
 			case OC_ex2_projvar_velmul_z:
 				v = BytecodeFloat(p.velmul[2])
-			case OC_ex2_projvar_remvelocity_x:
-				v = BytecodeFloat(p.remvelocity[0] * p.localscl / oc.localscl)
-			case OC_ex2_projvar_remvelocity_y:
-				v = BytecodeFloat(p.remvelocity[1] * p.localscl / oc.localscl)
-			case OC_ex2_projvar_remvelocity_z:
-				v = BytecodeFloat(p.remvelocity[2] * p.localscl / oc.localscl)
-			case OC_ex2_projvar_accel_x:
-				v = BytecodeFloat(p.accel[0] * p.localscl)
-			case OC_ex2_projvar_accel_y:
-				v = BytecodeFloat(p.accel[1] * p.localscl)
-			case OC_ex2_projvar_accel_z:
-				v = BytecodeFloat(p.accel[2] * p.localscl)
-			case OC_ex2_projvar_projscale_x:
-				v = BytecodeFloat(p.scale[0])
-			case OC_ex2_projvar_projscale_y:
-				v = BytecodeFloat(p.scale[1])
-			case OC_ex2_projvar_projangle:
-				v = BytecodeFloat(p.angle)
-			case OC_ex2_projvar_projxshear:
-				v = BytecodeFloat(p.xshear)
-			case OC_ex2_projvar_pos_x:
-				v = BytecodeFloat((p.pos[0]*p.localscl - sys.cam.Pos[0]) / oc.localscl)
-			case OC_ex2_projvar_pos_y:
-				v = BytecodeFloat(p.pos[1] * p.localscl / oc.localscl)
-			case OC_ex2_projvar_pos_z:
-				v = BytecodeFloat(p.pos[2] * p.localscl / oc.localscl)
-			case OC_ex2_projvar_projsprpriority:
-				v = BytecodeInt(p.sprpriority)
-			case OC_ex2_projvar_projlayerno:
-				v = BytecodeInt(p.layerno)
-			case OC_ex2_projvar_projstagebound:
-				v = BytecodeInt(int32(float32(p.stagebound) * p.localscl / oc.localscl))
-			case OC_ex2_projvar_projedgebound:
-				v = BytecodeInt(int32(float32(p.edgebound) * p.localscl / oc.localscl))
-			case OC_ex2_projvar_lowbound:
-				v = BytecodeInt(int32(float32(p.heightbound[0]) * p.localscl / oc.localscl))
-			case OC_ex2_projvar_highbound:
-				v = BytecodeInt(int32(float32(p.heightbound[1]) * p.localscl / oc.localscl))
-			case OC_ex2_projvar_projanim:
-				v = BytecodeInt(p.anim)
-			case OC_ex2_projvar_animelem:
-				v = BytecodeInt(p.ani.current + 1)
-			case OC_ex2_projvar_supermovetime:
-				v = BytecodeInt(p.supermovetime)
-			case OC_ex2_projvar_pausemovetime:
-				v = BytecodeInt(p.pausemovetime)
-			case OC_ex2_projvar_projid:
-				v = BytecodeInt(int32(p.id))
-			case OC_ex2_projvar_teamside:
-				v = BytecodeInt(int32(p.hitdef.teamside))
-			case OC_ex2_projvar_guardflag:
-				v = BytecodeBool(p.hitdef.guardflag&fl != 0)
-			case OC_ex2_projvar_hitflag:
-				v = BytecodeBool(p.hitdef.hitflag&fl != 0)
-			case OC_ex2_projvar_facing:
-				v = BytecodeFloat(p.facing)
-			case OC_ex2_projvar_drawpal_group:
-				v = BytecodeInt(c.projDrawPal(p)[0])
-			case OC_ex2_projvar_drawpal_index:
-				v = BytecodeInt(c.projDrawPal(p)[1])
 			}
 			break
 		}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1113,8 +1113,6 @@ func (c *Compiler) oneArg(out *BytecodeExp, in *string,
 
 // Read with two optional arguments
 // Currently only for IsHelper
-// Read with two optional arguments
-// Currently only for IsHelper
 func (c *Compiler) twoOptArg(out *BytecodeExp, in *string,
 	rd, appendVal bool, defval ...BytecodeValue) (BytecodeValue, BytecodeValue, error) {
 

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2251,63 +2251,6 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		vname := c.token
 
 		switch vname {
-		case "anim":
-			opc = OC_ex2_explodvar_anim
-		case "animelem":
-			opc = OC_ex2_explodvar_animelem
-		case "drawpal":
-			c.token = c.tokenizer(in)
-
-			switch c.token {
-			case "group":
-				opc = OC_ex2_explodvar_drawpal_group
-			case "index":
-				opc = OC_ex2_explodvar_drawpal_index
-			default:
-				return bvNone(), Error("Invalid data: " + c.token)
-			}
-		case "removetime":
-			opc = OC_ex2_explodvar_removetime
-		case "pausemovetime":
-			opc = OC_ex2_explodvar_pausemovetime
-		case "sprpriority":
-			opc = OC_ex2_explodvar_sprpriority
-		case "layerno":
-			opc = OC_ex2_explodvar_layerno
-		case "id":
-			opc = OC_ex2_explodvar_id
-		case "bindtime":
-			opc = OC_ex2_explodvar_bindtime
-		case "time":
-			opc = OC_ex2_explodvar_time
-		case "facing":
-			opc = OC_ex2_explodvar_facing
-		case "pos":
-			c.token = c.tokenizer(in)
-
-			switch c.token {
-			case "x":
-				opc = OC_ex2_explodvar_pos_x
-			case "y":
-				opc = OC_ex2_explodvar_pos_y
-			case "z":
-				opc = OC_ex2_explodvar_pos_z
-			default:
-				return bvNone(), Error(fmt.Sprint("Invalid ExplodVar pos argument: %s", c.token))
-			}
-		case "vel":
-			c.token = c.tokenizer(in)
-
-			switch c.token {
-			case "x":
-				opc = OC_ex2_explodvar_vel_x
-			case "y":
-				opc = OC_ex2_explodvar_vel_y
-			case "z":
-				opc = OC_ex2_explodvar_vel_z
-			default:
-				return bvNone(), Error(fmt.Sprint("Invalid ExplodVar vel argument: %s", c.token))
-			}
 		case "accel":
 			c.token = c.tokenizer(in)
 
@@ -2321,6 +2264,38 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			default:
 				return bvNone(), Error(fmt.Sprint("Invalid ExplodVar accel argument: %s", c.token))
 			}
+		case "angle":
+			c.token = c.tokenizer(in)
+
+			switch c.token {
+			case "x":
+				opc = OC_ex2_explodvar_angle_x
+			case "y":
+				opc = OC_ex2_explodvar_angle_y
+			case ")":
+				opc = OC_ex2_explodvar_angle
+			default:
+				return bvNone(), Error(fmt.Sprint("Invalid ExplodVar angle argument: %s", c.token))
+			}
+		case "anim":
+			opc = OC_ex2_explodvar_anim
+		case "animelem":
+			opc = OC_ex2_explodvar_animelem
+		case "bindtime":
+			opc = OC_ex2_explodvar_bindtime
+		case "drawpal":
+			c.token = c.tokenizer(in)
+
+			switch c.token {
+			case "group":
+				opc = OC_ex2_explodvar_drawpal_group
+			case "index":
+				opc = OC_ex2_explodvar_drawpal_index
+			default:
+				return bvNone(), Error("Invalid data: " + c.token)
+			}
+		case "facing":
+			opc = OC_ex2_explodvar_facing
 		case "friction":
 			c.token = c.tokenizer(in)
 
@@ -2334,6 +2309,27 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			default:
 				return bvNone(), Error(fmt.Sprint("Invalid ExplodVar friction argument: %s", c.token))
 			}
+		case "id":
+			opc = OC_ex2_explodvar_id
+		case "layerno":
+			opc = OC_ex2_explodvar_layerno
+		case "pausemovetime":
+			opc = OC_ex2_explodvar_pausemovetime
+		case "pos":
+			c.token = c.tokenizer(in)
+
+			switch c.token {
+			case "x":
+				opc = OC_ex2_explodvar_pos_x
+			case "y":
+				opc = OC_ex2_explodvar_pos_y
+			case "z":
+				opc = OC_ex2_explodvar_pos_z
+			default:
+				return bvNone(), Error(fmt.Sprint("Invalid ExplodVar pos argument: %s", c.token))
+			}
+		case "removetime":
+			opc = OC_ex2_explodvar_removetime
 		case "scale":
 			c.token = c.tokenizer(in)
 
@@ -2345,18 +2341,22 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			default:
 				return bvNone(), Error(fmt.Sprint("Invalid ExplodVar scale argument: %s", c.token))
 			}
-		case "angle":
+		case "sprpriority":
+			opc = OC_ex2_explodvar_sprpriority
+		case "time":
+			opc = OC_ex2_explodvar_time
+		case "vel":
 			c.token = c.tokenizer(in)
 
 			switch c.token {
 			case "x":
-				opc = OC_ex2_explodvar_angle_x
+				opc = OC_ex2_explodvar_vel_x
 			case "y":
-				opc = OC_ex2_explodvar_angle_y
-			case ")":
-				opc = OC_ex2_explodvar_angle
+				opc = OC_ex2_explodvar_vel_y
+			case "z":
+				opc = OC_ex2_explodvar_vel_z
 			default:
-				return bvNone(), Error(fmt.Sprint("Invalid ExplodVar angle argument: %s", c.token))
+				return bvNone(), Error(fmt.Sprint("Invalid ExplodVar vel argument: %s", c.token))
 			}
 		case "xshear":
 			opc = OC_ex2_explodvar_xshear
@@ -3048,10 +3048,115 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		isFlag := false
 
 		switch vname {
+		case "accel":
+			c.token = c.tokenizer(in)
+
+			switch c.token {
+			case "x":
+				opc = OC_ex2_projvar_accel_x
+			case "y":
+				opc = OC_ex2_projvar_accel_y
+			case "z":
+				opc = OC_ex2_projvar_accel_z
+			default:
+				return bvNone(), Error(fmt.Sprint("Invalid ProjVar accel argument: %s", c.token))
+			}
+		case "angle":
+			opc = OC_ex2_projvar_projangle
+		case "anim":
+			opc = OC_ex2_projvar_projanim
+		case "animelem":
+			opc = OC_ex2_projvar_animelem
+		case "drawpal":
+			c.token = c.tokenizer(in)
+
+			switch c.token {
+			case "group":
+				opc = OC_ex2_projvar_drawpal_group
+			case "index":
+				opc = OC_ex2_projvar_drawpal_index
+			default:
+				return bvNone(), Error("Invalid data: " + c.token)
+			}
+		case "facing":
+			opc = OC_ex2_projvar_facing
+		case "guardflag":
+			opc = OC_ex2_projvar_guardflag
+			isFlag = true
+		case "highbound":
+			opc = OC_ex2_projvar_highbound
+		case "hitflag":
+			opc = OC_ex2_projvar_hitflag
+			isFlag = true
+		case "lowbound":
+			opc = OC_ex2_projvar_lowbound
+		case "pausemovetime":
+			opc = OC_ex2_projvar_pausemovetime
+		case "pos":
+			c.token = c.tokenizer(in)
+
+			switch c.token {
+			case "x":
+				opc = OC_ex2_projvar_pos_x
+			case "y":
+				opc = OC_ex2_projvar_pos_y
+			case "z":
+				opc = OC_ex2_projvar_pos_z
+			default:
+				return bvNone(), Error(fmt.Sprint("Invalid ProjVar angle argument: %s", c.token))
+			}
+		case "projcancelanim":
+			opc = OC_ex2_projvar_projcancelanim
+		case "projedgebound":
+			opc = OC_ex2_projvar_projedgebound
+		case "projhitanim":
+			opc = OC_ex2_projvar_projhitanim
+		case "projhits":
+			opc = OC_ex2_projvar_projhits
+		case "projhitsmax":
+			opc = OC_ex2_projvar_projhitsmax
+		case "projid":
+			opc = OC_ex2_projvar_projid
+		case "projlayerno":
+			opc = OC_ex2_projvar_projlayerno
+		case "projmisstime":
+			opc = OC_ex2_projvar_projmisstime
+		case "projpriority":
+			opc = OC_ex2_projvar_projpriority
+		case "projremanim":
+			opc = OC_ex2_projvar_projremanim
 		case "projremove":
 			opc = OC_ex2_projvar_projremove
 		case "projremovetime":
 			opc = OC_ex2_projvar_projremovetime
+		case "projsprpriority":
+			opc = OC_ex2_projvar_projsprpriority
+		case "projstagebound":
+			opc = OC_ex2_projvar_projstagebound
+		case "remvelocity":
+			c.token = c.tokenizer(in)
+
+			switch c.token {
+			case "x":
+				opc = OC_ex2_projvar_remvelocity_x
+			case "y":
+				opc = OC_ex2_projvar_remvelocity_y
+			case "z":
+				opc = OC_ex2_projvar_remvelocity_z
+			default:
+				return bvNone(), Error(fmt.Sprint("Invalid ProjVar remvelocity argument: %s", c.token))
+			}
+		case "scale":
+			c.token = c.tokenizer(in)
+
+			switch c.token {
+			case "x":
+				opc = OC_ex2_projvar_projscale_x
+			case "y":
+				opc = OC_ex2_projvar_projscale_y
+			default:
+				return bvNone(), Error(fmt.Sprint("Invalid ProjVar scale argument: %s", c.token))
+			}
 		case "shadow":
 			c.token = c.tokenizer(in)
 
@@ -3065,22 +3170,12 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			default:
 				return bvNone(), Error(fmt.Sprint("Invalid ProjVar shadow argument: %s", c.token))
 			}
-		case "projmisstime":
-			opc = OC_ex2_projvar_projmisstime
-		case "projhits":
-			opc = OC_ex2_projvar_projhits
-		case "projhitsmax":
-			opc = OC_ex2_projvar_projhitsmax
-		case "projlayerno":
-			opc = OC_ex2_projvar_projlayerno
-		case "projpriority":
-			opc = OC_ex2_projvar_projpriority
-		case "projhitanim":
-			opc = OC_ex2_projvar_projhitanim
-		case "projremanim":
-			opc = OC_ex2_projvar_projremanim
-		case "projcancelanim":
-			opc = OC_ex2_projvar_projcancelanim
+		case "supermovetime":
+			opc = OC_ex2_projvar_supermovetime
+		case "teamside":
+			opc = OC_ex2_projvar_teamside
+		case "time":
+			opc = OC_ex2_projvar_time
 		case "vel":
 			c.token = c.tokenizer(in)
 
@@ -3107,101 +3202,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			default:
 				return bvNone(), Error(fmt.Sprint("Invalid ProjVar velmul argument: %s", c.token))
 			}
-		case "remvelocity":
-			c.token = c.tokenizer(in)
-
-			switch c.token {
-			case "x":
-				opc = OC_ex2_projvar_remvelocity_x
-			case "y":
-				opc = OC_ex2_projvar_remvelocity_y
-			case "z":
-				opc = OC_ex2_projvar_remvelocity_z
-			default:
-				return bvNone(), Error(fmt.Sprint("Invalid ProjVar remvelocity argument: %s", c.token))
-			}
-		case "accel":
-			c.token = c.tokenizer(in)
-
-			switch c.token {
-			case "x":
-				opc = OC_ex2_projvar_accel_x
-			case "y":
-				opc = OC_ex2_projvar_accel_y
-			case "z":
-				opc = OC_ex2_projvar_accel_z
-			default:
-				return bvNone(), Error(fmt.Sprint("Invalid ProjVar accel argument: %s", c.token))
-			}
-		case "scale":
-			c.token = c.tokenizer(in)
-
-			switch c.token {
-			case "x":
-				opc = OC_ex2_projvar_projscale_x
-			case "y":
-				opc = OC_ex2_projvar_projscale_y
-			default:
-				return bvNone(), Error(fmt.Sprint("Invalid ProjVar scale argument: %s", c.token))
-			}
-		case "angle":
-			opc = OC_ex2_projvar_projangle
 		case "xshear":
 			opc = OC_ex2_projvar_projxshear
-		case "pos":
-			c.token = c.tokenizer(in)
-
-			switch c.token {
-			case "x":
-				opc = OC_ex2_projvar_pos_x
-			case "y":
-				opc = OC_ex2_projvar_pos_y
-			case "z":
-				opc = OC_ex2_projvar_pos_z
-			default:
-				return bvNone(), Error(fmt.Sprint("Invalid ProjVar angle argument: %s", c.token))
-			}
-		case "projsprpriority":
-			opc = OC_ex2_projvar_projsprpriority
-		case "projstagebound":
-			opc = OC_ex2_projvar_projstagebound
-		case "projedgebound":
-			opc = OC_ex2_projvar_projedgebound
-		case "lowbound":
-			opc = OC_ex2_projvar_lowbound
-		case "highbound":
-			opc = OC_ex2_projvar_highbound
-		case "anim":
-			opc = OC_ex2_projvar_projanim
-		case "animelem":
-			opc = OC_ex2_projvar_animelem
-		case "drawpal":
-			c.token = c.tokenizer(in)
-
-			switch c.token {
-			case "group":
-				opc = OC_ex2_projvar_drawpal_group
-			case "index":
-				opc = OC_ex2_projvar_drawpal_index
-			default:
-				return bvNone(), Error("Invalid data: " + c.token)
-			}
-		case "pausemovetime":
-			opc = OC_ex2_projvar_pausemovetime
-		case "projid":
-			opc = OC_ex2_projvar_projid
-		case "supermovetime":
-			opc = OC_ex2_projvar_supermovetime
-		case "teamside":
-			opc = OC_ex2_projvar_teamside
-		case "guardflag":
-			opc = OC_ex2_projvar_guardflag
-			isFlag = true
-		case "hitflag":
-			opc = OC_ex2_projvar_hitflag
-			isFlag = true
-		case "facing":
-			opc = OC_ex2_projvar_facing
 		default:
 			return bvNone(), Error(fmt.Sprint("Invalid ProjVar argument: %s", vname))
 		}

--- a/src/script.go
+++ b/src/script.go
@@ -3656,64 +3656,66 @@ func triggerFunctions(l *lua.LState) {
 		for i, e := range sys.debugWC.getExplods(id) {
 			if i == idx {
 				switch strings.ToLower(vname) {
-				case "anim":
-					ln = lua.LNumber(e.animNo)
-				case "animelem":
-					ln = lua.LNumber(e.anim.current + 1)
-				case "pos x":
-					ln = lua.LNumber(e.pos[0] + e.offset[0] + e.relativePos[0] + e.interpolate_pos[0])
-				case "pos y":
-					ln = lua.LNumber(e.pos[1] + e.offset[1] + e.relativePos[1] + e.interpolate_pos[1])
-				case "pos z":
-					ln = lua.LNumber(e.pos[2] + e.offset[2] + e.relativePos[2] + e.interpolate_pos[2])
-				case "vel x":
-					ln = lua.LNumber(e.velocity[0])
-				case "vel y":
-					ln = lua.LNumber(e.velocity[1])
-				case "vel z":
-					ln = lua.LNumber(e.velocity[2])
 				case "accel x":
 					ln = lua.LNumber(e.accel[0])
 				case "accel y":
 					ln = lua.LNumber(e.accel[1])
 				case "accel z":
 					ln = lua.LNumber(e.accel[2])
-				case "friction x":
-					ln = lua.LNumber(e.friction[0])
-				case "friction y":
-					ln = lua.LNumber(e.friction[1])
-				case "friction z":
-					ln = lua.LNumber(e.friction[2])
-				case "scale x":
-					ln = lua.LNumber(e.scale[0] * e.interpolate_scale[0])
-				case "scale y":
-					ln = lua.LNumber(e.scale[1] * e.interpolate_scale[1])
+				case "anim":
+					ln = lua.LNumber(e.animNo)
 				case "angle":
 					ln = lua.LNumber(e.anglerot[0] + e.interpolate_angle[0])
 				case "angle x":
 					ln = lua.LNumber(e.anglerot[1] + e.interpolate_angle[1])
 				case "angle y":
 					ln = lua.LNumber(e.anglerot[2] + e.interpolate_angle[2])
-				case "xshear":
-					ln = lua.LNumber(e.xshear)
-				case "removetime":
-					ln = lua.LNumber(e.removetime)
-				case "pausemovetime":
-					ln = lua.LNumber(e.pausemovetime)
-				case "sprpriority":
-					ln = lua.LNumber(e.sprpriority)
-				case "layerno":
-					ln = lua.LNumber(e.layerno)
-				case "id":
-					ln = lua.LNumber(e.id)
+				case "animelem":
+					ln = lua.LNumber(e.anim.current + 1)
 				case "bindtime":
 					ln = lua.LNumber(e.bindtime)
-				case "facing":
-					ln = lua.LNumber(e.facing)
 				case "drawpal group":
 					ln = lua.LNumber(sys.debugWC.explodDrawPal(e)[0])
 				case "drawpal index":
 					ln = lua.LNumber(sys.debugWC.explodDrawPal(e)[1])
+				case "facing":
+					ln = lua.LNumber(e.facing)
+				case "friction x":
+					ln = lua.LNumber(e.friction[0])
+				case "friction y":
+					ln = lua.LNumber(e.friction[1])
+				case "friction z":
+					ln = lua.LNumber(e.friction[2])
+				case "id":
+					ln = lua.LNumber(e.id)
+				case "layerno":
+					ln = lua.LNumber(e.layerno)
+				case "pausemovetime":
+					ln = lua.LNumber(e.pausemovetime)
+				case "pos x":
+					ln = lua.LNumber(e.pos[0] + e.offset[0] + e.relativePos[0] + e.interpolate_pos[0])
+				case "pos y":
+					ln = lua.LNumber(e.pos[1] + e.offset[1] + e.relativePos[1] + e.interpolate_pos[1])
+				case "pos z":
+					ln = lua.LNumber(e.pos[2] + e.offset[2] + e.relativePos[2] + e.interpolate_pos[2])
+				case "removetime":
+					ln = lua.LNumber(e.removetime)
+				case "scale x":
+					ln = lua.LNumber(e.scale[0] * e.interpolate_scale[0])
+				case "scale y":
+					ln = lua.LNumber(e.scale[1] * e.interpolate_scale[1])
+				case "sprpriority":
+					ln = lua.LNumber(e.sprpriority)
+				case "time":
+					ln = lua.LNumber(e.time)
+				case "vel x":
+					ln = lua.LNumber(e.velocity[0])
+				case "vel y":
+					ln = lua.LNumber(e.velocity[1])
+				case "vel z":
+					ln = lua.LNumber(e.velocity[2])
+				case "xshear":
+					ln = lua.LNumber(e.xshear)
 				default:
 					l.RaiseError("\nInvalid argument: %v\n", vname)
 				}
@@ -4612,30 +4614,86 @@ func triggerFunctions(l *lua.LState) {
 		for i, p := range sys.debugWC.getProjs(id) {
 			if i == idx {
 				switch strings.ToLower(vname) {
-				case "projremove":
-					lv = lua.LBool(p.remove)
-				case "projremovetime":
-					lv = lua.LNumber(p.removetime)
-				case "shadow r":
-					lv = lua.LNumber(p.shadow[0])
-				case "shadow g":
-					lv = lua.LNumber(p.shadow[0])
-				case "shadow b":
-					lv = lua.LNumber(p.shadow[0])
-				case "projmisstime":
-					lv = lua.LNumber(p.curmisstime)
+				case "accel x":
+					lv = lua.LNumber(p.accel[0])
+				case "accel y":
+					lv = lua.LNumber(p.accel[1])
+				case "accel z":
+					lv = lua.LNumber(p.accel[2])
+				case "anim":
+					lv = lua.LNumber(p.anim)
+				case "animelem":
+					lv = lua.LNumber(p.ani.current + 1)
+				case "angle":
+					lv = lua.LNumber(p.angle)
+				case "drawpal group":
+					lv = lua.LNumber(sys.debugWC.projDrawPal(p)[0])
+				case "drawpal index":
+					lv = lua.LNumber(sys.debugWC.projDrawPal(p)[1])
+				case "facing":
+					lv = lua.LNumber(p.facing)
+				case "highbound":
+					lv = lua.LNumber(p.heightbound[1])
+				case "lowbound":
+					lv = lua.LNumber(p.heightbound[0])
+				case "pausemovetime":
+					lv = lua.LNumber(p.pausemovetime)
+				case "pos x":
+					lv = lua.LNumber(p.pos[0])
+				case "pos y":
+					lv = lua.LNumber(p.pos[1])
+				case "pos z":
+					lv = lua.LNumber(p.pos[2])
+				case "projcancelanim":
+					lv = lua.LNumber(p.cancelanim)
+				case "projedgebound":
+					lv = lua.LNumber(p.edgebound)
+				case "projhitanim":
+					lv = lua.LNumber(p.hitanim)
 				case "projhits":
 					lv = lua.LNumber(p.hits)
 				case "projhitsmax":
 					lv = lua.LNumber(p.totalhits)
+				case "projid":
+					lv = lua.LNumber(p.id)
+				case "projlayerno":
+					lv = lua.LNumber(p.layerno)
+				case "projmisstime":
+					lv = lua.LNumber(p.curmisstime)
 				case "projpriority":
 					lv = lua.LNumber(p.priority)
-				case "projhitanim":
-					lv = lua.LNumber(p.hitanim)
+				case "projremove":
+					lv = lua.LBool(p.remove)
 				case "projremanim":
 					lv = lua.LNumber(p.remanim)
-				case "projcancelanim":
-					lv = lua.LNumber(p.cancelanim)
+				case "projremovetime":
+					lv = lua.LNumber(p.removetime)
+				case "projsprpriority":
+					lv = lua.LNumber(p.sprpriority)
+				case "projstagebound":
+					lv = lua.LNumber(p.stagebound)
+				case "remvelocity x":
+					lv = lua.LNumber(p.remvelocity[0])
+				case "remvelocity y":
+					lv = lua.LNumber(p.remvelocity[1])
+				case "remvelocity z":
+					lv = lua.LNumber(p.remvelocity[2])
+				case "scale x":
+					lv = lua.LNumber(p.scale[0])
+				case "scale y":
+					lv = lua.LNumber(p.scale[1])
+				case "shadow b":
+					lv = lua.LNumber(p.shadow[0])
+				case "shadow g":
+					lv = lua.LNumber(p.shadow[0])
+				case "shadow r":
+					lv = lua.LNumber(p.shadow[0])
+				case "supermovetime":
+					lv = lua.LNumber(p.supermovetime)
+				case "teamside":
+					lv = lua.LNumber(p.hitdef.teamside)
+				case "time":
+					lv = lua.LNumber(p.time)
 				case "vel x":
 					lv = lua.LNumber(p.velocity[0])
 				case "vel y":
@@ -4648,66 +4706,12 @@ func triggerFunctions(l *lua.LState) {
 					lv = lua.LNumber(p.velmul[1])
 				case "velmul z":
 					lv = lua.LNumber(p.velmul[2])
-				case "remvelocity x":
-					lv = lua.LNumber(p.remvelocity[0])
-				case "remvelocity y":
-					lv = lua.LNumber(p.remvelocity[1])
-				case "remvelocity z":
-					lv = lua.LNumber(p.remvelocity[2])
-				case "accel x":
-					lv = lua.LNumber(p.accel[0])
-				case "accel y":
-					lv = lua.LNumber(p.accel[1])
-				case "accel z":
-					lv = lua.LNumber(p.accel[2])
-				case "scale x":
-					lv = lua.LNumber(p.scale[0])
-				case "scale y":
-					lv = lua.LNumber(p.scale[1])
-				case "angle":
-					lv = lua.LNumber(p.angle)
 				case "xshear":
 					lv = lua.LNumber(p.xshear)
-				case "pos x":
-					lv = lua.LNumber(p.pos[0])
-				case "pos y":
-					lv = lua.LNumber(p.pos[1])
-				case "pos z":
-					lv = lua.LNumber(p.pos[2])
-				case "projsprpriority":
-					lv = lua.LNumber(p.sprpriority)
-				case "projlayerno":
-					lv = lua.LNumber(p.layerno)
-				case "projstagebound":
-					lv = lua.LNumber(p.stagebound)
-				case "projedgebound":
-					lv = lua.LNumber(p.edgebound)
-				case "lowbound":
-					lv = lua.LNumber(p.heightbound[0])
-				case "highbound":
-					lv = lua.LNumber(p.heightbound[1])
-				case "anim":
-					lv = lua.LNumber(p.anim)
-				case "animelem":
-					lv = lua.LNumber(p.ani.current + 1)
-				case "supermovetime":
-					lv = lua.LNumber(p.supermovetime)
-				case "pausemovetime":
-					lv = lua.LNumber(p.pausemovetime)
-				case "projid":
-					lv = lua.LNumber(p.id)
-				case "teamside":
-					lv = lua.LNumber(p.hitdef.teamside)
 				//case "guardflag":
 				//	lv = lua.LBool(p.hitdef.guardflag&fl != 0)
 				//case "hitflag":
 				//	lv = lua.LNumber(p.hitdef.hitflag&fl != 0)
-				case "facing":
-					lv = lua.LNumber(p.facing)
-				case "drawpal group":
-					lv = lua.LNumber(sys.debugWC.projDrawPal(p)[0])
-				case "drawpal index":
-					lv = lua.LNumber(sys.debugWC.projDrawPal(p)[1])
 				default:
 					l.RaiseError("\nInvalid argument: %v\n", vname)
 				}

--- a/src/script.go
+++ b/src/script.go
@@ -5764,7 +5764,7 @@ func triggerFunctions(l *lua.LState) {
 	})
 	luaRegister(l, "scaleX", func(*lua.LState) int {
 		if sys.debugWC.csf(CSF_angledraw) {
-			l.Push(lua.LNumber(sys.debugWC.scale[0]))
+			l.Push(lua.LNumber(sys.debugWC.angleDrawScale[0]))
 		} else {
 			l.Push(lua.LNumber(1))
 		}
@@ -5772,7 +5772,7 @@ func triggerFunctions(l *lua.LState) {
 	})
 	luaRegister(l, "scaleY", func(*lua.LState) int {
 		if sys.debugWC.csf(CSF_angledraw) {
-			l.Push(lua.LNumber(sys.debugWC.scale[1]))
+			l.Push(lua.LNumber(sys.debugWC.angleDrawScale[1]))
 		} else {
 			l.Push(lua.LNumber(1))
 		}


### PR DESCRIPTION
Feat:
- ProjVar can now also return how many frames a projectile has existed for

Fix:
- Native module vars are back to initializing at RoundState = 0, as RoundTime = 0 is not supported by some characters
- Adjusted Tag auto turning code so it activates faster
- Standardized Tag jumping in velocity so that chars with low acceleration don't fly away
- PosFreeze no longer prevents physics from updating velocity

Refactor:
- If a constant's name is found but has nothing assigned, it will default to 0 (like Mugen) and print an error
- Transparency no longer jumps to invisible when destination is 255 and source is under 5. This was mostly noticeable with interpolated blending
- Standby flag is back to being ignored by EnemyNear, but the rules are clearer: all "enemy" triggers ignore it
- Compared to previous stable version, during Tag NumEnemy returns the number of active enemies rather than being forced to 1

Issues:
- Fixes #1755
- Fixes #2302
- Fixes #2422
- Fixes #2424
- Fixes #2428