### PR TITLE
fix: regressions; refactor: explods

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5538,7 +5538,6 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 	}
 
 	redirscale := c.localscl / crun.localscl
-	rp := [...]int32{-1, 0}
 
 	e, i := crun.newExplod()
 	if e == nil {
@@ -5573,9 +5572,9 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 		case explod_ownpal:
 			e.ownpal = exp[0].evalB(c)
 		case explod_remappal:
-			rp[0] = exp[0].evalI(c)
+			e.remappal[0] = exp[0].evalI(c)
 			if len(exp) > 1 {
-				rp[1] = exp[1].evalI(c)
+				e.remappal[1] = exp[1].evalI(c)
 			}
 		case explod_id:
 			e.id = Max(0, exp[0].evalI(c))
@@ -5769,7 +5768,8 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 	//	e.localscl = (320 / crun.localcoord)
 	//} else {
 
-	e.setStartParams(crun, &e.palfxdef, rp)
+	//e.setStartParams(crun, &e.palfxdef, rp) // Merged with insertExplod
+
 	e.setPos(crun)
 	crun.insertExplod(i)
 	return false
@@ -5867,11 +5867,11 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 	eid := int32(-1)
 	idx := int32(-1)
 	var expls []*Explod
-	rp := [...]int32{-1, 0}
 	remap := false
 	ptexists := false
 	animPN := -1
 	spritePN := -1
+
 	// Mugen chars can only modify some parameters after defining PosType
 	// Ikemen chars don't have this restriction
 	paramlock := func() bool {
@@ -5903,9 +5903,9 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				spritePN = pn
 			}
 		case explod_remappal:
-			rp[0] = exp[0].evalI(c)
+			e.remappal[0] = exp[0].evalI(c)
 			if len(exp) > 1 {
-				rp[1] = exp[1].evalI(c)
+				e.remappal[1] = exp[1].evalI(c)
 			}
 			remap = true
 		case explod_id:
@@ -5922,7 +5922,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				}
 				eachExpl(func(e *Explod) {
 					if e.ownpal && remap {
-						crun.remapPal(e.palfx, [...]int32{1, 1}, rp)
+						crun.remapPal(e.palfx, [...]int32{1, 1}, e.remappal)
 					}
 				})
 			}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5543,6 +5543,7 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 	if e == nil {
 		return false
 	}
+
 	e.id = 0
 
 	// Mugenversion 1.1 chars default postype to "None"
@@ -5867,6 +5868,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 	eid := int32(-1)
 	idx := int32(-1)
 	var expls []*Explod
+	rp := [2]int32{-1, 0}
 	remap := false
 	ptexists := false
 	animPN := -1
@@ -5903,9 +5905,9 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				spritePN = pn
 			}
 		case explod_remappal:
-			e.remappal[0] = exp[0].evalI(c)
+			rp[0] = exp[0].evalI(c)
 			if len(exp) > 1 {
-				e.remappal[1] = exp[1].evalI(c)
+				rp[1] = exp[1].evalI(c)
 			}
 			remap = true
 		case explod_id:
@@ -5922,7 +5924,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				}
 				eachExpl(func(e *Explod) {
 					if e.ownpal && remap {
-						crun.remapPal(e.palfx, [...]int32{1, 1}, e.remappal)
+						crun.remapPal(e.palfx, [...]int32{1, 1}, rp)
 					}
 				})
 			}
@@ -6237,10 +6239,10 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				if c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 { // You could not modify this one in Mugen
 					apn := crun.playerNo // Default to own player number
 					spn := crun.playerNo
-					if animPN != -1 {
+					if animPN >= 0 {
 						apn = animPN
 					}
-					if spritePN != -1 {
+					if spritePN >= 0 {
 						spn = spritePN
 					}
 					animNo := exp[1].evalI(c)
@@ -6248,9 +6250,13 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 
 					eachExpl(func(e *Explod) {
 						e.animNo = animNo
+						e.anim_ffx = ffx
 						e.animelem = 1
 						e.animelemtime = 0
-						e.setAnim(e.animNo, apn, spn, ffx)
+						e.animPN = apn
+						e.spritePN = spn
+						e.setAnim()
+						e.setAnimElem()
 					})
 				}
 			case explod_animelem:
@@ -6418,6 +6424,7 @@ func (sc gameMakeAnim) Run(c *Char, _ []int32) bool {
 	e.relativePos[1] -= float32(crun.size.draw.offset[1])
 	e.setPos(crun)
 	crun.insertExplod(i)
+
 	return false
 }
 

--- a/src/char.go
+++ b/src/char.go
@@ -1473,34 +1473,65 @@ func (e *Explod) matchId(eid, pid int32) bool {
 	return e.id >= 0 && e.playerId == pid && (eid < 0 || e.id == eid)
 }
 
-func (e *Explod) setAnim(animNo int32, animPlayerNo int, spritePlayerNo int, ffx string) {
+func (e *Explod) setAnim() {
 	c := sys.playerID(e.playerId)
 	if c == nil {
 		return
 	}
 
-	if a := sys.chars[animPlayerNo][0].getAnim(animNo, ffx, false); a != nil {
-		e.anim = a
-		e.animPN = animPlayerNo
-		e.spritePN = spritePlayerNo
+	// Check if using common FX
+	common := e.anim_ffx != "" && e.anim_ffx != "s"
 
-		if e.spritePN < 0 {
-			e.spritePN = c.playerNo
+	// Check animPN bounds
+	animPN := e.animPN
+	if animPN < 0 || common { // Common FX run getAnim with the owner's player number for the sake of scaling
+		animPN = c.playerNo
+	}
+	if animPN < 0 || animPN >= len(sys.chars) || len(sys.chars[animPN]) == 0 {
+		return
+	}
+	animChar := sys.chars[animPN][0]
+
+	// Get animation
+	a := animChar.getAnim(e.animNo, e.anim_ffx, false)
+	if a == nil {
+		return
+	}
+	e.anim = a
+
+	// Ignore SpritePN for common FX
+	if common {
+		// Set anim data owners to undefined for the sake of triggers
+		e.animPN = -1
+		e.spritePN = -1
+		return
+	}
+
+	// Palette setup
+	spritePN := e.spritePN
+	if spritePN < 0 {
+		spritePN = c.playerNo
+	}
+	if spritePN < 0 || spritePN >= len(sys.cgi) {
+		return
+	}
+
+	a.sff = sys.cgi[spritePN].sff
+	a.palettedata = &sys.cgi[spritePN].palettedata.palList
+
+	// Remap sprite palette if necessary
+	if c.playerNo != spritePN && !e.ownpal {
+		if len(sys.chars[spritePN]) == 0 {
+			return
 		}
-		if ffx == "" {
-			a.sff = sys.cgi[e.spritePN].sff
-			a.palettedata = &sys.cgi[e.spritePN].palettedata.palList
-			if c.playerNo != e.spritePN && !e.ownpal {
-				ownerChar := sys.chars[e.spritePN][0]
-				ownerPal := ownerChar.drawPal()
-				key := [2]int16{int16(ownerPal[0]), int16(ownerPal[1])}
+		spriteChar := sys.chars[spritePN][0]
+		ownerPal := spriteChar.drawPal()
+		key := [2]int16{int16(ownerPal[0]), int16(ownerPal[1])}
 
-				if di, ok := a.palettedata.PalTable[key]; ok {
-					for _, id := range [...]int32{0, 9000} {
-						if spr := a.sff.GetSprite(int16(id), 0); spr != nil {
-							a.palettedata.Remap(spr.palidx, di)
-						}
-					}
+		if di, ok := a.palettedata.PalTable[key]; ok {
+			for _, id := range [...]int32{0, 9000} {
+				if spr := a.sff.GetSprite(int16(id), 0); spr != nil {
+					a.palettedata.Remap(spr.palidx, di)
 				}
 			}
 		}
@@ -5782,11 +5813,9 @@ func (c *Char) explodDrawPal(e *Explod) [2]int32 {
 func (c *Char) insertExplod(i int) {
 	e := &sys.explods[c.playerNo][i]
 
-	// Init animation unless it already has been (e.g. sparks)
-	if e.anim == nil {
-		e.setAnim(e.animNo, e.animPN, e.spritePN, e.anim_ffx)
-		e.setAnimElem()
-	}
+	// Init animation
+	e.setAnim()
+	e.setAnimElem()
 
 	// If invalid animation, whole explod becomes invalid
 	// Note: If animation is not specified, it defaults to 0. If it is specified but invalid, explod is invalid
@@ -5796,6 +5825,7 @@ func (c *Char) insertExplod(i int) {
 	}
 
 	// Update local scale according to sprite owner
+	// Note: Common FX have undefined player number
 	if e.spritePN >= 0 && e.spritePN < len(sys.chars) {
 		e.localscl = 320 / sys.chars[e.spritePN][0].localcoord
 	}
@@ -5925,15 +5955,19 @@ func (c *Char) getAnim(n int32, ffx string, fx bool) (a *Animation) {
 	if n == -2 {
 		return &Animation{}
 	}
+
 	if n == -1 {
 		return nil
 	}
+
 	current_ffx := ffx
+
 	if current_ffx == "f" {
 		if c.gi().fightfxPrefix != "" {
 			current_ffx = c.gi().fightfxPrefix // 固有プレフィックスで上書き
 		}
 	}
+
 	if current_ffx != "" && current_ffx != "s" {
 		if sys.ffx[current_ffx] != nil && sys.ffx[current_ffx].fat != nil {
 			a = sys.ffx[current_ffx].fat.get(n)
@@ -5941,6 +5975,7 @@ func (c *Char) getAnim(n int32, ffx string, fx bool) (a *Animation) {
 	} else {
 		a = c.gi().anim.get(n)
 	}
+
 	if a == nil {
 		if fx {
 			if current_ffx != "" && current_ffx != "s" {
@@ -5968,6 +6003,7 @@ func (c *Char) getAnim(n int32, ffx string, fx bool) (a *Animation) {
 		a.start_scale[0] /= c.localscl
 		a.start_scale[1] /= c.localscl
 	}
+
 	return
 }
 
@@ -7702,11 +7738,8 @@ func (c *Char) makeDust(x, y, z float32, spacing int) {
 		return
 	}
 	if e, i := c.newExplod(); e != nil {
-		e.anim = c.getAnim(120, "f", true)
-		if e.anim != nil {
-			e.anim.start_scale[0] *= c.localscl
-			e.anim.start_scale[1] *= c.localscl
-		}
+		e.animNo = 120
+		e.anim_ffx = "f"
 		e.sprpriority = math.MaxInt32
 		e.layerno = c.layerNo
 		e.ownpal = true
@@ -9535,27 +9568,36 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 			off[1] += p1.hitdef.sparkxy[1] * c.localscl
 		}
 
+		// Convert offset back to character's coordinate space
+		for i := range off {
+			off[i] /= c.localscl
+		}
+
 		// Save hitspark position to MoveHitVar
-		// Currently it is saved even if the hit is a projectile
-		c.mhv.sparkxy[0] = off[0]
-		c.mhv.sparkxy[1] = off[1]
+		if !isProjectile {
+			c.mhv.sparkxy[0] = off[0]
+			c.mhv.sparkxy[1] = off[1]
+		}
 
 		if animNo >= 0 {
 			if e, i := c.newExplod(); e != nil {
-				e.anim = c.getAnim(animNo, ffx, true)
+				//e.anim = c.getAnim(animNo, ffx, true)
+				e.animNo = animNo
+				e.anim_ffx = ffx
 				e.layerno = 1 // e.ontop = true
 				e.sprpriority = math.MinInt32
 				e.ownpal = true
-				e.relativePos = [...]float32{off[0], off[1], off[2]}
+				e.relativePos = [3]float32{off[0], off[1], off[2]}
 				e.supermovetime = -1
 				e.pausemovetime = -1
-				e.localscl = 1
-				if ffx == "" || ffx == "s" {
-					e.scale = [...]float32{c.localscl * sparkscale[0], c.localscl * sparkscale[1]}
-				} else if e.anim != nil {
-					e.anim.start_scale[0] *= c.localscl * sparkscale[0]
-					e.anim.start_scale[1] *= c.localscl * sparkscale[1]
-				}
+				e.scale = [2]float32{sparkscale[0], sparkscale[1]}
+				//e.localscl = 1
+				//if ffx == "" || ffx == "s" {
+				//	e.scale = [2]float32{c.localscl * sparkscale[0], c.localscl * sparkscale[1]}
+				//} else if e.anim != nil {
+				//	e.anim.start_scale[0] *= c.localscl * sparkscale[0]
+				//	e.anim.start_scale[1] *= c.localscl * sparkscale[1]
+				//}
 				e.setPos(p1)
 				e.anglerot[0] = sparkangle
 				c.insertExplod(i)

--- a/src/common.go
+++ b/src/common.go
@@ -1133,14 +1133,18 @@ func (al *AnimLayout) Read(pre string, is IniSection, at AnimationTable, ln int1
 }
 
 func (al *AnimLayout) Reset() {
-	al.anim.Reset()
+	if al.anim != nil {
+		al.anim.Reset()
+	}
 }
 
 func (al *AnimLayout) Action() {
 	if al.palfx != nil {
 		al.palfx.step()
 	}
-	al.anim.Action()
+	if al.anim != nil {
+		al.anim.Action()
+	}
 }
 
 func (al *AnimLayout) Draw(x, y float32, layerno int16, scale float32) {

--- a/src/stage.go
+++ b/src/stage.go
@@ -365,15 +365,21 @@ func readBackGround(is IniSection, link *backGround, sff *Sff, at AnimationTable
 }
 
 func (bg *backGround) reset() {
-	bg.palfx.clear()
-	bg.anim.Reset()
 	bg.bga.clear()
 	bg.bga.vel = bg.startv
 	bg.bga.radius = bg.startrad
 	bg.bga.sintime = bg.startsint
 	bg.bga.sinlooptime = bg.startsinlt
-	bg.palfx.time = -1
-	bg.palfx.invertblend = -3
+
+	if bg.anim != nil {
+		bg.anim.Reset()
+	}
+
+	if bg.palfx != nil {
+		bg.palfx.clear()
+		bg.palfx.time = -1
+		bg.palfx.invertblend = -3
+	}
 }
 
 // Changes BG animation without changing the surrounding parameters
@@ -1425,66 +1431,6 @@ func loadStage(def string, maindef bool) (*Stage, error) {
 
 	s.mainstage = maindef
 	return s, nil
-}
-
-// TODO: This can be removed after rollback fight() is merged with system fight()
-func (s *Stage) copyStageVars(src *Stage) {
-	s.stageCamera.boundleft = src.stageCamera.boundleft
-	s.stageCamera.boundright = src.stageCamera.boundright
-	s.stageCamera.boundhigh = src.stageCamera.boundhigh
-	s.stageCamera.boundlow = src.stageCamera.boundlow
-	s.stageCamera.verticalfollow = src.stageCamera.verticalfollow
-	s.stageCamera.floortension = src.stageCamera.floortension
-	s.stageCamera.tensionhigh = src.stageCamera.tensionhigh
-	s.stageCamera.tensionlow = src.stageCamera.tensionlow
-	s.stageCamera.tension = src.stageCamera.tension
-	s.stageCamera.startzoom = src.stageCamera.startzoom
-	s.stageCamera.zoomout = src.stageCamera.zoomout
-	s.stageCamera.zoomin = src.stageCamera.zoomin
-	s.stageCamera.ytensionenable = src.stageCamera.ytensionenable
-	s.leftbound = src.leftbound
-	s.rightbound = src.rightbound
-	s.stageCamera.topz = src.stageCamera.topz
-	s.stageCamera.botz = src.stageCamera.botz
-	s.stageCamera.ztopscale = src.stageCamera.ztopscale
-	s.stageCamera.zbotscale = src.stageCamera.zbotscale
-	s.screenleft = src.screenleft
-	s.screenright = src.screenright
-	s.stageCamera.zoffset = src.stageCamera.zoffset
-	s.zoffsetlink = src.zoffsetlink
-	s.scale[0] = src.scale[0]
-	s.scale[1] = src.scale[1]
-	s.sdw.intensity = src.sdw.intensity
-	s.sdw.color = src.sdw.color
-	s.sdw.yscale = src.sdw.yscale
-	s.sdw.fadeend = src.sdw.fadeend
-	s.sdw.fadebgn = src.sdw.fadebgn
-	s.sdw.xshear = src.sdw.xshear
-	s.sdw.rot.angle = src.sdw.rot.angle
-	s.sdw.rot.xangle = src.sdw.rot.xangle
-	s.sdw.rot.yangle = src.sdw.rot.yangle
-	s.sdw.fLength = src.sdw.fLength
-	s.sdw.projection = src.sdw.projection
-	s.sdw.offset[0] = src.sdw.offset[0]
-	s.sdw.offset[1] = src.sdw.offset[1]
-	s.sdw.window[0] = src.sdw.window[0]
-	s.sdw.window[1] = src.sdw.window[1]
-	s.sdw.window[2] = src.sdw.window[2]
-	s.sdw.window[3] = src.sdw.window[3]
-	s.reflection.intensity = src.reflection.intensity
-	s.reflection.offset[0] = src.reflection.offset[0]
-	s.reflection.offset[1] = src.reflection.offset[1]
-	s.reflection.xshear = src.reflection.xshear
-	s.reflection.yscale = src.reflection.yscale
-	s.reflection.rot.angle = src.reflection.rot.angle
-	s.reflection.rot.xangle = src.reflection.rot.xangle
-	s.reflection.rot.yangle = src.reflection.rot.yangle
-	s.reflection.fLength = src.reflection.fLength
-	s.reflection.projection = src.reflection.projection
-	s.reflection.window[0] = src.reflection.window[0]
-	s.reflection.window[1] = src.reflection.window[1]
-	s.reflection.window[2] = src.reflection.window[2]
-	s.reflection.window[3] = src.reflection.window[3]
 }
 
 func (s *Stage) getBg(id int32) (bg []*backGround) {

--- a/src/system.go
+++ b/src/system.go
@@ -2786,33 +2786,32 @@ func (bk *RoundStartBackup) Restore() {
 			continue
 		}
 
+		c := chars[0]
+
 		// Restore shallow copy
-		*chars[0] = bk.charBackup[i]
+		*c = bk.charBackup[i]
 
-		// Restore CharGlobalInfo shallow copy
-		sys.cgi[i] = bk.cgiBackup[i]
-
-		// Deep copy maps and slices
-		chars[0].cnsvar = make(map[int32]int32, len(bk.charBackup[i].cnsvar))
+		// Remake the CNS variable maps
+		// Then restore only var and fvar (losing sysvar and sysfvar)
+		c.initCnsVar()
 		for k, v := range bk.charBackup[i].cnsvar {
-			chars[0].cnsvar[k] = v
+			c.cnsvar[k] = v
 		}
-
-		chars[0].cnsfvar = make(map[int32]float32, len(bk.charBackup[i].cnsfvar))
 		for k, v := range bk.charBackup[i].cnsfvar {
-			chars[0].cnsfvar[k] = v
+			c.cnsfvar[k] = v
 		}
 
-		chars[0].mapArray = make(map[string]float32, len(bk.charBackup[i].mapArray))
+		// Restore maps
+		c.mapArray = make(map[string]float32, len(bk.charBackup[i].mapArray))
 		for k, v := range bk.charBackup[i].mapArray {
-			chars[0].mapArray[k] = v
+			c.mapArray[k] = v
 		}
 
-		chars[0].dialogue = append([]string{}, bk.charBackup[i].dialogue...)
+		c.dialogue = append([]string{}, bk.charBackup[i].dialogue...)
 
-		chars[0].remapSpr = make(RemapPreset)
+		c.remapSpr = make(RemapPreset)
 		for k, v := range bk.charBackup[i].remapSpr {
-			chars[0].remapSpr[k] = v
+			c.remapSpr[k] = v
 		}
 	}
 
@@ -2822,7 +2821,7 @@ func (bk *RoundStartBackup) Restore() {
 	}
 
 	// Restore stage
-	// We preserve the stage time as a cosmetic thing just match Mugen. Might as well restore it to where it was when we use F4
+	// We preserve the stage time as a cosmetic thing just to match Mugen. Might as well restore it to where it was when we use F4
 	// NOTE: If reloading stage time we'd need backups of the BGCtrls as well
 	// NOTE: This save and restore of stage variables makes ModifyStageVar not persist. Maybe that should not be the case?
 	stageTime := sys.stage.stageTime


### PR DESCRIPTION
Fix:
- Added char and stage names to rollback checksum as a safeguard against random select going wrong. This check only runs in the first frame of each round
- Fixed crashing on some explods with invalid animations
- Fixed crashing after trying to use a sysvar after reloading with shift F4
- Fixed nil crash for anim layouts without animations
- Fixes #2660

Refactor:
- Condensed rollback checksum to one function
- Regular explods, hitsparks and explods using common FX now all use the same logic