### PR TITLE
fix: rollback desync, SuperPause effects, explod regressions; refactoring

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -2794,6 +2794,7 @@ main.t_itemname = {
 	end,
 	--SERVER CONNECT
 	['serverconnect'] = function(t, item)
+		sndPlay(motif.files.snd_data, motif[main.group].cursor_done_snd[1], motif[main.group].cursor_done_snd[2]) -- Needs manual sndPlay due to special menu behavior
 		if main.f_connect(gameOption('Netplay.IP.' .. t[item].displayname), main.f_extractText(motif.title_info.connecting_join_text, t[item].displayname, gameOption('Netplay.IP.' .. t[item].displayname))) then
 			synchronize()
 			math.randomseed(sszRandom())
@@ -2807,6 +2808,7 @@ main.t_itemname = {
 	end,
 	--SERVER HOST
 	['serverhost'] = function(t, item)
+		sndPlay(motif.files.snd_data, motif[main.group].cursor_done_snd[1], motif[main.group].cursor_done_snd[2]) -- Needs manual sndPlay due to special menu behavior
 		if main.f_connect("", main.f_extractText(motif.title_info.connecting_host_text, gameOption('Netplay.ListenPort'))) then
 			synchronize()
 			math.randomseed(sszRandom())

--- a/src/anim.go
+++ b/src/anim.go
@@ -173,10 +173,6 @@ type Animation struct {
 	start_scale                [2]float32
 }
 
-func (a *Animation) isBlank() bool {
-	return a.scale_x == 0 || a.scale_y == 0 || a.spr == nil || a.spr.isBlank()
-}
-
 func newAnimation(sff *Sff, pal *PaletteList) *Animation {
 	return &Animation{
 		sff:         sff,
@@ -345,6 +341,19 @@ func (a *Animation) Reset() {
 	a.curelemtime, a.curtime = 0, 0
 	a.newframe, a.loopend = true, false
 	a.spr = nil
+}
+
+func (a *Animation) isBlank() bool {
+	return a.scale_x == 0 || a.scale_y == 0 || a.spr == nil || a.spr.isBlank()
+}
+
+func (a *Animation) isCommonFX() bool {
+	for _, fx := range sys.ffx {
+		if fx.fsff == a.sff {
+			return true
+		}
+	}
+	return false
 }
 
 func (a *Animation) AnimTime() int32 {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -9374,7 +9374,7 @@ func (sc superPause) Run(c *Char, _ []int32) bool {
 	sys.superdarken = true
 	sys.superpausebg = true
 	sys.superendcmdbuftime = 0
-	sys.superp2defmul = crun.gi().constants["super.targetdefencemul"]
+	p2defmul := crun.gi().constants["super.targetdefencemul"]
 
 	// Default super FX
 	fx_anim := int32(100)
@@ -9405,9 +9405,9 @@ func (sc superPause) Run(c *Char, _ []int32) bool {
 				fx_pos[2] = exp[2].evalF(c)
 			}
 		case superPause_p2defmul:
-			sys.superp2defmul = exp[0].evalF(c)
-			if sys.superp2defmul == 0 {
-				sys.superp2defmul = crun.gi().constants["super.targetdefencemul"]
+			v := exp[0].evalF(c)
+			if v > 0 {
+				p2defmul = v
 			}
 		case superPause_poweradd:
 			crun.powerAdd(exp[0].evalI(c))
@@ -9441,7 +9441,8 @@ func (sc superPause) Run(c *Char, _ []int32) bool {
 		// TODO: It also seems to inherit the player's remapped palette in Mugen
 	}
 
-	crun.setSuperPauseTime(t, mt, uh)
+	crun.setSuperPauseTime(t, mt, uh, p2defmul)
+
 	return false
 }
 

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6367,8 +6367,11 @@ func (sc gameMakeAnim) Run(c *Char, _ []int32) bool {
 	if e == nil {
 		return false
 	}
+
 	e.id = 0
-	e.layerno, e.sprpriority, e.ownpal = 1, math.MinInt32, true
+	e.layerno = 1
+	e.sprpriority = math.MinInt32
+	e.ownpal = true
 
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
@@ -6395,8 +6398,10 @@ func (sc gameMakeAnim) Run(c *Char, _ []int32) bool {
 			if exp[0].evalB(c) {
 				e.layerno = 0
 			}
-		case gameMakeAnim_anim: // Minor: Mugen uses anim 0 if nothing is specified
-			e.anim = crun.getAnim(exp[1].evalI(c), string(*(*[]byte)(unsafe.Pointer(&exp[0]))), true)
+		case gameMakeAnim_anim:
+			e.anim_ffx = string(*(*[]byte)(unsafe.Pointer(&exp[0])))
+			e.animNo = exp[1].evalI(c)
+			e.anim = crun.getSelfAnimSprite(e.animNo, e.anim_ffx, e.ownpal, true)
 		}
 		return true
 	})
@@ -9426,8 +9431,11 @@ func (sc superPause) Run(c *Char, _ []int32) bool {
 		sys.superanim = crun.getAnim(100, "f", true) // Default animation
 	}
 	if sys.superanim != nil {
-		sys.superanim.start_scale[0] *= crun.localscl
-		sys.superanim.start_scale[1] *= crun.localscl
+		// No longer needed
+		// TODO: Maybe we ought to make these as regular explods instead of a system thing
+		//sys.superanim.start_scale[0] *= crun.localscl
+		//sys.superanim.start_scale[1] *= crun.localscl
+
 		// Apply Z axis perspective
 		if sys.zEnabled() {
 			sys.superpos = sys.drawposXYfromZ(sys.superpos, crun.localscl, crun.interPos[2], crun.zScale)

--- a/src/char.go
+++ b/src/char.go
@@ -5760,7 +5760,7 @@ func (c *Char) helperPos(pt PosType, pos [3]float32, facing int32,
 }
 
 func (c *Char) newExplod() (*Explod, int) {
-	// Reuse free explod slots
+	// Reuse a free explod slot
 	for i := range sys.explods[c.playerNo] {
 		if sys.explods[c.playerNo][i].id == IErr {
 			return sys.explods[c.playerNo][i].initFromChar(c), i
@@ -7700,17 +7700,20 @@ func (c *Char) setPauseTime(pausetime, movetime int32) {
 func (c *Char) setSuperPauseTime(pausetime, movetime int32, unhittable bool) {
 	if ^pausetime < sys.supertimebuffer || c.playerNo != c.ss.sb.playerNo || sys.superplayerno == c.playerNo {
 		sys.supertimebuffer = ^pausetime
-		sys.superplayerno = c.playerNo
+		sys.superplayerno = c.playerNo // TODO: For simultaneous pauses, maybe both players should ignore "darken"
 		if sys.superendcmdbuftime < 0 || sys.superendcmdbuftime > pausetime {
 			sys.superendcmdbuftime = 0
 		}
 	}
+
 	c.superMovetime = Max(0, movetime)
+
 	if c.superMovetime > pausetime {
 		c.superMovetime = 0
 	} else if sys.supertime > 0 && c.superMovetime > 0 {
 		c.superMovetime--
 	}
+
 	if unhittable {
 		c.unhittableTime = pausetime + Btoi(pausetime > 0)
 	}

--- a/src/char.go
+++ b/src/char.go
@@ -1618,13 +1618,16 @@ func (e *Explod) update(mugenverF float32, playerNo int) {
 			off[0] = (off[0] + float32(sys.gameWidth)) / sys.cam.Scale
 		}
 	}
+
 	var facing float32 = e.facing * e.relativef
 	//if e.lockSpriteFacing {
 	//	facing = -1
 	//}
+
 	if sys.tickFrame() && act {
 		e.anim.UpdateSprite()
 	}
+
 	sprs := &sys.spritesLayer0
 	if e.layerno > 0 {
 		sprs = &sys.spritesLayer1
@@ -1633,14 +1636,16 @@ func (e *Explod) update(mugenverF float32, playerNo int) {
 	} else if e.under {
 		sprs = &sys.spritesLayerU
 	}
+
 	var pfx *PalFX
-	if e.palfx != nil && (e.anim.sff != sys.ffx["f"].fsff || e.ownpal) {
+	if e.palfx != nil && (!e.anim.isCommonFX() || e.ownpal) {
 		pfx = e.palfx
 	} else {
 		pfx = &PalFX{}
 		*pfx = *e.palfx
 		pfx.remap = nil
 	}
+
 	alp := e.alpha
 	anglerot := e.anglerot
 	fLength := e.fLength
@@ -5866,7 +5871,7 @@ func (c *Char) insertExplod(i int) {
 	// Init "ownpal" PalFX and RemapPal
 	// Note: Must be placed after setting up interpolation
 	if e.ownpal {
-		if e.anim.sff != sys.ffx["f"].fsff {
+		if !e.anim.isCommonFX() {
 			// Keep parent's remapped palette while resetting PalFX
 			parentRemap := make([]int, len(c.getPalfx().remap))
 			copy(parentRemap, c.getPalfx().remap)

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1138,25 +1138,19 @@ func (c *Compiler) gameMakeAnim(is IniSection, sc *StateControllerBase, _ int8) 
 			gameMakeAnim_under, VT_Bool, 1, false); err != nil {
 			return err
 		}
-		b := false
+
+		// Previously, Ikemen accepted either "value" or "anim" here. Turns out Mugen only accepts "value"
 		anim := func(data string) error {
-			b = true
 			prefix := c.getDataPrefix(&data, true)
 			return c.scAdd(sc, gameMakeAnim_anim, data, VT_Int, 1,
 				sc.beToExp(BytecodeExp(prefix))...)
 		}
-		if err := c.stateParam(is, "anim", false, func(data string) error {
+		if err := c.stateParam(is, "value", false, func(data string) error {
 			return anim(data)
 		}); err != nil {
 			return err
 		}
-		if !b {
-			if err := c.stateParam(is, "value", false, func(data string) error {
-				return anim(data)
-			}); err != nil {
-				return err
-			}
-		}
+
 		return nil
 	})
 	return *ret, err

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -3380,7 +3380,7 @@ func (c *Compiler) superPause(is IniSection, sc *StateControllerBase, _ int8) (S
 			return err
 		}
 		if err := c.paramValue(is, sc, "pos",
-			superPause_pos, VT_Float, 2, false); err != nil {
+			superPause_pos, VT_Float, 3, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "p2defmul",

--- a/src/config.go
+++ b/src/config.go
@@ -149,6 +149,7 @@ type Config struct {
 		StartStage        string  `ini:"StartStage"`
 		ForceStageZoomout float32 `ini:"ForceStageZoomout"`
 		ForceStageZoomin  float32 `ini:"ForceStageZoomin"`
+		KeepSpritesOnReload bool    `ini:"KeepSpritesOnReload"`
 	} `ini:"Debug"`
 	Video struct {
 		RenderMode              string   `ini:"RenderMode"`

--- a/src/image.go
+++ b/src/image.go
@@ -106,7 +106,7 @@ func (pf *PalFX) getSynFx(blending int) *PalFX {
 			pf.eColor = pf.color
 			pf.eHue = pf.hue
 		} else {
-			return &sys.allPalFX
+			return sys.allPalFX
 		}
 	}
 	if !sys.allPalFX.enable {
@@ -307,7 +307,7 @@ func (pf *PalFX) step() {
 	}
 }
 
-func (pf *PalFX) synthesize(pfx PalFX, blending int) {
+func (pf *PalFX) synthesize(pfx *PalFX, blending int) {
 	if blending == -2 {
 		for i, a := range pfx.eAdd {
 			pf.eAdd[i] = Clamp(pf.eAdd[i]-Abs(a), 0, 255)

--- a/src/input.go
+++ b/src/input.go
@@ -491,44 +491,6 @@ func (ibit *InputBits) KeysToBits(buttons [14]bool) {
 		Btoi(buttons[13])<<13)
 }
 
-func (ibit InputBits) RollbackBitsToKeys(cb *InputBuffer, facing int32) {
-	var U, D, L, R, B, F, a, b, c, x, y, z, s, d, w, m bool
-	// Convert bits to logical symbols
-	U = ibit&IB_PU != 0
-	D = ibit&IB_PD != 0
-	L = ibit&IB_PL != 0
-	R = ibit&IB_PR != 0
-	if facing < 0 {
-		B, F = ibit&IB_PR != 0, ibit&IB_PL != 0
-	} else {
-		B, F = ibit&IB_PL != 0, ibit&IB_PR != 0
-	}
-	a = ibit&IB_A != 0
-	b = ibit&IB_B != 0
-	c = ibit&IB_C != 0
-	x = ibit&IB_X != 0
-	y = ibit&IB_Y != 0
-	z = ibit&IB_Z != 0
-	s = ibit&IB_S != 0
-	d = ibit&IB_D != 0
-	w = ibit&IB_W != 0
-	m = ibit&IB_M != 0
-	// Absolute priority SOCD resolution is enforced during netplay
-	// TODO: Port the other options as well
-	if U && D {
-		D = false
-	}
-	if B && F {
-		B = false
-		if facing < 0 {
-			R = false
-		} else {
-			L = false
-		}
-	}
-	cb.updateInputTime(U, D, L, R, B, F, a, b, c, x, y, z, s, d, w, m)
-}
-
 // Convert received input bits back into keys
 func (ibit InputBits) BitsToKeys() [14]bool {
 	var U, D, L, R, a, b, c, x, y, z, s, d, w, m bool

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -1718,7 +1718,7 @@ func (fa *LifeBarFace) draw(layerno int16, ref int, far *LifeBarFace) {
 
 		// Reset system brightness if player initiated SuperPause (cancel "darken" parameter)
 		ob := sys.brightness
-		if ref == sys.superplayerno {
+		if sys.chars[ref][0].ignoreDarkenTime > 0{ //ref == sys.superplayerno
 			sys.brightness = 256
 		}
 

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -173,6 +173,8 @@ StartStage        = stages/stage0-720.def
 ; This is a debug parameter and may be removed in future versions.
 ForceStageZoomout = 0
 ForceStageZoomin  = 0
+; Set to 1 to prevent character SFF files from being reloaded when Shift+F4 is used.
+KeepSpritesOnReload = 0
 
 ; -------------------------------------------------------------------------------
 [Video]

--- a/src/rollback.go
+++ b/src/rollback.go
@@ -32,56 +32,11 @@ func (rs *RollbackSystem) hijackRunMatch(s *System) bool {
 	// Reset variables
 	rs.ggpoInputs = make([]InputBits, 2)
 
-	var running bool
-	if rs.session != nil && s.netConnection != nil {
-		if rs.session.host != "" {
-			rs.session.InitP2(2, 7550, 7600, rs.session.host)
-			rs.session.playerNo = 2
-		} else {
-			rs.session.InitP1(2, 7600, 7550, rs.session.remoteIp)
-			rs.session.playerNo = 1
-		}
-		//s.time = rs.session.netTime // What was this for? s.time is the round timer
-		s.preFightTime = s.netConnection.preFightTime
-		//if !rs.session.IsConnected() {
-		// for !rs.session.synchronized {
-		// 	rs.session.backend.Idle(0)
-		// }
-		//}
-		// s.netConnection.Close()
-		rs.session.recording = s.netConnection.recording
-		rs.netConnection = s.netConnection
-		s.netConnection = nil
-	} else if s.netConnection == nil && rs.session == nil {
-		session := NewRollbackSession(s.cfg.Netplay.Rollback)
-		rs.session = &session
-		rs.session.InitSyncTest(2)
-	}
-	rs.session.netTime = 0
-
-	// These empty frames help the netcode stabilize. Without them, the chances of it desyncing at match start increase a lot
-	// Update: Might not be necessary after syncTest fix
-	/*
-		for i := 0; i < 120; i++ {
-			err := rs.session.backend.Idle(
-				int(math.Max(0, float64(120))))
-			fmt.Printf("difference: %d\n", rs.session.next-rs.session.now-1)
-			if err != nil {
-				panic(err)
-			}
-
-			s.renderFrame() // Do we need to render at this point? Is there anything to render?
-
-			//rs.session.loopTimer.usToWaitThisLoop()
-			running = s.update()
-
-			if !running {
-				break
-			}
-		}
-	*/
+	// Initialize rollback network session and synchronize state
+	rs.preMatchSetup()
 
 	var didTryLoadBGM bool
+	var running bool
 
 	// Loop until end of match
 	for !s.endMatch {
@@ -92,14 +47,15 @@ func (rs *RollbackSystem) hijackRunMatch(s *System) bool {
 			panic(err)
 		}
 
+		// Sync speculative inputs and run a speculative frame
 		running = rs.runFrame(s)
 
-		// default bgm playback, used only in Quick VS or if externalized Lua implementaion is disabled
-		if s.round == 1 && (s.gameMode == "" || len(sys.cfg.Common.Lua) == 0) && sys.stage.stageTime > 0 && !didTryLoadBGM {
+		// Default BGM playback. Used only in Quick VS or if externalized Lua implementaion is disabled
+		if !didTryLoadBGM && s.round == 1 && (s.gameMode == "" || len(sys.cfg.Common.Lua) == 0) && sys.stage.stageTime > 0 {
+			didTryLoadBGM = true
 			// Need to search first
 			LoadFile(&s.stage.bgmusic, []string{s.stage.def, "", "sound/"}, func(path string) error {
 				s.bgm.Open(path, 1, int(s.stage.bgmvolume), int(s.stage.bgmloopstart), int(s.stage.bgmloopend), int(s.stage.bgmstartposition), s.stage.bgmfreqmul, -1)
-				didTryLoadBGM = true
 				return nil
 			})
 		}
@@ -123,15 +79,50 @@ func (rs *RollbackSystem) hijackRunMatch(s *System) bool {
 			break
 		}
 	}
+
+	rs.postMatchSetup()
+
+	return false
+}
+
+func (rs *RollbackSystem) preMatchSetup() {
+	if rs.session != nil && sys.netConnection != nil {
+		if rs.session.host != "" {
+			rs.session.InitP2(2, 7550, 7600, rs.session.host)
+			rs.session.playerNo = 2
+		} else {
+			rs.session.InitP1(2, 7600, 7550, rs.session.remoteIp)
+			rs.session.playerNo = 1
+		}
+		//s.time = rs.session.netTime // What was this for? s.time is the round timer
+		s.preFightTime = s.netConnection.preFightTime
+		//if !rs.session.IsConnected() {
+		//	for !rs.session.synchronized {
+		//		rs.session.backend.Idle(0)
+		//	}
+		//}
+		// s.netConnection.Close()
+		rs.session.recording = s.netConnection.recording
+		rs.netConnection = s.netConnection
+		s.netConnection = nil
+	} else if s.netConnection == nil && rs.session == nil {
+		session := NewRollbackSession(s.cfg.Netplay.Rollback)
+		rs.session = &session
+		rs.session.InitSyncTest(2)
+	}
+	rs.session.netTime = 0
+}
+
+func (rs *RollbackSystem) postMatchSetup() {
 	rs.session.SaveReplay()
 	// sys.esc = true
 	//sys.rollback.currentFight.fin = true
-	s.netConnection = rs.netConnection
+	sys.netConnection = rs.netConnection
 	rs.session.backend.Close()
 
 	// Prep for the next match.
-	if s.netConnection != nil {
-		newSession := NewRollbackSession(s.cfg.Netplay.Rollback)
+	if sys.netConnection != nil {
+		newSession := NewRollbackSession(sys.cfg.Netplay.Rollback)
 		host := rs.session.host
 		remoteIp := rs.session.remoteIp
 
@@ -141,7 +132,6 @@ func (rs *RollbackSystem) hijackRunMatch(s *System) bool {
 	} else {
 		rs.session = nil
 	}
-	return false
 }
 
 // Called once per frame by the main game loop
@@ -174,6 +164,7 @@ func (rs *RollbackSystem) runFrame(s *System) bool {
 		values, ggpoerr = rs.session.backend.SyncInput(&disconnectFlags)
 		rs.ggpoInputs = decodeInputs(values)
 
+		// TODO: Why does this depend on the replay?
 		if rs.session.recording != nil {
 			rs.session.SetInput(rs.session.netTime, 0, rs.ggpoInputs[0])
 			rs.session.SetInput(rs.session.netTime, 1, rs.ggpoInputs[1])
@@ -205,21 +196,10 @@ func (rs *RollbackSystem) runFrame(s *System) bool {
 	return true
 }
 
-func (rs *RollbackSystem) runShortcutScripts(s *System) {
-	for _, v := range s.shortcutScripts {
-		if v.Activate {
-			if err := s.luaLState.DoString(v.Script); err != nil {
-				s.errLog.Println(err.Error())
-			}
-		}
-	}
-}
-
 // Contains the logic for a single frame of the game
 // Called by both runFrame for speculative execution, and AdvanceFrame for confirmed execution
 func (rs *RollbackSystem) simulateFrame(s *System) bool {
 	s.frameStepFlag = false
-	//rs.runShortcutScripts(s)
 
 	// If next round
 	if !sys.runNextRound() {
@@ -230,13 +210,13 @@ func (rs *RollbackSystem) simulateFrame(s *System) bool {
 	s.stage.action()
 
 	// If frame is ready to tick and not paused
-	//rs.updateStage(s)
+	//sys.stage.action()
 
 	// Update game state
 	s.action()
 
 	// if rs.handleFlags(s) {
-	// 	return true
+	//	return true
 	// }
 
 	if !rs.updateEvents(s) {
@@ -262,11 +242,6 @@ func (rs *RollbackSystem) simulateFrame(s *System) bool {
 		return false
 	}
 	return true
-}
-
-func (rs *RollbackSystem) updateStage(s *System) {
-	// Update stage
-	s.stage.action()
 }
 
 func (rs *RollbackSystem) updateEvents(s *System) bool {
@@ -358,14 +333,6 @@ func decodeInputs(buffer [][]byte) []InputBits {
 	var inputs = make([]InputBits, len(buffer))
 	for i, b := range buffer {
 		inputs[i] = InputBits(readI32(b))
-	}
-	return inputs
-}
-
-// HACK: So you won't be playing eachothers characters
-func reverseInputs(inputs []InputBits) []InputBits {
-	for i, j := 0, len(inputs)-1; i < j; i, j = i+1, j-1 {
-		inputs[i], inputs[j] = inputs[j], inputs[i]
 	}
 	return inputs
 }

--- a/src/script.go
+++ b/src/script.go
@@ -1477,7 +1477,6 @@ func systemScriptInit(l *lua.LState) {
 				sys.clearAllSound()
 				sys.allPalFX = *newPalFX()
 				sys.bgPalFX = *newPalFX()
-				sys.superpmap = *newPalFX()
 				sys.resetGblEffect()
 				sys.dialogueFlg = false
 				sys.dialogueForce = 0
@@ -2235,7 +2234,6 @@ func systemScriptInit(l *lua.LState) {
 	luaRegister(l, "resetMatchData", func(*lua.LState) int {
 		sys.allPalFX = *newPalFX()
 		sys.bgPalFX = *newPalFX()
-		sys.superpmap = *newPalFX()
 		sys.resetGblEffect()
 		for i, p := range sys.chars {
 			if len(p) > 0 {

--- a/src/script.go
+++ b/src/script.go
@@ -1364,8 +1364,10 @@ func systemScriptInit(l *lua.LState) {
 					// Match is restarting
 					for i, b := range sys.reloadCharSlot {
 						if b {
-							if s := sys.cgi[i].sff; s != nil {
-								removeSFFCache(s.filename)
+							if !sys.cfg.Debug.KeepSpritesOnReload {
+								if s := sys.cgi[i].sff; s != nil {
+									removeSFFCache(s.filename)
+								}
 							}
 							sys.chars[i] = []*Char{}
 							b = false

--- a/src/script.go
+++ b/src/script.go
@@ -1475,8 +1475,8 @@ func systemScriptInit(l *lua.LState) {
 					sys.playBgmFlg = false
 				}
 				sys.clearAllSound()
-				sys.allPalFX = *newPalFX()
-				sys.bgPalFX = *newPalFX()
+				sys.allPalFX = newPalFX()
+				sys.bgPalFX = newPalFX()
 				sys.resetGblEffect()
 				sys.dialogueFlg = false
 				sys.dialogueForce = 0
@@ -2232,8 +2232,8 @@ func systemScriptInit(l *lua.LState) {
 		return 0
 	})
 	luaRegister(l, "resetMatchData", func(*lua.LState) int {
-		sys.allPalFX = *newPalFX()
-		sys.bgPalFX = *newPalFX()
+		sys.allPalFX = newPalFX()
+		sys.bgPalFX = newPalFX()
 		sys.resetGblEffect()
 		for i, p := range sys.chars {
 			if len(p) > 0 {

--- a/src/script.go
+++ b/src/script.go
@@ -848,11 +848,7 @@ func systemScriptInit(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "connected", func(*lua.LState) int {
-		if sys.cfg.Netplay.RollbackNetcode {
-			l.Push(lua.LBool(sys.netConnection.IsConnected() || sys.rollback.session.IsConnected()))
-		} else {
-			l.Push(lua.LBool(sys.netConnection.IsConnected()))
-		}
+		l.Push(lua.LBool(sys.netConnection.IsConnected())) // No need to check rollback here as this deals with the main menu connection
 		return 1
 	})
 	luaRegister(l, "dialogueReset", func(*lua.LState) int {

--- a/src/state.go
+++ b/src/state.go
@@ -134,10 +134,6 @@ type GameState struct {
 	superendcmdbuftime int32
 	superplayerno      int
 	superdarken        bool
-	superanim          *Animation
-	superpmap          PalFX
-	superpos           [2]float32
-	superscale         [2]float32
 	superp2defmul      float32
 
 	envShake            EnvShake
@@ -793,14 +789,6 @@ func (gs *GameState) saveSuperData(a *arena.Arena, gsp *GameStatePool) {
 	gs.superendcmdbuftime = sys.superendcmdbuftime
 	gs.superplayerno = sys.superplayerno
 	gs.superdarken = sys.superdarken
-	if sys.superanim != nil {
-		gs.superanim = sys.superanim.Clone(a, gsp)
-	} else {
-		gs.superanim = sys.superanim
-	}
-	gs.superpmap = sys.superpmap.Clone(a)
-	gs.superpos = [2]float32{sys.superpos[0], sys.superpos[1]}
-	gs.superscale = sys.superscale
 	gs.superp2defmul = sys.superp2defmul
 }
 
@@ -876,14 +864,6 @@ func (gs *GameState) loadSuperData(a *arena.Arena, gsp *GameStatePool) {
 	sys.superendcmdbuftime = gs.superendcmdbuftime
 	sys.superplayerno = gs.superplayerno
 	sys.superdarken = gs.superdarken
-	if gs.superanim != nil {
-		sys.superanim = gs.superanim.Clone(a, gsp)
-	} else {
-		sys.superanim = gs.superanim
-	}
-	sys.superpmap = gs.superpmap.Clone(a)
-	sys.superpos = [2]float32{gs.superpos[0], gs.superpos[1]}
-	sys.superscale = gs.superscale
 	sys.superp2defmul = gs.superp2defmul
 }
 

--- a/src/state.go
+++ b/src/state.go
@@ -82,7 +82,7 @@ func (gs *GameState) Checksum() int {
 }
 
 func (gs *GameState) String() (str string) {
-	str = fmt.Sprintf("Time: %d GameTime %d \n", gs.curRoundTime, gs.GameTime)
+	str = fmt.Sprintf("GameTime %d CurRoundTime: %d\n", gs.gameTime, gs.curRoundTime)
 	str += fmt.Sprintf("bcStack: %v\n", gs.bcStack)
 	str += fmt.Sprintf("bcVarStack: %v\n", gs.bcVarStack)
 	str += fmt.Sprintf("bcVar: %v\n", gs.bcVar)
@@ -99,13 +99,16 @@ func (gs *GameState) String() (str string) {
 const MaxSaveStates = 8
 
 type GameState struct {
+	// Identifiers
 	bytes        []byte
 	id           int
 	saved        bool
 	frame        int32
+
+	// Selective copy of the system struct
 	randseed     int32
+	gameTime     int32
 	curRoundTime int32
-	GameTime     int32
 
 	projs          [MaxPlayerNo][]*Projectile
 	chars          [MaxPlayerNo][]*Char
@@ -287,13 +290,16 @@ func (gs *GameState) LoadState(stateID int) {
 	gsp := &sys.loadPool
 
 	sys.randseed = gs.randseed
+	sys.gameTime = gs.gameTime
 	sys.curRoundTime = gs.curRoundTime // UIT
-	sys.gameTime = gs.GameTime
+
 	gs.loadCharData(a, gsp)
 	gs.loadExplodData(a, gsp)
 	sys.cam = gs.cam
+
 	gs.loadPauseData()
-	gs.loadSuperData(a, gsp)
+	gs.loadSuperPauseData()
+
 	gs.loadPalFX(a)
 	gs.loadProjectileData(a, gsp)
 	sys.aiLevel = gs.aiLevel
@@ -337,7 +343,6 @@ func (gs *GameState) LoadState(stateID int) {
 	sys.winskipped = gs.winskipped
 
 	sys.intro = gs.intro
-	sys.curRoundTime = gs.curRoundTime
 	sys.nextCharId = gs.nextCharId
 
 	sys.scrrect = gs.scrrect
@@ -505,15 +510,18 @@ func (gs *GameState) SaveState(stateID int) {
 	gs.cgi = sys.cgi
 	gs.saved = true
 	gs.frame = sys.frameCounter
+
 	gs.randseed = sys.randseed
+	gs.gameTime = sys.gameTime
 	gs.curRoundTime = sys.curRoundTime
-	gs.GameTime = sys.gameTime
 
 	gs.saveCharData(a, gsp)
 	gs.saveExplodData(a, gsp)
 	gs.cam = sys.cam
+
 	gs.savePauseData()
-	gs.saveSuperData(a, gsp)
+	gs.saveSuperPauseData()
+
 	gs.savePalFX(a)
 	gs.saveProjectileData(a, gsp)
 
@@ -555,7 +563,6 @@ func (gs *GameState) SaveState(stateID int) {
 	gs.slowtime = sys.slowtime
 	gs.winskipped = sys.winskipped
 	gs.intro = sys.intro
-	gs.curRoundTime = sys.curRoundTime
 	gs.nextCharId = sys.nextCharId
 
 	gs.scrrect = sys.scrrect
@@ -758,21 +765,21 @@ func (gs *GameState) saveProjectileData(a *arena.Arena, gsp *GameStatePool) {
 	}
 }
 
-func (gs *GameState) saveSuperData(a *arena.Arena, gsp *GameStatePool) {
-	gs.supertimebuffer = sys.supertimebuffer
-	gs.supertime = sys.supertime
-	gs.superpausebg = sys.superpausebg
-	gs.superendcmdbuftime = sys.superendcmdbuftime
-	gs.superplayerno = sys.superplayerno
-	gs.superdarken = sys.superdarken
-}
-
 func (gs *GameState) savePauseData() {
 	gs.pausetimebuffer = sys.pausetimebuffer
 	gs.pausetime = sys.pausetime
 	gs.pausebg = sys.pausebg
 	gs.pauseendcmdbuftime = sys.pauseendcmdbuftime
 	gs.pauseplayerno = sys.pauseplayerno
+}
+
+func (gs *GameState) saveSuperPauseData() {
+	gs.supertimebuffer = sys.supertimebuffer
+	gs.supertime = sys.supertime
+	gs.superpausebg = sys.superpausebg
+	gs.superendcmdbuftime = sys.superendcmdbuftime
+	gs.superplayerno = sys.superplayerno
+	gs.superdarken = sys.superdarken
 }
 
 func (gs *GameState) saveExplodData(a *arena.Arena, gsp *GameStatePool) {
@@ -841,7 +848,7 @@ func (gs *GameState) loadCharData(a *arena.Arena, gsp *GameStatePool) {
 	sys.charList = gs.charList.Clone(a, gsp)
 }
 
-func (gs *GameState) loadSuperData(a *arena.Arena, gsp *GameStatePool) {
+func (gs *GameState) loadSuperPauseData() {
 	sys.supertimebuffer = gs.supertimebuffer
 	sys.supertime = gs.supertime
 	sys.superpausebg = gs.superpausebg

--- a/src/state.go
+++ b/src/state.go
@@ -127,14 +127,13 @@ type GameState struct {
 	pausebg            bool
 	pauseendcmdbuftime int32
 	pausetimebuffer    int32
-	pauseplayer        int
+	pauseplayerno      int
 	supertimebuffer    int32
 	supertime          int32
 	superpausebg       bool
 	superendcmdbuftime int32
 	superplayerno      int
 	superdarken        bool
-	superp2defmul      float32
 
 	envShake            EnvShake
 	specialFlag         GlobalSpecialFlag // UIT
@@ -789,7 +788,6 @@ func (gs *GameState) saveSuperData(a *arena.Arena, gsp *GameStatePool) {
 	gs.superendcmdbuftime = sys.superendcmdbuftime
 	gs.superplayerno = sys.superplayerno
 	gs.superdarken = sys.superdarken
-	gs.superp2defmul = sys.superp2defmul
 }
 
 func (gs *GameState) savePauseData() {
@@ -797,7 +795,7 @@ func (gs *GameState) savePauseData() {
 	gs.pausetime = sys.pausetime
 	gs.pausebg = sys.pausebg
 	gs.pauseendcmdbuftime = sys.pauseendcmdbuftime
-	gs.pauseplayer = sys.pauseplayer
+	gs.pauseplayerno = sys.pauseplayerno
 }
 
 func (gs *GameState) saveExplodData(a *arena.Arena, gsp *GameStatePool) {
@@ -864,7 +862,6 @@ func (gs *GameState) loadSuperData(a *arena.Arena, gsp *GameStatePool) {
 	sys.superendcmdbuftime = gs.superendcmdbuftime
 	sys.superplayerno = gs.superplayerno
 	sys.superdarken = gs.superdarken
-	sys.superp2defmul = gs.superp2defmul
 }
 
 func (gs *GameState) loadPauseData() {
@@ -872,7 +869,7 @@ func (gs *GameState) loadPauseData() {
 	sys.pausetime = gs.pausetime
 	sys.pausebg = gs.pausebg
 	sys.pauseendcmdbuftime = gs.pauseendcmdbuftime
-	sys.pauseplayer = gs.pauseplayer
+	sys.pauseplayerno = gs.pauseplayerno
 }
 
 func (gs *GameState) loadExplodData(a *arena.Arena, gsp *GameStatePool) {

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -268,17 +268,15 @@ func (c *Char) Clone(a *arena.Arena, gsp *GameStatePool) (result Char) {
 		result.animBackup = c.animBackup.Clone(a, gsp)
 	}
 
-	result.aimg = c.aimg.Clone(a, gsp)
-
-	// Link curFrame to the corresponding frame in the cloned animation
-	if c.curFrame != nil && result.anim != nil {
-		for i := range result.anim.frames {
-			if &result.anim.frames[i] == c.curFrame {
-				result.curFrame = &result.anim.frames[i]
-				break
-			}
-		}
+	// Since curFrame is desynced from anim's state, we must save it as well
+	if c.curFrame != nil {
+		result.curFrame = c.curFrame.Clone(a)
+	} else {
+		result.curFrame = nil
 	}
+
+	// TODO: Profiling shows this is hotter than it should be
+	result.aimg = c.aimg.Clone(a, gsp)
 
 	// Manually copy references that shallow copy poorly, as needed
 	// Pointers, slices, maps, functions, channels etc

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -177,39 +177,72 @@ func (ghv *GetHitVar) Clone(a *arena.Arena) (result *GetHitVar) {
 	return
 }
 
-func (ai AfterImage) Clone(a *arena.Arena) (result AfterImage) {
+func (ai AfterImage) Clone(a *arena.Arena, gsp *GameStatePool) (result AfterImage) {
 	result = ai
-	result.palfx = arena.MakeSlice[PalFX](a, len(ai.palfx), len(ai.palfx))
-	for i := 0; i < len(ai.palfx); i++ {
-		result.palfx[i] = ai.palfx[i].Clone(a)
+
+	// Deep copy Animations
+	for i := range ai.imgs {
+		if ai.imgs[i].anim != nil {
+			result.imgs[i].anim = ai.imgs[i].anim.Clone(a, gsp)
+		}
 	}
+
+	// Deep copy PalFX
+	if ai.palfx != nil {
+		result.palfx = arena.MakeSlice[*PalFX](a, len(ai.palfx), len(ai.palfx))
+		for i := range ai.palfx {
+			if ai.palfx[i] != nil {
+				result.palfx[i] = ai.palfx[i].Clone(a)
+			}
+		}
+	}
+
 	return
 }
 
-func (e *Explod) Clone(a *arena.Arena, gsp *GameStatePool) (result *Explod) {
-	result = &Explod{}
+func (e *Explod) Clone(a *arena.Arena, gsp *GameStatePool) *Explod {
+	if e == nil {
+		return nil
+	}
+
+	result := &Explod{}
 	*result = *e
+
 	if e.anim != nil {
 		result.anim = e.anim.Clone(a, gsp)
 	}
-	palfx := e.palfx.Clone(a)
-	result.palfx = &palfx
-	return
+
+	if e.palfx != nil {
+		result.palfx = e.palfx.Clone(a)
+	}
+
+	return result
 }
 
-func (p Projectile) clone(a *arena.Arena, gsp *GameStatePool) (result Projectile) {
-	result = p
-	if p.ani != nil {
-		*result.ani = *p.ani.Clone(a, gsp)
-	}
-	result.aimg.palfx = arena.MakeSlice[PalFX](a, len(p.aimg.palfx), len(p.aimg.palfx))
-	for i := 0; i < len(p.aimg.palfx); i++ {
-		result.aimg.palfx[i] = p.aimg.palfx[i].Clone(a)
+func (p *Projectile) clone(a *arena.Arena, gsp *GameStatePool) *Projectile {
+	if p == nil {
+		return nil
 	}
 
-	palfx := p.palfx.Clone(a)
-	result.palfx = &palfx
-	return
+	result := &Projectile{}
+	*result = *p
+
+	if p.ani != nil {
+		result.ani = p.ani.Clone(a, gsp)
+	}
+
+	if p.aimg.palfx != nil {
+		result.aimg.palfx = arena.MakeSlice[*PalFX](a, len(p.aimg.palfx), len(p.aimg.palfx))
+		for i := range p.aimg.palfx {
+			result.aimg.palfx[i] = p.aimg.palfx[i].Clone(a)
+		}
+	}
+
+	if p.palfx != nil {
+		result.palfx = p.palfx.Clone(a)
+	}
+
+	return result
 }
 
 func (ss *StateState) Clone(a *arena.Arena) (result StateState) {
@@ -228,17 +261,23 @@ func (c *Char) Clone(a *arena.Arena, gsp *GameStatePool) (result Char) {
 	result = Char{}
 	result = *c
 
-	result.aimg = c.aimg.Clone(a)
-
-	// todo, find the curFrame index and set result.curFrame as the pointer at that index
 	if c.anim != nil {
 		result.anim = c.anim.Clone(a, gsp)
 	}
 	if c.animBackup != nil {
 		result.animBackup = c.animBackup.Clone(a, gsp)
 	}
-	if c.curFrame != nil {
-		result.curFrame = c.curFrame.Clone(a)
+
+	result.aimg = c.aimg.Clone(a, gsp)
+
+	// Link curFrame to the corresponding frame in the cloned animation
+	if c.curFrame != nil && result.anim != nil {
+		for i := range result.anim.frames {
+			if &result.anim.frames[i] == c.curFrame {
+				result.curFrame = &result.anim.frames[i]
+				break
+			}
+		}
 	}
 
 	// Manually copy references that shallow copy poorly, as needed
@@ -251,6 +290,9 @@ func (c *Char) Clone(a *arena.Arena, gsp *GameStatePool) (result Char) {
 	result.targets = arena.MakeSlice[int32](a, len(c.targets), len(c.targets))
 	copy(result.targets, c.targets)
 
+	result.hitdefTargets = arena.MakeSlice[int32](a, len(c.hitdefTargets), len(c.hitdefTargets))
+	copy(result.hitdefTargets, c.hitdefTargets)
+
 	result.hitdefTargetsBuffer = arena.MakeSlice[int32](a, len(c.hitdefTargetsBuffer), len(c.hitdefTargetsBuffer))
 	copy(result.hitdefTargetsBuffer, c.hitdefTargetsBuffer)
 
@@ -259,6 +301,11 @@ func (c *Char) Clone(a *arena.Arena, gsp *GameStatePool) (result Char) {
 
 	result.p2EnemyList = arena.MakeSlice[*Char](a, len(c.p2EnemyList), len(c.p2EnemyList))
 	copy(result.p2EnemyList, c.p2EnemyList)
+
+	if c.p2EnemyBackup != nil {
+		tmp := *c.p2EnemyBackup
+		result.p2EnemyBackup = &tmp
+	}
 
 	result.clipboardText = arena.MakeSlice[string](a, len(c.clipboardText), len(c.clipboardText))
 	copy(result.clipboardText, c.clipboardText)
@@ -280,16 +327,16 @@ func (c *Char) Clone(a *arena.Arena, gsp *GameStatePool) (result Char) {
 	for k, v := range c.cnsvar {
 		result.cnsvar[k] = v
 	}
-	result.cnssysvar = *gsp.Get(c.cnssysvar).(*map[int32]int32)
-	maps.Clear(result.cnssysvar)
-	for k, v := range c.cnssysvar {
-		result.cnssysvar[k] = v
-	}
-
 	result.cnsfvar = *gsp.Get(c.cnsfvar).(*map[int32]float32)
 	maps.Clear(result.cnsfvar)
 	for k, v := range c.cnsfvar {
 		result.cnsfvar[k] = v
+	}
+
+	result.cnssysvar = *gsp.Get(c.cnssysvar).(*map[int32]int32)
+	maps.Clear(result.cnssysvar)
+	for k, v := range c.cnssysvar {
+		result.cnssysvar[k] = v
 	}
 	result.cnssysfvar = *gsp.Get(c.cnssysfvar).(*map[int32]float32)
 	maps.Clear(result.cnssysfvar)
@@ -301,6 +348,11 @@ func (c *Char) Clone(a *arena.Arena, gsp *GameStatePool) (result Char) {
 	maps.Clear(result.mapArray)
 	for k, v := range c.mapArray {
 		result.mapArray[k] = v
+	}
+
+	if c.inputShift != nil {
+		result.inputShift = arena.MakeSlice[[2]int](a, len(c.inputShift), len(c.inputShift))
+		copy(result.inputShift, c.inputShift)
 	}
 
 	return
@@ -325,11 +377,16 @@ func (cl *CharList) Clone(a *arena.Arena, gsp *GameStatePool) (result CharList) 
 	return
 }
 
-func (pf PalFX) Clone(a *arena.Arena) (result PalFX) {
-	result = pf
-	result.remap = arena.MakeSlice[int](a, len(pf.remap), len(pf.remap))
-	copy(result.remap, pf.remap)
-	return
+func (pf *PalFX) Clone(a *arena.Arena) *PalFX {
+	if pf == nil {
+		return nil
+	}
+	result := *pf
+	if pf.remap != nil {
+		result.remap = arena.MakeSlice[int](a, len(pf.remap), len(pf.remap))
+		copy(result.remap, pf.remap)
+	}
+	return &result
 }
 
 func (ce *CommandStep) Clone(a *arena.Arena) (result CommandStep) {

--- a/src/system.go
+++ b/src/system.go
@@ -47,8 +47,8 @@ var sys = System{
 	soundMixer:        &beep.Mixer{},
 	bgm:               *newBgm(),
 	soundChannels:     newSoundChannels(16),
-	allPalFX:          *newPalFX(),
-	bgPalFX:           *newPalFX(),
+	allPalFX:          newPalFX(),
+	bgPalFX:           newPalFX(),
 	ffx:               make(map[string]*FightFx),
 	//ffxRegexp:         "^(f)|^(s)|^(go)", // https://github.com/ikemen-engine/Ikemen-GO/issues/1620
 	sel:      *newSelect(),
@@ -115,7 +115,8 @@ type System struct {
 	soundMixer              *beep.Mixer
 	bgm                     Bgm
 	soundChannels           *SoundChannels
-	allPalFX, bgPalFX       PalFX
+	allPalFX                *PalFX
+	bgPalFX                 *PalFX
 	lifebar                 Lifebar
 	cfg                     Config
 	ffx                     map[string]*FightFx
@@ -217,8 +218,8 @@ type System struct {
 	slowtime                int32
 	slowtimeTrigger         int32
 	wintime                 int32
-	projs                   [MaxPlayerNo][]Projectile
-	explods                 [MaxPlayerNo][]Explod
+	projs                   [MaxPlayerNo][]*Projectile
+	explods                 [MaxPlayerNo][]*Explod
 	explodsLayerN1          [MaxPlayerNo][]int
 	explodsLayer0           [MaxPlayerNo][]int
 	explodsLayer1           [MaxPlayerNo][]int

--- a/src/system.go
+++ b/src/system.go
@@ -162,7 +162,7 @@ type System struct {
 	pausetimebuffer         int32
 	pausebg                 bool
 	pauseendcmdbuftime      int32
-	pauseplayer             int
+	pauseplayerno           int
 	supertime               int32
 	supertimebuffer         int32
 	superpausebg            bool


### PR DESCRIPTION
Fix:
- Fixed a typo that apparently made moves that relied on GameTime often cause desync
- Changing into the enemy's sprites with SpritePlayerNo now automatically corrects localcoord scale
- Made GameMakeAnim compatible with explod refactor
- Fixed explod PalFX being applied twice in some scenarios
- The SuperPause effects are now explods instead of objects that have to be tracked by system.go. This simplifies the code as well as allows multiple effects when multiple pauses happen simultaneously
- If multiple players initiate a SuperPause, they now all ignore the "darken" parameter
- SuperPause p2defmul can now stack if multiple players trigger it in the same frame
- Fixed "workingchar" getting a full clone in save states, when it's just a pointer to the character which code is currently running
- All common FX prefixes now ignore palette remaps. Previously they were only skipped if the FX prefix was "F"
- A net connection is now only initialized after both peers complete a handshake. This makes our IsConnected() check work as intended, so if a client tries to join before the host is hosting, it will automatically retry until a session exists
- Patched menu confirmation sounds into "host" and "join" options
- Fixes #1274
- Fixes #1719
- Fixes #2664

Feat:
- KeepSpritesOnReload debug option. Enabling this option makes character SFF files not be reloaded when shift F4 is used, making debugging faster

Refactor:
- Refactored anim/sprite getting functions. Now when we "get" an animation we can also get a SFF with it
- GameMakeAnim no longer supports "anim" syntax. Only "value", like Mugen
- Some data used values or pointers arbitrarily. More of them now use pointers for consistency and rollback performance, such as projectiles and explods
- Removed more unused rollback functions
- Extracted some rollback code blocks into dedicated functions