### PR TITLE
fix: some command line flags, added setvolume flag

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -358,7 +358,7 @@ if main.flags['-speedtest'] ~= nil then
 	setGameSpeed(100 * gameOption('Config.Framerate'))
 end
 if main.flags['-nosound'] ~= nil then
-	setVolumeMaster(0)
+	modifyGameOption('Sound.MasterVolume', 0)
 end
 if main.flags['-togglelifebars'] ~= nil then
 	toggleLifebarDisplay()
@@ -371,6 +371,18 @@ if main.flags['-debug'] ~= nil then
 end
 if main.flags['-setport'] ~= nil then
 	setListenPort(main.flags['-setport'])
+end
+if main.flags['-setvolume'] ~= nil and main.flags['-nosound'] == nil then
+	modifyGameOption('Sound.MasterVolume', main.flags['-setvolume'])
+end
+if main.flags['-windowed'] ~= nil then
+	modifyGameOption('Video.Fullscreen', false)
+end
+if main.flags['-width'] then
+	modifyGameOption('Video.GameWidth', main.flags['-width'])
+end
+if main.flags['-height'] then 
+	modifyGameOption('Video.GameHeight', main.flags['-height'])
 end
 
 --motif

--- a/src/main.go
+++ b/src/main.go
@@ -154,8 +154,10 @@ func processCommandLine() {
 -r <path>               Loads motif <path>. eg. -r motifdir or -r motifdir/system.def
 -lifebar <path>         Loads lifebar <path>. eg. -lifebar data/fight.def
 -storyboard <path>      Loads storyboard <path>. eg. -storyboard chars/kfm/intro.def
--width <num>            Overrides game window width
--height <num>           Overrides game window height
+-windowed               Starts in windowed mode (disables fullscreen)
+-width <num>            Sets game width
+-height <num>           Sets game height
+-setvolume <num>        Sets master volume to <num> (0-100)
 
 Quick VS Options:
 -p<n> <playername>      Loads player n, eg. -p3 kfm
@@ -173,7 +175,6 @@ Debug Options:
 -nojoy                  Disables joysticks
 -nomusic                Disables music
 -nosound                Disables all sound effects and music
--windowed               Windowed mode (disables fullscreen)
 -togglelifebars         Disables display of the Life and Power bars
 -maxpowermode           Enables auto-refill of Power bars
 -ailevel <level>        Changes game difficulty setting to <level> (1-8)


### PR DESCRIPTION
Fixed -nosound, windowed, width and height flags when launching through command line. Added setvolume option.