### PR TITLE
fix(trigger): Make outrostate 3 match its intended use.

### DIFF
--- a/src/system.go
+++ b/src/system.go
@@ -816,7 +816,7 @@ func (s *System) outroState() int32 {
 	case s.roundWinStates():
 		// Player win states
 		return 4
-	case sys.intro < -sys.lifebar.ro.over_waittime || sys.lifebar.ro.over_waittime == 1:
+	case sys.intro <= -sys.lifebar.ro.over_waittime && sys.wintime >= 0:
 		// Players lose control, but the round has not yet entered win states
 		return 3
 	case s.intro < -s.lifebar.ro.over_hittime || sys.lifebar.ro.over_hittime == 1:


### PR DESCRIPTION
For some reason, outrostate 3 was making a different check than what it says, leading to the situation where if a character is waiting for outrostate = 3 in order to set ctrl to 1 so that they can be put into their win state, the game would stall.