### PR TITLE
fix: Cygwin for build.sh, Makefile cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,6 @@ srcFiles=src/anim.go \
 Ikemen_GO.exe: ${srcFiles}
 	cd ./build && bash ./build.sh Win64
 
-# Windows 64-bit target (GL 3.2)
-Ikemen_GO_GL32.exe: ${srcFiles}
-	cd ./build && bash ./build.sh Win64GL32
-
 # Windows 32-bit target
 Ikemen_GO_86.exe: ${srcFiles}
 	cd ./build && bash ./build.sh Win32
@@ -40,17 +36,9 @@ Ikemen_GO_86.exe: ${srcFiles}
 Ikemen_GO_Linux: ${srcFiles}
 	cd ./build && ./build.sh Linux
 
-# Linux target (GL 3.2)
-Ikemen_GO_Linux_GL32: ${srcFiles}
-	cd ./build && ./build.sh LinuxGL32
-
 # Linux ARM target
 Ikemen_GO_LinuxARM: ${srcFiles}
 	cd ./build && ./build.sh LinuxARM
-
-# Linux ARM target (GL 3.2)
-Ikemen_GO_LinuxARM_GL32: ${srcFiles}
-	cd ./build && ./build.sh LinuxARMGL32
 
 # MacOS x64 target
 Ikemen_GO_MacOS: ${srcFiles}

--- a/build/build.sh
+++ b/build/build.sh
@@ -20,7 +20,7 @@ function main() {
 	mkdir -p bin
 
 	# Check OS
-	checkOS
+	checkOS $targetOS
 	# If a build target has not been specified use the current OS.
 	if [[ "$1" == "" ]]; then
 		targetOS=$currentOS
@@ -126,7 +126,7 @@ function checkOS() {
 		linux*)
 			currentOS="Linux"
 		;;
-		msys)
+		msys|cygwin)
 			if [[ "$osArch" == "x86_64" ]]; then
 				currentOS="Win64"
 			else


### PR DESCRIPTION
This PR has miscellaneous fixes regarding the build system:
- Added Cygwin as a valid `OSTYPE` in `build/build.sh`, detected as Windows
- Fixed `build/build.sh` not using the command-line argument if it was unable to detect an `OSTYPE`
- Removed leftover OpenGL 3.2 targets from `Makefile`