### PR TITLE
feat: HitOverride and ReversalDef guard parameters; fix: redirectID, others

### DIFF
--- a/src/anim.go
+++ b/src/anim.go
@@ -445,11 +445,13 @@ func (a *Animation) SetAnimElem(elem, elemtime int32) {
 
 	// Shortcut the most common elemtime
 	// Out of range elemtime is also set to 0, as with elem
-	if elemtime <= 0 || elemtime > a.frames[a.curelem].Time-1 {
-		a.curelemtime = 0
-	} else {
-		a.curelemtime = elemtime
+	if elemtime != 0 {
+		frametime := a.frames[a.curelem].Time
+		if elemtime < 0 || (frametime != -1 && elemtime >= frametime) {
+			elemtime = 0
+		}
 	}
+	a.curelemtime = elemtime
 
 	a.newframe = true
 	a.loopend = false

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -7369,6 +7369,8 @@ type modifyReversalDef hitDef
 
 const (
 	modifyReversalDef_reversal_attr = iota + hitDef_last + 1
+	modifyReversalDef_reversal_guardflag
+	modifyReversalDef_reversal_guardflag_not
 	modifyReversalDef_redirectid
 )
 
@@ -7387,6 +7389,10 @@ func (sc modifyReversalDef) Run(c *Char, _ []int32) bool {
 		switch paramID {
 		case modifyReversalDef_reversal_attr:
 			crun.hitdef.reversal_attr = exp[0].evalI(c)
+		case modifyReversalDef_reversal_guardflag:
+			crun.hitdef.reversal_guardflag = exp[0].evalI(c)
+		case modifyReversalDef_reversal_guardflag_not:
+			crun.hitdef.reversal_guardflag_not = exp[0].evalI(c)
 		case modifyReversalDef_redirectid:
 			return true // Already handled. Avoid default
 		default:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -4137,8 +4137,7 @@ func (scb *StateControllerBase) add(paramID byte, exp []BytecodeExp) {
 	}
 }
 
-func (scb StateControllerBase) run(c *Char,
-	f func(byte, []BytecodeExp) bool) {
+func (scb StateControllerBase) run(c *Char, f func(byte, []BytecodeExp) bool) {
 	for i := 0; i < len(scb); {
 		id := scb[i]
 		i++
@@ -5499,11 +5498,10 @@ func (sc palFX) Run(c *Char, _ []int32) bool {
 		if paramID == palFX_redirectid {
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-			} else {
-				return false
 			}
+			return false // Found. Stop scanning
 		}
-		return true
+		return true // Keep scanning
 	})
 
 	if !crun.ownpal {
@@ -6651,14 +6649,13 @@ func (sc afterImage) runSub(c *Char, ai *AfterImage, paramID byte, exp []Bytecod
 func (sc afterImage) Run(c *Char, _ []int32) bool {
 	crun := c
 
-	// Get redirection first because we need to know which char is running this
+	// Get redirection
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		if paramID == afterImage_redirectid {
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-			} else {
-				return false
 			}
+			return false
 		}
 		return true
 	})
@@ -7216,9 +7213,8 @@ func (sc hitDef) Run(c *Char, _ []int32) bool {
 		if paramID == hitDef_redirectid {
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-			} else {
-				return false
 			}
+			return false
 		}
 		return true
 	})
@@ -7272,9 +7268,8 @@ func (sc reversalDef) Run(c *Char, _ []int32) bool {
 		if paramID == reversalDef_redirectid {
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
-			} else {
-				return false
 			}
+			return false
 		}
 		return true
 	})
@@ -9183,8 +9178,8 @@ const (
 )
 
 func (sc lifeAdd) Run(c *Char, _ []int32) bool {
-	abs, kill := false, true
 	crun := c
+	abs, kill := false, true
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
 		case lifeAdd_absolute:
@@ -9666,7 +9661,9 @@ const (
 
 func (sc trans) Run(c *Char, _ []int32) bool {
 	crun := c
-	crun.alpha[1] = 255
+	// Mugen 1.1 doesn't seem to do this. Leftover code?
+	//crun.alpha[1] = 255
+
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
 		case trans_trans:
@@ -11011,8 +11008,8 @@ const (
 )
 
 func (sc dizzyPointsAdd) Run(c *Char, _ []int32) bool {
-	abs := false
 	crun := c
+	abs := false
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
 		case dizzyPointsAdd_absolute:
@@ -11115,8 +11112,8 @@ const (
 )
 
 func (sc guardPointsAdd) Run(c *Char, _ []int32) bool {
-	abs := false
 	crun := c
+	abs := false
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
 		case guardPointsAdd_absolute:
@@ -11410,8 +11407,8 @@ const (
 )
 
 func (sc redLifeAdd) Run(c *Char, _ []int32) bool {
-	abs := false
 	crun := c
+	abs := false
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
 		case redLifeAdd_absolute:
@@ -11659,6 +11656,7 @@ func (sc modifyBGCtrl) Run(c *Char, _ []int32) bool {
 	sinadd, sinmul := [4]int32{IErr, IErr, IErr, IErr}, [4]int32{IErr, IErr, IErr, IErr}
 	sincolor, sinhue := [2]int32{IErr, IErr}, [2]int32{IErr, IErr}
 	invall, invblend, color, hue := IErr, IErr, float32(math.NaN()), float32(math.NaN())
+
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
 		case modifyBGCtrl_id:
@@ -11767,9 +11765,9 @@ const (
 
 func (sc modifyBGCtrl3d) Run(c *Char, _ []int32) bool {
 	//crun := c
-
 	var cid int32
 	t, v := [3]int32{IErr, IErr, IErr}, [3]int32{IErr, IErr, IErr}
+
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
 		case modifyBGCtrl3d_ctrlid:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3669,9 +3669,9 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	case OC_ex2_hitdefvar_guard_dist_depth_top:
 		sys.bcStack.PushF(c.hitdef.guard_dist_z[0] * (c.localscl / oc.localscl))
 	case OC_ex2_hitdefvar_guard_pausetime:
-		sys.bcStack.PushI(c.hitdef.guard_pausetime)
+		sys.bcStack.PushI(c.hitdef.guard_pausetime[0])
 	case OC_ex2_hitdefvar_guard_shaketime:
-		sys.bcStack.PushI(c.hitdef.guard_shaketime)
+		sys.bcStack.PushI(c.hitdef.guard_pausetime[1])
 	case OC_ex2_hitdefvar_guard_sparkno:
 		sys.bcStack.PushI(c.hitdef.guard_sparkno)
 	case OC_ex2_hitdefvar_guarddamage:
@@ -3705,11 +3705,11 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	case OC_ex2_hitdefvar_p2stateno:
 		sys.bcStack.PushI(c.hitdef.p2stateno)
 	case OC_ex2_hitdefvar_pausetime:
-		sys.bcStack.PushI(c.hitdef.pausetime)
+		sys.bcStack.PushI(c.hitdef.pausetime[0])
 	case OC_ex2_hitdefvar_priority:
 		sys.bcStack.PushI(c.hitdef.priority)
 	case OC_ex2_hitdefvar_shaketime:
-		sys.bcStack.PushI(c.hitdef.shaketime)
+		sys.bcStack.PushI(c.hitdef.pausetime[1])
 	case OC_ex2_hitdefvar_sparkno:
 		sys.bcStack.PushI(c.hitdef.sparkno)
 	case OC_ex2_hitdefvar_sparkx:
@@ -7058,14 +7058,14 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, paramID byte, exp []BytecodeExp) bo
 			hd.guard_dist_z[1] = v2
 		}
 	case hitDef_pausetime:
-		hd.pausetime = exp[0].evalI(c)
+		hd.pausetime[0] = exp[0].evalI(c)
 		if len(exp) > 1 {
-			hd.shaketime = exp[1].evalI(c)
+			hd.pausetime[1] = exp[1].evalI(c)
 		}
 	case hitDef_guard_pausetime:
-		hd.guard_pausetime = exp[0].evalI(c)
+		hd.guard_pausetime[0] = exp[0].evalI(c)
 		if len(exp) > 1 {
-			hd.guard_shaketime = exp[1].evalI(c)
+			hd.guard_pausetime[1] = exp[1].evalI(c)
 		}
 	case hitDef_air_velocity:
 		hd.air_velocity[0] = exp[0].evalF(c)
@@ -8261,9 +8261,9 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 					p.hitdef.ground_fall = v1
 				})
 			case hitDef_air_fall:
-				v1 := exp[0].evalB(c)
+				v1 := Btoi(exp[0].evalB(c))
 				eachProj(func(p *Projectile) {
-					p.hitdef.air_fall = Btoi(v1)
+					p.hitdef.air_fall = v1
 				})
 			//case hitDef_air_cornerpush_veloff:
 			//	p.hitdef.air_cornerpush_veloff = exp[0].evalF(c)
@@ -8347,8 +8347,8 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 					v2 = exp[1].evalI(c)
 				}
 				eachProj(func(p *Projectile) {
-					p.hitdef.pausetime = v1
-					p.hitdef.shaketime = v2
+					p.hitdef.pausetime[0] = v1
+					p.hitdef.pausetime[1] = v2
 				})
 			case hitDef_guard_pausetime:
 				var v1, v2 int32
@@ -8357,8 +8357,8 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 					v2 = exp[1].evalI(c)
 				}
 				eachProj(func(p *Projectile) {
-					p.hitdef.guard_pausetime = v1
-					p.hitdef.guard_shaketime = v2
+					p.hitdef.guard_pausetime[0] = v1
+					p.hitdef.guard_pausetime[1] = v2
 				})
 			case hitDef_air_velocity:
 				var v1, v2, v3 float32

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5493,7 +5493,8 @@ func (sc palFX) runSub(c *Char, pfd *PalFXDef, paramID byte, exp []BytecodeExp) 
 func (sc palFX) Run(c *Char, _ []int32) bool {
 	crun := c
 
-	// Get redirection first because we need to know which char is running this
+	// Get redirection
+	// Every sctrl where we must do preliminary operations on crun needs redirection to be determined first
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		if paramID == palFX_redirectid {
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
@@ -7259,6 +7260,7 @@ type reversalDef hitDef
 const (
 	reversalDef_reversal_attr = iota + hitDef_last + 1
 	reversalDef_reversal_guardflag
+	reversalDef_reversal_guardflag_not
 	reversalDef_redirectid
 )
 
@@ -7287,6 +7289,8 @@ func (sc reversalDef) Run(c *Char, _ []int32) bool {
 			crun.hitdef.reversal_attr = exp[0].evalI(c)
 		case reversalDef_reversal_guardflag:
 			crun.hitdef.reversal_guardflag = exp[0].evalI(c)
+		case reversalDef_reversal_guardflag_not:
+			crun.hitdef.reversal_guardflag_not = exp[0].evalI(c)
 		case reversalDef_redirectid:
 			return true // Already handled
 		default:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -2922,7 +2922,7 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_helperindexexist:
 		*sys.bcStack.Top() = c.helperByIndexExist(*sys.bcStack.Top())
 	case OC_ex_hitoverridden:
-		sys.bcStack.PushB(c.hoIdx >= 0)
+		sys.bcStack.PushB(c.hoverIdx >= 0)
 	case OC_ex_ikemenversion:
 		sys.bcStack.PushF(c.gi().ikemenverF)
 	case OC_ex_incustomanim:
@@ -9395,23 +9395,24 @@ const (
 	hitOverride_stateno
 	hitOverride_time
 	hitOverride_forceair
+	hitOverride_forceguard
 	hitOverride_keepstate
 	hitOverride_redirectid
 )
 
 func (sc hitOverride) Run(c *Char, _ []int32) bool {
 	crun := c
-	var a, s, st, t int32 = 0, 0, -1, 1
-	fa := false
-	ks := false
+	var at, sl, st, t int32 = 0, 0, -1, 1
+	var fa, fg, ks bool
+
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
 		case hitOverride_attr:
-			a = exp[0].evalI(c)
+			at = exp[0].evalI(c)
 		case hitOverride_slot:
-			s = Max(0, exp[0].evalI(c))
-			if s > 7 {
-				s = 0
+			sl = Max(0, exp[0].evalI(c))
+			if sl > 7 {
+				sl = 0
 			}
 		case hitOverride_stateno:
 			st = exp[0].evalI(c)
@@ -9422,6 +9423,8 @@ func (sc hitOverride) Run(c *Char, _ []int32) bool {
 			}
 		case hitOverride_forceair:
 			fa = exp[0].evalB(c)
+		case hitOverride_forceguard:
+			fg = exp[0].evalB(c)
 		case hitOverride_keepstate:
 			if st == -1 { // StateNo disables KeepState
 				ks = exp[0].evalB(c)
@@ -9435,16 +9438,18 @@ func (sc hitOverride) Run(c *Char, _ []int32) bool {
 		}
 		return true
 	})
+
 	// In Mugen, using an undefined state number is still a valid HitOverride
 	//if st < 0 && !ks && !f {
 	//	t = 0
 	//}
 	pn := crun.playerNo
-	crun.ho[s] = HitOverride{
-		attr: a
+	crun.hover[sl] = HitOverride{
+		attr: at,
 		stateno: st,
 		time: t,
 		forceair: fa,
+		forceguard: fg,
 		keepState: ks,
 		playerNo: pn, // This seems to be unused currently
 	}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -9414,6 +9414,7 @@ const (
 	hitOverride_forceair
 	hitOverride_forceguard
 	hitOverride_guardflag
+	hitOverride_guardflag_not
 	hitOverride_keepstate
 	hitOverride_redirectid
 )
@@ -9422,7 +9423,8 @@ func (sc hitOverride) Run(c *Char, _ []int32) bool {
 	crun := c
 	var at, sl, st, t int32 = 0, 0, -1, 1
 	var fa, fg, ks bool
-	gf := ^int32(0) // Default to all flags // int32(HF_H | HF_L | HF_A)
+	gf := IErr
+	gfn := IErr
 
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
@@ -9448,6 +9450,8 @@ func (sc hitOverride) Run(c *Char, _ []int32) bool {
 			ks = exp[0].evalB(c) // Shouldn't be used together with StateNo but no need to block it either
 		case hitOverride_guardflag:
 			gf = exp[0].evalI(c)
+		case hitOverride_guardflag_not:
+			gfn = exp[0].evalI(c)
 		case hitOverride_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -9471,6 +9475,7 @@ func (sc hitOverride) Run(c *Char, _ []int32) bool {
 		forceguard: fg,
 		keepState: ks,
 		guardflag: gf,
+		guardflag_not: gfn,
 		playerNo: pn, // This seems to be unused currently
 	}
 	return false

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -9402,7 +9402,7 @@ const (
 func (sc hitOverride) Run(c *Char, _ []int32) bool {
 	crun := c
 	var a, s, st, t int32 = 0, 0, -1, 1
-	f := false
+	fa := false
 	ks := false
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
@@ -9421,7 +9421,7 @@ func (sc hitOverride) Run(c *Char, _ []int32) bool {
 				t = 1
 			}
 		case hitOverride_forceair:
-			f = exp[0].evalB(c)
+			fa = exp[0].evalB(c)
 		case hitOverride_keepstate:
 			if st == -1 { // StateNo disables KeepState
 				ks = exp[0].evalB(c)
@@ -9435,11 +9435,19 @@ func (sc hitOverride) Run(c *Char, _ []int32) bool {
 		}
 		return true
 	})
-	if st < 0 && !ks && !f {
-		t = 0
-	}
+	// In Mugen, using an undefined state number is still a valid HitOverride
+	//if st < 0 && !ks && !f {
+	//	t = 0
+	//}
 	pn := crun.playerNo
-	crun.ho[s] = HitOverride{attr: a, stateno: st, time: t, forceair: f, keepState: ks, playerNo: pn}
+	crun.ho[s] = HitOverride{
+		attr: a
+		stateno: st,
+		time: t,
+		forceair: fa,
+		keepState: ks,
+		playerNo: pn, // This seems to be unused currently
+	}
 	return false
 }
 

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5124,19 +5124,19 @@ func (sc posSet) Run(c *Char, _ []int32) bool {
 		switch paramID {
 		case posSet_x:
 			x := sys.cam.Pos[0]/crun.localscl + exp[0].evalF(c)*redirscale
-			crun.setX(x)
+			crun.setAllPosX(x)
 			if crun.bindToId > 0 && !math.IsNaN(float64(crun.bindPos[0])) && sys.playerID(crun.bindToId) != nil {
 				crun.bindPosAdd[0] = x
 			}
 		case posSet_y:
 			y := exp[0].evalF(c)*redirscale + crun.groundLevel + crun.platformPosY
-			crun.setY(y)
+			crun.setAllPosY(y)
 			if crun.bindToId > 0 && !math.IsNaN(float64(crun.bindPos[1])) && sys.playerID(crun.bindToId) != nil {
 				crun.bindPosAdd[1] = y
 			}
 		case posSet_z:
 			z := exp[0].evalF(c) * redirscale
-			crun.setZ(z)
+			crun.setAllPosZ(z)
 			if crun.bindToId > 0 && !math.IsNaN(float64(crun.bindPos[2])) && sys.playerID(crun.bindToId) != nil {
 				crun.bindPosAdd[2] = z
 			}
@@ -6057,9 +6057,9 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 							e.relativef = 1
 						}
 						e.offset = [3]float32{0, 0, 0}
-						e.setX(e.offset[0])
-						e.setY(e.offset[1])
-						e.setZ(e.offset[2])
+						e.setAllPosX(e.offset[0])
+						e.setAllPosY(e.offset[1])
+						e.setAllPosZ(e.offset[2])
 						e.relativePos = [3]float32{0, 0, 0}
 						e.velocity = [3]float32{0, 0, 0}
 						e.accel = [3]float32{0, 0, 0}
@@ -6221,9 +6221,9 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 					if (crun.stWgi().ikemenver[0] != 0 || crun.stWgi().ikemenver[1] != 0) && t > 0 {
 						e.bindtime = e.time + t
 					}
-					e.setX(e.pos[0])
-					e.setY(e.pos[1])
-					e.setZ(e.pos[2])
+					e.setAllPosX(e.pos[0])
+					e.setAllPosY(e.pos[1])
+					e.setAllPosZ(e.pos[2])
 				})
 			case explod_removetime:
 				t := exp[0].evalI(c)
@@ -7324,10 +7324,11 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 	var redirscale float32 = 1.0
 	var p *Projectile
 	pt := PT_P1
-	var x, y, z float32 = 0, 0, 0
+	var offx, offy, offz float32 = 0, 0, 0
 	op := false
 	clsnscale := false
 	rp := [...]int32{-1, 0}
+
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		if p == nil {
 			if paramID == projectile_redirectid {
@@ -7420,11 +7421,11 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 		case projectile_projxangle:
 			p.anglerot[1] = exp[0].evalF(c)
 		case projectile_offset:
-			x = exp[0].evalF(c) * redirscale
+			offx = exp[0].evalF(c) * redirscale
 			if len(exp) > 1 {
-				y = exp[1].evalF(c) * redirscale
+				offy = exp[1].evalF(c) * redirscale
 				if len(exp) > 2 {
-					z = exp[2].evalF(c) * redirscale
+					offz = exp[2].evalF(c) * redirscale
 				}
 			}
 		case projectile_projsprpriority:
@@ -7528,7 +7529,7 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 	if p.aimg.time != 0 {
 		p.aimg.setupPalFX()
 	}
-	crun.projInit(p, pt, x, y, z, op, rp[0], rp[1], clsnscale)
+	crun.projInit(p, pt, offx, offy, offz, op, rp[0], rp[1], clsnscale)
 	return false
 }
 

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -9412,6 +9412,7 @@ const (
 	hitOverride_time
 	hitOverride_forceair
 	hitOverride_forceguard
+	hitOverride_guardflag
 	hitOverride_keepstate
 	hitOverride_redirectid
 )
@@ -9420,6 +9421,7 @@ func (sc hitOverride) Run(c *Char, _ []int32) bool {
 	crun := c
 	var at, sl, st, t int32 = 0, 0, -1, 1
 	var fa, fg, ks bool
+	gf := ^int32(0) // Default to all flags // int32(HF_H | HF_L | HF_A)
 
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
@@ -9443,6 +9445,8 @@ func (sc hitOverride) Run(c *Char, _ []int32) bool {
 			fg = exp[0].evalB(c)
 		case hitOverride_keepstate:
 			ks = exp[0].evalB(c) // Shouldn't be used together with StateNo but no need to block it either
+		case hitOverride_guardflag:
+			gf = exp[0].evalI(c)
 		case hitOverride_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid
@@ -9465,6 +9469,7 @@ func (sc hitOverride) Run(c *Char, _ []int32) bool {
 		forceair: fa,
 		forceguard: fg,
 		keepState: ks,
+		guardflag: gf,
 		playerNo: pn, // This seems to be unused currently
 	}
 	return false

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -9426,9 +9426,7 @@ func (sc hitOverride) Run(c *Char, _ []int32) bool {
 		case hitOverride_forceguard:
 			fg = exp[0].evalB(c)
 		case hitOverride_keepstate:
-			if st == -1 { // StateNo disables KeepState
-				ks = exp[0].evalB(c)
-			}
+			ks = exp[0].evalB(c) // Shouldn't be used together with StateNo but no need to block it either
 		case hitOverride_redirectid:
 			if rid := sys.playerID(exp[0].evalI(c)); rid != nil {
 				crun = rid

--- a/src/char.go
+++ b/src/char.go
@@ -978,6 +978,7 @@ type HitOverride struct {
 	forceair  bool
 	forceguard bool
 	guardflag  int32
+	guardflag_not int32
 	keepState bool
 	playerNo  int
 }
@@ -8702,7 +8703,11 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 				}
 			}
 			// Check guardflag
-			if ho.guardflag&hd.guardflag == 0 || c.asf(ASF_unguardable) {
+			if ho.guardflag != IErr && (ho.guardflag&hd.guardflag == 0 || c.asf(ASF_unguardable)) {
+				continue
+			}
+			// Check guardflag.not
+			if ho.guardflag_not != IErr && (ho.guardflag_not&hd.guardflag != 0 && !c.asf(ASF_unguardable)) {
 				continue
 			}
 			// Miss if using p1stateno or p2stateno and HitOverride together

--- a/src/char.go
+++ b/src/char.go
@@ -1333,15 +1333,15 @@ func (e *Explod) clear() {
 	}
 }
 
-func (e *Explod) setX(x float32) {
+func (e *Explod) setAllPosX(x float32) {
 	e.pos[0], e.oldPos[0], e.newPos[0] = x, x, x
 }
 
-func (e *Explod) setY(y float32) {
+func (e *Explod) setAllPosY(y float32) {
 	e.pos[1], e.oldPos[1], e.newPos[1] = y, y, y
 }
 
-func (e *Explod) setZ(z float32) {
+func (e *Explod) setAllPosZ(z float32) {
 	e.pos[2], e.oldPos[2], e.newPos[2] = z, z, z
 }
 
@@ -1368,9 +1368,9 @@ func (e *Explod) setPos(c *Char) {
 			e.offset[1] = sys.cam.GroundLevel()*e.localscl + posY
 			e.offset[2] = ClampF(posZ, sys.stage.stageCamera.topz, sys.stage.stageCamera.botz)
 		} else {
-			e.setX(posX)
-			e.setY(posY)
-			e.setZ(posZ)
+			e.setAllPosX(posX)
+			e.setAllPosY(posY)
+			e.setAllPosZ(posZ)
 		}
 	}
 	lPos := func() {
@@ -1507,8 +1507,8 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 			// Doesn't seem necessary to do this, since MUGEN 1.1 seems to carry bindtime even if
 			// you change bindId to something that doesn't point to any character
 			// e.bindtime = 0
-			// e.setX(e.pos[0])
-			// e.setY(e.pos[1])
+			// e.setAllPosX(e.pos[0])
+			// e.setAllPosY(e.pos[1])
 		}
 	} else {
 		// Explod position interpolation
@@ -1690,9 +1690,9 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 				e.bindtime--
 			}
 		} else {
-			e.setX(e.pos[0])
-			e.setY(e.pos[1])
-			e.setZ(e.pos[2])
+			e.setAllPosX(e.pos[0])
+			e.setAllPosY(e.pos[1])
+			e.setAllPosZ(e.pos[2])
 		}
 	}
 }
@@ -1904,8 +1904,11 @@ func (p *Projectile) clear() {
 	}
 }
 
-func (p *Projectile) setPos(pos [3]float32) {
-	p.pos, p.oldPos, p.newPos = pos, pos, pos
+func (p *Projectile) setAllPos(pos [3]float32) {
+	p.pos = pos
+	p.oldPos = pos
+	p.newPos = pos
+	p.interPos = pos
 }
 
 func (p *Projectile) paused(playerNo int) bool {
@@ -1991,7 +1994,7 @@ func (p *Projectile) update() {
 		}
 	}
 	if p.paused(p.playerno) || p.hitpause > 0 || p.freezeflag {
-		p.setPos(p.pos)
+		p.setAllPos(p.pos)
 		// There's a minor issue here where a projectile will lag behind one frame relative to Mugen if created during a pause
 	} else {
 		if sys.tickFrame() {
@@ -5456,9 +5459,9 @@ func (c *Char) newHelper() (h *Char) {
 func (c *Char) helperInit(h *Char, st int32, pt PosType, x, y, z float32,
 	facing int32, rp [2]int32, extmap bool) {
 	p := c.helperPos(pt, [...]float32{x, y, z}, facing, &h.facing, h.localscl, false)
-	h.setX(p[0])
-	h.setY(p[1])
-	h.setZ(p[2])
+	h.setAllPosX(p[0])
+	h.setAllPosY(p[1])
+	h.setAllPosZ(p[2])
 	h.vel = [3]float32{}
 	if h.ownpal {
 		h.palfx = newPalFX()
@@ -5776,45 +5779,45 @@ func (c *Char) setPosZ(z float32) {
 func (c *Char) posReset() {
 	if c.teamside == -1 || c.playerNo < 0 || c.playerNo >= len(sys.stage.p) {
 		c.facing = 1
-		c.setX(0)
-		c.setY(0)
-		c.setZ(0)
+		c.setAllPosX(0)
+		c.setAllPosY(0)
+		c.setAllPosZ(0)
 	} else {
 		c.facing = float32(sys.stage.p[c.playerNo].facing)
-		c.setX((float32(sys.stage.p[c.playerNo].startx) * sys.stage.localscl) / c.localscl)
-		c.setY(float32(sys.stage.p[c.playerNo].starty) * sys.stage.localscl / c.localscl)
-		c.setZ(float32(sys.stage.p[c.playerNo].startz) * sys.stage.localscl / c.localscl)
+		c.setAllPosX((float32(sys.stage.p[c.playerNo].startx) * sys.stage.localscl) / c.localscl)
+		c.setAllPosY(float32(sys.stage.p[c.playerNo].starty) * sys.stage.localscl / c.localscl)
+		c.setAllPosZ(float32(sys.stage.p[c.playerNo].startz) * sys.stage.localscl / c.localscl)
 	}
 	c.vel[0] = 0
 	c.vel[1] = 0
 	c.vel[2] = 0
 }
 
-func (c *Char) setX(x float32) {
+func (c *Char) setAllPosX(x float32) {
 	c.oldPos[0], c.interPos[0] = x, x
 	c.setPosX(x)
 }
 
-func (c *Char) setY(y float32) {
+func (c *Char) setAllPosY(y float32) {
 	c.oldPos[1], c.interPos[1] = y, y
 	c.setPosY(y)
 }
 
-func (c *Char) setZ(z float32) {
+func (c *Char) setAllPosZ(z float32) {
 	c.oldPos[2], c.interPos[2] = z, z
 	c.setPosZ(z)
 }
 
 func (c *Char) addX(x float32) {
-	c.setX(c.pos[0] + c.facing*x)
+	c.setAllPosX(c.pos[0] + c.facing*x)
 }
 
 func (c *Char) addY(y float32) {
-	c.setY(c.pos[1] + y)
+	c.setAllPosY(c.pos[1] + y)
 }
 
 func (c *Char) addZ(z float32) {
-	c.setZ(c.pos[2] + z)
+	c.setAllPosZ(c.pos[2] + z)
 }
 
 func (c *Char) hitAdd(h int32) {
@@ -5888,11 +5891,15 @@ func (c *Char) newProj() *Projectile {
 	return p
 }
 
-func (c *Char) projInit(p *Projectile, pt PosType, x, y, z float32,
+func (c *Char) projInit(p *Projectile, pt PosType, offx, offy, offz float32,
 	op bool, rpg, rpn int32, clsnscale bool) {
-	pos := c.helperPos(pt, [...]float32{x, y, z}, 1, &p.facing, p.localscl, true)
-	p.setPos([...]float32{pos[0], pos[1], pos[2]})
+	// Set starting position
+	pos := c.helperPos(pt, [...]float32{offx, offy, offz}, 1, &p.facing, p.localscl, true)
+	p.setAllPos([...]float32{pos[0], pos[1], pos[2]})
+
+	// Projectile attackmul is decided upon its creation only
 	p.parentAttackMul = c.attackMul
+
 	if p.anim < -1 {
 		p.anim = 0
 	}
@@ -5906,7 +5913,10 @@ func (c *Char) projInit(p *Projectile, pt PosType, x, y, z float32,
 	if p.ani != nil {
 		p.ani.UpdateSprite()
 	}
-	p.totalhits = p.hits // Save total hits for later use
+
+	// Save total hits for later use
+	p.totalhits = p.hits
+
 	if c.size.proj.doscale != 0 {
 		p.scale[0] *= c.size.xscale
 		p.scale[1] *= c.size.yscale
@@ -5915,16 +5925,21 @@ func (c *Char) projInit(p *Projectile, pt PosType, x, y, z float32,
 	if !clsnscale {
 		p.clsnScale = c.clsnBaseScale
 	}
+
 	if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
 		p.hitdef.chainid = -1
 		p.hitdef.nochainid = [8]int32{-1, -1, -1, -1, -1, -1, -1, -1}
 	}
+
 	p.removefacing = c.facing
+
 	if p.velocity[0] < 0 {
 		p.facing *= -1
 		p.velocity[0] *= -1
 		p.accel[0] *= -1
 	}
+
+	// Ownpal
 	if op {
 		remap := make([]int, len(p.palfx.remap))
 		copy(remap, p.palfx.remap)
@@ -6669,13 +6684,13 @@ func (c *Char) bindToTarget(tar []int32, time int32, x, y, z float32, hmf HMF) {
 				y += t.size.head.pos[1] * ((320 / t.localcoord) / c.localscl)
 			}
 			if !math.IsNaN(float64(x)) {
-				c.setX(t.pos[0]*(t.localscl/c.localscl) + t.facing*x)
+				c.setAllPosX(t.pos[0]*(t.localscl/c.localscl) + t.facing*x)
 			}
 			if !math.IsNaN(float64(y)) {
-				c.setY(t.pos[1]*(t.localscl/c.localscl) + y)
+				c.setAllPosY(t.pos[1]*(t.localscl/c.localscl) + y)
 			}
 			if !math.IsNaN(float64(z)) {
-				c.setZ(t.pos[2]*(t.localscl/c.localscl) + z)
+				c.setAllPosZ(t.pos[2]*(t.localscl/c.localscl) + z)
 			}
 			c.targetBind(tar[:1], time,
 				c.facing*c.distX(t, c),
@@ -7988,20 +8003,20 @@ func (c *Char) bind() {
 			if AbsF(c.bindFacing) == 2 {
 				f = c.bindFacing / 2
 			}
-			c.setX(bt.pos[0]*bt.localscl/c.localscl + f*(c.bindPos[0]+c.bindPosAdd[0]))
+			c.setAllPosX(bt.pos[0]*bt.localscl/c.localscl + f*(c.bindPos[0]+c.bindPosAdd[0]))
 			c.interPos[0] += bt.interPos[0] - bt.pos[0]
 			c.oldPos[0] += bt.oldPos[0] - bt.pos[0]
 			c.pushed = c.pushed || bt.pushed
 			c.ghv.xoff = 0
 		}
 		if !math.IsNaN(float64(c.bindPos[1])) {
-			c.setY(bt.pos[1]*bt.localscl/c.localscl + (c.bindPos[1] + c.bindPosAdd[1]))
+			c.setAllPosY(bt.pos[1]*bt.localscl/c.localscl + (c.bindPos[1] + c.bindPosAdd[1]))
 			c.interPos[1] += bt.interPos[1] - bt.pos[1]
 			c.oldPos[1] += bt.oldPos[1] - bt.pos[1]
 			c.ghv.yoff = 0
 		}
 		if !math.IsNaN(float64(c.bindPos[2])) {
-			c.setZ(bt.pos[2]*bt.localscl/c.localscl + (c.bindPos[2] + c.bindPosAdd[2]))
+			c.setAllPosZ(bt.pos[2]*bt.localscl/c.localscl + (c.bindPos[2] + c.bindPosAdd[2]))
 			c.interPos[2] += bt.interPos[2] - bt.pos[2]
 			c.oldPos[2] += bt.oldPos[2] - bt.pos[2]
 			c.ghv.zoff = 0
@@ -8057,7 +8072,7 @@ func (c *Char) xPlatformBound(pxmin, pxmax float32) {
 		}
 		x = ClampF(x, min+pxmin/c.localscl, max+pxmax/c.localscl)
 	}
-	c.setX(x)
+	c.setAllPosX(x)
 	c.xScreenBound()
 }
 

--- a/src/char.go
+++ b/src/char.go
@@ -7129,54 +7129,54 @@ func (c *Char) consecutiveWins() int32 {
 func (c *Char) dizzyEnabled() bool {
 	return sys.lifebar.stunbar
 	/*
-	   switch sys.tmode[c.playerNo&1] {
-	   case TM_Single:
-	       return sys.cfg.Options.Single.Dizzy
-	   case TM_Simul:
-	       return sys.cfg.Options.Simul.Dizzy
-	   case TM_Tag:
-	       return sys.cfg.Options.Tag.Dizzy
-	   case TM_Turns:
-	       return sys.cfg.Options.Turns.Dizzy
-	   default:
-	       return false
-	   }
+	switch sys.tmode[c.playerNo&1] {
+	case TM_Single:
+		return sys.cfg.Options.Single.Dizzy
+	case TM_Simul:
+		return sys.cfg.Options.Simul.Dizzy
+	case TM_Tag:
+		return sys.cfg.Options.Tag.Dizzy
+	case TM_Turns:
+		return sys.cfg.Options.Turns.Dizzy
+	default:
+		return false
+	}
 	*/
 }
 
 func (c *Char) guardBreakEnabled() bool {
 	return sys.lifebar.guardbar
 	/*
-	   switch sys.tmode[c.playerNo&1] {
-	   case TM_Single:
-	       return sys.cfg.Options.Single.GuardBreak
-	   case TM_Simul:
-	       return sys.cfg.Options.Simul.GuardBreak
-	   case TM_Tag:
-	       return sys.cfg.Options.Tag.GuardBreak
-	   case TM_Turns:
-	       return sys.cfg.Options.Turns.GuardBreak
-	   default:
-	       return false
-	   }
+	switch sys.tmode[c.playerNo&1] {
+	case TM_Single:
+		return sys.cfg.Options.Single.GuardBreak
+	case TM_Simul:
+		return sys.cfg.Options.Simul.GuardBreak
+	case TM_Tag:
+		return sys.cfg.Options.Tag.GuardBreak
+	case TM_Turns:
+		return sys.cfg.Options.Turns.GuardBreak
+	default:
+		return false
+	}
 	*/
 }
 
 func (c *Char) redLifeEnabled() bool {
 	return sys.lifebar.redlifebar
 	/*
-			switch sys.tmode[c.playerNo&1] {
-		    case TM_Single:
-		        return sys.cfg.Options.Single.RedLife
-		    case TM_Simul:
-		        return sys.cfg.Options.Simul.RedLife
-		    case TM_Tag:
-		        return sys.cfg.Options.Tag.RedLife
-		    case TM_Turns:
-		        return sys.cfg.Options.Turns.RedLife
-		    default:
-		        return false
-		    }
+	switch sys.tmode[c.playerNo&1] {
+	case TM_Single:
+		return sys.cfg.Options.Single.RedLife
+	case TM_Simul:
+		return sys.cfg.Options.Simul.RedLife
+	case TM_Tag:
+		return sys.cfg.Options.Tag.RedLife
+	case TM_Turns:
+		return sys.cfg.Options.Turns.RedLife
+	default:
+		return false
+    }
 	*/
 }
 

--- a/src/char.go
+++ b/src/char.go
@@ -980,6 +980,7 @@ type HitOverride struct {
 	time      int32
 	forceair  bool
 	forceguard bool
+	guardflag  int32
 	keepState bool
 	playerNo  int
 }
@@ -8683,6 +8684,10 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 				if ho.attr&int32(c.ss.stateType) == 0 {
 					continue
 				}
+			}
+			// Check guardflag
+			if ho.guardflag&hd.guardflag == 0 || c.asf(ASF_unguardable) {
+				continue
 			}
 			// Miss if using p1stateno or p2stateno and HitOverride together
 			// In Mugen, it misses even if the enemy guards // && Abs(hitResult) == 1

--- a/src/char.go
+++ b/src/char.go
@@ -1446,8 +1446,11 @@ func (e *Explod) setAnimElem() {
 			e.animelem = 1
 		}
 		// Validate animelemtime just in case
-		if e.animelemtime < 0 || e.animelemtime >= e.anim.frames[e.animelem-1].Time {
-			e.animelemtime = 0
+		if e.animelemtime != 0 {
+			frametime := e.anim.frames[e.animelem-1].Time
+			if e.animelemtime < 0 || (frametime != -1 && e.animelemtime >= frametime) {
+				e.animelemtime = 0
+			}
 		}
 		// Set them
 		e.anim.SetAnimElem(e.animelem, e.animelemtime)
@@ -3744,9 +3747,10 @@ func (c *Char) setAnimElem(elem, elemtime int32) {
 		sys.appendToConsole(c.warn() + fmt.Sprintf("changed to invalid animelem %v within action %v", elem, c.animNo))
 		elem = 1
 		elemtime = 0
-	} else {
-		// Validate elemtime only if elem is valid
-		if elemtime < 0 || elemtime >= c.anim.frames[elem-1].Time {
+	} else if elemtime != 0 {
+		// Validate elemtime only if it's unusual and elem is valid
+		frametime := c.anim.frames[elem-1].Time
+		if elemtime < 0 || (frametime != -1 && elemtime >= frametime) {
 			sys.appendToConsole(c.warn() + fmt.Sprintf("changed to invalid elemtime %v in animelem %v", elemtime, elem))
 			elemtime = 0
 		}

--- a/src/char.go
+++ b/src/char.go
@@ -985,7 +985,7 @@ type HitOverride struct {
 }
 
 func (ho *HitOverride) clear() {
-	*ho = HitOverride{stateno: -1, keepState: false, playerNo: -1}
+	*ho = HitOverride{stateno: -1, playerNo: -1}
 }
 
 type MoveHitVar struct {
@@ -2662,7 +2662,9 @@ func (c *Char) clearState() {
 	c.ghv.clear(c)
 	c.ghv.clearOff()
 	c.mhv.clear()
-	c.hitby = [8]HitBy{}
+	for i := range c.hitby {
+		c.hitby[i].clear()
+	}
 	for i := range c.hover {
 		c.hover[i].clear()
 	}
@@ -9719,26 +9721,25 @@ func (c *Char) actionRun() {
 			c.updateCurFrame()
 		}
 		if c.ghv.damage != 0 {
-			// HitOverride KeepState flag still allows damage to get through
-			if c.ss.moveType == MT_H || c.hoverKeepState {
+			if c.ss.moveType == MT_H {
 				c.lifeAdd(-float64(c.ghv.damage), true, true)
 			}
 			c.ghv.damage = 0
 		}
 		if c.ghv.redlife != 0 {
-			if c.ss.moveType == MT_H || c.hoverKeepState {
+			if c.ss.moveType == MT_H {
 				c.redLifeAdd(-float64(c.ghv.redlife), true)
 			}
 			c.ghv.redlife = 0
 		}
 		if c.ghv.dizzypoints != 0 {
-			if c.ss.moveType == MT_H || c.hoverKeepState {
+			if c.ss.moveType == MT_H {
 				c.dizzyPointsAdd(-float64(c.ghv.dizzypoints), true)
 			}
 			c.ghv.dizzypoints = 0
 		}
 		if c.ghv.guardpoints != 0 {
-			if c.ss.moveType == MT_H || c.hoverKeepState {
+			if c.ss.moveType == MT_H {
 				c.guardPointsAdd(-float64(c.ghv.guardpoints), true)
 			}
 			c.ghv.guardpoints = 0
@@ -9768,14 +9769,13 @@ func (c *Char) actionRun() {
 					c.hittmp = 0
 				}
 				if !c.scf(SCF_dizzy) {
-					// HitOverride KeepState preserves some GetHitVars for 1 frame so they can be accessed by the char
-					if !c.hoverKeepState {
-						c.ghv.hitshaketime = 0
-						c.ghv.attr = 0
-						c.ghv.guardflag = 0
-						c.ghv.playerId = 0
-						c.ghv.playerNo = -1
-					}
+					// HitOverride KeepState used to freeze some GetHitVars around here to keep them from resetting instantly,
+					// but that no longer seems necessary with this being placed in actionRun()
+					c.ghv.hitshaketime = 0
+					c.ghv.attr = 0
+					c.ghv.guardflag = 0
+					c.ghv.playerId = 0
+					c.ghv.playerNo = -1
 					c.superDefenseMul = 1
 					c.fallDefenseMul = 1
 					c.ghv.fallflag = false

--- a/src/char.go
+++ b/src/char.go
@@ -7800,7 +7800,7 @@ func (c *Char) posUpdate() {
 	// In Mugen 1.0 and 1.1 this threshold is bugged, varying with game resolution
 	// In Ikemen, this threshold is obsolete
 	c.mhv.cornerpush = 0
-	friction := float32(0.7)
+	pushmul := float32(0.7)
 	if c.cornerVelOff != 0 && sys.supertime == 0 {
 		for _, p := range sys.chars {
 			if len(p) > 0 && p[0].ss.moveType == MT_H && p[0].ghv.playerId == c.id {
@@ -7811,12 +7811,12 @@ func (c *Char) posUpdate() {
 				// In Mugen cornerpush friction is hardcoded at 0.7
 				// In Ikemen the cornerpush friction is defined by the target instead
 				if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
-					friction = 0.7
+					pushmul = 0.7
 				} else {
 					if p[0].ss.stateType == ST_C || p[0].ss.stateType == ST_L {
-						friction = p[0].gi().movement.crouch.friction
+						pushmul = p[0].gi().movement.crouch.friction
 					} else {
-						friction = p[0].gi().movement.stand.friction
+						pushmul = p[0].gi().movement.stand.friction
 					}
 				}
 			}
@@ -7862,15 +7862,17 @@ func (c *Char) posUpdate() {
 		}
 	}
 
+	originLs := c.localscl * (320 / float32(sys.gameWidth))
+
 	// Apply physics types
 	switch c.ss.physics {
 	case ST_S:
 		c.vel[0] *= c.gi().movement.stand.friction
-		if AbsF(c.vel[0]) < 1 {
+		if AbsF(c.vel[0]) < 1 / originLs { // TODO: These probably shouldn't be hardcoded
 			c.vel[0] = 0
 		}
 		c.vel[2] *= c.gi().movement.stand.friction
-		if AbsF(c.vel[2]) < 1 {
+		if AbsF(c.vel[2]) < 1 / originLs {
 			c.vel[2] = 0
 		}
 	case ST_C:
@@ -7882,8 +7884,8 @@ func (c *Char) posUpdate() {
 
 	// Apply friction to corner push
 	if sys.supertime == 0 {
-		c.cornerVelOff *= friction
-		if AbsF(c.cornerVelOff) < 1 {
+		c.cornerVelOff *= pushmul
+		if AbsF(c.cornerVelOff) < 1 / originLs {
 			c.cornerVelOff = 0
 		}
 	}

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1029,7 +1029,7 @@ func (c *Compiler) modifyExplod(is IniSection, sc *StateControllerBase,
 	ihp int8) (StateController, error) {
 	ret, err := (*modifyExplod)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
-			explod_redirectid, VT_Int, 1, false); err != nil {
+			modifyexplod_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "index",
@@ -4945,10 +4945,6 @@ func (c *Compiler) modifyBGCtrl(is IniSection, sc *StateControllerBase, _ int8) 
 
 func (c *Compiler) modifyBGCtrl3d(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*modifyBGCtrl3d)(sc), c.stateSec(is, func() error {
-		if err := c.paramValue(is, sc, "redirectid",
-			modifyBGCtrl3d_redirectid, VT_Int, 1, false); err != nil {
-			return err
-		}
 		if err := c.paramValue(is, sc, "id",
 			modifyBGCtrl3d_ctrlid, VT_Int, 1, true); err != nil {
 			return err
@@ -5035,10 +5031,6 @@ func (c *Compiler) modifySnd(is IniSection, sc *StateControllerBase, _ int8) (St
 
 func (c *Compiler) modifyBgm(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*modifyBgm)(sc), c.stateSec(is, func() error {
-		if err := c.paramValue(is, sc, "redirectid",
-			modifyBgm_redirectid, VT_Int, 1, false); err != nil {
-			return err
-		}
 		if err := c.paramValue(is, sc, "volume",
 			modifyBgm_volume, VT_Int, 1, false); err != nil {
 			return err

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -2267,6 +2267,11 @@ func (c *Compiler) reversalDef(is IniSection, sc *StateControllerBase, _ int8) (
 		}); err != nil {
 			return err
 		}
+		if err := c.stateParam(is, "reversal.guardflag.not", false, func(data string) error {
+			return c.parseHitFlag(sc, reversalDef_reversal_guardflag_not, data)
+		}); err != nil {
+			return err
+		}
 		return c.hitDefSub(is, sc)
 	})
 	return *ret, err

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -2259,8 +2259,14 @@ func (c *Compiler) reversalDef(is IniSection, sc *StateControllerBase, _ int8) (
 		}
 		if attr == -1 {
 			return Error("ReversalDef reversal.attr not specified")
+		} else {
+			sc.add(reversalDef_reversal_attr, sc.iToExp(attr))
 		}
-		sc.add(reversalDef_reversal_attr, sc.iToExp(attr))
+		if err := c.stateParam(is, "reversal.guardflag", false, func(data string) error {
+			return c.parseHitFlag(sc, reversalDef_reversal_guardflag, data)
+		}); err != nil {
+			return err
+		}
 		return c.hitDefSub(is, sc)
 	})
 	return *ret, err

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -3307,6 +3307,10 @@ func (c *Compiler) hitOverride(is IniSection, sc *StateControllerBase, _ int8) (
 			hitOverride_keepstate, VT_Bool, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "forceguard",
+			hitOverride_forceguard, VT_Bool, 1, false); err != nil {
+			return err
+		}
 		return nil
 	})
 	return *ret, err

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -2279,20 +2279,30 @@ func (c *Compiler) reversalDef(is IniSection, sc *StateControllerBase, _ int8) (
 
 func (c *Compiler) modifyReversalDef(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*modifyReversalDef)(sc), c.stateSec(is, func() error {
-		attr := int32(-1)
 		var err error
 		if err = c.paramValue(is, sc, "redirectid",
 			modifyReversalDef_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
 		if err = c.stateParam(is, "reversal.attr", false, func(data string) error {
-			attr, err = c.attr(data, false)
-			return err
+			attr, err := c.attr(data, true)
+			if err != nil {
+				return err
+			}
+			sc.add(modifyReversalDef_reversal_attr, sc.iToExp(attr))
+			return nil
 		}); err != nil {
 			return err
 		}
-		if attr != -1 {
-			sc.add(modifyReversalDef_reversal_attr, sc.iToExp(attr))
+		if err := c.stateParam(is, "reversal.guardflag", false, func(data string) error {
+			return c.parseHitFlag(sc, modifyReversalDef_reversal_guardflag, data)
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "reversal.guardflag.not", false, func(data string) error {
+			return c.parseHitFlag(sc, modifyReversalDef_reversal_guardflag_not, data)
+		}); err != nil {
+			return err
 		}
 		return c.hitDefSub(is, sc)
 	})

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -3317,6 +3317,11 @@ func (c *Compiler) hitOverride(is IniSection, sc *StateControllerBase, _ int8) (
 		}); err != nil {
 			return err
 		}
+		if err := c.stateParam(is, "guardflag.not", false, func(data string) error {
+			return c.parseHitFlag(sc, hitOverride_guardflag_not, data)
+		}); err != nil {
+			return err
+		}
 		return nil
 	})
 	return *ret, err

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -504,7 +504,7 @@ func (hb *HealthBar) step(ref int, hbr *HealthBar) {
 	hb.top.Action()
 	hb.mid.Action()
 	// Multiple front elements - red life
-	if sys.lifebar.redlifebar {
+	if sys.chars[ref][0].redLifeEnabled() {
 		var rv int32
 		for k := range hb.red {
 			if k > rv && redVal >= k {
@@ -626,7 +626,9 @@ func (hb *HealthBar) draw(layerno int16, ref int, hbr *HealthBar, f []*Fnt) {
 			//rr[2] -= Min(rr[2], lr[2])
 		}
 	}
-	if sys.lifebar.redlifebar {
+
+	// Draw red life
+	if sys.chars[ref][0].redLifeEnabled() {
 		var rv int32
 		for k := range hb.red {
 			if k > rv && redval >= k {
@@ -1085,7 +1087,7 @@ func readGuardBar(pre string, is IniSection,
 }
 
 func (gb *GuardBar) step(ref int, gbr *GuardBar, snd *Snd) {
-	if !sys.lifebar.guardbar {
+	if !sys.chars[ref][0].guardBreakEnabled() {
 		return
 	}
 
@@ -1151,18 +1153,21 @@ func (gb *GuardBar) reset() {
 }
 
 func (gb *GuardBar) bgDraw(layerno int16) {
-	if !sys.lifebar.guardbar {
-		return
-	}
+	// Handled in outer loop
+	//if !sys.lifebar.guardbar {
+	//	return
+	//}
+
 	gb.bg0.Draw(float32(gb.pos[0])+sys.lifebarOffsetX, float32(gb.pos[1])+sys.lifebarOffsetY, layerno, sys.lifebarScale)
 	gb.bg1.Draw(float32(gb.pos[0])+sys.lifebarOffsetX, float32(gb.pos[1])+sys.lifebarOffsetY, layerno, sys.lifebarScale)
 	gb.bg2.Draw(float32(gb.pos[0])+sys.lifebarOffsetX, float32(gb.pos[1])+sys.lifebarOffsetY, layerno, sys.lifebarScale)
 }
 
 func (gb *GuardBar) draw(layerno int16, ref int, gbr *GuardBar, f []*Fnt) {
-	if !sys.lifebar.guardbar {
-		return
-	}
+	// Handled in outer loop
+	//if !sys.lifebar.guardbar {
+	//	return
+	//}
 
 	points := float32(sys.chars[ref][0].guardPoints) / float32(sys.chars[ref][0].guardPointsMax)
 	if gb.invertfill {
@@ -1317,7 +1322,7 @@ func readStunBar(pre string, is IniSection,
 }
 
 func (sb *StunBar) step(ref int, sbr *StunBar, snd *Snd) {
-	if !sys.lifebar.stunbar {
+	if !sys.chars[ref][0].dizzyEnabled() {
 		return
 	}
 
@@ -1381,18 +1386,21 @@ func (sb *StunBar) reset() {
 }
 
 func (sb *StunBar) bgDraw(layerno int16) {
-	if !sys.lifebar.stunbar {
-		return
-	}
+	// Handled in outer loop
+	//if !sys.lifebar.stunbar {
+	//	return
+	//}
+
 	sb.bg0.Draw(float32(sb.pos[0])+sys.lifebarOffsetX, float32(sb.pos[1])+sys.lifebarOffsetY, layerno, sys.lifebarScale)
 	sb.bg1.Draw(float32(sb.pos[0])+sys.lifebarOffsetX, float32(sb.pos[1])+sys.lifebarOffsetY, layerno, sys.lifebarScale)
 	sb.bg2.Draw(float32(sb.pos[0])+sys.lifebarOffsetX, float32(sb.pos[1])+sys.lifebarOffsetY, layerno, sys.lifebarScale)
 }
 
 func (sb *StunBar) draw(layerno int16, ref int, sbr *StunBar, f []*Fnt) {
-	if !sys.lifebar.stunbar {
-		return
-	}
+	// Handled in outer loop
+	//if !sys.lifebar.stunbar {
+	//	return
+	//}
 
 	points := float32(sys.chars[ref][0].dizzyPoints) / float32(sys.chars[ref][0].dizzyPointsMax)
 	if sb.invertfill {
@@ -4866,7 +4874,7 @@ func (l *Lifebar) draw(layerno int16) {
 			for ti := range sys.tmode {
 				for i, v := range l.order[ti] {
 					index := i*2 + ti
-					if !sys.chars[v][0].asf(ASF_noguardbardisplay) {
+					if sys.chars[v][0].guardBreakEnabled() && !sys.chars[v][0].asf(ASF_noguardbardisplay) {
 						l.gb[l.ref[ti]][index].bgDraw(layerno)
 						l.gb[l.ref[ti]][index].draw(layerno, v, l.gb[l.ref[ti]][v], l.fnt[:])
 					}
@@ -4876,7 +4884,7 @@ func (l *Lifebar) draw(layerno int16) {
 			for ti := range sys.tmode {
 				for i, v := range l.order[ti] {
 					index := i*2 + ti
-					if !sys.chars[v][0].asf(ASF_nostunbardisplay) {
+					if sys.chars[v][0].dizzyEnabled() && !sys.chars[v][0].asf(ASF_nostunbardisplay) {
 						l.sb[l.ref[ti]][index].bgDraw(layerno)
 						l.sb[l.ref[ti]][index].draw(layerno, v, l.sb[l.ref[ti]][v], l.fnt[:])
 					}

--- a/src/script.go
+++ b/src/script.go
@@ -5453,7 +5453,7 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "hitoverridden", func(*lua.LState) int {
-		l.Push(lua.LBool(sys.debugWC.hoIdx >= 0))
+		l.Push(lua.LBool(sys.debugWC.hoverIdx >= 0))
 		return 1
 	})
 	luaRegister(l, "ikemenversion", func(*lua.LState) int {

--- a/src/script.go
+++ b/src/script.go
@@ -3813,13 +3813,13 @@ func triggerFunctions(l *lua.LState) {
 		case "sparky":
 			l.Push(lua.LNumber(c.hitdef.sparkxy[1]))
 		case "pausetime":
-			l.Push(lua.LNumber(c.hitdef.pausetime))
+			l.Push(lua.LNumber(c.hitdef.pausetime[0]))
 		case "guard.pausetime":
-			l.Push(lua.LNumber(c.hitdef.guard_pausetime))
+			l.Push(lua.LNumber(c.hitdef.guard_pausetime[0]))
 		case "shaketime":
-			l.Push(lua.LNumber(c.hitdef.shaketime))
+			l.Push(lua.LNumber(c.hitdef.pausetime[1]))
 		case "guard.shaketime":
-			l.Push(lua.LNumber(c.hitdef.guard_shaketime))
+			l.Push(lua.LNumber(c.hitdef.guard_pausetime[1]))
 		case "hitsound.group":
 			l.Push(lua.LNumber(c.hitdef.hitsound[0]))
 		case "hitsound.number":


### PR DESCRIPTION
Features:
- HitOverride forceguard parameter: makes the hit be considered as guarded instead
- HitOverride guardflag parameter: will only override the hit if at least one flag matches the HitDef
- HitOverride guardflag.not parameter: will only override attacks without the flags specified
- ReversalDef guardflag parameter: same as HitOverride
- ReversalDef guardflag.not parameter: same as HitOverride

Fixes:
- Fixed friction threshold for hires characters being the same as 320x240 characters
- Fixed projectiles being drawn at pos 0, 0 if created during a pause
- Fixed redirectID unintentionally affecting the original char when ID is invalid
- Fixes #2506
- Fixes #2545
- Fixes #2551
- Fixes #2552

Refactor:
- Some ground work so that dizzy, guard break and red life can be configured by team mode in the future
- HitOverride should be a little more accurate to Mugen
- RedirectID cleanup. This was a bit of a repetitive task so some errors might appear