### PR TITLE
feat: neutral direction, extra parameters; fixes

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -12954,6 +12954,8 @@ const (
 	getHitVarSet_attr
 	getHitVarSet_chainid
 	getHitVarSet_ctrltime
+	getHitVarSet_damage
+	getHitVarSet_dizzypoints
 	getHitVarSet_down_recover
 	getHitVarSet_down_recovertime
 	getHitVarSet_fall
@@ -12973,12 +12975,15 @@ const (
 	getHitVarSet_fallcount
 	getHitVarSet_ground_animtype
 	getHitVarSet_groundtype
+	getHitVarSet_guardcount
 	getHitVarSet_guarded
+	getHitVarSet_guardpoints
+	getHitVarSet_hitcount
 	getHitVarSet_hitshaketime
 	getHitVarSet_hittime
 	getHitVarSet_id
 	getHitVarSet_playerno
-	getHitVarSet_recovertime
+	getHitVarSet_redlife
 	getHitVarSet_slidetime
 	getHitVarSet_xvel
 	getHitVarSet_yvel
@@ -13004,6 +13009,10 @@ func (sc getHitVarSet) Run(c *Char, _ []int32) bool {
 			crun.ghv.hitid = exp[0].evalI(c)
 		case getHitVarSet_ctrltime:
 			crun.ghv.ctrltime = exp[0].evalI(c)
+		case getHitVarSet_damage:
+			crun.ghv.damage = exp[0].evalI(c)
+		case getHitVarSet_dizzypoints:
+			crun.ghv.dizzypoints = exp[0].evalI(c)
 		case getHitVarSet_down_recover:
 			crun.ghv.down_recover = exp[0].evalB(c)
 		case getHitVarSet_down_recovertime:
@@ -13040,8 +13049,14 @@ func (sc getHitVarSet) Run(c *Char, _ []int32) bool {
 			crun.ghv.fallcount = exp[0].evalI(c)
 		case getHitVarSet_groundtype:
 			crun.ghv.groundtype = HitType(exp[0].evalI(c))
+		case getHitVarSet_guardcount:
+			crun.ghv.guardcount = exp[0].evalI(c)
 		case getHitVarSet_guarded:
 			crun.ghv.guarded = exp[0].evalB(c)
+		case getHitVarSet_guardpoints:
+			crun.ghv.guardpoints = exp[0].evalI(c)
+		case getHitVarSet_hitcount:
+			crun.ghv.hitcount = exp[0].evalI(c)
 		case getHitVarSet_hittime:
 			crun.ghv.hittime = exp[0].evalI(c)
 		case getHitVarSet_hitshaketime:
@@ -13050,6 +13065,8 @@ func (sc getHitVarSet) Run(c *Char, _ []int32) bool {
 			crun.ghv.playerId = exp[0].evalI(c)
 		case getHitVarSet_playerno:
 			crun.ghv.playerNo = int(exp[0].evalI(c))
+		case getHitVarSet_redlife:
+			crun.ghv.redlife = exp[0].evalI(c)
 		case getHitVarSet_slidetime:
 			crun.ghv.slidetime = exp[0].evalI(c)
 		case getHitVarSet_xvel:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -7230,6 +7230,7 @@ const (
 	// projectile_platformheight
 	// projectile_platformfence
 	// projectile_platformangle
+	projectile_last = iota + hitDef_last + 1 - 1
 	projectile_redirectid
 )
 
@@ -7504,10 +7505,10 @@ func (sc modifyReversalDef) Run(c *Char, _ []int32) bool {
 	return false
 }
 
-type modifyProjectile hitDef
+type modifyProjectile projectile
 
 const (
-	modifyProjectile_redirectid = iota + hitDef_last + 1
+	modifyProjectile_redirectid = iota + projectile_last + 1
 	modifyProjectile_id
 	modifyProjectile_index
 )
@@ -7551,6 +7552,11 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				}
 			}
 			switch paramID {
+			case projectile_projid:
+				v1 := exp[0].evalI(c)
+				eachProj(func(p *Projectile) {
+					p.id = v1
+				})
 			case projectile_projremove:
 				v1 := exp[0].evalB(c)
 				eachProj(func(p *Projectile) {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -620,6 +620,7 @@ const (
 	OC_ex_inputtime_U
 	OC_ex_inputtime_L
 	OC_ex_inputtime_R
+	OC_ex_inputtime_N
 	OC_ex_inputtime_a
 	OC_ex_inputtime_b
 	OC_ex_inputtime_c
@@ -721,11 +722,11 @@ const (
 	OC_ex_fightscreenvar_round_start_waittime
 	OC_ex_fightscreenvar_round_callfight_time
 	OC_ex_fightscreenvar_time_framespercount
-	OC_ex_groundlevel
-	OC_ex_layerno
 )
 const (
 	OC_ex2_index OpCode = iota
+	OC_ex2_groundlevel
+	OC_ex2_layerno
 	OC_ex2_runorder
 	OC_ex2_palfxvar_time
 	OC_ex2_palfxvar_addr
@@ -2895,8 +2896,6 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		*i += 4
 	case OC_ex_groundangle:
 		sys.bcStack.PushF(c.groundAngle)
-	case OC_ex_groundlevel:
-		sys.bcStack.PushF(c.groundLevel * (c.localscl / oc.localscl))
 	case OC_ex_guardbreak:
 		sys.bcStack.PushB(c.scf(SCF_guardbreak))
 	case OC_ex_guardcount:
@@ -2925,7 +2924,7 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_indialogue:
 		sys.bcStack.PushB(sys.dialogueFlg)
 	// InputTime
-	case OC_ex_inputtime_B, OC_ex_inputtime_D, OC_ex_inputtime_F, OC_ex_inputtime_U, OC_ex_inputtime_L, OC_ex_inputtime_R,
+	case OC_ex_inputtime_B, OC_ex_inputtime_D, OC_ex_inputtime_F, OC_ex_inputtime_U, OC_ex_inputtime_L, OC_ex_inputtime_R, OC_ex_inputtime_N,
 		OC_ex_inputtime_a, OC_ex_inputtime_b, OC_ex_inputtime_c, OC_ex_inputtime_x, OC_ex_inputtime_y, OC_ex_inputtime_z,
 		OC_ex_inputtime_s, OC_ex_inputtime_d, OC_ex_inputtime_w, OC_ex_inputtime_m:
 		// Check for valid inputs
@@ -2943,6 +2942,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 				sys.bcStack.PushI(c.cmd[0].Buffer.Lb)
 			case OC_ex_inputtime_R:
 				sys.bcStack.PushI(c.cmd[0].Buffer.Rb)
+			case OC_ex_inputtime_N:
+				sys.bcStack.PushI(c.cmd[0].Buffer.Nb)
 			case OC_ex_inputtime_a:
 				sys.bcStack.PushI(c.cmd[0].Buffer.ab)
 			case OC_ex_inputtime_b:
@@ -2977,8 +2978,6 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushB(c.isHost())
 	case OC_ex_jugglepoints:
 		*sys.bcStack.Top() = c.jugglePoints(*sys.bcStack.Top())
-	case OC_ex_layerno:
-		sys.bcStack.PushI(c.layerNo)
 	case OC_ex_localcoord_x:
 		sys.bcStack.PushF(sys.cgi[c.playerNo].localcoord[0])
 	case OC_ex_localcoord_y:
@@ -3163,6 +3162,10 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	camOff := float32(0)
 	camCorrected := false
 	switch opc {
+	case OC_ex2_groundlevel:
+		sys.bcStack.PushF(c.groundLevel * (c.localscl / oc.localscl))
+	case OC_ex2_layerno:
+		sys.bcStack.PushI(c.layerNo)
 	case OC_ex2_index:
 		sys.bcStack.PushI(c.index)
 	case OC_ex2_runorder:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -867,6 +867,12 @@ const (
 	OC_ex2_projvar_velmul_x
 	OC_ex2_projvar_velmul_y
 	OC_ex2_projvar_velmul_z
+	OC_ex2_hitdefvar_guard_dist_depth_bottom
+	OC_ex2_hitdefvar_guard_dist_depth_top
+	OC_ex2_hitdefvar_guard_dist_height_bottom
+	OC_ex2_hitdefvar_guard_dist_height_top
+	OC_ex2_hitdefvar_guard_dist_width_back
+	OC_ex2_hitdefvar_guard_dist_width_front
 	OC_ex2_hitdefvar_guard_pausetime
 	OC_ex2_hitdefvar_guard_shaketime
 	OC_ex2_hitdefvar_guard_sparkno
@@ -3644,54 +3650,66 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	case OC_ex2_systemvar_superpausetime:
 		sys.bcStack.PushI(sys.supertime)
 	// HitDefVar
+	case OC_ex2_hitdefvar_guard_dist_width_back:
+		sys.bcStack.PushF(c.hitdef.guard_dist_x[1] * (c.localscl / oc.localscl))
+	case OC_ex2_hitdefvar_guard_dist_width_front:
+		sys.bcStack.PushF(c.hitdef.guard_dist_x[0] * (c.localscl / oc.localscl))
+	case OC_ex2_hitdefvar_guard_dist_height_bottom:
+		sys.bcStack.PushF(c.hitdef.guard_dist_y[1] * (c.localscl / oc.localscl))
+	case OC_ex2_hitdefvar_guard_dist_height_top:
+		sys.bcStack.PushF(c.hitdef.guard_dist_y[0] * (c.localscl / oc.localscl))
+	case OC_ex2_hitdefvar_guard_dist_depth_bottom:
+		sys.bcStack.PushF(c.hitdef.guard_dist_z[1] * (c.localscl / oc.localscl))
+	case OC_ex2_hitdefvar_guard_dist_depth_top:
+		sys.bcStack.PushF(c.hitdef.guard_dist_z[0] * (c.localscl / oc.localscl))
+	case OC_ex2_hitdefvar_guard_pausetime:
+		sys.bcStack.PushI(c.hitdef.guard_pausetime)
+	case OC_ex2_hitdefvar_guard_shaketime:
+		sys.bcStack.PushI(c.hitdef.guard_shaketime)
+	case OC_ex2_hitdefvar_guard_sparkno:
+		sys.bcStack.PushI(c.hitdef.guard_sparkno)
+	case OC_ex2_hitdefvar_guarddamage:
+		sys.bcStack.PushI(c.hitdef.guarddamage)
 	case OC_ex2_hitdefvar_guardflag:
 		attr := (*(*int32)(unsafe.Pointer(&be[*i])))
 		sys.bcStack.PushB(
 			c.hitdef.guardflag&attr != 0,
 		)
 		*i += 4
+	case OC_ex2_hitdefvar_guardsound_group:
+		sys.bcStack.PushI(c.hitdef.guardsound[0])
+	case OC_ex2_hitdefvar_guardsound_number:
+		sys.bcStack.PushI(c.hitdef.guardsound[1])
+	case OC_ex2_hitdefvar_hitdamage:
+		sys.bcStack.PushI(c.hitdef.hitdamage)
 	case OC_ex2_hitdefvar_hitflag:
 		attr := (*(*int32)(unsafe.Pointer(&be[*i])))
 		sys.bcStack.PushB(
 			c.hitdef.hitflag&attr != 0,
 		)
 		*i += 4
-	case OC_ex2_hitdefvar_hitdamage:
-		sys.bcStack.PushI(c.hitdef.hitdamage)
-	case OC_ex2_hitdefvar_guarddamage:
-		sys.bcStack.PushI(c.hitdef.guarddamage)
-	case OC_ex2_hitdefvar_p1stateno:
-		sys.bcStack.PushI(c.hitdef.p1stateno)
-	case OC_ex2_hitdefvar_p2stateno:
-		sys.bcStack.PushI(c.hitdef.p2stateno)
-	case OC_ex2_hitdefvar_priority:
-		sys.bcStack.PushI(c.hitdef.priority)
-	case OC_ex2_hitdefvar_id:
-		sys.bcStack.PushI(c.hitdef.id)
-	case OC_ex2_hitdefvar_sparkno:
-		sys.bcStack.PushI(c.hitdef.sparkno)
-	case OC_ex2_hitdefvar_guard_sparkno:
-		sys.bcStack.PushI(c.hitdef.guard_sparkno)
-	case OC_ex2_hitdefvar_sparkx:
-		sys.bcStack.PushF(c.hitdef.sparkxy[0] * (c.localscl / oc.localscl))
-	case OC_ex2_hitdefvar_sparky:
-		sys.bcStack.PushF(c.hitdef.sparkxy[1] * (c.localscl / oc.localscl))
-	case OC_ex2_hitdefvar_pausetime:
-		sys.bcStack.PushI(c.hitdef.pausetime)
-	case OC_ex2_hitdefvar_guard_pausetime:
-		sys.bcStack.PushI(c.hitdef.guard_pausetime)
-	case OC_ex2_hitdefvar_shaketime:
-		sys.bcStack.PushI(c.hitdef.shaketime)
-	case OC_ex2_hitdefvar_guard_shaketime:
-		sys.bcStack.PushI(c.hitdef.guard_shaketime)
 	case OC_ex2_hitdefvar_hitsound_group:
 		sys.bcStack.PushI(c.hitdef.hitsound[0])
 	case OC_ex2_hitdefvar_hitsound_number:
 		sys.bcStack.PushI(c.hitdef.hitsound[1])
-	case OC_ex2_hitdefvar_guardsound_group:
-		sys.bcStack.PushI(c.hitdef.guardsound[0])
-	case OC_ex2_hitdefvar_guardsound_number:
-		sys.bcStack.PushI(c.hitdef.guardsound[1])
+	case OC_ex2_hitdefvar_id:
+		sys.bcStack.PushI(c.hitdef.id)
+	case OC_ex2_hitdefvar_p1stateno:
+		sys.bcStack.PushI(c.hitdef.p1stateno)
+	case OC_ex2_hitdefvar_p2stateno:
+		sys.bcStack.PushI(c.hitdef.p2stateno)
+	case OC_ex2_hitdefvar_pausetime:
+		sys.bcStack.PushI(c.hitdef.pausetime)
+	case OC_ex2_hitdefvar_priority:
+		sys.bcStack.PushI(c.hitdef.priority)
+	case OC_ex2_hitdefvar_shaketime:
+		sys.bcStack.PushI(c.hitdef.shaketime)
+	case OC_ex2_hitdefvar_sparkno:
+		sys.bcStack.PushI(c.hitdef.sparkno)
+	case OC_ex2_hitdefvar_sparkx:
+		sys.bcStack.PushF(c.hitdef.sparkxy[0] * (c.localscl / oc.localscl))
+	case OC_ex2_hitdefvar_sparky:
+		sys.bcStack.PushF(c.hitdef.sparkxy[1] * (c.localscl / oc.localscl))
 	// HitByAttr
 	case OC_ex2_hitbyattr:
 		sys.bcStack.PushB(c.hitByAttrTrigger(*(*int32)(unsafe.Pointer(&be[*i]))))

--- a/src/char.go
+++ b/src/char.go
@@ -7634,7 +7634,7 @@ func (c *Char) posUpdate() {
 	}
 
 	// Check if character is bound
-	nobind := [...]bool{c.bindTime == 0 || math.IsNaN(float64(c.bindPos[0])),
+	nobind := [3]bool{c.bindTime == 0 || math.IsNaN(float64(c.bindPos[0])),
 		c.bindTime == 0 || math.IsNaN(float64(c.bindPos[1])),
 		c.bindTime == 0 || math.IsNaN(float64(c.bindPos[2]))}
 	for i := range nobind {
@@ -9844,16 +9844,19 @@ func (c *Char) tick() {
 				c.selfState(5050, -1, -1, -1, "")
 				c.gethitBindClear()
 			} else if !bt.pause() {
-				c.bindTime -= 1
+				// c.bindTime -= 1
+				c.setBindTime(c.bindTime - 1)
 			}
 		} else {
 			if !c.pause() {
-				c.bindTime -= 1
+				// c.bindTime -= 1
+				c.setBindTime(c.bindTime - 1)
+				// The fix below was necessary before because bindTime should not be decremented directly but rather via setBindTime
 				// Fixes BindToRoot/BindToParent of 1 immediately after PosSets (MUGEN 1.0/1.1 behavior)
 				// This must not run for target binds so that they end the same time as MUGEN's do.
-				if c.bindToId > 0 {
-					c.setBindTime(c.bindTime)
-				}
+				//if c.bindToId > 0 {
+				//	c.setBindTime(c.bindTime)
+				//}
 			}
 		}
 	}

--- a/src/char.go
+++ b/src/char.go
@@ -8495,6 +8495,9 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 					pn = hd.playerNo
 				}
 				if getter.stateChange1(hd.p2stateno, pn) {
+					// In Mugen, using p2stateno forces movetype to H
+					// https://github.com/ikemen-engine/Ikemen-GO/issues/2466
+					getter.ss.changeMoveType(MT_H)
 					getter.setCtrl(false)
 					p2s = true
 					getter.hoIdx = -1

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2687,48 +2687,60 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		}
 		isFlag := false
 		switch param {
+		case "guard.dist.depth.bottom":
+			opc = OC_ex2_hitdefvar_guard_dist_depth_bottom
+		case "guard.dist.depth.top":
+			opc = OC_ex2_hitdefvar_guard_dist_depth_top
+		case "guard.dist.height.bottom":
+			opc = OC_ex2_hitdefvar_guard_dist_height_bottom
+		case "guard.dist.height.top":
+			opc = OC_ex2_hitdefvar_guard_dist_height_top
+		case "guard.dist.width.back":
+			opc = OC_ex2_hitdefvar_guard_dist_width_back
+		case "guard.dist.width.front":
+			opc = OC_ex2_hitdefvar_guard_dist_width_front
+		case "guard.pausetime":
+			opc = OC_ex2_hitdefvar_guard_pausetime
+		case "guard.shaketime":
+			opc = OC_ex2_hitdefvar_guard_shaketime
+		case "guard.sparkno":
+			opc = OC_ex2_hitdefvar_guard_sparkno
+		case "guarddamage":
+			opc = OC_ex2_hitdefvar_guarddamage
 		case "guardflag":
 			opc = OC_ex2_hitdefvar_guardflag
 			isFlag = true
-		case "hitflag":
-			opc = OC_ex2_hitdefvar_hitflag
-			isFlag = true
-		case "hitdamage":
-			opc = OC_ex2_hitdefvar_hitdamage
-		case "guarddamage":
-			opc = OC_ex2_hitdefvar_guarddamage
-		case "p1stateno":
-			opc = OC_ex2_hitdefvar_p1stateno
-		case "p2stateno":
-			opc = OC_ex2_hitdefvar_p2stateno
-		case "priority":
-			opc = OC_ex2_hitdefvar_priority
-		case "id":
-			opc = OC_ex2_hitdefvar_id
-		case "sparkno":
-			opc = OC_ex2_hitdefvar_sparkno
-		case "guard.sparkno":
-			opc = OC_ex2_hitdefvar_guard_sparkno
-		case "sparkx":
-			opc = OC_ex2_hitdefvar_sparkx
-		case "sparky":
-			opc = OC_ex2_hitdefvar_sparky
-		case "pausetime":
-			opc = OC_ex2_hitdefvar_pausetime
-		case "guard.pausetime":
-			opc = OC_ex2_hitdefvar_guard_pausetime
-		case "shaketime":
-			opc = OC_ex2_hitdefvar_shaketime
-		case "guard.shaketime":
-			opc = OC_ex2_hitdefvar_guard_shaketime
-		case "hitsound.group":
-			opc = OC_ex2_hitdefvar_hitsound_group
-		case "hitsound.number":
-			opc = OC_ex2_hitdefvar_hitsound_number
 		case "guardsound.group":
 			opc = OC_ex2_hitdefvar_guardsound_group
 		case "guardsound.number":
 			opc = OC_ex2_hitdefvar_guardsound_number
+		case "hitdamage":
+			opc = OC_ex2_hitdefvar_hitdamage
+		case "hitflag":
+			opc = OC_ex2_hitdefvar_hitflag
+			isFlag = true
+		case "hitsound.group":
+			opc = OC_ex2_hitdefvar_hitsound_group
+		case "hitsound.number":
+			opc = OC_ex2_hitdefvar_hitsound_number
+		case "id":
+			opc = OC_ex2_hitdefvar_id
+		case "p1stateno":
+			opc = OC_ex2_hitdefvar_p1stateno
+		case "p2stateno":
+			opc = OC_ex2_hitdefvar_p2stateno
+		case "pausetime":
+			opc = OC_ex2_hitdefvar_pausetime
+		case "priority":
+			opc = OC_ex2_hitdefvar_priority
+		case "shaketime":
+			opc = OC_ex2_hitdefvar_shaketime
+		case "sparkno":
+			opc = OC_ex2_hitdefvar_sparkno
+		case "sparkx":
+			opc = OC_ex2_hitdefvar_sparkx
+		case "sparky":
+			opc = OC_ex2_hitdefvar_sparky
 		default:
 			return bvNone(), Error("Invalid HitDefVar argument: " + c.token)
 		}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2623,7 +2623,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		}
 		// no-op (for y/xveladd and fall.envshake.dir)
 	case "groundlevel":
-		out.append(OC_ex_, OC_ex_groundlevel)
+		out.append(OC_ex2_, OC_ex2_groundlevel)
 	case "guardcount":
 		out.append(OC_ex_, OC_ex_guardcount)
 	case "helperindexexist":
@@ -2782,7 +2782,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 	case "index":
 		out.append(OC_ex2_, OC_ex2_index)
 	case "layerno":
-		out.append(OC_ex_, OC_ex_layerno)
+		out.append(OC_ex2_, OC_ex2_layerno)
 	case "leftedge":
 		out.append(OC_leftedge)
 	case "life", "p2life":
@@ -4366,6 +4366,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.append(OC_ex_, OC_ex_inputtime_L)
 		case "R":
 			out.append(OC_ex_, OC_ex_inputtime_R)
+		case "N":
+			out.append(OC_ex_, OC_ex_inputtime_N)
 		case "a":
 			out.append(OC_ex_, OC_ex_inputtime_a)
 		case "b":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -5918,6 +5918,14 @@ func (c *Compiler) getHitVarSet(is IniSection, sc *StateControllerBase, _ int8) 
 			getHitVarSet_ctrltime, VT_Int, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "damage",
+			getHitVarSet_damage, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "dizzypoints",
+			getHitVarSet_dizzypoints, VT_Int, 1, false); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "down.recover",
 			getHitVarSet_down_recover, VT_Bool, 1, false); err != nil {
 			return err
@@ -5990,8 +5998,20 @@ func (c *Compiler) getHitVarSet(is IniSection, sc *StateControllerBase, _ int8) 
 			getHitVarSet_groundtype, VT_Int, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "guardcount",
+			getHitVarSet_guardcount, VT_Int, 1, false); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "guarded",
 			getHitVarSet_guarded, VT_Bool, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "guardpoints",
+			getHitVarSet_guardpoints, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "hitcount",
+			getHitVarSet_hittime, VT_Int, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "hitshaketime",
@@ -6010,8 +6030,8 @@ func (c *Compiler) getHitVarSet(is IniSection, sc *StateControllerBase, _ int8) 
 			getHitVarSet_playerno, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.paramValue(is, sc, "recovertime",
-			getHitVarSet_recovertime, VT_Int, 1, false); err != nil {
+		if err := c.paramValue(is, sc, "redlife",
+			getHitVarSet_redlife, VT_Int, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "slidetime",

--- a/src/system.go
+++ b/src/system.go
@@ -758,13 +758,17 @@ func (s *System) roundNoDamage() bool {
 	return sys.intro < 0 && sys.intro <= -sys.lifebar.ro.over_hittime && sys.intro >= -sys.lifebar.ro.over_waittime
 }
 
+// In Mugen, RoundState 2 begins as soon as the "Fight" screen appears, before players have control
+// That causes more harm than good and is not clearly stated in the documentation, so Ikemen changes it
 func (s *System) roundState() int32 {
 	switch {
 	case sys.intro > sys.lifebar.ro.ctrl_time+1 || sys.postMatchFlg:
 		return 0
-	case sys.lifebar.ro.current == 0:
+	//case sys.lifebar.ro.current == 0:
+	case sys.intro > 0:
 		return 1
-	case sys.intro >= 0 || sys.finishType == FT_NotYet:
+	//case sys.intro >= 0 || sys.finishType == FT_NotYet:
+	case sys.intro == 0 || sys.finishType == FT_NotYet:
 		return 2
 	case sys.intro < -sys.lifebar.ro.over_waittime:
 		return 4

--- a/src/system.go
+++ b/src/system.go
@@ -2200,11 +2200,17 @@ func (s *System) fight() (reload bool) {
 	}
 	s.wincnt.init()
 
-	// Initialize super meter values, and max power for teams sharing meter
+	// Prepare next round for all players
+	for _, p := range s.chars {
+		if len(p) > 0 {
+			p[0].prepareNextRound()
+		}
+	}
+
+	// Initialize super meter values and max power for teams sharing meter
 	var level [len(s.chars)]int32
 	for i, p := range s.chars {
 		if len(p) > 0 && p[0].teamside != -1 {
-			p[0].prepareNextRound()
 			level[i] = s.wincnt.getLevel(i)
 			if s.cfg.Options.Team.PowerShare {
 				pmax := Max(s.cgi[i&1].data.power, s.cgi[i].data.power)
@@ -2216,6 +2222,7 @@ func (s *System) fight() (reload bool) {
 			}
 		}
 	}
+
 	minlv, maxlv := level[0], level[0]
 	for i, lv := range level[1:] {
 		if len(s.chars[i+1]) > 0 {
@@ -2295,7 +2302,7 @@ func (s *System) fight() (reload bool) {
 			p[0].lifeMax = Max(1, int32(math.Floor(foo*float64(lm))))
 
 			if p[0].roundsExisted() > 0 {
-				// If character already existed for a round, presumably because of turns mode, just update life
+				// If character already existed for a round, presumably because of Turns mode, just update life
 				p[0].life = Min(p[0].lifeMax, int32(math.Ceil(foo*float64(p[0].life))))
 			} else if s.round == 1 || s.tmode[i&1] == TM_Turns {
 				// If round 1 or a new character in Turns mode, initialize values


### PR DESCRIPTION
Feat:
- Commands can now also use the "N" direction (neutral). InputTime trigger updated accordingly
- ModifyProjectile can now modify the projectile's ID
- GetHitVarSet damage, dizzypoints, guardcount, guardpoints, hitcount and redlife
- HitDefVar guard.dist.depth.top, guard.dist.depth.bottom, guard.dist.height.top, guard.dist.height.bottom, guard.dist.width.back, guard.dist.width.front

Fix:
- Using P2StateNo in ReversalDef will now force the enemy into Movetype H, as in Mugen
- Fixed previous regression that made it necessary to have extra workarounds in order for BindToRoot and BindToParent to work correctly in some scenarios
- Minor fix so that attached chars don't end up filling the wrong power bar
- Fixed prepareNextRound() acting different for attached characters
- Fixes #2466 
- Fixes #2481 

Refactor:
- RoundState no longer returns 2 during the "Fight!" screen, before players are given control