### PR TITLE
feat: AssertInput B/F, StageVar ikemenversion and mugenversion; fixes; refactor

### DIFF
--- a/data/training.zss
+++ b/data/training.zss
@@ -177,26 +177,16 @@ ignoreHitPause if gameMode = "training" {
 					}
 					# If dummy should move forward and player is not trying to move dummy manually
 					if map(_iksys_trainingDirection) = 1 {
-						if facing = 1 && inputTime(L) < 0 && inputTime(D) < 0 && inputTime(U) < 0 {
+						if inputTime(B) < 0 && inputTime(D) < 0 && inputTime(U) < 0 {
 							for i = 0; numHelper; 1 {
-								assertInput{flag: R; redirectID: helperIndex($i), ID} # Index 0 being the root
-							}
-						}
-						if facing = -1 && inputTime(R) < 0 && inputTime(D) < 0 && inputTime(U) < 0 {
-							for i = 0; numHelper; 1 {
-								assertInput{flag: L; redirectID: helperIndex($i), ID}
+								assertInput{flag: F; redirectID: helperIndex($i), ID} # Index 0 being the root
 							}
 						}
 					# If dummy should move backward and player is not trying to move dummy manually
 					} else if map(_iksys_trainingDirection) = -1 {
-						if facing = 1 && inputTime(R) < 0 && inputTime(D) < 0 && inputTime(U) < 0 {
+						if inputTime(F) < 0 && inputTime(D) < 0 && inputTime(U) < 0 {
 							for i = 0; numHelper; 1 {
-								assertInput{flag: L; redirectID: helperIndex($i), ID}
-							}
-						}
-						if facing = -1 && inputTime(L) < 0 && inputTime(D) < 0 && inputTime(U) < 0 {
-							for i = 0; numHelper; 1 {
-								assertInput{flag: R; redirectID: helperIndex($i), ID}
+								assertInput{flag: B; redirectID: helperIndex($i), ID}
 							}
 						}
 					}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -10691,6 +10691,8 @@ type assertInput StateControllerBase
 
 const (
 	assertInput_flag byte = iota
+	assertInput_flag_B
+	assertInput_flag_F
 	assertInput_redirectid
 )
 
@@ -10704,6 +10706,18 @@ func (sc assertInput) Run(c *Char, _ []int32) bool {
 		switch paramID {
 		case assertInput_flag:
 			crun.inputFlag |= InputBits(exp[0].evalI(c))
+		case assertInput_flag_B:
+			if crun.facing >= 0 {
+				crun.inputFlag |= IB_PL
+			} else {
+				crun.inputFlag |= IB_PR
+			}
+		case assertInput_flag_F:
+			if crun.facing >= 0 {
+				crun.inputFlag |= IB_PR
+			} else {
+				crun.inputFlag |= IB_PL
+			}
 		}
 		return true
 	})

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -394,6 +394,8 @@ const (
 	OC_const_displayname
 	OC_const_stagevar_info_author
 	OC_const_stagevar_info_displayname
+	OC_const_stagevar_info_ikemenversion
+	OC_const_stagevar_info_mugenversion
 	OC_const_stagevar_info_name
 	OC_const_stagevar_camera_boundleft
 	OC_const_stagevar_camera_boundright
@@ -2377,8 +2379,8 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 			p8.gi().nameLow == sys.stringPool[sys.workingState.playerNo].List[*(*int32)(unsafe.Pointer(&be[*i]))])
 		*i += 4
 	// StageVar
-	case OC_const_stagevar_info_name:
-		sys.bcStack.PushB(sys.stage.nameLow ==
+	case OC_const_stagevar_info_author:
+		sys.bcStack.PushB(sys.stage.authorLow ==
 			sys.stringPool[sys.workingState.playerNo].List[*(*int32)(
 				unsafe.Pointer(&be[*i]))])
 		*i += 4
@@ -2387,8 +2389,12 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 			sys.stringPool[sys.workingState.playerNo].List[*(*int32)(
 				unsafe.Pointer(&be[*i]))])
 		*i += 4
-	case OC_const_stagevar_info_author:
-		sys.bcStack.PushB(sys.stage.authorLow ==
+	case OC_const_stagevar_info_ikemenversion:
+		sys.bcStack.PushF(sys.stage.ikemenverF)
+	case OC_const_stagevar_info_mugenversion:
+		sys.bcStack.PushF(sys.stage.mugenverF)
+	case OC_const_stagevar_info_name:
+		sys.bcStack.PushB(sys.stage.nameLow ==
 			sys.stringPool[sys.workingState.playerNo].List[*(*int32)(
 				unsafe.Pointer(&be[*i]))])
 		*i += 4
@@ -3047,7 +3053,9 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_movecountered:
 		sys.bcStack.PushI(c.moveCountered())
 	case OC_ex_mugenversion:
-		sys.bcStack.PushF(c.mugenVersionF())
+		sys.bcStack.PushF(c.gi().mugenverF)
+		// Here the version is always checked directly in the character instead of the working state
+		// This is because in a custom state this trigger will be used to know the enemy's version rather than our own
 	case OC_ex_pausetime:
 		sys.bcStack.PushI(c.pauseTimeTrigger())
 	case OC_ex_physics:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6273,20 +6273,21 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 					})
 				}
 			case explod_animelem:
-				animelem := exp[0].evalI(c)
+				v1 := exp[0].evalI(c)
 				eachExpl(func(e *Explod) {
+					e.animelem = v1
+					e.animelemtime = 0
 					e.interpolate_animelem[1] = -1
-					e.animelem = animelem
 					if e.anim != nil {
 						e.anim.Action() // This being in this place can cause a nil animation crash
 					}
 					e.setAnimElem()
 				})
 			case explod_animelemtime:
-				animelemtime := exp[0].evalI(c)
+				v1 := exp[0].evalI(c)
 				eachExpl(func(e *Explod) {
 					//e.interpolate_animelem[1] = -1 // TODO: Check animelemtime and interpolation interaction
-					e.animelemtime = animelemtime
+					e.animelemtime = v1
 					e.setAnimElem()
 				})
 			case explod_animfreeze:

--- a/src/char.go
+++ b/src/char.go
@@ -10865,7 +10865,7 @@ func (cl *CharList) commandUpdate() {
 					c.autoTurn()
 				}
 				if (c.helperIndex == 0 || c.helperIndex > 0 && &c.cmd[0] != &root.cmd[0]) &&
-					c.cmd[0].InputUpdate(c.controller, int32(c.facing), sys.aiLevel[i], c.inputFlag, false) {
+					c.cmd[0].InputUpdate(c.controller, c.facing, sys.aiLevel[i], c.inputFlag, false) {
 					// Clear input buffers and skip the rest of the loop
 					// This used to apply only to the root, but that caused some issues with helper-based custom input systems
 					if c.inputWait() || c.asf(ASF_noinput) {
@@ -10900,7 +10900,7 @@ func (cl *CharList) commandUpdate() {
 					for i := range c.cmd {
 						extratime := Btoi(hpbuf || pausebuf) + Btoi(winbuf)
 						helperbug := c.helperIndex != 0 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0
-						c.cmd[i].Step(int32(c.facing), c.controller < 0, helperbug, hpbuf, pausebuf, extratime)
+						c.cmd[i].Step(c.controller < 0, helperbug, hpbuf, pausebuf, extratime)
 					}
 					// Enable AI cheated command
 					c.cpucmd = cheat

--- a/src/char.go
+++ b/src/char.go
@@ -1680,13 +1680,19 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 			sdwalp = 256
 		}
 		drawZoff := sys.posZtoYoffset(e.interPos[2], e.localscl)
+		// Add shadow sprite
 		sys.shadows.add(&ShadowSprite{
-			SprData:       sd,
-			shadowColor:   sdwclr,
-			shadowAlpha:   sdwalp,
-			shadowOffset:  [2]float32{0, sys.stage.sdw.yscale*drawZoff + drawZoff},
-			reflectOffset: [2]float32{0, sys.stage.reflection.yscale*drawZoff + drawZoff},
-			fadeOffset:    drawZoff,
+			SprData:      sd,
+			shadowColor:  sdwclr,
+			shadowAlpha:  sdwalp,
+			shadowOffset: [2]float32{0, sys.stage.sdw.yscale*drawZoff + drawZoff},
+			fadeOffset:   drawZoff,
+		})
+		// Add reflection sprite
+		sys.reflections.add(&ReflectionSprite{
+			SprData:        sd,
+			reflectOffset:  [2]float32{0, sys.stage.reflection.yscale*drawZoff + drawZoff},
+			fadeOffset:     drawZoff,
 		})
 	}
 	if sys.tickNextFrame() {
@@ -2319,11 +2325,17 @@ func (p *Projectile) cueDraw(oldVer bool) {
 		sdwclr := p.shadow[0]<<16 | p.shadow[1]&0xff<<8 | p.shadow[2]&0xff
 		if sdwclr != 0 {
 			drawZoff := sys.posZtoYoffset(p.interPos[2], p.localscl)
+			// Add shadow
 			sys.shadows.add(&ShadowSprite{
+				SprData:      sd,
+				shadowColor:  sdwclr,
+				shadowAlpha:  255,
+				shadowOffset: [2]float32{0, sys.stage.sdw.yscale*drawZoff + drawZoff},
+				fadeOffset:   drawZoff,
+			})
+			// Add reflection
+			sys.reflections.add(&ReflectionSprite{
 				SprData:       sd,
-				shadowColor:   sdwclr,
-				shadowAlpha:   255,
-				shadowOffset:  [2]float32{0, sys.stage.sdw.yscale*drawZoff + drawZoff},
 				reflectOffset: [2]float32{0, sys.stage.reflection.yscale*drawZoff + drawZoff},
 				fadeOffset:    drawZoff,
 			})
@@ -10701,6 +10713,7 @@ func (c *Char) cueDraw() {
 				sdwYscale := getYscale(c.shadowYscale, sys.stage.sdw.yscale)
 				refYscale := getYscale(c.reflectYscale, sys.stage.reflection.yscale)
 
+				// Add shadow to shadow list
 				sys.shadows.add(&ShadowSprite{
 					SprData:         sd,
 					shadowColor:     sdwclr,
@@ -10716,7 +10729,12 @@ func (c *Char) cueDraw() {
 					shadowRot:        c.shadowRot,
 					shadowProjection: int32(c.shadowProjection),
 					shadowfLength:    c.shadowfLength,
-					reflectColor:     reflectclr,
+					fadeOffset:       c.offsetY() + drawZoff,
+				})
+				// Add reflection to reflection list
+				sys.reflections.add(&ReflectionSprite{
+					SprData:         sd,
+					reflectColor:    reflectclr,
 					reflectIntensity: c.reflectIntensity,
 					reflectOffset: [2]float32{
 						c.reflectOffset[0] * c.localscl,

--- a/src/char.go
+++ b/src/char.go
@@ -1543,8 +1543,10 @@ func (e *Explod) update(oldVer bool, playerNo int) {
 			return
 		}
 	}
-	if e.bindtime != 0 && (e.space == Space_stage ||
-		(e.space == Space_screen && e.postype <= PT_P2)) {
+	// Bind explod to parent
+	// In Mugen this only happens if the explod is not paused, hence "act"
+	if act && e.bindtime != 0 &&
+		(e.space == Space_stage || (e.space == Space_screen && e.postype <= PT_P2)) {
 		if c := sys.playerID(e.bindId); c != nil {
 			e.pos[0] = c.interPos[0]*c.localscl/e.localscl + c.offsetX()*c.localscl/e.localscl
 			e.pos[1] = c.interPos[1]*c.localscl/e.localscl + c.offsetY()*c.localscl/e.localscl

--- a/src/char.go
+++ b/src/char.go
@@ -2367,6 +2367,7 @@ type CharGlobalInfo struct {
 	ikemenver               [3]uint16
 	ikemenverF              float32
 	mugenver                [2]uint16
+	mugenverF               float32
 	data                    CharData
 	velocity                CharVelocity
 	movement                CharMovement
@@ -4443,23 +4444,6 @@ func (c *Char) moveReversed() int32 {
 		return Abs(c.mctime)
 	}
 	return 0
-}
-
-// Mugen version trigger
-func (c *Char) mugenVersionF() float32 {
-	// Here the version is always checked directly in the character instead of the working state
-	// This is because in a custom state this trigger will be used to know the enemy's version rather than our own
-	if c.gi().ikemenver[0] != 0 || c.gi().ikemenver[1] != 0 {
-		return 1.1
-	} else if c.gi().mugenver[0] == 1 && c.gi().mugenver[1] == 1 {
-		return 1.1
-	} else if c.gi().mugenver[0] == 1 && c.gi().mugenver[1] == 0 {
-		return 1.0
-	} else if c.gi().mugenver[0] != 1 {
-		return 0.5 // Arbitrary value
-	} else {
-		return 0
-	}
 }
 
 func (c *Char) numEnemy() int32 {
@@ -11660,6 +11644,7 @@ func (cl *CharList) collisionDetection() {
 	// Push detection for players
 	// This must happen before hit detection
 	// https://github.com/ikemen-engine/Ikemen-GO/issues/1941
+	// It doesn't need to run in "sortedOrder", but it should be harmless
 	// An attempt was made to skip redundant player pair checks, but that makes chars push each other too slowly in screen corners
 	for _, idx := range sortedOrder {
 		cl.pushDetection(cl.runOrder[idx])

--- a/src/char.go
+++ b/src/char.go
@@ -10939,7 +10939,7 @@ func (cl *CharList) sortActionRunOrder() []int {
 	}
 
 	// Sort by priority
-	sort.Slice(sorting, func(i, j int) bool {
+	sort.SliceStable(sorting, func(i, j int) bool {
 		return sorting[i][1] > sorting[j][1]
 	})
 
@@ -11647,7 +11647,7 @@ func (cl *CharList) collisionDetection() {
 	}
 
 	// Sort by priority
-	sort.Slice(sorting, func(i, j int) bool {
+	sort.SliceStable(sorting, func(i, j int) bool {
 		return sorting[i][1] > sorting[j][1]
 	})
 
@@ -11880,7 +11880,7 @@ func (cl *CharList) enemyNear(c *Char, n int32, p2list, log bool) *Char {
 	}
 
 	// Sort enemies by shortest absolute distance
-	sort.Slice(pairs, func(i, j int) bool {
+	sort.SliceStable(pairs, func(i, j int) bool {
 		return AbsF(pairs[i].dist) < AbsF(pairs[j].dist)
 	})
 

--- a/src/common.go
+++ b/src/common.go
@@ -719,6 +719,7 @@ func sliceMoveInt(array []int, srcIndex int, dstIndex int) []int {
 	return sliceInsertInt(sliceRemoveInt(array, srcIndex), value, dstIndex)
 }
 
+// We save an array for precise checking, and a float for triggers
 func parseIkemenVersion(versionStr string) ([3]uint16, float32) {
 	var ver [3]uint16
 	parts := SplitAndTrim(versionStr, ".")
@@ -749,8 +750,11 @@ func parseIkemenVersion(versionStr string) ([3]uint16, float32) {
 	return ver, verF
 }
 
-func parseMugenVersion(versionStr string) [2]uint16 {
+func parseMugenVersion(versionStr string) ([2]uint16, float32) {
 	var ver [2]uint16
+	var verF float32
+
+	// Parse the string into the array
 	parts := SplitAndTrim(versionStr, ".")
 	for i, s := range parts {
 		if i >= len(ver) {
@@ -763,7 +767,17 @@ func parseMugenVersion(versionStr string) [2]uint16 {
 			break
 		}
 	}
-	return ver
+	
+	// Turn the array into the versions we know
+	if ver[0] == 1 && ver[1] == 1 {
+		verF = 1.1
+	} else if ver[0] == 1 && ver[1] == 0 {
+		verF = 1.0
+	} else if ver[0] != 0 {
+		verF = 0.5 // Arbitrary value
+	}
+
+	return ver, verF
 }
 
 type Error string

--- a/src/common.go
+++ b/src/common.go
@@ -719,6 +719,53 @@ func sliceMoveInt(array []int, srcIndex int, dstIndex int) []int {
 	return sliceInsertInt(sliceRemoveInt(array, srcIndex), value, dstIndex)
 }
 
+func parseIkemenVersion(versionStr string) ([3]uint16, float32) {
+	var ver [3]uint16
+	parts := SplitAndTrim(versionStr, ".")
+	for i, s := range parts {
+		if i >= len(ver) {
+			break
+		}
+		if v, err := strconv.ParseUint(s, 10, 16); err == nil {
+			ver[i] = uint16(v)
+		} else {
+			break
+		}
+	}
+
+	// Convert into a float for triggers
+	re := regexp.MustCompile(`[^0-9.]`)
+	cleanStr := re.ReplaceAllString(versionStr, "")
+	// Keep only the first decimal point
+	strParts := strings.Split(cleanStr, ".")
+	if len(strParts) > 1 {
+		cleanStr = strParts[0] + "." + strings.Join(strParts[1:], "")
+	}
+	var verF float32
+	if result, err := strconv.ParseFloat(cleanStr, 32); err == nil {
+		verF = float32(result)
+	}
+
+	return ver, verF
+}
+
+func parseMugenVersion(versionStr string) [2]uint16 {
+	var ver [2]uint16
+	parts := SplitAndTrim(versionStr, ".")
+	for i, s := range parts {
+		if i >= len(ver) {
+			break
+		}
+		if v, err := strconv.ParseUint(s, 10, 16); err == nil {
+			ver[i] = uint16(v)
+		} else {
+			ver = [2]uint16{}
+			break
+		}
+	}
+	return ver
+}
+
 type Error string
 
 func (e Error) Error() string {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1736,6 +1736,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "volume":
 			opct = OC_ex2_
 			opc = OC_ex2_bgmvar_volume
+		default:
+			return bvNone(), Error("Invalid BGMVar argument: " + vname)
 		}
 		if isStr {
 			if err := nameSub(opct, opc); err != nil {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -7362,48 +7362,16 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 				info = false
 				var ok bool
 				var str string
+				// Clear then read MugenVersion
 				sys.cgi[pn].mugenver = [2]uint16{}
 				if str, ok = is["mugenversion"]; ok {
-					for i, s := range SplitAndTrim(str, ".") {
-						if i >= len(sys.cgi[pn].mugenver) {
-							break
-						}
-						if v, err := strconv.ParseUint(s, 10, 16); err == nil {
-							sys.cgi[pn].mugenver[i] = uint16(v)
-						} else {
-							sys.cgi[pn].mugenver[0] = 0
-							sys.cgi[pn].mugenver[1] = 0
-							break
-						}
-					}
+					sys.cgi[pn].mugenver = parseMugenVersion(str)
 				}
-				// Clear previous character's version
+				// Clear then read IkemenVersion
 				sys.cgi[pn].ikemenver = [3]uint16{}
 				sys.cgi[pn].ikemenverF = 0
 				if str, ok = is["ikemenversion"]; ok {
-					for i, s := range SplitAndTrim(str, ".") {
-						if i >= len(sys.cgi[pn].ikemenver) {
-							break
-						}
-						if v, err := strconv.ParseUint(s, 10, 16); err == nil {
-							sys.cgi[pn].ikemenver[i] = uint16(v)
-						} else {
-							break
-						}
-					}
-					// Convert into a float for triggers
-					// TODO: Same thing for stages etc
-					re := regexp.MustCompile(`[^0-9.]`)
-					str = re.ReplaceAllString(str, "")
-					// Keep only the first decimal point
-					parts := strings.Split(str, ".")
-					if len(parts) > 1 {
-						str = parts[0] + "." + strings.Join(parts[1:], "")
-					}
-					// Convert clean string to float
-					if result, err := strconv.ParseFloat(str, 32); err == nil {
-						sys.cgi[pn].ikemenverF = float32(result)
-					}
+					sys.cgi[pn].ikemenver, sys.cgi[pn].ikemenverF = parseIkemenVersion(str)
 				}
 				// Ikemen characters adopt Mugen 1.1 version as a safeguard
 				if sys.cgi[pn].ikemenver[0] != 0 || sys.cgi[pn].ikemenver[1] != 0 {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -3537,14 +3537,18 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		}
 		isStr := false
 		switch svname {
-		case "info.name":
-			opc = OC_const_stagevar_info_name
+		case "info.author":
+			opc = OC_const_stagevar_info_author
 			isStr = true
 		case "info.displayname":
 			opc = OC_const_stagevar_info_displayname
 			isStr = true
-		case "info.author":
-			opc = OC_const_stagevar_info_author
+		case "info.ikemenversion":
+			opc = OC_const_stagevar_info_ikemenversion
+		case "info.mugenversion":
+			opc = OC_const_stagevar_info_mugenversion
+		case "info.name":
+			opc = OC_const_stagevar_info_name
 			isStr = true
 		case "camera.boundleft":
 			opc = OC_const_stagevar_camera_boundleft
@@ -7364,8 +7368,9 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 				var str string
 				// Clear then read MugenVersion
 				sys.cgi[pn].mugenver = [2]uint16{}
+				sys.cgi[pn].mugenverF = 0
 				if str, ok = is["mugenversion"]; ok {
-					sys.cgi[pn].mugenver = parseMugenVersion(str)
+					sys.cgi[pn].mugenver, sys.cgi[pn].mugenverF = parseMugenVersion(str)
 				}
 				// Clear then read IkemenVersion
 				sys.cgi[pn].ikemenver = [3]uint16{}

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1842,6 +1842,7 @@ func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 		return err
 	}
 	if !b {
+		// DOS Mugen used "sprpriority" instead of "p1sprpriority". Later versions seemingly kept both syntaxes
 		if err := c.paramValue(is, sc, "sprpriority",
 			hitDef_p1sprpriority, VT_Int, 1, false); err != nil {
 			return err
@@ -4376,30 +4377,35 @@ func (c *Compiler) assertInput(is IniSection, sc *StateControllerBase, _ int8) (
 				sc.add(assertInput_flag, sc.iToExp(int32(IB_W)))
 			case "m":
 				sc.add(assertInput_flag, sc.iToExp(int32(IB_M)))
+			case "B":
+				sc.add(assertInput_flag_B, nil)
+			case "F":
+				sc.add(assertInput_flag_F, nil)
 			default:
 				return Error("Invalid AssertInput flag: " + data)
 			}
 			return nil
 		}
-		f := false
+		// Flag
+		flagSet := false
 		if err := c.stateParam(is, "flag", false, func(data string) error {
-			f = true
+			flagSet = true
 			return foo(data)
 		}); err != nil {
 			return err
 		}
-		if !f {
-			return Error("No AssertInput flags specified")
+		// Flag2-8
+		for i := 2; i <= 8; i++ {
+			key := fmt.Sprintf("flag%d", i)
+			if err := c.stateParam(is, key, false, func(data string) error {
+				flagSet = true
+				return foo(data)
+			}); err != nil {
+				return err
+			}
 		}
-		if err := c.stateParam(is, "flag2", false, func(data string) error {
-			return foo(data)
-		}); err != nil {
-			return err
-		}
-		if err := c.stateParam(is, "flag3", false, func(data string) error {
-			return foo(data)
-		}); err != nil {
-			return err
+		if !flagSet {
+			return Error("Must specify at least one AssertInput flag")
 		}
 		return nil
 	})

--- a/src/config.go
+++ b/src/config.go
@@ -207,7 +207,7 @@ type Config struct {
 	} `ini:"Netplay"`
 	Input struct {
 		ButtonAssist               bool    `ini:"ButtonAssist"`
-		SOCDResolution             int32   `ini:"SOCDResolution"`
+		SOCDResolution             int     `ini:"SOCDResolution"`
 		ControllerStickSensitivity float32 `ini:"ControllerStickSensitivity"`
 		XinputTriggerSensitivity   float32 `ini:"XinputTriggerSensitivity"`
 	} `ini:"Input"`
@@ -322,7 +322,7 @@ func (c *Config) normalize() {
 	c.SetValueUpdate("Sound.WavChannels", Clamp(c.Sound.WavChannels, 1, 256))
 	c.SetValueUpdate("Sound.PauseMasterVolume", int(Clamp(int32(c.Sound.PauseMasterVolume), 0, 100)))
 	c.SetValueUpdate("Sound.MaxBGMVolume", int(Clamp(int32(c.Sound.MaxBGMVolume), 100, 250)))
-	c.SetValueUpdate("Input.SOCDResolution", Clamp(c.Input.SOCDResolution, 0, 4))
+	c.SetValueUpdate("Input.SOCDResolution", int(Clamp(int32(c.Input.SOCDResolution), 0, 4)))
 	switch c.Video.MSAA {
 	case 0, 2, 4, 6, 8, 16, 32:
 	default:

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -18,7 +18,7 @@ Const   = data/common.const
 States  = data/functions.zss, data/action.zss, data/dizzy.zss, data/guardbreak.zss, data/score.zss, data/system.zss, data/tag.zss, data/training.zss
 ; Common packs of graphic and/or sound effects called during the match by using
 ; a specific prefix before animation and sound numbers (like lifebar fightfx)
-Fx      = 
+Fx      = data/gofx.def
 ; External modules (no need to add modules placed in external/mods directory)
 Modules = 
 ; Pure Lua code executed on each frame during match

--- a/src/script.go
+++ b/src/script.go
@@ -792,7 +792,7 @@ func systemScriptInit(l *lua.LState) {
 			userDataError(l, 1, cl)
 		}
 		if cl.InputUpdate(int(numArg(l, 2))-1, 1, 0, 0, true) {
-			cl.Step(1, false, false, false, false, 0)
+			cl.Step(false, false, false, false, 0)
 		}
 		return 0
 	})
@@ -2114,14 +2114,14 @@ func systemScriptInit(l *lua.LState) {
 	})
 	luaRegister(l, "replayRecord", func(*lua.LState) int {
 		if sys.netConnection != nil {
-			sys.netConnection.rep, _ = os.Create(strArg(l, 1))
+			sys.netConnection.recording, _ = os.Create(strArg(l, 1))
 		}
 		return 0
 	})
 	luaRegister(l, "replayStop", func(*lua.LState) int {
-		if sys.netConnection != nil && sys.netConnection.rep != nil {
-			sys.netConnection.rep.Close()
-			sys.netConnection.rep = nil
+		if sys.netConnection != nil && sys.netConnection.recording != nil {
+			sys.netConnection.recording.Close()
+			sys.netConnection.recording = nil
 		}
 		return 0
 	})

--- a/src/script.go
+++ b/src/script.go
@@ -4996,12 +4996,16 @@ func triggerFunctions(l *lua.LState) {
 	})
 	luaRegister(l, "stagevar", func(*lua.LState) int {
 		switch strings.ToLower(strArg(l, 1)) {
-		case "info.name":
-			l.Push(lua.LString(sys.stage.name))
-		case "info.displayname":
-			l.Push(lua.LString(sys.stage.displayname))
 		case "info.author":
 			l.Push(lua.LString(sys.stage.author))
+		case "info.displayname":
+			l.Push(lua.LString(sys.stage.displayname))
+		case "info.ikemenversion":
+			l.Push(lua.LNumber(sys.stage.ikemenverF))
+		case "info.mugenversion":
+			l.Push(lua.LNumber(sys.stage.mugenverF))
+		case "info.name":
+			l.Push(lua.LString(sys.stage.name))
 		case "camera.boundleft":
 			l.Push(lua.LNumber(sys.stage.stageCamera.boundleft))
 		case "camera.boundright":
@@ -5746,7 +5750,7 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "mugenversion", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.mugenVersionF()))
+		l.Push(lua.LNumber(sys.debugWC.gi().mugenverF))
 		return 1
 	})
 	luaRegister(l, "numplayer", func(*lua.LState) int {

--- a/src/stage.go
+++ b/src/stage.go
@@ -843,11 +843,12 @@ type Stage struct {
 	stageTime         int32
 	constants         map[string]float32
 	partnerspacing    int32
+	ikemenver         [3]uint16
+	ikemenverF        float32
 	mugenver          [2]uint16
 	reload            bool
 	stageprops        StageProps
 	model             *Model
-	ikemenver         [3]uint16
 	topbound          float32
 	botbound          float32
 }
@@ -929,31 +930,15 @@ func loadStage(def string, maindef bool) (*Stage, error) {
 		s.nameLow = strings.ToLower(s.name)
 		s.displaynameLow = strings.ToLower(s.displayname)
 		s.authorLow = strings.ToLower(s.author)
+		// Clear then read MugenVersion
 		s.mugenver = [2]uint16{}
 		if str, ok := sec[0]["mugenversion"]; ok {
-			for k, v := range SplitAndTrim(str, ".") {
-				if k >= len(s.mugenver) {
-					break
-				}
-				if v, err := strconv.ParseUint(v, 10, 16); err == nil {
-					s.mugenver[k] = uint16(v)
-				} else {
-					break
-				}
-			}
+			s.mugenver = parseMugenVersion(str)
 		}
+		// Clear then read IkemenVersion
 		s.ikemenver = [3]uint16{}
 		if str, ok := sec[0]["ikemenversion"]; ok {
-			for k, v := range SplitAndTrim(str, ".") {
-				if k >= len(s.ikemenver) {
-					break
-				}
-				if v, err := strconv.ParseUint(v, 10, 16); err == nil {
-					s.ikemenver[k] = uint16(v)
-				} else {
-					break
-				}
-			}
+			s.ikemenver, s.ikemenverF = parseIkemenVersion(str)
 		}
 		// If the MUGEN version is lower than 1.0, default to camera pixel rounding (floor)
 		if s.ikemenver[0] == 0 && s.ikemenver[1] == 0 && s.mugenver[0] != 1 {

--- a/src/stage.go
+++ b/src/stage.go
@@ -846,6 +846,7 @@ type Stage struct {
 	ikemenver         [3]uint16
 	ikemenverF        float32
 	mugenver          [2]uint16
+	mugenverF         float32
 	reload            bool
 	stageprops        StageProps
 	model             *Model
@@ -932,8 +933,9 @@ func loadStage(def string, maindef bool) (*Stage, error) {
 		s.authorLow = strings.ToLower(s.author)
 		// Clear then read MugenVersion
 		s.mugenver = [2]uint16{}
+		s.mugenverF = 0
 		if str, ok := sec[0]["mugenversion"]; ok {
-			s.mugenver = parseMugenVersion(str)
+			s.mugenver, s.mugenverF = parseMugenVersion(str)
 		}
 		// Clear then read IkemenVersion
 		s.ikemenver = [3]uint16{}

--- a/src/stage.go
+++ b/src/stage.go
@@ -958,7 +958,7 @@ func loadStage(def string, maindef bool) (*Stage, error) {
 				}
 			}
 			if ac >= MaxAttachedChar {
-				sys.appendToConsole(fmt.Sprintf("Warning: You can define up to %d attachedchar(s). '%s' ignored.", MaxAttachedChar, i))
+				sys.appendToConsole(fmt.Sprintf("Warning: You can only define up to %d attachedchar(s). '%s' ignored.", MaxAttachedChar, i))
 				continue
 			}
 			if err := sec[0].LoadFile(i, []string{def, "", sys.motifDir, "data/"}, func(filename string) error {
@@ -1168,6 +1168,11 @@ func loadStage(def string, maindef bool) (*Stage, error) {
 			s.stageCamera.ytensionenable = true
 			sec[0].ReadI32("tensionhigh", &s.stageCamera.tensionhigh)
 		}
+		// Camera group warnings
+		// Warn when camera boundaries are smaller than player boundaries
+		if int32(s.leftbound) > s.stageCamera.boundleft || int32(s.rightbound) < s.stageCamera.boundright {
+			sys.appendToConsole("Warning: Stage player boundaries defined incorrectly")
+		}
 	}
 
 	// Music group
@@ -1333,6 +1338,10 @@ func loadStage(def string, maindef bool) (*Stage, error) {
 		}
 		sec[0].readF32ForStage("offset", &s.sdw.offset[0], &s.sdw.offset[1])
 		sec[0].readF32ForStage("window", &s.sdw.window[0], &s.sdw.window[1], &s.sdw.window[2], &s.sdw.window[3])
+		// Shadow group warnings
+		if s.sdw.fadeend > s.sdw.fadebgn {
+			sys.appendToConsole("Warning: Stage shadow fade.range defined incorrectly")
+		}
 	}
 
 	// Reflection group

--- a/src/system.go
+++ b/src/system.go
@@ -223,6 +223,7 @@ type System struct {
 	spritesLayer0           DrawList
 	spritesLayer1           DrawList
 	shadows                 ShadowList
+	reflections             ReflectionList
 	debugc1hit              ClsnRect
 	debugc1rev              ClsnRect
 	debugc1not              ClsnRect
@@ -1336,6 +1337,7 @@ func (s *System) action() {
 	s.spritesLayer0 = s.spritesLayer0[:0]
 	s.spritesLayer1 = s.spritesLayer1[:0]
 	s.shadows = s.shadows[:0]
+	s.reflections = s.reflections[:0]
 	s.debugc1hit = s.debugc1hit[:0]
 	s.debugc1rev = s.debugc1rev[:0]
 	s.debugc1not = s.debugc1not[:0]
@@ -1859,8 +1861,8 @@ func (s *System) draw(x, y, scl float32) {
 
 		// Draw reflections on layer -1
 		if !s.gsf(GSF_globalnoshadow) {
-			if s.stage.reflection.intensity > 0 && s.stage.reflectionlayerno < 0 {
-				s.shadows.drawReflection(x, y, scl*s.cam.BaseScale())
+			if s.stage.reflectionlayerno < 0 {
+				s.reflections.draw(x, y, scl*s.cam.BaseScale())
 			}
 		}
 
@@ -1879,8 +1881,8 @@ func (s *System) draw(x, y, scl float32) {
 		// Draw reflections on layer 0
 		// TODO: Make shadows render in same layers as their sources?
 		if !s.gsf(GSF_globalnoshadow) {
-			if s.stage.reflection.intensity > 0 && s.stage.reflectionlayerno >= 0 {
-				s.shadows.drawReflection(x, y, scl*s.cam.BaseScale())
+			if s.stage.reflectionlayerno >= 0 {
+				s.reflections.draw(x, y, scl*s.cam.BaseScale())
 			}
 			s.shadows.draw(x, y, scl*s.cam.BaseScale())
 		}

--- a/src/system.go
+++ b/src/system.go
@@ -3679,10 +3679,6 @@ func (l *Loader) loadStage() bool {
 						sys.appendToConsole("Stage with unknown engine version.")
 					}
 				}
-				// Warn when camera boundaries are smaller than player boundaries
-				if int32(sys.stage.leftbound) > sys.stage.stageCamera.boundleft || int32(sys.stage.rightbound) < sys.stage.stageCamera.boundright {
-					sys.appendToConsole("Warning: Stage player boundaries defined incorrectly")
-				}
 			}
 		}()
 		var def string


### PR DESCRIPTION
Feat:
- AssertInput can now assert B or F directly, so that one doesn't need to conditionally assert L or R every time
- AssertInput can now set 8 flags at a time, for consistency's sake
- StageVar can now also return engine versions

Fix:
- Changed the sorting function used in previous refactor to the "stable" algorithm, improving results when sprpriority is equal
- AssertInput finally works online and in replays
- Fixed explods binding to players even while they (the explods) are paused
- Fixed crash that could occur if ModifyBGM was used before any BGM was loaded into the game

Refactor:
- Centralized the parsing of ikemenversion and mugenversion fields
- Internal separation of shadows and reflections, making the code easier to maintain
- Added incorrect shadow fade.range warning when loading a stage
- AssertInput can no longer bypass SOCD resolution
- gofx.def is now loaded in the default common FX