### PR TITLE
feat: Add 'clsnproxy' helpers to extend what's possible with clsn boxes.

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -777,6 +777,7 @@ const (
 	OC_ex2_clsnvar_top
 	OC_ex2_clsnvar_right
 	OC_ex2_clsnvar_bottom
+	OC_ex2_isclsnproxy
 	OC_ex2_debug_accel
 	OC_ex2_debug_clsndisplay
 	OC_ex2_debug_debugdisplay
@@ -3163,6 +3164,8 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	camOff := float32(0)
 	camCorrected := false
 	switch opc {
+	case OC_ex2_isclsnproxy:
+		sys.bcStack.PushB(c.isclsnproxy)
 	case OC_ex2_index:
 		sys.bcStack.PushI(c.index)
 	case OC_ex2_runorder:
@@ -4851,6 +4854,7 @@ type helper StateControllerBase
 
 const (
 	helper_helpertype byte = iota
+	helper_clsnproxy
 	helper_name
 	helper_postype
 	helper_ownpal
@@ -4927,6 +4931,8 @@ func (sc helper) Run(c *Char, _ []int32) bool {
 			}
 		case helper_name:
 			h.name = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
+		case helper_clsnproxy:
+			h.isclsnproxy = exp[0].evalB(c)
 		case helper_postype:
 			pt = PosType(exp[0].evalI(c))
 		case helper_ownpal:

--- a/src/char.go
+++ b/src/char.go
@@ -2488,6 +2488,7 @@ type Char struct {
 	mctype              MoveContact
 	mctime              int32
 	children            []*Char
+	isclsnproxy         bool
 	targets             []int32
 	hitdefTargets       []int32
 	hitdefTargetsBuffer []int32
@@ -2658,7 +2659,7 @@ func (c *Char) clsnOverlapTrigger(box1, pid, box2 int32) bool {
 	if getter == nil {
 		return false
 	}
-	return c.clsnCheck(getter, box1, box2, false, true)
+	return c.clsnCheck(getter, box1, box2, false, true, false, false)
 }
 
 func (c *Char) addChild(ch *Char) {
@@ -7926,9 +7927,21 @@ func (c *Char) offsetY() float32 {
 	return float32(c.size.draw.offset[1]) + c.offset[1]/c.localscl
 }
 
-func (c *Char) projClsnCheck(p *Projectile, cbox, pbox int32) bool {
+func (c *Char) projClsnCheck(p *Projectile, cbox, pbox int32, clsnproxycheck bool) bool {
 	if p.ani == nil || c.curFrame == nil || c.scf(SCF_standby) || c.scf(SCF_disabled) {
 		return false
+	}
+	// Clsnproxies do not hit nor get hit themselves, they act as an extension of their parent's clsn boxes.
+	if (c.isclsnproxy && !clsnproxycheck) {
+		return false
+	}
+	// Recursively check clsnproxy children, god I hope this works and doesn't ruin performance. A child being the parent of its parent isn't something that can happen, right...?
+	if (cbox != 3 || !clsnproxycheck) {
+		for _, chi := range c.children {
+			if chi != nil && chi.isclsnproxy && chi.projClsnCheck(p, cbox, pbox, true) {
+				return true
+			}
+		}
 	}
 
 	// Get projectile animation frame
@@ -8004,10 +8017,27 @@ func (c *Char) projClsnCheck(p *Projectile, cbox, pbox int32) bool {
 		charangle)
 }
 
-func (c *Char) clsnCheck(getter *Char, charbox, getterbox int32, reqcheck, trigger bool) bool {
+func (c *Char) clsnCheck(getter *Char, charbox, getterbox int32, reqcheck, trigger, clsnproxycheck, getterclsnproxycheck bool) bool {
 	// Safety checks
 	if c == nil || getter == nil || c.anim == nil || getter.anim == nil {
 		return false
+	}
+	// Clsnproxies do not hit nor get hit themselves, they act as an extension of their parent's clsn boxes.
+	if (c.isclsnproxy && !clsnproxycheck) || (getter.isclsnproxy && !getterclsnproxycheck) {
+		return false
+	}
+	// Recursively check clsnproxy children, god I hope this works and doesn't ruin performance. A child being the parent of its parent isn't something that can happen, right...?
+	if (getterbox != 3 || !getterclsnproxycheck) && (charbox != 3 || !clsnproxycheck) {
+		for _, chi := range c.children {
+			if chi != nil && chi.isclsnproxy && chi.clsnCheck(getter, charbox, getterbox, reqcheck, trigger, true, getterclsnproxycheck) {
+				return true
+			}
+		}
+		for _, chi := range getter.children {
+			if chi != nil && chi.isclsnproxy && c.clsnCheck(chi, charbox, getterbox, reqcheck, trigger, clsnproxycheck, true) {
+				return true
+			}
+		}
 	}
 
 	// What this does is normally check the Clsn in the currently displayed frame
@@ -8289,7 +8319,7 @@ func (c *Char) hittableByChar(getter *Char, ghd *HitDef, gst StateType, proj boo
 			return (getter.atktmp >= 0 || !c.hasTarget(getter.id)) &&
 				!getter.hasTargetOfHitdef(c.id) &&
 				getter.attrCheck(c, hd, c.ss.stateType) &&
-				c.clsnCheck(getter, 1, c.hitdef.p2clsncheck, true, false) &&
+				c.clsnCheck(getter, 1, c.hitdef.p2clsncheck, true, false, false, false) &&
 				sys.zAxisOverlap(c.pos[2], c.hitdef.attack_depth[0], c.hitdef.attack_depth[1], c.localscl,
 					getter.pos[2], getter.sizeDepth[0], getter.sizeDepth[1], getter.localscl)
 		}
@@ -10737,7 +10767,7 @@ func (cl *CharList) hitDetectionPlayer(getter *Char) {
 				}
 
 				// If collision OK then get the hit type and act accordingly
-				if zok && c.clsnCheck(getter, 1, c.hitdef.p2clsncheck, true, false) {
+				if zok && c.clsnCheck(getter, 1, c.hitdef.p2clsncheck, true, false, false, false) {
 					if hitResult := c.hitResultCheck(getter, nil); hitResult != 0 {
 						// Check if MoveContact should be updated
 						// Hit type None should also set MoveHit here
@@ -10962,7 +10992,7 @@ func (cl *CharList) hitDetectionProjectile(getter *Char) {
 			if getter.atktmp != 0 && (getter.hitdef.affectteam == 0 ||
 				(p.hitdef.teamside-1 != getter.teamside) == (getter.hitdef.affectteam > 0)) &&
 				getter.hitdef.hitflag&int32(HF_P) != 0 &&
-				getter.projClsnCheck(p, 1, 2) &&
+				getter.projClsnCheck(p, 1, 2, false) &&
 				sys.zAxisOverlap(getter.pos[2], getter.hitdef.attack_depth[0], getter.hitdef.attack_depth[1], getter.localscl,
 					p.pos[2], p.hitdef.attack_depth[0], p.hitdef.attack_depth[1], p.localscl) {
 				if getter.hitdef.p1stateno >= 0 && getter.stateChange1(getter.hitdef.p1stateno, getter.hitdef.playerNo) {
@@ -10987,7 +11017,7 @@ func (cl *CharList) hitDetectionProjectile(getter *Char) {
 					getter.hittmp = int8(Btoi(getter.ghv.fallflag)) + 1
 				}
 
-				if getter.projClsnCheck(p, p.hitdef.p2clsncheck, 1) &&
+				if getter.projClsnCheck(p, p.hitdef.p2clsncheck, 1, false) &&
 					sys.zAxisOverlap(p.pos[2], p.hitdef.attack_depth[0], p.hitdef.attack_depth[1], p.localscl,
 						getter.pos[2], getter.sizeDepth[0], getter.sizeDepth[1], getter.localscl) {
 
@@ -11080,7 +11110,7 @@ func (cl *CharList) pushDetection(getter *Char) {
 			}
 
 			// Push characters away from each other
-			if c.asf(ASF_sizepushonly) || getter.clsnCheck(c, 2, 2, false, false) {
+			if c.asf(ASF_sizepushonly) || getter.clsnCheck(c, 2, 2, false, false, false, false) {
 
 				getter.pushed, c.pushed = true, true
 

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -399,6 +399,7 @@ var triggerMap = map[string]int{
 	"inputtime":          1,
 	"introstate":         1,
 	"isasserted":         1,
+	"isclsnproxy":        1,
 	"ishost":             1,
 	"lastplayerid":       1,
 	"layerno":            1,
@@ -2779,6 +2780,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_ishelper)
 	case "ishometeam":
 		out.append(OC_ex_, OC_ex_ishometeam)
+	case "isclsnproxy":
+		out.append(OC_ex2_, OC_ex2_index)
 	case "index":
 		out.append(OC_ex2_, OC_ex2_index)
 	case "layerno":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -592,6 +592,10 @@ func (c *Compiler) helper(is IniSection, sc *StateControllerBase, _ int8) (State
 		}); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "clsnproxy",
+			helper_clsnproxy, VT_Bool, 1, false); err != nil {
+			return err
+		}
 		if err := c.stateParam(is, "name", false, func(data string) error {
 			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
 				return Error("Helper name not enclosed in \"")

--- a/src/script.go
+++ b/src/script.go
@@ -4166,6 +4166,10 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LBool(sys.debugWC.inguarddist))
 		return 1
 	})
+	luaRegister(l, "isclsnproxy", func(*lua.LState) int {
+		l.Push(lua.LBool(sys.debugWC.isclsnproxy))
+		return 1
+	})
 	luaRegister(l, "ishelper", func(l *lua.LState) int {
 		id, index := int32(-1), -1
 		// Check if ID is provided


### PR DESCRIPTION
Clsnproxy helpers act as an extension of the character's hitboxes, making it easy to do things with hitboxes that would otherwise be very complicated and inherently janky or impossible with current ZSS features, such as angling, moving, and scaling individual boxes independently.

I believe many people, myself included, would like to be able to make more dynamic hitboxes, and this is by far the simplest, easiest way to do that. Many of the things that are now possible with this could otherwise only be done in a full game environment, and were needlessly complicated even then. If, for whatever reason, this needs to be removed, it is also very simple to do that as well.