### PR TITLE
feat: X/Y Truncate setting

### DIFF
--- a/data/system.base.def
+++ b/data/system.base.def
@@ -1652,6 +1652,7 @@
 	menu.itemname.menuvideo.resolution.back = "Back"
 	menu.itemname.menuvideo.fullscreen = "Fullscreen"
 	menu.itemname.menuvideo.keepaspect = "Keep Aspect Ratio"
+	menu.itemname.menuvideo.xytruncate = "X/Y Rounding"
 	menu.itemname.menuvideo.windowscalemode = "Bilinear Filtering"
 	menu.itemname.menuvideo.vsync = "VSync"
 	menu.itemname.menuvideo.msaa = "MSAA"

--- a/external/script/motif.lua
+++ b/external/script/motif.lua
@@ -2041,6 +2041,7 @@ function motif.setBaseOptionInfo()
 	motif.option_info.menu_itemname_menuvideo_fullscreen = "Fullscreen"
 	motif.option_info.menu_itemname_menuvideo_vsync = "VSync"
 	motif.option_info.menu_itemname_menuvideo_keepaspect = "Keep Aspect Ratio"
+	motif.option_info.menu_itemname_menuvideo_xytruncate = "X/Y Rounding"
 	motif.option_info.menu_itemname_menuvideo_windowscalemode = "Bilinear Filtering"
 	motif.option_info.menu_itemname_menuvideo_msaa = "MSAA"
 	motif.option_info.menu_itemname_menuvideo_shaders = "Shaders" --reserved submenu
@@ -2175,6 +2176,7 @@ function motif.setBaseOptionInfo()
 		"menuvideo_fullscreen",
 		"menuvideo_vsync",
 		"menuvideo_keepaspect",
+		"menuvideo_xytruncate",
 		"menuvideo_windowscalemode",
 		"menuvideo_msaa",
 		"menuvideo_shaders",

--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -213,7 +213,8 @@ options.t_itemname = {
 			--modifyGameOption('Video.WindowCentered', true)
 			modifyGameOption('Video.ExternalShaders', {})
 			modifyGameOption('Video.WindowScaleMode', true)
-			modifyGameOption('Video.KeepAspect', true)	
+			modifyGameOption('Video.KeepAspect', true)
+			modifyGameOption('Video.XyTruncate', true)
 			modifyGameOption('Video.EnableModel', true)
 			modifyGameOption('Video.EnableModelShadow', true)
 			--modifyGameOption('Sound.SampleRate', 44100)
@@ -939,6 +940,20 @@ options.t_itemname = {
 		end
 		return true
 	end,
+	--X/Y Trunccate
+	['xytruncate'] = function(t, item, cursorPosY, moveTxt)
+		if main.f_input(main.t_players, {'$F', '$B', 'pal', 's'}) then
+			sndPlay(motif.files.snd_data, motif.option_info.cursor_move_snd[1], motif.option_info.cursor_move_snd[2])
+			if gameOption('Video.XyTruncate') then
+				modifyGameOption('Video.XyTruncate', false)
+			else
+				modifyGameOption('Video.XyTruncate', true)
+			end
+			t.items[item].vardisplay = options.f_boolDisplay(gameOption('Video.XyTruncate'), motif.option_info.menu_valuename_enabled, motif.option_info.menu_valuename_disabled)
+			options.modified = true
+		end
+		return true
+	end,
 	--Shaders (submenu)
 	['shaders'] = function(t, item, cursorPosY, moveTxt)
 		if main.f_input(main.t_players, {'$F', '$B', 'pal', 's'}) then
@@ -1551,6 +1566,9 @@ options.t_vardisplay = {
 	end,
 	['windowscalemode'] = function()
 		return options.f_boolDisplay(gameOption('Video.WindowScaleMode'), motif.option_info.menu_valuename_enabled, motif.option_info.menu_valuename_disabled)
+	end,
+	['xytruncate'] = function()
+		return options.f_boolDisplay(gameOption('Video.XyTruncate'), motif.option_info.menu_valuename_enabled, motif.option_info.menu_valuename_disabled)
 	end,
 }
 

--- a/src/config.go
+++ b/src/config.go
@@ -165,6 +165,7 @@ type Config struct {
 		ExternalShaders         []string `ini:"ExternalShaders"`
 		WindowScaleMode         bool     `ini:"WindowScaleMode"`
 		KeepAspect              bool     `ini:"KeepAspect"`
+		XyTruncate              bool     `ini:"XyTruncate"`
 		EnableModel             bool     `ini:"EnableModel"`
 		EnableModelShadow       bool     `ini:"EnableModelShadow"`
 	} `ini:"Video"`

--- a/src/render.go
+++ b/src/render.go
@@ -407,6 +407,11 @@ func rmInitSub(rp *RenderParams) {
 		rp.y *= -1
 	}
 	rp.y += rp.rcy
+
+	if sys.cfg.Video.XyTruncate {
+		rp.x = float32(int(rp.x))
+		rp.y = float32(int(rp.y))
+	}
 }
 
 func BlendReset() {

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -214,6 +214,9 @@ ExternalShaders   =
 WindowScaleMode   = 1
 ; Toggles Keep Aspect mode.
 KeepAspect        = 1
+; Toggles whether or not to truncate X/Y coordinates to whole numbers when rendering.
+; Helps to solve "blurring" artifacts, particularly on lower resolution characters.
+XyTruncate        = 1
 ; Toggles 3D Model support.
 EnableModel       = 1
 ; Toggles 3D Model Shadow support.


### PR DESCRIPTION
This commit adds a new video setting called _X/Y Truncate_ or _X/Y Rounding_. When enabled, it will forcibly clamp the X and Y coords of all 2D assets to integer numbers just before they get rendered to the screen. (e.g. [152.49, 202.17] becomes [152.00, 202.00]). **This is purely visual; the underlying coordinates for the characters remain the same.**

This helps to deal with a sort of "blurring" artifact that occurs on low-res characters when playing with MSAA on, which is particularly noticeable when doing short dashes by characters such as Kung Fu Man.

https://github.com/user-attachments/assets/5d40a5fd-f588-41d5-b980-081d9326f2de

The reason I made this an option is that it may also cause off-by-one-pixel effects in certain cases (namely screenpacks), and thus it can't just be something that's done all the time. Still, it's enough of an improvement that I opted to enable it by default.