### PR TITLE
feat: Add ProjClsnOverlap trigger

### DIFF
--- a/data/common1.cns.zss
+++ b/data/common1.cns.zss
@@ -568,7 +568,7 @@ if anim != [5000, 5199] && selfAnimExist(5030) {
 if time = 0 {
 	hitVelSet{x: 1; y: 1}
 } else {
-	velAdd{x: getHitVar(xAccel); y: getHitVar(yAccel)}
+	velAdd{y: getHitVar(yAccel)}
 }
 if hitOver || vel y > 0 && pos y >= const(movement.air.gethit.groundlevel) {
 	if hitFall {
@@ -589,7 +589,7 @@ if time = 0 && selfAnimExist(5035) && anim != [5051, 5059] && anim != 5090 {
 	changeAnim{value: 5035}
 }
 if time > 0 {
-	velAdd{x: getHitVar(xAccel); y: getHitVar(yAccel)}
+	velAdd{y: getHitVar(yAccel)}
 }
 if hitOver || animTime = 0 ||
 	vel y > 0 && pos y >= const(movement.air.gethit.groundlevel) ||
@@ -616,7 +616,7 @@ if hitOver {
 	stateTypeSet{movetype: I}
 }
 if time > 0 {
-	velAdd{x: getHitVar(xAccel); y: getHitVar(yAccel)}
+	velAdd{y: getHitVar(yAccel)}
 }
 if vel y > 0 && pos y >= 0 {
 	changeState{value: 52}
@@ -635,7 +635,7 @@ persistent(0) if anim = [5050, 5059] && vel y >= ifElse(anim = 5050,
 	changeAnim{value: anim + 10}
 }
 if time > 0 {
-	velAdd{x: getHitVar(xAccel); y: getHitVar(yAccel)}
+	velAdd{y: getHitVar(yAccel)}
 }
 if alive && canRecover && command = "recovery" {
 	if vel y > 0 &&
@@ -669,7 +669,7 @@ if time = 0 {
 if time = 0 {
 	hitVelSet{x: 1; y: 1}
 } else {
-	velAdd{x: getHitVar(xAccel); y: getHitVar(yAccel)}
+	velAdd{y: getHitVar(yAccel)}
 }
 if vel y > 0 && pos y >= const(movement.air.gethit.trip.groundlevel) {
 	changeState{value: 5110}
@@ -884,7 +884,7 @@ if anim = 5035 && animTime = 0 {
 	changeAnim{value: 5050}
 }
 if time > 0 {
-	velAdd{x: getHitVar(xAccel); y: getHitVar(yAccel)}
+	velAdd{y: getHitVar(yAccel)}
 }
 if vel y > 0 && pos y >= const(movement.air.gethit.groundrecover.groundlevel) {
 	selfState{value: 5201}

--- a/data/system.zss
+++ b/data/system.zss
@@ -1,0 +1,10 @@
+#===============================================================================
+# Global states (not halted by Pause/SuperPause, no helper limitations)
+#===============================================================================
+[StateDef -4]
+
+if PauseTime = 0 {
+	if time > 0 && (stateNo = 5030 || stateNo = 5035 || stateNo = 5040 || stateNo = 5050 || stateNo = 5071 || stateNo = 5200){
+		velAdd{x: getHitVar(xAccel); z: getHitVar(zAccel)}
+	}
+}

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -2303,7 +2303,10 @@ function start.f_selectScreen()
 						member = k
 					end
 					--member selection
-					v.selectState, start.needUpdateDrawList = start.f_selectMenu(side, v.cmd, v.player, member, v.selectState)
+					v.selectState, DrawUpdateflag = start.f_selectMenu(side, v.cmd, v.player, member, v.selectState)
+					if start.needUpdateDrawList == false then
+						start.needUpdateDrawList= DrawUpdateflag
+					end
 					--draw active cursor
 					if side == 2 and motif.select_info.p2_cursor_blink == 1 then
 						local sameCell = false

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -946,6 +946,7 @@ const (
 	OC_ex2_envshakevar_dir
 	OC_ex2_gethitvar_fall_envshake_dir
 	OC_ex2_xshear
+	OC_ex2_projclsnoverlap
 )
 
 type StringPool struct {
@@ -3826,6 +3827,11 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.ghv.fall_envshake_dir)
 	case OC_ex2_xshear:
 		sys.bcStack.PushF(c.xshear)
+	case OC_ex2_projclsnoverlap:
+		boxType := sys.bcStack.Pop().ToI()
+		targetID := sys.bcStack.Pop().ToI()
+		index := sys.bcStack.Pop().ToI()
+		sys.bcStack.PushB(c.projClsnOverlapTrigger(index, targetID, boxType))
 	default:
 		sys.errLog.Printf("%v\n", be[*i-1])
 		c.panic()
@@ -9414,6 +9420,9 @@ func (sc trans) Run(c *Char, _ []int32) bool {
 	//crun.alpha[1] = 255
 
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		if len(exp) == 0 {
+			return false
+		}
 		switch paramID {
 		case trans_trans:
 			crun.alpha[0] = exp[0].evalI(c)
@@ -9429,9 +9438,9 @@ func (sc trans) Run(c *Char, _ []int32) bool {
 				}
 			}
 		}
+		crun.setCSF(CSF_trans)
 		return true
 	})
-	crun.setCSF(CSF_trans)
 	return false
 }
 

--- a/src/char.go
+++ b/src/char.go
@@ -8711,7 +8711,21 @@ func (c *Char) projClsnCheckSingle(p *Projectile, cbox, pbox int32) bool {
 		charangle,
 	)
 }
+func (c *Char) projClsnOverlapTrigger(index, targetID, boxType int32) bool {
+	projs := c.getProjs(-1)
 
+	if index < 0 || int(index) >= len(projs) {
+		return false
+	}
+	proj := projs[index]
+
+	target := sys.playerID(targetID)
+	if target == nil {
+		return false
+	}
+
+	return target.projClsnCheck(proj, boxType, 1)
+}
 func (c *Char) clsnCheck(getter *Char, charbox, getterbox int32, reqcheck, trigger bool) bool {
 	// Safety checks
 	if c == nil || getter == nil || c.anim == nil || getter.anim == nil {

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -93,7 +93,11 @@ func (c *Compiler) hitBySub(is IniSection, sc *StateControllerBase, sctrlName st
 
 	// Cannot mix old and new syntax
 	if old && new {
-		return Error("Cannot mix old and new " + sctrlName + " syntaxes")
+		if c.zssMode {
+			return Error("Cannot mix old and new " + sctrlName + " syntaxes")
+		} else {
+			sys.appendToConsole("WARNING: " + sys.cgi[c.playerNo].nameLow + fmt.Sprintf(": Cannot mix old and new: "+sctrlName+" in state %v ", c.stateNo))
+		}
 	}
 
 	// Must have at least one parameter

--- a/src/script.go
+++ b/src/script.go
@@ -4744,6 +4744,27 @@ func triggerFunctions(l *lua.LState) {
 			BytecodeInt(int32(numArg(l, 1)))).ToI()))
 		return 1
 	})
+	luaRegister(l, "projclsnoverlap", func(l *lua.LState) int {
+		idx := int32(numArg(l, 1))
+		pid := int32(numArg(l, 2))
+		cboxStr := strings.ToLower(strArg(l, 3))
+
+		var cbox int32
+		switch cboxStr {
+		case "clsn1":
+			cbox = 1
+		case "clsn2":
+			cbox = 2
+		case "size":
+			cbox = 3
+		default:
+			l.RaiseError("Invalid collision box type: " + cboxStr)
+			l.Push(lua.LBool(false))
+			return 1
+		}
+		l.Push(lua.LBool(sys.debugWC.projClsnOverlapTrigger(idx, pid, cbox)))
+		return 1
+	})
 	// projguarded (deprecated by projguardedtime)
 	luaRegister(l, "projguardedtime", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.projGuardedTime(


### PR DESCRIPTION
・Add ProjClsnOverlap trigger
The format:
ProjClsnOverlap(index, Target_PlayerID, box_type)
This index is equivalent to the index when -1 is specified for the ID in ProjVar.

・Moved xAccel from common1.cns.zss to system.zss
This makes xAccel enable even for characters that do not use common1.cns.zss. Additionally, zAccel is now enable.

・Fixed #2710 a bug where changes to char slots were not reflected during multiplayer

・Fixed Trans Sctrl so that specifying default results in "do nothing"

・Relaxed the conditions that cause a crash when using both old and new syntax together in Hitby
This because a few of the chars I created long ago was crashing.
Additionally, I confirmed that several other chars were also crashing.