### PR TITLE
fix: lifebar elements xshear offset, timer counter, combo bg0 and top default layerno

### DIFF
--- a/src/common.go
+++ b/src/common.go
@@ -881,9 +881,13 @@ func (l *Layout) DrawAnim(r *[4]int32, x, y, scl, xscl, yscl float32, ln int16, 
 		if l.vfacing < 0 {
 			y += sys.lifebar.fnt_scale
 		}
-		a.Draw(r, x+l.offset[0], y+l.offset[1]+float32(sys.gameHeight-240),
+		// Xshear offset correction
+		xshear := -l.xshear
+		xsoffset := xshear * (float32(a.spr.Offset[1]) * l.scale[1] * scl)
+
+		a.Draw(r, x+l.offset[0]-xsoffset, y+l.offset[1]+float32(sys.gameHeight-240),
 			scl, scl, (l.scale[0]*xscl)*float32(l.facing), (l.scale[0]*xscl)*float32(l.facing),
-			(l.scale[1]*yscl)*float32(l.vfacing), -l.xshear, Rotation{l.angle, 0, 0},
+			(l.scale[1]*yscl)*float32(l.vfacing), xshear, Rotation{l.angle, 0, 0},
 			float32(sys.gameWidth-320)/2, palfx, false, 1, [2]float32{1, 1}, 0, 0, 0, false)
 	}
 }
@@ -898,9 +902,13 @@ func (l *Layout) DrawText(x, y, scl float32, ln int16,
 		if l.vfacing < 0 {
 			y += sys.lifebar.fnt_scale
 		}
-		f.Print(text, (x+l.offset[0])*scl, (y+l.offset[1])*scl,
+		// Xshear offset correction
+		xshear := -l.xshear
+		xsoffset := xshear * (float32(f.offset[1]) * l.scale[1] * scl)
+
+		f.Print(text, (x+l.offset[0]-xsoffset)*scl, (y+l.offset[1])*scl,
 			l.scale[0]*sys.lifebar.fnt_scale*float32(l.facing)*scl,
-			l.scale[1]*sys.lifebar.fnt_scale*float32(l.vfacing)*scl, -l.xshear, b, a,
+			l.scale[1]*sys.lifebar.fnt_scale*float32(l.vfacing)*scl, xshear, b, a,
 			&l.window, palfx, frgba)
 	}
 }

--- a/src/font.go
+++ b/src/font.go
@@ -683,11 +683,15 @@ func (ts *TextSprite) Draw() {
 				totalCharsShown += charsToShow
 			}
 
+			// Xshear offset correction
+			xshear := -ts.xshear
+			xsoffset := xshear * (float32(ts.fnt.offset[1]) * ts.yscl)
+
 			// Draws the visible line
 			if ts.fnt.Type == "truetype" {
 				ts.fnt.DrawTtf(line[:charsToShow], ts.x, newY, ts.xscl, ts.yscl, ts.align, true, &ts.window, ts.frgba)
 			} else {
-				ts.fnt.DrawText(line[:charsToShow], ts.x, newY, ts.xscl, ts.yscl, -ts.xshear, ts.bank, ts.align, &ts.window, ts.palfx)
+				ts.fnt.DrawText(line[:charsToShow], ts.x-xsoffset, newY, ts.xscl, ts.yscl, xshear, ts.bank, ts.align, &ts.window, ts.palfx)
 			}
 
 			if ts.textDelay > 0 && totalCharsShown >= int(maxChars) {

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -323,22 +323,21 @@ func readMultipleLbText(pre string, name string, is IniSection, fmtstr string, l
 func calcBarFillRect(pos int32, range_ [2]int32, offset, scale, screenScale, midPos float32, fill float32) (start, size int32) {
 	isDescending := range_[0] > range_[1]
 	var r0, r1 int32
-	var base float32
-
+	
 	if isDescending {
 		r0, r1 = range_[1], range_[0]
-		base = float32(pos + r1 + 1)
 	} else {
 		r0, r1 = range_[0], range_[1]
-		base = float32(pos + r0)
 	}
 
 	fillLength := float32(r1 - r0 + 1)
-	start = int32(((base*scale+midPos)*screenScale)+0.5) - size
-	size = int32((((fillLength * scale * fill) - (offset * scale)) * screenScale) + 0.5)
+	size = int32((fillLength * scale * fill * screenScale) + 0.5)
+
+	base := float32(pos + r0)
+	start = int32(((base + offset) * scale + midPos) * screenScale + 0.5)
 
 	if isDescending {
-		start -= size
+		start = int32(((float32(pos + r1 + 1) + offset) * scale + midPos) * screenScale + 0.5) - size
 	}
 	return
 }

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -301,7 +301,7 @@ func readMultipleValuesF(pre string, name string, is IniSection, sff *Sff, at An
 }
 
 // Text version of readMultipleValues
-func readMultipleLbText(pre string, name string, is IniSection, fmtstr string, f []*Fnt, align int32) map[int32]*LbText {
+func readMultipleLbText(pre string, name string, is IniSection, fmtstr string, ln int16, f []*Fnt, align int32) map[int32]*LbText {
 	result := make(map[int32]*LbText)
 	r, _ := regexp.Compile(pre + name + "[0-9]+\\.")
 	for k := range is {
@@ -311,7 +311,7 @@ func readMultipleLbText(pre string, name string, is IniSection, fmtstr string, f
 			if len(submatchall) >= 1 {
 				v := Atoi(submatchall[len(submatchall)-1])
 				if _, ok := result[v]; !ok {
-					result[v] = readLbText(pre+name+fmt.Sprintf("%v", v)+".", is, fmtstr, 2, f, align)
+					result[v] = readLbText(pre+name+fmt.Sprintf("%v", v)+".", is, fmtstr, ln, f, align)
 				}
 			}
 		}
@@ -686,7 +686,7 @@ func readPowerBar(pre string, is IniSection,
 	// Lifebar power counter.
 	pb.shift = *ReadAnimLayout(pre+"shift.", is, sff, at, 0)
 	pb.counter[0] = readLbText(pre+"counter.", is, "%i", 0, f, 0)
-	for k, v := range readMultipleLbText(pre, "counter", is, "%i", f, 0) {
+	for k, v := range readMultipleLbText(pre, "counter", is, "%i", 0, f, 0) {
 		pb.counter[k] = v
 	}
 	pb.value = *readLbText(pre+"value.", is, "", 0, f, 0)
@@ -1769,7 +1769,7 @@ func readLifeBarTime(is IniSection,
 	ti := newLifeBarTime()
 	is.ReadI32("pos", &ti.pos[0], &ti.pos[1])
 	ti.counter[0] = readLbText("counter.", is, "", 0, f, 0)
-	for k, v := range readMultipleLbText("", "counter", is, "", f, 0) {
+	for k, v := range readMultipleLbText("", "counter", is, "", 0, f, 0) {
 		ti.counter[k] = v
 	}
 	ti.bg = *ReadAnimLayout("bg.", is, sff, at, 0)
@@ -1886,18 +1886,18 @@ func readLifeBarCombo(pre string, is IniSection,
 		}
 	}
 	co.counter[0] = readLbText(pre+"counter.", is, "%i", 2, f, align)
-	for k, v := range readMultipleLbText(pre, "counter", is, "%i", f, align) {
+	for k, v := range readMultipleLbText(pre, "counter", is, "%i", 2, f, align) {
 		co.counter[k] = v
 	}
 	is.ReadBool(pre+"counter.shake", &co.counter_shake)
 	is.ReadI32(pre+"counter.time", &co.counter_time)
 	is.ReadF32(pre+"counter.mult", &co.counter_mult)
 	co.text[0] = readLbText(pre+"text.", is, "", 2, f, align)
-	for k, v := range readMultipleLbText(pre, "text", is, "", f, align) {
+	for k, v := range readMultipleLbText(pre, "text", is, "", 2, f, align) {
 		co.text[k] = v
 	}
-	co.bg = *ReadAnimLayout(pre+"bg0.", is, sff, at, 0)
-	co.top = *ReadAnimLayout(pre+"top.", is, sff, at, 0)
+	co.bg = *ReadAnimLayout(pre+"bg0.", is, sff, at, 2)
+	co.top = *ReadAnimLayout(pre+"top.", is, sff, at, 2)
 	is.ReadI32(pre+"displaytime", &co.displaytime)
 	is.ReadF32(pre+"showspeed", &co.showspeed)
 	co.showspeed = MaxF(1, co.showspeed)


### PR DESCRIPTION
Fix:
- Lifebar elements and texts now apply xshear with proper offset correction
- team<n>.bg0 and team<n>.top now default to layerno = 2, matching combo.counter and combo.text.
- lifebar range.x breaking in 16:9 resolutions.