### PR TITLE
fix: lifebar portraits offset, projection syntax

### DIFF
--- a/src/common.go
+++ b/src/common.go
@@ -981,7 +981,7 @@ func (l *Layout) DrawFaceSprite(x, y float32, ln int16, s *Sprite, fx *PalFX, fs
 			drawwindow = &fwin
 		}
 
-		s.Draw(x+l.offset[0]-xsoffset*sys.lifebarScale, y+l.offset[1]*sys.lifebarScale,
+		s.Draw(x+l.offset[0]*sys.lifebarScale-xsoffset, y+l.offset[1]*sys.lifebarScale,
 			l.scale[0]*float32(l.facing)*fscale, l.scale[1]*float32(l.vfacing)*fscale,
 			xshear, Rotation{l.angle, 0, 0}, fx, drawwindow)
 	}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -5612,22 +5612,19 @@ func (c *Compiler) paramSpace(is IniSection, sc *StateControllerBase, id byte) e
 
 func (c *Compiler) paramProjection(is IniSection, sc *StateControllerBase, key string, id byte) error {
 	return c.stateParam(is, key, false, func(data string) error {
-		if len(data) <= 1 {
-			return Error("projection not specified")
-		}
 		var proj Projection
-		if len(data) >= 2 {
-			if strings.ToLower(data[:2]) == "or" {
-				proj = Projection_Orthographic
-			} else if strings.ToLower(data[:2]) == "pe" {
-				if data[len(data)-1] != '2' {
-					proj = Projection_Perspective
-				} else {
-					proj = Projection_Perspective2
-				}
 
-			}
+		switch strings.ToLower(strings.TrimSpace(data)) {
+		case "orthographic":
+			proj = Projection_Orthographic
+		case "perspective":
+			proj = Projection_Perspective
+		case "perspective2":
+			proj = Projection_Perspective2
+		default:
+			return Error("invalid projection type: " + data)
 		}
+
 		sc.add(id, sc.iToExp(int32(proj)))
 		return nil
 	})

--- a/src/stage.go
+++ b/src/stage.go
@@ -226,11 +226,11 @@ func readBackGround(is IniSection, link *backGround,
 	is.readF32ForStage("focallength", &bg.fLength)
 	if str, ok := is["projection"]; ok {
 		switch strings.ToLower(strings.TrimSpace(str)) {
-		case "orthographic", "or":
+		case "orthographic":
 			bg.projection = Projection_Orthographic
-		case "perspective", "pe":
+		case "perspective":
 			bg.projection = Projection_Perspective
-		case "perspective2", "pe2":
+		case "perspective2":
 			bg.projection = Projection_Perspective2
 		}
 	}
@@ -1328,11 +1328,11 @@ func loadStage(def string, maindef bool) (*Stage, error) {
 		sec[0].ReadF32("focallength", &s.sdw.fLength)
 		if str, ok := sec[0]["projection"]; ok {
 			switch strings.ToLower(strings.TrimSpace(str)) {
-			case "orthographic", "or":
+			case "orthographic":
 				s.sdw.projection = Projection_Orthographic
-			case "perspective", "pe":
+			case "perspective":
 				s.sdw.projection = Projection_Perspective
-			case "perspective2", "pe2":
+			case "perspective2":
 				s.sdw.projection = Projection_Perspective2
 			}
 		}
@@ -1388,11 +1388,11 @@ func loadStage(def string, maindef bool) (*Stage, error) {
 		}
 		if str, ok := sec[0]["projection"]; ok {
 			switch strings.ToLower(strings.TrimSpace(str)) {
-			case "orthographic", "or":
+			case "orthographic":
 				s.reflection.projection = Projection_Orthographic
-			case "perspective", "pe":
+			case "perspective":
 				s.reflection.projection = Projection_Perspective
-			case "perspective2", "pe2":
+			case "perspective2":
 				s.reflection.projection = Projection_Perspective2
 			}
 		}


### PR DESCRIPTION
Fixes:
- Fixes the offset issue with lifebar portraits in 16:9 resolutions
- Removed 'or', 'pe', and 'pe2' from the projection syntax