### PR TITLE
fix: Update Ikemen_GO.command to point to appbundle executable paths for macOS

### DIFF
--- a/build/Ikemen_GO.command
+++ b/build/Ikemen_GO.command
@@ -3,6 +3,7 @@ cd $(dirname $0)
 
 case "$OSTYPE" in
 	darwin*) #echo "It's a Mac!!" ;
+		xattr -d com.apple.quarantine I.K.E.M.E.N-Go.app
 		chmod +x ./I.K.E.M.E.N-Go.app/Contents/MacOS/bundle_run.sh
 		./I.K.E.M.E.N-Go.app/Contents/MacOS/bundle_run.sh
 	;;

--- a/build/Ikemen_GO.command
+++ b/build/Ikemen_GO.command
@@ -3,8 +3,8 @@ cd $(dirname $0)
 
 case "$OSTYPE" in
 	darwin*) #echo "It's a Mac!!" ;
-		chmod +x Ikemen_GO_MacOS
-		./Ikemen_GO_MacOS -AppleMagnifiedMode YES
+		chmod +x ./I.K.E.M.E.N-Go.app/Contents/MacOS/bundle_run.sh
+		./I.K.E.M.E.N-Go.app/Contents/MacOS/bundle_run.sh
 	;;
 	linux*)
 		#export MESA_GL_VERSION_OVERRIDE=2.1


### PR DESCRIPTION
Ikemen_GO.command now points to executable path inside appbundle for macOS. Verified working (must `chmod +x Ikemen_GO.command` first)