### PR TITLE
feat: projection support, lifebar features, multiple ACs, xshear interpolation, new triggers; fixes

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -1954,9 +1954,17 @@ function main.f_addStage(file, hidden)
 	})
 	--attachedchar
 	if t_info.attachedchardef ~= '' then
-		main.t_selStages[stageNo].attachedChar = getCharAttachedInfo(t_info.attachedchardef)
-		if main.t_selStages[stageNo].attachedChar ~= nil then
-			main.t_selStages[stageNo].attachedChar.dir = main.t_selStages[stageNo].attachedChar.def:gsub('[^/]+%.def$', '')
+		local attachedList = t_info.attachedchardef
+		if type(attachedList) ~= 'table' then
+			attachedList = {attachedList} -- Convert string to list
+		end
+		main.t_selStages[stageNo].attachedChar = {}
+		for i = 1, #attachedList do
+			local acInfo = getCharAttachedInfo(attachedList[i])
+			if acInfo ~= nil then
+				acInfo.dir = acInfo.def:gsub('[^/]+%.def$', '')
+				table.insert(main.t_selStages[stageNo].attachedChar, acInfo)
+			end
 		end
 	end
 	--music

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -12494,12 +12494,22 @@ const (
 	modifyStageVar_shadow_intensity
 	modifyStageVar_shadow_color
 	modifyStageVar_shadow_yscale
+	modifyStageVar_shadow_angle
+	modifyStageVar_shadow_xangle
+	modifyStageVar_shadow_yangle
+	modifyStageVar_shadow_focallength
+	modifyStageVar_shadow_projection
 	modifyStageVar_shadow_fade_range
 	modifyStageVar_shadow_xshear
 	modifyStageVar_shadow_offset
 	modifyStageVar_shadow_window
 	modifyStageVar_reflection_intensity
 	modifyStageVar_reflection_yscale
+	modifyStageVar_reflection_angle
+	modifyStageVar_reflection_xangle
+	modifyStageVar_reflection_yangle
+	modifyStageVar_reflection_focallength
+	modifyStageVar_reflection_projection
 	modifyStageVar_reflection_xshear
 	modifyStageVar_reflection_color
 	modifyStageVar_reflection_offset
@@ -12632,6 +12642,16 @@ func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 			s.sdw.color = uint32(r<<16 | g<<8 | b)
 		case modifyStageVar_shadow_yscale:
 			s.sdw.yscale = exp[0].evalF(c)
+		case modifyStageVar_shadow_angle:
+			s.sdw.rot.angle = exp[0].evalF(c)
+		case modifyStageVar_shadow_xangle:
+			s.sdw.rot.xangle = exp[0].evalF(c)
+		case modifyStageVar_shadow_yangle:
+			s.sdw.rot.yangle = exp[0].evalF(c)
+		case modifyStageVar_shadow_focallength:
+			s.sdw.fLength = exp[0].evalF(c)
+		case modifyStageVar_shadow_projection:
+			s.sdw.projection = Projection(exp[0].evalI(c))
 		case modifyStageVar_shadow_fade_range:
 			s.sdw.fadeend = exp[0].evalI(c)
 			s.sdw.fadebgn = exp[1].evalI(c)
@@ -12650,6 +12670,16 @@ func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 			s.reflection.intensity = Clamp(exp[0].evalI(c), 0, 255)
 		case modifyStageVar_reflection_yscale:
 			s.reflection.yscale = exp[0].evalF(c)
+		case modifyStageVar_reflection_angle:
+			s.reflection.rot.angle = exp[0].evalF(c)
+		case modifyStageVar_reflection_xangle:
+			s.reflection.rot.xangle = exp[0].evalF(c)
+		case modifyStageVar_reflection_yangle:
+			s.reflection.rot.yangle = exp[0].evalF(c)
+		case modifyStageVar_reflection_focallength:
+			s.reflection.fLength = exp[0].evalF(c)
+		case modifyStageVar_reflection_projection:
+			s.reflection.projection = Projection(exp[0].evalI(c))
 		case modifyStageVar_reflection_xshear:
 			s.reflection.xshear = exp[0].evalF(c)
 		case modifyStageVar_reflection_color:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -12150,6 +12150,7 @@ const (
 	text_velocity
 	text_friction
 	text_accel
+	text_angle
 	text_scale
 	text_color
 	text_xshear
@@ -12234,6 +12235,8 @@ func (sc text) Run(c *Char, _ []int32) bool {
 			if len(exp) > 1 {
 				ts.accel[1] = exp[1].evalF(c) / ts.localScale
 			}
+		case text_angle:
+			ts.angle = exp[0].evalF(c)
 		case text_scale:
 			xscl = exp[0].evalF(c)
 			if len(exp) > 1 {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -7190,6 +7190,8 @@ const (
 	projectile_remappal
 	projectile_projwindow
 	projectile_projxshear
+	projectile_projprojection
+	projectile_projfocallength
 	// projectile_platform
 	// projectile_platformwidth
 	// projectile_platformheight
@@ -7363,6 +7365,10 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 			p.window = [4]float32{exp[0].evalF(c) * redirscale, exp[1].evalF(c) * redirscale, exp[2].evalF(c) * redirscale, exp[3].evalF(c) * redirscale}
 		case projectile_projxshear:
 			p.xshear = exp[0].evalF(c)
+		case projectile_projfocallength:
+			p.fLength = exp[0].evalF(c)
+		case projectile_projprojection:
+			p.projection = Projection(exp[0].evalI(c))
 		// case projectile_platform:
 		// 	p.platform = exp[0].evalB(c)
 		// case projectile_platformwidth:
@@ -7754,6 +7760,14 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				v1 := exp[0].evalF(c)
 				eachProj(func(p *Projectile) {
 					p.xshear = v1
+				})
+			case projectile_projprojection:
+				eachProj(func(p *Projectile) {
+					p.projection = Projection(exp[0].evalI(c))
+				})
+			case projectile_projfocallength:
+				eachProj(func(p *Projectile) {
+					p.fLength = exp[0].evalF(c)
 				})
 			case hitDef_attr:
 				v1 := exp[0].evalI(c)
@@ -13109,6 +13123,8 @@ type transformSprite StateControllerBase
 
 const (
 	transformSprite_window byte = iota
+	transformSprite_focallength
+	transformSprite_projection
 	transformSprite_xshear
 	transformSprite_redirectid
 )
@@ -13122,6 +13138,10 @@ func (sc transformSprite) Run(c *Char, _ []int32) bool {
 			crun.window = [4]float32{exp[0].evalF(c) * redirscale, exp[1].evalF(c) * redirscale, exp[2].evalF(c) * redirscale, exp[3].evalF(c) * redirscale}
 		case transformSprite_xshear:
 			crun.xshear = exp[0].evalF(c)
+		case transformSprite_focallength:
+			c.fLength = exp[0].evalF(c)
+		case transformSprite_projection:
+			c.projection = Projection(exp[0].evalI(c))
 		case transformSprite_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -13229,6 +13229,8 @@ const (
 	modifyStageBG_actionno
 	modifyStageBG_alpha
 	modifyStageBG_angle
+	modifyStageBG_xangle
+	modifyStageBG_yangle
 	modifyStageBG_delta_x
 	modifyStageBG_delta_y
 	modifyStageBG_layerno
@@ -13242,6 +13244,8 @@ const (
 	modifyStageBG_velocity_x
 	modifyStageBG_velocity_y
 	modifyStageBG_xshear
+	modifyStageBG_focallength
+	modifyStageBG_projection
 )
 
 func (sc modifyStageBG) Run(c *Char, _ []int32) bool {
@@ -13297,7 +13301,17 @@ func (sc modifyStageBG) Run(c *Char, _ []int32) bool {
 			case modifyStageBG_angle:
 				val := exp[0].evalF(c)
 				eachBg(func(bg *backGround) {
-					bg.angle = val
+					bg.rot.angle = val
+				})
+			case modifyStageBG_xangle:
+				val := exp[0].evalF(c)
+				eachBg(func(bg *backGround) {
+					bg.rot.xangle = val
+				})
+			case modifyStageBG_yangle:
+				val := exp[0].evalF(c)
+				eachBg(func(bg *backGround) {
+					bg.rot.yangle = val
 				})
 			case modifyStageBG_delta_x:
 				val := exp[0].evalF(c)
@@ -13392,6 +13406,16 @@ func (sc modifyStageBG) Run(c *Char, _ []int32) bool {
 				val := exp[0].evalF(c)
 				eachBg(func(bg *backGround) {
 					bg.xshear = val
+				})
+			case modifyStageBG_focallength:
+				val := exp[0].evalF(c)
+				eachBg(func(bg *backGround) {
+					bg.fLength = val
+				})
+			case modifyStageBG_projection:
+				val := Projection(exp[0].evalI(c))
+				eachBg(func(bg *backGround) {
+					bg.projection = val
 				})
 			}
 		}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -932,6 +932,7 @@ const (
 	OC_ex2_numstagebg
 	OC_ex2_envshakevar_dir
 	OC_ex2_gethitvar_fall_envshake_dir
+	OC_ex2_xshear
 )
 
 type StringPool struct {
@@ -3781,6 +3782,8 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(sys.envShake.dir / float32(math.Pi) * 180)
 	case OC_ex2_gethitvar_fall_envshake_dir:
 		sys.bcStack.PushF(c.ghv.fall_envshake_dir)
+	case OC_ex2_xshear:
+		sys.bcStack.PushF(c.xshear)
 	default:
 		sys.errLog.Printf("%v\n", be[*i-1])
 		c.panic()

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5236,6 +5236,11 @@ const (
 	modifyShadow_window
 	modifyShadow_xshear
 	modifyShadow_yscale
+	modifyShadow_angle
+	modifyShadow_xangle
+	modifyShadow_yangle
+	modifyShadow_focallength
+	modifyShadow_projection
 	modifyShadow_redirectid
 )
 
@@ -5262,6 +5267,16 @@ func (sc modifyShadow) Run(c *Char, _ []int32) bool {
 			crun.shadowXshear = exp[0].evalF(c)
 		case modifyShadow_yscale:
 			crun.shadowYscale = exp[0].evalF(c)
+		case modifyShadow_angle:
+			crun.shadowRot.angle = exp[0].evalF(c)
+		case modifyShadow_xangle:
+			crun.shadowRot.xangle = exp[0].evalF(c)
+		case modifyShadow_yangle:
+			crun.shadowRot.yangle = exp[0].evalF(c)
+		case modifyShadow_focallength:
+			crun.shadowfLength = exp[0].evalF(c)
+		case modifyShadow_projection:
+			crun.shadowProjection = Projection(exp[0].evalI(c))
 		case modifyShadow_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -5284,6 +5299,11 @@ const (
 	modifyReflection_window
 	modifyReflection_xshear
 	modifyReflection_yscale
+	modifyReflection_angle
+	modifyReflection_xangle
+	modifyReflection_yangle
+	modifyReflection_focallength
+	modifyReflection_projection
 	modifyReflection_redirectid
 )
 
@@ -5310,6 +5330,16 @@ func (sc modifyReflection) Run(c *Char, _ []int32) bool {
 			crun.reflectXshear = exp[0].evalF(c)
 		case modifyReflection_yscale:
 			crun.reflectYscale = exp[0].evalF(c)
+		case modifyReflection_angle:
+			crun.reflectRot.angle = exp[0].evalF(c)
+		case modifyReflection_xangle:
+			crun.reflectRot.xangle = exp[0].evalF(c)
+		case modifyReflection_yangle:
+			crun.reflectRot.yangle = exp[0].evalF(c)
+		case modifyReflection_focallength:
+			crun.reflectfLength = exp[0].evalF(c)
+		case modifyReflection_projection:
+			crun.reflectProjection = Projection(exp[0].evalI(c))
 		case modifyReflection_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -831,6 +831,8 @@ const (
 	OC_ex2_projvar_pos_y
 	OC_ex2_projvar_pos_z
 	OC_ex2_projvar_projangle
+	OC_ex2_projvar_projyangle
+	OC_ex2_projvar_projxangle
 	OC_ex2_projvar_projanim
 	OC_ex2_projvar_projcancelanim
 	OC_ex2_projvar_projedgebound
@@ -3556,6 +3558,10 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	case OC_ex2_projvar_projscale_y:
 		fallthrough
 	case OC_ex2_projvar_projangle:
+		fallthrough
+	case OC_ex2_projvar_projyangle:
+		fallthrough
+	case OC_ex2_projvar_projxangle:
 		fallthrough
 	case OC_ex2_projvar_projxshear:
 		fallthrough
@@ -7166,6 +7172,8 @@ const (
 	projectile_accel
 	projectile_projscale
 	projectile_projangle
+	projectile_projxangle
+	projectile_projyangle
 	projectile_projclsnscale
 	projectile_projclsnangle
 	projectile_offset
@@ -7286,7 +7294,11 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 				p.scale[1] = exp[1].evalF(c)
 			}
 		case projectile_projangle:
-			p.angle = exp[0].evalF(c)
+			p.anglerot[0] = exp[0].evalF(c)
+		case projectile_projyangle:
+			p.anglerot[2] = exp[0].evalF(c)
+		case projectile_projxangle:
+			p.anglerot[1] = exp[0].evalF(c)
 		case projectile_offset:
 			x = exp[0].evalF(c) * redirscale
 			if len(exp) > 1 {
@@ -7627,9 +7639,19 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 					p.scale[1] = v2
 				})
 			case projectile_projangle:
-				v1 := exp[0].evalF(c)
+				a := exp[0].evalF(c)
 				eachProj(func(p *Projectile) {
-					p.angle = v1
+					p.anglerot[0] = a
+				})
+			case projectile_projyangle:
+				ya := exp[0].evalF(c)
+				eachProj(func(p *Projectile) {
+					p.anglerot[2] = ya
+				})
+			case projectile_projxangle:
+				xa := exp[0].evalF(c)
+				eachProj(func(p *Projectile) {
+					p.anglerot[1] = xa
 				})
 			//case projectile_offset: // Pointless because it's only used when the projectile is created
 			case projectile_projsprpriority:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5538,6 +5538,7 @@ const (
 	explod_interpolate_angle
 	explod_interpolate_alpha
 	explod_interpolate_focallength
+	explod_interpolate_xshear
 	explod_interpolate_pfx_mul
 	explod_interpolate_pfx_add
 	explod_interpolate_pfx_color
@@ -5844,6 +5845,8 @@ func (sc explod) setInterpolation(c *Char, e *Explod, paramID byte, exp []Byteco
 		}
 	case explod_interpolate_focallength:
 		e.interpolate_fLength[1] = exp[0].evalF(c)
+	case explod_interpolate_xshear:
+		e.interpolate_xshear[1] = exp[0].evalF(c)
 	case explod_interpolate_pfx_mul:
 		pfd.imul[0] = exp[0].evalI(c)
 		if len(exp) > 1 {

--- a/src/char.go
+++ b/src/char.go
@@ -1644,12 +1644,6 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 		//	}
 		//}
 
-		if e.bindtime > 0 {
-			c := sys.playerID(e.playerId)
-			if e.ignorehitpause || c == nil || (!c.pause() && !c.hitPause()) {
-				e.bindtime--
-			}
-		}
 		if act {
 			if e.palfx != nil && e.ownpal {
 				e.palfx.step()
@@ -1672,6 +1666,9 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 				e.anim.Action()
 			}
 			e.time++
+			if e.bindtime > 0 {
+				e.bindtime--
+			}
 		} else {
 			e.setX(e.pos[0])
 			e.setY(e.pos[1])
@@ -2627,12 +2624,6 @@ func (c *Char) init(n int, idx int32) {
 		c.playerFlag = false
 		c.kovelocity = false
 		c.keyctrl = [4]bool{false, false, false, true}
-	}
-
-	if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
-		c.projection = Projection_Perspective
-	} else {
-		c.projection = Projection_Orthographic
 	}
 
 	// Set controller to CPU if applicable
@@ -5743,12 +5734,6 @@ func (c *Char) newProj() *Projectile {
 			p.localscl = (320 / c.localcoord)
 		} else {
 			p.localscl = c.localscl
-		}
-
-		if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
-			p.projection = Projection_Perspective
-		} else {
-			p.projection = Projection_Orthographic
 		}
 
 		p.layerno = c.layerNo
@@ -9332,11 +9317,7 @@ func (c *Char) actionPrepare() {
 		c.window = [4]float32{}
 		c.xshear = 0
 		c.fLength = 2048
-		if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
-			c.projection = Projection_Perspective
-		} else {
-			c.projection = Projection_Orthographic
-		}
+		c.projection = Projection_Orthographic
 	}
 	// Decrease unhittable timer
 	// This used to be in tick(), but Mugen Clsn display suggests it happens sooner than that

--- a/src/char.go
+++ b/src/char.go
@@ -1283,6 +1283,7 @@ type Explod struct {
 	start_rot            [3]float32
 	start_alpha          [2]int32
 	start_fLength        float32
+	start_xshear         float32
 	interpolate          bool
 	interpolate_time     [2]int32
 	interpolate_animelem [3]int32
@@ -1291,6 +1292,7 @@ type Explod struct {
 	interpolate_pos      [6]float32
 	interpolate_angle    [6]float32
 	interpolate_fLength  [2]float32
+	interpolate_xshear   [2]float32
 	animNo               int32
 	interPos             [3]float32
 }
@@ -1531,8 +1533,9 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 	anglerot := e.anglerot
 	fLength := e.fLength
 	scale := e.scale
+	xshear := e.xshear
 	if e.interpolate {
-		e.Interpolate(act, &scale, &alp, &anglerot, &fLength)
+		e.Interpolate(act, &scale, &alp, &anglerot, &fLength, &xshear)
 	}
 	if alp[0] < 0 {
 		alp[0] = -1
@@ -1599,7 +1602,7 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 		projection:   int32(e.projection),
 		fLength:      fLength,
 		window:       ewin,
-		xshear:       e.xshear,
+		xshear:       xshear,
 	}
 	sprs.add(sd)
 
@@ -1677,10 +1680,11 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 	}
 }
 
-func (e *Explod) Interpolate(act bool, scale *[2]float32, alpha *[2]int32, anglerot *[3]float32, fLength *float32) {
+func (e *Explod) Interpolate(act bool, scale *[2]float32, alpha *[2]int32, anglerot *[3]float32, fLength *float32, xshear *float32) {
 	if sys.tickNextFrame() && act {
 		t := float32(e.interpolate_time[1]) / float32(e.interpolate_time[0])
 		e.interpolate_fLength[0] = Lerp(e.interpolate_fLength[1], e.start_fLength, t)
+		e.interpolate_xshear[0] = Lerp(e.interpolate_xshear[1], e.start_xshear, t)
 		if e.interpolate_animelem[1] >= 0 {
 			elem := Ceil(Lerp(float32(e.interpolate_animelem[0]-1), float32(e.interpolate_animelem[1]), 1-t))
 
@@ -1718,11 +1722,13 @@ func (e *Explod) Interpolate(act bool, scale *[2]float32, alpha *[2]int32, angle
 		(*anglerot)[i] = e.interpolate_angle[i] + e.anglerot[i]
 	}
 	*fLength = e.interpolate_fLength[0] + e.fLength
+	*xshear = e.interpolate_xshear[0]
 }
 
 func (e *Explod) setStartParams(pfd *PalFXDef) {
 	e.start_animelem = e.animelem
 	e.start_fLength = e.fLength
+	e.start_xshear = e.xshear
 	for i := 0; i < 3; i++ {
 		if i < 2 {
 			e.start_scale[i] = e.scale[i]
@@ -1776,6 +1782,7 @@ func (e *Explod) resetInterpolation(pfd *PalFXDef) {
 	for i := 0; i < 2; i++ {
 		e.interpolate_animelem[i] = -1
 		e.interpolate_fLength[i] = e.fLength
+		e.interpolate_xshear[i] = e.xshear
 	}
 }
 

--- a/src/char.go
+++ b/src/char.go
@@ -1642,7 +1642,10 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 		//}
 
 		if e.bindtime > 0 {
-			e.bindtime--
+			c := sys.playerID(e.playerId)
+			if e.ignorehitpause || c == nil || (!c.pause() && !c.hitPause()) {
+				e.bindtime--
+			}
 		}
 		if act {
 			if e.palfx != nil && e.ownpal {

--- a/src/char.go
+++ b/src/char.go
@@ -2507,58 +2507,64 @@ type Char struct {
 	cnssysvar           map[int32]int32
 	cnssysfvar          map[int32]float32
 	CharSystemVar
-	aimg             AfterImage
-	soundChannels    SoundChannels
-	p1facing         float32
-	cpucmd           int32
-	offset           [2]float32
-	stchtmp          bool
-	inguarddist      bool
-	pushed           bool
-	hitdefContact    bool
-	atktmp           int8 // 1 hitdef can hit, 0 cannot hit, -1 other
-	hittmp           int8 // 0 idle, 1 being hit, 2 falling, -1 reversaldef
-	acttmp           int8 // 1 unpaused, 0 default, -1 hitpause, -2 pause
-	minus            int8 // Essentially the current negative state
-	platformPosY     float32
-	groundAngle      float32
-	ownpal           bool
-	winquote         int32
-	memberNo         int
-	selectNo         int
-	inheritJuggle    int32
-	inheritChannels  int32
-	mapArray         map[string]float32
-	mapDefault       map[string]float32
-	remapSpr         RemapPreset
-	clipboardText    []string
-	dialogue         []string
-	immortal         bool
-	kovelocity       bool
-	preserve         int32
-	inputFlag        InputBits
-	pauseBool        bool
-	downHitOffset    bool
-	koEchoTimer      int32
-	groundLevel      float32
-	sizeBox          [4]float32
-	shadowColor      [3]int32
-	shadowIntensity  int32
-	shadowOffset     [2]float32
-	shadowWindow     [4]float32
-	shadowXshear     float32
-	shadowYscale     float32
-	reflectColor     [3]int32
-	reflectIntensity int32
-	reflectOffset    [2]float32
-	reflectWindow    [4]float32
-	reflectXshear    float32
-	reflectYscale    float32
-	ownclsnscale     bool
-	pushPriority     int32
-	prevfallflag     bool
-	dustOldPos       [3]float32
-	dustTime         int
+	aimg              AfterImage
+	soundChannels     SoundChannels
+	p1facing          float32
+	cpucmd            int32
+	offset            [2]float32
+	stchtmp           bool
+	inguarddist       bool
+	pushed            bool
+	hitdefContact     bool
+	atktmp            int8 // 1 hitdef can hit, 0 cannot hit, -1 other
+	hittmp            int8 // 0 idle, 1 being hit, 2 falling, -1 reversaldef
+	acttmp            int8 // 1 unpaused, 0 default, -1 hitpause, -2 pause
+	minus             int8 // Essentially the current negative state
+	platformPosY      float32
+	groundAngle       float32
+	ownpal            bool
+	winquote          int32
+	memberNo          int
+	selectNo          int
+	inheritJuggle     int32
+	inheritChannels   int32
+	mapArray          map[string]float32
+	mapDefault        map[string]float32
+	remapSpr          RemapPreset
+	clipboardText     []string
+	dialogue          []string
+	immortal          bool
+	kovelocity        bool
+	preserve          int32
+	inputFlag         InputBits
+	pauseBool         bool
+	downHitOffset     bool
+	koEchoTimer       int32
+	groundLevel       float32
+	sizeBox           [4]float32
+	shadowColor       [3]int32
+	shadowIntensity   int32
+	shadowOffset      [2]float32
+	shadowWindow      [4]float32
+	shadowXshear      float32
+	shadowYscale      float32
+	shadowRot         Rotation
+    shadowProjection  Projection
+	shadowfLength     float32
+	reflectColor      [3]int32
+	reflectIntensity  int32
+	reflectOffset     [2]float32
+	reflectWindow     [4]float32
+	reflectXshear     float32
+	reflectYscale     float32
+	reflectRot        Rotation
+	reflectProjection Projection
+	reflectfLength    float32
+	ownclsnscale      bool
+	pushPriority      int32
+	prevfallflag      bool
+	dustOldPos        [3]float32
+	dustTime          int
 }
 
 // Add a new char to the game
@@ -9309,6 +9315,9 @@ func (c *Char) actionPrepare() {
 		c.shadowWindow = [4]float32{}
 		c.shadowXshear = 0
 		c.shadowYscale = 0
+		c.shadowRot = Rotation{0, 0, 0}
+		c.shadowProjection = -1
+	    c.shadowfLength = 0
 		// Reset modifyReflection
 		c.reflectColor = [3]int32{-1, -1, -1}
 		c.reflectIntensity = -1
@@ -9316,6 +9325,9 @@ func (c *Char) actionPrepare() {
 		c.reflectWindow = [4]float32{}
 		c.reflectXshear = 0
 		c.reflectYscale = 0
+		c.reflectRot = Rotation{0, 0, 0}
+		c.reflectProjection = -1
+	    c.reflectfLength = 0
 		// Reset TransformSprite
 		c.window = [4]float32{}
 		c.xshear = 0
@@ -10334,16 +10346,22 @@ func (c *Char) cueDraw() {
 					shadowWindow:     c.shadowWindow,
 					shadowXshear:     c.shadowXshear,
 					shadowYscale:     c.shadowYscale,
+					shadowRot:        c.shadowRot,
+					shadowProjection: int32(c.shadowProjection),
+					shadowfLength:    c.shadowfLength,
 					reflectColor:     reflectclr,
 					reflectIntensity: c.reflectIntensity,
 					reflectOffset: [2]float32{
 						c.reflectOffset[0] * c.localscl,
 						(c.size.shadowoffset+c.reflectOffset[1])*c.localscl + refYscale*drawZoff + drawZoff,
 					},
-					reflectWindow: c.reflectWindow,
-					reflectXshear: c.reflectXshear,
-					reflectYscale: c.reflectYscale,
-					fadeOffset:    c.offsetY() + drawZoff,
+					reflectWindow:     c.reflectWindow,
+					reflectXshear:     c.reflectXshear,
+					reflectYscale:     c.reflectYscale,
+					reflectRot:        c.reflectRot,
+					reflectProjection: int32(c.reflectProjection),
+					reflectfLength:    c.reflectfLength,
+					fadeOffset:        c.offsetY() + drawZoff,
 				})
 			}
 		}

--- a/src/char.go
+++ b/src/char.go
@@ -2384,7 +2384,8 @@ type CharSystemVar struct {
 	bindPosAdd        [3]float32
 	bindFacing        float32
 	hitPauseTime      int32
-	angle             float32
+	rot               Rotation
+	anglerot          [3]float32
 	angleDrawScale    [2]float32
 	alpha             [2]int32
 	systemFlag        SystemCharFlag
@@ -7171,7 +7172,15 @@ func (c *Char) hitPause() bool {
 }
 
 func (c *Char) angleSet(a float32) {
-	c.angle = a
+	c.anglerot[0] = a
+}
+
+func (c *Char) XangleSet(xa float32) {
+	c.anglerot[1] = xa
+}
+
+func (c *Char) YangleSet(ya float32) {
+	c.anglerot[2] = ya
 }
 
 func (c *Char) inputWait() bool {
@@ -10142,14 +10151,19 @@ func (c *Char) cueDraw() {
 		//	pos[1] += c.interPos[2] * c.localscl
 		//}
 
-		agl := float32(0)
+		anglerot := c.anglerot
+		rot := c.rot
+
 		if c.csf(CSF_angledraw) {
-			agl = c.angle
+			rot.angle = anglerot[0]
+			rot.xangle = anglerot[1]
+			rot.yangle = anglerot[2]
 			// if agl == 0 {
 			// 	agl = 360 // Is it really necessary for the initial angle to be 360?
 			// } else if c.facing < 0 {
 			if c.facing < 0 {
-				agl *= -1
+				anglerot[0] *= -1
+				anglerot[2] *= -1
 			}
 		}
 
@@ -10197,7 +10211,7 @@ func (c *Char) cueDraw() {
 			scl:          scl,
 			alpha:        c.alpha,
 			priority:     c.sprPriority + int32(c.pos[2]*c.localscl),
-			rot:          Rotation{agl, 0, 0},
+			rot:          rot,
 			screen:       false,
 			undarken:     c.playerNo == sys.superplayerno,
 			oldVer:       c.gi().mugenver[0] != 1,

--- a/src/common.go
+++ b/src/common.go
@@ -957,9 +957,13 @@ func (l *Layout) DrawFaceSprite(x, y float32, ln int16, s *Sprite, fx *PalFX, fs
 		if s.coldepth <= 8 && s.PalTex == nil {
 			s.CachePalette(s.Pal)
 		}
-		s.Draw(x+l.offset[0]*sys.lifebarScale, y+l.offset[1]*sys.lifebarScale,
+		// Xshear offset correction
+		xshear := -l.xshear
+		xsoffset := xshear * (float32(s.Offset[1]) * l.scale[1] * fscale)
+
+		s.Draw(x+l.offset[0]-xsoffset*sys.lifebarScale, y+l.offset[1]*sys.lifebarScale,
 			l.scale[0]*float32(l.facing)*fscale, l.scale[1]*float32(l.vfacing)*fscale,
-			l.angle, -l.xshear, fx, window)
+			xshear, Rotation{l.angle, 0, 0}, fx, window)
 	}
 }
 

--- a/src/common.go
+++ b/src/common.go
@@ -961,9 +961,29 @@ func (l *Layout) DrawFaceSprite(x, y float32, ln int16, s *Sprite, fx *PalFX, fs
 		xshear := -l.xshear
 		xsoffset := xshear * (float32(s.Offset[1]) * l.scale[1] * fscale)
 
+		drawwindow := window
+
+		if *window != sys.scrrect {
+			w := window
+			if w[0] > w[2] {
+				w[0], w[2] = w[2], w[0]
+			}
+			if w[1] > w[3] {
+				w[1], w[3] = w[3], w[1]
+			}
+
+			var fwin [4]int32
+			fwin[0] = int32(float32(w[0]) * l.scale[0] * fscale)
+			fwin[1] = int32(float32(w[1]) * l.scale[1] * fscale)
+			fwin[2] = int32(float32(w[2]-w[0]) * l.scale[0] * fscale)
+			fwin[3] = int32(float32(w[3]-w[1]) * l.scale[1] * fscale)
+
+			drawwindow = &fwin
+		}
+
 		s.Draw(x+l.offset[0]-xsoffset*sys.lifebarScale, y+l.offset[1]*sys.lifebarScale,
 			l.scale[0]*float32(l.facing)*fscale, l.scale[1]*float32(l.vfacing)*fscale,
-			xshear, Rotation{l.angle, 0, 0}, fx, window)
+			xshear, Rotation{l.angle, 0, 0}, fx, drawwindow)
 	}
 }
 

--- a/src/common.go
+++ b/src/common.go
@@ -1027,8 +1027,8 @@ func (l *Layout) DrawText(x, y, scl float32, ln int16,
 
 		f.Print(text, (x+l.offset[0]-xsoffset)*scl, (y+l.offset[1])*scl,
 			l.scale[0]*sys.lifebar.fnt_scale*float32(l.facing)*scl,
-			l.scale[1]*sys.lifebar.fnt_scale*float32(l.vfacing)*scl, xshear, b, a,
-			&l.window, palfx, frgba)
+			l.scale[1]*sys.lifebar.fnt_scale*float32(l.vfacing)*scl, xshear, Rotation{l.angle, 0, 0}, 
+			b, a, &l.window, palfx, frgba)
 	}
 }
 

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -3057,7 +3057,18 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				return bvNone(), Error(fmt.Sprint("Invalid ProjVar accel argument: %s", c.token))
 			}
 		case "angle":
-			opc = OC_ex2_projvar_projangle
+			c.token = c.tokenizer(in)
+
+			switch c.token {
+			case "x":
+				opc = OC_ex2_projvar_projxangle
+			case "y":
+				opc = OC_ex2_projvar_projyangle
+			case ")":
+				opc = OC_ex2_projvar_projangle
+			default:
+				return bvNone(), Error(fmt.Sprint("Invalid ProjVar angle argument: %s", c.token))
+			}
 		case "anim":
 			opc = OC_ex2_projvar_projanim
 		case "animelem":
@@ -3202,10 +3213,12 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		default:
 			return bvNone(), Error(fmt.Sprint("Invalid ProjVar argument: %s", vname))
 		}
+		if opc != OC_ex2_projvar_projangle {
+			c.token = c.tokenizer(in)
 
-		c.token = c.tokenizer(in)
-		if err := c.checkClosingParenthesis(); err != nil {
-			return bvNone(), err
+			if err := c.checkClosingParenthesis(); err != nil {
+				return bvNone(), err
+			}
 		}
 
 		// If bv1 is ever 0 Ikemen crashes.

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -4753,7 +4753,17 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 	case "timetotal":
 		out.append(OC_ex_, OC_ex_timetotal)
 	case "angle":
-		out.append(OC_ex_, OC_ex_angle)
+		c.token = c.tokenizer(in)
+		switch c.token {
+		case "x":
+			out.append(OC_ex2_, OC_ex2_angle_x)
+		case "y":
+			out.append(OC_ex2_, OC_ex2_angle_y)
+		case "":
+			out.append(OC_ex_, OC_ex_angle)
+		default:
+			return bvNone(), Error("Invalid Angle trigger argument: " + c.token)
+		}
 	case "scale":
 		c.token = c.tokenizer(in)
 		switch c.token {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -461,6 +461,7 @@ var triggerMap = map[string]int{
 	"timetotal":          1,
 	"winhyper":           1,
 	"winspecial":         1,
+	"xshear":             1,
 }
 
 func (c *Compiler) tokenizer(in *string) string {
@@ -4805,6 +4806,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		default:
 			return bvNone(), Error("Invalid Alpha trigger argument: " + c.token)
 		}
+	case "xshear":
+		out.append(OC_ex2_, OC_ex2_xshear)
 	case "=", "!=", ">", ">=", "<", "<=", "&", "&&", "^", "^^", "|", "||",
 		"+", "*", "**", "/", "%":
 		if !sys.ignoreMostErrors || len(c.previousOperator) > 0 {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -5607,8 +5607,8 @@ func (c *Compiler) paramSpace(is IniSection, sc *StateControllerBase, id byte) e
 	})
 }
 
-func (c *Compiler) paramProjection(is IniSection, sc *StateControllerBase, id byte) error {
-	return c.stateParam(is, "projection", false, func(data string) error {
+func (c *Compiler) paramProjection(is IniSection, sc *StateControllerBase, key string, id byte) error {
+	return c.stateParam(is, key, false, func(data string) error {
 		if len(data) <= 1 {
 			return Error("projection not specified")
 		}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -352,6 +352,8 @@ var triggerMap = map[string]int{
 	"airjumpcount":       1,
 	"alpha":              1,
 	"angle":              1,
+	"xangle":             1,
+	"yangle":             1,
 	"animelemvar":        1,
 	"animlength":         1,
 	"animplayerno":       1,
@@ -4766,17 +4768,11 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 	case "timetotal":
 		out.append(OC_ex_, OC_ex_timetotal)
 	case "angle":
-		c.token = c.tokenizer(in)
-		switch c.token {
-		case "x":
-			out.append(OC_ex2_, OC_ex2_angle_x)
-		case "y":
-			out.append(OC_ex2_, OC_ex2_angle_y)
-		case "":
-			out.append(OC_ex_, OC_ex_angle)
-		default:
-			return bvNone(), Error("Invalid Angle trigger argument: " + c.token)
-		}
+		out.append(OC_ex_, OC_ex_angle)
+	case "XAngle":
+		out.append(OC_ex2_, OC_ex2_angle_x)
+	case "YAngle":
+		out.append(OC_ex2_, OC_ex2_angle_y)
 	case "scale":
 		c.token = c.tokenizer(in)
 		switch c.token {

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -2303,6 +2303,14 @@ func (c *Compiler) projectileSub(is IniSection, sc *StateControllerBase, ihp int
 		projectile_projangle, VT_Float, 1, false); err != nil {
 		return err
 	}
+	if err := c.paramValue(is, sc, "projxangle",
+		projectile_projxangle, VT_Float, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "projyangle",
+		projectile_projyangle, VT_Float, 1, false); err != nil {
+		return err
+	}
 	if err := c.paramValue(is, sc, "projclsnscale",
 		projectile_projclsnscale, VT_Float, 2, false); err != nil {
 		return err

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -929,6 +929,10 @@ func (c *Compiler) explodInterpolate(is IniSection,
 		explod_interpolate_focallength, VT_Float, 1, false); err != nil {
 		return err
 	}
+	if err := c.paramValue(is, sc, "interpolation.xshear",
+		explod_interpolate_xshear, VT_Float, 1, false); err != nil {
+		return err
+	}
 	if err := c.paramValue(is, sc, "interpolation.palfx.mul",
 		explod_interpolate_pfx_mul, VT_Int, 3, false); err != nil {
 		return err

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -5334,6 +5334,10 @@ func (c *Compiler) text(is IniSection, sc *StateControllerBase, _ int8) (StateCo
 			text_scale, VT_Float, 2, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "angle",
+			text_angle, VT_Float, 1, false); err != nil {
+			return err
+		}
 		if err := c.palFXSub(is, sc, "palfx."); err != nil {
 			return err
 		}

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -816,7 +816,8 @@ func (c *Compiler) explodSub(is IniSection,
 		explod_accel, VT_Float, 3, false); err != nil {
 		return err
 	}
-	if err := c.paramProjection(is, sc, explod_projection); err != nil {
+	if err := c.paramProjection(is, sc, "projection", 
+		explod_projection); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "scale",
@@ -1233,7 +1234,8 @@ func (c *Compiler) modifyShadow(is IniSection, sc *StateControllerBase, _ int8) 
 			modifyShadow_focallength, VT_Float, 1, false); err != nil {
 			return err
 		}
-		if err := c.paramProjection(is, sc, modifyShadow_projection); err != nil {
+		if err := c.paramProjection(is, sc, "projection", 
+			modifyShadow_projection); err != nil {
 			return err
 		}
 		return c.posSetSub(is, sc)
@@ -1287,7 +1289,8 @@ func (c *Compiler) modifyReflection(is IniSection, sc *StateControllerBase, _ in
 			modifyReflection_focallength, VT_Float, 1, false); err != nil {
 			return err
 		}
-		if err := c.paramProjection(is, sc, modifyReflection_projection); err != nil {
+		if err := c.paramProjection(is, sc, "projection",
+			modifyReflection_projection); err != nil {
 			return err
 		}
 		return c.posSetSub(is, sc)
@@ -2365,11 +2368,12 @@ func (c *Compiler) projectileSub(is IniSection, sc *StateControllerBase, ihp int
 		projectile_projxshear, VT_Float, 1, false); err != nil {
 		return err
 	}
-	if err := c.paramValue(is, sc, "focallength",
+	if err := c.paramValue(is, sc, "projfocallength",
 		projectile_projfocallength, VT_Float, 1, false); err != nil {
 		return err
 	}
-	if err := c.paramProjection(is, sc, projectile_projprojection); err != nil {
+	if err := c.paramProjection(is, sc, "projprojection",
+		projectile_projprojection); err != nil {
 		return err
 	}
 	// HitDef section
@@ -5600,6 +5604,26 @@ func (c *Compiler) modifyStageVar(is IniSection, sc *StateControllerBase, _ int8
 			modifyStageVar_shadow_yscale, VT_Float, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "shadow.angle",
+			modifyStageVar_shadow_angle, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "shadow.xangle",
+			modifyStageVar_shadow_xangle, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "shadow.yangle",
+			modifyStageVar_shadow_yangle, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "shadow.focallength",
+			modifyStageVar_shadow_focallength, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramProjection(is, sc, "shadow.projection", 
+			modifyStageVar_shadow_projection); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "shadow.fade.range",
 			modifyStageVar_shadow_fade_range, VT_Int, 2, false); err != nil {
 			return err
@@ -5622,6 +5646,26 @@ func (c *Compiler) modifyStageVar(is IniSection, sc *StateControllerBase, _ int8
 		}
 		if err := c.paramValue(is, sc, "reflection.yscale",
 			modifyStageVar_reflection_yscale, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "reflection.angle",
+			modifyStageVar_reflection_angle, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "reflection.xangle",
+			modifyStageVar_reflection_xangle, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "reflection.yangle",
+			modifyStageVar_reflection_yangle, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "reflection.focallength",
+			modifyStageVar_reflection_focallength, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramProjection(is, sc, "reflection.projection", 
+			modifyStageVar_reflection_projection); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "reflection.xshear",
@@ -6083,7 +6127,8 @@ func (c *Compiler) transformSprite(is IniSection, sc *StateControllerBase, _ int
 		}
 		if _, ok := is["projection"]; ok {
 			any = true
-			if err := c.paramProjection(is, sc, transformSprite_projection); err != nil {
+			if err := c.paramProjection(is, sc, "projection",
+				transformSprite_projection); err != nil {
 				return err
 			}
 		}

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -6256,6 +6256,18 @@ func (c *Compiler) modifyStageBG(is IniSection, sc *StateControllerBase, _ int8)
 		}); err != nil {
 			return err
 		}
+		if err := c.stateParam(is, "xangle", false, func(data string) error {
+			any = true
+			return c.scAdd(sc, modifyStageBG_xangle, data, VT_Float, 1)
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "yangle", false, func(data string) error {
+			any = true
+			return c.scAdd(sc, modifyStageBG_yangle, data, VT_Float, 1)
+		}); err != nil {
+			return err
+		}
 		if err := c.stateParam(is, "velocity.x", false, func(data string) error {
 			any = true
 			return c.scAdd(sc, modifyStageBG_velocity_x, data, VT_Float, 2)
@@ -6273,6 +6285,19 @@ func (c *Compiler) modifyStageBG(is IniSection, sc *StateControllerBase, _ int8)
 			return c.scAdd(sc, modifyStageBG_xshear, data, VT_Float, 1)
 		}); err != nil {
 			return err
+		}
+		if err := c.stateParam(is, "focallength", false, func(data string) error {
+			any = true
+			return c.scAdd(sc, modifyStageBG_focallength, data, VT_Float, 1)
+		}); err != nil {
+			return err
+		}
+		if _, ok := is["projection"]; ok {
+			any = true
+			if err := c.paramProjection(is, sc, "projection",
+				modifyStageBG_projection); err != nil {
+				return err
+			}
 		}
 		if !any {
 			return Error("Must specify at least one ModifyStageBG parameter")

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -3454,6 +3454,14 @@ func (c *Compiler) angleDraw(is IniSection, sc *StateControllerBase, _ int8) (St
 			angleDraw_value, VT_Float, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "xangle",
+			angleDraw_x, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "yangle",
+			angleDraw_y, VT_Float, 1, false); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "scale",
 			angleDraw_scale, VT_Float, 2, false); err != nil {
 			return err
@@ -3473,6 +3481,14 @@ func (c *Compiler) angleSet(is IniSection, sc *StateControllerBase, _ int8) (Sta
 			angleSet_value, VT_Float, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "xangle",
+			angleSet_x, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "yangle",
+			angleSet_y, VT_Float, 1, false); err != nil {
+			return err
+		}
 		return nil
 	})
 	return *ret, err
@@ -3488,6 +3504,14 @@ func (c *Compiler) angleAdd(is IniSection, sc *StateControllerBase, _ int8) (Sta
 			angleAdd_value, VT_Float, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "xangle",
+			angleAdd_x, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "yangle",
+			angleAdd_y, VT_Float, 1, false); err != nil {
+			return err
+		}
 		return nil
 	})
 	return *ret, err
@@ -3501,6 +3525,14 @@ func (c *Compiler) angleMul(is IniSection, sc *StateControllerBase, _ int8) (Sta
 		}
 		if err := c.paramValue(is, sc, "value",
 			angleMul_value, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "xangle",
+			angleMul_x, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "yangle",
+			angleMul_y, VT_Float, 1, false); err != nil {
 			return err
 		}
 		return nil

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1217,6 +1217,25 @@ func (c *Compiler) modifyShadow(is IniSection, sc *StateControllerBase, _ int8) 
 			modifyShadow_yscale, VT_Float, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "angle",
+			modifyShadow_angle, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "xangle",
+			modifyShadow_xangle, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "yangle",
+			modifyShadow_yangle, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "focallength",
+			modifyShadow_focallength, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramProjection(is, sc, modifyShadow_projection); err != nil {
+			return err
+		}
 		return c.posSetSub(is, sc)
 	})
 	return *ret, err
@@ -1250,6 +1269,25 @@ func (c *Compiler) modifyReflection(is IniSection, sc *StateControllerBase, _ in
 		}
 		if err := c.paramValue(is, sc, "yscale",
 			modifyReflection_yscale, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "angle",
+			modifyReflection_angle, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "xangle",
+			modifyReflection_xangle, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "yangle",
+			modifyReflection_yangle, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "focallength",
+			modifyReflection_focallength, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramProjection(is, sc, modifyReflection_projection); err != nil {
 			return err
 		}
 		return c.posSetSub(is, sc)
@@ -2327,11 +2365,11 @@ func (c *Compiler) projectileSub(is IniSection, sc *StateControllerBase, ihp int
 		projectile_projxshear, VT_Float, 1, false); err != nil {
 		return err
 	}
-	if err := c.paramProjection(is, sc, projectile_projprojection); err != nil {
-		return err
-	}
 	if err := c.paramValue(is, sc, "focallength",
 		projectile_projfocallength, VT_Float, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramProjection(is, sc, projectile_projprojection); err != nil {
 		return err
 	}
 	// HitDef section

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -2327,6 +2327,13 @@ func (c *Compiler) projectileSub(is IniSection, sc *StateControllerBase, ihp int
 		projectile_projxshear, VT_Float, 1, false); err != nil {
 		return err
 	}
+	if err := c.paramProjection(is, sc, projectile_projprojection); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "focallength",
+		projectile_projfocallength, VT_Float, 1, false); err != nil {
+		return err
+	}
 	// HitDef section
 	if err := c.hitDefSub(is, sc); err != nil {
 		return err
@@ -6029,6 +6036,18 @@ func (c *Compiler) transformSprite(is IniSection, sc *StateControllerBase, _ int
 			return c.scAdd(sc, transformSprite_xshear, data, VT_Float, 1)
 		}); err != nil {
 			return err
+		}
+		if err := c.stateParam(is, "focallength", false, func(data string) error {
+			any = true
+			return c.scAdd(sc, transformSprite_focallength, data, VT_Float, 1)
+		}); err != nil {
+			return err
+		}
+		if _, ok := is["projection"]; ok {
+			any = true
+			if err := c.paramProjection(is, sc, transformSprite_projection); err != nil {
+				return err
+			}
 		}
 		if !any {
 			return Error("Must specify at least one TransformSprite parameter")

--- a/src/image.go
+++ b/src/image.go
@@ -1205,23 +1205,52 @@ func (s *Sprite) CachePalette(pal []uint32) Texture {
 	return s.PalTex
 }
 
-func (s *Sprite) Draw(x, y, xscale, yscale, angle, xshear float32, fx *PalFX, window *[4]int32) {
-	x += float32(sys.gameWidth-320)/2 - xscale*float32(s.Offset[0])
-	y += float32(sys.gameHeight-240) - yscale*float32(s.Offset[1])
-	if xscale < 0 {
-		x *= -1
-	}
-	if yscale < 0 {
-		y *= -1
-	}
-	rp := RenderParams{
-		s.Tex, s.PalTex, s.Size,
-		-x * sys.widthScale, -y * sys.heightScale, notiling,
-		xscale * sys.widthScale, xscale * sys.widthScale, yscale * sys.heightScale, 1, xshear, 1, 1,
-		Rotation{angle, 0, 0}, 0, sys.brightness*255>>8 | 1<<9, 0, fx, window, 0, 0, 0, 0,
-		-xscale * float32(s.Offset[0]), -yscale * float32(s.Offset[1]),
-	}
-	RenderSprite(rp)
+func (s *Sprite) Draw(x, y, xscale, yscale float32, rxadd float32, rot Rotation, fx *PalFX, window *[4]int32) {
+    x += float32(sys.gameWidth-320)/2 - xscale*float32(s.Offset[0])
+    y += float32(sys.gameHeight-240) - yscale*float32(s.Offset[1])
+    var rcx, rcy float32
+
+    if rot.IsZero() {
+		if xscale < 0 {
+			x *= -1
+		}
+		if yscale < 0 {
+			y *= -1
+		}
+		rcx, rcy = rcx*sys.widthScale, 0
+    } else {
+        rcx, rcy = (x+rcx)*sys.widthScale, y*sys.heightScale
+		x, y = AbsF(xscale)*float32(s.Offset[0]), AbsF(yscale)*float32(s.Offset[1])
+    }
+
+    rp := RenderParams{
+        tex:            s.Tex,
+        paltex:         s.PalTex,
+        size:           s.Size,
+        x:              -x * sys.widthScale,
+        y:              -y * sys.heightScale,
+        tile:           notiling,
+        xts:            xscale * sys.widthScale,
+        xbs:            xscale * sys.widthScale,
+        ys:             yscale * sys.heightScale,
+        vs:             1,
+        rxadd:          rxadd,
+        xas:            1,
+        yas:            1,
+        rot:            rot,
+        tint:           0,
+        trans:          sys.brightness*255>>8 | 1<<9,
+        mask:           0,
+        pfx:            fx,
+        window:         window,
+        rcx:            rcx,
+        rcy:            rcy,
+        projectionMode: 0,
+        fLength:        0,
+        xOffset:        -xscale * float32(s.Offset[0]),
+        yOffset:        -yscale * float32(s.Offset[1]),
+    }
+    RenderSprite(rp)
 }
 
 type Sff struct {

--- a/src/script.go
+++ b/src/script.go
@@ -691,7 +691,7 @@ func systemScriptInit(l *lua.LState) {
 							sprite.CachePalette(sprite.Pal)
 						}
 						sprite.Draw(x, y, scale[0]*float32(facing)*fscale, scale[1]*fscale, 0,
-							0, pfx, window)
+							Rotation{0, 0, 0}, pfx, window)
 						ok = true
 					}
 				}

--- a/src/script.go
+++ b/src/script.go
@@ -5242,6 +5242,10 @@ func triggerFunctions(l *lua.LState) {
 		}
 		return 1
 	})
+	luaRegister(l, "xshear", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.xshear))
+		return 1
+	})
 	luaRegister(l, "animelemvar", func(l *lua.LState) int {
 		vname := strings.ToLower(strArg(l, 1))
 		var ln lua.LNumber

--- a/src/script.go
+++ b/src/script.go
@@ -1748,7 +1748,11 @@ func systemScriptInit(l *lua.LState) {
 		tbl.RawSetString("name", lua.LString(c.name))
 		tbl.RawSetString("def", lua.LString(c.def))
 		tbl.RawSetString("portrait_scale", lua.LNumber(c.portrait_scale))
-		tbl.RawSetString("attachedchardef", lua.LString(c.attachedchardef))
+		acTable := l.NewTable()
+		for _, v := range c.attachedchardef {
+			acTable.Append(lua.LString(v))
+		}
+		tbl.RawSetString("attachedchardef", acTable)
 		subt := l.NewTable()
 		for k, v := range c.stagebgm {
 			subt.RawSetString(k, lua.LString(v))

--- a/src/script.go
+++ b/src/script.go
@@ -5197,7 +5197,23 @@ func triggerFunctions(l *lua.LState) {
 	// atan2 (dedicated functionality already exists in Lua)
 	luaRegister(l, "angle", func(*lua.LState) int {
 		if sys.debugWC.csf(CSF_angledraw) {
-			l.Push(lua.LNumber(sys.debugWC.angle))
+			l.Push(lua.LNumber(sys.debugWC.anglerot[0]))
+		} else {
+			l.Push(lua.LNumber(0))
+		}
+		return 1
+	})
+	luaRegister(l, "angle x", func(*lua.LState) int {
+		if sys.debugWC.csf(CSF_angledraw) {
+			l.Push(lua.LNumber(sys.debugWC.anglerot[1]))
+		} else {
+			l.Push(lua.LNumber(0))
+		}
+		return 1
+	})
+	luaRegister(l, "angle y", func(*lua.LState) int {
+		if sys.debugWC.csf(CSF_angledraw) {
+			l.Push(lua.LNumber(sys.debugWC.anglerot[2]))
 		} else {
 			l.Push(lua.LNumber(0))
 		}

--- a/src/script.go
+++ b/src/script.go
@@ -5207,7 +5207,7 @@ func triggerFunctions(l *lua.LState) {
 		}
 		return 1
 	})
-	luaRegister(l, "angle x", func(*lua.LState) int {
+	luaRegister(l, "xangle", func(*lua.LState) int {
 		if sys.debugWC.csf(CSF_angledraw) {
 			l.Push(lua.LNumber(sys.debugWC.anglerot[1]))
 		} else {
@@ -5215,7 +5215,7 @@ func triggerFunctions(l *lua.LState) {
 		}
 		return 1
 	})
-	luaRegister(l, "angle y", func(*lua.LState) int {
+	luaRegister(l, "yangle", func(*lua.LState) int {
 		if sys.debugWC.csf(CSF_angledraw) {
 			l.Push(lua.LNumber(sys.debugWC.anglerot[2]))
 		} else {

--- a/src/script.go
+++ b/src/script.go
@@ -4635,7 +4635,11 @@ func triggerFunctions(l *lua.LState) {
 				case "animelem":
 					lv = lua.LNumber(p.ani.current + 1)
 				case "angle":
-					lv = lua.LNumber(p.angle)
+					lv = lua.LNumber(p.anglerot[0])
+				case "angle x":
+					lv = lua.LNumber(p.anglerot[1])
+				case "angle y":
+					lv = lua.LNumber(p.anglerot[2])
 				case "drawpal group":
 					lv = lua.LNumber(sys.debugWC.projDrawPal(p)[0])
 				case "drawpal index":

--- a/src/stage.go
+++ b/src/stage.go
@@ -758,14 +758,17 @@ func (bgct *bgcTimeLine) step(s *Stage) {
 }
 
 type stageShadow struct {
-	intensity int32
-	color     uint32
-	yscale    float32
-	fadeend   int32
-	fadebgn   int32
-	xshear    float32
-	offset    [2]float32
-	window    [4]float32
+	intensity   int32
+	color       uint32
+	yscale      float32
+	fadeend     int32
+	fadebgn     int32
+	xshear      float32
+	rot         Rotation
+	fLength     float32
+	projection  Projection
+	offset      [2]float32
+	window      [4]float32
 }
 type stagePlayer struct {
 	startx, starty, startz, facing int32
@@ -1302,6 +1305,20 @@ func loadStage(def string, maindef bool) (*Stage, error) {
 		sec[0].ReadF32("yscale", &s.sdw.yscale)
 		sec[0].readI32ForStage("fade.range", &s.sdw.fadeend, &s.sdw.fadebgn)
 		sec[0].ReadF32("xshear", &s.sdw.xshear)
+		sec[0].ReadF32("angle", &s.sdw.rot.angle)
+		sec[0].ReadF32("xangle", &s.sdw.rot.xangle)
+		sec[0].ReadF32("yangle", &s.sdw.rot.yangle)
+		sec[0].ReadF32("focallength", &s.sdw.fLength)
+		if str, ok := sec[0]["projection"]; ok {
+			switch strings.ToLower(strings.TrimSpace(str)) {
+			case "orthographic", "or":
+				s.sdw.projection = Projection_Orthographic
+			case "perspective", "pe":
+				s.sdw.projection = Projection_Perspective
+			case "perspective2", "pe2":
+				s.sdw.projection = Projection_Perspective2
+			}
+		}
 		sec[0].readF32ForStage("offset", &s.sdw.offset[0], &s.sdw.offset[1])
 		sec[0].readF32ForStage("window", &s.sdw.window[0], &s.sdw.window[1], &s.sdw.window[2], &s.sdw.window[3])
 	}
@@ -1339,6 +1356,28 @@ func loadStage(def string, maindef bool) (*Stage, error) {
 		}
 		if sec[0].ReadF32("xshear", &tmp2) {
 			s.reflection.xshear = tmp2
+		}
+		if sec[0].ReadF32("angle", &tmp2) {
+			s.reflection.rot.angle = tmp2
+		}
+		if sec[0].ReadF32("xangle", &tmp2) {
+			s.reflection.rot.xangle = tmp2
+		}
+		if sec[0].ReadF32("yangle", &tmp2) {
+			s.reflection.rot.yangle = tmp2
+		}
+		if sec[0].ReadF32("focallength", &tmp2) {
+			s.reflection.fLength = tmp2
+		}
+		if str, ok := sec[0]["projection"]; ok {
+			switch strings.ToLower(strings.TrimSpace(str)) {
+			case "orthographic", "or":
+				s.reflection.projection = Projection_Orthographic
+			case "perspective", "pe":
+				s.reflection.projection = Projection_Perspective
+			case "perspective2", "pe2":
+				s.reflection.projection = Projection_Perspective2
+			}
 		}
 		if sec[0].readF32ForStage("offset", &tmp3[0], &tmp3[1]) {
 			s.reflection.offset[0] = tmp3[0]
@@ -1478,6 +1517,11 @@ func (s *Stage) copyStageVars(src *Stage) {
 	s.sdw.fadeend = src.sdw.fadeend
 	s.sdw.fadebgn = src.sdw.fadebgn
 	s.sdw.xshear = src.sdw.xshear
+	s.sdw.rot.angle = src.sdw.rot.angle
+	s.sdw.rot.xangle = src.sdw.rot.xangle
+	s.sdw.rot.yangle = src.sdw.rot.yangle
+	s.sdw.fLength = src.sdw.fLength
+	s.sdw.projection = src.sdw.projection
 	s.sdw.offset[0] = src.sdw.offset[0]
 	s.sdw.offset[1] = src.sdw.offset[1]
 	s.sdw.window[0] = src.sdw.window[0]
@@ -1489,6 +1533,11 @@ func (s *Stage) copyStageVars(src *Stage) {
 	s.reflection.offset[1] = src.reflection.offset[1]
 	s.reflection.xshear = src.reflection.xshear
 	s.reflection.yscale = src.reflection.yscale
+	s.reflection.rot.angle = src.reflection.rot.angle
+	s.reflection.rot.xangle = src.reflection.rot.xangle
+	s.reflection.rot.yangle = src.reflection.rot.yangle
+	s.reflection.fLength = src.reflection.fLength
+	s.reflection.projection = src.reflection.projection
 	s.reflection.window[0] = src.reflection.window[0]
 	s.reflection.window[1] = src.reflection.window[1]
 	s.reflection.window[2] = src.reflection.window[2]

--- a/src/stage.go
+++ b/src/stage.go
@@ -931,11 +931,31 @@ func loadStage(def string, maindef bool) (*Stage, error) {
 		if s.ikemenver[0] == 0 && s.ikemenver[1] == 0 && s.mugenver[0] != 1 {
 			s.stageprops.roundpos = true
 		}
-		if sec[0].LoadFile("attachedchar", []string{def, "", sys.motifDir, "data/"}, func(filename string) error {
-			s.attachedchardef = append(s.attachedchardef, filename)
-			return nil
-		}); err != nil {
-			return nil, err
+		// AttachedChars
+		ac := 0
+		for i := range sec[0] {
+			if !strings.HasPrefix(i, "attachedchar") {
+				continue
+			}
+			if suffix := strings.TrimPrefix(i, "attachedchar"); suffix != "" {
+				if _, err := strconv.Atoi(suffix); err != nil {
+					continue
+				}
+			}
+			if ac >= MaxAttachedChar {
+				sys.appendToConsole(fmt.Sprintf("Warning: You can define up to %d attachedchar(s). '%s' ignored.", MaxAttachedChar, i))
+				continue
+			}
+			if err := sec[0].LoadFile(i, []string{def, "", sys.motifDir, "data/"}, func(filename string) error {
+				// Ensure slice has correct length
+				for len(s.attachedchardef) <= ac {
+					s.attachedchardef = append(s.attachedchardef, "")
+				}
+				s.attachedchardef[ac] = filename
+				return nil
+			}); err == nil {
+				ac++
+			}
 		}
 		// RoundXdef
 		if maindef {

--- a/src/system.go
+++ b/src/system.go
@@ -2010,7 +2010,7 @@ func (s *System) drawDebugText() {
 			}
 			*y += float32(s.debugFont.fnt.Size[1]) * s.debugFont.yscl / s.heightScale
 			s.debugFont.fnt.Print(drawTxt, *x, *y, s.debugFont.xscl/s.widthScale,
-				s.debugFont.yscl/s.heightScale, 0, 0, 1, &s.scrrect,
+				s.debugFont.yscl/s.heightScale, 0, Rotation{0, 0, 0}, 0, 1, &s.scrrect,
 				s.debugFont.palfx, s.debugFont.frgba)
 		}
 	}
@@ -2087,7 +2087,7 @@ func (s *System) drawDebugText() {
 	for _, t := range s.clsnText {
 		s.debugFont.SetColor(t.r, t.g, t.b)
 		s.debugFont.fnt.Print(t.text, t.x, t.y, s.debugFont.xscl/s.widthScale,
-			s.debugFont.yscl/s.heightScale, 0, 0, 0, &s.scrrect,
+			s.debugFont.yscl/s.heightScale, 0, Rotation{0, 0, 0}, 0, 0, &s.scrrect,
 			s.debugFont.palfx, s.debugFont.frgba)
 	}
 	//}


### PR DESCRIPTION
Feat:

- Ikemen now supports up to 4 AttachedChars per stage, e.g.:
```ini
AttachedChar = "path to ac1"
AttachedChar2 = "path to ac2"
```
- Added xshear interpolation to explods
- Added xshear trigger
- Added xangle and yangle triggers
- Added xangle and yangle to projVar
- Various controllers now support projection and focalLength parameters, including:
  - TransformSprite
  - ModifyShadow
  - ModifyReflection
  - Projectiles
  - Shadow and Reflection groups in stage.def
  - BGelements in stage.def
  - ModifyStageBG
  - ModifyStageVar, e.g.:
  ```ini
  [State -2]
  type = modifyStageVar  
  trigger1 = 1  
  shadow.projection = perspective
  ```
  - All of the items listed above, except for TransformSprite, also support xangle and yangle.
On the char side, `angleDraw`, `angleMul` and `angleSet` now support xangle and yangle as well.

- New lifebar features:
  - `pn.red.value` now displays the red life value as text and supports multiple fonts
  - Lifebar, PowerBar, GuardBar, and StunBar `value` parameter now support multiple fonts
  - All lifebar texts and TextSctrl texts now support the angle parameter

- Fix:
- Fixes https://github.com/ikemen-engine/Ikemen-GO/issues/967
- Fixes https://github.com/ikemen-engine/Ikemen-GO/issues/1061
- Fixes https://github.com/ikemen-engine/Ikemen-GO/issues/2453


