### PR TITLE
fix:Fix GetHitVarSet airtype, groundtype, animtype, and attr.

### DIFF
--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -5975,16 +5975,20 @@ func (c *Compiler) getHitVarSet(is IniSection, sc *StateControllerBase, _ int8) 
 			getHitVarSet_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.paramValue(is, sc, "airtype",
-			getHitVarSet_airtype, VT_Int, 1, false); err != nil {
+		if err := c.paramHittype(is, sc, "airtype", getHitVarSet_airtype); err != nil {
 			return err
 		}
-		if err := c.paramValue(is, sc, "animtype",
-			getHitVarSet_animtype, VT_Int, 1, false); err != nil {
+		if err := c.paramAnimtype(is, sc, "animtype", getHitVarSet_animtype); err != nil {
 			return err
 		}
-		if err := c.paramValue(is, sc, "attr",
-			getHitVarSet_attr, VT_Int, 1, false); err != nil {
+		if err := c.stateParam(is, "attr", false, func(data string) error {
+			attr, err := c.attr(data, true)
+			if err != nil {
+				return err
+			}
+			sc.add(getHitVarSet_attr, sc.iToExp(attr))
+			return nil
+		}); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "chainid",
@@ -6071,8 +6075,7 @@ func (c *Compiler) getHitVarSet(is IniSection, sc *StateControllerBase, _ int8) 
 			getHitVarSet_fallcount, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.paramValue(is, sc, "groundtype",
-			getHitVarSet_groundtype, VT_Int, 1, false); err != nil {
+		if err := c.paramHittype(is, sc, "groundtype", getHitVarSet_groundtype); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "guardcount",


### PR DESCRIPTION
These parameters would literally just crash if you tried to use them, copied functional code from HitDef.