### PR TITLE
feat: ChangeAnim elemtime, HitDef unhittabletime, other

### DIFF
--- a/data/common.cmd
+++ b/data/common.cmd
@@ -1,5 +1,7 @@
 ; Common Commands
-; The commands defined in this file will be appended to every character's command list
+; The commands defined in this file will be appended to every character's command list.
+; Commands used by common states should be placed here to prevent crashing due to missing commands.
+; Most of these are kept blank so that they won't interfere with a character trying to remap them.
 
 [Command]
 name = "recovery"
@@ -20,6 +22,129 @@ buffer.pauseend = 1
 [Command]
 name = "TagShiftFwd"
 command = w
+time = 1
+buffer.time = 1
+buffer.hitpause = 1
+buffer.pauseend = 1
+
+[Command]
+name = "holdfwd"
+command =
+time = 1
+buffer.time = 1
+buffer.hitpause = 1
+buffer.pauseend = 1
+
+[Command]
+name = "holdback"
+command =
+time = 1
+buffer.time = 1
+buffer.hitpause = 1
+buffer.pauseend = 1
+
+[Command]
+name = "holdup"
+command =
+time = 1
+buffer.time = 1
+buffer.hitpause = 1
+buffer.pauseend = 1
+
+[Command]
+name = "holddown"
+command =
+time = 1
+buffer.time = 1
+buffer.hitpause = 1
+buffer.pauseend = 1
+
+; Every common command below this point is deprecated.
+; It is recommended that a character that doesn't need commands for itself but still wishes to use the command trigger should still define the necessary commands in its own command file.
+
+[Command]
+name = "x"
+command =
+time = 1
+buffer.time = 1
+buffer.hitpause = 1
+buffer.pauseend = 1
+
+[Command]
+name = "y"
+command =
+time = 1
+buffer.time = 1
+buffer.hitpause = 1
+buffer.pauseend = 1
+
+[Command]
+name = "z"
+command =
+time = 1
+buffer.time = 1
+buffer.hitpause = 1
+buffer.pauseend = 1
+
+[Command]
+name = "a"
+command =
+time = 1
+buffer.time = 1
+buffer.hitpause = 1
+buffer.pauseend = 1
+
+[Command]
+name = "b"
+command =
+time = 1
+buffer.time = 1
+buffer.hitpause = 1
+buffer.pauseend = 1
+
+[Command]
+name = "c"
+command =
+time = 1
+buffer.time = 1
+buffer.hitpause = 1
+buffer.pauseend = 1
+
+[Command]
+name = "start"
+command =
+time = 1
+buffer.time = 1
+buffer.hitpause = 1
+buffer.pauseend = 1
+
+[Command]
+name = "d"
+command =
+time = 1
+buffer.time = 1
+buffer.hitpause = 1
+buffer.pauseend = 1
+
+[Command]
+name = "w"
+command =
+time = 1
+buffer.time = 1
+buffer.hitpause = 1
+buffer.pauseend = 1
+
+[Command]
+name = "m"
+command =
+time = 1
+buffer.time = 1
+buffer.hitpause = 1
+buffer.pauseend = 1
+
+[Command]
+name = "menu"
+command =
 time = 1
 buffer.time = 1
 buffer.hitpause = 1

--- a/data/training.zss
+++ b/data/training.zss
@@ -175,24 +175,26 @@ ignoreHitPause if gameMode = "training" {
 							map(_iksys_trainingDirection) := 0;
 						}
 					}
-					# If dummy should move forward and player is not trying to move dummy back
-					if map(_iksys_trainingDirection) = 1 && command != "holdback" {
-						if facing = 1 {
+					# If dummy should move forward and player is not trying to move dummy manually
+					if map(_iksys_trainingDirection) = 1 {
+						if facing = 1 && inputTime(L) < 0 && inputTime(D) < 0 && inputTime(U) < 0 {
 							for i = 0; numHelper; 1 {
 								assertInput{flag: R; redirectID: helperIndex($i), ID} # Index 0 being the root
 							}
-						} else {
+						}
+						if facing = -1 && inputTime(R) < 0 && inputTime(D) < 0 && inputTime(U) < 0 {
 							for i = 0; numHelper; 1 {
 								assertInput{flag: L; redirectID: helperIndex($i), ID}
 							}
 						}
-					# If dummy should move backward and player is not trying to move dummy forward
-					} else if map(_iksys_trainingDirection) = -1 && command != "holdfwd" {
-						if facing = 1 {
+					# If dummy should move backward and player is not trying to move dummy manually
+					} else if map(_iksys_trainingDirection) = -1 {
+						if facing = 1 && inputTime(R) < 0 && inputTime(D) < 0 && inputTime(U) < 0 {
 							for i = 0; numHelper; 1 {
 								assertInput{flag: L; redirectID: helperIndex($i), ID}
 							}
-						} else {
+						}
+						if facing = -1 && inputTime(L) < 0 && inputTime(D) < 0 && inputTime(U) < 0 {
 							for i = 0; numHelper; 1 {
 								assertInput{flag: R; redirectID: helperIndex($i), ID}
 							}
@@ -203,19 +205,25 @@ ignoreHitPause if gameMode = "training" {
 					switch map(_iksys_trainingDummyMode) {
 					# Crouch
 					case 1:
-						for i = 0; numHelper; 1 {
-							assertInput{flag: D; redirectID: helperIndex($i), ID}
+						if inputTime(L) < 0 && inputTime(R) < 0 && inputTime(U) < 0 {
+							for i = 0; numHelper; 1 {
+								assertInput{flag: D; redirectID: helperIndex($i), ID}
+							}
 						}
 					# Jump
 					case 2:
-						for i = 0; numHelper; 1 {
-							assertInput{flag: U; redirectID: helperIndex($i), ID}
+						if inputTime(L) < 0 && inputTime(R) < 0 && inputTime(D) < 0 {
+							for i = 0; numHelper; 1 {
+								assertInput{flag: U; redirectID: helperIndex($i), ID}
+							}
 						}
 					# W Jump
 					case 3:
-						if vel y >= 0 {
-							for i = 0; numHelper; 1 {
-								assertInput{flag: U; redirectID: helperIndex($i), ID}
+						if inputTime(L) < 0 && inputTime(R) < 0 && inputTime(D) < 0 {
+							if vel y >= 0 {
+								for i = 0; numHelper; 1 {
+									assertInput{flag: U; redirectID: helperIndex($i), ID}
+								}
 							}
 						}
 					default:

--- a/data/training.zss
+++ b/data/training.zss
@@ -142,9 +142,14 @@ ignoreHitPause if gameMode = "training" {
 				let dir = 0;
 				if map(_iksys_trainingDistance) != 0 {
 					# Close
-					if map(_iksys_trainingDistance) = 1 && p2BodyDist x > const240p(10) {
-						let dir = 1;
-						map(_iksys_trainingDirection) := 1;
+					if map(_iksys_trainingDistance) = 1 {
+						if p2BodyDist x > const240p(10) {
+							let dir = 1;
+							map(_iksys_trainingDirection) := 1;
+						} else if p2BodyDist x < -(const(size.ground.front) + const(size.ground.back) + const240p(10)) {
+							let dir = -1;
+							map(_iksys_trainingDirection) := -1;
+						}
 					# Medium
 					} else if map(_iksys_trainingDistance) = 2 {
 						if p2BodyDist x > const240p(130) {

--- a/src/anim.go
+++ b/src/anim.go
@@ -442,11 +442,20 @@ func (a *Animation) SetAnimElem(elem, elemtime int32) {
 		a.curelem = 0
 	}
 	a.drawidx = a.curelem
-	a.curelemtime = Clamp(elemtime, 0, Max(0, a.curFrame().Time-1))
+
+	// Shortcut the most common elemtime
+	// Out of range elemtime is also set to 0, as with elem
+	if elemtime <= 0 || elemtime > a.frames[a.curelem].Time-1 {
+		a.curelemtime = 0
+	} else {
+		a.curelemtime = elemtime
+	}
+
 	a.newframe = true
-	a.UpdateSprite()
 	a.loopend = false
-	a.curtime = 0 // Used within AnimElemTime
+	a.UpdateSprite()
+
+	a.curtime = 0 // Used within AnimElemTime, so must be set to 0 first
 	a.curtime = -a.AnimElemTime(a.curelem + 1) + a.curelemtime
 }
 

--- a/src/anim.go
+++ b/src/anim.go
@@ -149,11 +149,10 @@ type Animation struct {
 	interpolate_scale  []int32
 	interpolate_angle  []int32
 	interpolate_blend  []int32
-	// Current frame
-	current                    int32
+	curtime                    int32
+	curelem                    int32
+	curelemtime                int32
 	drawidx                    int32
-	elemtime                   int32
-	sumtime                    int32
 	totaltime                  int32
 	looptime                   int32
 	prelooptime                int32
@@ -341,14 +340,14 @@ func ReadAction(sff *Sff, pal *PaletteList, lines []string, i *int) (no int32, a
 }
 
 func (a *Animation) Reset() {
-	a.current, a.drawidx = 0, 0
-	a.elemtime, a.sumtime = 0, 0
+	a.curelem, a.drawidx = 0, 0
+	a.curelemtime, a.curtime = 0, 0
 	a.newframe, a.loopend = true, false
 	a.spr = nil
 }
 
 func (a *Animation) AnimTime() int32 {
-	return a.sumtime - a.totaltime
+	return a.curtime - a.totaltime
 }
 
 func (a *Animation) AnimElemTime(elem int32) int32 {
@@ -359,7 +358,7 @@ func (a *Animation) AnimElemTime(elem int32) int32 {
 		}
 		return t
 	}
-	e, t := Max(0, elem)-1, a.sumtime
+	e, t := Max(0, elem)-1, a.curtime
 	for i := int32(0); i < e; i++ {
 		t -= Max(0, a.frames[i].Time)
 	}
@@ -368,16 +367,16 @@ func (a *Animation) AnimElemTime(elem int32) int32 {
 
 func (a *Animation) AnimElemNo(time int32) int32 {
 	if len(a.frames) > 0 {
-		i, oldt := a.current, int32(0)
+		i, oldt := a.curelem, int32(0)
 		if time <= 0 {
-			time += a.elemtime
+			time += a.curelemtime
 			loop := false
 			for {
 				if time >= 0 {
 					return i + 1
 				}
 				i--
-				if i < 0 || a.current >= a.loopstart && i < a.loopstart {
+				if i < 0 || a.curelem >= a.loopstart && i < a.loopstart {
 					if time == oldt {
 						break
 					}
@@ -391,7 +390,7 @@ func (a *Animation) AnimElemNo(time int32) int32 {
 				}
 			}
 		} else {
-			time += a.elemtime
+			time += a.curelemtime
 			for {
 				time -= Max(0, a.frames[i].Time)
 				if time < 0 || i == int32(len(a.frames))-1 && a.frames[i].Time == -1 {
@@ -412,7 +411,7 @@ func (a *Animation) AnimElemNo(time int32) int32 {
 }
 
 func (a *Animation) curFrame() *AnimFrame {
-	return &a.frames[a.current]
+	return &a.frames[a.curelem]
 }
 
 func (a *Animation) CurrentFrame() *AnimFrame {
@@ -430,9 +429,9 @@ func (a *Animation) drawFrame() *AnimFrame {
 }
 
 func (a *Animation) SetAnimElem(elem, elemtime int32) {
-	a.current = Max(0, elem-1)
+	a.curelem = Max(0, elem-1)
 	// If trying to set an element higher than the last one in the animation
-	if int(a.current) >= len(a.frames) {
+	if int(a.curelem) >= len(a.frames) {
 		//if a.totaltime == -1 {
 		//	a.current = int32(len(a.frames)) - 1
 		//} else if int32(len(a.frames))-a.loopstart > 0 { // Prevent division by zero crash
@@ -440,15 +439,15 @@ func (a *Animation) SetAnimElem(elem, elemtime int32) {
 		//		(a.current-a.loopstart)%(int32(len(a.frames))-a.loopstart)
 		//}
 		// Mugen merely sets the element to 1
-		a.current = 0
+		a.curelem = 0
 	}
-	a.drawidx = a.current
-	a.elemtime = Clamp(elemtime, 0, Max(0, a.curFrame().Time-1))
+	a.drawidx = a.curelem
+	a.curelemtime = Clamp(elemtime, 0, Max(0, a.curFrame().Time-1))
 	a.newframe = true
 	a.UpdateSprite()
 	a.loopend = false
-	a.sumtime = 0 // Used within AnimElemTime
-	a.sumtime = -a.AnimElemTime(a.current + 1) + a.elemtime
+	a.curtime = 0 // Used within AnimElemTime
+	a.curtime = -a.AnimElemTime(a.curelem + 1) + a.curelemtime
 }
 
 func (a *Animation) animSeek(elem int32) {
@@ -457,26 +456,26 @@ func (a *Animation) animSeek(elem int32) {
 	}
 	foo := true
 	for {
-		a.current = elem
-		for int(a.current) < len(a.frames) && a.curFrame().Time <= 0 {
-			if int(a.current) == len(a.frames)-1 && a.curFrame().Time == -1 {
+		a.curelem = elem
+		for int(a.curelem) < len(a.frames) && a.curFrame().Time <= 0 {
+			if int(a.curelem) == len(a.frames)-1 && a.curFrame().Time == -1 {
 				break
 			}
-			a.current++
+			a.curelem++
 		}
-		if int(a.current) < len(a.frames) {
+		if int(a.curelem) < len(a.frames) {
 			break
 		}
 		foo = !foo
 		if foo {
-			a.current = int32(len(a.frames) - 1)
+			a.curelem = int32(len(a.frames) - 1)
 			break
 		}
 	}
-	if a.current < 0 {
-		a.current = 0
-	} else if int(a.current) >= len(a.frames) {
-		a.current = int32(len(a.frames) - 1)
+	if a.curelem < 0 {
+		a.curelem = 0
+	} else if int(a.curelem) >= len(a.frames) {
+		a.curelem = int32(len(a.frames) - 1)
 	}
 }
 
@@ -485,18 +484,20 @@ func (a *Animation) UpdateSprite() {
 		return
 	}
 	if a.totaltime > 0 {
-		if a.sumtime >= a.totaltime {
-			a.elemtime, a.newframe, a.current = 0, true, a.loopstart
+		if a.curtime >= a.totaltime {
+			a.curelemtime, a.newframe, a.curelem = 0, true, a.loopstart
 		}
-		a.animSeek(a.current)
-		if a.prelooptime < 0 && a.sumtime >= a.totaltime+a.prelooptime &&
-			a.sumtime >= a.totaltime-a.looptime &&
-			(a.sumtime == a.totaltime+a.prelooptime ||
-				a.sumtime == a.totaltime-a.looptime) {
-			a.elemtime, a.newframe, a.current = 0, true, 0
+		a.animSeek(a.curelem)
+		if a.prelooptime < 0 && a.curtime >= a.totaltime+a.prelooptime &&
+			a.curtime >= a.totaltime-a.looptime &&
+			(a.curtime == a.totaltime+a.prelooptime ||
+				a.curtime == a.totaltime-a.looptime) {
+			a.curelemtime = 0
+			a.newframe = true
+			a.curelem = 0
 		}
 	}
-	if a.newframe && a.sff != nil && a.frames[a.current].Time != 0 {
+	if a.newframe && a.sff != nil && a.frames[a.curelem].Time != 0 {
 		group, number := a.curFrame().Group, a.curFrame().Number
 		if mg, ok := a.remap[group]; ok {
 			if mn, ok := mg[number]; ok {
@@ -505,7 +506,7 @@ func (a *Animation) UpdateSprite() {
 		}
 		a.spr = a.sff.GetSprite(group, number)
 	}
-	a.newframe, a.drawidx = false, a.current
+	a.newframe, a.drawidx = false, a.curelem
 
 	a.scale_x = a.frames[a.drawidx].Xscale
 	a.scale_y = a.frames[a.drawidx].Yscale
@@ -522,8 +523,8 @@ func (a *Animation) UpdateSprite() {
 	}
 	for _, i := range a.interpolate_offset {
 		if nextDrawidx == i && (a.frames[a.drawidx].Time >= 0) {
-			a.interpolate_offset_x = float32(a.frames[nextDrawidx].Xoffset-a.frames[a.drawidx].Xoffset) / float32(a.curFrame().Time) * float32(a.elemtime)
-			a.interpolate_offset_y = float32(a.frames[nextDrawidx].Yoffset-a.frames[a.drawidx].Yoffset) / float32(a.curFrame().Time) * float32(a.elemtime)
+			a.interpolate_offset_x = float32(a.frames[nextDrawidx].Xoffset-a.frames[a.drawidx].Xoffset) / float32(a.curFrame().Time) * float32(a.curelemtime)
+			a.interpolate_offset_y = float32(a.frames[nextDrawidx].Yoffset-a.frames[a.drawidx].Yoffset) / float32(a.curFrame().Time) * float32(a.curelemtime)
 			break
 		}
 	}
@@ -537,8 +538,8 @@ func (a *Animation) UpdateSprite() {
 			nextframe_scale_x = a.frames[nextDrawidx].Xscale
 			nextframe_scale_y = a.frames[nextDrawidx].Yscale
 
-			a.scale_x += (nextframe_scale_x - drawframe_scale_x) / float32(a.curFrame().Time) * float32(a.elemtime)
-			a.scale_y += (nextframe_scale_y - drawframe_scale_y) / float32(a.curFrame().Time) * float32(a.elemtime)
+			a.scale_x += (nextframe_scale_x - drawframe_scale_x) / float32(a.curFrame().Time) * float32(a.curelemtime)
+			a.scale_y += (nextframe_scale_y - drawframe_scale_y) / float32(a.curFrame().Time) * float32(a.curelemtime)
 			break
 		}
 	}
@@ -551,7 +552,7 @@ func (a *Animation) UpdateSprite() {
 			drawframe_angle = a.frames[a.drawidx].Angle
 			nextframe_angle = a.frames[nextDrawidx].Angle
 
-			a.angle += (nextframe_angle - drawframe_angle) / float32(a.curFrame().Time) * float32(a.elemtime)
+			a.angle += (nextframe_angle - drawframe_angle) / float32(a.curFrame().Time) * float32(a.curelemtime)
 			break
 		}
 	}
@@ -559,8 +560,8 @@ func (a *Animation) UpdateSprite() {
 		byte(a.interpolate_blend_dstalpha) != 255 {
 		for _, i := range a.interpolate_blend {
 			if nextDrawidx == i && (a.frames[a.drawidx].Time >= 0) {
-				a.interpolate_blend_srcalpha += (float32(a.frames[nextDrawidx].SrcAlpha) - a.interpolate_blend_srcalpha) / float32(a.curFrame().Time) * float32(a.elemtime)
-				a.interpolate_blend_dstalpha += (float32(a.frames[nextDrawidx].DstAlpha) - a.interpolate_blend_dstalpha) / float32(a.curFrame().Time) * float32(a.elemtime)
+				a.interpolate_blend_srcalpha += (float32(a.frames[nextDrawidx].SrcAlpha) - a.interpolate_blend_srcalpha) / float32(a.curFrame().Time) * float32(a.curelemtime)
+				a.interpolate_blend_dstalpha += (float32(a.frames[nextDrawidx].DstAlpha) - a.interpolate_blend_dstalpha) / float32(a.curFrame().Time) * float32(a.curelemtime)
 				if byte(a.interpolate_blend_srcalpha) == 1 && byte(a.interpolate_blend_dstalpha) == 255 {
 					a.interpolate_blend_srcalpha = 0
 				}
@@ -581,13 +582,13 @@ func (a *Animation) Action() {
 	}
 	a.UpdateSprite()
 	next := func() {
-		if a.totaltime != -1 || int(a.current) < len(a.frames)-1 {
-			a.elemtime = 0
+		if a.totaltime != -1 || int(a.curelem) < len(a.frames)-1 {
+			a.curelemtime = 0
 			a.newframe = true
 			for {
-				a.current++
-				if a.totaltime == -1 && int(a.current) == len(a.frames)-1 ||
-					int(a.current) >= len(a.frames) || a.curFrame().Time > 0 {
+				a.curelem++
+				if a.totaltime == -1 && int(a.curelem) == len(a.frames)-1 ||
+					int(a.curelem) >= len(a.frames) || a.curFrame().Time > 0 {
 					break
 				}
 			}
@@ -596,22 +597,22 @@ func (a *Animation) Action() {
 	if a.curFrame().Time <= 0 {
 		next()
 	}
-	if int(a.current) < len(a.frames) {
-		a.elemtime++
-		if a.elemtime >= a.curFrame().Time {
+	if int(a.curelem) < len(a.frames) {
+		a.curelemtime++
+		if a.curelemtime >= a.curFrame().Time {
 			next()
-			if int(a.current) >= len(a.frames) {
-				a.current = a.loopstart
+			if int(a.curelem) >= len(a.frames) {
+				a.curelem = a.loopstart
 			}
 		}
 	} else {
-		a.current = a.loopstart
+		a.curelem = a.loopstart
 	}
-	if a.totaltime != -1 && a.sumtime >= a.totaltime {
-		a.sumtime = a.totaltime - a.looptime
+	if a.totaltime != -1 && a.curtime >= a.totaltime {
+		a.curtime = a.totaltime - a.looptime
 	}
-	a.sumtime++
-	if a.totaltime != -1 && a.sumtime >= a.totaltime {
+	a.curtime++
+	if a.totaltime != -1 && a.curtime >= a.totaltime {
 		a.loopend = true
 	}
 }

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -4790,6 +4790,7 @@ type changeAnim StateControllerBase
 
 const (
 	changeAnim_elem byte = iota
+	changeAnim_elemtime
 	changeAnim_value
 	changeAnim_readplayerid
 	changeAnim_redirectid
@@ -4797,13 +4798,16 @@ const (
 
 func (sc changeAnim) Run(c *Char, _ []int32) bool {
 	crun := c
-	var elem int32
+	var elem, elemtime int32
 	var rpid int = -1
 	setelem := false
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
 		case changeAnim_elem:
 			elem = exp[0].evalI(c)
+			setelem = true
+		case changeAnim_elemtime:
+			elemtime = exp[0].evalI(c)
 			setelem = true
 		case changeAnim_value:
 			pn := crun.playerNo // Default to own player number
@@ -4812,7 +4816,7 @@ func (sc changeAnim) Run(c *Char, _ []int32) bool {
 			}
 			crun.changeAnim(exp[1].evalI(c), pn, string(*(*[]byte)(unsafe.Pointer(&exp[0]))))
 			if setelem {
-				crun.setAnimElem(elem)
+				crun.setAnimElem(elem, elemtime)
 			}
 		case changeAnim_readplayerid:
 			if read := sys.playerID(exp[0].evalI(c)); read != nil {
@@ -4836,13 +4840,16 @@ type changeAnim2 changeAnim
 
 func (sc changeAnim2) Run(c *Char, _ []int32) bool {
 	crun := c
-	var elem int32
+	var elem, elemtime int32
 	var rpid int = -1
 	setelem := false
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
 		case changeAnim_elem:
-			elem = exp[0].evalI(c)
+			elemtime = exp[0].evalI(c)
+			setelem = true
+		case changeAnim_elemtime:
+			elemtime = exp[0].evalI(c)
 			setelem = true
 		case changeAnim_value:
 			pn := crun.ss.sb.playerNo // Default to state owner player number
@@ -4851,7 +4858,7 @@ func (sc changeAnim2) Run(c *Char, _ []int32) bool {
 			}
 			crun.changeAnim2(exp[1].evalI(c), pn, string(*(*[]byte)(unsafe.Pointer(&exp[0]))))
 			if setelem {
-				crun.setAnimElem(elem)
+				crun.setAnimElem(elem, elemtime)
 			}
 		case changeAnim_readplayerid:
 			if read := sys.playerID(exp[0].evalI(c)); read != nil {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6802,6 +6802,7 @@ const (
 	hitDef_attack_depth
 	hitDef_sparkscale
 	hitDef_guard_sparkscale
+	hitDef_unhittabletime
 	hitDef_last = iota + afterImage_last + 1 - 1
 	hitDef_redirectid
 )
@@ -7166,6 +7167,11 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, paramID byte, exp []BytecodeExp) bo
 		hd.guard_sparkscale[0] = exp[0].evalF(c)
 		if len(exp) > 1 {
 			hd.guard_sparkscale[1] = exp[1].evalF(c)
+		}
+	case hitDef_unhittabletime:
+		hd.unhittabletime[0] = exp[0].evalI(c)
+		if len(exp) > 1 {
+			hd.unhittabletime[1] = exp[1].evalI(c)
 		}
 	default:
 		if !palFX(sc).runSub(c, &hd.palfx, paramID, exp) {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -10228,7 +10228,7 @@ func (sc hitFallSet) Run(c *Char, _ []int32) bool {
 		switch paramID {
 		case hitFallSet_value:
 			f = exp[0].evalI(c)
-			if len(crun.ghv.hitBy) == 0 {
+			if len(crun.ghv.targetedBy) == 0 {
 				return false
 			}
 		case hitFallSet_xvel:
@@ -13222,14 +13222,14 @@ func (sc targetAdd) Run(c *Char, _ []int32) bool {
 						// Add char to target's "hit by" list
 						// Keep juggle points if target already exists
 						jug := crun.gi().data.airjuggle
-						for _, v := range sys.chars[i][j].ghv.hitBy {
+						for _, v := range sys.chars[i][j].ghv.targetedBy {
 							if v[0] == crun.id {
 								jug = v[1]
 							}
 						}
 						// Remove then readd char to the list with the new juggle points
 						sys.chars[i][j].ghv.dropId(crun.id)
-						sys.chars[i][j].ghv.hitBy = append(sys.chars[i][j].ghv.hitBy, [...]int32{crun.id, jug})
+						sys.chars[i][j].ghv.targetedBy = append(sys.chars[i][j].ghv.targetedBy, [...]int32{crun.id, jug})
 						done = true
 						break
 					}
@@ -13540,19 +13540,32 @@ func newStateBytecode(pn int) *StateBytecode {
 }
 
 func (sb *StateBytecode) init(c *Char) {
+	// StateType
 	if sb.stateType != ST_U {
 		c.ss.changeStateType(sb.stateType)
 	}
+
+	// MoveType
 	if sb.moveType != MT_U {
 		if !c.ss.storeMoveType {
 			c.ss.prevMoveType = c.ss.moveType
 		}
 		c.ss.moveType = sb.moveType
 	}
+	c.ss.storeMoveType = false
+
+	// Physics
 	if sb.physics != ST_U {
 		c.ss.physics = sb.physics
 	}
-	c.ss.storeMoveType = false
+
+	// Reset juggle points
+	// Mugen doesn't do this, but since most people forget it the engine should handle it
+	if c.ss.moveType != MT_A {
+		c.juggle = 0
+	}
+
+	// Rest of StateDef
 	sys.workingState = sb
 	sb.stateDef.Run(c)
 }

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -12909,6 +12909,7 @@ const (
 	modifyPlayer_hitpausetime
 	modifyPlayer_pausemovetime
 	modifyPlayer_supermovetime
+	modifyPlayer_unhittabletime
 	modifyPlayer_redirectid
 )
 
@@ -12993,6 +12994,8 @@ func (sc modifyPlayer) Run(c *Char, _ []int32) bool {
 			crun.pauseMovetime = Max(0, exp[0].evalI(c))
 		case modifyPlayer_supermovetime:
 			crun.superMovetime = Max(0, exp[0].evalI(c))
+		case modifyPlayer_unhittabletime:
+			crun.unhittableTime = Max(0, exp[0].evalI(c))
 		case modifyPlayer_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -795,6 +795,7 @@ const (
 	OC_ex2_explodvar_angle_y
 	OC_ex2_explodvar_anim
 	OC_ex2_explodvar_animelem
+	OC_ex2_explodvar_animelemtime
 	OC_ex2_explodvar_bindtime
 	OC_ex2_explodvar_drawpal_group
 	OC_ex2_explodvar_drawpal_index
@@ -3429,6 +3430,8 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		fallthrough
 	case OC_ex2_explodvar_animelem:
 		fallthrough
+	case OC_ex2_explodvar_animelemtime:
+		fallthrough
 	case OC_ex2_explodvar_drawpal_group:
 		fallthrough
 	case OC_ex2_explodvar_drawpal_index:
@@ -5607,6 +5610,7 @@ const (
 	explod_removeonchangestate
 	explod_trans
 	explod_animelem
+	explod_animelemtime
 	explod_animfreeze
 	explod_angle
 	explod_yangle
@@ -5676,6 +5680,8 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 			}
 			e.animNo = exp[1].evalI(c)
 			e.anim = crun.getAnim(e.animNo, ffx, true)
+			e.animelem = 1
+			e.animelemtime = 0
 		case explod_ownpal:
 			e.ownpal = exp[0].evalB(c)
 		case explod_remappal:
@@ -5829,11 +5835,13 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 				}
 			}
 		case explod_animelem:
-			animelem := exp[0].evalI(c)
-			e.animelem = animelem
+			e.animelem = exp[0].evalI(c)
 			if e.anim != nil {
 				e.anim.Action() // This being in this place can cause a nil animation crash
 			}
+			e.setAnimElem()
+		case explod_animelemtime:
+			e.animelemtime = exp[0].evalI(c)
 			e.setAnimElem()
 		case explod_animfreeze:
 			e.animfreeze = exp[0].evalB(c)
@@ -6339,6 +6347,8 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 					eachExpl(func(e *Explod) {
 						e.anim = anim
 						e.animNo = animNo
+						e.animelem = 1
+						e.animelemtime = 0
 					})
 				}
 			case explod_animelem:
@@ -6349,6 +6359,13 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 					if e.anim != nil {
 						e.anim.Action() // This being in this place can cause a nil animation crash
 					}
+					e.setAnimElem()
+				})
+			case explod_animelemtime:
+				animelemtime := exp[0].evalI(c)
+				eachExpl(func(e *Explod) {
+					//e.interpolate_animelem[1] = -1 // TODO: Check animelemtime and interpolation interaction
+					e.animelemtime = animelemtime
 					e.setAnimElem()
 				})
 			case explod_animfreeze:

--- a/src/char.go
+++ b/src/char.go
@@ -9888,7 +9888,7 @@ func (c *Char) track() {
 		if c.csf(CSF_movecamera_y) && !c.scf(SCF_standby) && !math.IsInf(float64(c.pos[1]), 0) {
 			sys.cam.highest = MinF(c.interPos[1]*c.localscl, sys.cam.highest)
 			sys.cam.lowest = MaxF(c.interPos[1]*c.localscl, sys.cam.lowest)
-			sys.cam.Pos[1] = 0
+			//sys.cam.Pos[1] = 0 // This doesn't seem necessary in the current state of the code
 			// Mugen ignores characters that have infinite position
 			// https://github.com/ikemen-engine/Ikemen-GO/issues/1917
 		}

--- a/src/common.go
+++ b/src/common.go
@@ -1250,8 +1250,8 @@ func (ats *AnimTextSnd) NoDisplay() bool {
 func (ats *AnimTextSnd) End(dt int32, inf bool) bool {
 	if ats.displaytime < 0 {
 		return len(ats.anim.anim.frames) == 0 || ats.anim.anim.loopend ||
-			(inf && ats.anim.anim.frames[ats.anim.anim.current].Time == -1 &&
-				ats.anim.anim.current == int32(len(ats.anim.anim.frames)-1))
+			(inf && ats.anim.anim.frames[ats.anim.anim.curelem].Time == -1 &&
+				ats.anim.anim.curelem == int32(len(ats.anim.anim.frames)-1))
 	}
 	return dt >= ats.displaytime
 }

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2284,6 +2284,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			opc = OC_ex2_explodvar_anim
 		case "animelem":
 			opc = OC_ex2_explodvar_animelem
+		case "animelemtime":
+			opc = OC_ex2_explodvar_animelemtime
 		case "bindtime":
 			opc = OC_ex2_explodvar_bindtime
 		case "drawpal":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -542,6 +542,10 @@ func (c *Compiler) changeAnimSub(is IniSection,
 		changeAnim_elem, VT_Int, 1, false); err != nil {
 		return err
 	}
+	if err := c.paramValue(is, sc, "elemtime",
+		changeAnim_elemtime, VT_Int, 1, false); err != nil {
+		return err
+	}
 	if err := c.stateParam(is, "value", true, func(data string) error {
 		prefix := c.getDataPrefix(&data, false)
 		return c.scAdd(sc, changeAnim_value, data, VT_Int, 1,

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -2213,6 +2213,10 @@ func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 		hitDef_guard_sparkscale, VT_Float, 2, false); err != nil {
 		return err
 	}
+	if err := c.paramValue(is, sc, "unhittabletime",
+		hitDef_unhittabletime, VT_Int, 2, false); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -986,6 +986,10 @@ func (c *Compiler) explod(is IniSection, sc *StateControllerBase,
 			explod_animelem, VT_Int, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "animelemtime",
+			explod_animelemtime, VT_Int, 1, false); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "animfreeze",
 			explod_animfreeze, VT_Bool, 1, false); err != nil {
 			return err
@@ -1044,6 +1048,10 @@ func (c *Compiler) modifyExplod(is IniSection, sc *StateControllerBase,
 		}
 		if err := c.paramValue(is, sc, "animelem",
 			explod_animelem, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "animelemtime",
+			explod_animelemtime, VT_Int, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "animfreeze",

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -5883,6 +5883,10 @@ func (c *Compiler) modifyPlayer(is IniSection, sc *StateControllerBase, _ int8) 
 			modifyPlayer_supermovetime, VT_Int, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "unhittabletime",
+			modifyPlayer_unhittabletime, VT_Int, 1, false); err != nil {
+			return err
+		}
 		return nil
 	})
 	return *ret, err

--- a/src/script.go
+++ b/src/script.go
@@ -3689,7 +3689,7 @@ func triggerFunctions(l *lua.LState) {
 				case "angle y":
 					ln = lua.LNumber(e.anglerot[2] + e.interpolate_angle[2])
 				case "animelem":
-					ln = lua.LNumber(e.anim.current + 1)
+					ln = lua.LNumber(e.anim.curelem + 1)
 				case "bindtime":
 					ln = lua.LNumber(e.bindtime)
 				case "drawpal group":
@@ -4645,7 +4645,7 @@ func triggerFunctions(l *lua.LState) {
 				case "anim":
 					lv = lua.LNumber(p.anim)
 				case "animelem":
-					lv = lua.LNumber(p.ani.current + 1)
+					lv = lua.LNumber(p.ani.curelem + 1)
 				case "angle":
 					lv = lua.LNumber(p.anglerot[0])
 				case "angle x":
@@ -5939,7 +5939,7 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "animtimesum", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.anim.sumtime))
+		l.Push(lua.LNumber(sys.debugWC.anim.curtime))
 		return 1
 	})
 	luaRegister(l, "continue", func(*lua.LState) int {

--- a/src/script.go
+++ b/src/script.go
@@ -629,7 +629,7 @@ func systemScriptInit(l *lua.LState) {
 			}
 			c[0].changeAnim(an, c[0].playerNo, preffix)
 			if !nilArg(l, 2) {
-				c[0].setAnimElem(int32(numArg(l, 2)))
+				c[0].setAnimElem(int32(numArg(l, 2)), 0)
 			}
 			l.Push(lua.LBool(true))
 			return 1
@@ -6050,7 +6050,7 @@ func deprecatedFunctions(l *lua.LState) {
 				}
 				c[0].changeAnim(an, c[0].playerNo, preffix)
 				if l.GetTop() >= 3 {
-					c[0].setAnimElem(int32(numArg(l, 3)))
+					c[0].setAnimElem(int32(numArg(l, 3)), 0)
 				}
 				l.Push(lua.LBool(true))
 				return 1


### PR DESCRIPTION
Features:
- ChangeAnim elemtime parameter. Defines at which exact point of an elem to change to
- Explod animelemtime parameter. Sets at which point in the animelem the animation should start playing
- ModifyPlayer can now use the "unhittabletime" parameter to change the player's "unhittable" timer (set during SuperPause)
- HitDef unhittabletime parameter. Makes p1 or p2 unhittable for X frames after the hit

Fixes:
- Add back common commands (again)
- Fixed training dummy sometimes not turning
- Fixed CameraFreeze flag resetting the camera's y position (regression)
- Fixed projectile hits clearing the root's juggle points
- Fixes #2533

Refactor:
- Training dummy will not crouch/jump if player 2 is trying to control it manually
- Juggle system now acts a bit more like Mugen if mugenversion, or in a more deliberate way if ikemenversion
- StateDef now resets juggle value if MoveType is not A
- Some internal hit limitations now make use of unhittable time (like Mugen, seemingly)