### PR TITLE
feat: envshake dir parameter

### DIFF
--- a/src/anim.go
+++ b/src/anim.go
@@ -1004,8 +1004,9 @@ func (dl DrawList) draw(cameraX, cameraY, cameraScl float32) {
 			pos = [2]float32{s.pos[0], s.pos[1] + float32(sys.gameHeight-240)}
 			cs = 1
 		} else {
-			pos = [2]float32{sys.cam.Offset[0]/cs - (cameraX - s.pos[0]),
-				(sys.cam.GroundLevel()+sys.cam.Offset[1]-sys.envShake.getOffset())/cs -
+			es := sys.envShake.getOffset()
+			pos = [2]float32{(sys.cam.Offset[0]-es[0])/cs - (cameraX - s.pos[0]),
+				(sys.cam.GroundLevel() + (sys.cam.Offset[1]-es[1]))/cs -
 					(cameraY/cs - s.pos[1])}
 		}
 
@@ -1164,6 +1165,7 @@ func (sl ShadowList) draw(x, y, scl float32) {
 		}
 
 		drawwindow := &sys.scrrect
+		es := sys.envShake.getOffset()
 		// TODO: If the char has an active window sctrl, shadows should also be affected, in addition to the stage window
 		if sys.stage.sdw.window != [4]float32{0, 0, 0, 0} || s.shadowWindow != [4]float32{0, 0, 0, 0} {
 			var w [4]float32
@@ -1187,8 +1189,8 @@ func (sl ShadowList) draw(x, y, scl float32) {
 				w[i] *= sys.stage.localscl
 			}
 
-			window[0] = int32((sys.cam.Offset[0] - (x * scl) + w[0]*scl + float32(sys.gameWidth)/2) * sys.widthScale)
-			window[1] = int32((sys.cam.GroundLevel() + sys.cam.Offset[1] - sys.envShake.getOffset() - y + w[1]*SignF(yscale)*scl) * sys.heightScale)
+			window[0] = int32(((sys.cam.Offset[0]-es[0]) - (x * scl) + w[0]*scl + float32(sys.gameWidth)/2) * sys.widthScale)
+			window[1] = int32((sys.cam.GroundLevel() + (sys.cam.Offset[1]-es[1]) - y + w[1]*SignF(yscale)*scl) * sys.heightScale)
 			window[2] = int32(scl * (w[2] - w[0]) * sys.widthScale)
 			window[3] = int32(scl * (w[3] - w[1]) * sys.heightScale * SignF(yscale))
 
@@ -1196,8 +1198,8 @@ func (sl ShadowList) draw(x, y, scl float32) {
 		}
 
 		s.anim.ShadowDraw(drawwindow,
-			sys.cam.Offset[0]-((x-s.pos[0]-offsetX)*scl),
-			sys.cam.GroundLevel()+sys.cam.Offset[1]-sys.envShake.getOffset()-y-(s.pos[1]*yscale-offsetY)*scl,
+			(sys.cam.Offset[0]-es[0])-((x-s.pos[0]-offsetX)*scl),
+			sys.cam.GroundLevel()+(sys.cam.Offset[1]-es[1])-y-(s.pos[1]*yscale-offsetY)*scl,
 			scl*s.scl[0], scl*-s.scl[1],
 			yscale, xshear, s.rot,
 			s.fx, s.oldVer, uint32(color), intensity, s.facing, s.airOffsetFix, s.projection, s.fLength)
@@ -1284,6 +1286,7 @@ func (sl ShadowList) drawReflection(x, y, scl float32) {
 		}
 
 		drawwindow := &sys.scrrect
+		es := sys.envShake.getOffset()
 		// TODO: If the char has an active window sctrl, reflections should also be affected, in addition to the stage window
 		if sys.stage.reflection.window != [4]float32{0, 0, 0, 0} || s.reflectWindow != [4]float32{0, 0, 0, 0} {
 			var w [4]float32
@@ -1307,8 +1310,8 @@ func (sl ShadowList) drawReflection(x, y, scl float32) {
 				w[i] *= sys.stage.localscl
 			}
 
-			window[0] = int32((sys.cam.Offset[0] - (x * scl) + w[0]*scl + float32(sys.gameWidth)/2) * sys.widthScale)
-			window[1] = int32((sys.cam.GroundLevel() + sys.cam.Offset[1] - sys.envShake.getOffset() - y + w[1]*SignF(yscale)*scl) * sys.heightScale)
+			window[0] = int32(((sys.cam.Offset[0]-es[0]) - (x * scl) + w[0]*scl + float32(sys.gameWidth)/2) * sys.widthScale)
+			window[1] = int32((sys.cam.GroundLevel() + (sys.cam.Offset[1]-es[1]) - y + w[1]*SignF(yscale)*scl) * sys.heightScale)
 			window[2] = int32(scl * (w[2] - w[0]) * sys.widthScale)
 			window[3] = int32(scl * (w[3] - w[1]) * sys.heightScale * SignF(yscale))
 
@@ -1316,8 +1319,8 @@ func (sl ShadowList) drawReflection(x, y, scl float32) {
 		}
 
 		s.anim.Draw(drawwindow,
-			sys.cam.Offset[0]/scl-(x-s.pos[0]-offsetX),
-			(sys.cam.GroundLevel()+sys.cam.Offset[1]-sys.envShake.getOffset())/scl-y/scl-(s.pos[1]*yscale-offsetY),
+			(sys.cam.Offset[0]-es[0])/scl-(x-s.pos[0]-offsetX),
+			(sys.cam.GroundLevel()+sys.cam.Offset[1]-es[1])/scl-y/scl-(s.pos[1]*yscale-offsetY),
 			scl, scl, s.scl[0], s.scl[0],
 			-s.scl[1]*yscale, xshear, s.rot, float32(sys.gameWidth)/2,
 			s.fx, s.oldVer, s.facing, s.airOffsetFix, s.projection, s.fLength, color, true)

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3760,7 +3760,7 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	case OC_ex2_envshakevar_dir:
 		sys.bcStack.PushF(sys.envShake.dir / float32(math.Pi) * 180)
 	case OC_ex2_gethitvar_fall_envshake_dir:
-		sys.bcStack.PushF(c.ghv.fall_envshake_dir / float32(math.Pi) * 180)
+		sys.bcStack.PushF(c.ghv.fall_envshake_dir)
 	default:
 		sys.errLog.Printf("%v\n", be[*i-1])
 		c.panic()
@@ -9961,7 +9961,7 @@ func (sc fallEnvShake) Run(c *Char, _ []int32) bool {
 					ampl:  float32(crun.ghv.fall_envshake_ampl) * c.localscl,
 					phase: crun.ghv.fall_envshake_phase,
 					mul:   crun.ghv.fall_envshake_mul,
-					dir:   crun.ghv.fall_envshake_dir}
+					dir:   crun.ghv.fall_envshake_dir * float32(math.Pi) / 180}
 				sys.envShake.setDefaultPhase()
 				crun.ghv.fall_envshake_time = 0
 			}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6995,7 +6995,7 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, paramID byte, exp []BytecodeExp) bo
 	case hitDef_envshake_mul:
 		hd.envshake_mul = exp[0].evalF(c)
 	case hitDef_envshake_dir:
-		hd.envshake_dir = float32(exp[0].evalF(c) * (math.Pi/180))
+		hd.envshake_dir = exp[0].evalF(c)
 	case hitDef_fall_envshake_time:
 		hd.fall_envshake_time = exp[0].evalI(c)
 	case hitDef_fall_envshake_ampl:
@@ -7007,7 +7007,7 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, paramID byte, exp []BytecodeExp) bo
 	case hitDef_fall_envshake_mul:
 		hd.fall_envshake_mul = exp[0].evalF(c)
 	case hitDef_fall_envshake_dir:
-		hd.fall_envshake_dir = float32(exp[0].evalF(c) * (math.Pi/180))
+		hd.fall_envshake_dir = exp[0].evalF(c)
 	case hitDef_dizzypoints:
 		hd.dizzypoints = Max(IErr+1, exp[0].evalI(c))
 	case hitDef_guardpoints:
@@ -12766,7 +12766,7 @@ func (sc getHitVarSet) Run(c *Char, _ []int32) bool {
 		case getHitVarSet_fall_envshake_mul:
 			crun.ghv.fall_envshake_mul = exp[0].evalF(c)
 		case getHitVarSet_fall_envshake_dir:
-			crun.ghv.fall_envshake_dir = float32(exp[0].evalF(c) * (math.Pi/180))
+			crun.ghv.fall_envshake_dir = exp[0].evalF(c)
 		case getHitVarSet_fall_envshake_phase:
 			crun.ghv.fall_envshake_phase = exp[0].evalF(c)
 		case getHitVarSet_fall_envshake_time:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3760,7 +3760,7 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	case OC_ex2_envshakevar_dir:
 		sys.bcStack.PushF(sys.envShake.dir / float32(math.Pi) * 180)
 	case OC_ex2_gethitvar_fall_envshake_dir:
-		sys.bcStack.PushF(c.ghv.fall_envshake_dir)
+		sys.bcStack.PushF(c.ghv.fall_envshake_dir / float32(math.Pi) * 180)
 	default:
 		sys.errLog.Printf("%v\n", be[*i-1])
 		c.panic()

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6995,7 +6995,7 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, paramID byte, exp []BytecodeExp) bo
 	case hitDef_envshake_mul:
 		hd.envshake_mul = exp[0].evalF(c)
 	case hitDef_envshake_dir:
-		hd.envshake_dir = exp[0].evalF(c)
+		hd.envshake_dir = float32(exp[0].evalF(c) * (math.Pi/180))
 	case hitDef_fall_envshake_time:
 		hd.fall_envshake_time = exp[0].evalI(c)
 	case hitDef_fall_envshake_ampl:
@@ -7007,7 +7007,7 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, paramID byte, exp []BytecodeExp) bo
 	case hitDef_fall_envshake_mul:
 		hd.fall_envshake_mul = exp[0].evalF(c)
 	case hitDef_fall_envshake_dir:
-		hd.fall_envshake_dir = exp[0].evalF(c)
+		hd.fall_envshake_dir = float32(exp[0].evalF(c) * (math.Pi/180))
 	case hitDef_dizzypoints:
 		hd.dizzypoints = Max(IErr+1, exp[0].evalI(c))
 	case hitDef_guardpoints:
@@ -12766,7 +12766,7 @@ func (sc getHitVarSet) Run(c *Char, _ []int32) bool {
 		case getHitVarSet_fall_envshake_mul:
 			crun.ghv.fall_envshake_mul = exp[0].evalF(c)
 		case getHitVarSet_fall_envshake_dir:
-			crun.ghv.fall_envshake_dir = exp[0].evalF(c)
+			crun.ghv.fall_envshake_dir = float32(exp[0].evalF(c) * (math.Pi/180))
 		case getHitVarSet_fall_envshake_phase:
 			crun.ghv.fall_envshake_phase = exp[0].evalF(c)
 		case getHitVarSet_fall_envshake_time:

--- a/src/char.go
+++ b/src/char.go
@@ -596,6 +596,7 @@ type HitDef struct {
 	envshake_ampl              int32
 	envshake_phase             float32
 	envshake_mul               float32
+	envshake_dir               float32
 	mindist                    [3]float32
 	maxdist                    [3]float32
 	snap                       [3]float32
@@ -613,6 +614,7 @@ type HitDef struct {
 	fall_envshake_ampl         int32
 	fall_envshake_phase        float32
 	fall_envshake_mul          float32
+	fall_envshake_dir          float32
 	playerNo                   int
 	kill                       bool
 	guard_kill                 bool
@@ -704,6 +706,7 @@ func (hd *HitDef) clear(c *Char, localscl float32) {
 		envshake_ampl:       -4,
 		envshake_phase:      float32(math.NaN()),
 		envshake_mul:        1.0,
+		envshake_dir:        0.0,
 		mindist:             [...]float32{float32(math.NaN()), float32(math.NaN()), float32(math.NaN())},
 		maxdist:             [...]float32{float32(math.NaN()), float32(math.NaN()), float32(math.NaN())},
 		snap:                [...]float32{float32(math.NaN()), float32(math.NaN()), float32(math.NaN())},
@@ -731,6 +734,7 @@ func (hd *HitDef) clear(c *Char, localscl float32) {
 		fall_envshake_ampl:  IErr,
 		fall_envshake_phase: float32(math.NaN()),
 		fall_envshake_mul:   1.0,
+		fall_envshake_dir:   0.0,
 		attack_depth:        [2]float32{c.size.attack.depth[0], c.size.attack.depth[1]},
 	}
 
@@ -803,6 +807,7 @@ type GetHitVar struct {
 	fall_envshake_ampl  int32
 	fall_envshake_phase float32
 	fall_envshake_mul   float32
+	fall_envshake_dir   float32
 	playerId            int32
 	playerNo            int
 	fallflag            bool
@@ -8508,6 +8513,7 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 				ghv.fall_envshake_ampl = int32(float32(hd.fall_envshake_ampl) * scaleratio)
 				ghv.fall_envshake_phase = hd.fall_envshake_phase
 				ghv.fall_envshake_mul = hd.fall_envshake_mul
+				ghv.fall_envshake_dir = hd.fall_envshake_dir
 
 				if getter.ss.stateType == ST_A {
 					ghv.hittime = hd.air_hittime
@@ -9035,6 +9041,7 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 			sys.envShake.ampl = float32(int32(float32(hd.envshake_ampl) * c.localscl))
 			sys.envShake.phase = hd.envshake_phase
 			sys.envShake.mul = hd.envshake_mul
+			sys.envShake.dir = hd.envshake_dir
 			sys.envShake.setDefaultPhase()
 		}
 		// Cornerpush on hit
@@ -10655,6 +10662,7 @@ func (cl *CharList) hitDetectionPlayer(getter *Char) {
 								getter.ghv.fall_envshake_ampl = int32(float32(c.hitdef.fall_envshake_ampl) * scaleratio)
 								getter.ghv.fall_envshake_phase = c.hitdef.fall_envshake_phase
 								getter.ghv.fall_envshake_mul = c.hitdef.fall_envshake_mul
+								getter.ghv.fall_envshake_dir = c.hitdef.fall_envshake_dir
 
 								getter.ghv.down_recover = c.hitdef.down_recover
 								if c.hitdef.down_recovertime < 0 {

--- a/src/char.go
+++ b/src/char.go
@@ -8513,7 +8513,7 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 				ghv.fall_envshake_ampl = int32(float32(hd.fall_envshake_ampl) * scaleratio)
 				ghv.fall_envshake_phase = hd.fall_envshake_phase
 				ghv.fall_envshake_mul = hd.fall_envshake_mul
-				ghv.fall_envshake_dir = hd.fall_envshake_dir * float32(math.Pi) / 180
+				ghv.fall_envshake_dir = hd.fall_envshake_dir
 
 				if getter.ss.stateType == ST_A {
 					ghv.hittime = hd.air_hittime
@@ -10662,7 +10662,7 @@ func (cl *CharList) hitDetectionPlayer(getter *Char) {
 								getter.ghv.fall_envshake_ampl = int32(float32(c.hitdef.fall_envshake_ampl) * scaleratio)
 								getter.ghv.fall_envshake_phase = c.hitdef.fall_envshake_phase
 								getter.ghv.fall_envshake_mul = c.hitdef.fall_envshake_mul
-								getter.ghv.fall_envshake_dir = c.hitdef.fall_envshake_dir * float32(math.Pi) / 180
+								getter.ghv.fall_envshake_dir = c.hitdef.fall_envshake_dir
 
 								getter.ghv.down_recover = c.hitdef.down_recover
 								if c.hitdef.down_recovertime < 0 {

--- a/src/char.go
+++ b/src/char.go
@@ -8513,7 +8513,7 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 				ghv.fall_envshake_ampl = int32(float32(hd.fall_envshake_ampl) * scaleratio)
 				ghv.fall_envshake_phase = hd.fall_envshake_phase
 				ghv.fall_envshake_mul = hd.fall_envshake_mul
-				ghv.fall_envshake_dir = hd.fall_envshake_dir
+				ghv.fall_envshake_dir = hd.fall_envshake_dir * float32(math.Pi) / 180
 
 				if getter.ss.stateType == ST_A {
 					ghv.hittime = hd.air_hittime
@@ -9041,7 +9041,7 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 			sys.envShake.ampl = float32(int32(float32(hd.envshake_ampl) * c.localscl))
 			sys.envShake.phase = hd.envshake_phase
 			sys.envShake.mul = hd.envshake_mul
-			sys.envShake.dir = hd.envshake_dir
+			sys.envShake.dir = hd.envshake_dir * float32(math.Pi) / 180
 			sys.envShake.setDefaultPhase()
 		}
 		// Cornerpush on hit
@@ -10662,7 +10662,7 @@ func (cl *CharList) hitDetectionPlayer(getter *Char) {
 								getter.ghv.fall_envshake_ampl = int32(float32(c.hitdef.fall_envshake_ampl) * scaleratio)
 								getter.ghv.fall_envshake_phase = c.hitdef.fall_envshake_phase
 								getter.ghv.fall_envshake_mul = c.hitdef.fall_envshake_mul
-								getter.ghv.fall_envshake_dir = c.hitdef.fall_envshake_dir
+								getter.ghv.fall_envshake_dir = c.hitdef.fall_envshake_dir * float32(math.Pi) / 180
 
 								getter.ghv.down_recover = c.hitdef.down_recover
 								if c.hitdef.down_recovertime < 0 {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2417,15 +2417,9 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		if err := c.checkOpeningParenthesis(in); err != nil {
 			return bvNone(), err
 		}
-		isFlag := -1
+		opct := OC_ex_
+		isFlag := 0
 		switch c.token {
-		// no-op triggers
-		case "fall.envshake.dir":
-			bv.SetI(0)
-		default:
-			// triggers that do things
-			isFlag = 0
-			switch c.token {
 			case "animtype":
 				opc = OC_ex_gethitvar_animtype
 			case "air.animtype":
@@ -2514,6 +2508,9 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				opc = OC_ex_gethitvar_fall_envshake_phase
 			case "fall.envshake.mul":
 				opc = OC_ex_gethitvar_fall_envshake_mul
+			case "fall.envshake.dir":
+				opct = OC_ex2_
+				opc = OC_ex2_gethitvar_fall_envshake_dir
 			case "attr":
 				opc = OC_ex_gethitvar_attr
 				isFlag = 1
@@ -2584,7 +2581,6 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				isFlag = 2
 			default:
 				return bvNone(), Error("Invalid GetHitVar argument: " + c.token)
-			}
 		}
 		c.token = c.tokenizer(in)
 		if err := c.checkClosingParenthesis(); err != nil {
@@ -2597,7 +2593,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				if attr, err := c.trgAttr(in); err != nil {
 					return err
 				} else {
-					out.append(OC_ex_)
+					out.append(opct)
 					out.appendI32Op(opc, attr)
 				}
 				return nil
@@ -2611,7 +2607,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				if flg, err := flagSub(); err != nil {
 					return err
 				} else {
-					out.append(OC_ex_)
+					out.append(opct)
 					out.appendI32Op(opc, flg)
 					return nil
 				}
@@ -2621,7 +2617,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			}
 		case 0:
 			// no flag
-			out.append(OC_ex_, opc)
+			out.append(opct, opc)
 		}
 		// no-op (for y/xveladd and fall.envshake.dir)
 	case "groundlevel":
@@ -4201,17 +4197,21 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		if err := c.checkOpeningParenthesis(in); err != nil {
 			return bvNone(), err
 		}
-		out.append(OC_ex_)
+		opct := OC_ex_
 		switch c.token {
-		case "time":
-			out.append(OC_ex_envshakevar_time)
-		case "freq":
-			out.append(OC_ex_envshakevar_freq)
-		case "ampl":
-			out.append(OC_ex_envshakevar_ampl)
-		default:
-			return bvNone(), Error("Invalid EnvShakeVar argument: " + c.token)
+			case "time":
+				opc = OC_ex_envshakevar_time
+			case "freq":
+				opc = OC_ex_envshakevar_freq
+			case "ampl":
+				opc = OC_ex_envshakevar_ampl
+			case "dir":
+				opct = OC_ex2_
+				opc = OC_ex2_envshakevar_dir
+			default:
+				return bvNone(), Error("Invalid EnvShakeVar argument: " + c.token)
 		}
+		out.append(opct, opc)
 		c.token = c.tokenizer(in)
 		if err := c.checkClosingParenthesis(); err != nil {
 			return bvNone(), err

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -3163,6 +3163,10 @@ func (c *Compiler) envShake(is IniSection, sc *StateControllerBase, _ int8) (Sta
 			envShake_mul, VT_Float, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "dir",
+			envShake_dir, VT_Float, 1, false); err != nil {
+			return err
+		}
 		return nil
 	})
 	return *ret, err

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -2034,6 +2034,10 @@ func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 		hitDef_envshake_mul, VT_Float, 1, false); err != nil {
 		return err
 	}
+	if err := c.paramValue(is, sc, "envshake.dir",
+		hitDef_envshake_dir, VT_Float, 1, false); err != nil {
+		return err
+	}
 	if err := c.paramValue(is, sc, "fall.envshake.time",
 		hitDef_fall_envshake_time, VT_Int, 1, false); err != nil {
 		return err
@@ -2052,6 +2056,10 @@ func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 	}
 	if err := c.paramValue(is, sc, "fall.envshake.mul",
 		hitDef_fall_envshake_mul, VT_Float, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "fall.envshake.dir",
+		hitDef_fall_envshake_dir, VT_Float, 1, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "dizzypoints",
@@ -5794,6 +5802,10 @@ func (c *Compiler) getHitVarSet(is IniSection, sc *StateControllerBase, _ int8) 
 		}
 		if err := c.paramValue(is, sc, "fall.envshake.time",
 			getHitVarSet_fall_envshake_time, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "fall.envshake.dir",
+			getHitVarSet_fall_envshake_dir, VT_Float, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "fall.kill",

--- a/src/script.go
+++ b/src/script.go
@@ -3641,6 +3641,8 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(sys.envShake.freq / float32(math.Pi) * 180)
 		case "ampl":
 			ln = lua.LNumber(sys.envShake.ampl)
+		case "dir":
+			ln = lua.LNumber(sys.envShake.dir / float32(math.Pi) * 180)
 		default:
 			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}
@@ -3820,7 +3822,7 @@ func triggerFunctions(l *lua.LState) {
 		var ln lua.LNumber
 		switch strings.ToLower(strArg(l, 1)) {
 		case "fall.envshake.dir":
-			ln = lua.LNumber(0)
+			ln = lua.LNumber(c.ghv.fall_envshake_dir)
 		case "animtype":
 			ln = lua.LNumber(c.gethitAnimtype())
 		case "air.animtype":

--- a/src/stage.go
+++ b/src/stage.go
@@ -1739,7 +1739,8 @@ func (s *Stage) draw(layer int32, x, y, scl float32) {
 	if s.hires {
 		bgscl = 0.5
 	}
-	yofs, pos := sys.envShake.getOffset(), [...]float32{x, y}
+	ofs := sys.envShake.getOffset()
+	pos := [...]float32{x, y}
 	scl2 := s.localscl * scl
 	// This code makes the background scroll faster when surpassing boundhigh with the camera pushed down
 	// through floortension and boundlow. MUGEN 1.1 doesn't look like it does this, so it was commented.
@@ -1748,12 +1749,12 @@ func (s *Stage) draw(layer int32, x, y, scl float32) {
 	// extraBoundH = sys.cam.ExtraBoundH * ((1/scl)-1)/((1/sys.cam.zoomout)-1)
 	// }
 	// if pos[1] <= float32(s.stageCamera.boundlow) && pos[1] < float32(s.stageCamera.boundhigh)-extraBoundH {
-	// yofs += (pos[1]-float32(s.stageCamera.boundhigh))*scl2 +
+	// ofs[1] += (pos[1]-float32(s.stageCamera.boundhigh))*scl2 +
 	// extraBoundH*scl
 	// pos[1] = float32(s.stageCamera.boundhigh) - extraBoundH/s.localscl
 	// }
-	if yofs != 0 && s.stageCamera.verticalfollow > 0 {
-		if yofs < 0 {
+	if ofs[1] != 0 && s.stageCamera.verticalfollow > 0 {
+		if ofs[1] < 0 {
 			tmp := (float32(s.stageCamera.boundhigh) - pos[1]) * scl2
 			if scl > 1 {
 				tmp += (sys.cam.GroundLevel() + float32(sys.gameHeight-240)) * (1/scl - 1)
@@ -1761,29 +1762,30 @@ func (s *Stage) draw(layer int32, x, y, scl float32) {
 				tmp += float32(sys.gameHeight) * (1/scl - 1)
 			}
 			if tmp >= 0 {
-			} else if yofs < tmp {
-				yofs -= tmp
+			} else if ofs[1] < tmp {
+				ofs[1] -= tmp
 				pos[1] += tmp / scl2
 			} else {
-				pos[1] += yofs / scl2
-				yofs = 0
+				pos[1] += ofs[1] / scl2
+				ofs[1] = 0
 			}
 		} else {
-			if -yofs >= pos[1]*scl2 {
-				pos[1] += yofs / scl2
-				yofs = 0
+			if -ofs[1] >= pos[1]*scl2 {
+				pos[1] += ofs[1] / scl2
+				ofs[1] = 0
 			}
 		}
 	}
+	pos[0] += ofs[0] / scl2
 	if !sys.cam.ZoomEnable {
 		for i, p := range pos {
 			pos[i] = float32(math.Ceil(float64(p - 0.5)))
 		}
 	}
-	s.drawModel(pos, yofs, scl, layer)
+	s.drawModel(pos, ofs[1], scl, layer)
 	for _, b := range s.bg {
 		if b.layerno == layer && b.visible && b.anim.spr != nil {
-			b.draw(pos, scl, bgscl, s.localscl, s.scale, yofs, true)
+			b.draw(pos, scl, bgscl, s.localscl, s.scale, ofs[1], true)
 		}
 	}
 	BlendReset()

--- a/src/system.go
+++ b/src/system.go
@@ -3605,11 +3605,16 @@ type EnvShake struct {
 	ampl  float32
 	phase float32
 	mul   float32
+	dir   float32 // rad, for ampl=-4:  0: down first, 90: left first, 180: up first, 270: right first
 }
 
 func (es *EnvShake) clear() {
-	*es = EnvShake{freq: float32(math.Pi / 3), ampl: -4.0,
-		phase: float32(math.NaN()), mul: 1.0}
+	*es = EnvShake{
+		freq: float32(math.Pi / 3),
+		ampl: -4.0,
+		phase: float32(math.NaN()),
+		mul: 1.0,
+		dir: 0.0}
 }
 
 func (es *EnvShake) setDefaultPhase() {
@@ -3635,9 +3640,14 @@ func (es *EnvShake) next() {
 	}
 }
 
-func (es *EnvShake) getOffset() float32 {
+func (es *EnvShake) getOffset() [2]float32 {
 	if es.time > 0 {
-		return es.ampl * float32(math.Sin(float64(es.phase)))
+		offset := (es.ampl * float32(math.Sin(float64(es.phase))))
+		// I could have put the correction in EnvShake's bytecode,
+		// but I would have to edit HitDef and FallEnvShake and char...
+		dir := es.dir - (math.Pi/2)
+		return [2]float32{offset * float32(math.Cos(float64(dir))),
+			offset * float32(math.Sin(float64(dir)))}
 	}
-	return 0
+	return [2]float32{0, 0}
 }

--- a/src/system.go
+++ b/src/system.go
@@ -3642,12 +3642,9 @@ func (es *EnvShake) next() {
 
 func (es *EnvShake) getOffset() [2]float32 {
 	if es.time > 0 {
-		offset := (es.ampl * float32(math.Sin(float64(es.phase))))
-		// I could have put the correction in EnvShake's bytecode,
-		// but I would have to edit HitDef and FallEnvShake and char...
-		dir := es.dir - (math.Pi/2)
-		return [2]float32{offset * float32(math.Cos(float64(dir))),
-			offset * float32(math.Sin(float64(dir)))}
+		offset := -(es.ampl * float32(math.Sin(float64(es.phase))))
+		return [2]float32{offset * float32(math.Sin(float64(-es.dir))),
+			offset * float32(math.Cos(float64(-es.dir)))}
 	}
 	return [2]float32{0, 0}
 }


### PR DESCRIPTION
This PR adds a new parameter to the `EnvShake` controller (and its friends that use it, such as `HitDef`). The `dir` parameter specifies (in degrees, positive values only) in which direction the camera shaking is applied, allowing for horizontal or diagonal `EnvShake`s.

Consequently, this makes the no-op trigger `gethitvar(fall.envshake.dir)` work.