### PR TITLE
feat: new lifebar and text sctrl features; fix

### DIFF
--- a/src/anim.go
+++ b/src/anim.go
@@ -1011,7 +1011,7 @@ func (dl DrawList) draw(cameraX, cameraY, cameraScl float32) {
 
 		// Xshear offset correction
 		xshear := -s.xshear
-		xsoffset := xshear * (float32(s.anim.spr.Size[1]) * s.scl[1] * cs)
+		xsoffset := xshear * (float32(s.anim.spr.Offset[1]) * s.scl[1] * cs)
 
 		drawwindow := &sys.scrrect
 		// Sprite window, which can be from the Char, Explod, or Projectile
@@ -1150,7 +1150,7 @@ func (sl ShadowList) draw(x, y, scl float32) {
 		offsetY := s.shadowOffset[1] + sys.stage.sdw.offset[1]
 
 		// Rotation offset. Only shadow scale sign
-		xrotoff := xshear * SignF(yscale) * (float32(s.anim.spr.Size[1]) * s.scl[1])
+		xrotoff := xshear * SignF(yscale) * (float32(s.anim.spr.Offset[1]) * s.scl[1])
 
 		if s.rot.angle != 0 {
 			offsetX -= xrotoff
@@ -1269,7 +1269,7 @@ func (sl ShadowList) drawReflection(x, y, scl float32) {
 		offsetY := s.reflectOffset[1] + sys.stage.reflection.offset[1]
 
 		// Rotation offset
-		xrotoff := xshear * yscale * (float32(s.anim.spr.Size[1]) * s.scl[1] * scl)
+		xrotoff := xshear * yscale * (float32(s.anim.spr.Offset[1]) * s.scl[1] * scl)
 
 		if s.rot.angle != 0 {
 			xshear = -xshear

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -12099,7 +12099,7 @@ func (sc text) Run(c *Char, _ []int32) bool {
 				return false
 			}
 		default:
-			if applyPalFXToText(ts, paramID, exp, c) {
+			if applyTextPalFX(ts, paramID, exp, c) {
 				break
 			}
 		}
@@ -12119,10 +12119,10 @@ func (sc text) Run(c *Char, _ []int32) bool {
 	return false
 }
 
-func applyPalFXToText(ts *TextSprite, paramID byte, exp []BytecodeExp, c *Char) bool {
+func applyTextPalFX(ts *TextSprite, paramID byte, exp []BytecodeExp, c *Char) bool {
 	switch paramID {
 		case palFX_time:
-			ts.palfx.time = exp[0].evalI(c)
+			ts.palfx.time = exp[0].evalI(c) * 2
 		case palFX_color:
 			ts.palfx.color = exp[0].evalF(c) / 256
 		case palFX_hue:
@@ -12139,10 +12139,10 @@ func applyPalFXToText(ts *TextSprite, paramID byte, exp []BytecodeExp, c *Char) 
 			var side int32 = 1
 			if len(exp) > 3 {
 				if exp[3].evalI(c) < 0 {
-					ts.palfx.cycletime[0] = -exp[3].evalI(c)
+					ts.palfx.cycletime[0] = -exp[3].evalI(c) * 2
 					side = -1
 				} else {
-					ts.palfx.cycletime[0] = exp[3].evalI(c)
+					ts.palfx.cycletime[0] = exp[3].evalI(c) * 2
 				}
 			}
 			ts.palfx.sinadd[0] = exp[0].evalI(c) * side
@@ -12152,10 +12152,10 @@ func applyPalFXToText(ts *TextSprite, paramID byte, exp []BytecodeExp, c *Char) 
 			var side int32 = 1
 			if len(exp) > 3 {
 				if exp[3].evalI(c) < 0 {
-					ts.palfx.cycletime[1] = -exp[3].evalI(c)
+					ts.palfx.cycletime[1] = -exp[3].evalI(c) * 2
 					side = -1
 				} else {
-					ts.palfx.cycletime[1] = exp[3].evalI(c)
+					ts.palfx.cycletime[1] = exp[3].evalI(c) * 2
 				}
 			}
 			ts.palfx.sinmul[0] = exp[0].evalI(c) * side
@@ -12165,10 +12165,10 @@ func applyPalFXToText(ts *TextSprite, paramID byte, exp []BytecodeExp, c *Char) 
 			var side int32 = 1
 			if len(exp) > 1 {
 				if exp[1].evalI(c) < 0 {
-					ts.palfx.cycletime[2] = -exp[1].evalI(c)
+					ts.palfx.cycletime[2] = -exp[1].evalI(c) * 2
 					side = -1
 				} else {
-					ts.palfx.cycletime[2] = exp[1].evalI(c)
+					ts.palfx.cycletime[2] = exp[1].evalI(c) * 2
 				}
 			}
 			ts.palfx.sincolor = exp[0].evalI(c) * side
@@ -12176,10 +12176,10 @@ func applyPalFXToText(ts *TextSprite, paramID byte, exp []BytecodeExp, c *Char) 
 			var side int32 = 1
 			if len(exp) > 1 {
 				if exp[1].evalI(c) < 0 {
-					ts.palfx.cycletime[3] = -exp[1].evalI(c)
+					ts.palfx.cycletime[3] = -exp[1].evalI(c) * 2
 					side = -1
 				} else {
-					ts.palfx.cycletime[3] = exp[1].evalI(c)
+					ts.palfx.cycletime[3] = exp[1].evalI(c) * 2
 				}
 			}
 			ts.palfx.sinhue = exp[0].evalI(c) * side

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -11994,6 +11994,7 @@ const (
 	text_accel
 	text_scale
 	text_color
+	text_xshear
 	text_id
 	text_redirectid
 	text_last = iota + palFX_last + 1 - 1
@@ -12089,6 +12090,8 @@ func (sc text) Run(c *Char, _ []int32) bool {
 				}
 			}
 			ts.SetColor(r, g, b)
+		case text_xshear:
+			ts.xshear = exp[0].evalF(c)
 		case text_id:
 			ts.id = exp[0].evalI(c)
 		case text_redirectid:

--- a/src/char.go
+++ b/src/char.go
@@ -69,6 +69,7 @@ const (
 	ASF_noailevel
 	ASF_noairjump
 	ASF_nobrake
+	ASF_nocombodisplay
 	ASF_nocrouch
 	ASF_nodizzypointsdamage
 	ASF_nofacedisplay
@@ -88,6 +89,7 @@ const (
 	ASF_nojump
 	ASF_nokofall // In Mugen this seems hardcoded into Training mode
 	ASF_nokovelocity
+	ASF_nolifebaraction
 	ASF_nolifebardisplay
 	ASF_nomakedust
 	ASF_nonamedisplay

--- a/src/common.go
+++ b/src/common.go
@@ -900,7 +900,7 @@ func (l *Layout) DrawText(x, y, scl float32, ln int16,
 		}
 		f.Print(text, (x+l.offset[0])*scl, (y+l.offset[1])*scl,
 			l.scale[0]*sys.lifebar.fnt_scale*float32(l.facing)*scl,
-			l.scale[1]*sys.lifebar.fnt_scale*float32(l.vfacing)*scl, b, a,
+			l.scale[1]*sys.lifebar.fnt_scale*float32(l.vfacing)*scl, -l.xshear, b, a,
 			&l.window, palfx, frgba)
 	}
 }

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -4417,6 +4417,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		// Ikemen char flags
 		case "nobrake":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nobrake))
+		case "nocombodisplay":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nocombodisplay))
 		case "nocrouch":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nocrouch))
 		case "nostand":
@@ -4439,6 +4441,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noturntarget))
 		case "noinput":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noinput))
+		case "nolifebaraction":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nolifebaraction))
 		case "nolifebardisplay":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nolifebardisplay))
 		case "nopowerbardisplay":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -5227,6 +5227,9 @@ func (c *Compiler) text(is IniSection, sc *StateControllerBase, _ int8) (StateCo
 			text_scale, VT_Float, 2, false); err != nil {
 			return err
 		}
+		if err := c.palFXSub(is, sc, "palfx."); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "color",
 			text_color, VT_Int, 3, false); err != nil {
 			return err

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -168,6 +168,8 @@ func (c *Compiler) assertSpecial(is IniSection, sc *StateControllerBase, _ int8)
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_noairjump)))
 			case "nobrake":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nobrake)))
+			case "nocombodisplay":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nocombodisplay)))
 			case "nocrouch":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nocrouch)))
 			case "nodizzypointsdamage":
@@ -206,6 +208,8 @@ func (c *Compiler) assertSpecial(is IniSection, sc *StateControllerBase, _ int8)
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nokofall)))
 			case "nokovelocity":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nokovelocity)))
+			case "nolifebaraction":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nolifebaraction)))
 			case "nolifebardisplay":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nolifebardisplay)))
 			case "nomakedust":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -5234,6 +5234,10 @@ func (c *Compiler) text(is IniSection, sc *StateControllerBase, _ int8) (StateCo
 			text_color, VT_Int, 3, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "xshear",
+			text_xshear, VT_Float, 1, false); err != nil {
+			return err
+		}
 		return nil
 	})
 	return *ret, err

--- a/src/font.go
+++ b/src/font.go
@@ -467,19 +467,19 @@ func (f *Fnt) drawChar(
 	return float32(spr.Size[0]) * xscl
 }
 
-func (f *Fnt) Print(txt string, x, y, xscl, yscl float32, bank, align int32,
+func (f *Fnt) Print(txt string, x, y, xscl, yscl, rxadd float32, bank, align int32,
 	window *[4]int32, palfx *PalFX, frgba [4]float32) {
 	if !sys.frameSkip {
 		if f.Type == "truetype" {
 			f.DrawTtf(txt, x, y, xscl, yscl, align, true, window, frgba)
 		} else {
-			f.DrawText(txt, x, y, xscl, yscl, bank, align, window, palfx)
+			f.DrawText(txt, x, y, xscl, yscl, rxadd, bank, align, window, palfx)
 		}
 	}
 }
 
 // DrawText prints on screen a specified text with the current font sprites
-func (f *Fnt) DrawText(txt string, x, y, xscl, yscl float32, bank, align int32, window *[4]int32, palfx *PalFX) {
+func (f *Fnt) DrawText(txt string, x, y, xscl, yscl, rxadd float32, bank, align int32, window *[4]int32, palfx *PalFX) {
 
 	if len(txt) == 0 || xscl == 0 || yscl == 0 {
 		return
@@ -529,7 +529,7 @@ func (f *Fnt) DrawText(txt string, x, y, xscl, yscl float32, bank, align int32, 
 		xbs:            xscl * sys.widthScale,
 		ys:             yscl * sys.heightScale,
 		vs:             1,
-		rxadd:          0,
+		rxadd:          rxadd,
 		xas:            1,
 		yas:            1,
 		rot:            Rotation{},
@@ -589,6 +589,7 @@ type TextSprite struct {
 	friction         [2]float32
 	accel            [2]float32
 	forcecolor       bool
+	xshear           float32
 }
 
 func NewTextSprite() *TextSprite {
@@ -610,6 +611,7 @@ func NewTextSprite() *TextSprite {
 		velocity:    [2]float32{0.0, 0.0},
 		friction:    [2]float32{1.0, 1.0},
 		accel:       [2]float32{0.0, 0.0},
+		xshear:      0,
 	}
 	ts.palfx.setColor(255, 255, 255)
 	return ts
@@ -685,7 +687,7 @@ func (ts *TextSprite) Draw() {
 			if ts.fnt.Type == "truetype" {
 				ts.fnt.DrawTtf(line[:charsToShow], ts.x, newY, ts.xscl, ts.yscl, ts.align, true, &ts.window, ts.frgba)
 			} else {
-				ts.fnt.DrawText(line[:charsToShow], ts.x, newY, ts.xscl, ts.yscl, ts.bank, ts.align, &ts.window, ts.palfx)
+				ts.fnt.DrawText(line[:charsToShow], ts.x, newY, ts.xscl, ts.yscl, -ts.xshear, ts.bank, ts.align, &ts.window, ts.palfx)
 			}
 
 			if ts.textDelay > 0 && totalCharsShown >= int(maxChars) {

--- a/src/font.go
+++ b/src/font.go
@@ -588,6 +588,7 @@ type TextSprite struct {
 	velocity         [2]float32
 	friction         [2]float32
 	accel            [2]float32
+	forcecolor       bool
 }
 
 func NewTextSprite() *TextSprite {
@@ -631,6 +632,7 @@ func (ts *TextSprite) SetWindow(x, y, w, h float32) {
 }
 
 func (ts *TextSprite) SetColor(r, g, b int32) {
+	ts.forcecolor = true
 	ts.palfx.setColor(r, g, b)
 	ts.frgba = [...]float32{float32(r) / 255, float32(g) / 255,
 		float32(b) / 255, 1.0}
@@ -658,6 +660,9 @@ func (ts *TextSprite) Draw() {
 				ts.elapsedTicks++
 			}
 			ts.SetTextVel()
+			if ts.palfx != nil && !ts.forcecolor {
+				ts.palfx.step()
+			}
 		}
 
 		maxChars := int32(ts.elapsedTicks / ts.textDelay)

--- a/src/image.go
+++ b/src/image.go
@@ -1201,7 +1201,7 @@ func (s *Sprite) CachePalette(pal []uint32) Texture {
 	return s.PalTex
 }
 
-func (s *Sprite) Draw(x, y, xscale, yscale, angle float32, fx *PalFX, window *[4]int32) {
+func (s *Sprite) Draw(x, y, xscale, yscale, angle, xshear float32, fx *PalFX, window *[4]int32) {
 	x += float32(sys.gameWidth-320)/2 - xscale*float32(s.Offset[0])
 	y += float32(sys.gameHeight-240) - yscale*float32(s.Offset[1])
 	if xscale < 0 {
@@ -1213,7 +1213,7 @@ func (s *Sprite) Draw(x, y, xscale, yscale, angle float32, fx *PalFX, window *[4
 	rp := RenderParams{
 		s.Tex, s.PalTex, s.Size,
 		-x * sys.widthScale, -y * sys.heightScale, notiling,
-		xscale * sys.widthScale, xscale * sys.widthScale, yscale * sys.heightScale, 1, 0, 1, 1,
+		xscale * sys.widthScale, xscale * sys.widthScale, yscale * sys.heightScale, 1, xshear, 1, 1,
 		Rotation{angle, 0, 0}, 0, sys.brightness*255>>8 | 1<<9, 0, fx, window, 0, 0, 0, 0,
 		-xscale * float32(s.Offset[0]), -yscale * float32(s.Offset[1]),
 	}

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -4607,11 +4607,15 @@ func (l *Lifebar) draw(layerno int16) {
 		}
 		// LifeBarCombo
 		for i := range l.co {
-			l.co[i].draw(layerno, l.fnt[:], i)
+			if !sys.chars[i][0].asf(ASF_nocombodisplay) {
+				l.co[i].draw(layerno, l.fnt[:], i)
+			}
 		}
 		// LifeBarAction
 		for i := range l.ac {
-			l.ac[i].draw(layerno, l.fnt[:], i)
+			if !sys.chars[i][0].asf(ASF_nolifebaraction) {
+				l.ac[i].draw(layerno, l.fnt[:], i)
+			}
 		}
 		// LifeBarMode
 		if _, ok := l.mo[sys.gameMode]; ok {

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -1754,6 +1754,7 @@ type LifeBarTime struct {
 	bg             AnimLayout
 	top            AnimLayout
 	framespercount int32
+	activeIdx      int32
 }
 
 func newLifeBarTime() *LifeBarTime {
@@ -1780,7 +1781,7 @@ func readLifeBarTime(is IniSection,
 func (ti *LifeBarTime) step() {
 	ti.bg.Action()
 	ti.top.Action()
-	ti.counter[0].step()
+	ti.counter[ti.activeIdx].step()
 }
 
 func (ti *LifeBarTime) reset() {
@@ -1816,6 +1817,7 @@ func (ti *LifeBarTime) draw(layerno int16, f []*Fnt) {
 				}
 			}
 		}
+		ti.activeIdx = tv
 		ti.counter[tv].lay.DrawText(float32(ti.pos[0])+sys.lifebarOffsetX, float32(ti.pos[1]), sys.lifebarScale, layerno,
 			time, f[ti.counter[tv].font[0]], ti.counter[tv].font[1], ti.counter[tv].font[2], ti.counter[tv].palfx,
 			ti.counter[tv].frgba)

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -1904,7 +1904,6 @@ func (co *LifeBarCombo) step(combo, damage int32, percentage float32, dizzy bool
 	// Update team combo tracker
 	if combo > 0 {
 		combo = co.combo
-		co.tracker = co.combo
 	} else {
 		co.combo = 0
 	}
@@ -1929,10 +1928,14 @@ func (co *LifeBarCombo) step(combo, damage int32, percentage float32, dizzy bool
 	// Update if number of hits or total damage change
 	if combo >= 2 {
 		if co.oldhit != combo || co.olddmg != damage {
+			for i := range co.counter {
+				co.counter[i].resetTxtPfx()
+			}
 			co.curhit = combo
 			co.curdmg = damage
 			co.curpct = percentage
 			co.resttime = co.displaytime
+			co.tracker = co.combo
 			if co.counter_shake && co.oldhit != combo {
 				co.shaketime = co.counter_time
 			}
@@ -1954,9 +1957,6 @@ func (co *LifeBarCombo) step(combo, damage int32, percentage float32, dizzy bool
 		co.counter[cv].step()
 		co.text.step()
 	} else {
-		for i := range co.counter {
-			co.counter[i].resetTxtPfx()
-		}
 		co.text.resetTxtPfx()
 	}
 }

--- a/src/script.go
+++ b/src/script.go
@@ -683,14 +683,14 @@ func systemScriptInit(l *lua.LState) {
 						fspr.Pal = fspr.GetPal(&sys.cgi[pn-1].palettedata.palList)
 						sys.cgi[pn-1].palettedata.palList.SwapPalMap(&pfx.remap)
 						x := (float32(numArg(l, 3)) + sys.lifebarOffsetX) * sys.lifebarScale
-						y := float32(numArg(l, 4)) * sys.lifebarScale
+						y := (float32(numArg(l, 4)) + sys.lifebarOffsetY) * sys.lifebarScale
 						scale := [...]float32{float32(numArg(l, 5)), float32(numArg(l, 6))}
 						facing := int8(numArg(l, 7))
 						fscale := sys.chars[pn-1][0].localscl
 						if sprite.coldepth <= 8 && sprite.PalTex == nil {
 							sprite.CachePalette(sprite.Pal)
 						}
-						sprite.Draw(x, y, scale[0]*float32(facing)*fscale, scale[1]*fscale,
+						sprite.Draw(x, y, scale[0]*float32(facing)*fscale, scale[1]*fscale, 0,
 							0, pfx, window)
 						ok = true
 					}
@@ -2488,6 +2488,10 @@ func systemScriptInit(l *lua.LState) {
 	})
 	luaRegister(l, "setLifebarOffsetX", func(l *lua.LState) int {
 		sys.lifebarOffsetX = float32(numArg(l, 1))
+		return 0
+	})
+	luaRegister(l, "setLifebarOffsetY", func(l *lua.LState) int {
+		sys.lifebarOffsetY = float32(numArg(l, 1))
 		return 0
 	})
 	luaRegister(l, "setLifebarScale", func(l *lua.LState) int {

--- a/src/script.go
+++ b/src/script.go
@@ -5518,6 +5518,8 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_noairjump)))
 		case "nobrake":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_nobrake)))
+		case "nocombodisplay":
+			l.Push(lua.LBool(sys.debugWC.asf(ASF_nocombodisplay)))
 		case "nocrouch":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_nocrouch)))
 		case "nodizzypointsdamage":
@@ -5554,6 +5556,8 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_nokovelocity)))
 		case "nomakedust":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_nomakedust)))
+		case "nolifebaraction":
+			l.Push(lua.LBool(sys.debugWC.asf(ASF_nolifebaraction)))
 		case "nolifebardisplay":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_nolifebardisplay)))
 		case "nopowerbardisplay":

--- a/src/stage.go
+++ b/src/stage.go
@@ -461,7 +461,7 @@ func (bg backGround) draw(pos [2]float32, drawscl, bgscl, stglscl float32,
 	scly *= stglscl * stgscl[1]
 
 	// Xshear offset correction
-	xsoffset := -bg.xshear * SignF(bg.scalestart[1]) * (float32(bg.anim.spr.Size[1]) * scly)
+	xsoffset := -bg.xshear * SignF(bg.scalestart[1]) * (float32(bg.anim.spr.Offset[1]) * scly)
 
 	if bg.angle != 0 {
 		xsoffset /= bg.angle

--- a/src/system.go
+++ b/src/system.go
@@ -257,6 +257,7 @@ type System struct {
 	// Localcoord lifebar
 	lifebarScale         float32
 	lifebarOffsetX       float32
+	lifebarOffsetY       float32
 	lifebarPortraitScale float32
 	lifebarLocalcoord    [2]int32
 

--- a/src/system.go
+++ b/src/system.go
@@ -2010,7 +2010,7 @@ func (s *System) drawDebugText() {
 			}
 			*y += float32(s.debugFont.fnt.Size[1]) * s.debugFont.yscl / s.heightScale
 			s.debugFont.fnt.Print(drawTxt, *x, *y, s.debugFont.xscl/s.widthScale,
-				s.debugFont.yscl/s.heightScale, 0, 1, &s.scrrect,
+				s.debugFont.yscl/s.heightScale, 0, 0, 1, &s.scrrect,
 				s.debugFont.palfx, s.debugFont.frgba)
 		}
 	}
@@ -2087,7 +2087,7 @@ func (s *System) drawDebugText() {
 	for _, t := range s.clsnText {
 		s.debugFont.SetColor(t.r, t.g, t.b)
 		s.debugFont.fnt.Print(t.text, t.x, t.y, s.debugFont.xscl/s.widthScale,
-			s.debugFont.yscl/s.heightScale, 0, 0, &s.scrrect,
+			s.debugFont.yscl/s.heightScale, 0, 0, 0, &s.scrrect,
 			s.debugFont.palfx, s.debugFont.frgba)
 	}
 	//}


### PR DESCRIPTION
Feat:
- New parameters for lifebar, powerbar, guardbar, and stunbar:
  - ``pn.range.y``: defines a vertical range for the bar, allowing it to deplete vertically when used instead of range.x
  - ``pn.scalefill``: allows bars to deplete by scaling the sprite itself instead of cropping it
- All elements and texts in the lifebar now support xshear (note: xshear does not work with TrueType fonts)
- New assertSpecials: ``NoComboDisplay`` and ``NoLifeBarAction``
- Text Sctrl and lifebar texts now support xshear and PalFx (note: PalFx does not work with TrueType fonts)
- Combo and powerbar counters can now use multiple fonts
- Combo texts can now also use multiple fonts
- New toggle ``team<n>.autoalign`` added for the [combo] section. When set to 0, it disables automatic spacing adjustment. Defaults to 1

Fix:
- xshear is now applied based on the sprite’s pivot instead of its height

Refactor:
- Various parts of lifebar.go have been reorganized for better readability