### PR TITLE
fix: transparency regressions

### DIFF
--- a/src/compiler.go
+++ b/src/compiler.go
@@ -5890,34 +5890,28 @@ func (c *Compiler) paramTrans(is IniSection, sc *StateControllerBase,
 		// Parse the trans type and set default alpha
 		data = strings.ToLower(data)
 		switch data {
+		case "default":
+			tt = TT_default
+			defsrc, defdst = 255, 0
 		case "none":
 			tt = TT_none
 			defsrc, defdst = 255, 0
 		case "add1":
 			tt = TT_add
 			defsrc, defdst = 255, 128
+		case "add", "addalpha":
+			tt = TT_add
+			defsrc, defdst = 255, 255
 		case "sub":
 			tt = TT_sub
 			defsrc, defdst = 255, 255
 		default:
-			if afterImage {
-				if strings.HasPrefix(data, "add") {
-					tt = TT_add
-					defsrc, defdst = 255, 255
-				} else {
-					return Error("Invalid trans type: " + data)
-				}
+			// In Mugen, afterimages ignore invalid parameter names
+			if !afterImage || c.zssMode || !sys.ignoreMostErrors {
+				return Error("Invalid trans type: " + data)
 			} else {
-				switch data {
-				case "default":
-					tt = TT_default
-					defsrc, defdst = 255, 0
-				case "add", "addalpha":
-					tt = TT_add
-					defsrc, defdst = 255, 255
-				default:
-					return Error("Invalid trans type: " + data)
-				}
+				sys.appendToConsole("WARNING: " + sys.cgi[c.playerNo].nameLow + fmt.Sprintf(": Invalid trans type: "+data+" in state %v ", c.stateNo))
+				return nil
 			}
 		}
 

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -5896,12 +5896,15 @@ func (c *Compiler) paramTrans(is IniSection, sc *StateControllerBase,
 		case "none":
 			tt = TT_none
 			defsrc, defdst = 255, 0
+		case "add":
+			tt = TT_add
+			defsrc, defdst = 255, 255
 		case "add1":
 			tt = TT_add
 			defsrc, defdst = 255, 128
-		case "add", "addalpha":
+		case "addalpha":
 			tt = TT_add
-			defsrc, defdst = 255, 255
+			defsrc, defdst = 255, 0 // In Mugen it defaults to this before reading the alpha
 		case "sub":
 			tt = TT_sub
 			defsrc, defdst = 255, 255

--- a/src/image.go
+++ b/src/image.go
@@ -18,10 +18,10 @@ import (
 type TransType int32
 
 const (
-	TT_default TransType = iota
-	TT_none
+	TT_none TransType = iota
 	TT_add
 	TT_sub
+	TT_default
 )
 
 type PalFXDef struct {

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -1728,7 +1728,7 @@ func (fa *LifeBarFace) draw(layerno int16, ref int, far *LifeBarFace) {
 		// https://github.com/ikemen-engine/Ikemen-GO/issues/2269
 
 		// Reset system brightness if player initiated SuperPause (cancel "darken" parameter)
-		ob := sys.brightness
+		oldBright := sys.brightness
 		if sys.chars[ref][0].ignoreDarkenTime > 0 { //ref == sys.superplayerno
 			sys.brightness = 256
 		}
@@ -1743,7 +1743,7 @@ func (fa *LifeBarFace) draw(layerno int16, ref int, far *LifeBarFace) {
 		}
 
 		// Restore original system brightness
-		sys.brightness = ob
+		sys.brightness = oldBright
 
 		// Turns mode teammates
 		i := int32(len(far.teammate_face)) - 1
@@ -3303,7 +3303,7 @@ func (ro *LifeBarRound) reset() {
 }
 
 func (ro *LifeBarRound) draw(layerno int16, f []*Fnt) {
-	ob := sys.brightness
+	oldBright := sys.brightness
 	sys.brightness = 256
 
 	// Round call animations
@@ -3508,7 +3508,7 @@ func (ro *LifeBarRound) draw(layerno int16, f []*Fnt) {
 		ro.rt.Draw(layerno)
 	}
 
-	sys.brightness = ob
+	sys.brightness = oldBright
 }
 
 type LifeBarRoundTransition struct {

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -3303,6 +3303,7 @@ func (ro *LifeBarRound) reset() {
 }
 
 func (ro *LifeBarRound) draw(layerno int16, f []*Fnt) {
+	// Temporarily override system brightness
 	oldBright := sys.brightness
 	sys.brightness = 256
 
@@ -3326,23 +3327,34 @@ func (ro *LifeBarRound) draw(layerno int16, f []*Fnt) {
 			roundNum = sys.consecutiveWins[0] + 1
 		}
 
-		// Draw background
-		if ro.isSingleRound() &&
-			(ro.round_single.text.font[0] != -1 || len(ro.round_single.animLayout.anim.frames) > 0 || len(ro.round_single_bg[0].anim.frames) > 0) {
+		// Draw background and select round reference
+		switch {
+		case ro.isSingleRound() &&
+			 (ro.round_single.HasDrawable() || len(ro.round_single_bg) > 0 && ro.round_single_bg[0].HasAnim()):
 			// Single round
 			for i := range ro.round_single_bg {
-				ro.round_single_bg[i].Draw(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, sys.lifebarScale)
+				ro.round_single_bg[i].Draw(
+					float32(ro.pos[0])+sys.lifebarOffsetX,
+					float32(ro.pos[1]),
+					layerno,
+					sys.lifebarScale,
+				)
 			}
 			round_ref = ro.round_single
-		} else if ro.isFinalRound() &&
-			(ro.round_final.text.font[0] != -1 || len(ro.round_final.animLayout.anim.frames) > 0 || len(ro.round_final_bg[0].anim.frames) > 0) {
+		case ro.isFinalRound() &&
+			 (ro.round_final.HasDrawable() || len(ro.round_final_bg) > 0 && ro.round_final_bg[0].HasAnim()):
 			// Final round
 			for i := range ro.round_final_bg {
-				ro.round_final_bg[i].Draw(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, sys.lifebarScale)
+				ro.round_final_bg[i].Draw(
+					float32(ro.pos[0])+sys.lifebarOffsetX,
+					float32(ro.pos[1]),
+					layerno,
+					sys.lifebarScale,
+				)
 			}
 			round_ref = ro.round_final
-		} else if int(roundNum) <= len(ro.round) {
-			// Otherwise, use the appropriate round reference
+		case int(roundNum) <= len(ro.round) && ro.round[roundNum-1].HasDrawable():
+			// Normal round
 			round_ref = ro.round[roundNum-1]
 		}
 
@@ -3374,13 +3386,32 @@ func (ro *LifeBarRound) draw(layerno int16, f []*Fnt) {
 		// Restore round_ref text
 		round_ref.text.text = tmp
 
-		// Draw the single or final top layer if appropriate, otherwise draw the default top layer
-		if ro.isSingleRound() && len(ro.round_single_top.anim.frames) > 0 {
-			ro.round_single_top.Draw(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, sys.lifebarScale)
-		} else if ro.isFinalRound() && len(ro.round_final_top.anim.frames) > 0 {
-			ro.round_final_top.Draw(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, sys.lifebarScale)
-		} else {
-			ro.round_default_top.Draw(float32(ro.pos[0])+sys.lifebarOffsetX, float32(ro.pos[1]), layerno, sys.lifebarScale)
+		// Draw top layer
+		switch {
+		case ro.isSingleRound() && ro.round_single_top.anim != nil && len(ro.round_single_top.anim.frames) > 0:
+			// Single round
+			ro.round_single_top.Draw(
+				float32(ro.pos[0])+sys.lifebarOffsetX,
+				float32(ro.pos[1]),
+				layerno,
+				sys.lifebarScale,
+			)
+		case ro.isFinalRound() && ro.round_final_top.anim != nil && len(ro.round_final_top.anim.frames) > 0:
+			// Final round
+			ro.round_final_top.Draw(
+				float32(ro.pos[0])+sys.lifebarOffsetX,
+				float32(ro.pos[1]),
+				layerno,
+				sys.lifebarScale,
+			)
+		default:
+			// Normal round
+			ro.round_default_top.Draw(
+				float32(ro.pos[0])+sys.lifebarOffsetX,
+				float32(ro.pos[1]),
+				layerno,
+				sys.lifebarScale,
+			)
 		}
 	}
 
@@ -3508,6 +3539,7 @@ func (ro *LifeBarRound) draw(layerno int16, f []*Fnt) {
 		ro.rt.Draw(layerno)
 	}
 
+	// Restore system brightness
 	sys.brightness = oldBright
 }
 


### PR DESCRIPTION
- Restored the ability for afterimages to tolerate invalid transparency types. Only in the CNS format. ZSS will still crash
- Fixed SuperPause darken effect
- Restored Mugen bug where stage trans None is in reality trans Default
- Ikemen will now crash on invalid stage trans parameters (like Mugen)
- Minor adjustments to make transparency behavior closer to Mugen. AddAlpha now defaults to 255,0 instead of 255,255
- Added missing bit of refactoring to model transparency PalFX
- AnimTextSnd is a bit more robust against nil crashes
- Fixes #2733 