### PR TITLE
fix: Overflow damage has been adjusted to match MUGEN

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -10639,7 +10639,8 @@ func (cl *CharList) commandUpdate() {
 					}
 					// Update commands
 					for i := range c.cmd {
-						c.cmd[i].Step(int32(c.facing), c.controller < 0, c.helperIndex != 0, buffer, Btoi(buffer)+Btoi(winbuf))
+						c.cmd[i].Step(int32(c.facing), c.controller < 0, c.helperIndex != 0 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0,
+							buffer, Btoi(buffer)+Btoi(winbuf))
 					}
 					// Enable AI cheated command
 					c.cpucmd = cheat

--- a/src/script.go
+++ b/src/script.go
@@ -776,7 +776,7 @@ func systemScriptInit(l *lua.LState) {
 			userDataError(l, 1, cl)
 		}
 		if cl.InputUpdate(int(numArg(l, 2))-1, 1, 0, 0, true) {
-			cl.Step(1, false, false, 0)
+			cl.Step(1, false, false, false, 0)
 		}
 		return 0
 	})


### PR DESCRIPTION
・Overflow damage has been adjusted to match MUGEN. 
・The helper input buffer does not enable command inputs for labels that do not include "/" 
　https://mugenbinran.web.fc2.com/AIFlag.html
・Fixed #2494 invalid playsnd would overwrite the channel.