### PR TITLE
feat: Command key.time parameter. Refactoring

### DIFF
--- a/data/common.cmd
+++ b/data/common.cmd
@@ -3,18 +3,21 @@ name = "recovery"
 command = 
 time = 1
 buffer.time = 1
-pausebuffer = 1
+buffer.hitpause = 1
+buffer.pauseend = 1
 
 [Command]
 name = "TagShiftBack"
 command = d
 time = 1
 buffer.time = 1
-pausebuffer = 1
+buffer.hitpause = 1
+buffer.pauseend = 1
 
 [Command]
 name = "TagShiftFwd"
 command = w
 time = 1
 buffer.time = 1
-pausebuffer = 1
+buffer.hitpause = 1
+buffer.pauseend = 1

--- a/data/common.cmd
+++ b/data/common.cmd
@@ -1,3 +1,6 @@
+; Common Commands
+; The commands defined in this file will be appended to every character's command list
+
 [Command]
 name = "recovery"
 command = 

--- a/data/common.const
+++ b/data/common.const
@@ -13,7 +13,7 @@ Default.Enable.Tag = 1
 
 ; Backward compatibility toggles
 Default.LegacyGameDistanceSpec = 1  ; 1 prevents GameWidth/GameHeight from being affected by stage zoom for mugenversion 1.0 chars
-Input.PauseOnHitPause = 1           ; 1 makes inputs to be retained during hit pause
+Input.PauseOnHitPause = 1           ; 1 makes inputs to be retained during hit pause. Deprecated. See command parameters
 
 ; Rules
 Default.Attack.LifeToPowerMul = 0.7 ; multiplier for power the attacker gets when a normal/special attack successfully hits (overridden by getpower HitDef option)

--- a/data/common1.cns.zss
+++ b/data/common1.cns.zss
@@ -846,7 +846,7 @@ if time = 0 {
 }
 notHitBy{value: SCA; time: 1}
 if animTime = 0 {
-	hitFallSet{value: 1}
+	hitFallSet{value: 1} # This seems to have been a typo in the original common1.cns, but it is harmless anyway
 	notHitBy{value: , NT,ST,HT; time: 12}
 	notHitBy{value2: SCA; time: 3}
 	changeState{value: 0; ctrl: 1}

--- a/src/char.go
+++ b/src/char.go
@@ -9468,12 +9468,16 @@ func (c *Char) actionPrepare() {
 	}
 	// Decrease unhittable timer
 	// This used to be in tick(), but Mugen Clsn display suggests it happens sooner than that
-	// This used to be CharGlobalInfo, but that made root and helpers share the same timer
+	// This also used to be CharGlobalInfo, but that made root and helpers share the same timer
 	// In Mugen this timer won't decrease unless the char has a Clsn box (of any type)
 	if c.unhittableTime > 0 {
 		c.unhittableTime--
 	}
 	c.dropTargets()
+	// Enable autoguard. This placement gives it similar properties to other AssertSpecial flags
+	if sys.cfg.Options.AutoGuard {
+		c.setASF(ASF_autoguard)
+	}
 }
 
 func (c *Char) actionRun() {
@@ -9515,9 +9519,6 @@ func (c *Char) actionRun() {
 	}
 	// Guarding instructions
 	c.unsetSCF(SCF_guard)
-	if sys.cfg.Options.AutoGuard {
-		c.setASF(ASF_autoguard)
-	}
 	if ((c.scf(SCF_ctrl) || c.ss.no == 52) &&
 		c.ss.moveType == MT_I || c.inGuardState()) && c.cmd != nil &&
 		(c.cmd[0].Buffer.B > 0 || c.asf(ASF_autoguard)) &&

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -7476,10 +7476,11 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 				rm("m", &ckr.m, &ckr.nm)
 			}
 		case "defaults":
-			// Read default command time and buffer time
+			// Read default command parameters
 			if defaults {
 				defaults = false
 				is.ReadI32("command.time", &c.cmdl.DefaultTime)
+				is.ReadI32("command.key.time", &c.cmdl.DefaultKeyTime)
 				var i32 int32
 				if is.ReadI32("command.buffer.time", &i32) {
 					c.cmdl.DefaultBufferTime = Max(1, i32)
@@ -7488,7 +7489,7 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 				is.ReadBool("command.buffer.pauseend", &c.cmdl.DefaultBufferPauseEnd)
 			}
 		default:
-			// Read input commands
+			// Read command inputs
 			if len(name) >= 7 && name[:7] == "command" {
 				cmds = append(cmds, is)
 			}
@@ -7509,13 +7510,15 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 		// Default parameters
 		cm.maxtime = c.cmdl.DefaultTime
 		cm.maxbuftime = c.cmdl.DefaultBufferTime
+		cm.maxkeytime = c.cmdl.DefaultKeyTime
 		cm.buffer_hitpause = c.cmdl.DefaultBufferHitpause
 		cm.buffer_pauseend = c.cmdl.DefaultBufferPauseEnd
 		// Read specific parameters
 		is.ReadI32("time", &cm.maxtime)
+		is.ReadI32("key.time", &cm.maxkeytime)
 		var i32 int32
 		if is.ReadI32("buffer.time", &i32) {
-			cm.buftime = Max(1, i32)
+			cm.maxbuftime = Max(1, i32)
 		}
 		is.ReadBool("buffer.hitpause", &cm.buffer_hitpause)
 		is.ReadBool("buffer.pauseend", &cm.buffer_pauseend)

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -7484,7 +7484,8 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 				if is.ReadI32("command.buffer.time", &i32) {
 					c.cmdl.DefaultBufferTime = Max(1, i32)
 				}
-				is.ReadBool("command.pausebuffer", &c.cmdl.DefaultPauseBuffer)
+				is.ReadBool("command.buffer.hitpause", &c.cmdl.DefaultBufferHitpause)
+				is.ReadBool("command.buffer.pauseend", &c.cmdl.DefaultBufferPauseEnd)
 			}
 		default:
 			// Read input commands
@@ -7505,14 +7506,19 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 			return nil, Error(cmd + ":\nname = " + is["name"] +
 				"\ncommand = " + is["command"] + "\n" + err.Error())
 		}
-		cm.time, cm.buftime = c.cmdl.DefaultTime, c.cmdl.DefaultBufferTime
-		cm.pausebuffer = c.cmdl.DefaultPauseBuffer
-		is.ReadI32("time", &cm.time)
+		// Default parameters
+		cm.maxtime = c.cmdl.DefaultTime
+		cm.maxbuftime = c.cmdl.DefaultBufferTime
+		cm.buffer_hitpause = c.cmdl.DefaultBufferHitpause
+		cm.buffer_pauseend = c.cmdl.DefaultBufferPauseEnd
+		// Read specific parameters
+		is.ReadI32("time", &cm.maxtime)
 		var i32 int32
 		if is.ReadI32("buffer.time", &i32) {
 			cm.buftime = Max(1, i32)
 		}
-		is.ReadBool("pausebuffer", &cm.pausebuffer)
+		is.ReadBool("buffer.hitpause", &cm.buffer_hitpause)
+		is.ReadBool("buffer.pauseend", &cm.buffer_pauseend)
 		c.cmdl.Add(*cm)
 	}
 

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -38,7 +38,7 @@ Time                  = 99
 GameSpeed             = 0
 ; Rounds to win a match (can be overwritten by Team modes variants)
 Match.Wins            = 2
-; Max number of drawgames allowed (-1 for infinite, -2 for fight.def setting)
+; Max number of draw games allowed (-1 for infinite, -2 for fight.def setting)
 Match.MaxDrawGames    = -2
 ; Starting credits (continues) count outside Attract Mode
 Credits               = 10
@@ -106,14 +106,14 @@ Ratio.Level4.Life     = 1.4
 [Config]
 ; Motif to use. Motifs are themes that define the look and feel of Ikemen GO.
 Motif                = data/mugenclassic/system.def
-; Max amount of player controlled characters (2-8)
+; Max amount of player-controlled characters (2-8)
 Players             = 4
 ; The rate at which consecutive frames are rendered. The game can refresh
 ; internally at a different speed, while maintaining a separate gameplay speed.
 Framerate           = 60
 ; Preferred language (ISO 639-1), e.g. en, es, ja, etc.
 ; See http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
-; Leave blank automatically detect the system language.
+; Leave blank to automatically detect the system language.
 Language            = en
 ; Number of simultaneous afterimage effects allowed.
 ; Set to a lower number to save memory (minimum 1).
@@ -141,7 +141,7 @@ WindowTitle         = Ikemen GO
 WindowIcon          = external/icons/IkemenCylia_256.png, external/icons/IkemenCylia_96.png, external/icons/IkemenCylia_48.png
 ; Lua script file initializing motif and game mode logic loop.
 System              = external/script/main.lua
-; Path to directory where F12 screenshots will be saves.
+; Path to the directory where F12 screenshots will be saved.
 ScreenshotFolder    = 
 ; Path to character automatically loaded as P2 in training mode. Leave it blank
 ; to allow manual selection.
@@ -205,10 +205,10 @@ VSync             = 1
 ; Multisample anti-aliasing samples. Acceptable values are powers of 2 (2 to 32).
 ; Higher values provide better visual quality but may decrease performance.
 MSAA              = 0
-; Toggles centring initial window position.
+; Toggles centering initial window position.
 WindowCentered    = 1
 ; Paths to the post-processing shaders (with name, without file extension).
-; Multiple shaders can be defined as array, with values separated by commas.
+; Multiple shaders can be defined as an array, with values separated by commas.
 ExternalShaders   = 
 ; Toggles Window Scale mode.
 WindowScaleMode   = 1
@@ -304,7 +304,7 @@ survival.AIramp.end   = 16, 4
 [Netplay]
 ; Port number open in your router for directing outside traffic (Port Forwarding)
 ListenPort   = 7500
-; List of saved IP address that will populate netplay connection menu
+; List of saved IP addresses that will populate the netplay connection menu
 ; IP.<name> = <IP address>
 IP.localhost = 127.0.0.1
 
@@ -319,7 +319,7 @@ ButtonAssist               = 1
 ; 2: Absolute priority (F has priority over B. U has priority over D)
 ; 3: First direction priority (Only the first direction is registered)
 ; 4: Deny either direction (Ikemen default)
-; For now, this option only works in local play, during netplay SOCD uses type 2.
+; Currently, this option only works in local play. During netplay, type 4 is enforced.
 SOCDResolution             = 4
 ; Analog stick sensitivity
 ControllerStickSensitivity = 0.4

--- a/src/script.go
+++ b/src/script.go
@@ -742,8 +742,11 @@ func systemScriptInit(l *lua.LState) {
 		if err != nil {
 			l.RaiseError(err.Error())
 		}
-		time, buftime := cl.DefaultTime, cl.DefaultBufferTime
-		pausebuffer := cl.DefaultPauseBuffer
+		time := cl.DefaultTime
+		buftime := cl.DefaultBufferTime
+		buffer_hitpause := cl.DefaultBufferHitpause
+		buffer_pauseend := cl.DefaultBufferPauseEnd
+		keytime := cl.DefaultKeyTime
 		if !nilArg(l, 4) {
 			time = int32(numArg(l, 4))
 		}
@@ -751,11 +754,19 @@ func systemScriptInit(l *lua.LState) {
 			buftime = Max(1, int32(numArg(l, 5)))
 		}
 		if !nilArg(l, 6) {
-			pausebuffer = boolArg(l, 6)
+			buffer_hitpause = boolArg(l, 6)
 		}
-		cm.time = time
-		cm.buftime = buftime
-		cm.pausebuffer = pausebuffer
+		if !nilArg(l, 7) {
+			buffer_pauseend = boolArg(l, 7)
+		}
+		if !nilArg(l, 8) {
+			keytime = int32(numArg(l, 8))
+		}
+		cm.maxtime = time
+		cm.maxbuftime = buftime
+		cm.buffer_hitpause = buffer_hitpause
+		cm.buffer_pauseend = buffer_pauseend
+		cm.maxkeytime = keytime
 		cl.Add(*cm)
 		return 0
 	})
@@ -781,7 +792,7 @@ func systemScriptInit(l *lua.LState) {
 			userDataError(l, 1, cl)
 		}
 		if cl.InputUpdate(int(numArg(l, 2))-1, 1, 0, 0, true) {
-			cl.Step(1, false, false, false, 0)
+			cl.Step(1, false, false, false, false, 0)
 		}
 		return 0
 	})


### PR DESCRIPTION
Command key.time:
- Defines how long a command stays valid for if no correct input is detected
- Allows finer tuning of the maximum time allowed for completing a command
- e.g. A command with key.time = 10 will become invalid if the player doesn't hit the next button within the next 10 frames. Even if there was still more time to complete the full motion

Refactor:
- Separated hitpause and Pause/SuperPause command buffer logic
- Command pausebuffer parameter split into buffer.hitpause and buffer.pauseend