### PR TITLE
feat: AssertSpecial NoFaceP2; several fixes

### DIFF
--- a/data/tag.zss
+++ b/data/tag.zss
@@ -229,20 +229,12 @@ if animTime >= 0 {
 # Make players (any mode) only turn towards enemy Tag team leader
 # This benefits assist systems more than it does this native Tag code
 ignoreHitPause if roundState = 2 && !isHelper {
-	# Disable turning for player
 	if p2, teamMode = Tag && p2, playerNo != p2, teamLeader ||
 		p2, time <= 0 && p2, prevStateNo = p2, const(StateTagWaitingOutside) { # Run order fix
-		assertSpecial{flag: noAutoTurn}
-	}
-	# Disable turning towards enemy
-	# We use redirections here so that the flags are asserted as soon as possible
-	if numEnemy > 0 && enemy, teamMode = Tag {
-		for i = 0; numEnemy - 1; 1 {
-			if enemy($i), playerNo != enemy($i), teamLeader ||
-				enemy($i), time <= 0 && enemy($i), prevStateNo = enemy($i), const(StateTagWaitingOutside) { # Run order fix
-				assertSpecial{flag: noTurnTarget; redirectID: enemy($i), ID}
-			}
-		}
+		assertSpecial{flag: noAutoTurn; flag2: noFaceP2}
+		# Run order fix is necessary because when tagging in a player that was already processed in the current frame, they won't be repositioned immediately
+		# This makes enemies recognize that player as the new leader and turn towards them before the screen side where they should enter from has been decided
+		# TODO: This fix could be replaced with a function where the previous leader tags out while the next one is simultaneously repositioned
 	}
 }
 

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1530,7 +1530,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.Push(BytecodeSF())
 			i += int(*(*int32)(unsafe.Pointer(&be[i]))) + 4
 		case OC_parent:
-			if c = c.parent(); c != nil {
+			if c = c.parent(true); c != nil {
 				i += 4
 				continue
 			}
@@ -1611,7 +1611,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.Push(BytecodeSF())
 			i += int(*(*int32)(unsafe.Pointer(&be[i]))) + 4
 		case OC_helperindex:
-			if c = c.getPlayerHelperIndex(sys.bcStack.Pop().ToI(), true); c != nil {
+			if c = c.helperIndexTrigger(sys.bcStack.Pop().ToI(), true); c != nil {
 				i += 4
 				continue
 			}
@@ -2542,11 +2542,11 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_p2bodydist_z:
 		sys.bcStack.Push(c.p2BodyDistZ(oc))
 	case OC_ex_parentdist_x:
-		sys.bcStack.Push(c.rdDistX(c.parent(), oc))
+		sys.bcStack.Push(c.rdDistX(c.parent(true), oc))
 	case OC_ex_parentdist_y:
-		sys.bcStack.Push(c.rdDistY(c.parent(), oc))
+		sys.bcStack.Push(c.rdDistY(c.parent(true), oc))
 	case OC_ex_parentdist_z:
-		sys.bcStack.Push(c.rdDistZ(c.parent(), oc))
+		sys.bcStack.Push(c.rdDistZ(c.parent(true), oc))
 	case OC_ex_rootdist_x:
 		sys.bcStack.Push(c.rdDistX(c.root(), oc))
 	case OC_ex_rootdist_y:
@@ -10279,7 +10279,7 @@ const (
 func (sc bindToParent) Run(c *Char, _ []int32) bool {
 	crun := c
 	var redirscale float32 = 1.0
-	p := crun.parent()
+	p := crun.parent(true)
 	var x, y, z float32 = 0, 0, 0
 	var time int32 = 1
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
@@ -10304,7 +10304,7 @@ func (sc bindToParent) Run(c *Char, _ []int32) bool {
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
 				redirscale = c.localscl / crun.localscl
-				p = crun.parent()
+				p = crun.parent(true)
 			} else {
 				return false
 			}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -11199,6 +11199,7 @@ const (
 func (sc remapSprite) Run(c *Char, _ []int32) bool {
 	crun := c
 	src := [...]int16{-1, -1}
+
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
 		case remapSprite_reset:
@@ -11227,7 +11228,16 @@ func (sc remapSprite) Run(c *Char, _ []int32) bool {
 		}
 		return true
 	})
+
 	crun.anim.remap = crun.remapSpr
+
+	// Update sprite in case current sprite was remapped
+	// https://github.com/ikemen-engine/Ikemen-GO/issues/2456
+	if crun.anim != nil {
+		crun.anim.newframe = true
+		crun.anim.UpdateSprite()
+	}
+
 	return false
 }
 

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -4149,7 +4149,7 @@ func (sc stateDef) Run(c *Char) {
 			c.sprPriority = exp[0].evalI(c)
 			c.layerNo = 0 // Prevent char from being forgotten in a different layer
 		case stateDef_facep2:
-			if exp[0].evalB(c) && c.shouldFaceP2() {
+			if exp[0].evalB(c) && !c.asf(ASF_nofacep2) && c.shouldFaceP2() {
 				c.setFacing(-c.facing)
 			}
 		case stateDef_juggle:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1537,7 +1537,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.Push(BytecodeSF())
 			i += int(*(*int32)(unsafe.Pointer(&be[i]))) + 4
 		case OC_root:
-			if c = c.root(); c != nil {
+			if c = c.root(true); c != nil {
 				i += 4
 				continue
 			}
@@ -2548,11 +2548,11 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_parentdist_z:
 		sys.bcStack.Push(c.rdDistZ(c.parent(true), oc))
 	case OC_ex_rootdist_x:
-		sys.bcStack.Push(c.rdDistX(c.root(), oc))
+		sys.bcStack.Push(c.rdDistX(c.root(true), oc))
 	case OC_ex_rootdist_y:
-		sys.bcStack.Push(c.rdDistY(c.root(), oc))
+		sys.bcStack.Push(c.rdDistY(c.root(true), oc))
 	case OC_ex_rootdist_z:
-		sys.bcStack.Push(c.rdDistZ(c.root(), oc))
+		sys.bcStack.Push(c.rdDistZ(c.root(true), oc))
 	case OC_ex_win:
 		sys.bcStack.PushB(c.win())
 	case OC_ex_winko:
@@ -10279,9 +10279,9 @@ const (
 func (sc bindToParent) Run(c *Char, _ []int32) bool {
 	crun := c
 	var redirscale float32 = 1.0
-	p := crun.parent(true)
 	var x, y, z float32 = 0, 0, 0
 	var time int32 = 1
+
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
 		case bindToParent_time:
@@ -10304,16 +10304,18 @@ func (sc bindToParent) Run(c *Char, _ []int32) bool {
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
 				redirscale = c.localscl / crun.localscl
-				p = crun.parent(true)
 			} else {
 				return false
 			}
 		}
 		return true
 	})
+
+	p := crun.parent(true)
 	if p == nil {
 		return false
 	}
+
 	crun.bindPos[0] = x
 	crun.bindPos[1] = y
 	crun.bindPos[2] = z
@@ -10327,9 +10329,9 @@ type bindToRoot bindToParent
 func (sc bindToRoot) Run(c *Char, _ []int32) bool {
 	crun := c
 	var redirscale float32 = 1.0
-	r := crun.root()
 	var x, y, z float32 = 0, 0, 0
 	var time int32 = 1
+
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
 		case bindToParent_time:
@@ -10352,16 +10354,18 @@ func (sc bindToRoot) Run(c *Char, _ []int32) bool {
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
 				redirscale = c.localscl / crun.localscl
-				r = crun.root()
 			} else {
 				return false
 			}
 		}
 		return true
 	})
+
+	r := crun.root(true)
 	if r == nil {
 		return false
 	}
+
 	crun.bindPos[0] = x
 	crun.bindPos[1] = y
 	crun.bindPos[2] = z

--- a/src/char.go
+++ b/src/char.go
@@ -7360,35 +7360,27 @@ func (c *Char) mapSet(s string, Value float32, scType int32) BytecodeValue {
 	}
 	key := strings.ToLower(s)
 	switch scType {
-	case 0:
+	case 0: // MapSet
 		c.mapArray[key] = Value
-	case 1:
+	case 1: // MapAdd
 		c.mapArray[key] += Value
-	case 2:
-		if c.parent(true) != nil {
-			c.parent(true).mapArray[key] = Value
-		} else {
-			c.mapArray[key] = Value
+	case 2: // ParentMapSet
+		if p := c.parent(true); p != nil {
+			p.mapArray[key] = Value
 		}
-	case 3:
-		if c.parent(true) != nil {
-			c.parent(true).mapArray[key] += Value
-		} else {
-			c.mapArray[key] += Value
+	case 3: // ParentMapAdd
+		if p := c.parent(true); p != nil {
+			p.mapArray[key] += Value
 		}
-	case 4:
-		if c.root(true) != nil {
-			c.root(true).mapArray[key] = Value
-		} else {
-			c.mapArray[key] = Value
+	case 4: // RootMapSet
+		if r := c.root(true); r != nil {
+			r.mapArray[key] = Value
 		}
-	case 5:
-		if c.root(true) != nil {
-			c.root(true).mapArray[key] += Value
-		} else {
-			c.mapArray[key] += Value
+	case 5: // RootMapAdd
+		if r := c.root(true); r != nil {
+			r.mapArray[key] += Value
 		}
-	case 6:
+	case 6: // TeamMapSet
 		if c.teamside == -1 {
 			for i := MaxSimul * 2; i < MaxPlayerNo; i += 1 {
 				if len(sys.chars[i]) > 0 {
@@ -7402,7 +7394,7 @@ func (c *Char) mapSet(s string, Value float32, scType int32) BytecodeValue {
 				}
 			}
 		}
-	case 7:
+	case 7: // TeamMapAdd
 		if c.teamside == -1 {
 			for i := MaxSimul * 2; i < MaxPlayerNo; i += 1 {
 				if len(sys.chars[i]) > 0 {

--- a/src/char.go
+++ b/src/char.go
@@ -3048,7 +3048,7 @@ func (c *Char) load(def string) error {
 						is.ReadI32("fall.defence_up", &gi.data.fall.defence_up)
 						gi.data.fall.defence_mul = (float32(gi.data.fall.defence_up) + 100) / 100
 						is.ReadI32("liedown.time", &gi.data.liedown.time)
-						gi.data.liedown.time = Max(1, gi.data.liedown.time)
+						//gi.data.liedown.time = Max(1, gi.data.liedown.time) // Mugen doesn't actually handle it like this
 						is.ReadI32("airjuggle", &gi.data.airjuggle)
 						is.ReadI32("sparkno", &gi.data.sparkno)
 						is.ReadI32("guard.sparkno", &gi.data.guard.sparkno)
@@ -9331,7 +9331,8 @@ func (c *Char) actionRun() {
 	c.updateSizeBox()
 	if !c.pauseBool {
 		if !c.hitPause() {
-			if c.ss.no == 5110 && c.ghv.down_recovertime <= 0 && c.alive() && !c.asf(ASF_nogetupfromliedown) {
+			// In Mugen chars are forced to stay in state 5110 at least one frame before getting up
+			if c.ss.no == 5110 && c.ss.time >= 1 && c.ghv.down_recovertime <= 0 && c.alive() && !c.asf(ASF_nogetupfromliedown) {
 				c.changeState(5120, -1, -1, "")
 			}
 			for c.ss.no == 140 && (c.anim == nil || len(c.anim.frames) == 0 ||
@@ -9347,7 +9348,7 @@ func (c *Char) actionRun() {
 					c.changeState(52, -1, -1, "")
 				}
 			}
-			c.groundLevel = 0 // Only after position is updated
+			c.groundLevel = 0 // Reset only after position has been updated
 			c.setFacing(c.p1facing)
 			c.p1facing = 0
 			c.ss.time++

--- a/src/char.go
+++ b/src/char.go
@@ -73,6 +73,7 @@ const (
 	ASF_nocrouch
 	ASF_nodizzypointsdamage
 	ASF_nofacedisplay
+	ASF_nofacep2
 	ASF_nofallcount
 	ASF_nofalldefenceup
 	ASF_nofallhitflag

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -4381,33 +4381,31 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_ex_)
 		switch c.token {
 		// Mugen char flags
-		case "nostandguard":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nostandguard))
-		case "nocrouchguard":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nocrouchguard))
-		case "noairguard":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noairguard))
-		case "noshadow":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noshadow))
 		case "invisible":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_invisible))
-		case "unguardable":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_unguardable))
-		case "nojugglecheck":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nojugglecheck))
+		case "noairguard":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noairguard))
 		case "noautoturn":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noautoturn))
-		case "nowalk":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nowalk))
+		case "nocrouchguard":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nocrouchguard))
+		case "nojugglecheck":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nojugglecheck))
 		case "noko":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noko))
+		case "noshadow":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noshadow))
+		case "nostandguard":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nostandguard))
+		case "nowalk":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nowalk))
+		case "unguardable":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_unguardable))
 		// Mugen global flags
 		case "globalnoshadow":
 			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_globalnoshadow))
 		case "intro":
 			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_intro))
-		case "roundnotover":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_roundnotover))
 		case "nobardisplay":
 			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_nobardisplay))
 		case "nobg":
@@ -4420,102 +4418,106 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_nokosnd))
 		case "nomusic":
 			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_nomusic))
+		case "roundnotover":
+			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_roundnotover))
 		case "timerfreeze":
 			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_timerfreeze))
 		// Ikemen char flags
+		case "animatehitpause":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_animatehitpause))
+		case "animfreeze":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_animfreeze))
+		case "autoguard":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_autoguard))
+		case "drawunder":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_drawunder))
+		case "noailevel":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noailevel))
+		case "noairjump":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noairjump))
 		case "nobrake":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nobrake))
 		case "nocombodisplay":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nocombodisplay))
 		case "nocrouch":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nocrouch))
-		case "nostand":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nostand))
-		case "nojump":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nojump))
-		case "noairjump":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noairjump))
-		case "nohardcodedkeys":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nohardcodedkeys))
-		case "nogetupfromliedown":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nogetupfromliedown))
-		case "nofastrecoverfromliedown":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nofastrecoverfromliedown))
+		case "nodizzypointsdamage":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nodizzypointsdamage))
+		case "nofacedisplay":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nofacedisplay))
+		case "nofacep2":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nofacep2))
 		case "nofallcount":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nofallcount))
 		case "nofalldefenceup":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nofalldefenceup))
-		case "noturntarget":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noturntarget))
-		case "noinput":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noinput))
-		case "nolifebaraction":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nolifebaraction))
-		case "nolifebardisplay":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nolifebardisplay))
-		case "nopowerbardisplay":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nopowerbardisplay))
+		case "nofallhitflag":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nofallhitflag))
+		case "nofastrecoverfromliedown":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nofastrecoverfromliedown))
+		case "nogetupfromliedown":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nogetupfromliedown))
 		case "noguardbardisplay":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noguardbardisplay))
-		case "nostunbardisplay":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nostunbardisplay))
-		case "nofacedisplay":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nofacedisplay))
-		case "nonamedisplay":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nonamedisplay))
-		case "nowinicondisplay":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nowinicondisplay))
-		case "autoguard":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_autoguard))
-		case "animatehitpause":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_animatehitpause))
-		case "animfreeze":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_animfreeze))
-		case "postroundinput":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_postroundinput))
-		case "nohitdamage":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nohitdamage))
 		case "noguarddamage":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noguarddamage))
-		case "nodizzypointsdamage":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nodizzypointsdamage))
-		case "noguardpointsdamage":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noguardpointsdamage))
-		case "noredlifedamage":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noredlifedamage))
-		case "nomakedust":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nomakedust))
 		case "noguardko":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noguardko))
+		case "noguardpointsdamage":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noguardpointsdamage))
+		case "nohardcodedkeys":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nohardcodedkeys))
+		case "nohitdamage":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nohitdamage))
+		case "noinput":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noinput))
+		case "nointroreset":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nointroreset))
+		case "nojump":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nojump))
 		case "nokofall":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nokofall))
 		case "nokovelocity":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nokovelocity))
-		case "noailevel":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noailevel))
-		case "nointroreset":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nointroreset))
-		case "sizepushonly":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_sizepushonly))
-		case "drawunder":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_drawunder))
+		case "nolifebaraction":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nolifebaraction))
+		case "nolifebardisplay":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nolifebardisplay))
+		case "nomakedust":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nomakedust))
+		case "nonamedisplay":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nonamedisplay))
+		case "nopowerbardisplay":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nopowerbardisplay))
+		case "noredlifedamage":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noredlifedamage))
+		case "nostand":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nostand))
+		case "nostunbardisplay":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nostunbardisplay))
+		case "noturntarget":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noturntarget))
+		case "nowinicondisplay":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nowinicondisplay))
+		case "postroundinput":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_postroundinput))
+		case "projtypecollision":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_projtypecollision))
 		case "runfirst":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_runfirst))
 		case "runlast":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_runlast))
-		case "projtypecollision":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_projtypecollision))
-		case "nofallhitflag":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nofallhitflag))
+		case "sizepushonly":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_sizepushonly))
 		// Ikemen global flags
 		case "camerafreeze":
 			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_camerafreeze))
 		case "globalnoko":
 			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_globalnoko))
-		case "roundnotskip":
-			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_roundnotskip))
 		case "roundfreeze":
 			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_roundfreeze))
+		case "roundnotskip":
+			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_roundnotskip))
 		case "skipfightdisplay":
 			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_skipfightdisplay))
 		case "skipkodisplay":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -176,6 +176,8 @@ func (c *Compiler) assertSpecial(is IniSection, sc *StateControllerBase, _ int8)
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nodizzypointsdamage)))
 			case "nofacedisplay":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nofacedisplay)))
+			case "nofacep2":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nofacep2)))
 			case "nofallcount":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nofallcount)))
 			case "nofalldefenceup":

--- a/src/script.go
+++ b/src/script.go
@@ -3027,7 +3027,7 @@ func triggerFunctions(l *lua.LState) {
 	})
 	luaRegister(l, "root", func(*lua.LState) int {
 		ret := false
-		if c := sys.debugWC.root(); c != nil {
+		if c := sys.debugWC.root(true); c != nil {
 			sys.debugWC, ret = c, true
 		}
 		l.Push(lua.LBool(ret))
@@ -4784,15 +4784,15 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "rootdistX", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.rdDistX(sys.debugWC.root(), sys.debugWC).ToI()))
+		l.Push(lua.LNumber(sys.debugWC.rdDistX(sys.debugWC.root(true), sys.debugWC).ToI()))
 		return 1
 	})
 	luaRegister(l, "rootdistY", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.rdDistY(sys.debugWC.root(), sys.debugWC).ToI()))
+		l.Push(lua.LNumber(sys.debugWC.rdDistY(sys.debugWC.root(true), sys.debugWC).ToI()))
 		return 1
 	})
 	luaRegister(l, "rootdistZ", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.rdDistZ(sys.debugWC.root(), sys.debugWC).ToI()))
+		l.Push(lua.LNumber(sys.debugWC.rdDistZ(sys.debugWC.root(true), sys.debugWC).ToI()))
 		return 1
 	})
 	luaRegister(l, "roundno", func(*lua.LState) int {

--- a/src/script.go
+++ b/src/script.go
@@ -3019,7 +3019,7 @@ func triggerFunctions(l *lua.LState) {
 	})
 	luaRegister(l, "parent", func(*lua.LState) int {
 		ret := false
-		if c := sys.debugWC.parent(); c != nil {
+		if c := sys.debugWC.parent(true); c != nil {
 			sys.debugWC, ret = c, true
 		}
 		l.Push(lua.LBool(ret))
@@ -3137,7 +3137,7 @@ func triggerFunctions(l *lua.LState) {
 		if !nilArg(l, 1) {
 			id = int32(numArg(l, 1))
 		}
-		if c := sys.debugWC.getPlayerHelperIndex(id, true); c != nil {
+		if c := sys.debugWC.helperIndexTrigger(id, true); c != nil {
 			sys.debugWC, ret = c, true
 		}
 		l.Push(lua.LBool(ret))
@@ -4516,15 +4516,15 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "parentdistX", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.rdDistX(sys.debugWC.parent(), sys.debugWC).ToI()))
+		l.Push(lua.LNumber(sys.debugWC.rdDistX(sys.debugWC.parent(true), sys.debugWC).ToI()))
 		return 1
 	})
 	luaRegister(l, "parentdistY", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.rdDistY(sys.debugWC.parent(), sys.debugWC).ToI()))
+		l.Push(lua.LNumber(sys.debugWC.rdDistY(sys.debugWC.parent(true), sys.debugWC).ToI()))
 		return 1
 	})
 	luaRegister(l, "parentdistZ", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.rdDistZ(sys.debugWC.parent(), sys.debugWC).ToI()))
+		l.Push(lua.LNumber(sys.debugWC.rdDistZ(sys.debugWC.parent(true), sys.debugWC).ToI()))
 		return 1
 	})
 	luaRegister(l, "posX", func(*lua.LState) int {

--- a/src/script.go
+++ b/src/script.go
@@ -5526,6 +5526,8 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_nocrouch)))
 		case "nodizzypointsdamage":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_nodizzypointsdamage)))
+		case "nofacep2":
+			l.Push(lua.LBool(sys.debugWC.asf(ASF_nofacep2)))
 		case "nofallcount":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_nofallcount)))
 		case "nofalldefenceup":


### PR DESCRIPTION
Features:
- AssertSpecial NoFaceP2 flag. Disables the effect of a StateDef facep2 parameter

Fixes:
- Chars are now forced to stay in state 5110 at least 1 frame before changing to state 5120
- Remapping the current sprite is now instantly reflected on screen
- Fixed HelperIndex making Ikemen hang in specific scenarios
- Fixed Parent/RootMapSet setting the maps in the player itself when no parent or root exist
- Fixes #2456 
- Fixes #2462 

Refactor:
- liedown.time is no longer clamped to a minimum of 1
- Helpers can no longer have ghosted parents that are replaceable by other helpers. When the parent is destroyed, parent features permanently stop working