### PR TITLE
fix: XY-Truncate option is now turned off by default

### DIFF
--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -214,7 +214,7 @@ options.t_itemname = {
 			modifyGameOption('Video.ExternalShaders', {})
 			modifyGameOption('Video.WindowScaleMode', true)
 			modifyGameOption('Video.KeepAspect', true)
-			modifyGameOption('Video.XyTruncate', true)
+			modifyGameOption('Video.XyTruncate', false)
 			modifyGameOption('Video.EnableModel', true)
 			modifyGameOption('Video.EnableModelShadow', true)
 			--modifyGameOption('Sound.SampleRate', 44100)

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -216,7 +216,7 @@ WindowScaleMode   = 1
 KeepAspect        = 1
 ; Toggles whether or not to truncate X/Y coordinates to whole numbers when rendering.
 ; Helps to solve "blurring" artifacts, particularly on lower resolution characters.
-XyTruncate        = 1
+XyTruncate        = 0
 ; Toggles 3D Model support.
 EnableModel       = 1
 ; Toggles 3D Model Shadow support.


### PR DESCRIPTION
Related to: #2564

Until some other consensus is reached about the ultimate fate of XY-Truncate I propose at least turning it off by default, for it to not cause any more problems for the nightly users.