### PR TITLE
fix: Attachedchar input buffer is no longer written to the replay file

### DIFF
--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -4146,7 +4146,7 @@ function start.f_stageMusic()
 		didLoadStageBGM = false
 	end
 	-- bgmusic / bgmusic.roundX / bgmusic.final
-	if (stagetime() > 0 and not didLoadStageBGM) then
+	if (stagetime() > 0 and not didLoadStageBGM and roundstate() <= 2) then
 		-- only if the round is not restarted
 		if start.bgmround ~= roundno() then
 			start.bgmround = roundno()

--- a/src/char.go
+++ b/src/char.go
@@ -9978,6 +9978,7 @@ func (c *Char) tick() {
 				c.selfState(5050, -1, -1, -1, "")
 				c.gethitBindClear()
 			} else if !bt.pause() {
+				//setBindTime is not used here because the CSF_destroy flag may be enabled in a frame with BindTime=0. If bindTime becomes 0, the setBindTime processing will be performed later
 				c.bindTime -= 1
 				//c.setBindTime(c.bindTime - 1)
 			}

--- a/src/char.go
+++ b/src/char.go
@@ -9978,8 +9978,8 @@ func (c *Char) tick() {
 				c.selfState(5050, -1, -1, -1, "")
 				c.gethitBindClear()
 			} else if !bt.pause() {
-				// c.bindTime -= 1
-				c.setBindTime(c.bindTime - 1)
+				c.bindTime -= 1
+				//c.setBindTime(c.bindTime - 1)
 			}
 		} else {
 			if !c.pause() {


### PR DESCRIPTION
・Attachedchar input buffer is no longer written to the replay file 
・Fixed a bug where musicvictory was not functioning 
・Fixes the regression with 3ha Bishamon after TargetBind #2332 #2330 #194