### PR TITLE
fix: Use rounding in X/Y Truncate, fix inconsistent display name

### DIFF
--- a/data/system.base.def
+++ b/data/system.base.def
@@ -1652,7 +1652,7 @@
 	menu.itemname.menuvideo.resolution.back = "Back"
 	menu.itemname.menuvideo.fullscreen = "Fullscreen"
 	menu.itemname.menuvideo.keepaspect = "Keep Aspect Ratio"
-	menu.itemname.menuvideo.xytruncate = "X/Y Rounding"
+	menu.itemname.menuvideo.xytruncate = "X/Y Truncate"
 	menu.itemname.menuvideo.windowscalemode = "Bilinear Filtering"
 	menu.itemname.menuvideo.vsync = "VSync"
 	menu.itemname.menuvideo.msaa = "MSAA"

--- a/external/script/motif.lua
+++ b/external/script/motif.lua
@@ -2041,7 +2041,7 @@ function motif.setBaseOptionInfo()
 	motif.option_info.menu_itemname_menuvideo_fullscreen = "Fullscreen"
 	motif.option_info.menu_itemname_menuvideo_vsync = "VSync"
 	motif.option_info.menu_itemname_menuvideo_keepaspect = "Keep Aspect Ratio"
-	motif.option_info.menu_itemname_menuvideo_xytruncate = "X/Y Rounding"
+	motif.option_info.menu_itemname_menuvideo_xytruncate = "X/Y Truncate"
 	motif.option_info.menu_itemname_menuvideo_windowscalemode = "Bilinear Filtering"
 	motif.option_info.menu_itemname_menuvideo_msaa = "MSAA"
 	motif.option_info.menu_itemname_menuvideo_shaders = "Shaders" --reserved submenu

--- a/src/render.go
+++ b/src/render.go
@@ -409,8 +409,9 @@ func rmInitSub(rp *RenderParams) {
 	rp.y += rp.rcy
 
 	if sys.cfg.Video.XyTruncate {
-		rp.x = float32(int(rp.x))
-		rp.y = float32(int(rp.y))
+		// math.Round only accepts float64s, hence the need for conversion
+		rp.x = float32(int(math.Round(float64(rp.x))))
+		rp.y = float32(int(math.Round(float64(rp.y))))
 	}
 }
 


### PR DESCRIPTION
Some feedback in the Discord showed that X/Y Trunc would produce jitter in cases where something just *barely* crosses from 1 to 0.9999 or similar. Using math.Round should make results less "jittery" while still keeping things reasonably clean-looking in most cases.