### PR TITLE
fix: Fixed a bug where AttachedChar's palfx becomes empty when change rounds

### DIFF
--- a/data/tag.zss
+++ b/data/tag.zss
@@ -121,7 +121,7 @@ if time = 0 {
 	turn{}
 }
 
-velSet{x: min(ifElse(const(velocity.run.fwd.x) != 0, const(velocity.run.fwd.x), const(velocity.walk.fwd.x) * 2), const240p(const(TagInVelX))); y: 0}
+velSet{x: min(max(ifElse(const(velocity.run.fwd.x) != 0, const(velocity.run.fwd.x), const(velocity.walk.fwd.x) * 2),5), const240p(const(TagInVelX)));y: 0}
 
 if backEdgeDist < -const240p(160) || frontEdgeDist < -const240p(160) {
 	selfState{value: const(StateTagWaitingOutside)}
@@ -245,7 +245,7 @@ ignoreHitPause if roundState = 2 && !isHelper {
 
 if !const(Default.Enable.Tag) || isHelper || teamSide = 0 {
 	# do nothing, global code disabled locally or executed by helper/stage
-} else if roundState = 0 && teamMode = Tag {
+} else if roundState <= 1 && teamMode = Tag && map(_iksys_tagActive) = 0 {
 	map(_iksys_tagActive) := 1;
 	map(_iksys_tagLastId) := 0;
 	map(_iksys_tagPartnerId) := 0;

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -768,10 +768,11 @@ func (c *Compiler) attr(text string, hitdef bool) (int32, error) {
 		case "h", "a":
 			flg |= int32(AT_HA | AT_HT | AT_HP)
 		default:
-			if sys.ignoreMostErrors && sys.cgi[c.playerNo].mugenver[0] == 1 {
+			if sys.ignoreMostErrors {
 				//if hitdef {
 				//	flg = hitdefflg
 				//}
+				sys.appendToConsole("WARNING: " + sys.cgi[c.playerNo].nameLow + fmt.Sprintf(": Invalid attr value: "+a+" in state %v ", c.stateNo))
 				return flg, nil
 			}
 			return 0, Error("Invalid attr value: " + a)
@@ -7380,6 +7381,7 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 				if sys.cgi[pn].ikemenver[0] != 0 || sys.cgi[pn].ikemenver[1] != 0 {
 					sys.cgi[pn].mugenver[0] = 1
 					sys.cgi[pn].mugenver[1] = 1
+					sys.cgi[pn].mugenverF = 1.1
 				}
 			}
 		case "files":

--- a/src/image.go
+++ b/src/image.go
@@ -9,7 +9,9 @@ import (
 	"io"
 	"math"
 	"os"
+	"regexp"
 	"runtime"
+	"strings"
 	"unsafe"
 )
 
@@ -1640,8 +1642,18 @@ func captureScreen() {
 		}
 		img.Pix[j] = pixdata[i]
 	}
+
+	// Sanitize WindowTitle for use in filenames
+	re := regexp.MustCompile(`[<>:"/\\|?*]`)
+	safeTitle := re.ReplaceAllString(sys.cfg.Config.WindowTitle, "_")
+	safeTitle = strings.TrimSpace(safeTitle)
+	safeTitle = strings.ReplaceAll(safeTitle, " ", "_")
+	if safeTitle == "" {
+		safeTitle = "ikemen"
+	}
+
 	for i := sys.captureNum; i < 999; i++ {
-		filename := fmt.Sprintf("%sikemen%03d.png", sys.cfg.Config.ScreenshotFolder, i)
+		filename := fmt.Sprintf("%s%s%03d.png", sys.cfg.Config.ScreenshotFolder, safeTitle, i)
 		if _, err := os.Stat(filename); os.IsNotExist(err) {
 			file, _ := os.Create(filename)
 			defer file.Close()

--- a/src/system.go
+++ b/src/system.go
@@ -1779,7 +1779,7 @@ func (s *System) action() {
 		for i, el := range *edl {
 			for j := len(el) - 1; j >= 0; j-- {
 				if el[j] >= 0 {
-					s.explods[i][el[j]].update(s.cgi[i].mugenver[0] != 1, i)
+					s.explods[i][el[j]].update(s.cgi[i].mugenverF, i)
 					if s.explods[i][el[j]].id == IErr {
 						if drop {
 							el = append(el[:j], el[j+1:]...)


### PR DESCRIPTION
・Fixed a bug where AttachedChar's palfx becomes empty when change rounds.
・Fixed #1880 if mugenversion is not 1.1, vel and accel are disabled during bindtime. 
・Changed the screenshot filename to use the window title. 
・Fixed #1583 allow invalid syntax in attr.
・Fixed #1955 an issue where characters with velocity.walk.fwd.x=0 and characters that freeze during roundState=0 did not function in tag mode. 
・Set mugenverF when ikemenversion is set.

・Added a feature to random command when an empty name is specified in AssertCommand.