### PR TITLE
feat: Remove "X/Y Truncate"

### DIFF
--- a/data/system.base.def
+++ b/data/system.base.def
@@ -1652,7 +1652,6 @@
 	menu.itemname.menuvideo.resolution.back = "Back"
 	menu.itemname.menuvideo.fullscreen = "Fullscreen"
 	menu.itemname.menuvideo.keepaspect = "Keep Aspect Ratio"
-	menu.itemname.menuvideo.xytruncate = "X/Y Truncate"
 	menu.itemname.menuvideo.windowscalemode = "Bilinear Filtering"
 	menu.itemname.menuvideo.vsync = "VSync"
 	menu.itemname.menuvideo.msaa = "MSAA"

--- a/external/script/motif.lua
+++ b/external/script/motif.lua
@@ -2041,7 +2041,6 @@ function motif.setBaseOptionInfo()
 	motif.option_info.menu_itemname_menuvideo_fullscreen = "Fullscreen"
 	motif.option_info.menu_itemname_menuvideo_vsync = "VSync"
 	motif.option_info.menu_itemname_menuvideo_keepaspect = "Keep Aspect Ratio"
-	motif.option_info.menu_itemname_menuvideo_xytruncate = "X/Y Truncate"
 	motif.option_info.menu_itemname_menuvideo_windowscalemode = "Bilinear Filtering"
 	motif.option_info.menu_itemname_menuvideo_msaa = "MSAA"
 	motif.option_info.menu_itemname_menuvideo_shaders = "Shaders" --reserved submenu
@@ -2176,7 +2175,6 @@ function motif.setBaseOptionInfo()
 		"menuvideo_fullscreen",
 		"menuvideo_vsync",
 		"menuvideo_keepaspect",
-		"menuvideo_xytruncate",
 		"menuvideo_windowscalemode",
 		"menuvideo_msaa",
 		"menuvideo_shaders",

--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -214,7 +214,6 @@ options.t_itemname = {
 			modifyGameOption('Video.ExternalShaders', {})
 			modifyGameOption('Video.WindowScaleMode', true)
 			modifyGameOption('Video.KeepAspect', true)
-			modifyGameOption('Video.XyTruncate', false)
 			modifyGameOption('Video.EnableModel', true)
 			modifyGameOption('Video.EnableModelShadow', true)
 			--modifyGameOption('Sound.SampleRate', 44100)
@@ -940,20 +939,6 @@ options.t_itemname = {
 		end
 		return true
 	end,
-	--X/Y Trunccate
-	['xytruncate'] = function(t, item, cursorPosY, moveTxt)
-		if main.f_input(main.t_players, {'$F', '$B', 'pal', 's'}) then
-			sndPlay(motif.files.snd_data, motif.option_info.cursor_move_snd[1], motif.option_info.cursor_move_snd[2])
-			if gameOption('Video.XyTruncate') then
-				modifyGameOption('Video.XyTruncate', false)
-			else
-				modifyGameOption('Video.XyTruncate', true)
-			end
-			t.items[item].vardisplay = options.f_boolDisplay(gameOption('Video.XyTruncate'), motif.option_info.menu_valuename_enabled, motif.option_info.menu_valuename_disabled)
-			options.modified = true
-		end
-		return true
-	end,
 	--Shaders (submenu)
 	['shaders'] = function(t, item, cursorPosY, moveTxt)
 		if main.f_input(main.t_players, {'$F', '$B', 'pal', 's'}) then
@@ -1566,9 +1551,6 @@ options.t_vardisplay = {
 	end,
 	['windowscalemode'] = function()
 		return options.f_boolDisplay(gameOption('Video.WindowScaleMode'), motif.option_info.menu_valuename_enabled, motif.option_info.menu_valuename_disabled)
-	end,
-	['xytruncate'] = function()
-		return options.f_boolDisplay(gameOption('Video.XyTruncate'), motif.option_info.menu_valuename_enabled, motif.option_info.menu_valuename_disabled)
 	end,
 }
 

--- a/src/config.go
+++ b/src/config.go
@@ -165,7 +165,6 @@ type Config struct {
 		ExternalShaders         []string `ini:"ExternalShaders"`
 		WindowScaleMode         bool     `ini:"WindowScaleMode"`
 		KeepAspect              bool     `ini:"KeepAspect"`
-		XyTruncate              bool     `ini:"XyTruncate"`
 		EnableModel             bool     `ini:"EnableModel"`
 		EnableModelShadow       bool     `ini:"EnableModelShadow"`
 	} `ini:"Video"`

--- a/src/render.go
+++ b/src/render.go
@@ -407,12 +407,6 @@ func rmInitSub(rp *RenderParams) {
 		rp.y *= -1
 	}
 	rp.y += rp.rcy
-
-	if sys.cfg.Video.XyTruncate {
-		// math.Round only accepts float64s, hence the need for conversion
-		rp.x = float32(int(math.Round(float64(rp.x))))
-		rp.y = float32(int(math.Round(float64(rp.y))))
-	}
 }
 
 func BlendReset() {

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -214,9 +214,6 @@ ExternalShaders   =
 WindowScaleMode   = 1
 ; Toggles Keep Aspect mode.
 KeepAspect        = 1
-; Toggles whether or not to truncate X/Y coordinates to whole numbers when rendering.
-; Helps to solve "blurring" artifacts, particularly on lower resolution characters.
-XyTruncate        = 0
 ; Toggles 3D Model support.
 EnableModel       = 1
 ; Toggles 3D Model Shadow support.


### PR DESCRIPTION
This reverts the commit that added the "X/Y Truncate" video setting. I initially wrote it to fix a sort of "pixel doubling" artifact that would occur in many cases (particularly low-res characters and certain screenpacks), but as evidenced by issues like #2564 and #2587 (and others reported in the Discord), it ended up causing a LOT more problems than it solves (enabling it by default didn't help matters either).

Since keeping this around would likely cause more issues down the road with little if any benefit, I've opted to just remove it entirely until a better solution can be found.

fixes #2587