### PR TITLE
feat: add startx, starty, startz and facing to stagevar and modifystagevar

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -12315,6 +12315,14 @@ const (
 	modifyStageVar_playerinfo_rightbound
 	modifyStageVar_playerinfo_topbound
 	modifyStageVar_playerinfo_botbound
+	modifyStageVar_playerinfo_p1startx
+	modifyStageVar_playerinfo_p1starty
+	modifyStageVar_playerinfo_p2startx
+	modifyStageVar_playerinfo_p2starty
+	modifyStageVar_playerinfo_p1startz
+	modifyStageVar_playerinfo_p2startz
+	modifyStageVar_playerinfo_p1facing
+	modifyStageVar_playerinfo_p2facing
 	modifyStageVar_scaling_topz
 	modifyStageVar_scaling_botz
 	modifyStageVar_scaling_topscale
@@ -12434,6 +12442,22 @@ func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 			s.topbound = exp[0].evalF(c) * scaleratio
 		case modifyStageVar_playerinfo_botbound:
 			s.botbound = exp[0].evalF(c) * scaleratio
+		case modifyStageVar_playerinfo_p1startx:
+			s.p[0].startx = exp[0].evalI(c)
+		case modifyStageVar_playerinfo_p1starty:
+			s.p[0].starty = exp[0].evalI(c)
+		case modifyStageVar_playerinfo_p2startx:
+			s.p[1].startx = exp[0].evalI(c)
+		case modifyStageVar_playerinfo_p2starty:
+			s.p[1].starty = exp[0].evalI(c)
+		case modifyStageVar_playerinfo_p1startz:
+			s.p[0].startz = exp[0].evalI(c)
+		case modifyStageVar_playerinfo_p2startz:
+			s.p[1].startz = exp[0].evalI(c)
+		case modifyStageVar_playerinfo_p1facing:
+			s.p[0].facing = exp[0].evalI(c)
+		case modifyStageVar_playerinfo_p2facing:
+			s.p[1].facing = exp[0].evalI(c)
 		// Scaling group
 		case modifyStageVar_scaling_topz:
 			if s.mugenver[0] != 1 { // mugen 1.0+ removed support for topz

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -419,6 +419,14 @@ const (
 	OC_const_stagevar_playerinfo_rightbound
 	OC_const_stagevar_playerinfo_topbound
 	OC_const_stagevar_playerinfo_botbound
+	OC_const_stagevar_playerinfo_p1startx
+	OC_const_stagevar_playerinfo_p2startx
+	OC_const_stagevar_playerinfo_p1starty
+	OC_const_stagevar_playerinfo_p2starty
+	OC_const_stagevar_playerinfo_p1startz
+	OC_const_stagevar_playerinfo_p2startz
+	OC_const_stagevar_playerinfo_p1facing
+	OC_const_stagevar_playerinfo_p2facing
 	OC_const_stagevar_scaling_topz
 	OC_const_stagevar_scaling_botz
 	OC_const_stagevar_scaling_topscale
@@ -2438,6 +2446,22 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(sys.stage.topbound * sys.stage.localscl / oc.localscl)
 	case OC_const_stagevar_playerinfo_botbound:
 		sys.bcStack.PushF(sys.stage.botbound * sys.stage.localscl / oc.localscl)
+	case OC_const_stagevar_playerinfo_p1startx:
+		sys.bcStack.PushI(int32(float32(sys.stage.p[0].startx) * sys.stage.localscl / oc.localscl))
+	case OC_const_stagevar_playerinfo_p2startx:
+		sys.bcStack.PushI(int32(float32(sys.stage.p[1].startx) * sys.stage.localscl / oc.localscl))
+	case OC_const_stagevar_playerinfo_p1starty:
+		sys.bcStack.PushI(int32(float32(sys.stage.p[0].starty) * sys.stage.localscl / oc.localscl))
+	case OC_const_stagevar_playerinfo_p2starty:
+		sys.bcStack.PushI(int32(float32(sys.stage.p[1].starty) * sys.stage.localscl / oc.localscl))
+	case OC_const_stagevar_playerinfo_p1startz:
+		sys.bcStack.PushI(int32(float32(sys.stage.p[0].startz) * sys.stage.localscl / oc.localscl))
+	case OC_const_stagevar_playerinfo_p2startz:
+		sys.bcStack.PushI(int32(float32(sys.stage.p[1].startz) * sys.stage.localscl / oc.localscl))
+	case OC_const_stagevar_playerinfo_p1facing:
+		sys.bcStack.PushI(int32(float32(sys.stage.p[0].facing) * sys.stage.localscl / oc.localscl))
+	case OC_const_stagevar_playerinfo_p2facing:
+		sys.bcStack.PushI(int32(float32(sys.stage.p[1].facing) * sys.stage.localscl / oc.localscl))
 	case OC_const_stagevar_scaling_topz:
 		sys.bcStack.PushF(sys.stage.stageCamera.topz)
 	case OC_const_stagevar_scaling_botz:

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -3640,6 +3640,22 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			opc = OC_const_stagevar_playerinfo_topbound
 		case "playerinfo.botbound":
 			opc = OC_const_stagevar_playerinfo_botbound
+		case "playerinfo.p1startx":
+			opc = OC_const_stagevar_playerinfo_p1startx
+		case "playerinfo.p2startx":
+			opc = OC_const_stagevar_playerinfo_p2startx
+		case "playerinfo.p1starty":
+			opc = OC_const_stagevar_playerinfo_p1starty
+		case "playerinfo.p2starty":
+			opc = OC_const_stagevar_playerinfo_p2starty
+		case "playerinfo.p1startz":
+			opc = OC_const_stagevar_playerinfo_p1startz
+		case "playerinfo.p2startz":
+			opc = OC_const_stagevar_playerinfo_p2startz
+		case "playerinfo.p1facing":
+			opc = OC_const_stagevar_playerinfo_p1facing
+		case "playerinfo.p2facing":
+			opc = OC_const_stagevar_playerinfo_p2facing
 		case "scaling.topz":
 			opc = OC_const_stagevar_scaling_topz
 		case "scaling.botz":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -5624,6 +5624,38 @@ func (c *Compiler) modifyStageVar(is IniSection, sc *StateControllerBase, _ int8
 			modifyStageVar_playerinfo_botbound, VT_Float, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "playerinfo.p1startx",
+			modifyStageVar_playerinfo_p1startx, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "playerinfo.p1starty",
+			modifyStageVar_playerinfo_p1starty, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "playerinfo.p2startx",
+			modifyStageVar_playerinfo_p2startx, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "playerinfo.p2starty",
+			modifyStageVar_playerinfo_p2starty, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "playerinfo.p1startz",
+			modifyStageVar_playerinfo_p1startz, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "playerinfo.p2startz",
+			modifyStageVar_playerinfo_p2startz, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "playerinfo.p1facing",
+			modifyStageVar_playerinfo_p1facing, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "playerinfo.p2facing",
+			modifyStageVar_playerinfo_p2facing, VT_Int, 1, false); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "scaling.topz",
 			modifyStageVar_scaling_topz, VT_Float, 1, false); err != nil {
 			return err

--- a/src/script.go
+++ b/src/script.go
@@ -5251,6 +5251,22 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LNumber(sys.stage.topbound))
 		case "playerinfo.botbound":
 			l.Push(lua.LNumber(sys.stage.botbound))
+		case "playerinfo.p1startx":
+			l.Push(lua.LNumber(sys.stage.p[0].startx))
+		case "playerinfo.p1starty":
+			l.Push(lua.LNumber(sys.stage.p[0].starty))
+		case "playerinfo.p2startx":
+			l.Push(lua.LNumber(sys.stage.p[1].startx))
+		case "playerinfo.p2starty":
+			l.Push(lua.LNumber(sys.stage.p[1].starty))
+		case "playerinfo.p1startz":
+			l.Push(lua.LNumber(sys.stage.p[0].startz))
+		case "playerinfo.p2startz":
+			l.Push(lua.LNumber(sys.stage.p[1].startz))
+		case "playerinfo.p1facing":
+			l.Push(lua.LNumber(sys.stage.p[0].facing))
+		case "playerinfo.p2facing":
+			l.Push(lua.LNumber(sys.stage.p[1].facing))
 		case "scaling.topz":
 			l.Push(lua.LNumber(sys.stage.stageCamera.topz))
 		case "scaling.botz":


### PR DESCRIPTION
This relatively simple PR adds the following:

- Added functionality to the `stagevar` trigger
  - `playerinfo.p1startx`
  - `playerinfo.p2startx`
  - `playerinfo.p1starty`
  - `playerinfo.p2starty`
  - `playerinfo.p1startz`
  - `playerinfo.p2startz`
  - `playerinfo.p1facing`
  - `playerinfo.p2facing`
- Adds all of this to `modifystagevar` as well
- Adds corresponding functionality to the `stagevar` lua methods to return the appropriate values.

Successfully compiled and tested.