### PR TITLE
feat(sctrl): ShiftInput; fixes; refactor

### DIFF
--- a/data/common.const
+++ b/data/common.const
@@ -12,7 +12,7 @@ Default.Enable.Score = 1
 Default.Enable.Tag = 1
 
 ; Input toggles
-Input.FBFlipDistance = -1           ; Positive value inverts B and F inputs when an enemy is behind the player by that distance
+Input.FBFlipEnemyDistance = -1      ; Positive value inverts B and F inputs when an enemy is behind the player by that distance
 Input.PauseOnHitPause = 1           ; 1 makes commands be buffered during hit pause. Deprecated. See command parameters
 
 ; Backward compatibility toggles

--- a/src/char.go
+++ b/src/char.go
@@ -4253,22 +4253,31 @@ func (c *Char) command(pn, i int) bool {
 	if !c.keyctrl[0] || c.cmd == nil {
 		return false
 	}
+
+	// Get all commands with the specified first index (name)
 	cl := c.cmd[pn].At(i)
-	// Check if any command with that name is buffered
+
+	// Check if any of them are buffered
 	for _, c := range cl {
 		if c.curbuftime > 0 {
 			return true
 		}
 	}
+
 	// AI cheating for commands longer than 1 button
 	// Maybe it could just cheat all of them and skip these checks
 	if c.controller < 0 && len(cl) > 0 {
-		if c.helperIndex != 0 || len(cl[0].steps) > 1 || len(cl[0].steps[0].keys) > 1 { // || int(Btoi(cl[0].cmd[0].slash)) != len(cl[0].hold) {
+		steps := cl[0].steps
+		multiStep := len(steps) > 1
+		multiKey := len(steps) > 0 && len(steps[0].keys) > 1
+
+		if c.helperIndex != 0 || multiStep || multiKey {
 			if i == int(c.cpucmd) {
 				return true
 			}
 		}
 	}
+
 	return false
 }
 

--- a/src/char.go
+++ b/src/char.go
@@ -4440,7 +4440,31 @@ func (c *Char) isHelper(id int32, idx int) bool {
 }
 
 func (c *Char) isHost() bool {
-	return sys.netConnection != nil && sys.netConnection.host
+	// Local play has no host
+	if sys.netConnection == nil && sys.replayFile == nil {
+		return false
+	}
+
+	// Find first human player like in GetHostGuestRemap()
+	// This doesn't seem ideal somehow, but it's better than not having it
+	// When you think about it, it's almost the same as just returning true for player 1
+	var host int
+	for i, v := range sys.aiLevel {
+		if v == 0 {
+			host = i
+			break
+		}
+	}
+
+	// "host" already defaults to 0 so player 1 is the fallback host
+	return c.playerNo == host
+
+	// TODO: For Tag mode, this should probably return true for all characters controlled by the player
+
+	// For the host, this returned true for any player
+	// For the guest, it returned false for any player
+	// https://github.com/ikemen-engine/Ikemen-GO/issues/2523
+	//return sys.netConnection != nil && sys.netConnection.host
 }
 
 func (c *Char) jugglePoints(id int32) int32 {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -153,8 +153,11 @@ func newCompiler() *Compiler {
 		"modifyhitdef":         c.modifyHitDef,
 		"modifyplayer":         c.modifyPlayer,
 		"modifyprojectile":     c.modifyProjectile,
+		"modifyreflection":     c.modifyReflection,
 		"modifyreversaldef":    c.modifyReversalDef,
+		"modifyshadow":         c.modifyShadow,
 		"modifysnd":            c.modifySnd,
+		"modifystagebg":        c.modifyStageBG,
 		"modifystagevar":       c.modifyStageVar,
 		"parentmapadd":         c.parentMapAdd,
 		"parentmapset":         c.parentMapSet,
@@ -171,8 +174,7 @@ func newCompiler() *Compiler {
 		"roundtimeset":         c.roundTimeSet,
 		"savefile":             c.saveFile,
 		"scoreadd":             c.scoreAdd,
-		"modifyshadow":         c.modifyShadow,
-		"modifyreflection":     c.modifyReflection,
+		"shiftinput":           c.shiftInput,
 		"tagin":                c.tagIn,
 		"tagout":               c.tagOut,
 		"targetadd":            c.targetAdd,
@@ -185,7 +187,6 @@ func newCompiler() *Compiler {
 		"text":                 c.text,
 		"transformclsn":        c.transformClsn,
 		"transformsprite":      c.transformSprite,
-		"modifystagebg":        c.modifyStageBG,
 	}
 	return c
 }

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -6409,6 +6409,80 @@ func (c *Compiler) modifyStageBG(is IniSection, sc *StateControllerBase, _ int8)
 	return *ret, err
 }
 
+func (c *Compiler) shiftInput(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+	inputIndex := func(name string) (int32, error) {
+		switch name {
+		case "U":
+			return 0, nil
+		case "D":
+			return 1, nil
+		case "L":
+			return 2, nil
+		case "R":
+			return 3, nil
+		case "a":
+			return 4, nil
+		case "b":
+			return 5, nil
+		case "c":
+			return 6, nil
+		case "x":
+			return 7, nil
+		case "y":
+			return 8, nil
+		case "z":
+			return 9, nil
+		case "s":
+			return 10, nil
+		case "d":
+			return 11, nil
+		case "w":
+			return 12, nil
+		case "m":
+			return 13, nil
+		case "none":
+			return -1, nil
+		case "B", "F":
+			return -1, Error("'B' and 'F' symbols not accepted. Must be 'L' or 'R'")
+		default:
+			return -1, Error("Invalid key name: " + name)
+		}
+	}
+
+	ret, err := (*shiftInput)(sc), c.stateSec(is, func() error {
+		if err := c.paramValue(is, sc, "redirectid",
+			shiftInput_redirectid, VT_Int, 1, false); err != nil {
+			return err
+		}
+
+		if err := c.stateParam(is, "input", true, func(srcName string) error {
+			srcID, err := inputIndex(srcName)
+			if err != nil {
+				return err
+			}
+			sc.add(shiftInput_input, sc.iToExp(srcID))
+			return nil
+		}); err != nil {
+			return err
+		}
+
+		if err := c.stateParam(is, "output", true, func(dstName string) error {
+			dstID, err := inputIndex(dstName)
+			if err != nil {
+				return err
+			}
+			sc.add(shiftInput_output, sc.iToExp(dstID))
+			return nil
+		}); err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	return *ret, err
+}
+
 // It's just a Null... Has no effect whatsoever.
 func (c *Compiler) null(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	return nullStateController, nil

--- a/src/input.go
+++ b/src/input.go
@@ -2411,45 +2411,50 @@ func (c *Command) AutoGreaterExpand() {
 		return
 	}
 
-	// Check if expansion is needed
+	// Check if expansion is needed before doing all the work
 	needExpansion := false
 	for i := 1; i < len(c.steps); i++ {
-		prev := c.steps[i-1]
-		curr := c.steps[i]
-		if prev.IsSingleDirection() && curr.IsSingleDirection() && prev.EqualSteps(curr) {
+		if c.steps[i-1].IsSingleDirection() && c.steps[i].IsSingleDirection() && c.steps[i-1].EqualSteps(c.steps[i]) {
 			needExpansion = true
 			break
 		}
 	}
+	if !needExpansion {
+		return
+	}
 
 	// Replace command with new expanded command
-	if needExpansion {
-		var newCmd []CommandStep
-		for i := 0; i < len(c.steps); i++ {
-			if i+1 < len(c.steps) &&
-				c.steps[i].IsSingleDirection() &&
-				c.steps[i+1].IsSingleDirection() &&
-				c.steps[i].EqualSteps(c.steps[i+1]) {
+	// Keep the first step, expand each additional identical step into ">~X, >X"
+	newCmd := make([]CommandStep, 0, len(c.steps)*2) // Overestimate new capacity
+	newCmd = append(newCmd, c.steps[0])
 
-				// Mark next step as ">X"
-				c.steps[i+1].greater = true
+	for i := 1; i < len(c.steps); i++ {
+		prev := c.steps[i-1]
+		curr := c.steps[i]
 
-				// Insert ">~X" step between i and i+1
-				newStep := CommandStep{
+		if prev.IsSingleDirection() && curr.IsSingleDirection() && prev.EqualSteps(curr) {
+			// Expand repeat into ">~X, >X"
+			newCmd = append(newCmd,
+				CommandStep{
 					greater: true,
 					keys: []CommandStepKey{{
-						key:    c.steps[i+1].keys[0].key,
-						tilde:  !c.steps[i+1].keys[0].tilde,
-						dollar: c.steps[i+1].keys[0].dollar,
+						key:    curr.keys[0].key,
+						tilde:  !curr.keys[0].tilde,
+						dollar: curr.keys[0].dollar,
 					}},
-				}
-				newCmd = append(newCmd, c.steps[i], newStep)
-			} else {
-				newCmd = append(newCmd, c.steps[i])
-			}
+				},
+				CommandStep{
+					greater: true,
+					keys:    curr.keys,
+				},
+			)
+		} else {
+			// No expansion, just copy
+			newCmd = append(newCmd, curr)
 		}
-		c.steps = newCmd
 	}
+
+	c.steps = newCmd
 }
 
 func (c *Command) Clear(bufreset bool) {
@@ -2585,12 +2590,15 @@ func (c *Command) Step(ibuf *InputBuffer, ai, isHelper, hpbuf, pausebuf bool, ex
 		// This approach has a quirk in that foreign inputs are accepted if they're entered the same frame that the intended input matched
 		// Should be harmless because at least that's very hard for a human to perform
 		// Out of the methods tried, this one has the best results for the least work
-		if !inputMatched && i > 0 && c.steps[i].greater &&
-			len(c.steps) >= 2 && c.completed[i-1] && !c.completed[i] && ibuf.LastChangeTime() == 1 {
-			// && ibuf.State(c.steps[i-1].keys[0]) != ibuf.LastChangeTime() { // More work for same result as above
-
-			c.Clear(false)
-			return
+		if !inputMatched &&
+			i > 0 && c.steps[i].greater && len(c.steps) >= 2 &&
+			c.completed[i-1] && !c.completed[i] && ibuf.State(c.steps[i-1].keys[0]) != ibuf.LastChangeTime() {
+			// Ikemen used to do a c.Clear(false) here
+			// But Mugen seems to do something like this instead. Or it's more like a ">" failure just prevents "inputMatched"
+			// This makes mashing some commands like "D, D, D" easier to do
+			// Clear previous step only
+			c.completed[i-1] = false
+			c.stepTimers[i-1] = 0
 		}
 
 		if inputMatched {

--- a/src/script.go
+++ b/src/script.go
@@ -837,7 +837,7 @@ func systemScriptInit(l *lua.LState) {
 		if !ok {
 			userDataError(l, 1, cl)
 		}
-		if cl.InputUpdate(int(numArg(l, 2))-1, false, 0, 0, true) {
+		if cl.InputUpdate(int(numArg(l, 2))-1, false, 0, 0, nil, true) {
 			cl.Step(false, false, false, false, 0)
 		}
 		return 0


### PR DESCRIPTION
Feat:
- ShiftInput state controller. Allows "rewiring" a character's controls
- Example: shiftInput{input: a; output: b} makes button a work like button b. One way only

Fix:
- Fixed isHost to do what it says and return true for the player number hosting the match
- Fixed AI command crashing out of bounds
- Fixes #2523
- Fixes #2615

Refactor:
- Failing a ">" input now only invalidates the previous step instead of the entire command
- Improved auto expansion of multiple identical directions in commands
- AssertInput is no longer buffered during hitpause. Same as actual inputs
- "Input.FBFlipDistance" to "Input.FBFlipEnemyDistance"
- Uncluttered the System fight() function a little by externalizing round start backup and character initialization
- Random Test handicaps are now wrapped by "if sys.autolevel" conditions for the sake of clarity