### PR TITLE
fix: Global stage scaling `scaledelta` and `windowdelta` behavior.

### DIFF
--- a/src/stage.go
+++ b/src/stage.go
@@ -458,9 +458,9 @@ func (bg backGround) draw(pos [2]float32, drawscl, bgscl, stglscl float32,
 	y := bg.start[1] - yScrollPos + bg.bga.offset[1]
 
 	// Calculate Y scaling based on vertical scroll position and delta
-	ys2 := bg.scaledelta[1] * pos[1] * bg.delta[1] * bgscl / drawscl
+	ys2 := bg.scaledelta[1] * pos[1] * bg.delta[1] * bgscl / drawscl / stgscl[1]
 	ys := ((100-(pos[1])*bg.yscaledelta)*bgscl/bg.yscalestart)*bg.scalestart[1] + ys2
-	xs := bg.scaledelta[0] * pos[0] * bg.delta[0] * bgscl
+	xs := bg.scaledelta[0] * pos[0] * bg.delta[0] * bgscl / stgscl[0]
 	x *= bgscl
 
 	// Apply stage logic if BG is part of a stage

--- a/src/stage.go
+++ b/src/stage.go
@@ -497,7 +497,7 @@ func (bg backGround) draw(pos [2]float32, drawscl, bgscl, stglscl float32,
 	// Calculate window top left corner position
 	rect := bg.startrect
 
-	startrect0 := float32(rect[0]) - (pos[0])*bg.windowdelta[0] +
+	startrect0 := float32(rect[0]) - (pos[0])/stgscl[0]*bg.windowdelta[0] +
 		(float32(sys.gameWidth)/2/sclx - float32(bg.notmaskwindow)*(float32(sys.gameWidth)/2)*(1/lscl[0]))
 	startrect0 *= sys.widthScale * wscl[0]
 	if !isStage && wscl[0] == 1 {


### PR DESCRIPTION
Fixes the  `scaledelta` and `windowdelta` of the backgrounds, in a stage having an `xscale` and/or `yscale` (in the `[StageInfo]` section) other than the default `1.0`.

Fixes #2478
Fixes #2414