### PR TITLE
feat: animPlayerNo & spritePlayerNo ;fixes

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5551,11 +5551,11 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
 		case explod_anim:
-			apn := crun.playerNo
+			apn := crun.playerNo // Default to own player number
+			spn := crun.playerNo
 				if animPN != -1 {
 				apn = animPN
 			}
-			spn := crun.playerNo
 				if spritePN != -1 {
 				spn = spritePN
 			}
@@ -6258,12 +6258,12 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				})
 			case explod_anim:
 				if c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 { // You could not modify this one in Mugen
-					apn := crun.playerNo
+					apn := crun.playerNo // Default to own player number
+					spn := crun.playerNo
 					if animPN != -1 {
 						apn = animPN
 					}
-					spn := crun.playerNo
-						if spritePN != -1 {
+					if spritePN != -1 {
 						spn = spritePN
 					}
 					animNo := exp[1].evalI(c)

--- a/src/char.go
+++ b/src/char.go
@@ -3725,7 +3725,7 @@ func (c *Char) clearHitDef() {
 }
 
 func (c *Char) changeAnimEx(animNo int32, animPlayerNo int, spritePlayerNo int, ffx string, alt bool) {
-if a := sys.chars[animPlayerNo][0].getAnim(animNo, ffx, false); a != nil {
+	if a := sys.chars[animPlayerNo][0].getAnim(animNo, ffx, false); a != nil {
 		c.anim = a
 		c.anim.remap = c.remapSpr
 		c.animPN = animPlayerNo

--- a/src/common.go
+++ b/src/common.go
@@ -998,10 +998,10 @@ func (l *Layout) DrawFaceSprite(x, y float32, ln int16, s *Sprite, fx *PalFX, fs
 			}
 
 			var fwin [4]int32
-			fwin[0] = int32(float32(w[0]) * l.scale[0] * fscale)
-			fwin[1] = int32(float32(w[1]) * l.scale[1] * fscale)
-			fwin[2] = int32(float32(w[2]-w[0]) * l.scale[0] * fscale)
-			fwin[3] = int32(float32(w[3]-w[1]) * l.scale[1] * fscale)
+			fwin[0] = int32(float32(w[0]))
+			fwin[1] = int32(float32(w[1]) * fscale)
+			fwin[2] = int32(float32(w[2]))
+			fwin[3] = int32(float32(w[3]) * fscale)
 
 			drawwindow = &fwin
 		}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2286,6 +2286,10 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			opc = OC_ex2_explodvar_animelem
 		case "animelemtime":
 			opc = OC_ex2_explodvar_animelemtime
+		case "animplayerno":
+			opc = OC_ex2_explodvar_animplayerno
+		case "spriteplayerno":
+			opc = OC_ex2_explodvar_spriteplayerno
 		case "bindtime":
 			opc = OC_ex2_explodvar_bindtime
 		case "drawpal":

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -357,6 +357,7 @@ var triggerMap = map[string]int{
 	"animelemvar":        1,
 	"animlength":         1,
 	"animplayerno":       1,
+	"spriteplayerno":     1,
 	"atan2":              1,
 	"attack":             1,
 	"bgmvar":             1,
@@ -4196,6 +4197,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_ex_, OC_ex_animlength)
 	case "animplayerno":
 		out.append(OC_ex_, OC_ex_animplayerno)
+	case "spriteplayerno":
+		out.append(OC_ex_, OC_ex_spriteplayerno)
 	case "attack":
 		out.append(OC_ex_, OC_ex_attack)
 	case "combocount":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -990,6 +990,14 @@ func (c *Compiler) explod(is IniSection, sc *StateControllerBase,
 			explod_animelemtime, VT_Int, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "animplayerno",
+			explod_animplayerno, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "spriteplayerno",
+			explod_spriteplayerno, VT_Int, 1, false); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "animfreeze",
 			explod_animfreeze, VT_Bool, 1, false); err != nil {
 			return err
@@ -1052,6 +1060,14 @@ func (c *Compiler) modifyExplod(is IniSection, sc *StateControllerBase,
 		}
 		if err := c.paramValue(is, sc, "animelemtime",
 			explod_animelemtime, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "animplayerno",
+			explod_animplayerno, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "spriteplayerno",
+			explod_spriteplayerno, VT_Int, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "animfreeze",

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -534,6 +534,14 @@ func (c *Compiler) changeAnimSub(is IniSection,
 		changeAnim_redirectid, VT_Int, 1, false); err != nil {
 		return err
 	}
+	if err := c.paramValue(is, sc, "animplayerno",
+		changeAnim_animplayerno, VT_Int, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "spriteplayerno",
+		changeAnim_spriteplayerno, VT_Int, 1, false); err != nil {
+		return err
+	}
 	if err := c.paramValue(is, sc, "readplayerid",
 		changeAnim_readplayerid, VT_Int, 1, false); err != nil {
 		return err

--- a/src/script.go
+++ b/src/script.go
@@ -627,7 +627,7 @@ func systemScriptInit(l *lua.LState) {
 			if ffx {
 				preffix = "f"
 			}
-			c[0].changeAnim(an, c[0].playerNo, preffix)
+			c[0].changeAnim(an, c[0].playerNo, -1, preffix)
 			if !nilArg(l, 2) {
 				c[0].setAnimElem(int32(numArg(l, 2)), 0)
 			}
@@ -6054,7 +6054,7 @@ func deprecatedFunctions(l *lua.LState) {
 				if ffx {
 					preffix = "f"
 				}
-				c[0].changeAnim(an, c[0].playerNo, preffix)
+				c[0].changeAnim(an, c[0].playerNo, -1, preffix)
 				if l.GetTop() >= 3 {
 					c[0].setAnimElem(int32(numArg(l, 3)), 0)
 				}

--- a/src/script.go
+++ b/src/script.go
@@ -3690,6 +3690,12 @@ func triggerFunctions(l *lua.LState) {
 					ln = lua.LNumber(e.anglerot[2] + e.interpolate_angle[2])
 				case "animelem":
 					ln = lua.LNumber(e.anim.curelem + 1)
+				case "animelemtime":
+					ln = lua.LNumber(e.anim.curelemtime)
+				case "animplayerno":
+					ln = lua.LNumber(e.animPN + 1)
+				case "spriteplayerno":
+					ln = lua.LNumber(e.spritePN + 1)
 				case "bindtime":
 					ln = lua.LNumber(e.bindtime)
 				case "drawpal group":


### PR DESCRIPTION
Feat: 
 - AnimPlayerNo and SpritePlayerNo added to Explods and ChangeAnim
   - Allows using animations and sprites from another player. i.e:
   ```ini
   [State -3]
   Type = Explod
   Anim = 800
   AnimPlayerNo = p2,playerNo
   SpritePlayerNo = p2,playerNo
   ```
   - In ChangeAnim, it's now possible to change only the animation or only the sprites independently:
   ```ini
   [State -3]
   Type = ChangeAnim
   Value = stateOwner,anim
   AnimPlayerNo = stateOwner,playerNo
   ```
   If not declared, both AnimPlayerNo and SpritePlayerNo default to playerNo

- Added SpritePlayerNo trigger
- Added ExplodVar SpritePlayerNo

Fix:

- Face window multiplying incorrectly, causing arbitrary values
- Color parameter in ModifyShadow crashing when fewer than 3 values were provided
- Missing AnimElemTime from script.go
