### PR TITLE
feat: Add ability to skip past the warning screen when saving certain config options with joystick buttons

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -1689,7 +1689,7 @@ function main.f_warning(t, background, info, title, txt, overlay)
 		if esc() or main.f_input(main.t_players, {'m'}) then
 			sndPlay(motif.files.snd_data, cancel_snd[1], cancel_snd[2])
 			return false
-		elseif getKey() ~= '' then
+		elseif getKey() ~= '' or main.f_input(main.t_players, {'a','b','c','x','y','z','d','w','s'}) then
 			sndPlay(motif.files.snd_data, done_snd[1], done_snd[2])
 			resetKey()
 			return true


### PR DESCRIPTION
Very handy for setups centered around the controller (arcade cabs, consoles)