### PR TITLE
fix: added back the channel offset in SoundVar since it appears to be required in certain contexts

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -4424,7 +4424,11 @@ func (c *Char) soundVar(chid BytecodeValue, vtype OpCode) BytecodeValue {
 		return BytecodeSF()
 	}
 
+	// See compiler.go:SoundVar
 	var id = chid.ToI()
+	if id > 0 {
+		id--
+	}
 	var ch *SoundChannel
 
 	// First, grab a channel.

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -3354,6 +3354,14 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 
+		// If bv1 is ever 0 Ikemen crashes.
+		// I do not know why this happens.
+		// It happened with clsnVar.
+		idx := bv1.ToI()
+		if idx >= 0 {
+			bv1.SetI(idx + 1)
+		}
+
 		be2.appendValue(bv2)
 		be1.appendValue(bv1)
 


### PR DESCRIPTION
As the PR says, the offset appeared to be necessary in certain contexts. Whoops.