### PR TITLE
fix(input): input parsing code remake; new command features

### DIFF
--- a/data/common.const
+++ b/data/common.const
@@ -11,9 +11,12 @@ Default.Enable.GuardBreak = 1
 Default.Enable.Score = 1
 Default.Enable.Tag = 1
 
+; Input toggles
+Input.FBFlipDistance = -1           ; Positive value inverts B and F inputs when an enemy is behind the player by that distance
+Input.PauseOnHitPause = 1           ; 1 makes commands be buffered during hit pause. Deprecated. See command parameters
+
 ; Backward compatibility toggles
 Default.LegacyGameDistanceSpec = 1  ; 1 prevents GameWidth/GameHeight from being affected by stage zoom for mugenversion 1.0 chars
-Input.PauseOnHitPause = 1           ; 1 makes inputs to be retained during hit pause. Deprecated. See command parameters
 
 ; Rules
 Default.Attack.LifeToPowerMul = 0.7 ; multiplier for power the attacker gets when a normal/special attack successfully hits (overridden by getpower HitDef option)

--- a/src/char.go
+++ b/src/char.go
@@ -4260,7 +4260,7 @@ func (c *Char) command(pn, i int) bool {
 	// AI cheating for commands longer than 1 button
 	// Maybe it could just cheat all of them and skip these checks
 	if c.controller < 0 && len(cl) > 0 {
-		if c.helperIndex != 0 || len(cl[0].cmd) > 1 || len(cl[0].cmd[0].key) > 1 { // || int(Btoi(cl[0].cmd[0].slash)) != len(cl[0].hold) {
+		if c.helperIndex != 0 || len(cl[0].cmd) > 1 || len(cl[0].cmd[0].keys) > 1 { // || int(Btoi(cl[0].cmd[0].slash)) != len(cl[0].hold) {
 			if i == int(c.cpucmd) {
 				return true
 			}

--- a/src/char.go
+++ b/src/char.go
@@ -4258,9 +4258,9 @@ func (c *Char) command(pn, i int) bool {
 		}
 	}
 	// AI cheating for commands longer than 1 button
+	// Maybe it could just cheat all of them and skip these checks
 	if c.controller < 0 && len(cl) > 0 {
-		if c.helperIndex != 0 || len(cl[0].cmd) > 1 || len(cl[0].cmd[0].key) > 1 ||
-			int(Btoi(cl[0].cmd[0].slash)) != len(cl[0].hold) {
+		if c.helperIndex != 0 || len(cl[0].cmd) > 1 || len(cl[0].cmd[0].key) > 1 { // || int(Btoi(cl[0].cmd[0].slash)) != len(cl[0].hold) {
 			if i == int(c.cpucmd) {
 				return true
 			}
@@ -9640,9 +9640,9 @@ func (c *Char) actionPrepare() {
 			// In Mugen, characters can perform basic actions even if they are KO
 			if !c.asf(ASF_nohardcodedkeys) {
 				if c.ctrl() {
-					if c.scf(SCF_guard) && c.inguarddist && !c.inGuardState() && c.ss.stateType != ST_L && c.cmd[0].Buffer.B > 0 {
+					if c.scf(SCF_guard) && c.inguarddist && !c.inGuardState() && c.ss.stateType != ST_L && c.cmd[0].Buffer.Bb > 0 {
 						c.changeState(120, -1, -1, "") // Start guarding
-					} else if !c.asf(ASF_nojump) && c.ss.stateType == ST_S && c.cmd[0].Buffer.U > 0 &&
+					} else if !c.asf(ASF_nojump) && c.ss.stateType == ST_S && c.cmd[0].Buffer.Ub > 0 &&
 						(!(sys.intro < 0 && sys.intro > -sys.lifebar.ro.over_waittime) || c.asf(ASF_postroundinput)) {
 						if c.ss.no != 40 {
 							c.changeState(40, -1, -1, "") // Jump
@@ -9654,19 +9654,19 @@ func (c *Char) actionPrepare() {
 							c.airJumpCount++
 							c.changeState(45, -1, -1, "") // Air jump
 						}
-					} else if !c.asf(ASF_nocrouch) && c.ss.stateType == ST_S && c.cmd[0].Buffer.D > 0 {
+					} else if !c.asf(ASF_nocrouch) && c.ss.stateType == ST_S && c.cmd[0].Buffer.Db > 0 {
 						if c.ss.no != 10 {
 							if c.ss.no != 100 {
 								c.vel[0] = 0
 							}
 							c.changeState(10, -1, -1, "") // Stand to crouch
 						}
-					} else if !c.asf(ASF_nostand) && c.ss.stateType == ST_C && c.cmd[0].Buffer.D < 0 {
+					} else if !c.asf(ASF_nostand) && c.ss.stateType == ST_C && c.cmd[0].Buffer.Db < 0 {
 						if c.ss.no != 12 {
 							c.changeState(12, -1, -1, "") // Crouch to stand
 						}
 					} else if !c.asf(ASF_nowalk) && c.ss.stateType == ST_S &&
-						(c.cmd[0].Buffer.F > 0 != ((!c.inguarddist || c.prevNoStandGuard) && c.cmd[0].Buffer.B > 0)) {
+						(c.cmd[0].Buffer.Fb > 0 != ((!c.inguarddist || c.prevNoStandGuard) && c.cmd[0].Buffer.Bb > 0)) {
 						if c.ss.no != 20 {
 							c.changeState(20, -1, -1, "") // Walk
 						}
@@ -9674,7 +9674,7 @@ func (c *Char) actionPrepare() {
 				}
 				// Braking is special in that it does not require ctrl
 				if !c.asf(ASF_nobrake) && c.ss.no == 20 &&
-					(c.cmd[0].Buffer.B > 0) == (c.cmd[0].Buffer.F > 0) {
+					(c.cmd[0].Buffer.Bb > 0) == (c.cmd[0].Buffer.Fb > 0) {
 					c.changeState(0, -1, -1, "")
 				}
 				// At least one character has been found where forcing them to stand up when crouching without ctrl will break them
@@ -9822,7 +9822,7 @@ func (c *Char) actionRun() {
 	c.unsetSCF(SCF_guard)
 	if ((c.scf(SCF_ctrl) || c.ss.no == 52) &&
 		c.ss.moveType == MT_I || c.inGuardState()) && c.cmd != nil &&
-		(c.cmd[0].Buffer.B > 0 || c.asf(ASF_autoguard)) &&
+		(c.cmd[0].Buffer.Bb > 0 || c.asf(ASF_autoguard)) &&
 		(c.ss.stateType == ST_S && !c.asf(ASF_nostandguard) ||
 			c.ss.stateType == ST_C && !c.asf(ASF_nocrouchguard) ||
 			c.ss.stateType == ST_A && !c.asf(ASF_noairguard)) {
@@ -9832,7 +9832,7 @@ func (c *Char) actionRun() {
 		if c.keyctrl[0] && c.cmd != nil {
 			if c.ctrl() && (c.controller >= 0 || c.helperIndex == 0) {
 				if !c.asf(ASF_nohardcodedkeys) {
-					if c.inguarddist && c.scf(SCF_guard) && !c.inGuardState() && c.cmd[0].Buffer.B > 0 {
+					if c.inguarddist && c.scf(SCF_guard) && !c.inGuardState() && c.cmd[0].Buffer.Bb > 0 {
 						c.changeState(120, -1, -1, "")
 						// In Mugen the characters *can* change to the guarding states during pauses
 						// They can still block in Ikemen despite not changing state here
@@ -10917,7 +10917,7 @@ func (cl *CharList) commandUpdate() {
 					c.autoTurn()
 				}
 				if (c.helperIndex == 0 || c.helperIndex > 0 && &c.cmd[0] != &root.cmd[0]) &&
-					c.cmd[0].InputUpdate(c.controller, c.facing, sys.aiLevel[i], c.inputFlag, false) {
+					c.cmd[0].InputUpdate(c.controller, c.facing < 0, sys.aiLevel[i], c.inputFlag, false) {
 					// Clear input buffers and skip the rest of the loop
 					// This used to apply only to the root, but that caused some issues with helper-based custom input systems
 					if c.inputWait() || c.asf(ASF_noinput) {

--- a/src/char.go
+++ b/src/char.go
@@ -4298,12 +4298,13 @@ func (c *Char) assertCommand(name string, time int32) {
 		}
 	}
 
-	ok := false
 	// Assert the command in every command list
+	found := false
 	for i := range c.cmd {
-		ok = c.cmd[i].Assert(name, time) || ok
+		found = c.cmd[i].Assert(name, time) || found
 	}
-	if !ok {
+
+	if !found {
 		sys.appendToConsole(c.warn() + fmt.Sprintf("attempted to assert an invalid command: %s", name))
 	}
 }

--- a/src/char.go
+++ b/src/char.go
@@ -4260,7 +4260,7 @@ func (c *Char) command(pn, i int) bool {
 	// AI cheating for commands longer than 1 button
 	// Maybe it could just cheat all of them and skip these checks
 	if c.controller < 0 && len(cl) > 0 {
-		if c.helperIndex != 0 || len(cl[0].cmd) > 1 || len(cl[0].cmd[0].keys) > 1 { // || int(Btoi(cl[0].cmd[0].slash)) != len(cl[0].hold) {
+		if c.helperIndex != 0 || len(cl[0].steps) > 1 || len(cl[0].steps[0].keys) > 1 { // || int(Btoi(cl[0].cmd[0].slash)) != len(cl[0].hold) {
 			if i == int(c.cpucmd) {
 				return true
 			}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -7499,6 +7499,7 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 				}
 				is.ReadBool("command.buffer.hitpause", &c.cmdl.DefaultBufferHitpause)
 				is.ReadBool("command.buffer.pauseend", &c.cmdl.DefaultBufferPauseEnd)
+				is.ReadBool("command.buffer.shared", &c.cmdl.DefaultBufferShared)
 			}
 		default:
 			// Get command sections
@@ -7526,6 +7527,7 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 		cm.autogreater = c.cmdl.DefaultAutoGreater
 		cm.buffer_hitpause = c.cmdl.DefaultBufferHitpause
 		cm.buffer_pauseend = c.cmdl.DefaultBufferPauseEnd
+		cm.buffer_shared = c.cmdl.DefaultBufferShared
 
 		// Read specific parameters
 		is.ReadI32("time", &cm.maxtime)
@@ -7540,6 +7542,7 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 		}
 		is.ReadBool("buffer.hitpause", &cm.buffer_hitpause)
 		is.ReadBool("buffer.pauseend", &cm.buffer_pauseend)
+		is.ReadBool("buffer.shared", &cm.buffer_shared)
 
 		// Parse the command string and populate steps
 		err = cm.ReadCommandSymbols(is["command"], ckr)

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -7544,7 +7544,12 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 		// Parse the command string and populate steps
 		err = cm.ReadCommandSymbols(is["command"], ckr)
 		if err != nil {
-			return nil, fmt.Errorf("command %s parse error: %v", name, err)
+			if sys.ignoreMostErrors && sys.cgi[pn].ikemenver[0] == 0 && sys.cgi[pn].ikemenver[1] == 0 {
+				// Mugen characters ignore command definition errors
+			} else {
+				return nil, Error(cmd + ":\nname = " + is["name"] +
+					"\ncommand = " + is["command"] + "\n" + err.Error())
+			}
 		}
 
 		c.cmdl.Add(*cm)

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -7491,7 +7491,8 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 			if defaults {
 				defaults = false
 				is.ReadI32("command.time", &c.cmdl.DefaultTime)
-				is.ReadI32("command.step.time", &c.cmdl.DefaultStepTime)
+				is.ReadI32("command.steptime", &c.cmdl.DefaultStepTime)
+				is.ReadBool("command.autogreater", &c.cmdl.DefaultAutoGreater)
 				var i32 int32
 				if is.ReadI32("command.buffer.time", &i32) {
 					c.cmdl.DefaultBufferTime = Max(1, i32)
@@ -7522,15 +7523,17 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 		cm.maxtime = c.cmdl.DefaultTime
 		cm.maxbuftime = c.cmdl.DefaultBufferTime
 		cm.maxsteptime = c.cmdl.DefaultStepTime
+		cm.autogreater = c.cmdl.DefaultAutoGreater
 		cm.buffer_hitpause = c.cmdl.DefaultBufferHitpause
 		cm.buffer_pauseend = c.cmdl.DefaultBufferPauseEnd
 		// Read specific parameters
 		is.ReadI32("time", &cm.maxtime)
-		is.ReadI32("step.time", &cm.maxsteptime)
-		// Default step.time to overall time
+		is.ReadI32("steptime", &cm.maxsteptime)
+		// Default steptime to overall time
 		if cm.maxsteptime <= 0 {
 			cm.maxsteptime = cm.maxtime
 		}
+		is.ReadBool("autogreater", &cm.autogreater)
 		var i32 int32
 		if is.ReadI32("buffer.time", &i32) {
 			cm.maxbuftime = Max(1, i32)

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -7491,7 +7491,7 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 			if defaults {
 				defaults = false
 				is.ReadI32("command.time", &c.cmdl.DefaultTime)
-				is.ReadI32("command.key.time", &c.cmdl.DefaultKeyTime)
+				is.ReadI32("command.step.time", &c.cmdl.DefaultStepTime)
 				var i32 int32
 				if is.ReadI32("command.buffer.time", &i32) {
 					c.cmdl.DefaultBufferTime = Max(1, i32)
@@ -7521,12 +7521,16 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 		// Default parameters
 		cm.maxtime = c.cmdl.DefaultTime
 		cm.maxbuftime = c.cmdl.DefaultBufferTime
-		cm.maxkeytime = c.cmdl.DefaultKeyTime
+		cm.maxsteptime = c.cmdl.DefaultStepTime
 		cm.buffer_hitpause = c.cmdl.DefaultBufferHitpause
 		cm.buffer_pauseend = c.cmdl.DefaultBufferPauseEnd
 		// Read specific parameters
 		is.ReadI32("time", &cm.maxtime)
-		is.ReadI32("key.time", &cm.maxkeytime)
+		is.ReadI32("step.time", &cm.maxsteptime)
+		// Default step.time to overall time
+		if cm.maxsteptime <= 0 {
+			cm.maxsteptime = cm.maxtime
+		}
 		var i32 int32
 		if is.ReadI32("buffer.time", &i32) {
 			cm.maxbuftime = Max(1, i32)

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -7448,43 +7448,43 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 		is, name, _ := ReadIniSection(lines, &i)
 		switch name {
 		case "remap":
-			// Read controller remap
+			// Read button remapping
 			if remap {
 				remap = false
-				rm := func(name string, k, nk *CommandKey) {
+				rm := func(name string, k *CommandKey) {
 					switch strings.ToLower(is[name]) {
 					case "x":
-						*k, *nk = CK_x, CK_rx
+						*k = CK_x
 					case "y":
-						*k, *nk = CK_y, CK_ry
+						*k = CK_y
 					case "z":
-						*k, *nk = CK_z, CK_rz
+						*k = CK_z
 					case "a":
-						*k, *nk = CK_a, CK_ra
+						*k = CK_a
 					case "b":
-						*k, *nk = CK_b, CK_rb
+						*k = CK_b
 					case "c":
-						*k, *nk = CK_c, CK_rc
+						*k = CK_c
 					case "s":
-						*k, *nk = CK_s, CK_rs
+						*k = CK_s
 					case "d":
-						*k, *nk = CK_d, CK_rd
+						*k = CK_d
 					case "w":
-						*k, *nk = CK_w, CK_rw
+						*k = CK_w
 					case "m":
-						*k, *nk = CK_m, CK_rm
+						*k = CK_m
 					}
 				}
-				rm("x", &ckr.x, &ckr.nx)
-				rm("y", &ckr.y, &ckr.ny)
-				rm("z", &ckr.z, &ckr.nz)
-				rm("a", &ckr.a, &ckr.na)
-				rm("b", &ckr.b, &ckr.nb)
-				rm("c", &ckr.c, &ckr.nc)
-				rm("s", &ckr.s, &ckr.ns)
-				rm("d", &ckr.d, &ckr.nd)
-				rm("w", &ckr.w, &ckr.nw)
-				rm("m", &ckr.m, &ckr.nm)
+				rm("x", &ckr.x)
+				rm("y", &ckr.y)
+				rm("z", &ckr.z)
+				rm("a", &ckr.a)
+				rm("b", &ckr.b)
+				rm("c", &ckr.c)
+				rm("s", &ckr.s)
+				rm("d", &ckr.d)
+				rm("w", &ckr.w)
+				rm("m", &ckr.m)
 			}
 		case "defaults":
 			// Read default command parameters

--- a/src/input.go
+++ b/src/input.go
@@ -739,11 +739,10 @@ func (ib *InputBuffer) updateInputTime(U, D, L, R, B, F, a, b, c, x, y, z, s, d,
 }
 
 // Check buffer state of each key
-// Resolves conflicts
-func (__ *InputBuffer) StateStrict(ck CommandKey) int32 {
+func (__ *InputBuffer) State(ck CommandKey) int32 {
 	switch ck {
 
-	// Held cardinal directions
+	// Hold cardinal directions
 	case CK_U:
 		conflict := -Max(__.Bb, Max(__.Db, __.Fb))
 		intended := __.Ub
@@ -774,7 +773,7 @@ func (__ *InputBuffer) StateStrict(ck CommandKey) int32 {
 		intended := __.Rb
 		return Min(conflict, intended)
 
-	// Held diagonals
+	// Hold diagonals
 	case CK_UF:
 		conflict := -Max(__.Db, __.Bb)
 		intended := Min(__.Ub, __.Fb)
@@ -815,10 +814,7 @@ func (__ *InputBuffer) StateStrict(ck CommandKey) int32 {
 		intended := Min(__.Db, __.Rb)
 		return Min(conflict, intended)
 
-	// Held sign directions
-	case CK_N, CK_Ns:
-		return __.Nb
-
+	// Hold sign cardinal directions
 	case CK_Us:
 		return __.Ub
 
@@ -837,6 +833,7 @@ func (__ *InputBuffer) StateStrict(ck CommandKey) int32 {
 	case CK_Rs:
 		return __.Rb
 
+	// Hold sign diagonals
 	case CK_UBs:
 		return Min(__.Ub, __.Bb)
 
@@ -861,38 +858,7 @@ func (__ *InputBuffer) StateStrict(ck CommandKey) int32 {
 	case CK_DRs:
 		return Min(__.Db, __.Rb)
 
-	// Held buttons
-	case CK_a:
-		return __.ab
-
-	case CK_b:
-		return __.bb
-
-	case CK_c:
-		return __.cb
-
-	case CK_x:
-		return __.xb
-
-	case CK_y:
-		return __.yb
-
-	case CK_z:
-		return __.zb
-
-	case CK_s:
-		return __.sb
-
-	case CK_d:
-		return __.db
-
-	case CK_w:
-		return __.wb
-
-	case CK_m:
-		return __.mb
-
-	// Released cardinal directions
+	// Release cardinal directions
 	case CK_rU:
 		conflict := -Max(__.Bb, Max(__.Db, __.Fb))
 		intended := __.Ub
@@ -923,7 +889,7 @@ func (__ *InputBuffer) StateStrict(ck CommandKey) int32 {
 		intended := __.Rb
 		return -Min(conflict, intended)
 
-	// Released diagonals
+	// Release diagonals
 	case CK_rUF:
 		conflict := -Max(__.Db, __.Bb)
 		intended := Min(__.Ub, __.Fb)
@@ -964,153 +930,7 @@ func (__ *InputBuffer) StateStrict(ck CommandKey) int32 {
 		intended := Min(__.Db, __.Rb)
 		return -Min(conflict, intended)
 
-	// Released sign directions
-	case CK_rUs:
-		return -__.Ub
-
-	case CK_rDs:
-		return -__.Db
-
-	case CK_rBs:
-		return -__.Bb
-
-	case CK_rFs:
-		return -__.Fb
-
-	case CK_rLs:
-		return -__.Lb
-
-	case CK_rRs:
-		return -__.Rb
-
-	case CK_rUBs:
-		return -Min(__.Ub, __.Bb)
-
-	case CK_rUFs:
-		return -Min(__.Ub, __.Fb)
-
-	case CK_rDBs:
-		return -Min(__.Db, __.Bb)
-
-	case CK_rDFs:
-		return -Min(__.Db, __.Fb)
-
-	case CK_rULs:
-		return -Min(__.Ub, __.Lb)
-
-	case CK_rURs:
-		return -Min(__.Ub, __.Rb)
-
-	case CK_rDLs:
-		return -Min(__.Db, __.Lb)
-
-	case CK_rDRs:
-		return -Min(__.Db, __.Rb)
-
-	case CK_rN, CK_rNs:
-		return -__.Nb
-
-	// Released buttons
-	case CK_ra:
-		return -__.ab
-
-	case CK_rb:
-		return -__.bb
-
-	case CK_rc:
-		return -__.cb
-
-	case CK_rx:
-		return -__.xb
-
-	case CK_ry:
-		return -__.yb
-
-	case CK_rz:
-		return -__.zb
-
-	case CK_rs:
-		return -__.sb
-
-	case CK_rd:
-		return -__.db
-
-	case CK_rw:
-		return -__.wb
-
-	case CK_rm:
-		return -__.mb
-	}
-
-	return 0
-}
-
-// Check buffer state of each key
-// Does not resolve conflicts. So, essentially, "sign directions"
-func (__ *InputBuffer) StateLenient(ck CommandKey) int32 {
-	/*lastRelease := func(a, b, c int32) int32 {
-		switch {
-		case a > 0:
-			return -Max(b, c)
-		case b > 0:
-			return -Max(a, c)
-		case c > 0:
-			return -Max(a, b)
-		}
-		return -Max(a, b, c)
-	}*/
-
-	switch ck {
-
-	// Hold sign cardinal directions
-	case CK_Us:
-		return __.Ub
-
-	case CK_Ds:
-		return __.Db
-
-	case CK_Bs:
-		return __.Bb
-
-	case CK_Fs:
-		return __.Fb
-
-	case CK_Ls:
-		return __.Lb
-
-	case CK_Rs:
-		return __.Rb
-
-	// In MUGEN, adding '$' to diagonal inputs doesn't have any meaning.
-	// Update: It does actually. For instance, $DB is true even if you also press U or F, but DB isn't
-
-	// Hold sign diagonals
-	case CK_DBs:
-		return Min(__.Db, __.Bb)
-
-	case CK_UBs:
-		return Min(__.Ub, __.Bb)
-
-	case CK_DFs:
-		return Min(__.Db, __.Fb)
-
-	case CK_UFs:
-		return Min(__.Ub, __.Fb)
-
-	case CK_DLs:
-		return Min(__.Db, __.Lb)
-
-	case CK_DRs:
-		return Min(__.Db, __.Rb)
-
-	case CK_ULs:
-		return Min(__.Ub, __.Lb)
-
-	case CK_URs:
-		return Min(__.Ub, __.Rb)
-
-
-	// Released sign cardinal directions
+	// Release sign cardinal directions
 	case CK_rUs:
 		return -__.Ub
 
@@ -1154,18 +974,84 @@ func (__ *InputBuffer) StateLenient(ck CommandKey) int32 {
 	case CK_rDRs:
 		return -Min(__.Db, __.Rb)
 
+	// In MUGEN, adding '$' to diagonal inputs doesn't have any meaning.
+	// Update: It does actually. For instance, $DB is true even if you also press U or F, but DB isn't
+
+	// Hold buttons
+	case CK_a:
+		return __.ab
+
+	case CK_b:
+		return __.bb
+
+	case CK_c:
+		return __.cb
+
+	case CK_x:
+		return __.xb
+
+	case CK_y:
+		return __.yb
+
+	case CK_z:
+		return __.zb
+
+	case CK_s:
+		return __.sb
+
+	case CK_d:
+		return __.db
+
+	case CK_w:
+		return __.wb
+
+	case CK_m:
+		return __.mb
+
+	// Release buttons
+	case CK_ra:
+		return -__.ab
+
+	case CK_rb:
+		return -__.bb
+
+	case CK_rc:
+		return -__.cb
+
+	case CK_rx:
+		return -__.xb
+
+	case CK_ry:
+		return -__.yb
+
+	case CK_rz:
+		return -__.zb
+
+	case CK_rs:
+		return -__.sb
+
+	case CK_rd:
+		return -__.db
+
+	case CK_rw:
+		return -__.wb
+
+	case CK_rm:
+		return -__.mb
+
 	// Neutral
 	case CK_N:
-		return __.StateStrict(CK_N)
+		return __.Nb
 
-	case CK_rN, CK_rNs:
-		return __.StateStrict(CK_rN)
+	case CK_rN:
+		return -__.Nb
 
-	case CK_Ns:
+	case CK_Ns, CK_rNs:
 		return Min(Abs(__.Ub), Abs(__.Db), Abs(__.Bb), Abs(__.Fb), Abs(__.ab), Abs(__.bb), Abs(__.cb), Abs(__.xb), Abs(__.yb), Abs(__.zb), Abs(__.wb), Abs(__.db), Abs(__.sb))
+		// This one somehow returns "any change" in Mugen. Since "any neutral" is useless anyway we'll just add support for that
 	}
 
-	return __.StateStrict(ck)
+	return 0
 }
 
 // Return charge time of a key
@@ -1471,6 +1357,7 @@ func (ib *InputBuffer) StateCharge(ck CommandKey) int32 {
 	return 0
 }
 
+/*
 // Time since last press of a key. Used for ">" type commands
 func (__ *InputBuffer) LastPressTime() int32 {
 	dir := Max(__.Bb, __.Db, __.Fb, __.Ub, __.Lb, __.Rb)
@@ -1486,6 +1373,15 @@ func (__ *InputBuffer) LastReleaseTime() int32 {
 
 	// Invert since we want a timer and release times are negative
 	return -Min(dir, btn)
+}
+*/
+
+// Time since last change of a key. Used for ">" type commands
+func (__ *InputBuffer) LastChangeTime() int32 {
+	dir := Min(Abs(__.Ub), Abs(__.Db), Abs(__.Bb), Abs(__.Fb), Abs(__.Lb), Abs(__.Rb))
+	btn := Min(Abs(__.ab), Abs(__.bb), Abs(__.cb), Abs(__.xb), Abs(__.yb), Abs(__.zb), Abs(__.sb), Abs(__.db), Abs(__.wb), Abs(__.mb))
+
+	return Min(dir, btn)
 }
 
 // NetBuffer holds the inputs that are sent between players
@@ -2044,6 +1940,8 @@ func newCommand() *Command {
 }
 
 // This is used to first compile the commands
+// At one point this expanded consecutive directions as documented in Kung Fu Man's command file (F, F -> F, >~F, >F)
+// However the added extra steps might make the new step.time parameter less predictable
 func ReadCommand(name, cmdstr string, kr *CommandKeyRemap) (*Command, error) {
 	c := newCommand()
 	c.name = name
@@ -2416,7 +2314,6 @@ func ReadCommand(name, cmdstr string, kr *CommandKeyRemap) (*Command, error) {
 		}
 	}
 
-
 	return c, nil
 }
 
@@ -2438,10 +2335,7 @@ func (c *Command) Clear(bufreset bool) {
 	}
 }
 
-// Check if incorrect keys were entered before the ">" step.
-// For press -> press (e.g. F, >F) only an incorrect press invalidates
-// For release -> release (e.g. ~F, >~F): only an incorrect release invalidates
-// Mugen seems to only account for presses here, so this is a bit experimental
+// Check if incorrect keys were entered before the ">" step
 func (c *Command) greaterCheckFail(ibuf *InputBuffer, idx int) bool {
 	if idx <= 0 || idx >= len(c.cmd) || !c.cmd[idx].greater {
 		return false
@@ -2453,9 +2347,21 @@ func (c *Command) greaterCheckFail(ibuf *InputBuffer, idx int) bool {
 	}
 
 	prevKeys := c.cmd[idx-1].key
-	nextKeys := c.cmd[idx].key
+	//nextKeys := c.cmd[idx].key
 
-	// If all keys are release, treat as a release step
+	// Check if the key responsible for the last change is present in the previous step
+	for _, pk := range prevKeys {
+		if Abs(ibuf.State(pk)) == ibuf.LastChangeTime() {
+			return false // Don't fail
+		}
+	}
+
+	// Implementations like below break with "B, ~B, >B" and such mixed commands. TODO: Maybe revisit this idea
+	// For press -> press (e.g. F, >F) only an incorrect press invalidates
+	// For release -> release (e.g. ~F, >~F): only an incorrect release invalidates
+	// Mugen treats everything the same here, so this is a bit experimental
+	/*
+	// Determine edge based on nextKeys
 	expectRelease := true
 	for _, k := range nextKeys {
 		if !(k.IsDirectionRelease() || k.IsButtonRelease()) {
@@ -2464,28 +2370,27 @@ func (c *Command) greaterCheckFail(ibuf *InputBuffer, idx int) bool {
 		}
 	}
 
-	// Negative edge
 	if expectRelease {
 		// Check if the freshest key release can be found in the previous step
 		for _, pk := range prevKeys {
-			if ibuf.StateLenient(pk) == ibuf.LastReleaseTime() {
-				return false // Don't fail
+			if ibuf.State(pk) == ibuf.LastReleaseTime() {
+				return false
 			}
 		}
-		return true
-	}
-
-	// Positive edge
-	for _, pk := range prevKeys {
-		// Check if the freshest key press can be found in the previous step
-		if ibuf.StateLenient(pk) == ibuf.LastPressTime() {
-			return false // Don't fail
+	} else {
+		// Press or mixed edge: check freshest presses in previous step
+		for _, pk := range prevKeys {
+			if ibuf.State(pk) == ibuf.LastPressTime() {
+				return false
+			}
 		}
 	}
+	*/
 
-	// Freshest press is foreign to current step
+	// Freshest input is foreign to current step
 	return true
 }
+
 
 // Update an individual command
 func (c *Command) Step(ibuf *InputBuffer, ai, isHelper, hpbuf, pausebuf bool, extratime int32) {
@@ -2582,7 +2487,7 @@ func (c *Command) Step(ibuf *InputBuffer, ai, isHelper, hpbuf, pausebuf bool, ex
 		// That's accurate to Mugen so let's keep it for now
 		inputMatched := false
 		for _, k := range c.cmd[i].key {
-			t := ibuf.StateLenient(k)
+			t := ibuf.State(k)
 			if c.cmd[i].slash {
 				inputMatched = inputMatched || t > 0 // Hold can be any positive number
 			} else if t == 1 { // t >= 1 && t <= 7 { // Old input code had this leniency for some reason (Mugen input delay?)
@@ -2598,7 +2503,7 @@ func (c *Command) Step(ibuf *InputBuffer, ai, isHelper, hpbuf, pausebuf bool, ex
 		// It's also inaccuurate to Mugen. Commenting out for now
 		/*inputMatched := true
 		for _, k := range c.cmd[i].key {
-			t := ibuf.StateLenient(k)
+			t := ibuf.State(k)
 			if c.cmd[i].slash {
 				// Hold requirement: must be currently down (t > 0)
 				if t <= 0 {
@@ -2901,6 +2806,7 @@ func (cl *CommandList) CopyList(src CommandList) {
 	}
 }
 
+/*
 func withoutTildeKey(k CommandKey) CommandKey {
 	if k >= CK_rU && k <= CK_rN {
 		return k - (CK_rU - CK_U)
@@ -2913,6 +2819,7 @@ func withoutTildeKey(k CommandKey) CommandKey {
 	}
 	return k
 }
+*/
 
 /*
 func autoGenerateExtendedCommand(originalCmd *Command) *Command {

--- a/src/script.go
+++ b/src/script.go
@@ -775,15 +775,22 @@ func systemScriptInit(l *lua.LState) {
 		if !ok {
 			userDataError(l, 1, cl)
 		}
-		cm, err := ReadCommand(strArg(l, 2), strArg(l, 3), NewCommandKeyRemap())
-		if err != nil {
+
+		name := strArg(l, 2)
+		cmdstr := strArg(l, 3)
+
+		cm := newCommand()
+		cm.name = name
+		if err := cm.ReadCommandSymbols(cmdstr, NewCommandKeyRemap()); err != nil {
 			l.RaiseError(err.Error())
 		}
+
 		time := cl.DefaultTime
 		buftime := cl.DefaultBufferTime
 		buffer_hitpause := cl.DefaultBufferHitpause
 		buffer_pauseend := cl.DefaultBufferPauseEnd
 		steptime := cl.DefaultStepTime
+
 		if !nilArg(l, 4) {
 			time = int32(numArg(l, 4))
 		}
@@ -799,11 +806,13 @@ func systemScriptInit(l *lua.LState) {
 		if !nilArg(l, 8) {
 			steptime = int32(numArg(l, 8))
 		}
+
 		cm.maxtime = time
 		cm.maxbuftime = buftime
 		cm.buffer_hitpause = buffer_hitpause
 		cm.buffer_pauseend = buffer_pauseend
 		cm.maxsteptime = steptime
+
 		cl.Add(*cm)
 		return 0
 	})

--- a/src/script.go
+++ b/src/script.go
@@ -783,7 +783,7 @@ func systemScriptInit(l *lua.LState) {
 		buftime := cl.DefaultBufferTime
 		buffer_hitpause := cl.DefaultBufferHitpause
 		buffer_pauseend := cl.DefaultBufferPauseEnd
-		keytime := cl.DefaultKeyTime
+		steptime := cl.DefaultStepTime
 		if !nilArg(l, 4) {
 			time = int32(numArg(l, 4))
 		}
@@ -797,13 +797,13 @@ func systemScriptInit(l *lua.LState) {
 			buffer_pauseend = boolArg(l, 7)
 		}
 		if !nilArg(l, 8) {
-			keytime = int32(numArg(l, 8))
+			steptime = int32(numArg(l, 8))
 		}
 		cm.maxtime = time
 		cm.maxbuftime = buftime
 		cm.buffer_hitpause = buffer_hitpause
 		cm.buffer_pauseend = buffer_pauseend
-		cm.maxkeytime = keytime
+		cm.maxsteptime = steptime
 		cl.Add(*cm)
 		return 0
 	})
@@ -828,7 +828,7 @@ func systemScriptInit(l *lua.LState) {
 		if !ok {
 			userDataError(l, 1, cl)
 		}
-		if cl.InputUpdate(int(numArg(l, 2))-1, 1, 0, 0, true) {
+		if cl.InputUpdate(int(numArg(l, 2))-1, false, 0, 0, true) {
 			cl.Step(false, false, false, false, 0)
 		}
 		return 0

--- a/src/system.go
+++ b/src/system.go
@@ -611,6 +611,7 @@ func (s *System) synchronize() error {
 	return nil
 }
 
+/*
 func (s *System) anyHardButton() bool {
 	for _, kc := range s.keyConfig {
 		if kc.a() || kc.b() || kc.c() || kc.x() || kc.y() || kc.z() {
@@ -622,6 +623,35 @@ func (s *System) anyHardButton() bool {
 			return true
 		}
 	}
+	return false
+}
+*/
+
+// Joysticks were already refactored to be polled less times, but having these functions still makes them be polled twice as often during intros/outros
+// We're already polling them about 10 times less so that should be enough anyway
+// In Mugen, intro/outro skipping only happens on button press, not button hold
+func (s *System) anyHardButton() bool {
+	// Button indices for a, b, c, x, y, z
+	hardButtonIdx := []int{4, 5, 6, 7, 8, 9}
+
+	for _, kc := range s.keyConfig {
+		buttons := ControllerState(kc)
+		for _, idx := range hardButtonIdx {
+			if buttons[idx] {
+				return true
+			}
+		}
+	}
+
+	for _, kc := range s.joystickConfig {
+		buttons := ControllerState(kc)
+		for _, idx := range hardButtonIdx {
+			if buttons[idx] {
+				return true
+			}
+		}
+	}
+
 	return false
 }
 


### PR DESCRIPTION
- Recoded and/or refactored a large part of the input code. Commands now use a timer system for each of their steps instead of using an index that can only move forward
- This means inputting the first steps of a command allows one to restart them at any time, making inputs feel more responsive
- In addition, several command-related features were added

Features:
- Command "autogreater" parameter. Unhardcodes automatic ">" symbol attribution on repeated directions (like F, F)
- Improved support for multiple symbols in the same step. e.g. "/a+/b" now works
- Charge time can now be defined with "/" as well. If you charge B for 30 frames, "~30B" is true when you release it while "/30B" is true while you keep holding it
- Charge time can now be defined individually for each key in the same step
- "|" symbol. Makes command step use OR logic. Example "x|y|z" means press x or y or z
- New "Input.FBFlipDistance" constant allows characters to choose to invert B and F inputs when an enemy is behind them by a certain distance instead of relying solely on facing
- Command buffer.shared parameter. If true, the command steps will be reset when another command with the same name is completed (default behavior)

Refactor:
- Renamed command key.time parameter to steptime
- Identical directions are now actually internally expanded into ">" inputs as documented in Kung Fu Man
- Joysticks are only polled once per frame, down from 14 times
- Several parts of the input code are now more straightforward
- If char has ikemenversion, some invalid command syntaxes will produce an error message

See individual commit description for more details.

Fixes #1280 at a deeper level
Fixes #2530