### PR TITLE
feat(sctr): NoAICheat and NoAIButtonJam; fix BGCtrl; refactor rollback and system

### DIFF
--- a/external/script/global.lua
+++ b/external/script/global.lua
@@ -42,8 +42,8 @@ addHotkey('F10', false, false, false, true, false, 'saveState()')
 addHotkey('SPACE', false, false, false, false, true, 'full(1); full(2); full(3); full(4); full(5); full(6); full(7); full(8); setTime(getRoundTime()); debugFlag(1); debugFlag(2); clearConsole()')
 addHotkey('i', true, false, false, true, true, 'stand(1); stand(2); stand(3); stand(4); stand(5); stand(6); stand(7); stand(8)')
 addHotkey('PAUSE', false, false, false, true, false, 'togglePause(); closeMenu()')
-addHotkey('PAUSE', true, false, false, true, false, 'step()')
-addHotkey('SCROLLLOCK', false, false, false, true, false, 'step()')
+addHotkey('PAUSE', true, false, false, true, false, 'frameStep()')
+addHotkey('SCROLLLOCK', false, false, false, true, false, 'frameStep()')
 
 local speedMul = 1
 local speedAdd = 0

--- a/src/bgdef.go
+++ b/src/bgdef.go
@@ -257,8 +257,6 @@ func (s *BGDef) runBgCtrl(bgc *bgCtrl) {
 }
 
 func (s *BGDef) action() {
-	s.time++
-
 	// TODO: We could merge stage and motif BGCtrl's further. A lot of it is the same
 	for i := range s.bgc {
 		bgc := &s.bgc[i]
@@ -293,6 +291,10 @@ func (s *BGDef) action() {
 	if s.model != nil {
 		s.model.step(1)
 	}
+
+	// Global time must be incremented after updating BGCtrl
+	// https://github.com/ikemen-engine/Ikemen-GO/issues/2656
+	s.time++
 
 	link := 0
 	for i, b := range s.bg {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -11254,8 +11254,8 @@ func (sc roundTimeAdd) Run(c *Char, _ []int32) bool {
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
 		case roundTimeAdd_value:
-			if sys.roundTime != -1 {
-				sys.time = Clamp(sys.time+exp[0].evalI(c), 0, sys.roundTime)
+			if sys.maxRoundTime != -1 {
+				sys.curRoundTime = Clamp(sys.curRoundTime+exp[0].evalI(c), 0, sys.maxRoundTime)
 			}
 		}
 		return true
@@ -11274,8 +11274,8 @@ func (sc roundTimeSet) Run(c *Char, _ []int32) bool {
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
 		case roundTimeSet_value:
-			if sys.roundTime != -1 {
-				sys.time = Clamp(exp[0].evalI(c), 0, sys.roundTime)
+			if sys.maxRoundTime != -1 {
+				sys.curRoundTime = Clamp(exp[0].evalI(c), 0, sys.maxRoundTime)
 			}
 		}
 		return true

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1764,10 +1764,10 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 		case OC_swap:
 			sys.bcStack.Swap()
 		case OC_ailevel:
-			if !c.asf(ASF_noailevel) {
-				sys.bcStack.PushI(int32(c.getAILevel()))
-			} else {
+			if c.asf(ASF_noailevel) {
 				sys.bcStack.PushI(0)
+			} else {
+				sys.bcStack.PushI(int32(c.getAILevel()))
 			}
 		case OC_alive:
 			sys.bcStack.PushB(c.alive())
@@ -2785,10 +2785,10 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		)
 		*i += 4
 	case OC_ex_ailevelf:
-		if !c.asf(ASF_noailevel) {
-			sys.bcStack.PushF(c.getAILevel())
-		} else {
+		if c.asf(ASF_noailevel) {
 			sys.bcStack.PushI(0)
+		} else {
+			sys.bcStack.PushF(c.getAILevel())
 		}
 	case OC_ex_airjumpcount:
 		sys.bcStack.PushI(c.airJumpCount)

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5539,8 +5539,7 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 
 	redirscale := c.localscl / crun.localscl
 	rp := [...]int32{-1, 0}
-	animPN := -1
-	spritePN := -1
+
 	e, i := crun.newExplod()
 	if e == nil {
 		return false
@@ -5555,31 +5554,21 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
 		case explod_anim:
-			apn := crun.playerNo // Default to own player number
-			spn := crun.playerNo
-			if animPN != -1 {
-				apn = animPN
-			}
-			if spritePN != -1 {
-				spn = spritePN
-			}
 			ffx := string(*(*[]byte)(unsafe.Pointer(&exp[0])))
 			if ffx != "" && ffx != "s" {
 				e.ownpal = true
 			}
 			e.animNo = exp[1].evalI(c)
-			e.animelem = 1
-			e.animelemtime = 0
-			e.setAnim(e.animNo, apn, spn, ffx)
+			e.anim_ffx = ffx
 		case explod_animplayerno:
 			pn := int(exp[0].evalI(c)) - 1
 			if crun.validatePlayerNo(pn, "animPlayerNo", "Explod") {
-				animPN = pn
+				e.animPN = pn
 			}
 		case explod_spriteplayerno:
 			pn := int(exp[0].evalI(c)) - 1
 			if crun.validatePlayerNo(pn, "spritePlayerNo", "Explod") {
-				spritePN = pn
+				e.spritePN = pn
 			}
 		case explod_ownpal:
 			e.ownpal = exp[0].evalB(c)
@@ -5735,13 +5724,8 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 			}
 		case explod_animelem:
 			e.animelem = exp[0].evalI(c)
-			if e.anim != nil {
-				e.anim.Action() // This being in this place can cause a nil animation crash
-			}
-			e.setAnimElem()
 		case explod_animelemtime:
 			e.animelemtime = exp[0].evalI(c)
-			e.setAnimElem()
 		case explod_animfreeze:
 			e.animfreeze = exp[0].evalB(c)
 		case explod_angle:
@@ -5784,10 +5768,10 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 	//if c.minus == -2 || c.minus == -4 {
 	//	e.localscl = (320 / crun.localcoord)
 	//} else {
-	e.localscl = crun.localscl
-	e.setStartParams(&e.palfxdef)
+
+	e.setStartParams(crun, &e.palfxdef, rp)
 	e.setPos(crun)
-	crun.insertExplodEx(i, rp)
+	crun.insertExplod(i)
 	return false
 }
 

--- a/src/char.go
+++ b/src/char.go
@@ -67,6 +67,7 @@ const (
 	ASF_animfreeze
 	ASF_autoguard
 	ASF_drawunder
+	ASF_noaicheat
 	ASF_noailevel
 	ASF_noairjump
 	ASF_nobrake
@@ -4298,7 +4299,7 @@ func (c *Char) command(pn, i int) bool {
 
 	// AI cheating for commands longer than 1 button
 	// Maybe it could just cheat all of them and skip these checks
-	if c.controller < 0 && len(cl) > 0 {
+	if !c.asf(ASF_noaicheat) && c.controller < 0 && len(cl) > 0 {
 		steps := cl[0].steps
 		multiStep := len(steps) > 1
 		multiKey := len(steps) > 0 && len(steps[0].keys) > 1

--- a/src/char.go
+++ b/src/char.go
@@ -67,6 +67,7 @@ const (
 	ASF_animfreeze
 	ASF_autoguard
 	ASF_drawunder
+	ASF_noaibuttonjam
 	ASF_noaicheat
 	ASF_noailevel
 	ASF_noairjump
@@ -4309,6 +4310,9 @@ func (c *Char) command(pn, i int) bool {
 				return true
 			}
 		}
+		// Our AI cheating is more efficient but it's not accurate to Mugen
+		// In Mugen, essentially command trigger returns true on average once every 10 seconds for difficulty 8,
+		// and once every 30 seconds for difficulty 1. Other difficulties are probably linearly interpolated
 	}
 
 	return false
@@ -11010,7 +11014,7 @@ func (cl *CharList) commandUpdate() {
 				c.updateFBFlip()
 
 				if (c.helperIndex == 0 || c.helperIndex > 0 && &c.cmd[0] != &root.cmd[0]) &&
-					c.cmd[0].InputUpdate(c.controller, c.fbFlip, sys.aiLevel[i], c.inputFlag, c.inputShift, false) {
+					c.cmd[0].InputUpdate(c, c.controller, sys.aiLevel[i], false) {
 					// Clear input buffers and skip the rest of the loop
 					// This used to apply only to the root, but that caused some issues with helper-based custom input systems
 					if c.inputWait() || c.asf(ASF_noinput) {

--- a/src/char.go
+++ b/src/char.go
@@ -7667,9 +7667,8 @@ func (c *Char) inputWait() bool {
 	if c.asf(ASF_postroundinput) {
 		return false
 	}
-	// If match just starting
-	// Not sure if Mugen actually does this
-	if sys.time == 0 {
+	// If time over
+	if sys.curRoundTime == 0 {
 		return true
 	}
 	// If after round "over.waittime" and the win poses have not started

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -4468,6 +4468,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_autoguard))
 		case "drawunder":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_drawunder))
+		case "noaibuttonjam":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noaibuttonjam))
 		case "noaicheat":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noaicheat))
 		case "noailevel":

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -4468,6 +4468,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_autoguard))
 		case "drawunder":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_drawunder))
+		case "noaicheat":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noaicheat))
 		case "noailevel":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_noailevel))
 		case "noairjump":

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -5613,27 +5613,141 @@ func (c *Compiler) paramValue(is IniSection, sc *StateControllerBase,
 	return nil
 }
 
+func (c *Compiler) paramAnimtype(is IniSection, sc *StateControllerBase, paramName string, id byte) error {
+	return c.stateParam(is, paramName, false, func(data string) error {
+		if len(data) == 0 {
+			return Error(paramName + " not specified")
+		}
+		var ra Reaction
+		dataLower := strings.ToLower(data)
+		if sys.cgi[c.playerNo].ikemenver[0] == 0 && sys.cgi[c.playerNo].ikemenver[1] == 0 {
+			// Mugen chars: first letter is enough
+			switch dataLower[0] {
+			case 'l':
+				ra = RA_Light
+			case 'm':
+				ra = RA_Medium
+			case 'h':
+				ra = RA_Hard
+			case 'b':
+				ra = RA_Back
+			case 'u':
+				ra = RA_Up
+			case 'd':
+				ra = RA_Diagup
+			default:
+				return Error("Invalid " + paramName + ": " + data)
+			}
+		} else {
+			// Ikemen chars: require full word
+			switch dataLower {
+			case "light":
+				ra = RA_Light
+			case "medium":
+				ra = RA_Medium
+			case "hard":
+				ra = RA_Hard
+			case "back":
+				ra = RA_Back
+			case "up":
+				ra = RA_Up
+			case "diagup":
+				ra = RA_Diagup
+			default:
+				return Error("Invalid " + paramName + ": " + data)
+			}
+		}
+		sc.add(id, sc.iToExp(int32(ra)))
+		return nil
+	})
+}
+
+func (c *Compiler) paramHittype(is IniSection, sc *StateControllerBase, paramName string, id byte) error {
+	return c.stateParam(is, paramName, false, func(data string) error {
+		if len(data) == 0 {
+			return Error(paramName + " not specified")
+		}
+		var ht HitType
+		dataLower := strings.ToLower(data)
+		if sys.cgi[c.playerNo].ikemenver[0] == 0 && sys.cgi[c.playerNo].ikemenver[1] == 0 {
+			// Mugen chars: first letter is enough
+			switch dataLower[0] {
+			case 'h':
+				ht = HT_High
+			case 'l':
+				ht = HT_Low
+			case 't':
+				ht = HT_Trip
+			case 'n':
+				ht = HT_None
+			default:
+				return Error("Invalid " + paramName + ": " + data)
+			}
+		} else {
+			// Ikemen chars: require full word
+			switch dataLower {
+			case "high":
+				ht = HT_High
+			case "low":
+				ht = HT_Low
+			case "trip":
+				ht = HT_Trip
+			case "none":
+				ht = HT_None
+			default:
+				return Error("Invalid " + paramName + ": " + data)
+			}
+		}
+		sc.add(id, sc.iToExp(int32(ht)))
+		return nil
+	})
+}
+
 func (c *Compiler) paramPostype(is IniSection, sc *StateControllerBase, id byte) error {
 	return c.stateParam(is, "postype", false, func(data string) error {
 		if len(data) == 0 {
 			return Error("postype not specified")
 		}
 		var pt PosType
-		if len(data) >= 2 && strings.ToLower(data[:2]) == "p2" {
-			pt = PT_P2
+		dataLower := strings.ToLower(data)
+		if sys.cgi[c.playerNo].ikemenver[0] == 0 && sys.cgi[c.playerNo].ikemenver[1] == 0 {
+			// Mugen chars: first letter is enough
+			if len(dataLower) >= 2 && dataLower[:2] == "p2" {
+				pt = PT_P2
+			} else {
+				switch dataLower[0] {
+				case 'p':
+					pt = PT_P1
+				case 'f':
+					pt = PT_Front
+				case 'b':
+					pt = PT_Back
+				case 'l':
+					pt = PT_Left
+				case 'r':
+					pt = PT_Right
+				case 'n':
+					pt = PT_None
+				default:
+					return Error("Invalid postype: " + data)
+				}
+			}
 		} else {
-			switch strings.ToLower(data)[0] {
-			case 'p':
+			// Ikemen chars: require full word
+			switch dataLower {
+			case "p1":
 				pt = PT_P1
-			case 'f':
+			case "p2":
+				pt = PT_P2
+			case "front":
 				pt = PT_Front
-			case 'b':
+			case "back":
 				pt = PT_Back
-			case 'l':
+			case "left":
 				pt = PT_Left
-			case 'r':
+			case "right":
 				pt = PT_Right
-			case 'n':
+			case "none":
 				pt = PT_None
 			default:
 				return Error("Invalid postype: " + data)

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -162,6 +162,8 @@ func (c *Compiler) assertSpecial(is IniSection, sc *StateControllerBase, _ int8)
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_autoguard)))
 			case "drawunder":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_drawunder)))
+			case "noaibuttonjam":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_noaibuttonjam)))
 			case "noaicheat":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_noaicheat)))
 			case "noailevel":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -162,6 +162,8 @@ func (c *Compiler) assertSpecial(is IniSection, sc *StateControllerBase, _ int8)
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_autoguard)))
 			case "drawunder":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_drawunder)))
+			case "noaicheat":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_noaicheat)))
 			case "noailevel":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_noailevel)))
 			case "noairjump":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1637,73 +1637,19 @@ func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 	}); err != nil {
 		return err
 	}
-	htyp := func(id byte, data string) error {
-		if len(data) == 0 {
-			return Error("hit type not specified")
-		}
-		var ht HitType
-		switch data[0] {
-		case 'H', 'h':
-			ht = HT_High
-		case 'L', 'l':
-			ht = HT_Low
-		case 'T', 't':
-			ht = HT_Trip
-		case 'N', 'n':
-			ht = HT_None
-		default:
-			return Error("Invalid hit type: " + data)
-		}
-		sc.add(id, sc.iToExp(int32(ht)))
-		return nil
-	}
-	if err := c.stateParam(is, "ground.type", false, func(data string) error {
-		return htyp(hitDef_ground_type, data)
-	}); err != nil {
+	if err := c.paramHittype(is, sc, "ground.type", hitDef_ground_type); err != nil {
 		return err
 	}
-	if err := c.stateParam(is, "air.type", false, func(data string) error {
-		return htyp(hitDef_air_type, data)
-	}); err != nil {
+	if err := c.paramHittype(is, sc, "air.type", hitDef_air_type); err != nil {
 		return err
 	}
-	reac := func(id byte, data string) error {
-		if len(data) == 0 {
-			return Error("animtype not specified")
-		}
-		var ra Reaction
-		switch data[0] {
-		case 'L', 'l':
-			ra = RA_Light
-		case 'M', 'm':
-			ra = RA_Medium
-		case 'H', 'h':
-			ra = RA_Hard
-		case 'B', 'b':
-			ra = RA_Back
-		case 'U', 'u':
-			ra = RA_Up
-		case 'D', 'd':
-			ra = RA_Diagup
-		default:
-			return Error("Invalid animtype: " + data)
-		}
-		sc.add(id, sc.iToExp(int32(ra)))
-		return nil
-	}
-	if err := c.stateParam(is, "animtype", false, func(data string) error {
-		return reac(hitDef_animtype, data)
-	}); err != nil {
+	if err := c.paramAnimtype(is, sc, "animtype", hitDef_animtype); err != nil {
 		return err
 	}
-	if err := c.stateParam(is, "air.animtype", false, func(data string) error {
-		return reac(hitDef_air_animtype, data)
-	}); err != nil {
+	if err := c.paramAnimtype(is, sc, "air.animtype", hitDef_air_animtype); err != nil {
 		return err
 	}
-	if err := c.stateParam(is, "fall.animtype", false, func(data string) error {
-		return reac(hitDef_fall_animtype, data)
-	}); err != nil {
+	if err := c.paramAnimtype(is, sc, "fall.animtype", hitDef_fall_animtype); err != nil {
 		return err
 	}
 	if err := c.stateParam(is, "affectteam", false, func(data string) error {

--- a/src/net.go
+++ b/src/net.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"hash/crc32"
 	"log"
-	"math"
 	"os"
 	"sort"
 	"strings"
@@ -367,7 +366,7 @@ type CharChecksum struct {
 	guardPoints int32
 	power       int32
 	animNo      int32
-	pos         [3]float32
+	//pos         [3]float32
 }
 
 func (cc *CharChecksum) ToBytes() []byte {
@@ -378,9 +377,9 @@ func (cc *CharChecksum) ToBytes() []byte {
 	buf = binary.BigEndian.AppendUint32(buf, uint32(cc.guardPoints))
 	buf = binary.BigEndian.AppendUint32(buf, uint32(cc.power))
 	buf = binary.BigEndian.AppendUint32(buf, uint32(cc.animNo))
-	buf = binary.BigEndian.AppendUint32(buf, math.Float32bits(cc.pos[0]))
-	buf = binary.BigEndian.AppendUint32(buf, math.Float32bits(cc.pos[1]))
-	buf = binary.BigEndian.AppendUint32(buf, math.Float32bits(cc.pos[2]))
+	//buf = binary.BigEndian.AppendUint32(buf, math.Float32bits(cc.pos[0]))
+	//buf = binary.BigEndian.AppendUint32(buf, math.Float32bits(cc.pos[1]))
+	//buf = binary.BigEndian.AppendUint32(buf, math.Float32bits(cc.pos[2]))
 	return buf
 }
 
@@ -392,7 +391,7 @@ func (c *Char) LiveChecksum() []byte {
 		guardPoints: c.guardPoints,
 		power:       c.power,
 		animNo:      c.animNo,
-		pos:         c.pos,
+		//pos:         c.pos, // Seems to cause false positives. Probably the float math
 	}
 	return cc.ToBytes()
 }
@@ -404,7 +403,6 @@ func (rs *RollbackSession) LiveChecksum() uint32 {
 	// }
 	buf := writeI32(sys.randseed)
 	buf = append(buf, writeI32(sys.gameTime)...)
-	buf = append(buf, writeI32(sys.curRoundTime)...) // Round timer
 	buf = append(buf, writeI32(sys.curRoundTime)...) // Round timer
 	for i := range sys.chars {
 		if len(sys.chars[i]) > 0 {

--- a/src/net.go
+++ b/src/net.go
@@ -153,7 +153,7 @@ func NewLoopTimer(fps uint32, framesToSpread uint32) LoopTimer {
 }
 
 func (lt *LoopTimer) OnGGPOTimeSyncEvent(framesAhead float32) {
-	if sys.intro > 0 && sys.time == 0 {
+	if sys.intro > 0 && sys.tickCount == 0 {
 		lt.waitTotal = time.Duration(float32(time.Second/60) * framesAhead)
 		lt.lastAdvantage = float32(time.Second/60) * framesAhead
 		if lt.lastAdvantage < float32(0) {
@@ -404,6 +404,8 @@ func (rs *RollbackSession) LiveChecksum() uint32 {
 	// }
 	buf := writeI32(sys.randseed)
 	buf = append(buf, writeI32(sys.gameTime)...)
+	buf = append(buf, writeI32(sys.curRoundTime)...) // Round timer
+	buf = append(buf, writeI32(sys.curRoundTime)...) // Round timer
 	for i := range sys.chars {
 		if len(sys.chars[i]) > 0 {
 			buf = append(buf, sys.chars[i][0].LiveChecksum()...)

--- a/src/script.go
+++ b/src/script.go
@@ -1359,8 +1359,8 @@ func systemScriptInit(l *lua.LState) {
 				// -1 on quit, -2 on restarting match
 				winp := int32(0)
 
-				// fight loop
-				if sys.fight() {
+				// Match loop
+				if sys.runMatch() {
 					// Match is restarting
 					for i, b := range sys.reloadCharSlot {
 						if b {
@@ -1451,7 +1451,7 @@ func systemScriptInit(l *lua.LState) {
 				tbl.RawSetString("scoreRounds", tbl_score)
 				tbl.RawSetString("timerRounds", tbl_time)
 				tbl.RawSetString("matchTime", lua.LNumber(ti))
-				tbl.RawSetString("roundTime", lua.LNumber(sys.roundTime))
+				tbl.RawSetString("roundTime", lua.LNumber(sys.maxRoundTime))
 				tbl.RawSetString("winTeam", lua.LNumber(sys.winTeam))
 				tbl.RawSetString("lastRound", lua.LNumber(sys.round-1))
 				tbl.RawSetString("draws", lua.LNumber(sys.draws))
@@ -1822,7 +1822,7 @@ func systemScriptInit(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "getRoundTime", func(l *lua.LState) int {
-		l.Push(lua.LNumber(sys.roundTime))
+		l.Push(lua.LNumber(sys.maxRoundTime))
 		return 1
 	})
 	luaRegister(l, "getStageInfo", func(*lua.LState) int {
@@ -2720,7 +2720,7 @@ func systemScriptInit(l *lua.LState) {
 		return 0
 	})
 	luaRegister(l, "setRoundTime", func(l *lua.LState) int {
-		sys.roundTime = int32(numArg(l, 1))
+		sys.maxRoundTime = int32(numArg(l, 1))
 		return 0
 	})
 	luaRegister(l, "setConsecutiveRounds", func(l *lua.LState) int {
@@ -2754,7 +2754,7 @@ func systemScriptInit(l *lua.LState) {
 		return 0
 	})
 	luaRegister(l, "setTime", func(*lua.LState) int {
-		sys.time = int32(numArg(l, 1))
+		sys.curRoundTime = int32(numArg(l, 1))
 		return 0
 	})
 	luaRegister(l, "setTimeFramesPerCount", func(l *lua.LState) int {
@@ -2831,8 +2831,8 @@ func systemScriptInit(l *lua.LState) {
 		l.Push(lua.LNumber(Random()))
 		return 1
 	})
-	luaRegister(l, "step", func(*lua.LState) int {
-		sys.step = true
+	luaRegister(l, "frameStep", func(*lua.LState) int {
+		sys.frameStepFlag = true
 		return 0
 	})
 	luaRegister(l, "stopAllSound", func(l *lua.LState) int {
@@ -6109,7 +6109,7 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "paused", func(*lua.LState) int {
-		l.Push(lua.LBool(sys.paused && !sys.step))
+		l.Push(lua.LBool(sys.paused && !sys.frameStepFlag))
 		return 1
 	})
 	luaRegister(l, "postmatch", func(*lua.LState) int {

--- a/src/script.go
+++ b/src/script.go
@@ -837,7 +837,8 @@ func systemScriptInit(l *lua.LState) {
 		if !ok {
 			userDataError(l, 1, cl)
 		}
-		if cl.InputUpdate(int(numArg(l, 2))-1, false, 0, 0, nil, true) {
+		controller := int(numArg(l, 2)) - 1
+		if cl.InputUpdate(nil, controller, 0, true) {
 			cl.Step(false, false, false, false, 0)
 		}
 		return 0
@@ -5683,6 +5684,8 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_autoguard)))
 		case "drawunder":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_drawunder)))
+		case "noaibuttonjam":
+			l.Push(lua.LBool(sys.debugWC.asf(ASF_noaibuttonjam)))
 		case "noaicheat":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_noaicheat)))
 		case "noailevel":

--- a/src/script.go
+++ b/src/script.go
@@ -5683,6 +5683,8 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_autoguard)))
 		case "drawunder":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_drawunder)))
+		case "noaicheat":
+			l.Push(lua.LBool(sys.debugWC.asf(ASF_noaicheat)))
 		case "noailevel":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_noailevel)))
 		case "noairjump":

--- a/src/stage.go
+++ b/src/stage.go
@@ -1427,6 +1427,7 @@ func loadStage(def string, maindef bool) (*Stage, error) {
 	return s, nil
 }
 
+// TODO: This can be removed after rollback fight() is merged with system fight()
 func (s *Stage) copyStageVars(src *Stage) {
 	s.stageCamera.boundleft = src.stageCamera.boundleft
 	s.stageCamera.boundright = src.stageCamera.boundright
@@ -1708,12 +1709,16 @@ func (s *Stage) runBgCtrl(bgc *bgCtrl) {
 func (s *Stage) action() {
 	link, zlink, paused := 0, -1, true
 
-	if sys.tickFrame() && (sys.supertime <= 0 || !sys.superpausebg) &&
-		(sys.pausetime <= 0 || !sys.pausebg) {
+	if sys.tickFrame() && (sys.supertime <= 0 || !sys.superpausebg) && (sys.pausetime <= 0 || !sys.pausebg) {
 		paused = false
-		s.stageTime++
+
 		s.bgCtrlAction()
 		s.bga.action()
+
+		// Stage time must be incremented after updating BGCtrl
+		// https://github.com/ikemen-engine/Ikemen-GO/issues/2656
+		s.stageTime++
+
 		if s.model != nil {
 			s.model.step(sys.turbo)
 		}

--- a/src/state.go
+++ b/src/state.go
@@ -82,7 +82,7 @@ func (gs *GameState) Checksum() int {
 }
 
 func (gs *GameState) String() (str string) {
-	str = fmt.Sprintf("Time: %d GameTime %d \n", gs.Time, gs.GameTime)
+	str = fmt.Sprintf("Time: %d GameTime %d \n", gs.curRoundTime, gs.GameTime)
 	str += fmt.Sprintf("bcStack: %v\n", gs.bcStack)
 	str += fmt.Sprintf("bcVarStack: %v\n", gs.bcVarStack)
 	str += fmt.Sprintf("bcVar: %v\n", gs.bcVar)
@@ -104,7 +104,7 @@ type GameState struct {
 	saved    bool
 	frame    int32
 	randseed int32
-	Time     int32
+	curRoundTime int32
 	GameTime int32
 
 	projs          [MaxPlayerNo][]Projectile
@@ -153,7 +153,7 @@ type GameState struct {
 	widthScale, heightScale float32
 	gameEnd, frameSkip      bool
 	brightness              int32
-	roundTime               int32 // UIT
+	maxRoundTime            int32 // UIT
 	team1VS2Life            float32
 	turnsRecoveryRate       float32
 	match                   int32 // UIT
@@ -183,7 +183,7 @@ type GameState struct {
 	screenright             float32
 	xmin, xmax              float32
 	winskipped              bool
-	paused, step            bool
+	paused, frameStepFlag   bool
 	roundResetFlg           bool
 	reloadFlg               bool
 	reloadStageFlg          bool
@@ -294,7 +294,7 @@ func (gs *GameState) LoadState(stateID int) {
 	gsp := &sys.loadPool
 
 	sys.randseed = gs.randseed
-	sys.time = gs.Time // UIT
+	sys.curRoundTime = gs.curRoundTime // UIT
 	sys.gameTime = gs.GameTime
 	gs.loadCharData(a, gsp)
 	gs.loadExplodData(a, gsp)
@@ -344,7 +344,7 @@ func (gs *GameState) LoadState(stateID int) {
 	sys.winskipped = gs.winskipped
 
 	sys.intro = gs.intro
-	sys.time = gs.Time
+	sys.curRoundTime = gs.curRoundTime
 	sys.nextCharId = gs.nextCharId
 
 	sys.scrrect = gs.scrrect
@@ -355,7 +355,7 @@ func (gs *GameState) LoadState(stateID int) {
 	sys.gameEnd = gs.gameEnd
 	sys.frameSkip = gs.frameSkip
 	sys.brightness = gs.brightness
-	sys.roundTime = gs.roundTime
+	sys.maxRoundTime = gs.maxRoundTime
 	sys.turnsRecoveryRate = gs.turnsRecoveryRate
 
 	sys.changeStateNest = gs.changeStateNest
@@ -409,7 +409,7 @@ func (gs *GameState) LoadState(stateID int) {
 	sys.xmax = gs.xmax
 	sys.winskipped = gs.winskipped
 	sys.paused = gs.paused
-	sys.step = gs.step
+	sys.frameStepFlag = gs.frameStepFlag
 	sys.roundResetFlg = gs.roundResetFlg
 	sys.reloadFlg = gs.reloadFlg
 	sys.reloadStageFlg = gs.reloadStageFlg
@@ -524,7 +524,7 @@ func (gs *GameState) SaveState(stateID int) {
 	gs.saved = true
 	gs.frame = sys.frameCounter
 	gs.randseed = sys.randseed
-	gs.Time = sys.time
+	gs.curRoundTime = sys.curRoundTime
 	gs.GameTime = sys.gameTime
 
 	gs.saveCharData(a, gsp)
@@ -573,7 +573,7 @@ func (gs *GameState) SaveState(stateID int) {
 	gs.slowtime = sys.slowtime
 	gs.winskipped = sys.winskipped
 	gs.intro = sys.intro
-	gs.Time = sys.time
+	gs.curRoundTime = sys.curRoundTime
 	gs.nextCharId = sys.nextCharId
 
 	gs.scrrect = sys.scrrect
@@ -584,7 +584,7 @@ func (gs *GameState) SaveState(stateID int) {
 	gs.gameEnd = sys.gameEnd
 	gs.frameSkip = sys.frameSkip
 	gs.brightness = sys.brightness
-	gs.roundTime = sys.roundTime
+	gs.maxRoundTime = sys.maxRoundTime
 	gs.turnsRecoveryRate = sys.turnsRecoveryRate
 
 	gs.changeStateNest = sys.changeStateNest
@@ -637,7 +637,7 @@ func (gs *GameState) SaveState(stateID int) {
 	gs.xmax = sys.xmax
 	gs.winskipped = sys.winskipped
 	gs.paused = sys.paused
-	gs.step = sys.step
+	gs.frameStepFlag = sys.frameStepFlag
 	gs.roundResetFlg = sys.roundResetFlg
 	gs.reloadFlg = sys.reloadFlg
 	gs.reloadStageFlg = sys.reloadStageFlg


### PR DESCRIPTION
Feat:
- AssertSpecial NoAICheat. Disables AI command cheating
- AssertSpecial NoAIButtonJam. Makes the AI not jam buttons at random

Fix:
- Reworked explod code so that if its anim is not defined it will default to anim 0 instead of disappearing
- Fixed regression where BGCtrl's would not work in the stage's first frame
- Fixes #2651 
- Fixes #2656

Refactor:
- Refactored InputUpdate function to need less arguments
- Postype, animtype and hittype now require the full proper words for Ikemen characters. Mugen characters are not affected
- The round start backup now uses a simplified version of the method we use to save game states. This makes it more robust and easier to maintain, since we no longer have to cherrypick every single variable to backup
- Cleaned up system fight() a bit. Renamed it runMatch()
- More duplicate rollback code eliminated
- Removed positions from rollback state checksums, as their float math seems to cause false positives

Requires merging https://github.com/ikemen-engine/Ikemen_GO-Elecbyte-Screenpack/pull/27 to avoid crashing with KFM Z Axis.