### PR TITLE
fix: changeAnim not using prefix anims, face window, playerNo validation

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -4187,18 +4187,6 @@ func getRedirectedChar(c *Char, sc StateControllerBase, redirectID byte, scname 
 	return crun
 }
 
-func validatePlayerNo(c *Char, pn int, pname, scname string) bool {
-	valid := pn >= 0 &&
-		pn < len(sys.chars) &&
-		len(sys.chars[pn]) > 0 &&
-		sys.chars[pn][0] != nil
-	if !valid {
-		sys.appendToConsole(c.warn() + fmt.Sprintf("Invalid %s for %s: %v", pname, scname, pn+1))
-		return false
-	}
-	return true
-}
-
 type stateDef StateControllerBase
 
 const (
@@ -4863,12 +4851,12 @@ func (sc changeAnim) Run(c *Char, _ []int32) bool {
 			}
 		case changeAnim_animplayerno:
 			pn := int(exp[0].evalI(c)) - 1
-			if validatePlayerNo(c, pn, "animPlayerNo", "changeAnim") {
+			if crun.validatePlayerNo(pn, "animPlayerNo", "changeAnim") {
 				animPN = pn
 			}
 		case changeAnim_spriteplayerno:
 			pn := int(exp[0].evalI(c)) - 1
-			if validatePlayerNo(c, pn, "spritePlayerNo", "changeAnim") {
+			if crun.validatePlayerNo(pn, "spritePlayerNo", "changeAnim") {
 				spritePN = pn
 			}
 		case changeAnim_readplayerid:
@@ -5579,12 +5567,12 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 			e.setAnim(e.animNo, apn, spn, ffx)
 		case explod_animplayerno:
 			pn := int(exp[0].evalI(c)) - 1
-			if validatePlayerNo(c, pn, "animPlayerNo", "Explod") {
+			if crun.validatePlayerNo(pn, "animPlayerNo", "Explod") {
 				animPN = pn
 			}
 		case explod_spriteplayerno:
 			pn := int(exp[0].evalI(c)) - 1
-			if validatePlayerNo(c, pn, "spritePlayerNo", "Explod") {
+			if crun.validatePlayerNo(pn, "spritePlayerNo", "Explod") {
 				spritePN = pn
 			}
 		case explod_ownpal:
@@ -5923,12 +5911,12 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 			}
 		case explod_animplayerno:
 			pn := int(exp[0].evalI(c)) - 1
-			if validatePlayerNo(c, pn, "animPlayerNo", "modifyExplod") {
+			if crun.validatePlayerNo(pn, "animPlayerNo", "modifyExplod") {
 				animPN = pn
 			}
 		case explod_spriteplayerno:
 			pn := int(exp[0].evalI(c)) - 1
-			if validatePlayerNo(c, pn, "spritePlayerNo", "modifyExplod") {
+			if crun.validatePlayerNo(pn, "spritePlayerNo", "modifyExplod") {
 				spritePN = pn
 			}
 		case explod_remappal:

--- a/src/char.go
+++ b/src/char.go
@@ -3744,23 +3744,23 @@ func (c *Char) changeAnimEx(animNo int32, animPlayerNo int, spritePlayerNo int, 
 			}
 		}
 
-		a.sff = sys.cgi[c.spritePN].sff
-		a.palettedata = &sys.cgi[c.spritePN].palettedata.palList
+		if ffx == "" {
+			a.sff = sys.cgi[c.spritePN].sff
+			a.palettedata = &sys.cgi[c.spritePN].palettedata.palList
+			if c.playerNo != c.spritePN {
+				ownerChar := sys.chars[c.spritePN][0]
+				ownerPal := ownerChar.drawPal()
+				key := [2]int16{int16(ownerPal[0]), int16(ownerPal[1])}
 
-		if c.playerNo != c.spritePN {
-			ownerChar := sys.chars[c.spritePN][0]
-			ownerPal := ownerChar.drawPal()
-			key := [2]int16{int16(ownerPal[0]), int16(ownerPal[1])}
-
-			if di, ok := a.palettedata.PalTable[key]; ok {
-				for _, id := range [...]int32{0, 9000} {
-					if spr := a.sff.GetSprite(int16(id), 0); spr != nil {
-						a.palettedata.Remap(spr.palidx, di)
+				if di, ok := a.palettedata.PalTable[key]; ok {
+					for _, id := range [...]int32{0, 9000} {
+						if spr := a.sff.GetSprite(int16(id), 0); spr != nil {
+							a.palettedata.Remap(spr.palidx, di)
+						}
 					}
 				}
 			}
 		}
-
 		// Update animation local scale
 		c.animlocalscl = 320 / sys.chars[c.animPN][0].localcoord
 		// Clsn scale depends on the animation owner's scale, so it must be updated
@@ -3814,6 +3814,16 @@ func (c *Char) setAnimElem(elem, elemtime int32) {
 	// Set them
 	c.anim.SetAnimElem(elem, elemtime)
 	c.updateCurFrame()
+}
+
+func (c *Char) validatePlayerNo(pn int, pname, scname string) bool {
+	valid := pn >= 0 && pn < len(sys.chars) &&
+		len(sys.chars[pn]) > 0 && sys.chars[pn][0] != nil
+	if !valid {
+		sys.appendToConsole(c.warn() + fmt.Sprintf("Invalid %s for %s: %v", pname, scname, pn+1))
+		return false
+	}
+	return true
 }
 
 func (c *Char) setCtrl(ctrl bool) {

--- a/src/common.go
+++ b/src/common.go
@@ -990,12 +990,6 @@ func (l *Layout) DrawFaceSprite(x, y float32, ln int16, s *Sprite, fx *PalFX, fs
 
 		if *window != sys.scrrect {
 			w := window
-			if w[0] > w[2] {
-				w[0], w[2] = w[2], w[0]
-			}
-			if w[1] > w[3] {
-				w[1], w[3] = w[3], w[1]
-			}
 
 			var fwin [4]int32
 			fwin[0] = int32(float32(w[0]))


### PR DESCRIPTION
Fix:
 - ChangeAnim can read animations with a prefix again
 - x and y of the face window
 - The validation function of playerno for anim/spriteplayerno was moved to char.go so it doesn’t interfere with parameter execution in the bytecode anymore