### PR TITLE
fix: UI rendering to fill entire window and handle resize correctly

### DIFF
--- a/src/framebuffer_resize_callback.go
+++ b/src/framebuffer_resize_callback.go
@@ -1,0 +1,11 @@
+//go:build !kinc
+package main
+
+import glfw "github.com/go-gl/glfw/v3.3/glfw"
+
+func framebufferSizeCallback(w *glfw.Window, width int, height int) {
+	sys.setWindowSize(int32(width), int32(height))
+	if gfx != nil {
+		gfx.Resize(int32(width), int32(height))
+	}
+}

--- a/src/render.go
+++ b/src/render.go
@@ -75,6 +75,7 @@ type Renderer interface {
 	RenderCubeMap(envTexture Texture, cubeTexture Texture)
 	RenderFilteredCubeMap(distribution int32, cubeTexture Texture, filteredTexture Texture, mipmapLevel, sampleCount int32, roughness float32)
 	RenderLUT(distribution int32, cubeTexture Texture, lutTexture Texture, sampleCount int32)
+	Resize(width, height int32)
 }
 
 //go:embed shaders/sprite.vert.glsl

--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -1571,3 +1571,106 @@ func (r *Renderer_GL21) RenderLUT(distribution int32, cubeTex Texture, lutTex Te
 	gl.DrawArrays(gl.TRIANGLE_STRIP, 0, 4)
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo)
 }
+
+func (r *Renderer_GL21) Resize(width, height int32) {
+	// Update FBOs and textures that depend on screen size
+	// This logic is adapted from r.Init()
+
+	// Delete old textures and renderbuffers
+	gl.DeleteTextures(1, &r.fbo_texture)
+	gl.DeleteRenderbuffers(1, &r.rbo_depth)
+	if r.fbo_f_texture != nil {
+		gl.DeleteTextures(1, &r.fbo_f_texture.handle)
+	}
+	for i := 0; i < 2; i++ {
+		gl.DeleteTextures(1, &r.fbo_pp_texture[i])
+		gl.DeleteFramebuffers(1, &r.fbo_pp[i])
+	}
+	gl.DeleteFramebuffers(1, &r.fbo)
+	if sys.msaa > 0 {
+		gl.DeleteFramebuffers(1, &r.fbo_f)
+	}
+
+	// Recreate FBO texture
+	gl.GenTextures(1, &r.fbo_texture)
+	if sys.msaa > 0 {
+		gl.BindTexture(gl.TEXTURE_2D_MULTISAMPLE, r.fbo_texture)
+	} else {
+		gl.BindTexture(gl.TEXTURE_2D, r.fbo_texture)
+	}
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+	if sys.msaa > 0 {
+		gl.TexImage2DMultisample(gl.TEXTURE_2D_MULTISAMPLE, sys.msaa, gl.RGBA, width, height, true)
+	} else {
+		gl.TexImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, nil)
+	}
+
+	// Recreate post-processing FBO textures
+	// r.fbo_pp = make([]uint32, 2)        // Not needed, GenFramebuffers will create new ones
+	// r.fbo_pp_texture = make([]uint32, 2) // Not needed, GenTextures will create new ones
+	for i := 0; i < 2; i++ {
+		gl.GenTextures(1, &(r.fbo_pp_texture[i]))
+		gl.BindTexture(gl.TEXTURE_2D, r.fbo_pp_texture[i])
+		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
+		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
+		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+		gl.TexImage2D(gl.TEXTURE_2D, 0, gl.RGBA8_SNORM, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, nil)
+	}
+	gl.BindTexture(gl.TEXTURE_2D, 0)
+
+	// Recreate depth renderbuffer
+	gl.GenRenderbuffers(1, &r.rbo_depth)
+	gl.BindRenderbuffer(gl.RENDERBUFFER, r.rbo_depth)
+	if sys.msaa > 0 {
+		gl.RenderbufferStorageMultisample(gl.RENDERBUFFER, sys.msaa, gl.DEPTH_COMPONENT16, width, height)
+	} else {
+		gl.RenderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT16, width, height)
+	}
+	gl.BindRenderbuffer(gl.RENDERBUFFER, 0)
+
+	// Recreate MSAA resolve FBO texture if needed
+	if sys.msaa > 0 {
+		r.fbo_f_texture = r.newTexture(width, height, 32, false).(*Texture_GL21)
+		r.fbo_f_texture.SetData(nil)
+	}
+
+	// Recreate main FBO
+	gl.GenFramebuffers(1, &r.fbo)
+	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo)
+	if sys.msaa > 0 {
+		gl.FramebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D_MULTISAMPLE, r.fbo_texture, 0)
+		gl.FramebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, r.rbo_depth)
+		if status := gl.CheckFramebufferStatus(gl.FRAMEBUFFER); status != gl.FRAMEBUFFER_COMPLETE {
+			sys.errLog.Printf("framebuffer resize failed (main MSAA FBO): 0x%x", status)
+		}
+		// Recreate MSAA resolve FBO
+		gl.GenFramebuffers(1, &r.fbo_f)
+		gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_f)
+		gl.FramebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, r.fbo_f_texture.handle, 0)
+		if status := gl.CheckFramebufferStatus(gl.FRAMEBUFFER); status != gl.FRAMEBUFFER_COMPLETE {
+			sys.errLog.Printf("framebuffer resize failed (resolve FBO): 0x%x", status)
+		}
+	} else {
+		gl.FramebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, r.fbo_texture, 0)
+		gl.FramebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, r.rbo_depth)
+		if status := gl.CheckFramebufferStatus(gl.FRAMEBUFFER); status != gl.FRAMEBUFFER_COMPLETE {
+			sys.errLog.Printf("framebuffer resize failed (main FBO): 0x%x", status)
+		}
+	}
+
+	// Recreate post-processing FBOs
+	for i := 0; i < 2; i++ {
+		gl.GenFramebuffers(1, &(r.fbo_pp[i]))
+		gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_pp[i])
+		gl.FramebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, r.fbo_pp_texture[i], 0)
+		if status := gl.CheckFramebufferStatus(gl.FRAMEBUFFER); status != gl.FRAMEBUFFER_COMPLETE {
+			sys.errLog.Printf("framebuffer resize failed (post-proc FBO %d): 0x%x", i, status)
+		}
+	}
+
+	gl.BindFramebuffer(gl.FRAMEBUFFER, 0) // Bind default framebuffer
+}

--- a/src/render_gl_gl32.go
+++ b/src/render_gl_gl32.go
@@ -1578,3 +1578,106 @@ func (r *Renderer_GL32) RenderLUT(distribution int32, cubeTex Texture, lutTex Te
 	gl.DrawArrays(gl.TRIANGLE_STRIP, 0, 4)
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo)
 }
+
+func (r *Renderer_GL32) Resize(width, height int32) {
+	// Update FBOs and textures that depend on screen size
+	// This logic is adapted from r.Init()
+
+	// Delete old textures and renderbuffers
+	gl.DeleteTextures(1, &r.fbo_texture)
+	gl.DeleteRenderbuffers(1, &r.rbo_depth)
+	if r.fbo_f_texture != nil {
+		gl.DeleteTextures(1, &r.fbo_f_texture.handle)
+	}
+	for i := 0; i < 2; i++ {
+		gl.DeleteTextures(1, &r.fbo_pp_texture[i])
+		gl.DeleteFramebuffers(1, &r.fbo_pp[i])
+	}
+	gl.DeleteFramebuffers(1, &r.fbo)
+	if sys.msaa > 0 {
+		gl.DeleteFramebuffers(1, &r.fbo_f)
+	}
+
+	// Recreate FBO texture
+	gl.GenTextures(1, &r.fbo_texture)
+	if sys.msaa > 0 {
+		gl.BindTexture(gl.TEXTURE_2D_MULTISAMPLE, r.fbo_texture)
+	} else {
+		gl.BindTexture(gl.TEXTURE_2D, r.fbo_texture)
+	}
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+	if sys.msaa > 0 {
+		gl.TexImage2DMultisample(gl.TEXTURE_2D_MULTISAMPLE, sys.msaa, gl.RGBA, width, height, true)
+	} else {
+		gl.TexImage2D(gl.TEXTURE_2D, 0, gl.RGBA, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, nil)
+	}
+
+	// Recreate post-processing FBO textures
+	// r.fbo_pp = make([]uint32, 2)        // Not needed, GenFramebuffers will create new ones
+	// r.fbo_pp_texture = make([]uint32, 2) // Not needed, GenTextures will create new ones
+	for i := 0; i < 2; i++ {
+		gl.GenTextures(1, &(r.fbo_pp_texture[i]))
+		gl.BindTexture(gl.TEXTURE_2D, r.fbo_pp_texture[i])
+		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
+		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
+		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+		gl.TexImage2D(gl.TEXTURE_2D, 0, gl.RGBA8_SNORM, width, height, 0, gl.RGBA, gl.UNSIGNED_BYTE, nil)
+	}
+	gl.BindTexture(gl.TEXTURE_2D, 0)
+
+	// Recreate depth renderbuffer
+	gl.GenRenderbuffers(1, &r.rbo_depth)
+	gl.BindRenderbuffer(gl.RENDERBUFFER, r.rbo_depth)
+	if sys.msaa > 0 {
+		gl.RenderbufferStorageMultisample(gl.RENDERBUFFER, sys.msaa, gl.DEPTH_COMPONENT16, width, height)
+	} else {
+		gl.RenderbufferStorage(gl.RENDERBUFFER, gl.DEPTH_COMPONENT16, width, height)
+	}
+	gl.BindRenderbuffer(gl.RENDERBUFFER, 0)
+
+	// Recreate MSAA resolve FBO texture if needed
+	if sys.msaa > 0 {
+		r.fbo_f_texture = r.newTexture(width, height, 32, false).(*Texture_GL32)
+		r.fbo_f_texture.SetData(nil)
+	}
+
+	// Recreate main FBO
+	gl.GenFramebuffers(1, &r.fbo)
+	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo)
+	if sys.msaa > 0 {
+		gl.FramebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D_MULTISAMPLE, r.fbo_texture, 0)
+		gl.FramebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, r.rbo_depth)
+		if status := gl.CheckFramebufferStatus(gl.FRAMEBUFFER); status != gl.FRAMEBUFFER_COMPLETE {
+			sys.errLog.Printf("framebuffer resize failed (main MSAA FBO): 0x%x", status)
+		}
+		// Recreate MSAA resolve FBO
+		gl.GenFramebuffers(1, &r.fbo_f)
+		gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_f)
+		gl.FramebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, r.fbo_f_texture.handle, 0)
+		if status := gl.CheckFramebufferStatus(gl.FRAMEBUFFER); status != gl.FRAMEBUFFER_COMPLETE {
+			sys.errLog.Printf("framebuffer resize failed (resolve FBO): 0x%x", status)
+		}
+	} else {
+		gl.FramebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, r.fbo_texture, 0)
+		gl.FramebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, r.rbo_depth)
+		if status := gl.CheckFramebufferStatus(gl.FRAMEBUFFER); status != gl.FRAMEBUFFER_COMPLETE {
+			sys.errLog.Printf("framebuffer resize failed (main FBO): 0x%x", status)
+		}
+	}
+
+	// Recreate post-processing FBOs
+	for i := 0; i < 2; i++ {
+		gl.GenFramebuffers(1, &(r.fbo_pp[i]))
+		gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_pp[i])
+		gl.FramebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, r.fbo_pp_texture[i], 0)
+		if status := gl.CheckFramebufferStatus(gl.FRAMEBUFFER); status != gl.FRAMEBUFFER_COMPLETE {
+			sys.errLog.Printf("framebuffer resize failed (post-proc FBO %d): 0x%x", i, status)
+		}
+	}
+
+	gl.BindFramebuffer(gl.FRAMEBUFFER, 0) // Bind default framebuffer
+}

--- a/src/system_glfw.go
+++ b/src/system_glfw.go
@@ -83,6 +83,7 @@ func (s *System) newWindow(w, h int) (*Window, error) {
 	window.MakeContextCurrent()
 	window.SetKeyCallback(keyCallback)
 	window.SetCharModsCallback(charCallback)
+	window.SetFramebufferSizeCallback(framebufferSizeCallback)
 
 	// V-Sync
 	if s.cfg.Video.VSync >= 0 {


### PR DESCRIPTION
Previously, the game UI was rendered in the bottom-left quarter of the window. This was due to the main framebuffer being sized according to a fixed internal resolution (sys.scrrect) that was not updated to the actual window size, and the rendering viewport being set to this smaller dimension.

This commit implements the following changes:

1.  Ensured `sys.scrrect` is always updated to the actual window/framebuffer size via `sys.setWindowSize`.
2.  Added a framebuffer resize callback (`framebufferSizeCallback` in `src/system_glfw.go`) that calls `sys.setWindowSize` and a new `gfx.Resize` method.
3.  The `gfx.Resize` method, implemented for `Renderer_GL21` and `Renderer_GL32`, now correctly deletes and recreates Framebuffer Objects (FBOs) and their associated textures to match the new window dimensions.
4.  The main rendering viewport in `BeginFrame` and the orthographic projections in `RenderSprite` and `FillRect` now use the updated `sys.scrrect`, ensuring the scene is rendered to the FBO at full window resolution.
5.  The `EndFrame` post-processing step continues to use `sys.window.GetScaledViewportSize()` for the final viewport, which correctly handles aspect ratio preservation by scaling/letterboxing the (now) full-resolution FBO content.