### PR TITLE
fix: -speed and -speedtest command line arguments

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -351,11 +351,14 @@ end
 if main.flags['-ailevel'] ~= nil then
 	modifyGameOption('Options.Difficulty', math.max(1, math.min(tonumber(main.flags['-ailevel']), 8)))
 end
-if main.flags['-speed'] ~= nil and tonumber(main.flags['-speed']) > 0 then
-	setGameSpeed(tonumber(main.flags['-speed']) * gameOption('Config.Framerate') / 100)
+if main.flags['-speed'] ~= nil then
+	local speed_val = tonumber(main.flags['-speed'])
+	if speed_val ~= nil and speed_val >= -9 and speed_val <= 9 then
+		modifyGameOption('Options.GameSpeed', speed_val)
+	end
 end
 if main.flags['-speedtest'] ~= nil then
-	setGameSpeed(100 * gameOption('Config.Framerate'))
+	modifyGameOption('Options.GameSpeedMultiplier', 100)
 end
 if main.flags['-nosound'] ~= nil then
 	modifyGameOption('Sound.MasterVolume', 0)

--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -352,13 +352,25 @@ if main.flags['-ailevel'] ~= nil then
 	modifyGameOption('Options.Difficulty', math.max(1, math.min(tonumber(main.flags['-ailevel']), 8)))
 end
 if main.flags['-speed'] ~= nil then
-	local speed_val = tonumber(main.flags['-speed'])
-	if speed_val ~= nil and speed_val >= -9 and speed_val <= 9 then
-		modifyGameOption('Options.GameSpeed', speed_val)
+	local speed_input = tonumber(main.flags['-speed'])
+	if speed_input ~= nil and speed_input >= -9 and speed_input <= 9 then
+		local target_game_speed
+		if speed_input > 0 then
+			target_game_speed = speed_input
+		elseif speed_input == 0 then
+			target_game_speed = 0
+		else
+			if speed_input >= -1 then
+				target_game_speed = speed_input * 5
+			else
+				target_game_speed = speed_input * 0.5 - 4.5
+			end
+		end
+		setGameSpeed(target_game_speed)
 	end
 end
 if main.flags['-speedtest'] ~= nil then
-	modifyGameOption('Options.GameSpeedMultiplier', 100)
+	setGameSpeed(100)
 end
 if main.flags['-nosound'] ~= nil then
 	modifyGameOption('Sound.MasterVolume', 0)

--- a/src/config.go
+++ b/src/config.go
@@ -51,11 +51,12 @@ type Config struct {
 		Lua     map[string][]string `ini:"map:^(?i)Lua[0-9]*$" lua:"Lua"`
 	} `ini:"Common"`
 	Options struct {
-		Difficulty int     `ini:"Difficulty"`
-		Life       float32 `ini:"Life"`
-		Time       int32   `ini:"Time"`
-		GameSpeed  float32 `ini:"GameSpeed"`
-		Match      struct {
+		Difficulty          int     `ini:"Difficulty"`
+		Life                float32 `ini:"Life"`
+		Time                int32   `ini:"Time"`
+		GameSpeed           float32 `ini:"GameSpeed"`
+		GameSpeedMultiplier float32 `ini:"GameSpeedMultiplier"`
+		Match               struct {
 			Wins         int32 `ini:"Wins"`
 			MaxDrawGames int32 `ini:"MaxDrawGames"`
 		} `ini:"Match"`
@@ -296,7 +297,11 @@ func (c *Config) initStruct() {
 
 // Normalize values
 func (c *Config) normalize() {
+	if c.Options.GameSpeedMultiplier == 0 {
+		c.Options.GameSpeedMultiplier = 1.0
+	}
 	c.SetValueUpdate("Options.GameSpeed", ClampF(c.Options.GameSpeed, -9, 9))
+	c.SetValueUpdate("Options.GameSpeedMultiplier", ClampF(c.Options.GameSpeedMultiplier, 0.1, 10.0))
 	c.SetValueUpdate("Options.Simul.Min", int(Clamp(int32(c.Options.Simul.Min), 2, int32(MaxSimul))))
 	c.SetValueUpdate("Options.Simul.Max", int(Clamp(int32(c.Options.Simul.Max), int32(c.Options.Simul.Min), int32(MaxSimul))))
 	c.SetValueUpdate("Options.Tag.Min", int(Clamp(int32(c.Options.Tag.Min), 2, int32(MaxSimul))))

--- a/src/config.go
+++ b/src/config.go
@@ -51,12 +51,11 @@ type Config struct {
 		Lua     map[string][]string `ini:"map:^(?i)Lua[0-9]*$" lua:"Lua"`
 	} `ini:"Common"`
 	Options struct {
-		Difficulty          int     `ini:"Difficulty"`
-		Life                float32 `ini:"Life"`
-		Time                int32   `ini:"Time"`
-		GameSpeed           float32 `ini:"GameSpeed"`
-		GameSpeedMultiplier float32 `ini:"GameSpeedMultiplier"`
-		Match               struct {
+		Difficulty int     `ini:"Difficulty"`
+		Life       float32 `ini:"Life"`
+		Time       int32   `ini:"Time"`
+		GameSpeed  float32 `ini:"GameSpeed"`
+		Match      struct {
 			Wins         int32 `ini:"Wins"`
 			MaxDrawGames int32 `ini:"MaxDrawGames"`
 		} `ini:"Match"`
@@ -297,11 +296,7 @@ func (c *Config) initStruct() {
 
 // Normalize values
 func (c *Config) normalize() {
-	if c.Options.GameSpeedMultiplier == 0 {
-		c.Options.GameSpeedMultiplier = 1.0
-	}
 	c.SetValueUpdate("Options.GameSpeed", ClampF(c.Options.GameSpeed, -9, 9))
-	c.SetValueUpdate("Options.GameSpeedMultiplier", ClampF(c.Options.GameSpeedMultiplier, 0.1, 10.0))
 	c.SetValueUpdate("Options.Simul.Min", int(Clamp(int32(c.Options.Simul.Min), 2, int32(MaxSimul))))
 	c.SetValueUpdate("Options.Simul.Max", int(Clamp(int32(c.Options.Simul.Max), int32(c.Options.Simul.Min), int32(MaxSimul))))
 	c.SetValueUpdate("Options.Tag.Min", int(Clamp(int32(c.Options.Tag.Min), 2, int32(MaxSimul))))

--- a/src/main.go
+++ b/src/main.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 
 	lua "github.com/yuin/gopher-lua"
@@ -158,14 +159,16 @@ func processCommandLine() {
 		// Loop through arguments
 		for _, a := range os.Args[1:] {
 			// Check if the current argument 'a' is a flag (starts with '-')
-			if r2.MatchString(a) {
+			// Check if 'a' is a number (could be negative)
+			_, err := strconv.ParseFloat(a, 64)
+			isNumber := err == nil
+
+			// If there was a flag 'key' expecting a value, and 'a' is a number or not a flag
+			if key != "" && (isNumber || !r2.MatchString(a)) { // If 'a' is a number OR 'a' is not a flag, it's a value for 'key'
+				sys.cmdFlags[key] = a // Assign 'a' as the value for 'key'
+				key = ""              // Value consumed, clear key.
+			} else if r2.MatchString(a) { // 'a' is a flag (starts with '-')
 				flagsEncountered = true // A flag has been encountered
-				// If there was a flag 'key' expecting a value, but 'a' is another flag,
-				// then the 'key' flag didn't get its value. Set its value to "true".
-				if key != "" {
-					sys.cmdFlags[key] = "true"
-					key = "" // Clear key, as its value is now set
-				}
 
 				// If getting help about command line options
 				if r1.MatchString(a) {
@@ -199,7 +202,7 @@ Debug Options:
 -togglelifebars         Disables display of the Life and Power bars
 -maxpowermode           Enables auto-refill of Power bars
 -ailevel <level>        Changes game difficulty setting to <level> (1-8)
--speed <speed>          Changes game speed setting to <speed> (10%%-200%%)
+-speed <speed>          Changes game speed setting to <speed> (-9 to 9)
 -stresstest <frameskip> Stability test (AI matches at speed increased by <frameskip>)
 -speedtest              Speed test (match speed x100)`
 					//ShowInfoDialog(text, "I.K.E.M.E.N Command line options")
@@ -217,19 +220,13 @@ Debug Options:
 					sys.cmdFlags[a] = ""
 					key = a // Now 'key' expects a value in the next iteration.
 				}
-			} else { // 'a' is not a flag (it's a value or a player name)
-				// If 'key' is not empty, it means the previous argument was a flag expecting a value.
-				if key != "" {
-					sys.cmdFlags[key] = a // Assign 'a' as the value for 'key'
-					key = ""              // Value consumed, clear key.
-				} else if !flagsEncountered && player <= 2 { // Only assign to -p1 or -p2 if no flag has been encountered yet and player count is within limit
-					// This block handles initial positional player names like "kfm kfm"
-					sys.cmdFlags[fmt.Sprintf("-p%v", player)] = a
-					player += 1
-				}
-				// If key is empty and player > 2, and it's not a flag, then it's an unhandled positional argument.
-				// We just ignore it in this case to prevent the 8/8.def error.
+			} else if !flagsEncountered && player <= 2 { // Only assign to -p1 or -p2 if no flag has been encountered yet and player count is within limit
+				// This block handles initial positional player names like "kfm kfm"
+				sys.cmdFlags[fmt.Sprintf("-p%v", player)] = a
+				player += 1
 			}
+			// If key is empty and player > 2, and it's not a flag, then it's an unhandled positional argument.
+			// We just ignore it in this case to prevent the 8/8.def error.
 		}
 		// After the loop, if a key is still waiting for a value, set it to "true".
 		if key != "" {

--- a/src/main.go
+++ b/src/main.go
@@ -150,26 +150,26 @@ func processCommandLine() {
 			"-nosound":        true,
 			"-speedtest":      true,
 		}
-		const ignoreNextArg = "@@IGNORE_NEXT_ARG@@" // Special value for 'key'
-
 		key := ""
 		player := 1
+		flagsEncountered := false // New variable to track if any flags have been encountered
 		r1, _ := regexp.Compile("^-[h%?]$")
 		r2, _ := regexp.Compile("^-")
 		// Loop through arguments
 		for _, a := range os.Args[1:] {
-			if key == ignoreNextArg { // If previous flag was boolean, ignore this argument
-				key = "" // Reset for next iteration
-				continue
-			}
-			// If a key was expecting a value but the next argument is another flag, set the key to "true"
-			if key != "" && r2.MatchString(a) {
-				sys.cmdFlags[key] = "true"
-				key = ""
-			}
-			// If getting help about command line options
-			if r1.MatchString(a) {
-				text := `Options (case sensitive):
+			// Check if the current argument 'a' is a flag (starts with '-')
+			if r2.MatchString(a) {
+				flagsEncountered = true // A flag has been encountered
+				// If there was a flag 'key' expecting a value, but 'a' is another flag,
+				// then the 'key' flag didn't get its value. Set its value to "true".
+				if key != "" {
+					sys.cmdFlags[key] = "true"
+					key = "" // Clear key, as its value is now set
+				}
+
+				// If getting help about command line options
+				if r1.MatchString(a) {
+					text := `Options (case sensitive):
 -h -?                   Help
 -log <logfile>          Records match data to <logfile>
 -r <path>               Loads motif <path>. eg. -r motifdir or -r motifdir/system.def
@@ -179,7 +179,7 @@ func processCommandLine() {
 -width <num>            Sets game width
 -height <num>           Sets game height
 -setvolume <num>        Sets master volume to <num> (0-100)
-
+	
 Quick VS Options:
 -p<n> <playername>      Loads player n, eg. -p3 kfm
 -p<n>.ai <level>        Sets player n's AI to <level>, eg. -p1.ai 8
@@ -191,7 +191,7 @@ Quick VS Options:
 -time <num>             Round time (-1 to disable)
 -rounds <num>           Plays for <num> rounds, and then quits
 -s <stagename>          Loads stage <stagename>
-
+	
 Debug Options:
 -nojoy                  Disables joysticks
 -nomusic                Disables music
@@ -202,35 +202,37 @@ Debug Options:
 -speed <speed>          Changes game speed setting to <speed> (10%%-200%%)
 -stresstest <frameskip> Stability test (AI matches at speed increased by <frameskip>)
 -speedtest              Speed test (match speed x100)`
-				//ShowInfoDialog(text, "I.K.E.M.E.N Command line options")
-				fmt.Printf("I.K.E.M.E.N Command line options\n\n" + text + "\nPress ENTER to exit")
-				var s string
-				fmt.Scanln(&s)
-				os.Exit(0)
-				// If a control argument starting with - (eg. -p3, -s, -rounds)
-			} else if r2.MatchString(a) { // 'a' is a flag
-				// If it's a boolean flag, set its value to "true"
+					//ShowInfoDialog(text, "I.K.E.M.E.N Command line options")
+					fmt.Printf("I.K.E.M.E.N Command line options\n\n" + text + "\nPress ENTER to exit")
+					var s string
+					fmt.Scanln(&s)
+					os.Exit(0)
+				}
+				// If 'a' is a boolean flag, set its value to "true".
 				if _, isBool := boolFlags[a]; isBool {
 					sys.cmdFlags[a] = "true"
-					key = ignoreNextArg // Set key to ignore next argument
+					// key remains "" because boolean flags don't consume the next argument.
 				} else {
-					// Otherwise, it's a value-expecting flag. Set blank and prepare key.
+					// 'a' is a value-expecting flag. Set its value to blank and store its name in 'key'.
 					sys.cmdFlags[a] = ""
-					key = a // Prepare key for the next argument (value)
+					key = a // Now 'key' expects a value in the next iteration.
 				}
 			} else { // 'a' is not a flag (it's a value or a player name)
-				// If a key is waiting for a value
+				// If 'key' is not empty, it means the previous argument was a flag expecting a value.
 				if key != "" {
-					sys.cmdFlags[key] = a
-					key = "" // Value consumed, clear key
-				} else { // No active flag, treat as player name
+					sys.cmdFlags[key] = a // Assign 'a' as the value for 'key'
+					key = ""              // Value consumed, clear key.
+				} else if !flagsEncountered && player <= 2 { // Only assign to -p1 or -p2 if no flag has been encountered yet and player count is within limit
+					// This block handles initial positional player names like "kfm kfm"
 					sys.cmdFlags[fmt.Sprintf("-p%v", player)] = a
 					player += 1
 				}
+				// If key is empty and player > 2, and it's not a flag, then it's an unhandled positional argument.
+				// We just ignore it in this case to prevent the 8/8.def error.
 			}
 		}
-		// After the loop, if a key is still waiting for a value
-		if key != "" && key != ignoreNextArg {
+		// After the loop, if a key is still waiting for a value, set it to "true".
+		if key != "" {
 			sys.cmdFlags[key] = "true"
 		}
 	}

--- a/src/main.go
+++ b/src/main.go
@@ -140,12 +140,33 @@ func processCommandLine() {
 	// If there are command line arguments
 	if len(os.Args[1:]) > 0 {
 		sys.cmdFlags = make(map[string]string)
+		boolFlags := map[string]bool{
+			"-windowed":       true,
+			"-togglelifebars": true,
+			"-maxpowermode":   true,
+			"-debug":          true,
+			"-nojoy":          true,
+			"-nomusic":        true,
+			"-nosound":        true,
+			"-speedtest":      true,
+		}
+		const ignoreNextArg = "@@IGNORE_NEXT_ARG@@" // Special value for 'key'
+
 		key := ""
 		player := 1
 		r1, _ := regexp.Compile("^-[h%?]$")
 		r2, _ := regexp.Compile("^-")
 		// Loop through arguments
 		for _, a := range os.Args[1:] {
+			if key == ignoreNextArg { // If previous flag was boolean, ignore this argument
+				key = "" // Reset for next iteration
+				continue
+			}
+			// If a key was expecting a value but the next argument is another flag, set the key to "true"
+			if key != "" && r2.MatchString(a) {
+				sys.cmdFlags[key] = "true"
+				key = ""
+			}
 			// If getting help about command line options
 			if r1.MatchString(a) {
 				text := `Options (case sensitive):
@@ -187,22 +208,30 @@ Debug Options:
 				fmt.Scanln(&s)
 				os.Exit(0)
 				// If a control argument starting with - (eg. -p3, -s, -rounds)
-			} else if r2.MatchString(a) {
-				// Set a blank value for the key to start with
-				sys.cmdFlags[a] = ""
-				// Prepare the key for the next argument
-				key = a
-				// If an argument with no key
-			} else if key == "" {
-				// Set p1/p2's name
-				sys.cmdFlags[fmt.Sprintf("-p%v", player)] = a
-				player += 1
-				// If a key is prepared for this argument
-			} else {
-				// Set the argument for this key
-				sys.cmdFlags[key] = a
-				key = ""
+			} else if r2.MatchString(a) { // 'a' is a flag
+				// If it's a boolean flag, set its value to "true"
+				if _, isBool := boolFlags[a]; isBool {
+					sys.cmdFlags[a] = "true"
+					key = ignoreNextArg // Set key to ignore next argument
+				} else {
+					// Otherwise, it's a value-expecting flag. Set blank and prepare key.
+					sys.cmdFlags[a] = ""
+					key = a // Prepare key for the next argument (value)
+				}
+			} else { // 'a' is not a flag (it's a value or a player name)
+				// If a key is waiting for a value
+				if key != "" {
+					sys.cmdFlags[key] = a
+					key = "" // Value consumed, clear key
+				} else { // No active flag, treat as player name
+					sys.cmdFlags[fmt.Sprintf("-p%v", player)] = a
+					player += 1
+				}
 			}
+		}
+		// After the loop, if a key is still waiting for a value
+		if key != "" && key != ignoreNextArg {
+			sys.cmdFlags[key] = "true"
 		}
 	}
 }

--- a/src/script.go
+++ b/src/script.go
@@ -2653,7 +2653,7 @@ func systemScriptInit(l *lua.LState) {
 		return 0
 	})
 	luaRegister(l, "setGameSpeed", func(*lua.LState) int {
-		sys.gameSpeed = float32(numArg(l, 1))
+		sys.cfg.Options.GameSpeed = float32(numArg(l, 1))
 		return 0
 	})
 	luaRegister(l, "setRoundTime", func(l *lua.LState) int {

--- a/src/script.go
+++ b/src/script.go
@@ -2652,6 +2652,10 @@ func systemScriptInit(l *lua.LState) {
 		sys.debugWC.redLifeSet(int32(numArg(l, 1)))
 		return 0
 	})
+	luaRegister(l, "setGameSpeed", func(*lua.LState) int {
+		sys.gameSpeed = float32(numArg(l, 1))
+		return 0
+	})
 	luaRegister(l, "setRoundTime", func(l *lua.LState) int {
 		sys.roundTime = int32(numArg(l, 1))
 		return 0

--- a/src/system.go
+++ b/src/system.go
@@ -1796,7 +1796,7 @@ func (s *System) action() {
 	explUpdate(&s.explodsLayer1, false)
 	// Adjust game speed
 	if s.tickNextFrame() {
-		spd := (60 + s.cfg.Options.GameSpeed*5) / float32(s.cfg.Config.Framerate) * s.accel
+		spd := ((60 + s.cfg.Options.GameSpeed*5) / float32(s.cfg.Config.Framerate)) * s.accel * s.cfg.Options.GameSpeedMultiplier
 		// KO slowdown
 		s.slowtimeTrigger = 0
 		if s.intro < 0 && s.time != 0 && s.slowtime > 0 {

--- a/src/system.go
+++ b/src/system.go
@@ -281,7 +281,6 @@ type System struct {
 	consecutiveRounds bool
 	firstAttack       [3]int
 	teamLeader        [2]int
-	gameSpeed         float32
 	maxPowerMode      bool
 	clsnText          []ClsnText
 	consoleText       []string
@@ -400,7 +399,6 @@ func (s *System) init(w, h int32) *lua.LState {
 	l := lua.NewState()
 	l.Options.IncludeGoStackTrace = true
 	l.OpenLibs()
-	s.gameSpeed = 1.0
 	for i := range s.inputRemap {
 		s.inputRemap[i] = i
 	}
@@ -1797,7 +1795,7 @@ func (s *System) action() {
 	explUpdate(&s.explodsLayer1, false)
 	// Adjust game speed
 	if s.tickNextFrame() {
-		spd := ((60 + s.gameSpeed*5) / float32(s.cfg.Config.Framerate)) * s.accel
+		spd := ((60 + s.cfg.Options.GameSpeed*5) / float32(s.cfg.Config.Framerate)) * s.accel
 		// KO slowdown
 		s.slowtimeTrigger = 0
 		if s.intro < 0 && s.time != 0 && s.slowtime > 0 {

--- a/src/system.go
+++ b/src/system.go
@@ -400,6 +400,7 @@ func (s *System) init(w, h int32) *lua.LState {
 	l := lua.NewState()
 	l.Options.IncludeGoStackTrace = true
 	l.OpenLibs()
+	s.gameSpeed = 1.0
 	for i := range s.inputRemap {
 		s.inputRemap[i] = i
 	}
@@ -1796,7 +1797,7 @@ func (s *System) action() {
 	explUpdate(&s.explodsLayer1, false)
 	// Adjust game speed
 	if s.tickNextFrame() {
-		spd := ((60 + s.cfg.Options.GameSpeed*5) / float32(s.cfg.Config.Framerate)) * s.accel * s.cfg.Options.GameSpeedMultiplier
+		spd := ((60 + s.gameSpeed*5) / float32(s.cfg.Config.Framerate)) * s.accel
 		// KO slowdown
 		s.slowtimeTrigger = 0
 		if s.intro < 0 && s.time != 0 && s.slowtime > 0 {


### PR DESCRIPTION
Fixed #2385

Previously, using the command line arguments `-speed <speed>` and `-speedtest` crashed the game, but with these changes the game will no longer crash and will properly change the speed of the match.

Incredibly useful for bulk character testing, such as plotting win rates.