### PR TITLE
fix(rollback): lifebars and stages; refactoring

### DIFF
--- a/src/bgdef.go
+++ b/src/bgdef.go
@@ -8,44 +8,8 @@ import (
 	mgl "github.com/go-gl/mathgl/mgl32"
 )
 
-func (bgct *bgcTimeLine) stepBGDef(s *BGDef) {
-	if len(bgct.line) > 0 && bgct.line[0].waitTime <= 0 {
-		for _, b := range bgct.line[0].bgc {
-			for i, a := range bgct.al {
-				if b.idx < a.idx {
-					bgct.al = append(bgct.al, nil)
-					copy(bgct.al[i+1:], bgct.al[i:])
-					bgct.al[i] = b
-					b = nil
-					break
-				}
-			}
-			if b != nil {
-				bgct.al = append(bgct.al, b)
-			}
-		}
-		bgct.line = bgct.line[1:]
-	}
-	if len(bgct.line) > 0 {
-		bgct.line[0].waitTime--
-	}
-	var el []*bgCtrl
-	for i := 0; i < len(bgct.al); {
-		s.runBgCtrl(bgct.al[i])
-		if bgct.al[i].currenttime > bgct.al[i].endtime {
-			el = append(el, bgct.al[i])
-			bgct.al = append(bgct.al[:i], bgct.al[i+1:]...)
-			continue
-		}
-		i++
-	}
-	for _, b := range el {
-		bgct.add(b)
-	}
-}
-
-// BGDef is used on screenpacks lifebars and stages.
-// Also contains the SFF.
+// BGDef is essentially the screenpack version of stages
+// TODO: We could probably merge them better with stages
 type BGDef struct {
 	def          string
 	localcoord   [2]float32
@@ -53,8 +17,8 @@ type BGDef struct {
 	at           AnimationTable
 	bg           []*backGround
 	bgc          []bgCtrl
-	bgct         bgcTimeLine
 	bga          bgAction
+	time         int32
 	resetbg      bool
 	localscl     float32
 	scale        [2]float32
@@ -184,7 +148,6 @@ func (s *BGDef) getBg(id int32) (bg []*backGround) {
 }
 
 func (s *BGDef) runBgCtrl(bgc *bgCtrl) {
-	bgc.currenttime++
 	switch bgc._type {
 	case BT_Anim:
 		a := s.at.get(bgc.v[0])
@@ -294,11 +257,43 @@ func (s *BGDef) runBgCtrl(bgc *bgCtrl) {
 }
 
 func (s *BGDef) action() {
-	s.bgct.stepBGDef(s)
+	s.time++
+
+	// TODO: We could merge stage and motif BGCtrl's further. A lot of it is the same
+	for i := range s.bgc {
+		bgc := &s.bgc[i]
+		if bgc.starttime < 0 || (bgc.looptime >= 0 && bgc.starttime >= bgc.looptime) {
+			continue
+		}
+
+		if bgc.looptime > 0 && bgc.endtime > bgc.looptime {
+			bgc.endtime = bgc.looptime
+		}
+
+		active := false
+		if s.time >= bgc.starttime {
+			if bgc.looptime > 0 {
+				duration := bgc.endtime - bgc.starttime
+				if (s.time-bgc.starttime)%bgc.looptime <= duration {
+					active = true
+				}
+			} else {
+				if s.time <= bgc.endtime {
+					active = true
+				}
+			}
+		}
+
+		if active {
+			s.runBgCtrl(bgc)
+		}
+	}
+
 	s.bga.action()
 	if s.model != nil {
 		s.model.step(1)
 	}
+
 	link := 0
 	for i, b := range s.bg {
 		s.bg[i].bga.action()
@@ -344,11 +339,5 @@ func (s *BGDef) reset() {
 	for i := range s.bg {
 		s.bg[i].reset()
 	}
-	for i := range s.bgc {
-		s.bgc[i].currenttime = 0
-	}
-	s.bgct.clear()
-	for i := len(s.bgc) - 1; i >= 0; i-- {
-		s.bgct.add(&s.bgc[i])
-	}
+	s.time = 0
 }

--- a/src/bgdef.go
+++ b/src/bgdef.go
@@ -171,6 +171,7 @@ func loadBGDef(sff *Sff, model *Model, def string, bgname string) (*BGDef, error
 	s.localscl = 240 / s.localcoord[1]
 	return s, nil
 }
+
 func (s *BGDef) getBg(id int32) (bg []*backGround) {
 	if id >= 0 {
 		for _, b := range s.bg {
@@ -181,6 +182,7 @@ func (s *BGDef) getBg(id int32) (bg []*backGround) {
 	}
 	return
 }
+
 func (s *BGDef) runBgCtrl(bgc *bgCtrl) {
 	bgc.currenttime++
 	switch bgc._type {
@@ -189,7 +191,7 @@ func (s *BGDef) runBgCtrl(bgc *bgCtrl) {
 		if a != nil {
 			for i := range bgc.bg {
 				bgc.bg[i].actionno = bgc.v[0]
-				bgc.bg[i].anim = *a
+				bgc.bg[i].anim = a
 			}
 		}
 	case BT_Visible:
@@ -290,6 +292,7 @@ func (s *BGDef) runBgCtrl(bgc *bgCtrl) {
 		}
 	}
 }
+
 func (s *BGDef) action() {
 	s.bgct.stepBGDef(s)
 	s.bga.action()

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -2607,7 +2607,7 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_ishometeam:
 		sys.bcStack.PushB(c.teamside == sys.home)
 	case OC_ex_tickspersecond:
-		sys.bcStack.PushI(int32((60 + sys.cfg.Options.GameSpeed*5) * sys.accel))
+		sys.bcStack.PushI(sys.gameLogicSpeed())
 	case OC_ex_const240p:
 		*sys.bcStack.Top() = c.constp(320, sys.bcStack.Top().ToF())
 	case OC_ex_const480p:
@@ -3406,7 +3406,7 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		}
 		sys.bcStack.PushF(v * (c.localscl / oc.localscl))
 	case OC_ex2_debugmode_accel:
-		sys.bcStack.PushF(sys.accel)
+		sys.bcStack.PushF(sys.debugAccel)
 	case OC_ex2_debugmode_clsndisplay:
 		sys.bcStack.PushB(sys.clsnDisplay)
 	case OC_ex2_debugmode_debugdisplay:

--- a/src/char.go
+++ b/src/char.go
@@ -7977,9 +7977,9 @@ func (c *Char) appendLifebarAction(text string, snd, spr [2]int32, anim, time in
 		teammsg.is[fmt.Sprintf("team%v.front.spr", c.teamside+1)] = fmt.Sprintf("%v,%v", spr[0], spr[1])
 	}
 	// Read background
-	msg.bg = *ReadAnimLayout(fmt.Sprintf("team%v.bg.", c.teamside+1), teammsg.is, sys.lifebar.sff, sys.lifebar.at, 2)
+	msg.bg = ReadAnimLayout(fmt.Sprintf("team%v.bg.", c.teamside+1), teammsg.is, sys.lifebar.sff, sys.lifebar.at, 2)
 	// Read front
-	msg.front = *ReadAnimLayout(fmt.Sprintf("team%v.front.", c.teamside+1), teammsg.is, sys.lifebar.sff, sys.lifebar.at, 2)
+	msg.front = ReadAnimLayout(fmt.Sprintf("team%v.front.", c.teamside+1), teammsg.is, sys.lifebar.sff, sys.lifebar.at, 2)
 
 	// Insert new message
 	teammsg.messages = insertLbMsg(teammsg.messages, msg, index)

--- a/src/char.go
+++ b/src/char.go
@@ -10141,7 +10141,7 @@ func (c *Char) actionFinish() {
 		}
 	}
 	// Over flags (char is finished for the round)
-	if c.alive() && c.life > 0 && !sys.roundEnd() {
+	if c.alive() && c.life > 0 && !sys.roundEnded() {
 		c.unsetSCF(SCF_over_alive | SCF_over_ko)
 	}
 	if c.ss.no == 5150 && !c.scf(SCF_over_ko) { // Actual KO is not required in Mugen

--- a/src/config.go
+++ b/src/config.go
@@ -54,7 +54,7 @@ type Config struct {
 		Difficulty int     `ini:"Difficulty"`
 		Life       float32 `ini:"Life"`
 		Time       int32   `ini:"Time"`
-		GameSpeed  float32 `ini:"GameSpeed"`
+		GameSpeed  int     `ini:"GameSpeed"`
 		Match      struct {
 			Wins         int32 `ini:"Wins"`
 			MaxDrawGames int32 `ini:"MaxDrawGames"`
@@ -298,7 +298,7 @@ func (c *Config) initStruct() {
 
 // Normalize values
 func (c *Config) normalize() {
-	c.SetValueUpdate("Options.GameSpeed", ClampF(c.Options.GameSpeed, -9, 9))
+	c.SetValueUpdate("Options.GameSpeed", int(Clamp(int32(c.Options.GameSpeed), -9, 9)))
 	c.SetValueUpdate("Options.Simul.Min", int(Clamp(int32(c.Options.Simul.Min), 2, int32(MaxSimul))))
 	c.SetValueUpdate("Options.Simul.Max", int(Clamp(int32(c.Options.Simul.Max), int32(c.Options.Simul.Min), int32(MaxSimul))))
 	c.SetValueUpdate("Options.Tag.Min", int(Clamp(int32(c.Options.Tag.Min), 2, int32(MaxSimul))))

--- a/src/net.go
+++ b/src/net.go
@@ -284,7 +284,7 @@ func (r *RollbackSession) AdvanceFrame(flags int) {
 		//	}
 		//}()
 
-		err := r.backend.AdvanceFrame(r.LiveChecksum(&sys))
+		err := r.backend.AdvanceFrame(r.LiveChecksum())
 		if err != nil {
 			panic(err)
 		}
@@ -356,7 +356,9 @@ func encodeInputs(inputs InputBits) []byte {
 type CharChecksum struct {
 	life    int32
 	redLife int32
-	juggle  int32
+	dizzyPoints int32
+	guardPoints int32
+	power       int32
 	animNo  int32
 	pos     [3]float32
 }
@@ -365,7 +367,9 @@ func (cc *CharChecksum) ToBytes() []byte {
 	buf := make([]byte, 0, unsafe.Sizeof(*cc))
 	buf = binary.BigEndian.AppendUint32(buf, uint32(cc.life))
 	buf = binary.BigEndian.AppendUint32(buf, uint32(cc.redLife))
-	buf = binary.BigEndian.AppendUint32(buf, uint32(cc.juggle))
+	buf = binary.BigEndian.AppendUint32(buf, uint32(cc.dizzyPoints))
+	buf = binary.BigEndian.AppendUint32(buf, uint32(cc.guardPoints))
+	buf = binary.BigEndian.AppendUint32(buf, uint32(cc.power))
 	buf = binary.BigEndian.AppendUint32(buf, uint32(cc.animNo))
 	buf = binary.BigEndian.AppendUint32(buf, math.Float32bits(cc.pos[0]))
 	buf = binary.BigEndian.AppendUint32(buf, math.Float32bits(cc.pos[1]))
@@ -377,23 +381,25 @@ func (c *Char) LiveChecksum() []byte {
 	cc := CharChecksum{
 		life:    c.life,
 		redLife: c.redLife,
-		juggle:  c.juggle,
+		dizzyPoints: c.dizzyPoints,
+		guardPoints: c.guardPoints,
+		power:       c.power,
 		animNo:  c.animNo,
 		pos:     c.pos,
 	}
 	return cc.ToBytes()
 }
 
-func (rs *RollbackSession) LiveChecksum(s *System) uint32 {
+func (rs *RollbackSession) LiveChecksum() uint32 {
 	// This (the full checksum) is unstable in live gameplay, do not use. Looking for replacements.
 	// if rs.config.LogsEnabled {
 	// 	return uint32(rs.saveStates[sys.rollbackStateID].Checksum())
 	// }
-	buf := writeI32(s.randseed)
-	buf = append(buf, writeI32(s.gameTime)...)
-	for i := 0; i < len(s.chars); i++ {
-		if len(s.chars[i]) > 0 {
-			buf = append(buf, s.chars[i][0].LiveChecksum()...)
+	buf := writeI32(sys.randseed)
+	buf = append(buf, writeI32(sys.gameTime)...)
+	for i := range sys.chars {
+		if len(sys.chars[i]) > 0 {
+			buf = append(buf, sys.chars[i][0].LiveChecksum()...)
 		}
 	}
 	return crc32.ChecksumIEEE(buf)

--- a/src/rollback.go
+++ b/src/rollback.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"math"
 	"time"
 
@@ -109,6 +108,8 @@ func (rs *RollbackSystem) fight(s *System) bool {
 	rs.currentFight.reset()
 
 	// These empty frames help the netcode stabilize. Without them, the chances of it desyncing at match start increase a lot
+	// Update: Might not be necessary after syncTest fix
+	/*
 	for i := 0; i < 120; i++ {
 		err := rs.session.backend.Idle(
 			int(math.Max(0, float64(120))))
@@ -126,6 +127,7 @@ func (rs *RollbackSystem) fight(s *System) bool {
 			break
 		}
 	}
+	*/
 
 	// Loop until end of match
 	///fin := false
@@ -230,7 +232,7 @@ func (rs *RollbackSystem) runFrame(s *System) bool {
 				}
 			}()
 
-			err := rs.session.backend.AdvanceFrame(rs.session.LiveChecksum(s))
+			err := rs.session.backend.AdvanceFrame(rs.session.LiveChecksum())
 			if err != nil {
 				panic(err)
 			}

--- a/src/rollback.go
+++ b/src/rollback.go
@@ -30,7 +30,7 @@ type RollbackProperties struct {
 // TODO: Merge with system.go
 func (rs *RollbackSystem) fight(s *System) bool {
 	// Reset variables
-	s.gameTime, s.paused, s.accel = 0, false, 1
+	s.gameTime, s.paused, s.debugAccel = 0, false, 1
 	s.aiInput = [len(s.aiInput)]AiInput{}
 	rs.currentFight = NewFight()
 	rs.ggpoInputs = make([]InputBits, 2)

--- a/src/script.go
+++ b/src/script.go
@@ -985,7 +985,7 @@ func systemScriptInit(l *lua.LState) {
 		return 0
 	})
 	luaRegister(l, "findEntityByPlayerId", func(*lua.LState) int {
-		if !sys.cfg.Debug.AllowDebugMode {
+		if !sys.debugModeAllowed() {
 			return 0
 		}
 
@@ -1050,7 +1050,7 @@ func systemScriptInit(l *lua.LState) {
 		return 0
 	})
 	luaRegister(l, "findEntityByName", func(*lua.LState) int {
-		if !sys.cfg.Debug.AllowDebugMode {
+		if !sys.debugModeAllowed() {
 			return 0
 		}
 
@@ -1119,7 +1119,7 @@ func systemScriptInit(l *lua.LState) {
 		return 0
 	})
 	luaRegister(l, "findHelperById", func(*lua.LState) int {
-		if !sys.cfg.Debug.AllowDebugMode {
+		if !sys.debugModeAllowed() {
 			return 0
 		}
 
@@ -2948,7 +2948,7 @@ func systemScriptInit(l *lua.LState) {
 		return 0
 	})
 	luaRegister(l, "toggleClsnDisplay", func(*lua.LState) int {
-		if !sys.cfg.Debug.AllowDebugMode {
+		if !sys.debugModeAllowed() {
 			return 0
 		}
 		if !nilArg(l, 1) {
@@ -2967,7 +2967,7 @@ func systemScriptInit(l *lua.LState) {
 		return 0
 	})
 	luaRegister(l, "toggleDebugDisplay", func(*lua.LState) int {
-		if !sys.cfg.Debug.AllowDebugMode {
+		if !sys.debugModeAllowed() {
 			return 0
 		}
 		if !nilArg(l, 1) {
@@ -3104,7 +3104,7 @@ func systemScriptInit(l *lua.LState) {
 		return 0
 	})
 	luaRegister(l, "toggleWireframeDisplay", func(*lua.LState) int {
-		if !sys.cfg.Debug.AllowDebugMode {
+		if !sys.debugModeAllowed() {
 			return 0
 		}
 		if !nilArg(l, 1) {

--- a/src/script.go
+++ b/src/script.go
@@ -2374,7 +2374,7 @@ func systemScriptInit(l *lua.LState) {
 		return 0
 	})
 	luaRegister(l, "setAccel", func(*lua.LState) int {
-		sys.accel = float32(numArg(l, 1))
+		sys.debugAccel = float32(numArg(l, 1))
 		return 0
 	})
 	luaRegister(l, "setAILevel", func(*lua.LState) int {
@@ -2715,7 +2715,7 @@ func systemScriptInit(l *lua.LState) {
 		return 0
 	})
 	luaRegister(l, "setGameSpeed", func(*lua.LState) int {
-		sys.cfg.Options.GameSpeed = float32(numArg(l, 1))
+		sys.cfg.Options.GameSpeed = int(numArg(l, 1))
 		return 0
 	})
 	luaRegister(l, "setRoundTime", func(l *lua.LState) int {
@@ -5270,7 +5270,7 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "tickspersecond", func(*lua.LState) int {
-		l.Push(lua.LNumber((60 + sys.cfg.Options.GameSpeed*5) * sys.accel))
+		l.Push(lua.LNumber(sys.gameLogicSpeed()))
 		return 1
 	})
 	luaRegister(l, "time", func(*lua.LState) int {
@@ -5459,7 +5459,7 @@ func triggerFunctions(l *lua.LState) {
 	luaRegister(l, "debugmode", func(*lua.LState) int {
 		switch strings.ToLower(strArg(l, 1)) {
 		case "accel":
-			l.Push(lua.LNumber(sys.accel))
+			l.Push(lua.LNumber(sys.debugAccel))
 		case "clsndisplay":
 			l.Push(lua.LBool(sys.clsnDisplay))
 		case "debugdisplay":
@@ -6084,7 +6084,7 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "gamespeed", func(*lua.LState) int {
-		l.Push(lua.LNumber((60 + sys.cfg.Options.GameSpeed*5) / float32(sys.cfg.Config.Framerate) * sys.accel * 100))
+		l.Push(lua.LNumber(100 * float32(sys.gameLogicSpeed()) / float32(sys.gameRenderSpeed())))
 		return 1
 	})
 	luaRegister(l, "lasthitter", func(*lua.LState) int {

--- a/src/state.go
+++ b/src/state.go
@@ -106,6 +106,7 @@ type GameState struct {
 	randseed       int32
 	Time           int32
 	GameTime       int32
+
 	projs          [MaxPlayerNo][]Projectile
 	chars          [MaxPlayerNo][]*Char
 	charData       [MaxPlayerNo][]Char
@@ -134,7 +135,6 @@ type GameState struct {
 	superplayerno      int
 	superdarken        bool
 	superanim          *Animation
-	superanimRef       *Animation
 	superpmap          PalFX
 	superpos           [2]float32
 	superscale         [2]float32
@@ -201,20 +201,18 @@ type GameState struct {
 	finishType              FinishType // UIT
 	waitdown                int32
 	slowtime                int32
-	shuttertime             int32
-	fadeintime              int32
-	fadeouttime             int32
+
 	changeStateNest         int32
-	//accel                   float32
-	//clsnDisplay             bool
-	//debugDisplay            bool
 	workpal        []uint32
 	nomusic        bool
 	keyConfig      []KeyConfig
 	joystickConfig []KeyConfig
 	lifebar        Lifebar
-	redrawWait     struct{ nextTime, lastDraw time.Time }
 	cgi            [MaxPlayerNo]CharGlobalInfo
+
+	//accel                   float32
+	//clsnDisplay             bool
+	//debugDisplay            bool
 
 	// New 11/04/2022 all UIT
 	timerStart      int32
@@ -270,6 +268,7 @@ type GameState struct {
 	brightnessOld int32
 	wintime       int32
 
+	// Rollback
 	netTime int32
 }
 

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -393,15 +393,29 @@ func (cl *CommandList) Clone(a *arena.Arena) (result CommandList) {
 func (l *Lifebar) Clone(a *arena.Arena) (result Lifebar) {
 	result = *l
 
+	// Round
 	if l.ro != nil {
-		result.ro = arena.New[LifeBarRound](a)
+		result.ro = &LifeBarRound{} // Shallow copy
 		*result.ro = *l.ro
+		// Round Transition
+		// This needs a deep copy because it's a pointer inside LifebarRound and we need the timers
+		// When round transitions are expanded this can be revisited
 		if l.ro.rt != nil {
 			result.ro.rt = arena.New[LifeBarRoundTransition](a)
 			*result.ro.rt = *l.ro.rt
 		}
 	}
 
+	// Combo
+	for i := 0; i < len(l.co); i++ {
+		if l.co[i] != nil {
+			result.co[i] = arena.New[LifeBarCombo](a)
+			*result.co[i] = *l.co[i]
+		}
+	}
+
+	// We probably don't need a deep copy of these
+	/*
 	//UIT
 	for i := 0; i < len(l.sc); i++ {
 		if l.sc[i] != nil {
@@ -412,12 +426,6 @@ func (l *Lifebar) Clone(a *arena.Arena) (result Lifebar) {
 	if l.ti != nil {
 		result.ti = arena.New[LifeBarTime](a)
 		*result.ti = *l.ti
-	}
-	for i := 0; i < len(l.co); i++ {
-		if l.co[i] != nil {
-			result.co[i] = arena.New[LifeBarCombo](a)
-			*result.co[i] = *l.co[i]
-		}
 	}
 	//
 
@@ -443,11 +451,13 @@ func (l *Lifebar) Clone(a *arena.Arena) (result Lifebar) {
 	}
 	//
 
+	// Order
 	for i := range result.order {
 		result.order[i] = arena.MakeSlice[int](a, len(l.order[i]), len(l.order[i]))
 		copy(result.order[i], l.order[i])
 	}
 
+	// HealthBar
 	for i := range result.hb {
 		result.hb[i] = arena.MakeSlice[*HealthBar](a, len(l.hb[i]), len(l.hb[i]))
 		for j := 0; j < len(l.hb[i]); j++ {
@@ -456,6 +466,7 @@ func (l *Lifebar) Clone(a *arena.Arena) (result Lifebar) {
 		}
 	}
 
+	// PowerBar
 	for i := range result.pb {
 		result.pb[i] = arena.MakeSlice[*PowerBar](a, len(l.pb[i]), len(l.pb[i]))
 		for j := 0; j < len(l.pb[i]); j++ {
@@ -464,6 +475,7 @@ func (l *Lifebar) Clone(a *arena.Arena) (result Lifebar) {
 		}
 	}
 
+	// GuardBar
 	for i := range result.gb {
 		result.gb[i] = arena.MakeSlice[*GuardBar](a, len(l.gb[i]), len(l.gb[i]))
 		for j := 0; j < len(l.gb[i]); j++ {
@@ -472,6 +484,7 @@ func (l *Lifebar) Clone(a *arena.Arena) (result Lifebar) {
 		}
 	}
 
+	// StunBar
 	for i := range result.sb {
 		result.sb[i] = arena.MakeSlice[*StunBar](a, len(l.sb[i]), len(l.sb[i]))
 		for j := 0; j < len(l.sb[i]); j++ {
@@ -480,6 +493,7 @@ func (l *Lifebar) Clone(a *arena.Arena) (result Lifebar) {
 		}
 	}
 
+	// Face
 	for i := range result.fa {
 		result.fa[i] = arena.MakeSlice[*LifeBarFace](a, len(l.fa[i]), len(l.fa[i]))
 		for j := 0; j < len(l.fa[i]); j++ {
@@ -488,6 +502,7 @@ func (l *Lifebar) Clone(a *arena.Arena) (result Lifebar) {
 		}
 	}
 
+	// Name
 	for i := range result.nm {
 		result.nm[i] = arena.MakeSlice[*LifeBarName](a, len(l.nm[i]), len(l.nm[i]))
 		for j := 0; j < len(l.nm[i]); j++ {
@@ -495,8 +510,9 @@ func (l *Lifebar) Clone(a *arena.Arena) (result Lifebar) {
 			*result.nm[i][j] = *l.nm[i][j]
 		}
 	}
+	*/
 
-	// LifeBarAction
+	// Action
 	for i := range result.ac {
 		if l.ac[i] != nil {
 			result.ac[i] = arena.New[LifeBarAction](a)
@@ -519,7 +535,7 @@ func (l *Lifebar) Clone(a *arena.Arena) (result Lifebar) {
 func (bg *backGround) Clone(a *arena.Arena, gsp *GameStatePool) (result *backGround) {
 	result = &backGround{}
 	*result = *bg
-	result.anim = *bg.anim.Clone(a, gsp)
+	result.anim = bg.anim
 	return
 }
 

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -421,7 +421,7 @@ func (l *Lifebar) Clone(a *arena.Arena) (result Lifebar) {
 	}
 	//
 
-	// Not UIT adding amyway
+	// Not UIT adding anyway
 	for i := 0; i < len(l.wc); i++ {
 		result.wc[i] = arena.New[LifeBarWinCount](a)
 		*result.wc[i] = *l.wc[i]
@@ -493,6 +493,23 @@ func (l *Lifebar) Clone(a *arena.Arena) (result Lifebar) {
 		for j := 0; j < len(l.nm[i]); j++ {
 			result.nm[i][j] = arena.New[LifeBarName](a)
 			*result.nm[i][j] = *l.nm[i][j]
+		}
+	}
+
+	// LifeBarAction
+	for i := range result.ac {
+		if l.ac[i] != nil {
+			result.ac[i] = arena.New[LifeBarAction](a)
+
+			*result.ac[i] = *l.ac[i]
+
+			if l.ac[i].messages != nil {
+				result.ac[i].messages = arena.MakeSlice[*LbMsg](a, len(l.ac[i].messages), len(l.ac[i].messages))
+				for j := 0; j < len(l.ac[i].messages); j++ {
+					result.ac[i].messages[j] = arena.New[LbMsg](a)
+					*result.ac[i].messages[j] = *l.ac[i].messages[j]
+				}
+			}
 		}
 	}
 

--- a/src/system.go
+++ b/src/system.go
@@ -2231,6 +2231,7 @@ func (s *System) fight() (reload bool) {
 	// Reset variables
 	s.gameTime, s.paused, s.accel = 0, false, 1
 	s.aiInput = [len(s.aiInput)]AiInput{}
+	s.saveState = NewGameState()
 
 	// Disable debug during netplay (but not during replays)
 	if !s.debugModeAllowed() {
@@ -2262,10 +2263,6 @@ func (s *System) fight() (reload bool) {
 		defer s.netConnection.Stop()
 	}
 
-	// Struct to save char values at start of the round
-	// Rolback branch makes a similar backup in System instead of letting it be local. Maybe we'll need the same
-	var roundBackup RoundStartBackup
-
 	// Init wins counter
 	s.wincnt.init()
 
@@ -2276,6 +2273,9 @@ func (s *System) fight() (reload bool) {
 
 	// Setup characters
 	s.SetupCharRoundStart(autolvmul, autolevels)
+
+	// Struct to save char and stage values at the start of a round
+	var roundBackup RoundStartBackup
 
 	// Make a new backup once everything is initialized
 	roundBackup.Save()

--- a/src/system.go
+++ b/src/system.go
@@ -2233,7 +2233,7 @@ func (s *System) fight() (reload bool) {
 	s.aiInput = [len(s.aiInput)]AiInput{}
 
 	// Disable debug during netplay (but not during replays)
-	if sys.netConnection != nil {
+	if !s.debugModeAllowed() {
 		s.debugDisplay = false
 		s.clsnDisplay = false
 		s.lifebarHide = false
@@ -2626,6 +2626,13 @@ func (s *System) SetupCharRoundStart(autolvmul float64, autolevels [MaxPlayerNo]
 			}
 		}
 	}
+}
+
+func (s *System) debugModeAllowed() bool {
+	if s.netConnection != nil || s.rollback.session != nil {
+		return false
+	}
+	return s.cfg.Debug.AllowDebugMode
 }
 
 type RoundStartBackup struct {


### PR DESCRIPTION
Fix:
- Lifebar actions are now rolled back correctly
- Changed lifebar and stage animations to pointers. Fixes rollback hot spots
- BGCtrl's can now be rolled back as well
 
Refactor:
- Standardized the way we check if debug mode is allowed
- Added dizzy, guard points and power to rollback checksum. Removed juggle points
- Debug save state is cleared between matches. This just prevents crashing when loading a state that obviously wouldn't work
- Intros and win poses are now a separate function instead of a large block inside sys.action()
- Standardized how we check game speed
- Debug speed now persists between rounds
- BGCtrl's no longer rely on a complex timeline struct. Each BGCtrl handles its own timer
- Added a function that will allow normal game logic to run knowing if it's inside a rollback frame. Ground work