### PR TITLE
feat: Add support for loading characters from ZIP archives

### DIFF
--- a/src/compiler.go
+++ b/src/compiler.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"math"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -5938,7 +5937,7 @@ func (c *Compiler) stateCompile(states map[int32]StateBytecode,
 		var err error
 		// If this is a zss file
 		if zss {
-			b, err := os.ReadFile(filename)
+			b, err := LoadText(filename)
 			if err != nil {
 				return err
 			}
@@ -5953,7 +5952,7 @@ func (c *Compiler) stateCompile(states map[int32]StateBytecode,
 		// If filename doesn't exist, see if a zss file exists
 		fnz += ".zss"
 		if err := LoadFile(&fnz, dirs, func(filename string) error {
-			b, err := os.ReadFile(filename)
+			b, err := LoadText(filename)
 			if err != nil {
 				return err
 			}

--- a/src/sound.go
+++ b/src/sound.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"io"
 	"math"
 	"os"
 
@@ -369,7 +370,7 @@ type Sound struct {
 	length  int
 }
 
-func readSound(f *os.File, size uint32) (*Sound, error) {
+func readSound(f io.ReadSeekCloser, size uint32) (*Sound, error) {
 	if size < 128 {
 		return nil, fmt.Errorf("wav size is too small")
 	}
@@ -423,7 +424,7 @@ func LoadSnd(filename string) (*Snd, error) {
 // If max > 0, the function returns immediately when a matching entry is found. It also gives up after "max" non-matching entries.
 func LoadSndFiltered(filename string, keepItem func([2]int32) bool, max uint32) (*Snd, error) {
 	s := newSnd()
-	f, err := os.Open(filename)
+	f, err := OpenFile(filename)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
chars from zip archives can now be loaded #1929
currently, it only supports chars, not stages

It follows a similar behavior to MUGEN
If kfm.zip is specified in select.def, the engine will look for kfm.def (or kfm/kfm.def) inside the archive