### PR TITLE
feat: Add PauseBuffer parameter to commands.

### DIFF
--- a/data/common.cmd
+++ b/data/common.cmd
@@ -9,12 +9,14 @@ name = "TagShiftBack"
 command = d
 time = 1
 buffer.time = 1
+pausebuffer = 1
 
 [Command]
 name = "TagShiftFwd"
 command = w
 time = 1
 buffer.time = 1
+pausebuffer = 1
 
 [Command]
 name = "x"

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -7484,6 +7484,7 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 				if is.ReadI32("command.buffer.time", &i32) {
 					c.cmdl.DefaultBufferTime = Max(1, i32)
 				}
+				is.ReadBool("command.pausebuffer", &c.cmdl.DefaultPauseBuffer)
 			}
 		default:
 			// Read input commands
@@ -7505,11 +7506,13 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 				"\ncommand = " + is["command"] + "\n" + err.Error())
 		}
 		cm.time, cm.buftime = c.cmdl.DefaultTime, c.cmdl.DefaultBufferTime
+		cm.pausebuffer = c.cmdl.DefaultPauseBuffer
 		is.ReadI32("time", &cm.time)
 		var i32 int32
 		if is.ReadI32("buffer.time", &i32) {
 			cm.buftime = Max(1, i32)
 		}
+		is.ReadBool("pausebuffer", &cm.pausebuffer)
 		c.cmdl.Add(*cm)
 	}
 

--- a/src/input.go
+++ b/src/input.go
@@ -1575,6 +1575,7 @@ type Command struct {
 	buftime, curbuftime int32
 	completeflag        bool
 	hasSlash            bool
+	pausebuffer         bool
 }
 
 func newCommand() *Command {
@@ -2074,6 +2075,10 @@ func (c *Command) bufTest(ibuf *InputBuffer, ai bool, isHelper bool, holdTemp *[
 
 // Update an individual command
 func (c *Command) Step(ibuf *InputBuffer, ai, isHelper, hitpause bool, buftime int32) {
+	if !c.pausebuffer {
+		hitpause = false
+		buftime = 0
+	}
 	if !hitpause && c.curbuftime > 0 {
 		c.curbuftime--
 	}
@@ -2119,6 +2124,7 @@ type CommandList struct {
 	Commands          [][]Command
 	DefaultTime       int32
 	DefaultBufferTime int32
+	DefaultPauseBuffer bool
 }
 
 func NewCommandList(cb *InputBuffer) *CommandList {
@@ -2127,6 +2133,7 @@ func NewCommandList(cb *InputBuffer) *CommandList {
 		Names:             make(map[string]int),
 		DefaultTime:       15,
 		DefaultBufferTime: 1,
+		DefaultPauseBuffer: true,
 	}
 }
 

--- a/src/script.go
+++ b/src/script.go
@@ -743,14 +743,19 @@ func systemScriptInit(l *lua.LState) {
 			l.RaiseError(err.Error())
 		}
 		time, buftime := cl.DefaultTime, cl.DefaultBufferTime
+		pausebuffer := cl.DefaultPauseBuffer
 		if !nilArg(l, 4) {
 			time = int32(numArg(l, 4))
 		}
 		if !nilArg(l, 5) {
 			buftime = Max(1, int32(numArg(l, 5)))
 		}
+		if !nilArg(l, 6) {
+			pausebuffer = boolArg(l, 6)
+		}
 		cm.time = time
 		cm.buftime = buftime
+		cm.pausebuffer = pausebuffer
 		cl.Add(*cm)
 		return 0
 	})


### PR DESCRIPTION
Commands with this parameter set to 0 will not be buffered during a pause's EndCMDBufferTime or HitPause.

This is mainly useful for implementing custom input systems without requiring the use of RunFirst and RunLast helpers.