### PR TITLE
refactor(trigger): player indexes

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -691,7 +691,6 @@ const (
 	OC_ex_timeelapsed
 	OC_ex_timeremaining
 	OC_ex_timetotal
-	OC_ex_playercount
 	OC_ex_pos_z
 	OC_ex_vel_z
 	OC_ex_prevanim
@@ -1609,7 +1608,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.Push(BytecodeSF())
 			i += int(*(*int32)(unsafe.Pointer(&be[i]))) + 4
 		case OC_playerindex:
-			if c = sys.playerIndex(sys.bcStack.Pop().ToI()); c != nil {
+			if c = sys.playerIndexRedirect(sys.bcStack.Pop().ToI()); c != nil {
 				i += 4
 				continue
 			}
@@ -3109,8 +3108,6 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(timeRemaining())
 	case OC_ex_timetotal:
 		sys.bcStack.PushI(timeTotal())
-	case OC_ex_playercount:
-		sys.bcStack.PushI(sys.playercount())
 	case OC_ex_pos_z:
 		sys.bcStack.PushF(c.pos[2] * (c.localscl / oc.localscl))
 	case OC_ex_vel_z:
@@ -3185,7 +3182,7 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	camCorrected := false
 	switch opc {
 	case OC_ex2_index:
-		sys.bcStack.PushI(c.index)
+		sys.bcStack.PushI(c.indexTrigger())
 	case OC_ex2_isclsnproxy:
 		sys.bcStack.PushB(c.isclsnproxy)
 	case OC_ex2_groundlevel:

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -427,7 +427,6 @@ var triggerMap = map[string]int{
 	"palfxvar":           1,
 	"pausetime":          1,
 	"physics":            1,
-	"playercount":        1,
 	"playerindexexist":   1,
 	"playerno":           1,
 	"playernoexist":      1,
@@ -4701,8 +4700,6 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		}); err != nil {
 			return bvNone(), err
 		}
-	case "playercount":
-		out.append(OC_ex_, OC_ex_playercount)
 	case "playerindexexist":
 		if _, err := c.oneArg(out, in, rd, true); err != nil {
 			return bvNone(), err

--- a/src/script.go
+++ b/src/script.go
@@ -3241,7 +3241,7 @@ func triggerFunctions(l *lua.LState) {
 	})
 	luaRegister(l, "playerindex", func(*lua.LState) int {
 		ret := false
-		if c := sys.playerIndex(int32(numArg(l, 1))); c != nil {
+		if c := sys.playerIndexRedirect(int32(numArg(l, 1))); c != nil {
 			sys.debugWC, ret = c, true
 		}
 		l.Push(lua.LBool(ret))
@@ -4321,7 +4321,7 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "index", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.index))
+		l.Push(lua.LNumber(sys.debugWC.indexTrigger()))
 		return 1
 	})
 	luaRegister(l, "leftedge", func(*lua.LState) int {
@@ -5905,10 +5905,6 @@ func triggerFunctions(l *lua.LState) {
 			s = "N"
 		}
 		l.Push(lua.LString(s))
-		return 1
-	})
-	luaRegister(l, "playercount", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.playercount()))
 		return 1
 	})
 	luaRegister(l, "playerindexexist", func(*lua.LState) int {

--- a/src/system.go
+++ b/src/system.go
@@ -772,11 +772,28 @@ func (s *System) anyButton() bool {
 }
 
 func (s *System) playerID(id int32) *Char {
-	return s.charList.get(id)
+	return s.charList.getID(id)
 }
 
-func (s *System) playerIndex(id int32) *Char {
-	return s.charList.getIndex(id)
+func (s *System) playerIndexRedirect(idx int32) *Char {
+	if idx >= 0 && int(idx) < len(s.charList.runOrder) {
+		return s.charList.runOrder[idx]
+	}
+
+	// TODO: Should we ignore destroyed helpers? PlayerID doesn't but Helper does
+	/*
+	var searchIdx int32
+	for _, p := range sys.charList.runOrder {
+		if p != nil && !p.csf(CSF_destroy) {
+			if searchIdx == idx {
+				return p
+			}
+			searchIdx++
+		}
+	}
+	*/
+
+	return nil
 }
 
 // We must check if wins are greater than 0 because modes like Training may have "0 rounds to win"
@@ -792,11 +809,13 @@ func (s *System) playerIDExist(id BytecodeValue) BytecodeValue {
 	return BytecodeBool(s.playerID(id.ToI()) != nil)
 }
 
+// TODO: This is redundant since the index always exists if "NumPlayer >= idx-1"
+// Maybe remove it or make it ignore destroyed helpers at least
 func (s *System) playerIndexExist(idx BytecodeValue) BytecodeValue {
 	if idx.IsSF() {
 		return BytecodeSF()
 	}
-	return BytecodeBool(s.playerIndex(idx.ToI()) != nil)
+	return BytecodeBool(s.playerIndexRedirect(idx.ToI()) != nil)
 }
 
 func (s *System) playerNoExist(no BytecodeValue) BytecodeValue {
@@ -809,10 +828,6 @@ func (s *System) playerNoExist(no BytecodeValue) BytecodeValue {
 		exist = len(sys.chars[number]) > 0
 	}
 	return BytecodeBool(exist)
-}
-
-func (s *System) playercount() int32 {
-	return int32(len(s.charList.runOrder))
 }
 
 func (s *System) palfxvar(x int32, y int32) int32 {


### PR DESCRIPTION
- Index trigger now returns the player's current index rather than the index they were created with
- Player indexes are now base 0
- NumPlayer now works like previous PlayerCount. Returns total number of players (roots + helpers)
- PlayerCount trigger removed as a consequence
- These changes make iterating over players work like it already does for other objects like explods or helpers