### PR TITLE
feat: 3d model outline

### DIFF
--- a/src/bgdef.go
+++ b/src/bgdef.go
@@ -322,10 +322,11 @@ func (s *BGDef) draw(layer int32, x, y, scl float32) {
 			s.model.calculateTextureTransform()
 		}
 		drawFOV := s.fov * math.Pi / 180
+		outlineConst := float32(0.003 * math.Tan(float64(drawFOV)))
 		proj := mgl.Perspective(drawFOV, float32(sys.scrrect[2])/float32(sys.scrrect[3]), s.near, s.far)
 		view := mgl.Translate3D(s.modelOffset[0], s.modelOffset[1], s.modelOffset[2])
 		view = view.Mul4(mgl.Scale3D(s.modelScale[0], s.modelScale[1], s.modelScale[2]))
-		s.model.draw(1, int(s.sceneNumber), int(layer), 0, s.modelOffset, proj, view, proj.Mul4(view))
+		s.model.draw(1, int(s.sceneNumber), int(layer), 0, s.modelOffset, proj, view, proj.Mul4(view), outlineConst)
 	}
 	//x, y = x/s.localscl, y/s.localscl
 	for _, b := range s.bg {

--- a/src/render.go
+++ b/src/render.go
@@ -35,7 +35,8 @@ type Renderer interface {
 	setShadowMapPipeline(doubleSided, invertFrontFace, useUV, useNormal, useTangent, useVertColor, useJoint0, useJoint1 bool, numVertices, vertAttrOffset uint32)
 	ReleaseShadowPipeline()
 	prepareModelPipeline(bufferIndex uint32, env *Environment)
-	SetModelPipeline(eq BlendEquation, src, dst BlendFunc, depthTest, depthMask, doubleSided, invertFrontFace, useUV, useNormal, useTangent, useVertColor, useJoint0, useJoint1 bool, numVertices, vertAttrOffset uint32)
+	SetModelPipeline(eq BlendEquation, src, dst BlendFunc, depthTest, depthMask, doubleSided, invertFrontFace, useUV, useNormal, useTangent, useVertColor, useJoint0, useJoint1, useOutlineAttribute bool, numVertices, vertAttrOffset uint32)
+	SetMeshOulinePipeline(invertFrontFace bool, meshOutline float32)
 	ReleaseModelPipeline()
 
 	newTexture(width, height, depth int32, filter bool) (t Texture)

--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -341,19 +341,20 @@ type Renderer_GL21 struct {
 	GL21State
 }
 type GL21State struct {
-	depthTest       bool
-	depthMask       bool
-	invertFrontFace bool
-	doubleSided     bool
-	blendEquation   BlendEquation
-	blendSrc        BlendFunc
-	blendDst        BlendFunc
-	useUV           bool
-	useNormal       bool
-	useTangent      bool
-	useVertColor    bool
-	useJoint0       bool
-	useJoint1       bool
+	depthTest           bool
+	depthMask           bool
+	invertFrontFace     bool
+	doubleSided         bool
+	blendEquation       BlendEquation
+	blendSrc            BlendFunc
+	blendDst            BlendFunc
+	useUV               bool
+	useNormal           bool
+	useTangent          bool
+	useVertColor        bool
+	useJoint0           bool
+	useJoint1           bool
+	useOutlineAttribute bool
 }
 
 func (r *Renderer_GL21) GetName() string {
@@ -371,10 +372,10 @@ func (r *Renderer_GL21) InitModelShader() error {
 	if err != nil {
 		return err
 	}
-	r.modelShader.RegisterAttributes("vertexId", "position", "uv", "normalIn", "tangentIn", "vertColor", "joints_0", "joints_1", "weights_0", "weights_1")
+	r.modelShader.RegisterAttributes("vertexId", "position", "uv", "normalIn", "tangentIn", "vertColor", "joints_0", "joints_1", "weights_0", "weights_1", "outlineAttribute")
 	r.modelShader.RegisterUniforms("model", "view", "projection", "farPlane", "normalMatrix", "unlit", "baseColorFactor", "add", "mult", "useTexture", "useNormalMap", "useMetallicRoughnessMap", "useEmissionMap", "neg", "gray", "hue",
 		"enableAlpha", "alphaThreshold", "numJoints", "morphTargetWeight", "morphTargetOffset", "morphTargetTextureDimension", "numTargets", "numVertices",
-		"metallicRoughness", "ambientOcclusionStrength", "emission", "environmentIntensity", "mipCount",
+		"metallicRoughness", "ambientOcclusionStrength", "emission", "environmentIntensity", "mipCount", "meshOutline",
 		"cameraPosition", "environmentRotation", "texTransform", "normalMapTransform", "metallicRoughnessMapTransform", "ambientOcclusionMapTransform", "emissionMapTransform",
 		"lightMatrices[0]", "lightMatrices[1]", "lightMatrices[2]", "lightMatrices[3]",
 		"lights[0].direction", "lights[0].range", "lights[0].color", "lights[0].intensity", "lights[0].position", "lights[0].innerConeCos", "lights[0].outerConeCos", "lights[0].type", "lights[0].shadowBias", "lights[0].shadowMapFar",
@@ -396,7 +397,8 @@ func (r *Renderer_GL21) InitModelShader() error {
 			"lightMatrices[12]", "lightMatrices[13]", "lightMatrices[14]", "lightMatrices[15]", "lightMatrices[16]", "lightMatrices[17]",
 			"lightMatrices[18]", "lightMatrices[19]", "lightMatrices[20]", "lightMatrices[21]", "lightMatrices[22]", "lightMatrices[23]",
 			"lightType[0]", "lightType[1]", "lightType[2]", "lightType[3]", "lightPos[0]", "lightPos[1]", "lightPos[2]", "lightPos[3]",
-			"farPlane", "numJoints", "morphTargetWeight", "morphTargetOffset", "morphTargetTextureDimension", "numTargets", "numVertices", "enableAlpha", "alphaThreshold", "baseColorFactor", "useTexture", "texTransform", "lightIndex")
+			"farPlane[0]", "farPlane[1]", "farPlane[2]", "farPlane[3]", "numJoints", "morphTargetWeight", "morphTargetOffset", "morphTargetTextureDimension",
+			"numTargets", "numVertices", "enableAlpha", "alphaThreshold", "baseColorFactor", "useTexture", "texTransform", "layerOffset", "lightIndex")
 		r.shadowMapShader.RegisterTextures("morphTargetValues", "jointMatrices", "tex")
 	}
 	r.panoramaToCubeMapShader, err = r.newShaderProgram(identVertShader, panoramaToCubeMapFragShader, "", "Panorama To Cubemap Shader", false)
@@ -1090,7 +1092,7 @@ func (r *Renderer_GL21) prepareModelPipeline(bufferIndex uint32, env *Environmen
 		gl.Uniform1f(loc, 0)
 	}
 }
-func (r *Renderer_GL21) SetModelPipeline(eq BlendEquation, src, dst BlendFunc, depthTest, depthMask, doubleSided, invertFrontFace, useUV, useNormal, useTangent, useVertColor, useJoint0, useJoint1 bool, numVertices, vertAttrOffset uint32) {
+func (r *Renderer_GL21) SetModelPipeline(eq BlendEquation, src, dst BlendFunc, depthTest, depthMask, doubleSided, invertFrontFace, useUV, useNormal, useTangent, useVertColor, useJoint0, useJoint1, useOutlineAttribute bool, numVertices, vertAttrOffset uint32) {
 	r.SetDepthTest(depthTest)
 	r.SetDepthMask(depthMask)
 	r.SetFrontFace(invertFrontFace)
@@ -1199,6 +1201,23 @@ func (r *Renderer_GL21) SetModelPipeline(eq BlendEquation, src, dst BlendFunc, d
 		gl.DisableVertexAttribArray(uint32(loc))
 		gl.VertexAttrib4f(uint32(loc), 0, 0, 0, 0)
 	}
+	if useOutlineAttribute {
+		r.useOutlineAttribute = true
+		loc = r.modelShader.a["outlineAttribute"]
+		gl.EnableVertexAttribArray(uint32(loc))
+		gl.VertexAttribPointerWithOffset(uint32(loc), 4, gl.FLOAT, false, 0, uintptr(offset))
+		offset += 16 * numVertices
+	} else if r.useOutlineAttribute {
+		r.useOutlineAttribute = false
+		loc = r.modelShader.a["outlineAttribute"]
+		gl.DisableVertexAttribArray(uint32(loc))
+		gl.VertexAttrib4f(uint32(loc), 0, 0, 0, 0)
+	}
+}
+func (r *Renderer_GL21) SetMeshOulinePipeline(invertFrontFace bool, meshOutline float32) {
+	r.SetFrontFace(invertFrontFace)
+	loc := r.modelShader.u["meshOutline"]
+	gl.Uniform1f(loc, meshOutline)
 }
 func (r *Renderer_GL21) ReleaseModelPipeline() {
 	loc := r.modelShader.a["vertexId"]
@@ -1229,6 +1248,9 @@ func (r *Renderer_GL21) ReleaseModelPipeline() {
 	loc = r.modelShader.a["weights_1"]
 	gl.DisableVertexAttribArray(uint32(loc))
 	gl.VertexAttrib4f(uint32(loc), 0, 0, 0, 0)
+	loc = r.modelShader.a["outlineAttribute"]
+	gl.DisableVertexAttribArray(uint32(loc))
+	gl.VertexAttrib4f(uint32(loc), 0, 0, 0, 0)
 	//gl.Disable(gl.TEXTURE_2D)
 	gl.DepthMask(true)
 	gl.Disable(gl.DEPTH_TEST)
@@ -1239,6 +1261,7 @@ func (r *Renderer_GL21) ReleaseModelPipeline() {
 	r.useVertColor = false
 	r.useJoint0 = false
 	r.useJoint1 = false
+	r.useOutlineAttribute = false
 }
 func (r *Renderer_GL21) ProcessShadowMapTexture(index int) {
 	gl.BindTexture(gl.TEXTURE_CUBE_MAP, r.fbo_shadow_cube_texture[index])

--- a/src/shaders/model.frag.glsl
+++ b/src/shaders/model.frag.glsl
@@ -79,6 +79,7 @@ uniform bool useEmissionMap;
 uniform bool neg;
 uniform bool enableAlpha;
 uniform float alphaThreshold;
+uniform float meshOutline;
 
 COMPAT_VARYING vec2 texcoord;
 COMPAT_VARYING vec4 vColor;
@@ -410,7 +411,9 @@ void main(void) {
 	}
     FragColor *= baseColorFactor;
 	FragColor *= vColor;
-    if(!unlit){
+    if(meshOutline > 0) {
+        FragColor.rgb = vec3(0,0,0);
+    }else if(!unlit){
         vec3 normalF = normal;
         if(useNormalMap){
             normalF = getNormal();


### PR DESCRIPTION
Add new extras and custom attribute to draw 3d model outline.
The outline is drawn using inverse hull method

### New extras:
#### meshOutline
```
Values: float
Default: 0. 
```
Apply to nodes. Extrude the back facing vertices to draw a outline around the mesh if the value is greater than 0. Thicker outline will be drawn if the value is larger.

### New primitive attribute:
#### _OUTLINE_ATTRIBUTE
```
Values: vec4
Default: (0,0,0,0)
```
xyz of the attribute determines the direction of the vertex being extruded. w determines the amount of extrusion. Vertex normal will be used as the extrusion direction if this attribute is not provided.