### PR TITLE
feat: Added flag to prevent default fall.yvelocity and yaccel from being affected by localcoord

### DIFF
--- a/data/common.const
+++ b/data/common.const
@@ -17,6 +17,7 @@ Input.PauseOnHitPause = 1           ; 1 makes commands be buffered during hit pa
 
 ; Backward compatibility toggles
 Default.LegacyGameDistanceSpec = 1  ; 1 prevents GameWidth/GameHeight from being affected by stage zoom for mugenversion 1.0 chars
+Default.LegacyFallYVelYAccel = 0    ; 1 sets HitDef's fall.yvelocity and yaccel defaults to fixed values, ignoring chars localcoord scaling.
 
 ; Rules
 Default.Attack.LifeToPowerMul = 0.7 ; multiplier for power the attacker gets when a normal/special attack successfully hits (overridden by getpower HitDef option)

--- a/src/char.go
+++ b/src/char.go
@@ -638,6 +638,9 @@ type HitDef struct {
 }
 
 func (hd *HitDef) clear(c *Char, localscl float32) {
+	if c.gi().constants["default.legacyfallyvelyaccel"] == 1 {
+		localscl = 1
+	}
 	// Convert local scale back to 4:3 in order to keep values consistent in widescreen
 	originLs := localscl * (320 / float32(sys.gameWidth))
 
@@ -851,8 +854,12 @@ type GetHitVar struct {
 }
 
 func (ghv *GetHitVar) clear(c *Char) {
+	localscl := c.localscl
+	if c.gi().constants["default.legacyfallyvelyaccel"] == 1 {
+		localscl = 1
+	}
 	// Convert local scale back to 4:3 in order to keep values consistent in widescreen
-	originLs := c.localscl * (320 / float32(sys.gameWidth))
+	originLs := localscl * (320 / float32(sys.gameWidth))
 
 	*ghv = GetHitVar{
 		hittime:        -1,
@@ -3085,7 +3092,8 @@ func (c *Char) load(def string) error {
 	gi.constants["default.lifetoredlifemul"] = 0.75
 	gi.constants["super.lifetoredlifemul"] = 0.75
 	gi.constants["default.legacygamedistancespec"] = 0
-	gi.constants["default.ignoredefeatedenemies"] = 1
+	gi.constants["default.legacyfallyvelyaccel"] = 0
+	//gi.constants["default.ignoredefeatedenemies"] = 0
 	gi.constants["input.pauseonhitpause"] = 1
 	gi.constants["input.fbflipenemydistance"] = -1
 

--- a/src/input.go
+++ b/src/input.go
@@ -2573,11 +2573,14 @@ func (c *Command) Step(ibuf *InputBuffer, ai, isHelper, hpbuf, pausebuf bool, ex
 
 		// MUGEN's internal AI can't use commands without the "/" symbol on helpers
 		if ai && isHelper {
+			hasSlash := false
 			for _, k := range c.steps[i].keys {
-				if !k.slash {
-					inputMatched = false
-					break
+				if k.slash {
+					hasSlash = true
 				}
+			}
+			if !hasSlash {
+				return
 			}
 		}
 


### PR DESCRIPTION
・In MUGEN 1.0/1.1, the default values for yaccel and fall.yvelocity in Hitdef, when omitted, vary depending on localcoord. However, this specification can cause unexpected issues, such as combos failing to connect, for characters not designed with localcoord in mind.
https://sakisukebekkan.blog.fc2.com/blog-entry-87.html
http://yurusanae.blog98.fc2.com/blog-entry-143.html
While manual fixes are possible, they are time-consuming. This flag is intended to make it easy to apply these fixes on a per-character basis.When this flag is set to 1, the default values for yaccel and fall.yvelocity in Hitdef will no longer be affected by localcoord. The default value is 0. 

・Fixed a regression where AI Helper could use commands without a “/”