### PR TITLE
feat: Made BGM RAM Swap a toggleable feature; fix: possible deadlock in SwapSeeker; build fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,14 @@ Ikemen_GO_LinuxARM: ${srcFiles}
 # MacOS x64 target
 Ikemen_GO_MacOS: ${srcFiles}
 	cd ./build && bash ./build.sh MacOS
+	$(MAKE) clean_appbundle
+	$(MAKE) appbundle BINNAME=Ikemen_GO_MacOS
+
+# MacOS Apple Silicon target
+Ikemen_GO_MacOSARM: ${srcFiles}
+	cd ./build && bash ./build.sh MacOSARM
+	$(MAKE) clean_appbundle
+	$(MAKE) appbundle BINNAME=Ikemen_GO_MacOSARM
 
 # MacOS app bundle
 appbundle:
@@ -50,11 +58,11 @@ appbundle:
 	mkdir -p I.K.E.M.E.N-Go.app/Contents
 	mkdir -p I.K.E.M.E.N-Go.app/Contents/MacOS
 	mkdir -p I.K.E.M.E.N-Go.app/Contents/Resources
-	cp bin/Ikemen_GO_MacOS I.K.E.M.E.N-Go.app/Contents/MacOS/Ikemen_GO_MacOS
+	cp bin/$(BINNAME) I.K.E.M.E.N-Go.app/Contents/MacOS/$(BINNAME)
 	cp ./build/Info.plist I.K.E.M.E.N-Go.app/Contents/Info.plist
 	cp ./build/bundle_run.sh I.K.E.M.E.N-Go.app/Contents/MacOS/bundle_run.sh
 	chmod +x I.K.E.M.E.N-Go.app/Contents/MacOS/bundle_run.sh
-	chmod +x I.K.E.M.E.N-Go.app/Contents/MacOS/Ikemen_GO_MacOS
+	chmod +x I.K.E.M.E.N-Go.app/Contents/MacOS/$(BINNAME)
 	cd ./build && mkdir -p ./icontmp/icon.iconset && \
 	cp ../external/icons/IkemenCylia_256.png ./icontmp/icon.iconset/icon_256x256.png && \
 	iconutil -c icns ./icontmp/icon.iconset && \

--- a/build/build.sh
+++ b/build/build.sh
@@ -16,6 +16,9 @@ function main() {
 	# Enable CGO.
 	export CGO_ENABLED=1
 
+	# Enable arenas (required for rollback)
+	export GOEXPERIMENT=arenas
+
 	# Create "bin" folder.
 	mkdir -p bin
 
@@ -35,6 +38,10 @@ function main() {
 		[wW][iI][nN]32)
 			varWin32
 			buildWin
+		;;
+		[mM][aA][cC][oO][sS][aA][rR][mM])
+			varMacOSARM
+			build
 		;;
 		[mM][aA][cC][oO][sS])
 			varMacOS
@@ -77,8 +84,24 @@ function varWin64() {
 	binName="Ikemen_GO.exe"
 }
 
+function varMacOSARM() {
+	export GOOS=darwin
+	export GOARCH=arm64
+	case "${currentOS}" in
+		[mM][aA][cC][oO][sS])
+			export CC=clang
+			export CXX=clang++
+		;;
+		*)
+			export CC=o64-clang
+			export CXX=o64-clang++
+		;;
+	esac
+	binName="Ikemen_GO_MacOSARM"
+}
 function varMacOS() {
 	export GOOS=darwin
+	export GOARCH=amd64
 	case "${currentOS}" in
 		[mM][aA][cC][oO][sS])
 			export CC=clang

--- a/build/bundle_run.sh
+++ b/build/bundle_run.sh
@@ -7,17 +7,23 @@ SCRIPT_DIR="$(dirname "$0")"
 APP_DIR="$(cd "$SCRIPT_DIR/../../" && pwd)"
 
 # Define the path to the app executable relative to the MacOS directory
-APP_EXEC="$SCRIPT_DIR/Ikemen_GO_MacOS"
+APP_EXEC="$SCRIPT_DIR/Ikemen_GO_MacOSARM"
 
 # Output for debugging
 echo "SCRIPT_DIR: $SCRIPT_DIR"
 echo "APP_DIR: $APP_DIR"
 echo "APP_EXEC: $APP_EXEC"
 
-# Check if the executable exists
+# Check if the ARM executable exists
 if [ ! -x "$APP_EXEC" ]; then
-    echo "Executable $APP_EXEC not found or not executable"
-    exit 1
+    echo "Executable $APP_EXEC not found or not executable. Trying regular path..."
+    APP_EXEC="$SCRIPT_DIR/Ikemen_GO_MacOS"
+
+    # Check if the x64 executable exists
+    if [ ! -x "$APP_EXEC" ]; then
+        echo "Executable $APP_EXEC not found or not executable."
+        exit 1
+    fi
 fi
 
 # Change directory to the parent directory of the .app bundle

--- a/src/config.go
+++ b/src/config.go
@@ -177,6 +177,7 @@ type Config struct {
 		PauseMasterVolume int     `ini:"PauseMasterVolume"`
 		WavVolume         int     `ini:"WavVolume"`
 		BGMVolume         int     `ini:"BGMVolume"`
+		BGMRAMBuffer      bool    `ini:"BGMRAMBuffer"`
 		MaxBGMVolume      int     `ini:"MaxBGMVolume"`
 		AudioDucking      bool    `ini:"AudioDucking"`
 	} `ini:"Sound"`

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -250,6 +250,10 @@ BGMVolume         = 75
 MaxBGMVolume      = 100
 ; Toggles level of audio signal reducing by the presence of another signal.
 AudioDucking      = 0
+; Enables BGM swapping to RAM. This is required for looping to work properly with
+; some formats (namely FLAC). If I.K.E.M.E.N-Go hangs or crashes on your system,
+; try setting this to 0, at the cost of potential skipping during loop points.
+BGMRAMBuffer      = 1
 
 ; -------------------------------------------------------------------------------
 [Arcade]

--- a/src/sound.go
+++ b/src/sound.go
@@ -108,8 +108,8 @@ func newSwapSeeker(ss beep.StreamSeeker) *SwapSeeker {
 
 // Swap(next, absStart): next - new seeker
 func (sw *SwapSeeker) Swap(next beep.StreamSeeker) {
-	sw.mu.Lock()
 	speaker.Lock()
+	sw.mu.Lock()
 	pos := sw.ss.Position()
 
 	if ln := next.Len(); ln <= 0 { // guard against 0
@@ -395,8 +395,8 @@ func (bgm *Bgm) Open(filename string, loop, bgmVolume, bgmLoopStart, bgmLoopEnd,
 	bgm.streamer.Seek(startPosition)
 	speaker.Play(bgm.ctrl)
 
-	// Handle the RAM swap in the background (only for looped BGM)
-	if lc != 0 {
+	// Handle the RAM swap in the background (only for looped BGM and only if the user enabled it)
+	if lc != 0 && sys.cfg.Sound.BGMRAMBuffer {
 		go func(ctx context.Context) {
 			// Call the cancel function when the goroutine exits
 			// to ensure cleanup.


### PR DESCRIPTION
* Fixes a possible deadlock scenario that could occur with lock acquisition in SwapSeeker.Swap()
* If that doesn't fix it, then disabling the RAM swap entirely should (at the cost of skipping, nothing we can do about that at this point from what I can tell, otherwise the main thread would be stuck waiting on the BGM to begin to buffer & play)

Meant as a resolution for #2600 

Build fixes:
* Added arenas to the environment variables for all builds (required for rollback).
* Added macOS ARM target and made the previous macOS target specifically target x64 (macs would otherwise default to their own architecture which could make cross-distribution problematic for users still stuck on Intel)
* Updated app bundle run script to handle new macOS executable names.

As mentioned before, the pipeline probably needs to be changed to accommodate the appbundle now, not sure what needs to be done there but I will say the .app is a specialized folder in macOS, so it will appear as such on other systems.