### PR TITLE
fix: explods, intro sounds, ">" inputs; refactor: SystemVar renamed GameVar

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5554,9 +5554,9 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 			e.animNo = exp[1].evalI(c)
 			e.anim_ffx = ffx
 		case explod_animplayerno:
-			e.animPN = int(exp[0].evalI(c))
+			e.animPN = int(exp[0].evalI(c)) - 1
 		case explod_spriteplayerno:
-			e.spritePN = int(exp[0].evalI(c))
+			e.spritePN = int(exp[0].evalI(c)) - 1
 		case explod_ownpal:
 			e.ownpal = exp[0].evalB(c)
 		case explod_remappal:
@@ -5882,9 +5882,9 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
 		case explod_animplayerno:
-			animPN = int(exp[0].evalI(c))
+			animPN = int(exp[0].evalI(c)) - 1
 		case explod_spriteplayerno:
-			spritePN = int(exp[0].evalI(c))
+			spritePN = int(exp[0].evalI(c)) - 1
 		case explod_remappal:
 			rp[0] = exp[0].evalI(c)
 			if len(exp) > 1 {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -920,11 +920,11 @@ const (
 	OC_ex2_motifstate_continuescreen
 	OC_ex2_motifstate_victoryscreen
 	OC_ex2_motifstate_winscreen
-	OC_ex2_systemvar_introtime
-	OC_ex2_systemvar_outrotime
-	OC_ex2_systemvar_pausetime
-	OC_ex2_systemvar_slowtime
-	OC_ex2_systemvar_superpausetime
+	OC_ex2_gamevar_introtime
+	OC_ex2_gamevar_outrotime
+	OC_ex2_gamevar_pausetime
+	OC_ex2_gamevar_slowtime
+	OC_ex2_gamevar_superpausetime
 	OC_ex2_topbounddist
 	OC_ex2_topboundbodydist
 	OC_ex2_botbounddist
@@ -3651,24 +3651,24 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushB(sys.victoryScreenFlg)
 	case OC_ex2_motifstate_winscreen:
 		sys.bcStack.PushB(sys.winScreenFlg)
-	// SystemVar
-	case OC_ex2_systemvar_introtime:
+	// GameVar
+	case OC_ex2_gamevar_introtime:
 		if sys.intro > 0 {
 			sys.bcStack.PushI(sys.intro)
 		} else {
 			sys.bcStack.PushI(0)
 		}
-	case OC_ex2_systemvar_outrotime:
+	case OC_ex2_gamevar_outrotime:
 		if sys.intro < 0 {
 			sys.bcStack.PushI(-sys.intro)
 		} else {
 			sys.bcStack.PushI(0)
 		}
-	case OC_ex2_systemvar_pausetime:
+	case OC_ex2_gamevar_pausetime:
 		sys.bcStack.PushI(sys.pausetime)
-	case OC_ex2_systemvar_slowtime:
+	case OC_ex2_gamevar_slowtime:
 		sys.bcStack.PushI(sys.slowtimeTrigger)
-	case OC_ex2_systemvar_superpausetime:
+	case OC_ex2_gamevar_superpausetime:
 		sys.bcStack.PushI(sys.supertime)
 	// HitDefVar
 	case OC_ex2_hitdefvar_guard_dist_width_back:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -10176,7 +10176,7 @@ func (sc stopSnd) Run(c *Char, _ []int32) bool {
 		switch paramID {
 		case stopSnd_channel:
 			if ch := Min(255, exp[0].evalI(c)); ch < 0 {
-				sys.stopAllSound()
+				sys.stopAllCharSound()
 			} else if c := crun.soundChannels.Get(ch); c != nil {
 				c.Stop()
 			}

--- a/src/char.go
+++ b/src/char.go
@@ -10941,10 +10941,12 @@ func (c *Char) cueDraw() {
 		// This seems more complicated than it ought to be. Probably because our drawing functions are different from Mugen
 		// https://github.com/ikemen-engine/Ikemen-GO/issues/1459, 1778 and 2089
 		airOffsetFix := [2]float32{1, 1}
-		if c.playerNo != c.animPN {
+		if c.playerNo != c.animPN && c.animPN >= 0 && c.animPN < len(sys.chars) && len(sys.chars[c.animPN]) > 0 {
+			self := sys.chars[c.playerNo][0]
+			owner := sys.chars[c.animPN][0]
 			airOffsetFix = [2]float32{
-				(sys.chars[c.playerNo][0].localcoord / sys.chars[c.animPN][0].localcoord) / (sys.chars[c.playerNo][0].size.xscale / sys.chars[c.animPN][0].size.xscale),
-				(sys.chars[c.playerNo][0].localcoord / sys.chars[c.animPN][0].localcoord) / (sys.chars[c.playerNo][0].size.yscale / sys.chars[c.animPN][0].size.yscale),
+				(self.localcoord / owner.localcoord) / (self.size.xscale / owner.size.xscale),
+				(self.localcoord / owner.localcoord) / (self.size.yscale / owner.size.yscale),
 			}
 		}
 

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -386,6 +386,7 @@ var triggerMap = map[string]int{
 	"float":              1,
 	"gamemode":           1,
 	"gameoption":         1,
+	"gamevar":            1,
 	"groundangle":        1,
 	"guardbreak":         1,
 	"guardcount":         1,
@@ -457,7 +458,6 @@ var triggerMap = map[string]int{
 	"stagefrontedgedist": 1,
 	"stagetime":          1,
 	"standby":            1,
-	"systemvar":          1,
 	"teamleader":         1,
 	"teamsize":           1,
 	"timeelapsed":        1,
@@ -4340,6 +4340,31 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		if err := nameSub(OC_ex_, OC_ex_gamemode); err != nil {
 			return bvNone(), err
 		}
+	case "gamevar":
+		if err := c.checkOpeningParenthesis(in); err != nil {
+			return bvNone(), err
+		}
+		svname := c.token
+		c.token = c.tokenizer(in)
+		if err := c.checkClosingParenthesis(); err != nil {
+			return bvNone(), err
+		}
+		switch svname {
+		case "introtime":
+			opc = OC_ex2_gamevar_introtime
+		case "outrotime":
+			opc = OC_ex2_gamevar_outrotime
+		case "pausetime":
+			opc = OC_ex2_gamevar_pausetime
+		case "slowtime":
+			opc = OC_ex2_gamevar_slowtime
+		case "superpausetime":
+			opc = OC_ex2_gamevar_superpausetime
+		default:
+			return bvNone(), Error("Invalid GameVar argument: " + svname)
+		}
+		out.append(OC_ex2_)
+		out.append(opc)
 	case "groundangle":
 		out.append(OC_ex_, OC_ex_groundangle)
 	case "guardbreak":
@@ -4757,31 +4782,6 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_ex_, OC_ex_stagetime)
 	case "standby":
 		out.append(OC_ex_, OC_ex_standby)
-	case "systemvar":
-		if err := c.checkOpeningParenthesis(in); err != nil {
-			return bvNone(), err
-		}
-		svname := c.token
-		c.token = c.tokenizer(in)
-		if err := c.checkClosingParenthesis(); err != nil {
-			return bvNone(), err
-		}
-		switch svname {
-		case "introtime":
-			opc = OC_ex2_systemvar_introtime
-		case "outrotime":
-			opc = OC_ex2_systemvar_outrotime
-		case "pausetime":
-			opc = OC_ex2_systemvar_pausetime
-		case "slowtime":
-			opc = OC_ex2_systemvar_slowtime
-		case "superpausetime":
-			opc = OC_ex2_systemvar_superpausetime
-		default:
-			return bvNone(), Error("Invalid SystemVar argument: " + svname)
-		}
-		out.append(OC_ex2_)
-		out.append(opc)
 	case "teamleader":
 		out.append(OC_ex_, OC_ex_teamleader)
 	case "teamsize":

--- a/src/script.go
+++ b/src/script.go
@@ -5561,6 +5561,31 @@ func triggerFunctions(l *lua.LState) {
 		}
 		return 1
 	})
+	luaRegister(l, "gamevar", func(*lua.LState) int {
+		switch strings.ToLower(strArg(l, 1)) {
+		case "introtime":
+			if sys.intro > 0 {
+				l.Push(lua.LNumber(sys.intro))
+			} else {
+				l.Push(lua.LNumber(0))
+			}
+		case "outrotime":
+			if sys.intro < 0 {
+				l.Push(lua.LNumber(-sys.intro))
+			} else {
+				l.Push(lua.LNumber(0))
+			}
+		case "pausetime":
+			l.Push(lua.LNumber(sys.pausetime))
+		case "slowtime":
+			l.Push(lua.LNumber(sys.slowtimeTrigger))
+		case "superpausetime":
+			l.Push(lua.LNumber(sys.supertime))
+		default:
+			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
+		}
+		return 1
+	})
 	luaRegister(l, "guardbreak", func(*lua.LState) int {
 		l.Push(lua.LBool(sys.debugWC.scf(SCF_guardbreak)))
 		return 1
@@ -6012,31 +6037,6 @@ func triggerFunctions(l *lua.LState) {
 	})
 	luaRegister(l, "standby", func(*lua.LState) int {
 		l.Push(lua.LBool(sys.debugWC.scf(SCF_standby)))
-		return 1
-	})
-	luaRegister(l, "systemvar", func(*lua.LState) int {
-		switch strings.ToLower(strArg(l, 1)) {
-		case "introtime":
-			if sys.intro > 0 {
-				l.Push(lua.LNumber(sys.intro))
-			} else {
-				l.Push(lua.LNumber(0))
-			}
-		case "outrotime":
-			if sys.intro < 0 {
-				l.Push(lua.LNumber(-sys.intro))
-			} else {
-				l.Push(lua.LNumber(0))
-			}
-		case "pausetime":
-			l.Push(lua.LNumber(sys.pausetime))
-		case "slowtime":
-			l.Push(lua.LNumber(sys.slowtimeTrigger))
-		case "superpausetime":
-			l.Push(lua.LNumber(sys.supertime))
-		default:
-			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
-		}
 		return 1
 	})
 	luaRegister(l, "teamleader", func(*lua.LState) int {

--- a/src/script.go
+++ b/src/script.go
@@ -826,16 +826,19 @@ func systemScriptInit(l *lua.LState) {
 	})
 	luaRegister(l, "commandGetState", func(l *lua.LState) int {
 		cl, ok := toUserData(l, 1).(*CommandList)
-		if !ok {
+		if !ok || cl == nil {
 			userDataError(l, 1, cl)
+			l.Push(lua.LBool(false))
+			return 1 // Attempt to fix a rare registry overflow error while the window is unfocused
 		}
 		l.Push(lua.LBool(cl.GetState(strArg(l, 2))))
 		return 1
 	})
 	luaRegister(l, "commandInput", func(l *lua.LState) int {
 		cl, ok := toUserData(l, 1).(*CommandList)
-		if !ok {
+		if !ok || cl == nil {
 			userDataError(l, 1, cl)
+			return 0 // Attempt to fix a rare registry overflow error while the window is unfocused
 		}
 		controller := int(numArg(l, 2)) - 1
 		if cl.InputUpdate(nil, controller, 0, true) {

--- a/src/script.go
+++ b/src/script.go
@@ -2832,7 +2832,7 @@ func systemScriptInit(l *lua.LState) {
 		return 0
 	})
 	luaRegister(l, "stopAllSound", func(l *lua.LState) int {
-		sys.stopAllSound()
+		sys.stopAllCharSound()
 		return 0
 	})
 	luaRegister(l, "stopSnd", func(l *lua.LState) int {
@@ -6306,7 +6306,7 @@ func deprecatedFunctions(l *lua.LState) {
 	// deprecated by stopSnd, stopAllSound
 	luaRegister(l, "charSndStop", func(l *lua.LState) int {
 		if l.GetTop() == 0 {
-			sys.stopAllSound()
+			sys.stopAllCharSound()
 			return 0
 		}
 		pn := int(numArg(l, 1))


### PR DESCRIPTION
Fix:
- Restarting round with F4 now stops char sounds again
- Anim playerno out of bounds crash
- Attempt to fix a very rare "registry overflow" Lua crash while keys are pressed with window out of focus
- Checking if a ">" input is valid is now a lot more thorough
- When an explod or projectile changes coordinate space (when parent is thrown for instance) their scale is no longer affected
- Fixed index oversight in Explod anim/sprite playerno
- Fixes #2668 
- Fixes #2670 
- Fixes #2673 

Refactor:
- SystemVar renamed GameVar. Avoids overlap with the char's own system variables (as well as sysvar) and is more consitent with other "Game" triggers