### PR TITLE
fix(explod): ontop regression

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5443,7 +5443,6 @@ const (
 	explod_layerno
 	explod_under
 	explod_ontop
-	explod_strictontop
 	explod_shadow
 	explod_removeongethit
 	explod_removeonchangestate
@@ -5619,13 +5618,12 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 			}
 		case explod_ontop:
 			if exp[0].evalB(c) {
+				e.ontop = true
 				e.layerno = 1
-			} else {
-				e.layerno = 0
-			}
-		case explod_strictontop:
-			if e.layerno > 0 {
 				e.sprpriority = 0
+			} else {
+				e.ontop = false
+				e.layerno = 0
 			}
 		case explod_under:
 			e.under = exp[0].evalB(c)
@@ -6097,19 +6095,16 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 					}
 				})
 			case explod_ontop:
-				if exp[0].evalB(c) {
-					eachExpl(func(e *Explod) {
-						e.layerno = 1
-					})
-				} else {
-					eachExpl(func(e *Explod) {
-						e.layerno = 0
-					})
-				}
-			case explod_strictontop:
+				// At this point we'd better not change the explod's position in the slice like when the explod is created
+				v := exp[0].evalB(c)
 				eachExpl(func(e *Explod) {
-					if e.layerno > 0 {
+					if v {
+						e.ontop = true
+						e.layerno = 1
 						e.sprpriority = 0
+					} else if e.ontop {
+						e.ontop = false
+						e.layerno = 0
 					}
 				})
 			case explod_under:

--- a/src/char.go
+++ b/src/char.go
@@ -1298,7 +1298,7 @@ type Explod struct {
 	animelem            int32
 	animelemtime        int32
 	animfreeze          bool
-	//ontop                bool
+	ontop               bool // Legacy compatibility
 	under          bool
 	alpha          [2]int32
 	ownpal         bool
@@ -5975,6 +5975,14 @@ func (c *Char) commitExplod(i int) {
 			e.palfx.PalFXDef = e.palfxdef
 			e.palfx.remap = nil
 		}
+	}
+
+	// Emulate legacy ontop behavior
+	// Move from the end of the slice to the beginning to invert drawing order
+	if e.ontop {
+		playerExplods := &sys.explods[c.playerNo]
+		copy((*playerExplods)[1:i+1], (*playerExplods)[0:i])
+		(*playerExplods)[0] = e
 	}
 
 	// Explod ready

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -875,6 +875,10 @@ func (c *Compiler) explodSub(is IniSection,
 		explod_scale, VT_Float, 2, false); err != nil {
 		return err
 	}
+	if err := c.paramValue(is, sc, "bindid",
+		explod_bindid, VT_Int, 1, false); err != nil {
+		return err
+	}
 	if err := c.paramValue(is, sc, "bindtime",
 		explod_bindtime, VT_Int, 1, false); err != nil {
 		return err
@@ -899,27 +903,12 @@ func (c *Compiler) explodSub(is IniSection,
 		explod_sprpriority, VT_Int, 1, false); err != nil {
 		return err
 	}
-	if err := c.paramValue(is, sc, "bindid",
-		explod_bindid, VT_Int, 1, false); err != nil {
+	if err := c.paramValue(is, sc, "ontop",
+		explod_ontop, VT_Bool, 1, false); err != nil {
 		return err
 	}
-	if err := c.stateParam(is, "ontop", false, func(data string) error {
-		if err := c.scAdd(sc, explod_ontop, data, VT_Bool, 1); err != nil {
-			return err
-		}
-		if c.block != nil {
-			sc.add(explod_strictontop, nil)
-		}
-		return nil
-	}); err != nil {
-		return err
-	}
-	if err := c.stateParam(is, "under", false, func(data string) error {
-		if err := c.scAdd(sc, explod_under, data, VT_Bool, 1); err != nil {
-			return err
-		}
-		return nil
-	}); err != nil {
+	if err := c.paramValue(is, sc, "under",
+		explod_under, VT_Bool, 1, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "layerno",


### PR DESCRIPTION
- Restored compatibility with legacy ontop behavior
- Ontop's internal function is now to insert the explod at the beginning of the explod list instead of appending, thus inverting drawing order like Mugen
- Ontop now resets sprpriority for the same compatibility reasons
- Fixes #2712 