### PR TITLE
fix: Modified to prevent the engine from crashing with certain invalid syntax

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -258,12 +258,7 @@ function main.f_fileExists(file)
 	if file == '' then
 		return false
 	end
-	local f = io.open(file,'r')
-	if f ~= nil then
-		io.close(f)
-		return true
-	end
-	return false
+	return fileExists(file)
 end
 
 --prints "t" table content into "toFile" file

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -2018,11 +2018,10 @@ function launchFight(data)
 end
 
 function launchStoryboard(path)
-	if path == nil or not main.f_fileExists(path) then
+	if path == nil or path == '' then
 		return false
 	end
-	storyboard.f_storyboard(path)
-	return true
+	return storyboard.f_storyboard(path)
 end
 
 function codeInput(name)

--- a/external/script/storyboard.lua
+++ b/external/script/storyboard.lua
@@ -7,21 +7,23 @@ storyboard.t_storyboard = {} --stores all parsed storyboards (we parse each of t
 local function f_reset(t)
 	main.f_setStoryboardScale(t.info.localcoord)
 	for _, scene in pairs(t.scene) do
-		if scene.bg_name ~= '' then
+		if scene.bg_name ~= '' and scene.bg then
 			bgReset(scene.bg)
 		end
 		for _, layer in pairs(scene.layer) do
 			if layer.anim_data ~= nil then
 				animReset(layer.anim_data)
 				animUpdate(layer.anim_data)
-				animSetPalFX(layer.anim_data, {
-					time =      layer.palfx_time,
-					add =       layer.palfx_add,
-					mul =       layer.palfx_mul,
-					sinadd =    layer.palfx_sinadd,
-					invertall = layer.palfx_invertall,
-					color =     layer.palfx_color
-				})
+				if layer.palfx_time then
+					animSetPalFX(layer.anim_data, {
+						time =      layer.palfx_time,
+						add =       layer.palfx_add,
+						mul =       layer.palfx_mul,
+						sinadd =    layer.palfx_sinadd,
+						invertall = layer.palfx_invertall,
+						color =     layer.palfx_color
+					})
+				end
 			end
 		end
 	end
@@ -121,7 +123,10 @@ local function f_play(t, attract)
 end
 
 local function f_parse(path)
-	local file = io.open(path, 'r')
+	local content = LoadText(path)
+	if content == nil then
+		return nil
+	end
 	local fileDir, fileName = path:match('^(.-)([^/\\]+)$')
 	local t = {info = {localcoord = {320, 240}}}
 	local pos = t
@@ -146,7 +151,7 @@ local function f_parse(path)
 		},
 		scene = {},
 	}
-	for line in file:lines() do
+	for line in content:gmatch("([^\r\n]*)[\r\n]?") do
 		line = line:gsub('%s*;.*$', '')
 		if line:match('^%s*%[.-%s*%]%s*$') then --matched [] group
 			line = line:match('^%s*%[(.-)%s*%]%s*$') --match text between []
@@ -313,7 +318,6 @@ local function f_parse(path)
 			end
 		end
 	end
-	file:close()
 	--;===========================================================
 	--; FIX REFERENCES, LOAD DATA
 	--;===========================================================
@@ -435,13 +439,14 @@ end
 
 function storyboard.f_storyboard(path, attract)
 	path = path:gsub('\\', '/')
-	if not main.f_fileExists(path) then
-		return
-	end
 	main.f_cmdBufReset()
 	main.f_disableLuaScale()
 	if storyboard.t_storyboard[path] == nil then
 		storyboard.t_storyboard[path] = f_parse(path)
+		if storyboard.t_storyboard[path] == nil then
+			main.f_setLuaScale()
+			return false
+		end
 	else
 		f_reset(storyboard.t_storyboard[path])
 	end

--- a/external/script/storyboard.lua
+++ b/external/script/storyboard.lua
@@ -123,7 +123,7 @@ local function f_play(t, attract)
 end
 
 local function f_parse(path)
-	local content = LoadText(path)
+	local content = loadText(path)
 	if content == nil then
 		return nil
 	end

--- a/src/input.go
+++ b/src/input.go
@@ -1030,7 +1030,7 @@ func (__ *InputBuffer) State2(ck CommandKey) int32 {
 	case CK_rN, CK_rNs:
 		return __.State(CK_rN)
 	case CK_Ns:
-		return Min(Abs(__.Ub), Abs(__.Db), Abs(__.Bb), Abs(__.Fb), Abs(__.ab), Abs(__.bb), Abs(__.cb), Abs(__.xb), Abs(__.yb), Abs(__.zb), Abs(__.wb), Abs(__.db))
+		return Min(Abs(__.Ub), Abs(__.Db), Abs(__.Bb), Abs(__.Fb), Abs(__.ab), Abs(__.bb), Abs(__.cb), Abs(__.xb), Abs(__.yb), Abs(__.zb), Abs(__.wb), Abs(__.db), Abs(__.sb))
 	}
 	return __.State(ck)
 }

--- a/src/script.go
+++ b/src/script.go
@@ -1890,7 +1890,7 @@ func systemScriptInit(l *lua.LState) {
 		sys.loadStart()
 		return 0
 	})
-	luaRegister(l, "LoadText", func(l *lua.LState) int {
+	luaRegister(l, "loadText", func(l *lua.LState) int {
 		path := strArg(l, 1)
 		content, err := LoadText(path)
 		if err != nil {

--- a/src/script.go
+++ b/src/script.go
@@ -937,6 +937,11 @@ func systemScriptInit(l *lua.LState) {
 		l.Push(lua.LBool(true))
 		return 1
 	})
+	luaRegister(l, "fileExists", func(l *lua.LState) int {
+		path := strArg(l, 1)
+		l.Push(lua.LBool(FileExist(path) != ""))
+		return 1
+	})
 	luaRegister(l, "fillRect", func(l *lua.LState) int {
 		rect := [4]int32{int32((float32(numArg(l, 1))/sys.luaSpriteScale + float32(sys.gameWidth-320)/2 + sys.luaSpriteOffsetX) * sys.widthScale),
 			int32((float32(numArg(l, 2))/sys.luaSpriteScale + float32(sys.gameHeight-240)) * sys.heightScale),
@@ -1884,6 +1889,16 @@ func systemScriptInit(l *lua.LState) {
 		}
 		sys.loadStart()
 		return 0
+	})
+	luaRegister(l, "LoadText", func(l *lua.LState) int {
+		path := strArg(l, 1)
+		content, err := LoadText(path)
+		if err != nil {
+			l.Push(lua.LNil)
+			return 1
+		}
+		l.Push(lua.LString(content))
+		return 1
 	})
 	luaRegister(l, "modifyGameOption", func(l *lua.LState) int {
 		query := strArg(l, 1)


### PR DESCRIPTION
・Modified to prevent the engine from crashing with certain invalid syntax
Fixes #2423
Fixes #1954
Fixes #1004 
Fixes #2020
Fixes #2459
There are surprisingly many characters that use these invalid syntaxes, and considering compatibility with MUGEN, I decided it would be better for general users to avoid crashing due to these syntax errors. 
Instead of crashing, a warning will be displayed in the debug console. 
Also, if ikemenversion is set, these syntax errors will cause crashes as before.

・Fixes #2591 load intro and ending storyboards from within zip files 
・Fixed to allow the $N command to respond to the start button as well