### PR TITLE
feat(motif): xshear and angle text parameters

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -507,6 +507,8 @@ function text:create(t)
 	t.window[2] = t.window[2] or 0
 	t.window[3] = t.window[3] or motif.info.localcoord[1]
 	t.window[4] = t.window[4] or motif.info.localcoord[2]
+	t.xshear = t.xshear or 0
+	t.angle = t.angle or 0
 	t.defsc = t.defsc or false
 	t.ti = textImgNew()
 	setmetatable(t, self)
@@ -530,6 +532,8 @@ function text:create(t)
 	textImgSetPos(t.ti, t.x + main.f_alignOffset(t.align), t.y)
 	textImgSetScale(t.ti, t.scaleX, t.scaleY)
 	textImgSetWindow(t.ti, t.window[1], t.window[2], t.window[3] - t.window[1], t.window[4] - t.window[2])
+	textImgSetXShear(t.ti, t.xshear)
+	textImgSetAngle(t.ti, t.angle)
 	if t.defsc then main.f_setLuaScale() end
 	return t
 end
@@ -581,6 +585,8 @@ function text:update(t)
 		textImgSetPos(self.ti, self.x + main.f_alignOffset(self.align), self.y)
 		textImgSetScale(self.ti, self.scaleX, self.scaleY)
 		textImgSetWindow(self.ti, self.window[1], self.window[2], self.window[3] - self.window[1], self.window[4] - self.window[2])
+		textImgSetXShear(self.ti, self.xshear)
+		textImgSetAngle(self.ti, self.angle)
 		if self.defsc then main.f_setLuaScale() end
 	else
 		self.text = t
@@ -722,6 +728,8 @@ function main.f_createTextImg(t, prefix, mod)
 		g =      t[prefix .. '_font'][5],
 		b =      t[prefix .. '_font'][6],
 		height = t[prefix .. '_font'][7],
+		xshear = t[prefix .. '_xshear'] or 0,
+		angle  = t[prefix .. '_angle'] or 0,
 		window = t[prefix .. '_window'],
 		defsc = mod.defsc or false,
 	})
@@ -3965,6 +3973,8 @@ function main.f_menuCommonDraw(t, item, cursorPosY, moveTxt, section, bgdef, tit
 						g =      motif[section].menu_item_selected_active_font[5],
 						b =      motif[section].menu_item_selected_active_font[6],
 						height = motif[section].menu_item_selected_active_font[7],
+						xshear = motif[section].menu_item_selected_active_xshear,
+						angle  = motif[section].menu_item_selected_active_angle,
 						defsc =  defsc,
 					})
 					t[i].data:draw()
@@ -3982,6 +3992,8 @@ function main.f_menuCommonDraw(t, item, cursorPosY, moveTxt, section, bgdef, tit
 						g =      motif[section].menu_item_active_font[5],
 						b =      motif[section].menu_item_active_font[6],
 						height = motif[section].menu_item_active_font[7],
+						xshear = motif[section].menu_item_active_xshear,
+						angle  = motif[section].menu_item_active_angle,
 						defsc =  defsc,
 					})
 					t[i].data:draw()
@@ -4000,6 +4012,8 @@ function main.f_menuCommonDraw(t, item, cursorPosY, moveTxt, section, bgdef, tit
 						g =      motif[section].menu_item_value_active_font[5],
 						b =      motif[section].menu_item_value_active_font[6],
 						height = motif[section].menu_item_value_active_font[7],
+						xshear = motif[section].menu_item_value_active_xshear,
+						angle  = motif[section].menu_item_value_active_angle,
 						defsc =  defsc,
 					})
 					t[i].vardata:draw()
@@ -4025,6 +4039,8 @@ function main.f_menuCommonDraw(t, item, cursorPosY, moveTxt, section, bgdef, tit
 						g =      motif[section].menu_item_selected_font[5],
 						b =      motif[section].menu_item_selected_font[6],
 						height = motif[section].menu_item_selected_font[7],
+						xshear = motif[section].menu_item_selected_xshear,
+						angle  = motif[section].menu_item_selected_angle,
 						defsc =  defsc,
 					})
 					t[i].data:draw()
@@ -4042,6 +4058,8 @@ function main.f_menuCommonDraw(t, item, cursorPosY, moveTxt, section, bgdef, tit
 						g =      motif[section].menu_item_font[5],
 						b =      motif[section].menu_item_font[6],
 						height = motif[section].menu_item_font[7],
+						xshear = motif[section].menu_item_xshear,
+						angle  = motif[section].menu_item_angle,
 						defsc =  defsc,
 					})
 					t[i].data:draw()
@@ -4060,6 +4078,8 @@ function main.f_menuCommonDraw(t, item, cursorPosY, moveTxt, section, bgdef, tit
 						g =      motif[section].menu_item_value_font[5],
 						b =      motif[section].menu_item_value_font[6],
 						height = motif[section].menu_item_value_font[7],
+						xshear = motif[section].menu_item_value_xshear,
+						angle  = motif[section].menu_item_value_angle,
 						defsc =  defsc,
 					})
 					t[i].vardata:draw()

--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -2163,6 +2163,8 @@ function options.f_keyCfg(cfgType, controller, bgdef, skipClear)
 			g =      motif.option_info['keymenu_item_p' .. i .. '_font'][5],
 			b =      motif.option_info['keymenu_item_p' .. i .. '_font'][6],
 			height = motif.option_info['keymenu_item_p' .. i .. '_font'][7],
+			xshear = motif.option_info['keymenu_item_p' .. i .. '_xshear'],
+			angle  = motif.option_info['keymenu_item_p' .. i .. '_angle'],
 			defsc =  motif.defaultOptions,
 		})
 		txt_keyController[i]:draw()
@@ -2211,6 +2213,8 @@ function options.f_keyCfg(cfgType, controller, bgdef, skipClear)
 						g =      motif.option_info.keymenu_item_active_font[5],
 						b =      motif.option_info.keymenu_item_active_font[6],
 						height = motif.option_info.keymenu_item_active_font[7],
+						xshear = motif.option_info.keymenu_item_active_xshear,
+						angle  = motif.option_info.keymenu_item_active_angle,
 						defsc =  motif.defaultOptions,
 					})
 					t[i].data[j]:draw()
@@ -2230,6 +2234,8 @@ function options.f_keyCfg(cfgType, controller, bgdef, skipClear)
 								g =      motif.option_info.keymenu_item_value_conflict_font[5],
 								b =      motif.option_info.keymenu_item_value_conflict_font[6],
 								height = motif.option_info.keymenu_item_value_conflict_font[7],
+								xshear = motif.option_info.keymenu_item_value_conflict_xshear,
+								angle  = motif.option_info.keymenu_item_value_conflict_angle,
 								defsc =  motif.defaultOptions,
 							})
 							t[i].vardata[j]:draw()
@@ -2248,6 +2254,8 @@ function options.f_keyCfg(cfgType, controller, bgdef, skipClear)
 								g =      motif.option_info.keymenu_item_value_active_font[5],
 								b =      motif.option_info.keymenu_item_value_active_font[6],
 								height = motif.option_info.keymenu_item_value_active_font[7],
+								xshear = motif.option_info.keymenu_item_value_active_xshear,
+								angle  = motif.option_info.keymenu_item_value_active_angle,
 								defsc =  motif.defaultOptions,
 							})
 							t[i].vardata[j]:draw()
@@ -2267,6 +2275,8 @@ function options.f_keyCfg(cfgType, controller, bgdef, skipClear)
 							g =      motif.option_info.keymenu_item_info_active_font[5],
 							b =      motif.option_info.keymenu_item_info_active_font[6],
 							height = motif.option_info.keymenu_item_info_active_font[7],
+							xshear = motif.option_info.keymenu_item_info_active_xshear,
+							angle  = motif.option_info.keymenu_item_info_active_angle,
 							defsc =  motif.defaultOptions,
 						})
 						t[i].infodata[j]:draw()
@@ -2291,6 +2301,8 @@ function options.f_keyCfg(cfgType, controller, bgdef, skipClear)
 						g =      motif.option_info.keymenu_item_font[5],
 						b =      motif.option_info.keymenu_item_font[6],
 						height = motif.option_info.keymenu_item_font[7],
+						xshear = motif.option_info.keymenu_item_xshear,
+						angle  = motif.option_info.keymenu_item_angle,
 						defsc =  motif.defaultOptions,
 					})
 					t[i].data[j]:draw()
@@ -2310,6 +2322,8 @@ function options.f_keyCfg(cfgType, controller, bgdef, skipClear)
 								g =      motif.option_info.keymenu_item_value_conflict_font[5],
 								b =      motif.option_info.keymenu_item_value_conflict_font[6],
 								height = motif.option_info.keymenu_item_value_conflict_font[7],
+								xshear = motif.option_info.keymenu_item_value_conflict_xshear,
+								angle  = motif.option_info.keymenu_item_value_conflict_angle,
 								defsc =  motif.defaultOptions,
 							})
 							t[i].vardata[j]:draw()
@@ -2328,6 +2342,8 @@ function options.f_keyCfg(cfgType, controller, bgdef, skipClear)
 								g =      motif.option_info.keymenu_item_value_font[5],
 								b =      motif.option_info.keymenu_item_value_font[6],
 								height = motif.option_info.keymenu_item_value_font[7],
+								xshear = motif.option_info.keymenu_item_value_xshear,
+								angle  = motif.option_info.keymenu_item_value_angle,
 								defsc =  motif.defaultOptions,
 							})
 							t[i].vardata[j]:draw()
@@ -2347,6 +2363,8 @@ function options.f_keyCfg(cfgType, controller, bgdef, skipClear)
 							g =      motif.option_info.keymenu_item_info_font[5],
 							b =      motif.option_info.keymenu_item_info_font[6],
 							height = motif.option_info.keymenu_item_info_font[7],
+							xshear = motif.option_info.keymenu_item_info_xshear,
+							angle  = motif.option_info.keymenu_item_info_angle,
 							defsc =  motif.defaultOptions,
 						})
 						t[i].infodata[j]:draw()

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -2363,6 +2363,8 @@ function start.f_selectScreen()
 							g =      motif.select_info['p' .. side .. '_name_font'][5],
 							b =      motif.select_info['p' .. side .. '_name_font'][6],
 							height = motif.select_info['p' .. side .. '_name_font'][7],
+							xshear = motif.select_info['p' .. side .. '_name_xshear'],
+							angle  = motif.select_info['p' .. side .. '_name_angle'],
 						})
 						t_txt_name[side]:draw()
 					end
@@ -2434,6 +2436,8 @@ function start.f_selectScreen()
 						g =      motif.select_info[stageActiveType .. '_font'][5],
 						b =      motif.select_info[stageActiveType .. '_font'][6],
 						height = motif.select_info[stageActiveType .. '_font'][7],
+						xshear = motif.select_info[stageActiveType .. '_xshear'],
+						angle  = motif.select_info[stageActiveType .. '_angle'],
 					})
 					txt_selStage:draw()
 				end
@@ -2630,6 +2634,8 @@ function start.f_teamMenu(side, t)
 					g =      motif.select_info[t_teamActiveType[side] .. '_font'][5],
 					b =      motif.select_info[t_teamActiveType[side] .. '_font'][6],
 					height = motif.select_info[t_teamActiveType[side] .. '_font'][7],
+					xshear = motif.select_info[t_teamActiveType[side] .. '_xshear'],
+					angle  = motif.select_info[t_teamActiveType[side] .. '_angle'],
 				})
 				t[i].data:draw()
 			else
@@ -2649,6 +2655,8 @@ function start.f_teamMenu(side, t)
 					g =      motif.select_info['p' .. side .. '_teammenu_item_font'][5],
 					b =      motif.select_info['p' .. side .. '_teammenu_item_font'][6],
 					height = motif.select_info['p' .. side .. '_teammenu_item_font'][7],
+					xshear = motif.select_info['p' .. side .. '_teammenu_item_xshear'],
+					angle  = motif.select_info['p' .. side .. '_teammenu_item_angle'],
 				})
 				t[i].data:draw()
 			end
@@ -3142,6 +3150,8 @@ function start.f_selectVersus(active, t_orderSelect)
 						g =      motif.vs_screen['p' .. side .. '_name_font'][5],
 						b =      motif.vs_screen['p' .. side .. '_name_font'][6],
 						height = motif.vs_screen['p' .. side .. '_name_font'][7],
+						xshear = motif.vs_screen['p' .. side .. '_name_xshear'],
+						angle  = motif.vs_screen['p' .. side .. '_name_angle'],
 					})
 					t_txt_nameVS[side]:draw()
 				end
@@ -3875,6 +3885,8 @@ function start.f_continue()
 				g =      motif.continue_screen[var .. '_font'][5],
 				b =      motif.continue_screen[var .. '_font'][6],
 				height = motif.continue_screen[var .. '_font'][7],
+				xshear = motif.continue_screen[var .. '_xshear'],
+				angle  = motif.continue_screen[var .. '_angle'],
 			})
 			txt:draw()
 		end

--- a/src/script.go
+++ b/src/script.go
@@ -2880,6 +2880,22 @@ func systemScriptInit(l *lua.LState) {
 			float32(numArg(l, 4))/sys.luaSpriteScale, float32(numArg(l, 5))/sys.luaSpriteScale)
 		return 0
 	})
+	luaRegister(l, "textImgSetXShear", func(*lua.LState) int {
+		ts, ok := toUserData(l, 1).(*TextSprite)
+		if !ok {
+			userDataError(l, 1, ts)
+		}
+		ts.xshear = float32(numArg(l, 2))
+		return 0
+	})
+	luaRegister(l, "textImgSetAngle", func(*lua.LState) int {
+		ts, ok := toUserData(l, 1).(*TextSprite)
+		if !ok {
+			userDataError(l, 1, ts)
+		}
+		ts.angle = float32(numArg(l, 2))
+		return 0
+	})
 	luaRegister(l, "toggleClsnDisplay", func(*lua.LState) int {
 		if !sys.cfg.Debug.AllowDebugMode {
 			return 0


### PR DESCRIPTION
This PR adds `xshear` and `angle` parameters to screenpack text elements by using Rakíel's new font rendering features (#2437).

- Added Lua function `textImgSetXShear(TextImage, number)`
- Added Lua function `textImgSetAngle(TextImage, number)`
- The `text` Lua class now uses `xshear` and `angle` parameters