### PR TITLE
feat: Per-Character CommonFX and FightFX Override

### DIFF
--- a/src/common.go
+++ b/src/common.go
@@ -496,9 +496,9 @@ func FileExist(filename string) string {
 	for _, r := range filename {
 		if r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z' {
 			pattern += "[" + string(unicode.ToLower(r)) +
-				string(unicode.ToUpper(r)) + "]"
+				string(unicode.ToLower(r)+'A'-'a') + "]"
 		} else if r == '*' || r == '?' || r == '[' {
-			pattern += `\` + string(r)
+			pattern += "\\" + string(r)
 		} else {
 			pattern += string(r)
 		}
@@ -516,7 +516,7 @@ func FileExist(filename string) string {
 // 'dirs' elements can be plain directory paths or logical paths to .def files (which might be inside zips).
 // 'file' is the filename to search (e.g., "kfm.sff").
 func SearchFile(file string, dirs []string) string {
-	file = filepath.ToSlash(file)
+	file = strings.Replace(file, "\\", "/", -1)
 
 	if isZipFull, _, _ := IsZipPath(file); isZipFull {
 		if found := FileExist(file); found != "" {
@@ -569,7 +569,10 @@ func SearchFile(file string, dirs []string) string {
 func LoadFile(file *string, dirs []string, load func(string) error) error {
 	fp := SearchFile(*file, dirs)
 	if err := load(fp); err != nil {
-		return Error(dirs[0] + ":\n" + fp + "\n" + err.Error())
+		if len(dirs) > 0 {
+			return Error(dirs[0] + ":\n" + fp + "\n" + err.Error())
+		}
+		return Error(fp + "\n" + err.Error())
 	}
 	*file = fp
 	return nil

--- a/src/sound.go
+++ b/src/sound.go
@@ -200,7 +200,7 @@ func (bgm *Bgm) Open(filename string, loop, bgmVolume, bgmLoopStart, bgmLoopEnd,
 		return
 	}
 
-	f, err := os.Open(bgm.filename)
+	f, err := OpenFile(bgm.filename)
 	if err != nil {
 		// sys.bgm = *newBgm() // removing this gets pause step playsnd to work correctly 100% of the time
 		sys.errLog.Printf("Failed to open bgm: %v", err)


### PR DESCRIPTION
・Per-Character CommonFX and FightFX Override
1. Loading Character-Specific CommonFX
You can now load CommonFX files directly from a character's .def file. This is useful for character-specific effects that you don't want to load globally.
In character's .def file, under the [Files] section, add the fx key. You can specify one or more .def files, separated by commas.

Example (kfm.def):
```
[Files]
cns = kfm.cns
cmd = kfm.cmd
sprite = kfm.sff
anim = kfm.air
sound = kfm.snd
fx = fx/kfm_effects.def, fx/kfm_gofx.def
```
The engine will load kfm_effects.def and kfm_gofx.def when this character is loaded for a match. The associated assets will be automatically unloaded from memory when they are no longer in use.

2. Overriding the Default FightFX
Can now override the default fightfx (the one typically used with the F prefix in SCTRLs like Explod or PlaySnd) for a specific character.
In character's .def file, under the [Info] section, add the fightfx.prefix key. The value should be the prefix of a CommonFX that has been loaded either globally (in config.ini) or through the character's own fx definition.

Example (kfm.def):
```
[Info]
name = "Kung Fu Man"
author = "Elecbyte"
fightfx.prefix = KFMGO ; This character will now use 'KFMGO' as its default fightfx.

[Files]
; Make sure the corresponding CommonFX is loaded.
fx = fx/kfm_gofx.def
```
Example (:kfm_gofx.def)
```
[Info]
prefix = KFMGO 
fx.scale = 1
localcoord = 320, 240

[Files]
sff = kfm_gofx.sff 
air = kfm_gofx.air
snd = kfm_gofx.snd
```

When you use anim = F10 in this character's states, the engine will look for the animation from the CommonFX with the prefix KFMGO instead of the default one from fight.def.
This allows to give their characters unique hit sparks, guard effects, and other common visuals without modifying global files.

・Add support to Load zip-archived stages
Just like with chars, it reads the def file with the same name as the zip file specified in select.def.

・Fixed an issue where the chars localcoord and hitspark size were not linked