### PR TITLE
feat: Add option for macOS to use Command key (⌘) instead of Ctrl for hotkeys, add new controller strings to match new common gamecontrollerdb.txt entries

### DIFF
--- a/src/config.go
+++ b/src/config.go
@@ -213,6 +213,7 @@ type Config struct {
 		SOCDResolution             int     `ini:"SOCDResolution"`
 		ControllerStickSensitivity float32 `ini:"ControllerStickSensitivity"`
 		XinputTriggerSensitivity   float32 `ini:"XinputTriggerSensitivity"`
+		MacOSUseCommandKey         bool    `ini:MacOSUseCommandKey`
 	} `ini:"Input"`
 	Keys     map[string]*KeysProperties `ini:"map:^(?i)Keys_P[0-9]+$" lua:"Keys"`
 	Joystick map[string]*KeysProperties `ini:"map:^(?i)Joystick_P[0-9]+$" lua:"Joystick"`

--- a/src/config.go
+++ b/src/config.go
@@ -150,6 +150,7 @@ type Config struct {
 		ForceStageZoomout   float32 `ini:"ForceStageZoomout"`
 		ForceStageZoomin    float32 `ini:"ForceStageZoomin"`
 		KeepSpritesOnReload bool    `ini:"KeepSpritesOnReload"`
+		MacOSUseCommandKey  bool    `ini:"MacOSUseCommandKey"`
 	} `ini:"Debug"`
 	Video struct {
 		RenderMode              string   `ini:"RenderMode"`
@@ -213,7 +214,6 @@ type Config struct {
 		SOCDResolution             int     `ini:"SOCDResolution"`
 		ControllerStickSensitivity float32 `ini:"ControllerStickSensitivity"`
 		XinputTriggerSensitivity   float32 `ini:"XinputTriggerSensitivity"`
-		MacOSUseCommandKey         bool    `ini:"MacOSUseCommandKey"`
 	} `ini:"Input"`
 	Keys     map[string]*KeysProperties `ini:"map:^(?i)Keys_P[0-9]+$" lua:"Keys"`
 	Joystick map[string]*KeysProperties `ini:"map:^(?i)Joystick_P[0-9]+$" lua:"Joystick"`

--- a/src/config.go
+++ b/src/config.go
@@ -213,7 +213,7 @@ type Config struct {
 		SOCDResolution             int     `ini:"SOCDResolution"`
 		ControllerStickSensitivity float32 `ini:"ControllerStickSensitivity"`
 		XinputTriggerSensitivity   float32 `ini:"XinputTriggerSensitivity"`
-		MacOSUseCommandKey         bool    `ini:MacOSUseCommandKey`
+		MacOSUseCommandKey         bool    `ini:"MacOSUseCommandKey"`
 	} `ini:"Input"`
 	Keys     map[string]*KeysProperties `ini:"map:^(?i)Keys_P[0-9]+$" lua:"Keys"`
 	Joystick map[string]*KeysProperties `ini:"map:^(?i)Joystick_P[0-9]+$" lua:"Joystick"`

--- a/src/input.go
+++ b/src/input.go
@@ -11,9 +11,9 @@ import (
 	"time"
 )
 
-var ModAlt = NewModifierKey(false, true, false)
-var ModCtrlAlt = NewModifierKey(true, true, false)
-var ModCtrlAltShift = NewModifierKey(true, true, true)
+var ModAlt ModifierKey
+var ModCtrlAlt ModifierKey
+var ModCtrlAltShift ModifierKey
 
 // CommandList > Command > CommandStep > CommandStepKey
 type CommandStepKey struct {
@@ -93,6 +93,11 @@ type ShortcutKey struct {
 }
 
 func NewShortcutKey(key Key, ctrl, alt, shift bool) *ShortcutKey {
+	if ModAlt == 0 {
+		ModAlt = NewModifierKey(false, true, false)
+		ModCtrlAlt = NewModifierKey(true, true, false)
+		ModCtrlAltShift = NewModifierKey(true, true, true)
+	}
 	sk := &ShortcutKey{}
 	sk.Key = key
 	sk.Mod = NewModifierKey(ctrl, alt, shift)

--- a/src/input_glfw.go
+++ b/src/input_glfw.go
@@ -172,7 +172,12 @@ func KeyToString(k glfw.Key) string {
 
 func NewModifierKey(ctrl, alt, shift bool) (mod glfw.ModifierKey) {
 	if ctrl {
-		mod |= glfw.ModControl
+		// Convert Ctrl to Command (⌘) key for macOS if user prefers it
+		if runtime.GOOS == "darwin" && sys.cfg.Input.MacOSUseCommandKey {
+			mod |= glfw.ModSuper
+		} else {
+			mod |= glfw.ModControl
+		}
 	}
 	if alt {
 		mod |= glfw.ModAlt
@@ -324,7 +329,7 @@ func CheckAxisForTrigger(joy int, axes *[]float32) string {
 					fmt.Printf("[input_glfw.go][checkAxisForTrigger] 1.AXIS joy=%v i=%v s:%v axes[i]=%v, name = %s\n", joy, i, s, (*axes)[i], name)
 					break
 				}
-			} else if strings.Contains(name, "XInput") || strings.Contains(name, "X360") ||
+			} else if strings.Contains(name, "XInput") || strings.Contains(name, "X360") || strings.Contains(name, "Xbox 360") ||
 				strings.Contains(name, "Xbox Wireless") || strings.Contains(name, "Xbox Elite") || strings.Contains(name, "Xbox One") ||
 				strings.Contains(name, "Xbox Series") || strings.Contains(name, "Xbox Adaptive") {
 				if (i == 4 || i == 5) && os == "windows" {
@@ -332,7 +337,7 @@ func CheckAxisForTrigger(joy int, axes *[]float32) string {
 				} else if (i == 2 || i == 5) && os != "windows" {
 					// do nothing
 				}
-			} else if (i == 4 || i == 5) && (joyName == "PS4 Controller.windows.amd64.sdl" || (strings.Contains(name, "Atari Game") && os != "windows")) {
+			} else if (i == 4 || i == 5) && (joyName == "PS4 Controller.windows.amd64.sdl" || (strings.Contains(name, "Atari VCS") && os != "windows")) {
 				// do nothing
 			} else if (i == 2 || i == 5) && joyName == "Steam Virtual Gamepad.linux.amd64.glfw" {
 				// do nothing

--- a/src/input_glfw.go
+++ b/src/input_glfw.go
@@ -173,7 +173,7 @@ func KeyToString(k glfw.Key) string {
 func NewModifierKey(ctrl, alt, shift bool) (mod glfw.ModifierKey) {
 	if ctrl {
 		// Convert Ctrl to Command (⌘) key for macOS if user prefers it
-		if runtime.GOOS == "darwin" && sys.cfg.Input.MacOSUseCommandKey {
+		if runtime.GOOS == "darwin" && sys.cfg.Debug.MacOSUseCommandKey {
 			mod |= glfw.ModSuper
 		} else {
 			mod |= glfw.ModControl

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -345,6 +345,8 @@ SOCDResolution             = 4
 ControllerStickSensitivity = 0.5
 ; XInput trigger sensitivity
 XinputTriggerSensitivity   = 0.5
+; macOS Command Key in place of Ctrl for hotkeys (enabled by default)
+MacOSUseCommandKey         = 1
 
 ; -------------------------------------------------------------------------------
 [Keys_P1]

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -175,6 +175,8 @@ ForceStageZoomout = 0
 ForceStageZoomin  = 0
 ; Set to 1 to prevent character SFF files from being reloaded when Shift+F4 is used.
 KeepSpritesOnReload = 0
+; macOS Command Key in place of Ctrl for hotkeys (enabled by default)
+MacOSUseCommandKey         = 1
 
 ; -------------------------------------------------------------------------------
 [Video]
@@ -345,8 +347,6 @@ SOCDResolution             = 4
 ControllerStickSensitivity = 0.5
 ; XInput trigger sensitivity
 XinputTriggerSensitivity   = 0.5
-; macOS Command Key in place of Ctrl for hotkeys (enabled by default)
-MacOSUseCommandKey         = 1
 
 ; -------------------------------------------------------------------------------
 [Keys_P1]


### PR DESCRIPTION
feat:
* Add option for macOS to use Command key (⌘) instead of Ctrl for hotkeys
* Add Xbox 360 and Atari VCS controller strings to detect newer gamecontrollerdb.txt entries