### PR TITLE
fix: Positive value of boundhigh and reference pos of yscaledelta

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -638,11 +638,13 @@ type HitDef struct {
 }
 
 func (hd *HitDef) clear(c *Char, localscl float32) {
+	var originLs float32
 	if c.gi().constants["default.legacyfallyvelyaccel"] == 1 {
-		localscl = 1
+		originLs = 1
+	} else {
+		// Convert local scale back to 4:3 in order to keep values consistent in widescreen
+		originLs = c.localscl * (320 / float32(sys.gameWidth))
 	}
-	// Convert local scale back to 4:3 in order to keep values consistent in widescreen
-	originLs := localscl * (320 / float32(sys.gameWidth))
 
 	*hd = HitDef{
 		isprojectile:       false,
@@ -854,12 +856,13 @@ type GetHitVar struct {
 }
 
 func (ghv *GetHitVar) clear(c *Char) {
-	localscl := c.localscl
+	var originLs float32
 	if c.gi().constants["default.legacyfallyvelyaccel"] == 1 {
-		localscl = 1
+		originLs = 1
+	} else {
+		// Convert local scale back to 4:3 in order to keep values consistent in widescreen
+		originLs = c.localscl * (320 / float32(sys.gameWidth))
 	}
-	// Convert local scale back to 4:3 in order to keep values consistent in widescreen
-	originLs := localscl * (320 / float32(sys.gameWidth))
 
 	*ghv = GetHitVar{
 		hittime:        -1,

--- a/src/stage.go
+++ b/src/stage.go
@@ -461,9 +461,14 @@ func (bg backGround) draw(pos [2]float32, drawscl, bgscl, stglscl float32,
 
 	y := bg.start[1] - yScrollPos + bg.bga.offset[1]
 
+	//In MUGEN, if Boundhigh is a positive value, the reference pos of yscaledelta will change
+	var positiveBoundhigh float32
+	if isStage && sys.cam.boundhigh > 0 {
+		positiveBoundhigh = float32(sys.cam.boundhigh) * bg.delta[1] * bgscl / drawscl / stgscl[1]
+	}
 	// Calculate Y scaling based on vertical scroll position and delta
 	ys2 := bg.scaledelta[1] * pos[1] * bg.delta[1] * bgscl / drawscl / stgscl[1]
-	ys := ((100-(pos[1])*bg.yscaledelta)*bgscl/bg.yscalestart)*bg.scalestart[1] + ys2
+	ys := ((100-(pos[1]-positiveBoundhigh)*bg.yscaledelta)*bgscl/bg.yscalestart)*bg.scalestart[1] + ys2
 	xs := bg.scaledelta[0] * pos[0] * bg.delta[0] * bgscl / stgscl[0]
 	x *= bgscl
 


### PR DESCRIPTION
・Fixed #2577
 In MUGEN, if Boundhigh is a positive value, the reference pos of yscaledelta will change 

・Fixed Default.LegacyFallYVelYAccel to be unaffected by aspect ratio