### PR TITLE
fix: huge load time lag with bgm.Open() solved with a multithreaded buffer swap; feat: freqmul of 0 for ModifySnd and ModifyBGM

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -11710,6 +11710,11 @@ const (
 func (sc modifyBgm) Run(c *Char, _ []int32) bool {
 	var volumeSet, loopStartSet, loopEndSet, posSet, freqSet = false, false, false, false, false
 	var volume, loopstart, loopend, position int = 100, 0, 0, 0
+	// Safety default sets
+	if sl, ok := sys.bgm.volctrl.Streamer.(*StreamLooper); ok {
+		loopstart = sl.loopstart
+		loopend = sl.loopend
+	}
 	var freqmul float32 = 1.0
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {

--- a/src/sound.go
+++ b/src/sound.go
@@ -337,12 +337,12 @@ func (bgm *Bgm) Open(filename string, loop, bgmVolume, bgmLoopStart, bgmLoopEnd,
 		bgm.streamer, format, err = flac.Decode(f)
 		bgm.format = "flac"
 	} else if HasExtension(bgm.filename, ".mid") || HasExtension(bgm.filename, ".midi") {
-		sf, sferr := loadSoundFont(audioSoundFont)
-		if sferr != nil {
+		if sf, sferr := loadSoundFont(audioSoundFont); sferr != nil {
 			err = sferr
+		} else {
+			bgm.streamer, format, err = midi.Decode(f, sf, beep.SampleRate(int(sys.cfg.Sound.SampleRate)))
+			bgm.format = "midi"
 		}
-		bgm.streamer, format, err = midi.Decode(f, sf, beep.SampleRate(int(sys.cfg.Sound.SampleRate)))
-		bgm.format = "midi"
 	} else {
 		err = Error(fmt.Sprintf("unsupported file extension: %v", bgm.filename))
 	}

--- a/src/system.go
+++ b/src/system.go
@@ -572,8 +572,8 @@ func (s *System) tickSound() {
 		}
 	}
 
-	// Always pause if noMusic flag set or pause master volume is 0.
-	s.bgm.SetPaused(s.nomusic || (s.paused && s.cfg.Sound.PauseMasterVolume == 0))
+	// Always pause if noMusic flag set, pause master volume is 0, or freqmul is 0.
+	s.bgm.SetPaused(s.nomusic || (s.paused && s.cfg.Sound.PauseMasterVolume == 0) || (s.bgm.freqmul == 0))
 
 	// Set BGM volume if paused
 	if s.paused && s.bgm.volRestore == 0 {
@@ -1080,8 +1080,8 @@ func (s *System) restoreAllVolume() {
 				if c.soundChannels.channels[i].sfx != nil && c.soundChannels.channels[i].ctrl != nil {
 					c.soundChannels.channels[i].SetVolume(c.soundChannels.volResume[i])
 
-					// Unpause
-					if c.soundChannels.channels[i].ctrl.Paused {
+					// Unpause only those whose freqmul > 0
+					if c.soundChannels.channels[i].ctrl.Paused && c.soundChannels.channels[i].sfx.freqmul > 0 {
 						c.soundChannels.channels[i].SetPaused(false)
 					}
 				}


### PR DESCRIPTION
fix: huge initial load time lag with bgm.Open() (namely on menu screens). Pushed out memory loading to another thread that will load and swap the buffer that will cancel if another BGM is queued up.

feat: freqmul of 0 for ModifySnd and ModifyBGM now pauses playing sound or music