### PR TITLE
feat: "remove" palette limit, palette select modes, palmenu bg; fixes

### DIFF
--- a/data/system.base.def
+++ b/data/system.base.def
@@ -191,8 +191,8 @@
 	menu.item.active.xshear = 0.0
 	menu.item.active.angle = 0.0
 
-	; Enables Mugen menu tween (if > 0) and allows adjusting its velocity
-	menu.tween.time = 3
+	; Enables Mugen menu tween (if > 0.0) and allows adjusting its factor
+	menu.tween.factor = 0.3
 
 	; Title text rendered in main menu
 	title.offset = 159, 19
@@ -305,8 +305,8 @@
 
 	; Snap boxcursor on menu section change
 	menu.boxcursor.tween.snap = 0
-	; Enables boxcursor tween (if > 0) and allows adjusting its velocity
-	menu.boxcursor.tween.time = 3
+	; Enables boxcursor tween (if > 0.0) and allows adjusting its factor
+	menu.boxcursor.tween.factor = 0.3
 
 	; boxbg is an automatically generated overlay around itemnames, based on
 	; values assigned to menu.pos and menu.boxcursor.coords parameters.
@@ -621,12 +621,12 @@
 	; ticks between blinks when p2.cursor.blink = 1
 	p2.cursor.switchtime = 3
 
-	; Enables the Mugen 1.1 cursor tween (if > 0) and allows adjusting its x and y tween time
-	p1.cursor.tween.time = 0, 0
+	; Enables the Mugen 1.1 cursor tween (if > 0) and allows adjusting its x and y tween factors
+	p1.cursor.tween.factor = 0.0, 0.0
 	; Resets cursor animation when moving to a new cell
 	p1.cursor.reset = 0
 
-	p2.cursor.tween.time = 0, 0
+	p2.cursor.tween.factor = 0.0, 0.0
 	p2.cursor.reset = 0
 
 	; cursor parameters defaults to p1 and p2 values, if not specified
@@ -955,34 +955,53 @@
 	p2.teammenu.ratio7.icon.scale = 1.0, 1.0
 
 	paletteselect = 0
-	;p<pn>_member<num>.palette.number.offset = 0, 0
-	;p<pn>.member<num>.palette.number.font = -1, 0, 0
-	;p<pn>.member<num>.palette.number.scale = 1.0, 1.0
-	;p<pn>_member<num>_palette_number_xshear = 1.0
-	;p<pn>_member<num>_palette_number_angle = 1
-	;p<pn>.palette.number.offset = 0, 0
-	;p<pn>.palette.number.font = -1, 0, 0
-	;p<pn>.palette.number.scale = 1.0, 1.0
-	;p<pn>_palette_number_xshear = 1.0
-	;p<pn>_palette_number_angle = 1
-	;p<pn>_member<num>.palette.text.offset = 0, 0
-	;p<pn>.member<num>.palette.text.font = -1, 0, 0
-	;p<pn>.member<num>.palette.text.scale = 1.0, 1.0
-	;p<pn>_member<num>_palette_text_xshear = 1.0
-	;p<pn>_member<num>_palette_text_angle = 1
-	;p<pn>.palette.text.offset = 0, 0
-	;p<pn>.palette.text.font = -1, 0, 0
-	;p<pn>.palette.text.scale = 1.0, 1.0
-	;p<pn>_palette_text_xshear = 1.0
-	;p<pn>_palette_text_angle = 1
-	p1.palette.next.key = "$F"
-	p1.palette.previous.key = "$B"
-	p1.palette.accept.key = "a&b&c&x&y&z&s"
-	p2.palette.next.key = "$F"
-	p2.palette.previous.key = "$B"
-	p2.palette.accept.key = "a&b&c&x&y&z&s"
-	palette.move.snd = -1, 0
-	palette.done.snd = -1, 0
+	;p<pn>_member<num>.palmenu.number.offset = 0, 0
+	;p<pn>.member<num>.palmenu.number.font = -1, 0, 0
+	;p<pn>.member<num>.palmenu.number.scale = 1.0, 1.0
+	;p<pn>_member<num>.palmenu.number.xshear = 1.0
+	;p<pn>_member<num>.palmenu.number.angle = 1
+	;p<pn>.palmenu.number.offset = 0, 0
+	;p<pn>.palmenu.number.font = -1, 0, 0
+	;p<pn>.palmenu.number.scale = 1.0, 1.0
+	;p<pn>_palmenu.number.xshear = 1.0
+	;p<pn>_palmenu.number.angle = 1
+	;p<pn>_member<num>.palmenu.text.offset = 0, 0
+	;p<pn>.member<num>.palmenu.text.font = -1, 0, 0
+	;p<pn>.member<num>.palmenu.text.scale = 1.0, 1.0
+	;p<pn>_member<num>_palmenu.text.xshear = 1.0
+	;p<pn>_member<num>_palmenu.text.angle = 1
+	;p<pn>.palmenu.text.offset = 0, 0
+	;p<pn>.palmenu.text.font = -1, 0, 0
+	;p<pn>.palmenu.text.scale = 1.0, 1.0
+	;p<pn>_palmenu.text.xshear = 1.0
+	;p<pn>_palmenu.text.angle = 1
+	p1.palmenu.bg.pos = 0, 0
+	p1.palmenu.bg.anim = -1
+	p1.palmenu.bg.spr =
+	p1.palmenu.bg.offset = 0, 0
+	p1.palmenu.bg.facing = 1
+	p1.palmenu.bg.scale = 1.0, 1.0
+	p2.palmenu.bg.pos = 0, 0
+	p2.palmenu.bg.anim = -1
+	p2.palmenu.bg.spr = 
+	p2.palmenu.bg_offset = 0, 0
+	p2.palmenu.bg_facing = 1
+	p2.palmenu.bg_scale = 1.0, 1.0
+	p1.palmenu.next.key = "$F"
+	p1.palmenu.previous.key = "$B"
+	p1.palmenu.accept.key = "a&b&c"
+	p1.palmenu.cancel.key = "x&y&z"
+	p1.palmenu.random.key = "s"
+	p1.palmenu.random.text = "Random"
+	p2.palmenu.next.key = "$F"
+	p2.palmenu.previous.key = "$B"
+	p2.palmenu.accept.key = "a&b&c"
+	p2.palmenu.cancel.key = "x&y&z"
+	p2.palmenu.random.key = "s"
+	p2.palmenu.random.text = "Random"
+	palmenu.move.snd = -1, 0
+	palmenu.done.snd = -1, 0
+	palmenu.cancel.snd = -1, 0
 
 [SelectBgDef] ;Ikemen feature
 	spr = ""
@@ -1597,7 +1616,7 @@
 
 	menu.pos = 85, 33
 
-	menu.tween.time = 3
+	menu.tween.factor = 0.3
 
 	;menu.bg.<itemname>.anim = -1
 	;menu.bg.<itemname>.spr = 
@@ -1682,7 +1701,7 @@
 	menu.boxcursor.col = 255, 255, 255
 	menu.boxcursor.alpharange = 10, 40, 2, 255, 255, 0
 	menu.boxcursor.tween.snap = 0
-	menu.boxcursor.tween.time = 3
+	menu.boxcursor.tween.factor = 0.3
 
 	menu.boxbg.visible = 1
 	menu.boxbg.col = 0, 0, 0
@@ -1942,7 +1961,7 @@
 
 	menu.pos = 85, 33
 
-	menu.tween.time = 3
+	menu.tween.factor = 0.3
 
 	;menu.bg.<itemname>.anim = -1
 	;menu.bg.<itemname>.spr = 
@@ -1988,7 +2007,7 @@
 	menu.boxcursor.col = 255, 255, 255
 	menu.boxcursor.alpharange = 10, 40, 2, 255, 255, 0
 	menu.boxcursor.tween.snap = 0
-	menu.boxcursor.tween.time = 3
+	menu.boxcursor.tween.factor = 0.3
 
 	menu.boxbg.visible = 1
 	menu.boxbg.col = 0, 0, 0
@@ -2041,7 +2060,7 @@
 
 	menu.pos = 85, 33
 
-	menu.tween.time = 3
+	menu.tween.factor = 0.3
 
 	;menu.bg.<itemname>.anim = -1
 	;menu.bg.<itemname>.spr = 
@@ -2111,7 +2130,7 @@
 	menu.boxcursor.col = 255, 255, 255
 	menu.boxcursor.alpharange = 10, 40, 2, 255, 255, 0
 	menu.boxcursor.tween.snap = 0
-	menu.boxcursor.tween.time = 3
+	menu.boxcursor.tween.factor = 0.3
 
 	menu.boxbg.visible = 1
 	menu.boxbg.col = 0, 0, 0
@@ -2329,7 +2348,7 @@
 
 	menu.pos = 159, 158
 
-	menu.tween.time = 3
+	menu.tween.factor = 0.3
 
 	;menu.bg.<itemname>.anim = -1
 	;menu.bg.<itemname>.spr = 
@@ -2375,7 +2394,7 @@
 	menu.boxcursor.col = 255, 255, 255
 	menu.boxcursor.alpharange = 10, 40, 2, 255, 255, 0
 	menu.boxcursor.tween.snap = 0
-	menu.boxcursor.tween.time = 3
+	menu.boxcursor.tween.factor = 0.3
 
 	menu.boxbg.visible = 0
 	menu.boxbg.col = 0, 0, 0

--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -3872,16 +3872,15 @@ function main.f_demoStart()
 end
 
 --calculate menu.tween and boxcursor.tween
-local function f_tweenStep(val, target, velocity)
-    if not velocity or velocity <= 0 then
-		return target
-	end
-    local factor = math.min(velocity * 0.1, 1)
-	local newVal = val + (target - val) * factor
+local function f_tweenStep(val, target, factor)
+    if not factor or factor <= 0 then
+        return target
+    end
+    local newVal = val + (target - val) * math.min(factor, 1)
     if math.abs(newVal - target) < 1 then
-    	return target
-	end
-	return newVal
+        return target
+    end
+    return newVal
 end
 
 --common menu calculations
@@ -3958,7 +3957,7 @@ function main.f_menuCommonCalc(t, item, cursorPosY, moveTxt, section, keyPrev, k
 	local visible = motif[section].menu_window_visibleitems
 	local spacing = motif[section].menu_item_spacing[2]
 	local maxFirst = math.max(startItem, #t - visible + 1)
-	local t_time = motif[section].menu_tween_time
+	local t_factor = motif[section].menu_tween_factor
 	if maxFirst < startItem then 
 		maxFirst = startItem 
 	end
@@ -3986,8 +3985,8 @@ function main.f_menuCommonCalc(t, item, cursorPosY, moveTxt, section, keyPrev, k
 		return cursorPosY, moveTxt, item
 	end
 
-	if t_time > 0 then
-		td.slideOffset = f_tweenStep(td.slideOffset, 0, t_time)
+	if t_factor > 0 then
+		td.slideOffset = f_tweenStep(td.slideOffset, 0, t_factor)
 		td.currentPos = td.targetPos + td.slideOffset
 	else
 		td.currentPos = td.targetPos
@@ -4220,7 +4219,7 @@ function main.f_menuCommonDraw(t, item, cursorPosY, moveTxt, section, bgdef, tit
 	local bcd = main.boxCursorData[section]
 	--calculate target Y position for cursor
 	local targetY = motif[section].menu_pos[2] + motif[section].menu_boxcursor_coords[2] + (cursorPosY - 1) * motif[section].menu_item_spacing[2]
-	local t_time = motif[section].menu_boxcursor_tween_time
+	local t_factor = motif[section].menu_boxcursor_tween_factor
 
 	--snap cursor immediately if first use or snap enabled
 	if bcd.snap == 1 or not bcd.init then
@@ -4230,8 +4229,8 @@ function main.f_menuCommonDraw(t, item, cursorPosY, moveTxt, section, bgdef, tit
 	end
 
 	--apply tween if enabled, otherwise snap to target
-	if t_time > 0 then
-		bcd.offsetY = f_tweenStep(bcd.offsetY, targetY, t_time)
+	if t_factor > 0 then
+		bcd.offsetY = f_tweenStep(bcd.offsetY, targetY, t_factor)
 	else
 		bcd.offsetY = targetY
 	end

--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -3873,14 +3873,14 @@ end
 
 --calculate menu.tween and boxcursor.tween
 local function f_tweenStep(val, target, factor)
-    if not factor or factor <= 0 then
-        return target
-    end
-    local newVal = val + (target - val) * math.min(factor, 1)
-    if math.abs(newVal - target) < 1 then
-        return target
-    end
-    return newVal
+	if not factor or factor <= 0 then
+		return target
+	end
+	local newVal = val + (target - val) * math.min(factor, 1)
+	if math.abs(newVal - target) < 1 then
+		return target
+	end
+	return newVal
 end
 
 --common menu calculations

--- a/external/script/motif.lua
+++ b/external/script/motif.lua
@@ -1469,7 +1469,7 @@ local motif =
 		--menu_itemname_debugkeys = 'Debug Keys', --Ikemen feature
 		--menu_itemname_debugmode = 'Debug Mode', --Ikemen feature
 		--menu_itemname_helpermax = 'HelperMax', --Ikemen feature
-		--menu_itemname_projectilemax = 'PlayerProjectileMax', --Ikemen feature
+		--menu_itemname_projectilemax = 'ProjectileMax', --Ikemen feature
 		--menu_itemname_explodmax = 'ExplodMax', --Ikemen feature
 		--menu_itemname_afterimagemax = 'AfterImageMax', --Ikemen feature
 		--menu_itemname_portchange = 'Port Change', --Ikemen feature
@@ -2384,9 +2384,10 @@ function motif.setBaseOptionInfo()
 	motif.option_info.menu_itemname_menuengine_debugmode = "Debug Mode"
 	motif.option_info.menu_itemname_menuengine_empty = ""
 	motif.option_info.menu_itemname_menuengine_helpermax = "HelperMax"
-	motif.option_info.menu_itemname_menuengine_projectilemax = "PlayerProjectileMax"
+	motif.option_info.menu_itemname_menuengine_projectilemax = "ProjectileMax"
 	motif.option_info.menu_itemname_menuengine_explodmax = "ExplodMax"
 	motif.option_info.menu_itemname_menuengine_afterimagemax = "AfterImageMax"
+	motif.option_info.menu_itemname_menuengine_palettemax = "PaletteMax"
 	motif.option_info.menu_itemname_menuengine_empty = ""
 	motif.option_info.menu_itemname_menuengine_back = "Back"
 
@@ -2517,6 +2518,7 @@ function motif.setBaseOptionInfo()
 		"menuengine_projectilemax",
 		"menuengine_explodmax",
 		"menuengine_afterimagemax",
+		"menuengine_palettemax",
 		"menuengine_empty",
 		"menuengine_back",
 		"empty",

--- a/external/script/motif.lua
+++ b/external/script/motif.lua
@@ -165,7 +165,7 @@ local motif =
 		menu_accept_key = 'a&b&c&x&y&z&s', --Ikemen feature
 		menu_hiscore_key = 's', --Ikemen feature
 		menu_pos = {159, 158},
-		menu_tween_time = 3, --Ikemen feature
+		menu_tween_factor = 0.3, --Ikemen feature
 		--menu_bg_<itemname>_anim = -1, --Ikemen feature
 		--menu_bg_<itemname>_spr = {}, --Ikemen feature
 		--menu_bg_<itemname>_offset = {0, 0}, --Ikemen feature
@@ -199,7 +199,7 @@ local motif =
 		menu_window_visibleitems = 5,
 		menu_boxcursor_visible = 1,
 		menu_boxcursor_tween_snap = 0, --Ikemen feature
-		menu_boxcursor_tween_time = 3, --Ikemen feature
+		menu_boxcursor_tween_factor = 0.3, --Ikemen feature
 		menu_boxcursor_coords = {-40, -10, 39, 2},
 		menu_boxcursor_col = {255, 255, 255}, --Ikemen feature
 		menu_boxcursor_alpharange = {10, 40, 2, 255, 255, 0}, --Ikemen feature
@@ -305,7 +305,7 @@ local motif =
 		--cell_<col>_<row>_offset = {0, 0}, --Ikemen feature
 		--cell_<col>_<row>_facing = 1, --Ikemen feature
 		--cell_<col>_<row>_skip = 0, --Ikemen feature
-		p1_cursor_tween_time = {3, 3}, --Ikemen feature
+		p1_cursor_tween_factor = {0.3, 0.3}, --Ikemen feature
 		p1_cursor_startcell = {0, 0},
 		p1_cursor_active_anim = -1,
 		p1_cursor_active_spr = {},
@@ -321,7 +321,7 @@ local motif =
 		p1_cursor_done_snd = {100, 1},
 		p1_cursor_reset = 0, --Ikemen feature
 		p1_random_move_snd = {100, 0},
-		p2_cursor_tween_time = {3, 3}, --Ikemen feature
+		p2_cursor_tween_factor = {0.3, 0.3}, --Ikemen feature
 		p2_cursor_startcell = {0, 4},
 		p2_cursor_active_anim = -1,
 		p2_cursor_active_spr = {},
@@ -401,7 +401,6 @@ local motif =
 		p1_face_spr = {9000, 1},
 		p1_face_done_anim = -1, --Ikemen feature
 		p1_face_done_spr = {}, --Ikemen feature
-		p1_face_done_pal = 1, --Ikemen feature
 		p1_face_offset = {0, 0},
 		p1_face_facing = 1,
 		p1_face_scale = {1.0, 1.0},
@@ -735,34 +734,48 @@ local motif =
 		p1_select_snd = {-1, 0}, --Ikemen feature (data read from character SND)
 		p2_select_snd = {-1, 0}, --Ikemen feature (data read from character SND)
 		paletteselect = 0, --Ikemen feature
-		--p<pn>_member<num>_palette_number_offset = {0, 0}, --Ikemen feature
-		--p<pn>_member<num>_palette_number_font = {-1, 0, 0}, --Ikemen feature
-		--p<pn>_member<num>_palette_number_scale = {1.0, 1.0}, --Ikemen feature
-		--p<pn>_member<num>_palette_number_xshear = 1.0, --Ikemen feature
-		--p<pn>_member<num>_palette_number_angle = 1, --Ikemen feature
-		--p<pn>_palette_number_offset = {0, 0}, --Ikemen feature
-		--p<pn>_palette_number_font = {-1, 0, 0}, --Ikemen feature
-		--p<pn>_palette_number_scale = {1.0, 1.0}, --Ikemen feature
-		--p<pn>_palette_number_xshear = 1.0, --Ikemen feature
-		--p<pn>_palette_number_angle = 1, --Ikemen feature
-		--p<pn>_member<num>_palette_text_offset = {0, 0}, --Ikemen feature
-		--p<pn>_member<num>_palette_text_font = {-1, 0, 0}, --Ikemen feature
-		--p<pn>_member<num>_palette_text_scale = {1.0, 1.0}, --Ikemen feature
-		--p<pn>_member<num>_palette_text_xshear = 1.0, --Ikemen feature
-		--p<pn>_member<num>_palette_text_angle = 1, --Ikemen feature
-		--p<pn>_palette_text_offset = {0, 0}, --Ikemen feature
-		--p<pn>_palette_text_font = {-1, 0, 0}, --Ikemen feature
-		--p<pn>_palette_text_scale = {1.0, 1.0}, --Ikemen feature
-		--p<pn>_palette_text_xshear = 1.0, --Ikemen feature
-		--p<pn>_palette_text_angle = 1, --Ikemen feature
-		p1_palette_next_key = '$F', --Ikemen feature
-		p1_palette_previous_key = '$B', --Ikemen feature
-		p1_palette_accept_key = 'a&b&c&x&y&z&s', --Ikemen feature
-		p2_palette_next_key = '$F', --Ikemen feature
-		p2_palette_previous_key = '$B', --Ikemen feature
-		p2_palette_accept_key = 'a&b&c&x&y&z&s', --Ikemen feature
-		palette_move_snd = {-1, 0}, --Ikemen feature
-		palette_done_snd = {-1, 0}, --Ikemen feature
+		--p<pn>_member<num>_palmenu_number_offset = {0, 0}, --Ikemen feature
+		--p<pn>_member<num>_palmenu_number_font = {-1, 0, 0}, --Ikemen feature
+		--p<pn>_member<num>_palmenu_number_scale = {1.0, 1.0}, --Ikemen feature
+		--p<pn>_member<num>_palmenu_number_xshear = 1.0, --Ikemen feature
+		--p<pn>_member<num>_palmenu_number_angle = 1, --Ikemen feature
+		--p<pn>_palmenu_number_offset = {0, 0}, --Ikemen feature
+		--p<pn>_palmenu_number_font = {-1, 0, 0}, --Ikemen feature
+		--p<pn>_palmenu_number_scale = {1.0, 1.0}, --Ikemen feature
+		--p<pn>_palmenu_number_xshear = 1.0, --Ikemen feature
+		--p<pn>_palmenu_number_angle = 1, --Ikemen feature
+		--p<pn>_member<num>_palmenu_text_offset = {0, 0}, --Ikemen feature
+		--p<pn>_member<num>_palmenu_text_font = {-1, 0, 0}, --Ikemen feature
+		--p<pn>_member<num>_palmenu_text_scale = {1.0, 1.0}, --Ikemen feature
+		--p<pn>_member<num>_palmenu_text_xshear = 1.0, --Ikemen feature
+		--p<pn>_member<num>_palmenu_text_angle = 1, --Ikemen feature
+		--p<pn>_palmenu_text_offset = {0, 0}, --Ikemen feature
+		--p<pn>_palmenu_text_font = {-1, 0, 0}, --Ikemen feature
+		--p<pn>_palmenu_text_scale = {1.0, 1.0}, --Ikemen feature
+		--p<pn>_palmenu_text_xshear = 1.0, --Ikemen feature
+		--p<pn>_palmenu_text_angle = 1, --Ikemen feature
+		p1_palmenu_pos = {0, 0}, --Ikemen feature
+		p1_palmenu_bg_anim = -1, --Ikemen feature
+		p1_palmenu_bg_spr = {}, --Ikemen feature
+		p1_palmenu_bg_offset = {0, 0}, --Ikemen feature
+		p1_palmenu_bg_facing = 1, --Ikemen feature
+		p1_palmenu_bg_scale = {1.0, 1.0}, --Ikemen feature
+		p2_palmenu_pos = {0, 0}, --Ikemen feature
+		p2_palmenu_bg_anim = -1, --Ikemen feature
+		p2_palmenu_bg_spr = {}, --Ikemen feature
+		p2_palmenu_bg_offset = {0, 0}, --Ikemen feature
+		p2_palmenu_bg_facing = 1, --Ikemen feature
+		p2_palmenu_bg_scale = {1.0, 1.0}, --Ikemen feature
+		p1_palmenu_next_key = '$F', --Ikemen feature
+		p1_palmenu_previous_key = '$B', --Ikemen feature
+		p1_palmenu_accept_key = 'a&b&c&s', --Ikemen feature
+		p1_palmenu_cancel_key = 'x&y&z', --Ikemen feature
+		p2_palmenu_next_key = '$F', --Ikemen feature
+		p2_palmenu_previous_key = '$B', --Ikemen feature
+		p2_palmenu_accept_key = 'a&b&c&s', --Ikemen feature
+		palmenu_move_snd = {-1, 0}, --Ikemen feature
+		palmenu_done_snd = {-1, 0}, --Ikemen feature
+		palmenu_cancel_snd = {-1, 0}, --Ikemen feature
 	},
 	selectbgdef =
 	{
@@ -1227,7 +1240,7 @@ local motif =
 		title_text = 'OPTIONS', --Ikemen feature
 		menu_uselocalcoord = 0, --Ikemen feature
 		menu_pos = {85, 33}, --Ikemen feature
-		menu_tween_time = 3, --Ikemen feature
+		menu_tween_factor = 0.3, --Ikemen feature
 		--menu_bg_<itemname>_anim = -1, --Ikemen feature
 		--menu_bg_<itemname>_spr = {}, --Ikemen feature
 		--menu_bg_<itemname>_offset = {0, 0}, --Ikemen feature
@@ -1296,7 +1309,7 @@ local motif =
 		menu_window_visibleitems = 13, --Ikemen feature
 		menu_boxcursor_visible = 1, --Ikemen feature
 		menu_boxcursor_tween_snap = 0, --Ikemen feature
-		menu_boxcursor_tween_time = 3, --Ikemen feature
+		menu_boxcursor_tween_factor = 0.3, --Ikemen feature
 		menu_boxcursor_coords = {-5, -10, 154, 3}, --Ikemen feature
 		menu_boxcursor_col = {255, 255, 255}, --Ikemen feature
 		menu_boxcursor_alpharange = {10, 40, 2, 255, 255, 0}, --Ikemen feature
@@ -1482,7 +1495,7 @@ local motif =
 		title_text = 'REPLAY SELECT', --Ikemen feature
 		menu_uselocalcoord = 0, --Ikemen feature
 		menu_pos = {85, 33}, --Ikemen feature
-		menu_tween_time = 3, --Ikemen feature
+		menu_tween_factor = 0.3, --Ikemen feature
 		--menu_bg_<itemname>_anim = -1, --Ikemen feature
 		--menu_bg_<itemname>_spr = {}, --Ikemen feature
 		--menu_bg_<itemname>_offset = {0, 0}, --Ikemen feature
@@ -1516,7 +1529,7 @@ local motif =
 		menu_window_visibleitems = 13, --Ikemen feature
 		menu_boxcursor_visible = 1, --Ikemen feature
 		menu_boxcursor_tween_snap = 0, --Ikemen feature
-		menu_boxcursor_tween_time = 3, --Ikemen feature
+		menu_boxcursor_tween_factor = 0.3, --Ikemen feature
 		menu_boxcursor_coords = {-5, -10, 154, 3}, --Ikemen feature
 		menu_boxcursor_col = {255, 255, 255}, --Ikemen feature
 		menu_boxcursor_alpharange = {10, 40, 2, 255, 255, 0}, --Ikemen feature
@@ -1560,7 +1573,7 @@ local motif =
 		title_text = 'PAUSE', --Ikemen feature
 		menu_uselocalcoord = 0, --Ikemen feature
 		menu_pos = {85, 33}, --Ikemen feature
-		menu_tween_time = 3, --Ikemen feature
+		menu_tween_factor = 0.3, --Ikemen feature
 		--menu_bg_<itemname>_anim = -1, --Ikemen feature
 		--menu_bg_<itemname>_spr = {}, --Ikemen feature
 		--menu_bg_<itemname>_offset = {0, 0}, --Ikemen feature
@@ -1614,7 +1627,7 @@ local motif =
 		menu_window_visibleitems = 13, --Ikemen feature
 		menu_boxcursor_visible = 1, --Ikemen feature
 		menu_boxcursor_tween_snap = 0, --Ikemen feature
-		menu_boxcursor_tween_time = 3, --Ikemen feature
+		menu_boxcursor_tween_factor = 0.3, --Ikemen feature
 		menu_boxcursor_coords = {-5, -10, 154, 3}, --Ikemen feature
 		menu_boxcursor_col = {255, 255, 255}, --Ikemen feature
 		menu_boxcursor_alpharange = {10, 40, 2, 255, 255, 0}, --Ikemen feature
@@ -1798,7 +1811,7 @@ local motif =
 		menu_previous_key = '$U&$B', --Ikemen feature
 		menu_accept_key = 'a&b&c&x&y&z&s', --Ikemen feature
 		menu_pos = {159, 158}, --Ikemen feature
-		menu_tween_time = 3, --Ikemen feature
+		menu_tween_factor = 0.3, --Ikemen feature
 		--menu_bg_<itemname>_anim = -1, --Ikemen feature
 		--menu_bg_<itemname>_spr = {}, --Ikemen feature
 		--menu_bg_<itemname>_offset = {0, 0}, --Ikemen feature
@@ -1832,7 +1845,7 @@ local motif =
 		menu_window_visibleitems = 5, --Ikemen feature
 		menu_boxcursor_visible = 1, --Ikemen feature
 		menu_boxcursor_tween_snap = 0, --Ikemen feature
-		menu_boxcursor_tween_time = 3, --Ikemen feature
+		menu_boxcursor_tween_factor = 0.3, --Ikemen feature
 		menu_boxcursor_coords = {-40, -10, 39, 2},
 		menu_boxcursor_col = {255, 255, 255}, --Ikemen feature
 		menu_boxcursor_alpharange = {10, 40, 2, 255, 255, 0}, --Ikemen feature
@@ -2704,6 +2717,22 @@ for line in main.motifData:gmatch('([^\n]*)\n?') do
 						end
 					end
 					pos[param] = value
+				elseif param:match('^palmenu_itemname_') then
+				local subt, append = param:match('^([^_]+)_itemname_(.+)$')
+				if pos_sort[subt] == nil then
+					pos_sort[subt] = {}
+				end
+				table.insert(pos_sort[subt], append)
+				for i = 1, 2 do
+					local prefix = 'p' .. i .. '_'
+					local bg = param:gsub('_itemname_', '_bg_')
+					def_pos[prefix .. bg .. '_anim']   = -1
+					def_pos[prefix .. bg .. '_spr']    = {-1, 0}
+					def_pos[prefix .. bg .. '_offset'] = {0, 0}
+					def_pos[prefix .. bg .. '_facing'] = 1
+					def_pos[prefix .. bg .. '_scale']  = {1.0, 1.0}
+				end
+				pos[param] = value
 				elseif value:match('.+,.+') then --multiple values
 					local fontRef = -1
 					for i, c in ipairs(main.f_strsplit(',', value)) do --split value using "," delimiter
@@ -3005,7 +3034,7 @@ for i = 1, 3 do
 		currentSection = 'victory_screen'
 	end
 	for side = 1, 2 do
-		if motif[currentSection]['p' .. side .. '_pal'] == 1 or motif[currentSection]['p' .. side .. '_face_applypal'] == 1 or motif[currentSection]['p' .. side .. '_face2_applypal'] == 1 then
+		if motif[currentSection]['p' .. side .. '_applypal'] == 1 or motif[currentSection]['p' .. side .. '_face_applypal'] == 1 or motif[currentSection]['p' .. side .. '_face2_applypal'] == 1 then
 			usingPalettes = true
 		end
 		for member = 1, 4 do
@@ -3034,6 +3063,7 @@ for _, v in ipairs({
 	{s = 'p1_teammenu_ratio5_icon_',      x = t_pos.p1_teammenu_pos[1] + t_pos.p1_teammenu_item_offset[1], y = t_pos.p1_teammenu_pos[2] + t_pos.p1_teammenu_item_offset[2]},
 	{s = 'p1_teammenu_ratio6_icon_',      x = t_pos.p1_teammenu_pos[1] + t_pos.p1_teammenu_item_offset[1], y = t_pos.p1_teammenu_pos[2] + t_pos.p1_teammenu_item_offset[2]},
 	{s = 'p1_teammenu_ratio7_icon_',      x = t_pos.p1_teammenu_pos[1] + t_pos.p1_teammenu_item_offset[1], y = t_pos.p1_teammenu_pos[2] + t_pos.p1_teammenu_item_offset[2]},
+	{s = 'p1_palmenu_bg_',                x = t_pos.p1_palmenu_pos[1],                                     y = t_pos.p1_palmenu_pos[2]},
 	{s = 'p2_teammenu_bg_',               x = t_pos.p2_teammenu_pos[1],                                    y = t_pos.p2_teammenu_pos[2]},
 	{s = 'p2_teammenu_selftitle_',        x = t_pos.p2_teammenu_pos[1],                                    y = t_pos.p2_teammenu_pos[2]},
 	{s = 'p2_teammenu_enemytitle_',       x = t_pos.p2_teammenu_pos[1],                                    y = t_pos.p2_teammenu_pos[2]},
@@ -3047,6 +3077,7 @@ for _, v in ipairs({
 	{s = 'p2_teammenu_ratio5_icon_',      x = t_pos.p2_teammenu_pos[1] + t_pos.p2_teammenu_item_offset[1], y = t_pos.p2_teammenu_pos[2] + t_pos.p2_teammenu_item_offset[2]},
 	{s = 'p2_teammenu_ratio6_icon_',      x = t_pos.p2_teammenu_pos[1] + t_pos.p2_teammenu_item_offset[1], y = t_pos.p2_teammenu_pos[2] + t_pos.p2_teammenu_item_offset[2]},
 	{s = 'p2_teammenu_ratio7_icon_',      x = t_pos.p2_teammenu_pos[1] + t_pos.p2_teammenu_item_offset[1], y = t_pos.p2_teammenu_pos[2] + t_pos.p2_teammenu_item_offset[2]},
+	{s = 'p2_palmenu_bg_',                x = t_pos.p2_palmenu_pos[1],                                     y = t_pos.p2_palmenu_pos[2]},
 	{s = 'stage_portrait_random_',        x = t_pos.stage_pos[1],                                          y = t_pos.stage_pos[2]},
 	{s = 'stage_portrait_bg_',            x = t_pos.stage_pos[1],                                          y = t_pos.stage_pos[2]},
 }) do

--- a/external/script/motif.lua
+++ b/external/script/motif.lua
@@ -754,13 +754,13 @@ local motif =
 		--p<pn>_palmenu_text_scale = {1.0, 1.0}, --Ikemen feature
 		--p<pn>_palmenu_text_xshear = 1.0, --Ikemen feature
 		--p<pn>_palmenu_text_angle = 1, --Ikemen feature
-		p1_palmenu_pos = {0, 0}, --Ikemen feature
+		p1_palmenu_bg_pos = {0, 0}, --Ikemen feature
 		p1_palmenu_bg_anim = -1, --Ikemen feature
 		p1_palmenu_bg_spr = {}, --Ikemen feature
 		p1_palmenu_bg_offset = {0, 0}, --Ikemen feature
 		p1_palmenu_bg_facing = 1, --Ikemen feature
 		p1_palmenu_bg_scale = {1.0, 1.0}, --Ikemen feature
-		p2_palmenu_pos = {0, 0}, --Ikemen feature
+		p2_palmenu_bg_pos = {0, 0}, --Ikemen feature
 		p2_palmenu_bg_anim = -1, --Ikemen feature
 		p2_palmenu_bg_spr = {}, --Ikemen feature
 		p2_palmenu_bg_offset = {0, 0}, --Ikemen feature
@@ -768,11 +768,16 @@ local motif =
 		p2_palmenu_bg_scale = {1.0, 1.0}, --Ikemen feature
 		p1_palmenu_next_key = '$F', --Ikemen feature
 		p1_palmenu_previous_key = '$B', --Ikemen feature
-		p1_palmenu_accept_key = 'a&b&c&s', --Ikemen feature
+		p1_palmenu_accept_key = 'a&b&c', --Ikemen feature
 		p1_palmenu_cancel_key = 'x&y&z', --Ikemen feature
+		p1_palmenu_random_key = 's', --Ikemen feature
+		p1_palmenu_random_text = "Random", --Ikemen feature
 		p2_palmenu_next_key = '$F', --Ikemen feature
 		p2_palmenu_previous_key = '$B', --Ikemen feature
-		p2_palmenu_accept_key = 'a&b&c&s', --Ikemen feature
+		p2_palmenu_accept_key = 'a&b&c', --Ikemen feature
+		p2_palmenu_cancel_key = 'x&y&z', --Ikemen feature
+		p2_palmenu_random_key = 's', --Ikemen feature
+		p2_palmenu_random_text = "Random", --Ikemen feature
 		palmenu_move_snd = {-1, 0}, --Ikemen feature
 		palmenu_done_snd = {-1, 0}, --Ikemen feature
 		palmenu_cancel_snd = {-1, 0}, --Ikemen feature
@@ -3063,7 +3068,7 @@ for _, v in ipairs({
 	{s = 'p1_teammenu_ratio5_icon_',      x = t_pos.p1_teammenu_pos[1] + t_pos.p1_teammenu_item_offset[1], y = t_pos.p1_teammenu_pos[2] + t_pos.p1_teammenu_item_offset[2]},
 	{s = 'p1_teammenu_ratio6_icon_',      x = t_pos.p1_teammenu_pos[1] + t_pos.p1_teammenu_item_offset[1], y = t_pos.p1_teammenu_pos[2] + t_pos.p1_teammenu_item_offset[2]},
 	{s = 'p1_teammenu_ratio7_icon_',      x = t_pos.p1_teammenu_pos[1] + t_pos.p1_teammenu_item_offset[1], y = t_pos.p1_teammenu_pos[2] + t_pos.p1_teammenu_item_offset[2]},
-	{s = 'p1_palmenu_bg_',                x = t_pos.p1_palmenu_pos[1],                                     y = t_pos.p1_palmenu_pos[2]},
+	{s = 'p1_palmenu_bg_',                x = t_pos.p1_palmenu_bg_pos[1],                                  y = t_pos.p1_palmenu_bg_pos[2]},
 	{s = 'p2_teammenu_bg_',               x = t_pos.p2_teammenu_pos[1],                                    y = t_pos.p2_teammenu_pos[2]},
 	{s = 'p2_teammenu_selftitle_',        x = t_pos.p2_teammenu_pos[1],                                    y = t_pos.p2_teammenu_pos[2]},
 	{s = 'p2_teammenu_enemytitle_',       x = t_pos.p2_teammenu_pos[1],                                    y = t_pos.p2_teammenu_pos[2]},
@@ -3077,7 +3082,7 @@ for _, v in ipairs({
 	{s = 'p2_teammenu_ratio5_icon_',      x = t_pos.p2_teammenu_pos[1] + t_pos.p2_teammenu_item_offset[1], y = t_pos.p2_teammenu_pos[2] + t_pos.p2_teammenu_item_offset[2]},
 	{s = 'p2_teammenu_ratio6_icon_',      x = t_pos.p2_teammenu_pos[1] + t_pos.p2_teammenu_item_offset[1], y = t_pos.p2_teammenu_pos[2] + t_pos.p2_teammenu_item_offset[2]},
 	{s = 'p2_teammenu_ratio7_icon_',      x = t_pos.p2_teammenu_pos[1] + t_pos.p2_teammenu_item_offset[1], y = t_pos.p2_teammenu_pos[2] + t_pos.p2_teammenu_item_offset[2]},
-	{s = 'p2_palmenu_bg_',                x = t_pos.p2_palmenu_pos[1],                                     y = t_pos.p2_palmenu_pos[2]},
+	{s = 'p2_palmenu_bg_',                x = t_pos.p2_palmenu_bg_pos[1],                                  y = t_pos.p2_palmenu_bg_pos[2]},
 	{s = 'stage_portrait_random_',        x = t_pos.stage_pos[1],                                          y = t_pos.stage_pos[2]},
 	{s = 'stage_portrait_bg_',            x = t_pos.stage_pos[1],                                          y = t_pos.stage_pos[2]},
 }) do

--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -180,7 +180,8 @@ options.t_itemname = {
 			modifyGameOption('Config.AfterImageMax', 128)
 			modifyGameOption('Config.ExplodMax', 512)
 			modifyGameOption('Config.HelperMax', 56)
-			modifyGameOption('Config.PlayerProjectileMax', 256)
+			modifyGameOption('Config.ProjectileMax', 256)
+			modifyGameOption('Config.PaletteMax', 100)
 			--modifyGameOption('Config.ZoomActive', true)
 			--modifyGameOption('Config.EscOpensMenu', true)
 			--modifyGameOption('Config.BackgroundLoading', false) --TODO: not implemented
@@ -1203,17 +1204,17 @@ options.t_itemname = {
 		end
 		return true
 	end,
-	--PlayerProjectileMax
+	--ProjectileMax
 	['projectilemax'] = function(t, item, cursorPosY, moveTxt)
 		if main.f_input(main.t_players, {'$F'}) then
 			sndPlay(motif.files.snd_data, motif.option_info.cursor_move_snd[1], motif.option_info.cursor_move_snd[2])
-			modifyGameOption('Config.PlayerProjectileMax', gameOption('Config.PlayerProjectileMax') + 1)
-			t.items[item].vardisplay = gameOption('Config.PlayerProjectileMax')
+			modifyGameOption('Config.ProjectileMax', gameOption('Config.ProjectileMax') + 1)
+			t.items[item].vardisplay = gameOption('Config.ProjectileMax')
 			options.modified = true
-		elseif main.f_input(main.t_players, {'$B'}) and gameOption('Config.PlayerProjectileMax') > 1 then
+		elseif main.f_input(main.t_players, {'$B'}) and gameOption('Config.ProjectileMax') > 1 then
 			sndPlay(motif.files.snd_data, motif.option_info.cursor_move_snd[1], motif.option_info.cursor_move_snd[2])
-			modifyGameOption('Config.PlayerProjectileMax', gameOption('Config.PlayerProjectileMax') - 1)
-			t.items[item].vardisplay = gameOption('Config.PlayerProjectileMax')
+			modifyGameOption('Config.ProjectileMax', gameOption('Config.ProjectileMax') - 1)
+			t.items[item].vardisplay = gameOption('Config.ProjectileMax')
 			options.modified = true
 		end
 		return true
@@ -1246,6 +1247,22 @@ options.t_itemname = {
 			t.items[item].vardisplay = gameOption('Config.AfterImageMax')
 			options.modified = true
 		end
+		return true
+	end,
+	--PaletteMax
+	['palettemax'] = function(t, item, cursorPosY, moveTxt)
+		if main.f_input(main.t_players, {'$F'}) then
+			sndPlay(motif.files.snd_data, motif.option_info.cursor_move_snd[1], motif.option_info.cursor_move_snd[2])
+			modifyGameOption('Config.PaletteMax', gameOption('Config.PaletteMax') + 1)
+			t.items[item].vardisplay = gameOption('Config.PaletteMax')
+			options.modified = true
+		elseif main.f_input(main.t_players, {'$B'}) and gameOption('Config.PaletteMax') > 1 then
+			sndPlay(motif.files.snd_data, motif.option_info.cursor_move_snd[1], motif.option_info.cursor_move_snd[2])
+			modifyGameOption('Config.PaletteMax', gameOption('Config.PaletteMax') - 1)
+			t.items[item].vardisplay = gameOption('Config.PaletteMax')
+			options.modified = true
+		end
+		options.needReload = true
 		return true
 	end,
 	--Save and Return
@@ -1453,6 +1470,9 @@ options.t_vardisplay = {
 	['msaa'] = function()
 		return options.f_definedDisplay(gameOption('Video.MSAA'), {[0] = motif.option_info.menu_valuename_disabled}, gameOption('Video.MSAA') .. 'x')
 	end,
+	['palettemax'] = function()
+		return gameOption('Config.PaletteMax')
+	end,
 	['panningrange'] = function()
 		return gameOption('Sound.PanningRange') .. '%'
 	end,
@@ -1463,7 +1483,7 @@ options.t_vardisplay = {
 		return gameOption('Netplay.ListenPort')
 	end,
 	['projectilemax'] = function()
-		return gameOption('Config.PlayerProjectileMax')
+		return gameOption('Config.ProjectileMax')
 	end,
 	['quickcontinue'] = function()
 		return options.f_boolDisplay(gameOption('Options.QuickContinue'))

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -3141,7 +3141,15 @@ function start.f_selectMenu(side, cmd, player, member, selectState)
 			end
 		--confirm selection
 		elseif selectState == 3 then
-			local finalPal = (motif.select_info.paletteselect == 1) and start.p[side].t_selTemp[member].pal or start.f_selectPal(start.c[player].selRef, start.p[side].t_selTemp[member].pal)
+			local valid = {1,2,3}
+			local finalPal
+			for _, v in ipairs(valid) do
+				if motif.select_info.paletteselect == v then
+					finalPal = start.p[side].t_selTemp[member].pal
+					break
+				end
+			end
+			finalPal = finalPal or start.f_selectPal(start.c[player].selRef, start.p[side].t_selTemp[member].pal)
 			start.p[side].t_selected[member] = {
 				ref = start.c[player].selRef,
 				pal = finalPal,
@@ -4878,8 +4886,8 @@ function start.f_dialogue()
 			motif.dialogue_info['p' .. side .. '_face_facing'],
 			motif.dialogue_info['p' .. side .. '_face_window'][1],
 			motif.dialogue_info['p' .. side .. '_face_window'][2],
-			motif.dialogue_info['p' .. side .. '_face_window'][3] * gameOption('Video.GameWidth') / motifLocalcoord(0),
-			motif.dialogue_info['p' .. side .. '_face_window'][4] * gameOption('Video.GameHeight') / motifLocalcoord(1)
+			motif.dialogue_info['p' .. side .. '_face_window'][3] * gameOption('Video.GameWidth') / main.SP_Localcoord[1],
+			motif.dialogue_info['p' .. side .. '_face_window'][4] * gameOption('Video.GameHeight') / main.SP_Localcoord[2]
 		)
 		--draw names
 		start['txt_dialogue_p' .. side .. '_name']:draw()

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -2845,7 +2845,7 @@ function start.f_palMenuDraw(side, member)
 		}):draw()
 	end
 
-	-- desenha text
+	-- draw text
 	local textFontInfo = getInfo('palmenu_text_font')
 	local textOffset = getInfo('palmenu_text_offset')
 	local textScale = getInfo('palmenu_text_scale')
@@ -3129,7 +3129,7 @@ function start.f_selectMenu(side, cmd, player, member, selectState)
              			start.c[player].randPalCnt = motif.select_info.cell_random_switchtime
                 		start.c[player].randPalPreview = start.f_randomPal(charRef)
 
-						applyPalette(charData.pal[start.c[player].randPalPreview])
+						applyPalette(start.c[player].randPalPreview)
 						sndPlay(motif.files.snd_data, motif.select_info.palmenu_move_snd[1], motif.select_info.palmenu_move_snd[2])
 					else
 						start.c[player].randPalCnt = start.c[player].randPalCnt - 1

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -843,15 +843,15 @@ function start.f_animGet(ref, side, member, t, subname, prefix, loop, default)
 		if v[1] ~= nil and v[1] ~= -1 then
 			--Check if palettes should be used for this animation
 			if k == 1 or k == 3 then
-				usePal = t['p' .. side .. '_member' .. member .. subname .. prefix .. '_pal'] or 0
+				usePal = t['p' .. side .. '_member' .. member .. subname .. prefix .. '_applypal'] or 0
 			elseif k == 2 or k == 4 then
-				usePal = t['p' .. side .. subname .. prefix .. '_pal'] or 0 
+				usePal = t['p' .. side .. subname .. prefix .. '_applypal'] or 0 
 			elseif k == 5 then
 				usePal = 0
 			end
 			if subname == face then
 				if usePal == 0 then
-					usePal = t['p' .. side .. '_pal'] or 0
+					usePal = t['p' .. side .. '_applypal'] or 0
 				end
 			end
 			local a = animGetPreloadedCharData(ref, v[1], v[2], loop)
@@ -1102,21 +1102,16 @@ function start.f_searchEmptyBoxes(x, y, side, direction)
 end
 
 --calculate cursor.tween
-local function f_cursorTween(val, target, velocity)
-    if not velocity or not target then
-        return val
-    end
-    for i = 1, 2 do
-        local t = target[i] or 0
-        local v = velocity[i] or 0
-        if v > 0 then
-            local factor = math.min(v * 0.1, 1)
-            val[i] = val[i] + (t - val[i]) * factor
-        else
-            val[i] = t
-        end
-    end
-    return val
+local function f_cursorTween(val, target, factor)
+	if not factor or not target then
+		return val
+	end
+	for i = 1, 2 do
+		local t = target[i] or 0
+		local f = math.min(math.abs(factor[i] or 0.5), 1)
+		val[i] = val[i] + (t - val[i]) * f
+	end
+	return val
 end
 
 --returns player cursor data
@@ -1179,13 +1174,13 @@ function start.f_drawCursor(pn, x, y, param, done)
 		cd.slideOffset[1] = cd.startPos[1] - baseX
 		cd.slideOffset[2] = cd.startPos[2] - baseY
 	end
-	local t_time = {
-		motif.select_info['p' .. pn .. '_cursor_tween_time'][1],
-		motif.select_info['p' .. pn .. '_cursor_tween_time'][2]
+	local t_factor = {
+		motif.select_info['p' .. pn .. '_cursor_tween_factor'][1],
+		motif.select_info['p' .. pn .. '_cursor_tween_factor'][2]
 	}
 	-- apply tween if enabled, otherwise snap to target
-	if not done and t_time[1] > 0 and t_time[2] > 0 then
-		f_cursorTween(cd.slideOffset, {0, 0}, t_time)
+	if not done and t_factor[1] > 0 and t_factor[2] > 0 then
+		f_cursorTween(cd.slideOffset, {0, 0}, t_factor)
 	else
 		cd.slideOffset[1], cd.slideOffset[2] = 0, 0
 	end
@@ -2811,58 +2806,97 @@ function start.loadPalettes(a, ref, pal)
 	return a
 end
 
---;===========================================================
---; Draw Palette Number and Text
---;===========================================================
-function start.f_paletteNumberDraw(side, member)
-	local numFontInfo = motif.select_info['p' .. side .. '_member' .. member .. '_palette_number_font'] or motif.select_info['p' .. side  .. '_palette_number_font']
-	local numOffset = motif.select_info['p' .. side .. '_member' .. member .. '_palette_number_offset'] or  motif.select_info['p' .. side  .. '_palette_number_offset']
-	local numScale = motif.select_info['p' .. side .. '_member' .. member .. '_palette_number_scale'] or motif.select_info['p' .. side  .. '_palette_number_scale']
-	local numXshear = motif.select_info['p' .. side .. '_member' .. member .. '_palette_number_xshear'] or motif.select_info['p' .. side .. '_palette_number_xshear']
-	local numAngle = motif.select_info['p' .. side .. '_member' .. member .. '_palette_number_angle'] or motif.select_info['p' .. side .. '_palette_number_angle']
-	if (numFontInfo and numOffset and numScale) ~= nil then
-		currentPallete = text:create({
-			font =   numFontInfo[1],
-			bank =   numFontInfo[2],
-			align =  numFontInfo[3],
-			text =   start.f_getCharData(start.p[side].t_selTemp[member].ref).pal[start.p[side].t_selTemp[member].pal],
-			x =      numOffset[1],
-			y =      numOffset[2],
+--===========================================================
+-- Draw Palette Menu
+--===========================================================
+function start.f_palMenuDraw(side, member)
+	local charData = start.f_getCharData(start.p[side].t_selTemp[member].ref)
+	if not charData or not charData.pal then return end
+	local palIndex = start.p[side].t_selTemp[member].pal
+	local totalPals = #charData.pal
+	-- helper to get infos
+	local function getInfo(key)
+		return motif.select_info['p' .. side .. '_member' .. member .. '_' .. key]
+			or motif.select_info['p' .. side .. '_' .. key]
+	end
+	local displayText = (palIndex == totalPals + 1) and getInfo('palmenu_random_text') or tostring(palIndex)
+	-- bg
+	main.f_animPosDraw(motif.select_info['p' .. side .. '_palmenu_bg_data'])
+	-- draw number
+	local numFontInfo = getInfo('palmenu_number_font')
+	local numOffset = getInfo('palmenu_number_offset')
+	local numScale = getInfo('palmenu_number_scale')
+	if numFontInfo and numOffset and numScale then
+		text:create({
+			font   = numFontInfo[1],
+			bank   = numFontInfo[2],
+			align  = numFontInfo[3],
+			text   = displayText,
+			x      = numOffset[1],
+			y      = numOffset[2],
 			scaleX = numScale[1],
 			scaleY = numScale[2],
-			r =      numFontInfo[4],
-			g =      numFontInfo[5],
-			b =      numFontInfo[6],
+			r      = numFontInfo[4],
+			g      = numFontInfo[5],
+			b      = numFontInfo[6],
 			height = numFontInfo[7],
-			xshear = numXshear,
-			angle  = numAngle,
-		})
-		currentPallete:draw()
+			xshear = getInfo('palmenu_number_xshear'),
+			angle  = getInfo('palmenu_number_angle'),
+		}):draw()
 	end
-	local textFontInfo = motif.select_info['p' .. side .. '_member' .. member .. '_palette_text_font'] or motif.select_info['p' .. side  .. '_palette_text_font']
-	local textOffset = motif.select_info['p' .. side .. '_member' .. member .. '_palette_text_offset'] or  motif.select_info['p' .. side  .. '_palette_text_offset']
-	local textScale = motif.select_info['p' .. side .. '_member' .. member .. '_palette_text_scale'] or motif.select_info['p' .. side  .. '_palette_text_scale']
-	local textXshear = motif.select_info['p' .. side .. '_member' .. member .. '_palette_text_xshear'] or motif.select_info['p' .. side .. '_palette_text_xshear']
-	local textAngle = motif.select_info['p' .. side .. '_member' .. member .. '_palette_text_angle'] or motif.select_info['p' .. side .. '_palette_text_angle']
-	if (textFontInfo and textOffset and textScale) ~= nil then
-		palleteText = text:create({
-			font =   textFontInfo[1],
-			bank =   textFontInfo[2],
-			align =  textFontInfo[3],
-			text =   motif.select_info['p' .. side  .. '_palette_text_text'],
-			x =      textOffset[1],
-			y =      textOffset[2],
+
+	-- desenha text
+	local textFontInfo = getInfo('palmenu_text_font')
+	local textOffset = getInfo('palmenu_text_offset')
+	local textScale = getInfo('palmenu_text_scale')
+	if textFontInfo and textOffset and textScale then
+		text:create({
+			font   = textFontInfo[1],
+			bank   = textFontInfo[2],
+			align  = textFontInfo[3],
+			text   = motif.select_info['p' .. side .. '_palmenu_text_text'] or "",
+			x      = textOffset[1],
+			y      = textOffset[2],
 			scaleX = textScale[1],
 			scaleY = textScale[2],
-			r =      textFontInfo[4],
-			g =      textFontInfo[5],
-			b =      textFontInfo[6],
+			r      = textFontInfo[4],
+			g      = textFontInfo[5],
+			b      = textFontInfo[6],
 			height = textFontInfo[7],
-			xshear = textXshear,
-			angle  = textAngle,
-		})
-		palleteText:draw()
+			xshear = getInfo('palmenu_text_xshear'),
+			angle  = getInfo('palmenu_text_angle'),
+		}):draw()
 	end
+end
+
+function start.f_randomPal(charRef)
+    local charData = start.f_getCharData(charRef)
+    local pals = charData and charData.pal
+    if type(pals) ~= "table" or #pals == 0 then
+        return 1
+    end
+    return math.random(1, #pals)
+end
+
+local function resolvePalConflict(side, charRef, pal)
+    local charData = start.f_getCharData(charRef)
+    if not charData or not charData.pal then
+        return pal
+    end
+    local total = #charData.pal
+    local usedPals = {}
+
+    for s = 1, 2 do
+        for _, sel in ipairs(start.p[s].t_selected) do
+            if sel.ref == charRef and sel.pal then
+                usedPals[sel.pal] = true
+            end
+        end
+    end
+	while usedPals[pal] do
+		pal = (pal % total) + 1
+	end
+    return pal
 end
 
 --;===========================================================
@@ -2974,28 +3008,6 @@ function start.f_selectMenu(side, cmd, player, member, selectState)
 					if start.p[side].t_selTemp[member].pal == nil or start.p[side].t_selTemp[member].pal == 0 then
 						start.p[side].t_selTemp[member].pal = 1
 					end
-					if start.f_getCharData(start.p[side].t_selTemp[member].ref).pal ~= nil then
-						if motif.select_info['paletteselect'] == 2 then
-							for c, v in ipairs(start.f_getCharData(start.p[side].t_selTemp[member].ref).pal_keymap) do
-								if start.p[side].t_selTemp[member].pal == c then
-									start.p[side].t_selTemp[member].pal = v
-									break
-								end
-							end
-						elseif motif.select_info['paletteselect'] > 2 then
-							start.p[side].t_selTemp[member].pal = 1
-						end
-						validPalette = false
-						for _, v in ipairs(start.f_getCharData(start.p[side].t_selTemp[member].ref).pal) do
-							if start.p[side].t_selTemp[member].pal == v then
-								validPalette = true
-								break
-							end
-						end
-					end
-					if not validPalette then
-						start.p[side].t_selTemp[member].pal = 1
-					end
 					-- if select anim differs from done anim and coop or pX.face.num allows to display more than 1 portrait or it's the last team member
 					local done_anim = motif.select_info['p' .. side .. '_member' .. member .. '_face_done_anim'] or motif.select_info['p' .. side .. '_face_done_anim']
 					if done_anim ~= -1 and start.p[side].t_selTemp[member].anim ~= done_anim and (main.coop or motif.select_info['p' .. side .. '_face_num'] > 1 or main.f_tableLength(start.p[side].t_selected) + 1 == start.p[side].numChars) then
@@ -3006,15 +3018,38 @@ function start.f_selectMenu(side, cmd, player, member, selectState)
 						end
 					end
 					start.p[side].t_selTemp[member].ref = start.c[player].selRef
+					local charRef = start.p[side].t_selTemp[member].ref
+					local pal = start.p[side].t_selTemp[member].pal
+					local finalPal
+
+					if motif.select_info.paletteselect == 1 then
+						finalPal = 1
+					elseif motif.select_info.paletteselect == 2 then
+						finalPal = pal
+					elseif motif.select_info.paletteselect == 3 then
+						finalPal = start.f_keyPalMap(charRef, pal)
+					else
+						finalPal = start.f_keyPalMap(charRef, pal)
+					end
+
+					-- resolve visual palette conflict
+					finalPal = resolvePalConflict(side, charRef, finalPal)
+
+					if motif.select_info.paletteselect > 0 then
+						start.p[side].t_selTemp[member].pal = finalPal
+					end
+
 					if start.p[side].t_selTemp[member].anim_data ~= nil then
-						if (motif.select_info['p' .. side .. '_member' .. member .. '_face_applypal'] ~= nil and motif.select_info['p' .. side .. '_member' .. member .. '_face_applypal'] >= 1) or (motif.select_info['p' .. side .. '_face_applypal'] ~= nil and motif.select_info['p' .. side .. '_face_applypal'] >= 1)  then
-							start.p[side].t_selTemp[member].anim_data = start.loadPalettes(start.p[side].t_selTemp[member].anim_data, start.p[side].t_selTemp[member].ref, start.p[side].t_selTemp[member].pal)
+						local applyFlag = motif.select_info['p' .. side .. '_member' .. member .. '_face_applypal'] or motif.select_info['p' .. side .. '_face_applypal']
+						if applyFlag and applyFlag >= 1 then
+							start.p[side].t_selTemp[member].anim_data = start.loadPalettes(start.p[side].t_selTemp[member].anim_data, charRef, finalPal)
 							animUpdate(start.p[side].t_selTemp[member].anim_data)
 						end
 					end
 					if start.p[side].t_selTemp[member].face2_data ~= nil then
-						if (motif.select_info['p' .. side .. '_member' .. member .. '_face2_applypal'] ~= nil and motif.select_info['p' .. side .. '_member' .. member .. '_face2_applypal'] >= 1) or (motif.select_info['p' .. side .. '_face2_applypal'] ~= nil and motif.select_info['p' .. side .. '_face2_applypal'] >= 1)  then
-							start.p[side].t_selTemp[member].face2_data = start.loadPalettes(start.p[side].t_selTemp[member].face2_data, start.p[side].t_selTemp[member].ref, start.p[side].t_selTemp[member].pal)
+						local applyFlag = motif.select_info['p' .. side .. '_member' .. member .. '_face2_applypal'] or motif.select_info['p' .. side .. '_face2_applypal']
+						if applyFlag and applyFlag >= 1 then
+							start.p[side].t_selTemp[member].face2_data = start.loadPalettes(start.p[side].t_selTemp[member].face2_data, charRef, finalPal)
 							animUpdate(start.p[side].t_selTemp[member].face2_data)
 						end
 					end
@@ -3024,57 +3059,92 @@ function start.f_selectMenu(side, cmd, player, member, selectState)
 			end
 		--selection menu
 		elseif selectState == 1 then
-			if motif.select_info['paletteselect'] ~= nil and motif.select_info['paletteselect'] > 0 then
-				palleteCounter = 0
-				for _, v in ipairs(start.f_getCharData(start.p[side].t_selTemp[member].ref).pal) do
-					palleteCounter = palleteCounter + 1
-				end
-				if main.f_input({cmd}, main.f_extractKeys(motif.select_info['p' .. side .. '_palette_accept_key'])) then
-					sndPlay(motif.files.snd_data, motif.select_info.palette_done_snd[1], motif.select_info.palette_done_snd[2])
-					start.p[side].t_selTemp[member].pal = start.f_getCharData(start.p[side].t_selTemp[member].ref).pal[start.p[side].t_selTemp[member].pal]
-					for c, v in ipairs(start.f_getCharData(start.p[side].t_selTemp[member].ref).pal_keymap) do
-						if start.p[side].t_selTemp[member].pal == v then
-							start.p[side].t_selTemp[member].pal = c
-							break
-						end
+			if motif.select_info.paletteselect and motif.select_info.paletteselect > 0 then
+				local charRef = start.p[side].t_selTemp[member].ref
+				local charData = start.f_getCharData(charRef)
+				local totalPals = #charData.pal
+				local maxIndex = totalPals + 1
+				local pal = start.p[side].t_selTemp[member].pal
+
+				local function applyPalette(palIndex)
+					local sel = start.p[side].t_selTemp[member]
+					if sel.anim_data then
+						sel.anim_data = changeColorPalette(sel.anim_data, charData.pal[palIndex])
 					end
+					if sel.face2_data then
+						sel.face2_data = changeColorPalette(sel.face2_data, charData.pal[palIndex])
+					end
+				end
+
+				if main.f_input({cmd}, main.f_extractKeys(motif.select_info['p' .. side .. '_palmenu_accept_key'])) then
+					if pal == maxIndex then
+						pal = start.c[player].randPalPreview or start.f_randomPal(charRef)
+					end
+
+					pal = resolvePalConflict(side, charRef, pal)
+					start.p[side].t_selTemp[member].pal = pal
+
+					applyPalette(pal)
 					selectState = 3
-				elseif main.f_input({cmd}, {motif.select_info['p' .. side .. '_palette_next_key']})then 
-					if start.p[side].t_selTemp[member].pal == palleteCounter then
-						start.p[side].t_selTemp[member].pal = 1
-					else
-						start.p[side].t_selTemp[member].pal = start.p[side].t_selTemp[member].pal + 1
+
+					sndPlay(motif.files.snd_data, motif.select_info.palmenu_done_snd[1], motif.select_info.palmenu_done_snd[2])
+				-- next palette
+				elseif main.f_input({cmd}, {motif.select_info['p' .. side .. '_palmenu_next_key']}) then
+					pal = (pal == maxIndex) and 1 or pal + 1
+					start.p[side].t_selTemp[member].pal = pal
+
+					if pal <= totalPals then
+						applyPalette(pal)
 					end
-					if palleteCounter > 1 and (motif.select_info.p1_face_anim >= 0 or motif.select_info.p1_face_anim ~= nil or (motif.select_info['p' .. side .. '_member' .. member .. '_face_anim'] ~= nil or motif.select_info['p' .. side .. '_member' .. member .. '_face_spr'] ~= nil)) then
-						start.p[side].t_selTemp[member].anim_data = changeColorPalette(start.p[side].t_selTemp[member].anim_data, start.f_getCharData(start.p[side].t_selTemp[member].ref).pal[start.p[side].t_selTemp[member].pal])
-						if start.p[side].t_selTemp[member].face2_data ~= nil then
-							start.p[side].t_selTemp[member].face2_data = changeColorPalette(start.p[side].t_selTemp[member].face2_data, start.f_getCharData(start.p[side].t_selTemp[member].ref).pal[start.p[side].t_selTemp[member].pal])
-						end
+
+					sndPlay(motif.files.snd_data, motif.select_info.palmenu_move_snd[1], motif.select_info.palmenu_move_snd[2])
+				-- previous palette
+				elseif main.f_input({cmd}, {motif.select_info['p' .. side .. '_palmenu_previous_key']}) then
+					pal = (pal == 1) and maxIndex or pal - 1
+					start.p[side].t_selTemp[member].pal = pal
+
+					if pal <= totalPals then
+						applyPalette(pal)
 					end
-					sndPlay(motif.files.snd_data, motif.select_info.palette_move_snd[1], motif.select_info.palette_move_snd[2])
-				elseif main.f_input({cmd}, {motif.select_info['p' .. side .. '_palette_previous_key']})then 
-					if start.p[side].t_selTemp[member].pal == 1 then
-						start.p[side].t_selTemp[member].pal = palleteCounter
-					else
-						start.p[side].t_selTemp[member].pal = start.p[side].t_selTemp[member].pal - 1
+
+					sndPlay(motif.files.snd_data, motif.select_info.palmenu_move_snd[1], motif.select_info.palmenu_move_snd[2])
+				-- cancel
+				elseif main.f_input({cmd}, main.f_extractKeys(motif.select_info['p' .. side .. '_palmenu_cancel_key'])) then
+					local charRef = start.p[side].t_selTemp[member].ref
+					local a = start.f_animGet(charRef, side, member, motif.select_info, '_face', '', false)
+					if a then
+						start.p[side].t_selTemp[member].anim_data = a
 					end
-					if palleteCounter > 1 and (motif.select_info.p1_face_anim >= 0 or motif.select_info.p1_face_anim ~= nil or (motif.select_info['p' .. side .. '_member' .. member .. '_face_anim'] ~= nil or motif.select_info['p' .. side .. '_member' .. member .. '_face_spr'] ~= nil)) then
-						start.p[side].t_selTemp[member].anim_data = changeColorPalette(start.p[side].t_selTemp[member].anim_data, start.f_getCharData(start.p[side].t_selTemp[member].ref).pal[start.p[side].t_selTemp[member].pal])
-						if start.p[side].t_selTemp[member].face2_data ~= nil then
-							start.p[side].t_selTemp[member].face2_data = changeColorPalette(start.p[side].t_selTemp[member].face2_data, start.f_getCharData(start.p[side].t_selTemp[member].ref).pal[start.p[side].t_selTemp[member].pal])
-						end
-					end
-					sndPlay(motif.files.snd_data, motif.select_info.palette_move_snd[1], motif.select_info.palette_move_snd[2])
+					selectState = 0
+
+					sndPlay(motif.files.snd_data, motif.select_info.palmenu_cancel_snd[1], motif.select_info.palmenu_cancel_snd[2])
 				end
-				start.f_paletteNumberDraw(side, member)
+				-- random shortcut
+				if main.f_input({cmd}, main.f_extractKeys(motif.select_info['p' .. side .. '_palmenu_random_key'])) and pal ~= maxIndex then
+					start.p[side].t_selTemp[member].pal = maxIndex
+				end
+				-- random active
+				if pal == maxIndex then
+					if not start.c[player].randPalCnt or start.c[player].randPalCnt <= 0 then
+             			start.c[player].randPalCnt = motif.select_info.cell_random_switchtime
+                		start.c[player].randPalPreview = start.f_randomPal(charRef)
+
+						applyPalette(charData.pal[start.c[player].randPalPreview])
+						sndPlay(motif.files.snd_data, motif.select_info.palmenu_move_snd[1], motif.select_info.palmenu_move_snd[2])
+					else
+						start.c[player].randPalCnt = start.c[player].randPalCnt - 1
+					end
+				end
+				start.f_palMenuDraw(side, member)
 			else
 				selectState = 3
 			end
 		--confirm selection
 		elseif selectState == 3 then
+			local finalPal = (motif.select_info.paletteselect == 1) and start.p[side].t_selTemp[member].pal or start.f_selectPal(start.c[player].selRef, start.p[side].t_selTemp[member].pal)
 			start.p[side].t_selected[member] = {
 				ref = start.c[player].selRef,
-				pal = start.f_selectPal(start.c[player].selRef, start.p[side].t_selTemp[member].pal),
+				pal = finalPal,
 				pn = start.f_getPlayerNo(side, member),
 				cursor = {start.c[player].selX, start.c[player].selY},
 				ratioLevel = start.f_getRatio(side),
@@ -4808,8 +4878,8 @@ function start.f_dialogue()
 			motif.dialogue_info['p' .. side .. '_face_facing'],
 			motif.dialogue_info['p' .. side .. '_face_window'][1],
 			motif.dialogue_info['p' .. side .. '_face_window'][2],
-			motif.dialogue_info['p' .. side .. '_face_window'][3] * gameOption('Video.GameWidth') / main.SP_Localcoord[1],
-			motif.dialogue_info['p' .. side .. '_face_window'][4] * gameOption('Video.GameHeight') / main.SP_Localcoord[2]
+			motif.dialogue_info['p' .. side .. '_face_window'][3] * gameOption('Video.GameWidth') / motifLocalcoord(0),
+			motif.dialogue_info['p' .. side .. '_face_window'][4] * gameOption('Video.GameHeight') / motifLocalcoord(1)
 		)
 		--draw names
 		start['txt_dialogue_p' .. side .. '_name']:draw()

--- a/src/char.go
+++ b/src/char.go
@@ -2447,10 +2447,10 @@ const (
 )
 
 type PalInfo struct {
-    KeyMap     int32
-    Filename   string
-    Exists     bool
-    Selectable bool
+    keyMap     int32
+    filename   string
+    exists     bool
+    selectable bool
 }
 
 type CharGlobalInfo struct {
@@ -2465,7 +2465,7 @@ type CharGlobalInfo struct {
 	palettedata             *Palette
 	snd                     *Snd
 	anim                    AnimationTable
-	PalInfo 				map[int]PalInfo
+	palInfo 				map[int]PalInfo
 	palno                   int32
 	ikemenver               [3]uint16
 	ikemenverF              float32
@@ -2981,9 +2981,9 @@ func (c *Char) load(def string) error {
 	gi.anim = NewAnimationTable()
 	gi.fnt = [10]*Fnt{}
 	for i := 0; i < sys.cfg.Config.PaletteMax; i++ {
-		pal := gi.PalInfo[i]
-		pal.KeyMap = int32(i)
-		gi.PalInfo[i] = pal
+		pal := gi.palInfo[i]
+		pal.keyMap = int32(i)
+		gi.palInfo[i] = pal
 	}
 	c.mapDefault = make(map[string]float32)
 	// Helper to resolve paths relative to the .def file's logical location
@@ -3058,9 +3058,9 @@ func (c *Char) load(def string) error {
 				anim = decodeShiftJIS(is["anim"])
 				sound = decodeShiftJIS(is["sound"])
 				for i := 0; i < sys.cfg.Config.PaletteMax; i++ {
-					pal := gi.PalInfo[i]
-					pal.Filename = decodeShiftJIS(is[fmt.Sprintf("pal%v", i+1)])
-					gi.PalInfo[i] = pal
+					pal := gi.palInfo[i]
+					pal.filename = decodeShiftJIS(is[fmt.Sprintf("pal%v", i+1)])
+					gi.palInfo[i] = pal
 				}
 				for i := range fnt {
 					fnt[i][0] = is[fmt.Sprintf("font%v", i)]
@@ -3078,9 +3078,9 @@ func (c *Char) load(def string) error {
 						if i32 < 1 || int(i32) > sys.cfg.Config.PaletteMax {
 							i32 = 1
 						}
-						pal := gi.PalInfo[i]
-						pal.KeyMap = i32 - 1
-						gi.PalInfo[i] = pal
+						pal := gi.palInfo[i]
+						pal.keyMap = i32 - 1
+						gi.palInfo[i] = pal
 					}
 				}
 			}
@@ -3123,9 +3123,9 @@ func (c *Char) load(def string) error {
 				anim = decodeShiftJIS(is["anim"])
 				sound = decodeShiftJIS(is["sound"])
 				for i := 0; i < sys.cfg.Config.PaletteMax; i++ {
-					pal := gi.PalInfo[i]
-					pal.Filename = decodeShiftJIS(is[fmt.Sprintf("pal%v", i+1)])
-					gi.PalInfo[i] = pal
+					pal := gi.palInfo[i]
+					pal.filename = decodeShiftJIS(is[fmt.Sprintf("pal%v", i+1)])
+					gi.palInfo[i] = pal
 				}
 				for i := range fnt {
 					fnt[i][0] = is[fmt.Sprintf("font%v", i)]
@@ -3144,9 +3144,9 @@ func (c *Char) load(def string) error {
 						if i32 < 1 || int(i32) > sys.cfg.Config.PaletteMax {
 							i32 = 1
 						}
-						pal := gi.PalInfo[i]
-						pal.KeyMap = i32 - 1
-						gi.PalInfo[i] = pal
+						pal := gi.palInfo[i]
+						pal.keyMap = i32 - 1
+						gi.palInfo[i] = pal
 					}
 				}
 			}
@@ -3663,16 +3663,13 @@ func (c *Char) loadPalette() {
 			var f io.ReadSeekCloser
 			var err error
 
-			pal := gi.PalInfo[i]
-			if pal.Filename == "" {
-				pal.Filename = fmt.Sprintf("pal%v.act", i+1)
-			}
+			pal := gi.palInfo[i]
 
-			if LoadFile(&pal.Filename, []string{gi.def, "", sys.motifDir, "data/"}, func(file string) error {
+			if LoadFile(&pal.filename, []string{gi.def, "", sys.motifDir, "data/"}, func(file string) error {
 				f, err = OpenFile(file)
 				return err
 			}) == nil {
-				gi.PalInfo[i] = pal
+				gi.palInfo[i] = pal
 
 				for i := 255; i >= 0; i-- {
 					var rgb [3]byte
@@ -3690,8 +3687,8 @@ func (c *Char) loadPalette() {
 					if tmp == 0 && i > 0 {
 						copy(gi.palettedata.palList.Get(0), pl)
 					}
-					pal.Exists = true
-					gi.PalInfo[i] = pal
+					pal.exists = true
+					gi.palInfo[i] = pal
 					// Palette Texture Generation
 					if len(gi.palettedata.palList.PalTex) <= i {
 						newLen := i + 1
@@ -3706,8 +3703,8 @@ func (c *Char) loadPalette() {
 				chk(f.Close())
 			}
 			if err != nil {
-				pal.Exists = false
-				gi.PalInfo[i] = pal
+				pal.exists = false
+				gi.palInfo[i] = pal
 				if i > 0 {
 					delete(gi.palettedata.palList.PalTable, [...]int16{1, int16(i + 1)})
 				}
@@ -3718,9 +3715,9 @@ func (c *Char) loadPalette() {
 		}
 	} else {
 		for i := 0; i < maxPal; i++ {
-			pal := gi.PalInfo[i]
-			_, pal.Exists = gi.palettedata.palList.PalTable[[...]int16{1, int16(i + 1)}]
-			gi.PalInfo[i] = pal
+			pal := gi.palInfo[i]
+			_, pal.exists = gi.palettedata.palList.PalTable[[...]int16{1, int16(i + 1)}]
+			gi.palInfo[i] = pal
 		}
 		if gi.sff.header.NumberOfPalettes > 0 {
 			numPals := int(gi.sff.header.NumberOfPalettes)
@@ -3737,23 +3734,23 @@ func (c *Char) loadPalette() {
 	}
 
 	// Resets selectable
-	for k, pal := range gi.PalInfo {
-		pal.Selectable = false
-		gi.PalInfo[k] = pal
+	for k, pal := range gi.palInfo {
+		pal.selectable = false
+		gi.palInfo[k] = pal
 	}
 
 	// Fill selectable based on keymap
 	for i := 0; i < maxPal; i++ {
-		pal := gi.PalInfo[i]
-		startj := int(pal.KeyMap)
-		if p, ok := gi.PalInfo[startj]; !ok || !p.Exists {
+		pal := gi.palInfo[i]
+		startj := int(pal.keyMap)
+		if p, ok := gi.palInfo[startj]; !ok || !p.exists {
 			continue
 		}
 		j := startj
 		for {
-			if p, ok := gi.PalInfo[j]; ok && p.Exists {
-				p.Selectable = true
-				gi.PalInfo[j] = p
+			if p, ok := gi.palInfo[j]; ok && p.exists {
+				p.selectable = true
+				gi.palInfo[j] = p
 				break
 			}
 			j++
@@ -3770,10 +3767,10 @@ func (c *Char) loadPalette() {
 	if palIdx < 0 {
 		palIdx = 0
 	}
-	if p, ok := gi.PalInfo[int(palIdx)]; !ok || !p.Exists {
+	if p, ok := gi.palInfo[int(palIdx)]; !ok || !p.exists {
 		found := false
 		for i := 0; i < maxPal; i++ {
-			if p, ok := gi.PalInfo[i]; ok && p.Exists {
+			if p, ok := gi.palInfo[i]; ok && p.exists {
 				gi.palno = int32(i + 1)
 				found = true
 				break
@@ -3781,7 +3778,7 @@ func (c *Char) loadPalette() {
 		}
 		if !found {
 			gi.palno = 1
-			gi.PalInfo[0] = PalInfo{Exists: true, Selectable: true}
+			gi.palInfo[0] = PalInfo{exists: true, selectable: true}
 		}
 	}
 

--- a/src/char.go
+++ b/src/char.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 )
 
-const MaxPalNo = 12
 const MaxQuotes = 100
 
 type SystemCharFlag uint32
@@ -2447,6 +2446,13 @@ const (
 	PC_Cancel
 )
 
+type PalInfo struct {
+    KeyMap     int32
+    Filename   string
+    Exists     bool
+    Selectable bool
+}
+
 type CharGlobalInfo struct {
 	def                     string
 	nameLow                 string
@@ -2455,15 +2461,12 @@ type CharGlobalInfo struct {
 	author                  string
 	authorLow               string
 	lifebarname             string
-	palkeymap               [MaxPalNo]int32
 	sff                     *Sff
 	palettedata             *Palette
 	snd                     *Snd
 	anim                    AnimationTable
+	PalInfo 				map[int]PalInfo
 	palno                   int32
-	pal                     [MaxPalNo]string
-	palExist                [MaxPalNo]bool
-	palSelectable           [MaxPalNo]bool
 	ikemenver               [3]uint16
 	ikemenverF              float32
 	mugenver                [2]uint16
@@ -2977,8 +2980,10 @@ func (c *Char) load(def string) error {
 	gi.sff, gi.palettedata, gi.snd, gi.quotes = nil, nil, nil, [MaxQuotes]string{}
 	gi.anim = NewAnimationTable()
 	gi.fnt = [10]*Fnt{}
-	for i := range gi.palkeymap {
-		gi.palkeymap[i] = int32(i)
+	for i := 0; i < sys.cfg.Config.PaletteMax; i++ {
+		pal := gi.PalInfo[i]
+		pal.KeyMap = int32(i)
+		gi.PalInfo[i] = pal
 	}
 	c.mapDefault = make(map[string]float32)
 	// Helper to resolve paths relative to the .def file's logical location
@@ -3052,8 +3057,10 @@ func (c *Char) load(def string) error {
 				sprite = decodeShiftJIS(is["sprite"])
 				anim = decodeShiftJIS(is["anim"])
 				sound = decodeShiftJIS(is["sound"])
-				for i := range gi.pal {
-					gi.pal[i] = decodeShiftJIS(is[fmt.Sprintf("pal%v", i+1)])
+				for i := 0; i < sys.cfg.Config.PaletteMax; i++ {
+					pal := gi.PalInfo[i]
+					pal.Filename = decodeShiftJIS(is[fmt.Sprintf("pal%v", i+1)])
+					gi.PalInfo[i] = pal
 				}
 				for i := range fnt {
 					fnt[i][0] = is[fmt.Sprintf("font%v", i)]
@@ -3068,10 +3075,12 @@ func (c *Char) load(def string) error {
 					"a2", "b2", "c2", "x2", "y2", "z2"} {
 					var i32 int32
 					if is.ReadI32(v, &i32) {
-						if i32 < 1 || int(i32) > len(gi.palkeymap) {
+						if i32 < 1 || int(i32) > sys.cfg.Config.PaletteMax {
 							i32 = 1
 						}
-						gi.palkeymap[i] = i32 - 1
+						pal := gi.PalInfo[i]
+						pal.KeyMap = i32 - 1
+						gi.PalInfo[i] = pal
 					}
 				}
 			}
@@ -3113,8 +3122,10 @@ func (c *Char) load(def string) error {
 				sprite = decodeShiftJIS(is["sprite"])
 				anim = decodeShiftJIS(is["anim"])
 				sound = decodeShiftJIS(is["sound"])
-				for i := range gi.pal {
-					gi.pal[i] = decodeShiftJIS(is[fmt.Sprintf("pal%v", i+1)])
+				for i := 0; i < sys.cfg.Config.PaletteMax; i++ {
+					pal := gi.PalInfo[i]
+					pal.Filename = decodeShiftJIS(is[fmt.Sprintf("pal%v", i+1)])
+					gi.PalInfo[i] = pal
 				}
 				for i := range fnt {
 					fnt[i][0] = is[fmt.Sprintf("font%v", i)]
@@ -3130,10 +3141,12 @@ func (c *Char) load(def string) error {
 					"a2", "b2", "c2", "x2", "y2", "z2"} {
 					var i32 int32
 					if is.ReadI32(v, &i32) {
-						if i32 < 1 || int(i32) > len(gi.palkeymap) {
+						if i32 < 1 || int(i32) > sys.cfg.Config.PaletteMax {
 							i32 = 1
 						}
-						gi.palkeymap[i] = i32 - 1
+						pal := gi.PalInfo[i]
+						pal.KeyMap = i32 - 1
+						gi.PalInfo[i] = pal
 					}
 				}
 			}
@@ -3640,17 +3653,27 @@ func (c *Char) load(def string) error {
 
 func (c *Char) loadPalette() {
 	gi := c.gi()
+	maxPal := sys.cfg.Config.PaletteMax
+
 	if gi.sff.header.Ver0 == 1 {
 		gi.palettedata.palList.ResetRemap()
 		tmp := 0
-		for i := 0; i < MaxPalNo; i++ {
+		for i := 0; i < maxPal; i++ {
 			pl := gi.palettedata.palList.Get(i)
 			var f io.ReadSeekCloser
 			var err error
-			if LoadFile(&gi.pal[i], []string{gi.def, "", sys.motifDir, "data/"}, func(file string) error {
+
+			pal := gi.PalInfo[i]
+			if pal.Filename == "" {
+				pal.Filename = fmt.Sprintf("pal%v.act", i+1)
+			}
+
+			if LoadFile(&pal.Filename, []string{gi.def, "", sys.motifDir, "data/"}, func(file string) error {
 				f, err = OpenFile(file)
 				return err
 			}) == nil {
+				gi.PalInfo[i] = pal
+
 				for i := 255; i >= 0; i-- {
 					var rgb [3]byte
 					if _, err = io.ReadFull(f, rgb[:]); err != nil {
@@ -3667,8 +3690,15 @@ func (c *Char) loadPalette() {
 					if tmp == 0 && i > 0 {
 						copy(gi.palettedata.palList.Get(0), pl)
 					}
-					gi.palExist[i] = true
+					pal.Exists = true
+					gi.PalInfo[i] = pal
 					// Palette Texture Generation
+					if len(gi.palettedata.palList.PalTex) <= i {
+						newLen := i + 1
+						newSlice := make([]Texture, newLen)
+						copy(newSlice, gi.palettedata.palList.PalTex)
+						gi.palettedata.palList.PalTex = newSlice
+					}
 					gi.palettedata.palList.PalTex[i] = PaletteToTexture(pl)
 					tmp = i + 1
 				}
@@ -3676,7 +3706,8 @@ func (c *Char) loadPalette() {
 				chk(f.Close())
 			}
 			if err != nil {
-				gi.palExist[i] = false
+				pal.Exists = false
+				gi.PalInfo[i] = pal
 				if i > 0 {
 					delete(gi.palettedata.palList.PalTable, [...]int16{1, int16(i + 1)})
 				}
@@ -3686,9 +3717,10 @@ func (c *Char) loadPalette() {
 			delete(gi.palettedata.palList.PalTable, [...]int16{1, 1})
 		}
 	} else {
-		for i := 0; i < MaxPalNo; i++ {
-			_, gi.palExist[i] =
-				gi.palettedata.palList.PalTable[[...]int16{1, int16(i + 1)}]
+		for i := 0; i < maxPal; i++ {
+			pal := gi.PalInfo[i]
+			_, pal.Exists = gi.palettedata.palList.PalTable[[...]int16{1, int16(i + 1)}]
+			gi.PalInfo[i] = pal
 		}
 		if gi.sff.header.NumberOfPalettes > 0 {
 			numPals := int(gi.sff.header.NumberOfPalettes)
@@ -3703,22 +3735,29 @@ func (c *Char) loadPalette() {
 			}
 		}
 	}
-	for i := range gi.palSelectable {
-		gi.palSelectable[i] = false
+
+	// Resets selectable
+	for k, pal := range gi.PalInfo {
+		pal.Selectable = false
+		gi.PalInfo[k] = pal
 	}
-	for i := 0; i < MaxPalNo; i++ {
-		startj := gi.palkeymap[i]
-		if !gi.palExist[startj] {
-			startj %= 6
+
+	// Fill selectable based on keymap
+	for i := 0; i < maxPal; i++ {
+		pal := gi.PalInfo[i]
+		startj := int(pal.KeyMap)
+		if p, ok := gi.PalInfo[startj]; !ok || !p.Exists {
+			continue
 		}
 		j := startj
 		for {
-			if gi.palExist[j] {
-				gi.palSelectable[j] = true
+			if p, ok := gi.PalInfo[j]; ok && p.Exists {
+				p.Selectable = true
+				gi.PalInfo[j] = p
 				break
 			}
 			j++
-			if j >= MaxPalNo {
+			if j >= maxPal {
 				j = 0
 			}
 			if j == startj {
@@ -3726,11 +3765,15 @@ func (c *Char) loadPalette() {
 			}
 		}
 	}
+	// Validate palno
 	palIdx := gi.palno - 1
-	if palIdx < 0 || palIdx >= int32(len(gi.palExist)) || !gi.palExist[palIdx] {
+	if palIdx < 0 {
+		palIdx = 0
+	}
+	if p, ok := gi.PalInfo[int(palIdx)]; !ok || !p.Exists {
 		found := false
-		for i := 0; i < len(gi.palExist); i++ {
-			if gi.palExist[i] {
+		for i := 0; i < maxPal; i++ {
+			if p, ok := gi.PalInfo[i]; ok && p.Exists {
 				gi.palno = int32(i + 1)
 				found = true
 				break
@@ -3738,8 +3781,7 @@ func (c *Char) loadPalette() {
 		}
 		if !found {
 			gi.palno = 1
-			gi.palExist[0] = true
-			gi.palSelectable[0] = true
+			gi.PalInfo[0] = PalInfo{Exists: true, Selectable: true}
 		}
 	}
 
@@ -6318,7 +6360,7 @@ func (c *Char) spawnProjectile() *Projectile {
 	}
 
 	// If no inactive projectile was found, append a new one within the max limit
-	if p == nil && len(*playerProjs) < sys.cfg.Config.PlayerProjectileMax {
+	if p == nil && len(*playerProjs) < sys.cfg.Config.ProjectileMax {
 		newP := newProjectile()
 		*playerProjs = append(*playerProjs, newP)
 		p = newP

--- a/src/config.go
+++ b/src/config.go
@@ -128,7 +128,8 @@ type Config struct {
 		AfterImageMax       int32    `ini:"AfterImageMax"`
 		ExplodMax           int      `ini:"ExplodMax"`
 		HelperMax           int32    `ini:"HelperMax"`
-		PlayerProjectileMax int      `ini:"PlayerProjectileMax"`
+		ProjectileMax 		int      `ini:"ProjectileMax"`
+		PaletteMax          int      `ini:"PaletteMax"`
 		ZoomActive          bool     `ini:"ZoomActive"`
 		EscOpensMenu        bool     `ini:"EscOpensMenu"`
 		FirstRun            bool     `ini:"FirstRun"`

--- a/src/image.go
+++ b/src/image.go
@@ -1531,7 +1531,7 @@ func loadCharPalettes(sff *Sff, filename string, ref int) error {
 			}
 		}
 	} else {
-		var U *os.File
+		var U io.ReadSeekCloser
 		x := 0
 		c := sys.sel.charlist[ref]
 		pathname := ""
@@ -1542,7 +1542,7 @@ func loadCharPalettes(sff *Sff, filename string, ref int) error {
 		x = 0
 		for x < len(c.pal_files) {
 			replaceCondition := true
-			U, err = os.Open(pathname + c.pal_files[x])
+			U, err = OpenFile(pathname + c.pal_files[x])
 			if err != nil {
 				fmt.Println("Failed to open " + c.pal_files[x])
 				replaceCondition = false

--- a/src/image.go
+++ b/src/image.go
@@ -1268,7 +1268,7 @@ type Palette struct {
 func newSff() (s *Sff) {
 	s = &Sff{sprites: make(map[[2]int16]*Sprite)}
 	s.palList.init()
-	for i := int16(1); i <= int16(MaxPalNo); i++ {
+	for i := int16(1); i <= int16(sys.cfg.Config.PaletteMax); i++ {
 		s.palList.PalTable[[...]int16{1, i}], _ = s.palList.NewPal()
 	}
 	return
@@ -1277,7 +1277,7 @@ func newSff() (s *Sff) {
 func newPaldata() (p *Palette) {
 	p = &Palette{}
 	p.palList.init()
-	for i := int16(1); i <= int16(MaxPalNo); i++ {
+	for i := int16(1); i <= int16(sys.cfg.Config.PaletteMax); i++ {
 		p.palList.PalTable[[...]int16{1, i}], _ = p.palList.NewPal()
 	}
 	return
@@ -1369,13 +1369,13 @@ func loadSff(filename string, char bool) (*Sff, error) {
 			s.palList.SetSource(i, pal)
 			s.palList.PalTable[[...]int16{gn_[0], gn_[1]}] = idx
 			s.palList.numcols[[...]int16{gn_[0], gn_[1]}] = int(gn_[2])
-			if i <= MaxPalNo &&
+			if i <= sys.cfg.Config.PaletteMax &&
 				s.palList.PalTable[[...]int16{1, int16(i + 1)}] == s.palList.PalTable[[...]int16{gn_[0], gn_[1]}] &&
 				gn_[0] != 1 && gn_[1] != int16(i+1) {
 				s.palList.PalTable[[...]int16{1, int16(i + 1)}] = -1
 			}
-			if i <= MaxPalNo && i+1 == int(s.header.NumberOfPalettes) {
-				for j := i + 1; j < MaxPalNo; j++ {
+			if i <= sys.cfg.Config.PaletteMax && i+1 == int(s.header.NumberOfPalettes) {
+				for j := i + 1; j < sys.cfg.Config.PaletteMax; j++ {
 					delete(s.palList.PalTable, [...]int16{1, int16(j + 1)}) // Remove extra palette
 				}
 			}
@@ -1518,13 +1518,13 @@ func loadCharPalettes(sff *Sff, filename string, ref int) error {
 				sff.palList.SetSource(int(gn_[1])-1, pal)
 				sff.palList.PalTable[[...]int16{gn_[0], gn_[1]}] = int(gn_[1])
 				sff.palList.numcols[[...]int16{gn_[0], gn_[1]}] = int(gn_[2])
-				if i <= MaxPalNo &&
+				if i <= sys.cfg.Config.PaletteMax &&
 					sff.palList.PalTable[[...]int16{1, int16(i + 1)}] == sff.palList.PalTable[[...]int16{gn_[0], gn_[1]}] &&
 					gn_[0] != 1 && gn_[1] != int16(i+1) {
 					sff.palList.PalTable[[...]int16{1, int16(i + 1)}] = -1
 				}
-				if i <= MaxPalNo && i+1 == int(h.NumberOfPalettes) {
-					for j := i + 1; j < MaxPalNo; j++ {
+				if i <= sys.cfg.Config.PaletteMax && i+1 == int(h.NumberOfPalettes) {
+					for j := i + 1; j < sys.cfg.Config.PaletteMax; j++ {
 						delete(sff.palList.PalTable, [...]int16{1, int16(j + 1)}) // Remove extra palette
 					}
 				}
@@ -1787,21 +1787,20 @@ func preloadSff(filename string, char bool, preloadSpr map[[2]int16]bool) (*Sff,
 	var preSelPal []int32
 	var selPal []int32
 	if h.Ver0 != 1 && char {
-		//for i := 0; i < MaxPalNo; i++ {
 		for i := 0; i < int(h.NumberOfPalettes); i++ {
 			f.Seek(int64(h.FirstPaletteHeaderOffset)+int64(i*16), 0)
 			var gn_ [3]int16
 			if err := read(gn_[:]); err != nil {
 				return nil, nil, err
 			}
-			if gn_[0] == 1 && gn_[1] >= 1 && gn_[1] <= MaxPalNo {
+			if gn_[0] == 1 && gn_[1] >= 1 && gn_[1] <= int16(sys.cfg.Config.PaletteMax) {
 				preSelPal = append(preSelPal, int32(gn_[1]))
 			}
-			if len(preSelPal) >= MaxPalNo {
+			if len(preSelPal) >= sys.cfg.Config.PaletteMax {
 				break
 			}
 		}
-		for i := 0; i < MaxPalNo+1; i++ {
+		for i := 0; i <= sys.cfg.Config.PaletteMax; i++ {
 			for k := 0; k < len(preSelPal); k++ {
 				if preSelPal[k] == int32(i) {
 					selPal = append(selPal, int32(i))

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -127,7 +127,9 @@ ExplodMax           = 512
 HelperMax           = 56
 ; Maximum number of projectiles allowed per player.
 ; Set to a lower number to save memory (minimum 5).
-PlayerProjectileMax = 256
+ProjectileMax       = 256
+; Maximum number of palettes allowed per player.
+PaletteMax          = 100
 ; Zoom toggle (0 disables zoom for stages coded to have it).
 ZoomActive          = 1
 ; Toggles if Esc key should open Pause menu.

--- a/src/script.go
+++ b/src/script.go
@@ -2343,7 +2343,7 @@ func systemScriptInit(l *lua.LState) {
 			l.RaiseError("%v\nInvalid team side: %v\n", sys.sel.GetChar(cn).def, tn)
 		}
 		pl := int(numArg(l, 3))
-		if pl < 1 || pl > 12 {
+		if pl < 1 || pl > sys.cfg.Config.PaletteMax {
 			l.RaiseError("%v\nInvalid palette: %v\n", sys.sel.GetChar(cn).def, pl)
 		}
 		var ret int

--- a/src/system.go
+++ b/src/system.go
@@ -346,7 +346,7 @@ func isRunningInsideAppBundle(exePath string) bool {
 func (s *System) init(w, h int32) *lua.LState {
 	s.setWindowSize(w, h)
 	for i := range sys.cgi {
-		sys.cgi[i].PalInfo = make(map[int]PalInfo)
+		sys.cgi[i].palInfo = make(map[int]PalInfo)
 	}
 	var err error
 	// Create a system window.
@@ -2978,7 +2978,7 @@ func (wm wincntMap) getItem(def string) []int32 {
 func (wm wincntMap) setItem(pn int, item []int32) {
 	var ave, palcnt int32 = 0, 0
 	for i, v := range item {
-		if pal, ok := sys.cgi[pn].PalInfo[i]; ok && pal.Selectable {
+		if pal, ok := sys.cgi[pn].palInfo[i]; ok && pal.selectable {
 			ave += v
 			palcnt++
 		}
@@ -2987,7 +2987,7 @@ func (wm wincntMap) setItem(pn int, item []int32) {
 		ave /= palcnt
 	}
 	for i := range item {
-		if pal, ok := sys.cgi[pn].PalInfo[i]; !ok || !pal.Selectable {
+		if pal, ok := sys.cgi[pn].palInfo[i]; !ok || !pal.selectable {
 			item[i] = ave // Set non-selectable palettes to average value
 		}
 	}
@@ -3336,11 +3336,14 @@ func (s *Select) addChar(defLine string) {
 		case "palette ": // Note space
 			if keymap && len(subname) >= 6 && strings.ToLower(subname[:6]) == "keymap" {
 				keymap = false
-				for _, v := range [12]string{"a", "b", "c", "x", "y", "z",
+				sc.pal_keymap = make([]int32, 12)
+				for i, v := range [12]string{"a", "b", "c", "x", "y", "z",
 					"a2", "b2", "c2", "x2", "y2", "z2"} {
 					var i32 int32
 					if isec.ReadI32(v, &i32) {
-						sc.pal_keymap = append(sc.pal_keymap, i32)
+						sc.pal_keymap[i] = i32
+					} else {
+						sc.pal_keymap[i] = int32(i + 1) // default
 					}
 				}
 			}
@@ -3348,11 +3351,14 @@ func (s *Select) addChar(defLine string) {
 			if lanKeymap &&
 				len(subname) >= 6 && strings.ToLower(subname[:6]) == "keymap" {
 				keymap = false
-				for _, v := range [12]string{"a", "b", "c", "x", "y", "z",
+				sc.pal_keymap = make([]int32, 12)
+				for i, v := range [12]string{"a", "b", "c", "x", "y", "z",
 					"a2", "b2", "c2", "x2", "y2", "z2"} {
 					var i32 int32
 					if isec.ReadI32(v, &i32) {
-						sc.pal_keymap = append(sc.pal_keymap, i32)
+						sc.pal_keymap[i] = i32
+					} else {
+						sc.pal_keymap[i] = int32(i + 1)
 					}
 				}
 			}

--- a/src/system.go
+++ b/src/system.go
@@ -345,6 +345,9 @@ func isRunningInsideAppBundle(exePath string) bool {
 // Initialize stuff, this is called after the config int at main.go
 func (s *System) init(w, h int32) *lua.LState {
 	s.setWindowSize(w, h)
+	for i := range sys.cgi {
+		sys.cgi[i].PalInfo = make(map[int]PalInfo)
+	}
 	var err error
 	// Create a system window.
 	s.window, err = s.newWindow(int(s.scrrect[2]), int(s.scrrect[3]))
@@ -2900,8 +2903,8 @@ func (wm *wincntMap) init() {
 			tmp := strings.Split(l, ",")
 			if len(tmp) >= 2 {
 				item := toint(strings.Split(strings.TrimSpace(tmp[1]), " ")) // Get win counts per palette
-				if len(item) < MaxPalNo {
-					item = append(item, make([]int32, MaxPalNo-len(item))...) // Ensure item has MaxPalNo elements
+				if len(item) < sys.cfg.Config.PaletteMax {
+					item = append(item, make([]int32, sys.cfg.Config.PaletteMax-len(item))...) // Ensure item has sys.cfg.Config.PaletteMax elements
 				}
 				(*wm)[tmp[0]] = item // Map character definition to win counts
 			}
@@ -2962,11 +2965,11 @@ func (wm *wincntMap) update() {
 	}
 }
 
-// Retrieves win counts for a character, ensuring the slice has MaxPalNo elements
+// Retrieves win counts for a character, ensuring the slice has sys.cfg.Config.PaletteMax elements
 func (wm wincntMap) getItem(def string) []int32 {
 	lv := wm[def]
-	if len(lv) < MaxPalNo {
-		lv = append(lv, make([]int32, MaxPalNo-len(lv))...)
+	if len(lv) < sys.cfg.Config.PaletteMax {
+		lv = append(lv, make([]int32, sys.cfg.Config.PaletteMax-len(lv))...)
 	}
 	return lv
 }
@@ -2975,7 +2978,7 @@ func (wm wincntMap) getItem(def string) []int32 {
 func (wm wincntMap) setItem(pn int, item []int32) {
 	var ave, palcnt int32 = 0, 0
 	for i, v := range item {
-		if sys.cgi[pn].palSelectable[i] {
+		if pal, ok := sys.cgi[pn].PalInfo[i]; ok && pal.Selectable {
 			ave += v
 			palcnt++
 		}
@@ -2984,7 +2987,7 @@ func (wm wincntMap) setItem(pn int, item []int32) {
 		ave /= palcnt
 	}
 	for i := range item {
-		if !sys.cgi[pn].palSelectable[i] {
+		if pal, ok := sys.cgi[pn].PalInfo[i]; !ok || !pal.Selectable {
 			item[i] = ave // Set non-selectable palettes to average value
 		}
 	}
@@ -3298,7 +3301,7 @@ func (s *Select) addChar(defLine string) {
 				sprite_orig = decodeShiftJIS(isec["sprite"])
 				anim_orig = decodeShiftJIS(isec["anim"])
 				sc.sound = decodeShiftJIS(isec["sound"])
-				for i := 1; i <= MaxPalNo; i++ {
+				for i := 1; i <= sys.cfg.Config.PaletteMax; i++ {
 					if isec[fmt.Sprintf("pal%v", i)] != "" {
 						sc.pal = append(sc.pal, int32(i))
 						sc.pal_files = append(sc.pal_files, isec[fmt.Sprintf("pal%v", i)])
@@ -3318,7 +3321,7 @@ func (s *Select) addChar(defLine string) {
 				sprite_orig = decodeShiftJIS(isec["sprite"])
 				anim_orig = decodeShiftJIS(isec["anim"])
 				sc.sound = decodeShiftJIS(isec["sound"])
-				for i := 1; i <= MaxPalNo; i++ {
+				for i := 1; i <= sys.cfg.Config.PaletteMax; i++ {
 					if isec[fmt.Sprintf("pal%v", i)] != "" {
 						sc.pal = append(sc.pal, int32(i))
 						sc.pal_files = append(sc.pal_files, isec[fmt.Sprintf("pal%v", i)])
@@ -3690,7 +3693,7 @@ func (s *Select) AddSelectedChar(tn, cn, pl int) bool {
 			return false
 		}
 		n = int(Rand(0, int32(len(s.charlist))-1))
-		pl = int(Rand(1, MaxPalNo))
+		pl = int(Rand(1, int32(sys.cfg.Config.PaletteMax)))
 	}
 	sys.loadMutex.Lock()
 	s.selected[tn] = append(s.selected[tn], [...]int{n, pl})


### PR DESCRIPTION
Feat:
- Removed the palette limit — it can now be configured using PaletteMax in config.ini or through the options menu.
- Added random palette select when reaching the end of the palette list, or it can be triggered by assigning a key using ``pX.palmenu.random.key``,the display text can be changed with ``pX.palmenu.random.text``
- Added palmenu background, defined as:
```ini
p1.palmenu.bg.pos = 0, 0
p1.palmenu.bg.anim = -1
p1.palmenu.bg.spr =
p1.palmenu.bg.offset = 0, 0
p1.palmenu.bg.facing = 1
p1.palmenu.bg.scale = 1.0, 1.0
```
- Added ``pX.palmenu.cancel.key`` and ``palmenu.cancel.sound``
- Added paletteselect modes, defined with paletteselect =:
```
1 - Start from palette 1
2 - Key pressed, ignore keymap
3 - Key pressed and keymap
```
Fix:
- fixes #2687  
- fixes #2275 
- ``tween.time = int`` changed to ``tween.factor = float``
- palette select parameters with the ``palette`` prefix renamed to ``palmenu``
- .act palette not loading from zipped characters
- Fixed color conflict on the select screen

Refactor:
- The entire palette menu and navigation logic were refactored, making it easier to extend the system and support external modules
- PlayerProjectileMax renamed to ProjectileMax

Review with https://github.com/ikemen-engine/Ikemen_GO-Elecbyte-Screenpack/pull/35