### PR TITLE
fix: common FX prefixes; several refactors

### DIFF
--- a/src/anim.go
+++ b/src/anim.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"sort"
 	"strings"
 )
 
@@ -971,6 +972,9 @@ func (dl *DrawList) add(sd *SprData) {
 		return
 	}
 
+	// Before: sort every time we add a sprite
+	// After: add all sprites first then sort before drawing
+	/*
 	i, start := 0, 0
 	for l := len(*dl); l > 0; {
 		i = start + l>>1
@@ -987,9 +991,24 @@ func (dl *DrawList) add(sd *SprData) {
 	*dl = append(*dl, nil)
 	copy((*dl)[i+1:], (*dl)[i:])
 	(*dl)[i] = sd
+	*/
+
+	// Just append. We will sort everything later in one go
+	*dl = append(*dl, sd)
 }
 
 func (dl DrawList) draw(cameraX, cameraY, cameraScl float32) {
+	// Sort drawing order
+	sort.Slice(dl, func(i, j int) bool {
+		// If different priority, draw lower priority first
+		if dl[i].priority != dl[j].priority {
+			return dl[i].priority < dl[j].priority
+		}
+		// Else draw newer sprite first
+		return i > j
+	})
+
+	// Draw the entire list
 	for _, s := range dl {
 		// Skip blank SprData
 		// https://github.com/ikemen-engine/Ikemen-GO/issues/2433
@@ -1083,6 +1102,7 @@ func (sl *ShadowList) add(ss *ShadowSprite) {
 		return
 	}
 
+	/*
 	i, start := 0, 0
 	for l := len(*sl); l > 0; {
 		i = start + l>>1
@@ -1099,11 +1119,23 @@ func (sl *ShadowList) add(ss *ShadowSprite) {
 	*sl = append(*sl, nil)
 	copy((*sl)[i+1:], (*sl)[i:])
 	(*sl)[i] = ss
+	*/
+
+	// Just append. We will sort everything later in one go
+	*sl = append(*sl, ss)
 }
 
 func (sl ShadowList) draw(x, y, scl float32) {
-	for _, s := range sl {
+	// Sort drawing order
+	sort.Slice(sl, func(i, j int) bool {
+		if sl[i].priority != sl[j].priority {
+			return sl[i].priority < sl[j].priority
+		}
+		return i > j
+	})
 
+	// Draw the entire list
+	for _, s := range sl {
 		// Skip blank shadows
 		if s == nil || s.anim == nil || s.anim.isBlank() {
 			continue

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -2990,7 +2990,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_ishost:
 		sys.bcStack.PushB(c.isHost())
 	case OC_ex_jugglepoints:
-		*sys.bcStack.Top() = c.jugglePoints(*sys.bcStack.Top())
+		v1 := sys.bcStack.Pop()
+		sys.bcStack.PushI(c.jugglePoints(v1.ToI()))
 	case OC_ex_localcoord_x:
 		sys.bcStack.PushF(sys.cgi[c.playerNo].localcoord[0])
 	case OC_ex_localcoord_y:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -12981,30 +12981,7 @@ func (sc targetAdd) Run(c *Char, _ []int32) bool {
 		return true
 	})
 
-	// Check if ID exists
-	if pid > 0 {
-		for i := range sys.chars {
-			for j := range sys.chars[i] {
-				if sys.chars[i][j].id == pid {
-					// Add target to char's "target" list
-					// This function already prevents duplicating targets
-					crun.addTarget(pid)
-					// Add char to target's "targeted by" list
-					// Keep juggle points if target already exists
-					jug := crun.gi().data.airjuggle
-					for _, v := range sys.chars[i][j].ghv.targetedBy {
-						if v[0] == crun.id {
-							jug = v[1]
-						}
-					}
-					// Remove then readd char to the list with the new juggle points
-					sys.chars[i][j].ghv.dropId(crun.id)
-					sys.chars[i][j].ghv.targetedBy = append(sys.chars[i][j].ghv.targetedBy, [...]int32{crun.id, jug})
-					break
-				}
-			}
-		}
-	}
+	crun.targetAddSctrl(pid)
 
 	return false
 }

--- a/src/char.go
+++ b/src/char.go
@@ -8520,7 +8520,12 @@ func (c *Char) attrCheck(getter *Char, ghd *HitDef, gstyp StateType) bool {
 	//if ghd.chainid < 0 {
 
 	// ReversalDef vs HitDef attributes check
-	if ghd.reversal_attr > 0 && c.hitdef.attr > 0 && c.atktmp != 0 {
+	if ghd.reversal_attr > 0 {
+		// Check HitDef validity
+		if c.hitdef.attr <= 0 || c.atktmp == 0 {
+			return false
+		}
+
 		// Check attributes
 		if (c.hitdef.attr&ghd.reversal_attr&int32(ST_MASK)) == 0 ||
 			(c.hitdef.attr&ghd.reversal_attr&^int32(ST_MASK)) == 0 {

--- a/src/char.go
+++ b/src/char.go
@@ -4376,22 +4376,19 @@ func (c *Char) isHost() bool {
 	return sys.netConnection != nil && sys.netConnection.host
 }
 
-func (c *Char) jugglePoints(hid BytecodeValue) BytecodeValue {
-	if hid.IsSF() {
-		return BytecodeSF()
-	}
-	tid := hid.ToI()
+func (c *Char) jugglePoints(id int32) int32 {
 	max := c.gi().data.airjuggle
-	jp := max // If no target is found it returns the char's maximum juggle points
+
+	// Check if ID is already a target
 	for _, ct := range c.targets {
-		if ct >= 0 {
-			t := sys.playerID(ct)
-			if t != nil && t.id == tid {
-				jp = t.ghv.getJuggle(c.id, max)
-			}
+		t := sys.playerID(ct)
+		if t != nil && t.id == id {
+			return t.ghv.getJuggle(c.id, max)
 		}
 	}
-	return BytecodeInt(jp)
+
+	// If no target is found we just return the char's maximum juggle points
+	return max
 }
 
 func (c *Char) leftEdge() float32 {

--- a/src/char.go
+++ b/src/char.go
@@ -5446,7 +5446,7 @@ func (c *Char) destroy() {
 		}
 		// Remove ID from children
 		for _, ch := range c.children {
-			if ch != nil {
+			if ch != nil && ch.parentIndex > 0 {
 				ch.parentIndex *= -1
 			}
 		}
@@ -5767,6 +5767,10 @@ func (c *Char) removeExplod(id, idx int32) {
 	remove(&sys.explodsLayerN1[c.playerNo], true)
 	remove(&sys.explodsLayer0[c.playerNo], true)
 	remove(&sys.explodsLayer1[c.playerNo], false)
+
+	// Ontop/layer 1 explod indexes are not removed (drop = false) to preserve Mugen drawing order
+	// TODO: This is obsolete with our current logic and may not be working correctly in the first place
+	// The same also happens in system.go
 }
 
 func (c *Char) getAnim(n int32, ffx string, fx bool) (a *Animation) {
@@ -7488,8 +7492,8 @@ func (c *Char) getPalfx() *PalFX {
 		}
 	}
 	c.palfx = newPalFX()
-	// Mugen 1.1 behavior if invertblend param is omitted(Only if char mugenversion = 1.1)
-	if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 && c.palfx != nil {
+	// Mugen 1.1 behavior if invertblend param is omitted (only if char mugenversion = 1.1)
+	if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 && c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 && c.palfx != nil {
 		c.palfx.PalFXDef.invertblend = -2
 	}
 	return c.palfx

--- a/src/char.go
+++ b/src/char.go
@@ -8024,6 +8024,23 @@ func (c *Char) hasTargetOfHitdef(id int32) bool {
 	return false
 }
 
+func (c *Char) targetAddSctrl(id int32) {
+	// Check if ID exists
+	t := sys.playerID(id)
+	if t == nil {
+		sys.appendToConsole(c.warn() + fmt.Sprintf("Invalid player ID for TargetAdd: %v", id))
+		return
+	}
+
+	// Add target to char's "target" list
+	// These two functions already prevent duplicating players
+	c.addTarget(id)
+
+	// Add original char to target's "targeted by" list
+	t.ghv.addId(c.id, c.gi().data.airjuggle)
+}
+
+
 func (c *Char) setBindTime(time int32) {
 	c.bindTime = time
 	if time == 0 {

--- a/src/char.go
+++ b/src/char.go
@@ -5820,16 +5820,18 @@ func (c *Char) getAnim(n int32, ffx string, fx bool) (a *Animation) {
 
 // Position functions
 func (c *Char) setPosX(x float32) {
-	if c.pos[0] != x {
-		c.pos[0] = x
-		// We do this because Mugen is very sensitive to enemy position changes
-		// Perhaps what it does is only calculate who "enemynear" is when the trigger is called?
-		// "P2" enemy reference is less sensitive than this however
-		if c.playerFlag {
-			sys.charList.enemyNearChanged = true
-		} else {
-			c.enemyNearP2Clear()
-		}
+	if c.pos[0] == x {
+		return
+	}
+
+	c.pos[0] = x
+	// We do this because Mugen is very sensitive to enemy position changes
+	// Perhaps what it does is only calculate who "enemynear" is when the trigger is called?
+	// "P2" enemy reference is less sensitive than this however, and seems to update only once per frame
+	if c.playerFlag {
+		sys.charList.enemyNearChanged = true
+	} else {
+		c.enemyNearP2Clear()
 	}
 }
 
@@ -5838,6 +5840,10 @@ func (c *Char) setPosY(y float32) { // This function mostly exists right now so 
 }
 
 func (c *Char) setPosZ(z float32) {
+	if c.pos[2] == z {
+		return
+	}
+
 	c.pos[2] = z
 	// Z distance is also factored into enemy near lists
 	if sys.zEnabled() {
@@ -11019,7 +11025,10 @@ func (cl *CharList) hitDetectionPlayer(getter *Char) {
 	}
 
 	getter.unsetCSF(CSF_gethit)
-	getter.enemyNearP2Clear()
+
+	// This forces an enemy list cache reset every frame
+	// Has a perfomance impact and is probably not necessary in the current state of the code
+	//getter.enemyNearP2Clear()
 
 	for _, c := range cl.runOrder {
 

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -5522,10 +5522,18 @@ func (c *Compiler) getDataPrefix(data *string, ffxDefault bool) (prefix string) 
 	if len(*data) > 1 {
 		str := strings.ToLower(*data)
 
-		// Find the longest matching reserved prefix at the start of the string
-		// This allows "FFF" to be used even though "F" is reserved
+		// Find the longest matching valid prefix at the start of the string
+		// The length check allows "FFF" to be used even though "F" is reserved
 		longestMatch := ""
-		for _, p := range sys.ffxReserved {
+		// Check "F" and "S" reserved prefixes
+		if strings.HasPrefix(str, "f") {
+			longestMatch = "f"
+		}
+		if strings.HasPrefix(str, "s") {
+			longestMatch = "s"
+		}
+		// Check common FX prefixes currently in use
+		for p := range sys.ffx {
 			if strings.HasPrefix(str, p) && len(p) > len(longestMatch) {
 				longestMatch = p
 			}

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -89,8 +89,18 @@ func loadFightFx(def string, isGlobal bool) error {
 					return Error("A prefix must be declared")
 				}
 				prefix = strings.ToLower(prefix)
-				if prefix == "f" || prefix == "s" {
-					return Error(fmt.Sprintf("%v prefix is reserved for the system and cannot be used", strings.ToUpper(prefix)))
+				//if prefix == "f" || prefix == "s" {
+				//	return Error(fmt.Sprintf("%v prefix is reserved for the system and cannot be used", strings.ToUpper(prefix)))
+				//}
+				// Check if prefix overlaps a reserved one
+				for _, reserved := range sys.ffxReserved {
+					if prefix == reserved {
+						return Error(fmt.Sprintf("The %v prefix is already reserved for the system and cannot be used", strings.ToUpper(prefix)))
+					}
+				}
+				// Check if prefix conflicts with trigger names
+				if _, ok := triggerMap[prefix]; ok {
+					return Error(fmt.Sprintf("The %v prefix conflicts with an existing trigger name and cannot be used", strings.ToUpper(prefix)))
 				}
 				if ffx, ok := sys.ffx[prefix]; ok {
 					// グローバルFXは常に有効。キャラクターFXはカウントを増やす
@@ -153,7 +163,9 @@ func loadFightFx(def string, isGlobal bool) error {
 		a.start_scale = [...]float32{ffx.fx_scale, ffx.fx_scale}
 	}
 	if sys.ffx[prefix] == nil {
-		sys.ffxRegexp += "|^(" + prefix + ")"
+		// Add prefix to reserved list
+		//sys.ffxRegexp += "|^(" + prefix + ")"
+		sys.ffxReserved = append(sys.ffxReserved, prefix)
 	}
 	ffx.fileName = def
 	ffx.isGlobal = isGlobal

--- a/src/script.go
+++ b/src/script.go
@@ -5695,7 +5695,7 @@ func triggerFunctions(l *lua.LState) {
 		if !nilArg(l, 1) {
 			id = int32(numArg(l, 1))
 		}
-		l.Push(lua.LNumber(sys.debugWC.jugglePoints(BytecodeInt(id)).ToI()))
+		l.Push(lua.LNumber(sys.debugWC.jugglePoints(id)))
 		return 1
 	})
 	luaRegister(l, "lastplayerid", func(*lua.LState) int {

--- a/src/system.go
+++ b/src/system.go
@@ -49,7 +49,8 @@ var sys = System{
 	allPalFX:          *newPalFX(),
 	bgPalFX:           *newPalFX(),
 	ffx:               make(map[string]*FightFx),
-	ffxRegexp:         "^(f)|^(s)|^(go)",
+	//ffxRegexp:         "^(f)|^(s)|^(go)", // https://github.com/ikemen-engine/Ikemen-GO/issues/1620
+	ffxReserved:       []string{"f", "s"}, // GO is optionally added when loading gofx.def
 	sel:               *newSelect(),
 	keyState:          make(map[Key]bool),
 	match:             1,
@@ -107,7 +108,8 @@ type System struct {
 	lifebar                 Lifebar
 	cfg                     Config
 	ffx                     map[string]*FightFx
-	ffxRegexp               string
+	//ffxRegexp               string
+	ffxReserved             []string
 	sel                     Select
 	keyState                map[Key]bool
 	netConnection           *NetConnection

--- a/src/system.go
+++ b/src/system.go
@@ -50,7 +50,6 @@ var sys = System{
 	bgPalFX:           *newPalFX(),
 	ffx:               make(map[string]*FightFx),
 	//ffxRegexp:         "^(f)|^(s)|^(go)", // https://github.com/ikemen-engine/Ikemen-GO/issues/1620
-	ffxReserved:       []string{"f", "s"}, // GO is optionally added when loading gofx.def
 	sel:               *newSelect(),
 	keyState:          make(map[Key]bool),
 	match:             1,
@@ -108,8 +107,6 @@ type System struct {
 	lifebar                 Lifebar
 	cfg                     Config
 	ffx                     map[string]*FightFx
-	//ffxRegexp               string
-	ffxReserved             []string
 	sel                     Select
 	keyState                map[Key]bool
 	netConnection           *NetConnection


### PR DESCRIPTION
Fix:
- Fixed crash if text localcoord was set with only one value
- Fixed ReversalDef working against an inactive Clsn1 (regression)
- FX prefixes can now start with the reserved "F" or "S" as long as it's not an exact match
- FX prefixes can no longer overlap trigger names
- Fixes #1620

Refactor:
- Refactored EnemyNear sorting function to use Go's slice sorting method, making it more efficient and easier to read
- When using z axis, the "p2" enemy decision will be weighted towards enemies in the same z plane
- Similarly to enemynear, cleaned up action run and hit detection order decision loops
- Sprite draw order is now sorted in a single operation before drawing, rather than each time a sprite is added (again resorting to slice sorting)
- Cleaned up TargetAdd, JugglePoints and ButtonAssist codes