### PR TITLE
feat: Add MissOnOverride parameter to HitDef.

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6701,6 +6701,7 @@ const (
 	hitDef_p1stateno
 	hitDef_p2stateno
 	hitDef_p2getp1state
+	hitDef_missonoverride
 	hitDef_p1sprpriority
 	hitDef_p2sprpriority
 	hitDef_forcestand
@@ -6872,6 +6873,8 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, paramID byte, exp []BytecodeExp) bo
 		hd.p2getp1state = true
 	case hitDef_p2getp1state:
 		hd.p2getp1state = exp[0].evalB(c)
+	case hitDef_missonoverride:
+		hd.missonoverride = Btoi(exp[0].evalB(c))
 	case hitDef_p1sprpriority:
 		hd.p1sprpriority = exp[0].evalI(c)
 	case hitDef_p2sprpriority:

--- a/src/char.go
+++ b/src/char.go
@@ -575,6 +575,7 @@ type HitDef struct {
 	p1stateno                  int32
 	p2stateno                  int32
 	p2getp1state               bool
+	missonoverride             int32
 	forcestand                 int32
 	forcecrouch                int32
 	ground_fall                bool
@@ -693,6 +694,7 @@ func (hd *HitDef) clear(c *Char, localscl float32) {
 		p1sprpriority:       1,
 		p1stateno:           -1,
 		p2stateno:           -1,
+		missonoverride:      -1,
 		forcestand:          IErr,
 		forcecrouch:         IErr,
 		guard_dist_x:        hd.guard_dist_x, // These default to no change
@@ -8607,8 +8609,8 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 				}
 			}
 			// Miss if using p2stateno and HitOverride together
-			if !isProjectile && Abs(hitResult) == 1 &&
-				(hd.p2stateno >= 0 || hd.p1stateno >= 0) {
+			if hd.missonoverride == 1 || (hd.missonoverride == -1 && !isProjectile && Abs(hitResult) == 1 &&
+				(hd.p2stateno >= 0 || hd.p1stateno >= 0)) {
 				return 0
 			}
 			if ho.stateno >= 0 || ho.keepState {

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1793,6 +1793,10 @@ func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 		hitDef_p2getp1state, VT_Bool, 1, false); err != nil {
 		return err
 	}
+	if err := c.paramValue(is, sc, "missonoverride",
+		hitDef_missonoverride, VT_Bool, 1, false); err != nil {
+		return err
+	}
 	b := false
 	if err := c.stateParam(is, "p1sprpriority", false, func(data string) error {
 		b = true


### PR DESCRIPTION
This parameter allows you to choose whether or not a HitDef will miss if it would be overridden, defaulting to missing in the same circumstances as before.

Currently, p1stateno and p2stateno both already do not apply if the hit is overridden. This is probably as it should be.