### PR TITLE
fix: explodvar not updating anim value, with modifyexplod

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6266,7 +6266,8 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 					eachExpl(func(e *Explod) {
 						e.animelem = 1
 						e.animelemtime = 0
-						e.setAnim(animNo, apn, spn, ffx)
+						e.animNo = animNo
+						e.setAnim(e.animNo, apn, spn, ffx)
 					})
 				}
 			case explod_animelem:


### PR DESCRIPTION
Fix:
- A small fix to make explodVar show the correct animation value of the explod again after modifying the anim value using modifyExplod