### PR TITLE
fix(rollback): command desyncs, Tag inputs; refactor: less code duplication

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -9734,7 +9734,7 @@ func (c *Char) actionPrepare() {
 							}
 							c.changeState(10, -1, -1, "") // Stand to crouch
 						}
-					} else if !c.asf(ASF_nostand) && c.ss.stateType == ST_C && c.cmd[0].Buffer.Db < 0 {
+					} else if !c.asf(ASF_nostand) && c.ss.stateType == ST_C && c.cmd[0].Buffer.Db <= 0 {
 						if c.ss.no != 12 {
 							c.changeState(12, -1, -1, "") // Crouch to stand
 						}

--- a/src/net.go
+++ b/src/net.go
@@ -262,11 +262,11 @@ func (r *RollbackSession) AdvanceFrame(flags int) {
 	// the game state instead of reading from the keyboard.
 	// Get the confirmed inputs from the GGPO backend for the frame being simulated
 	inputs, ggpoerr := r.backend.SyncInput(&disconnectFlags)
-	sys.rollback.currentInputs = decodeInputs(inputs)
+	sys.rollback.ggpoInputs = decodeInputs(inputs)
 
 	if r.recording != nil {
-		r.SetInput(r.netTime, 0, sys.rollback.currentInputs[0])
-		r.SetInput(r.netTime, 1, sys.rollback.currentInputs[1])
+		r.SetInput(r.netTime, 0, sys.rollback.ggpoInputs[0])
+		r.SetInput(r.netTime, 1, sys.rollback.ggpoInputs[1])
 		r.netTime++
 	}
 
@@ -326,7 +326,7 @@ func (r *RollbackSession) OnEvent(info *ggpo.Event) {
 		sys.rollback.currentFight.fin = true
 		sys.endMatch = true
 		r.SaveReplay()
-		ShowInfoDialog("Desync Error. Please report your issue to the rollback alpha issues page at https://github.com/assemblaj/Ikemen-GO/issues. Thanks for your patience", "Desync Error")
+		ShowInfoDialog("Desync error.\nIf the problem persists, please report it at:\nhttps://github.com/ikemen-engine/Ikemen-GO/issues.\nThank you for your patience", "Desync Error")
 	case ggpo.EventCodeConnectionInterrupted:
 		fmt.Println("EventCodeconnectionInterrupted")
 	case ggpo.EventCodeConnectionResumed:
@@ -334,11 +334,11 @@ func (r *RollbackSession) OnEvent(info *ggpo.Event) {
 	}
 }
 
-func NewRollbackSesesion(config RollbackProperties) RollbackSession {
+func NewRollbackSession(config RollbackProperties) RollbackSession {
 	r := RollbackSession{}
 	r.saveStates = make(map[int]*GameState)
-	r.players = make([]ggpo.Player, 9)
-	r.handles = make([]ggpo.PlayerHandle, 9)
+	r.players = make([]ggpo.Player, 2) // MaxPlayerNo
+	r.handles = make([]ggpo.PlayerHandle, 2) // MaxPlayerNo
 	r.config = config
 	r.loopTimer = NewLoopTimer(60, 100)
 	r.timestamp = time.Now().Format("2006-01-02_03-04PM-05s")
@@ -348,6 +348,7 @@ func NewRollbackSesesion(config RollbackProperties) RollbackSession {
 	return r
 
 }
+
 func encodeInputs(inputs InputBits) []byte {
 	return writeI32(int32(inputs))
 }
@@ -397,11 +398,13 @@ func (rs *RollbackSession) LiveChecksum(s *System) uint32 {
 	}
 	return crc32.ChecksumIEEE(buf)
 }
+
 func (rs *RollbackSession) Input(time int32, player int) (input InputBits) {
 	inputs := rs.inputs[int(time)]
 	input = inputs[player]
 	return
 }
+
 func (rs *RollbackSession) AnyButton() bool {
 	for i := 0; i < len(rs.inputs[len(rs.inputs)-1]); i++ {
 		if rs.Input(sys.gameTime, i)&IB_anybutton != 0 {

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -311,10 +311,15 @@ ListenPort   = 7500
 ; List of saved IP addresses that will populate the netplay connection menu
 ; IP.<name> = <IP address>
 IP.localhost                   = 127.0.0.1
+; Toggles experimental rollback netcode in place of traditional delay netcode.
 RollbackNetcode                = false
+; Number of frames of input delay applied to local inputs to mitigate rollbacks.
 Rollback.FrameDelay            = 2
+; Time in milliseconds after a connection stalls before the player is notified.
 Rollback.DisconnectNotifyStart = 1000
+; Time in milliseconds after a connection stalls before the match is terminated.
 Rollback.DisconnectTimeout     = 3000
+; Debugging parameters.
 Rollback.LogsEnabled           = false
 Rollback.SaveStageData         = false
 Rollback.DesyncTest            = false

--- a/src/script.go
+++ b/src/script.go
@@ -878,7 +878,7 @@ func systemScriptInit(l *lua.LState) {
 
 		//Rollback only
 		if sys.cfg.Netplay.RollbackNetcode {
-			rs := NewRollbackSesesion(sys.cfg.Netplay.Rollback)
+			rs := NewRollbackSession(sys.cfg.Netplay.Rollback)
 			sys.rollback.session = &rs
 		}
 

--- a/src/state.go
+++ b/src/state.go
@@ -205,9 +205,9 @@ type GameState struct {
 	fadeintime              int32
 	fadeouttime             int32
 	changeStateNest         int32
-	accel                   float32
-	clsnDraw                bool
-	statusDraw              bool
+	//accel                   float32
+	//clsnDisplay             bool
+	//debugDisplay            bool
 	workpal                 []uint32
 	nomusic                 bool
 	keyConfig               []KeyConfig
@@ -361,8 +361,9 @@ func (gs *GameState) LoadState(stateID int) {
 
 	sys.changeStateNest = gs.changeStateNest
 
-	sys.accel = gs.accel
-	sys.clsnDisplay = gs.clsnDraw
+	//sys.accel = gs.accel
+	//sys.clsnDisplay = gs.clsnDisplay
+	//sys.debugDisplay = gs.debugDisplay
 
 	// Things that directly or indirectly get put into CGO can't go into arenas
 	sys.workpal = make([]uint32, len(gs.workpal)) //arena.MakeSlice[uint32](a, len(gs.workpal), len(gs.workpal))
@@ -506,7 +507,9 @@ func (gs *GameState) LoadState(stateID int) {
 	sys.wintime = gs.wintime
 
 	// Log state load
-	sys.appendToConsole(fmt.Sprintf("%v: Game state loaded", sys.tickCount))
+	if sys.rollback.session == nil {
+		sys.appendToConsole(fmt.Sprintf("%v: Game state loaded", sys.tickCount))
+	}
 }
 
 func (gs *GameState) SaveState(stateID int) {
@@ -587,9 +590,9 @@ func (gs *GameState) SaveState(stateID int) {
 
 	gs.changeStateNest = sys.changeStateNest
 
-	gs.accel = sys.accel
-	gs.clsnDraw = sys.clsnDisplay
-	gs.statusDraw = sys.debugDisplay
+	//gs.accel = sys.accel
+	//gs.clsnDisplay = sys.clsnDisplay
+	//gs.debugDisplay = sys.debugDisplay
 
 	// Things that directly or indirectly get put into CGO can't go into arenas
 	gs.workpal = make([]uint32, len(sys.workpal)) //arena.MakeSlice[uint32](a, len(sys.workpal), len(sys.workpal))
@@ -717,7 +720,9 @@ func (gs *GameState) SaveState(stateID int) {
 	gs.wintime = sys.wintime
 
 	// Log save state
-	sys.appendToConsole(fmt.Sprintf("%v: Game state saved", sys.tickCount))
+	if sys.rollback.session == nil {
+		sys.appendToConsole(fmt.Sprintf("%v: Game state saved", sys.tickCount))
+	}
 }
 
 func (gs *GameState) cloneLuaTable(s *lua.LTable) *lua.LTable {

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -230,8 +230,7 @@ func (c *Char) Clone(a *arena.Arena, gsp *GameStatePool) (result Char) {
 
 	result.aimg = c.aimg.Clone(a)
 
-	// todo, find the curFrame index and set result.curFrame as the pointer at
-	// that index
+	// todo, find the curFrame index and set result.curFrame as the pointer at that index
 	if c.anim != nil {
 		result.anim = c.anim.Clone(a, gsp)
 	}
@@ -303,6 +302,7 @@ func (c *Char) Clone(a *arena.Arena, gsp *GameStatePool) (result Char) {
 	for k, v := range c.mapArray {
 		result.mapArray[k] = v
 	}
+
 	return
 }
 
@@ -342,10 +342,19 @@ func (ce *CommandStep) Clone(a *arena.Arena) (result CommandStep) {
 func (c *Command) clone(a *arena.Arena) (result Command) {
 	result = *c
 
+	result.completed = arena.MakeSlice[bool](a, len(c.completed), len(c.completed))
+	copy(result.completed, c.completed)
+
+	result.stepTimers = arena.MakeSlice[int32](a, len(c.stepTimers), len(c.stepTimers))
+	copy(result.stepTimers, c.stepTimers)
+
+	// Maybe we don't need to save these or any other things that are only updated upon loading the char
+	/*
 	result.steps = arena.MakeSlice[CommandStep](a, len(c.steps), len(c.steps))
 	for i := 0; i < len(c.steps); i++ {
 		result.steps[i] = c.steps[i].Clone(a)
 	}
+	*/
 
 	// New input code does not use these
 	/*


### PR DESCRIPTION
Fix:
- Adjust how inputs are polled so that the same player can control all their characters during Tag
- Added more command state values to the game state. Should fix many desyncs
- Fixed chars sometimes not standing up from crouching when the round ends

Refactor:
- Collapsed some shared logic
- Merged update() and await() with system.go
- Commented rollback config settings
- Game states no longer save/restore debug modes