### PR TITLE
fix: add missing BGMVar(loopcount) to CNS/ZSS

### DIFF
--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1724,6 +1724,9 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "length":
 			opct = OC_ex2_
 			opc = OC_ex2_bgmvar_length
+		case "loop":
+			opct = OC_ex2_
+			opc = OC_ex2_bgmvar_loop
 		case "loopcount":
 			opct = OC_ex2_
 			opc = OC_ex2_bgmvar_loopcount

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1724,6 +1724,9 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "length":
 			opct = OC_ex2_
 			opc = OC_ex2_bgmvar_length
+		case "loopcount":
+			opct = OC_ex2_
+			opc = OC_ex2_bgmvar_loopcount
 		case "loopend":
 			opct = OC_ex2_
 			opc = OC_ex2_bgmvar_loopend


### PR DESCRIPTION
add missing BGMVar(loopcount) to CNS/ZSS