### PR TITLE
fix: intro skipping, reflections; feature: TextMax option; refactoring

### DIFF
--- a/data/system.zss
+++ b/data/system.zss
@@ -3,8 +3,31 @@
 #===============================================================================
 [StateDef -4]
 
-if PauseTime = 0 {
-	if time > 0 && (stateNo = 5030 || stateNo = 5035 || stateNo = 5040 || stateNo = 5050 || stateNo = 5071 || stateNo = 5200){
+# For backward compatibility, x and z-axis get hit acceleration must be handled here
+# TODO: These cases should maybe use the state number constants
+# TODO: These patches could be done by appending sctrl's to the common1.cns states
+if pauseTime = 0 {
+	if time > 0 && (stateNo = 5030 || stateNo = 5035 || stateNo = 5040 || stateNo = 5050 || stateNo = 5071 || stateNo = 5200) {
 		velAdd{x: getHitVar(xAccel); z: getHitVar(zAccel)}
 	}
 }
+
+[StateDef +1]
+
+# For backward compatibility, z-axis get hit velocity must be handled here
+if time = 0 && pauseTime = 0 {
+	if stateNo = 151 || stateNo = 153 || stateNo = 155 || stateNo = 5001 || stateNo = 5011 || stateNo = 5030 || stateNo = 5071 || stateNo = 5081 {
+		hitVelSet{z: 1}
+	}
+}
+
+# Ground dust effects
+if gameVar(pausetime) = 0 && gameVar(superpausetime) = 0 {
+	if (moveType = H && (stateType = S || stateType = C)) || stateNo = 52 {
+		if pos y = 0 && (Abs(pos x + cameraPos x - map(_iksys_dustposx)) >= 1 || Abs(pos z - map(_iksys_dustposz)) >= 1) {
+			makeDust{spacing: 3}
+		}
+	}
+}
+mapSet{map: "_iksys_dustposx"; value: pos x + cameraPos x}
+mapSet{map: "_iksys_dustposz"; value: pos z}

--- a/external/script/motif.lua
+++ b/external/script/motif.lua
@@ -1473,6 +1473,7 @@ local motif =
 		--menu_itemname_projectilemax = 'ProjectileMax', --Ikemen feature
 		--menu_itemname_explodmax = 'ExplodMax', --Ikemen feature
 		--menu_itemname_afterimagemax = 'AfterImageMax', --Ikemen feature
+		--menu_itemname_textmax = 'TextMax', --Ikemen feature
 		--menu_itemname_portchange = 'Port Change', --Ikemen feature
 		--menu_itemname_default = 'Default Values', --Ikemen feature
 		--menu_itemname_empty = '', --Ikemen feature
@@ -2389,6 +2390,7 @@ function motif.setBaseOptionInfo()
 	motif.option_info.menu_itemname_menuengine_explodmax = "ExplodMax"
 	motif.option_info.menu_itemname_menuengine_afterimagemax = "AfterImageMax"
 	motif.option_info.menu_itemname_menuengine_palettemax = "PaletteMax"
+	motif.option_info.menu_itemname_menuengine_textmax = "TextMax"
 	motif.option_info.menu_itemname_menuengine_empty = ""
 	motif.option_info.menu_itemname_menuengine_back = "Back"
 
@@ -2520,6 +2522,7 @@ function motif.setBaseOptionInfo()
 		"menuengine_explodmax",
 		"menuengine_afterimagemax",
 		"menuengine_palettemax",
+		"menuengine_textmax",
 		"menuengine_empty",
 		"menuengine_back",
 		"empty",

--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -182,6 +182,7 @@ options.t_itemname = {
 			modifyGameOption('Config.HelperMax', 56)
 			modifyGameOption('Config.ProjectileMax', 256)
 			modifyGameOption('Config.PaletteMax', 100)
+			modifyGameOption('Config.TextMax', 256)
 			--modifyGameOption('Config.ZoomActive', true)
 			--modifyGameOption('Config.EscOpensMenu', true)
 			--modifyGameOption('Config.BackgroundLoading', false) --TODO: not implemented
@@ -1265,6 +1266,21 @@ options.t_itemname = {
 		options.needReload = true
 		return true
 	end,
+	--TextMax
+	['textmax'] = function(t, item, cursorPosY, moveTxt)
+		if main.f_input(main.t_players, {'$F'}) then
+			sndPlay(motif.files.snd_data, motif.option_info.cursor_move_snd[1], motif.option_info.cursor_move_snd[2])
+			modifyGameOption('Config.TextMax', gameOption('Config.TextMax') + 1)
+			t.items[item].vardisplay = gameOption('Config.TextMax')
+			options.modified = true
+		elseif main.f_input(main.t_players, {'$B'}) and gameOption('Config.TextMax') > 1 then
+			sndPlay(motif.files.snd_data, motif.option_info.cursor_move_snd[1], motif.option_info.cursor_move_snd[2])
+			modifyGameOption('Config.TextMax', gameOption('Config.TextMax') - 1)
+			t.items[item].vardisplay = gameOption('Config.TextMax')
+			options.modified = true
+		end
+		return true
+	end,
 	--Save and Return
 	['savereturn'] = function(t, item, cursorPosY, moveTxt)
 		if main.f_input(main.t_players, {'$F', '$B', 'pal', 's'}) then
@@ -1562,6 +1578,9 @@ options.t_vardisplay = {
 	end,
 	['teampowershare'] = function()
 		return options.f_boolDisplay(gameOption('Options.Team.PowerShare'))
+	end,
+	['textmax'] = function()
+		return gameOption('Config.TextMax')
 	end,
 	['turnsrecoverybase'] = function()
 		return gameOption('Options.Turns.Recovery.Base') .. '%'

--- a/src/anim.go
+++ b/src/anim.go
@@ -736,7 +736,7 @@ func (a *Animation) drawSub1(angle, facing float32) (h, v, agl float32) {
 }
 
 func (a *Animation) Draw(window *[4]int32, x, y, xcs, ycs, xs, xbs, ys,
-	rxadd float32, rot Rotation, rcx float32, pfx *PalFX, old bool, facing float32,
+	rxadd float32, rot Rotation, rcx float32, pfx *PalFX, facing float32,
 	airOffsetFix [2]float32, projectionMode int32, fLength float32, color uint32, isReflection bool) {
 
 	// Skip blank animations
@@ -768,14 +768,13 @@ func (a *Animation) Draw(window *[4]int32, x, y, xcs, ycs, xs, xbs, ys,
 		if xs < 0 {
 			x *= -1
 			// This was deliberately replicating a Mugen bug, but we don't need that
-			// TODO: Maybe we don't need all these "old" arguments in the functions anymore
+			// https://github.com/ikemen-engine/Ikemen-GO/issues/1864
 			//if old {
 			//	x += xs
 			//}
 		}
 		if ys < 0 {
 			y *= -1
-			// This was deliberately replicating a Mugen bug, but we don't need that
 			//if old {
 			//	y += ys
 			//}
@@ -851,7 +850,7 @@ func (a *Animation) Draw(window *[4]int32, x, y, xcs, ycs, xs, xbs, ys,
 }
 
 func (a *Animation) ShadowDraw(window *[4]int32, x, y, xscl, yscl, vscl, rxadd float32, rot Rotation,
-	pfx *PalFX, old bool, color uint32, intensity int32, facing float32, airOffsetFix [2]float32, projectionMode int32, fLength float32) {
+	pfx *PalFX, color uint32, intensity int32, facing float32, airOffsetFix [2]float32, projectionMode int32, fLength float32) {
 
 	// Skip blank shadows
 	if a == nil || a.isBlank() {
@@ -1004,7 +1003,7 @@ func (at AnimationTable) get(no int32) *Animation {
 
 type SprData struct {
 	anim         *Animation
-	fx           *PalFX
+	pfx          *PalFX
 	pos          [2]float32
 	scl          [2]float32
 	trans        TransType
@@ -1013,7 +1012,6 @@ type SprData struct {
 	rot          Rotation
 	screen       bool
 	undarken     bool // Ignore SuperPause "darken"
-	oldVer       bool
 	facing       float32
 	airOffsetFix [2]float32 // posLocalscl replacement
 	projection   int32
@@ -1144,7 +1142,7 @@ func (dl DrawList) draw(cameraX, cameraY, cameraScl float32) {
 		}
 
 		s.anim.Draw(drawwindow, pos[0]-xsoffset, pos[1], cs, cs, s.scl[0], s.scl[0],
-			s.scl[1], xshear, s.rot, float32(sys.gameWidth)/2, s.fx, s.oldVer, s.facing,
+			s.scl[1], xshear, s.rot, float32(sys.gameWidth)/2, s.pfx, s.facing,
 			s.airOffsetFix, s.projection, s.fLength, 0, false)
 
 		// Restore original animation transparency just in case
@@ -1369,7 +1367,7 @@ func (sl ShadowList) draw(x, y, scl float32) {
 			sys.cam.GroundLevel()+(sys.cam.Offset[1]-shake[1])-y-(s.pos[1]*yscale-offsetY)*scl,
 			scl*s.scl[0], scl*-s.scl[1],
 			yscale, xshear, rot,
-			s.fx, s.oldVer, uint32(color), intensity, s.facing, s.airOffsetFix, projection, fLength)
+			s.pfx, uint32(color), intensity, s.facing, s.airOffsetFix, projection, fLength)
 	}
 }
 
@@ -1581,7 +1579,7 @@ func (rl ReflectionList) draw(x, y, scl float32) {
 			(sys.cam.GroundLevel()+sys.cam.Offset[1]-shake[1])/scl-y/scl-(s.pos[1]*yscale-offsetY),
 			scl, scl, s.scl[0], s.scl[0],
 			-s.scl[1]*yscale, xshear, rot, float32(sys.gameWidth)/2,
-			s.fx, s.oldVer, s.facing, s.airOffsetFix, projection, fLength, color, true)
+			s.pfx, s.facing, s.airOffsetFix, projection, fLength, color, true)
 
 		// Restore original animation transparency just in case
 		s.anim.transType = oldTransType
@@ -1710,7 +1708,7 @@ func (a *Anim) Draw() {
 	if !sys.frameSkip {
 		a.anim.Draw(&a.window, a.x+float32(sys.gameWidth-320)/2,
 			a.y+float32(sys.gameHeight-240), 1, 1, a.xscl, a.xscl, a.yscl,
-			0, Rotation{}, 0, a.palfx, false, 1, [2]float32{1, 1}, 0, 0, 0, false)
+			0, Rotation{}, 0, a.palfx, 1, [2]float32{1, 1}, 0, 0, 0, false)
 	}
 }
 

--- a/src/anim.go
+++ b/src/anim.go
@@ -1426,6 +1426,19 @@ func (rl ReflectionList) draw(x, y, scl float32) {
 			continue
 		}
 
+		// Use custom or stage reflection intensity
+		var ref int32
+		if s.reflectIntensity != -1 {
+			ref = s.reflectIntensity
+		} else {
+			ref = sys.stage.reflection.intensity
+		}
+
+		// Skip if no intensity
+		if ref <= 0 {
+			continue
+		}
+
 		// Backup animation transparency to temporarily change it
 		oldTransType := s.anim.transType
 		oldSrcAlpha := s.anim.srcAlpha
@@ -1447,19 +1460,11 @@ func (rl ReflectionList) draw(x, y, scl float32) {
 			s.anim.transType = TT_add
 		}
 
-		// Apply reflection intensity
-		var ref int32
-		if s.reflectIntensity != -1 {
-			ref = s.reflectIntensity
-		} else {
-			ref = sys.stage.reflection.intensity
-		}
-
 		// Scale intensity by linear interpolation
-		s.anim.srcAlpha = int16(int32(s.alpha[0]) * ref / 255)
-		s.anim.dstAlpha = int16(255 - (int32(255-s.alpha[1]) * ref / 255))
+		s.anim.srcAlpha = int16(int32(s.anim.srcAlpha) * ref / 255)
+		s.anim.dstAlpha = int16(255 - (int32(255-s.anim.dstAlpha) * ref / 255))
 
-		// Set the tint if it's there
+		// Use custom or stage reflection color
 		var color uint32
 		if s.reflectColor < 0 {
 			color = sys.stage.reflection.color
@@ -1468,6 +1473,7 @@ func (rl ReflectionList) draw(x, y, scl float32) {
 		}
 
 		// Add alpha if color is specified
+		// TODO: This method makes sprites with transparency have reflections that are too bright
 		if color != 0 {
 			color |= uint32(ref << 24)
 		}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5099,19 +5099,19 @@ func (sc posSet) Run(c *Char, _ []int32) bool {
 		switch paramID {
 		case posSet_x:
 			x := sys.cam.Pos[0]/crun.localscl + exp[0].evalF(c)*redirscale
-			crun.setAllPosX(x)
+			crun.setPosX(x, true)
 			if crun.bindToId > 0 && !math.IsNaN(float64(crun.bindPos[0])) && sys.playerID(crun.bindToId) != nil {
 				crun.bindPosAdd[0] = x
 			}
 		case posSet_y:
 			y := exp[0].evalF(c)*redirscale + crun.groundLevel + crun.platformPosY
-			crun.setAllPosY(y)
+			crun.setPosY(y, true)
 			if crun.bindToId > 0 && !math.IsNaN(float64(crun.bindPos[1])) && sys.playerID(crun.bindToId) != nil {
 				crun.bindPosAdd[1] = y
 			}
 		case posSet_z:
 			z := exp[0].evalF(c) * redirscale
-			crun.setAllPosZ(z)
+			crun.setPosZ(z, true)
 			if crun.bindToId > 0 && !math.IsNaN(float64(crun.bindPos[2])) && sys.playerID(crun.bindToId) != nil {
 				crun.bindPosAdd[2] = z
 			}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5333,7 +5333,7 @@ func (sc palFX) Run(c *Char, _ []int32) bool {
 	if pf == nil {
 		pf = newPalFX()
 	}
-	pf.clear2(true)
+	pf.clearWithNeg(true)
 
 	// Mugen 1.1 invertblend fallback
 	if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 &&

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1606,14 +1606,14 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.Push(BytecodeSF())
 			i += int(*(*int32)(unsafe.Pointer(&be[i]))) + 4
 		case OC_playerid:
-			if c = sys.playerID(sys.bcStack.Pop().ToI()); c != nil {
+			if c = c.playerIDTrigger(sys.bcStack.Pop().ToI()); c != nil {
 				i += 4
 				continue
 			}
 			sys.bcStack.Push(BytecodeSF())
 			i += int(*(*int32)(unsafe.Pointer(&be[i]))) + 4
 		case OC_playerindex:
-			if c = sys.playerIndexRedirect(sys.bcStack.Pop().ToI()); c != nil {
+			if c = c.playerIndexTrigger(sys.bcStack.Pop().ToI()); c != nil {
 				i += 4
 				continue
 			}
@@ -1634,7 +1634,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			sys.bcStack.Push(BytecodeSF())
 			i += int(*(*int32)(unsafe.Pointer(&be[i]))) + 4
 		case OC_helperindex:
-			if c = c.helperIndexTrigger(sys.bcStack.Pop().ToI(), true); c != nil {
+			if c = c.helperIndexTrigger(sys.bcStack.Pop().ToI()); c != nil {
 				i += 4
 				continue
 			}
@@ -2944,7 +2944,7 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 				unsafe.Pointer(&be[*i]))])
 		*i += 4
 	case OC_ex_helperindexexist:
-		*sys.bcStack.Top() = c.helperByIndexExist(*sys.bcStack.Top())
+		*sys.bcStack.Top() = c.helperIndexExist(*sys.bcStack.Top())
 	case OC_ex_hitoverridden:
 		sys.bcStack.PushB(c.hoverIdx >= 0)
 	case OC_ex_ikemenversion:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -12015,6 +12015,11 @@ func (sc text) Run(c *Char, _ []int32) bool {
 		return false
 	}
 
+	// Do nothing if text limit reached
+	if len(sys.lifebar.textsprite) >= sys.cfg.Config.TextMax {
+		return false
+	}
+
 	params := []interface{}{}
 	ts := NewTextSprite()
 	ts.ownerid = crun.id
@@ -12125,6 +12130,7 @@ func (sc text) Run(c *Char, _ []int32) bool {
 		}
 		return true
 	})
+
 	ts.xscl = xscl / ts.localScale
 	ts.yscl = yscl / ts.localScale
 	if fnt == -1 {

--- a/src/char.go
+++ b/src/char.go
@@ -1032,7 +1032,6 @@ type aimgImage struct {
 	rot        Rotation
 	projection int32
 	fLength    float32
-	oldVer     bool
 }
 
 type AfterImage struct {
@@ -1195,13 +1194,13 @@ func (ai *AfterImage) recAfterImg(sd *SprData, hitpause bool) {
 				img.anim.spr = newSprite()
 				*img.anim.spr = *sd.anim.spr
 				if sd.anim.palettedata != nil {
-					sd.anim.palettedata.SwapPalMap(&sd.fx.remap)
+					sd.anim.palettedata.SwapPalMap(&sd.pfx.remap)
 					img.anim.spr.Pal = sd.anim.spr.GetPal(sd.anim.palettedata)
-					sd.anim.palettedata.SwapPalMap(&sd.fx.remap)
+					sd.anim.palettedata.SwapPalMap(&sd.pfx.remap)
 				} else {
-					sd.anim.sff.palList.SwapPalMap(&sd.fx.remap)
+					sd.anim.sff.palList.SwapPalMap(&sd.pfx.remap)
 					img.anim.spr.Pal = sd.anim.spr.GetPal(&sd.anim.sff.palList)
-					sd.anim.sff.palList.SwapPalMap(&sd.fx.remap)
+					sd.anim.sff.palList.SwapPalMap(&sd.pfx.remap)
 				}
 			}
 		} else {
@@ -1212,7 +1211,6 @@ func (ai *AfterImage) recAfterImg(sd *SprData, hitpause bool) {
 		img.rot = sd.rot
 		img.projection = sd.projection
 		img.fLength = sd.fLength
-		img.oldVer = sd.oldVer
 		img.priority = sd.priority - 2 // Starting afterimage sprpriority offset
 		ai.imgidx = (ai.imgidx + 1) & 63
 		ai.reccount++
@@ -1249,10 +1247,10 @@ func (ai *AfterImage) recAndCue(sd *SprData, rec bool, hitpause bool, layer int3
 		}
 		if ai.time < 0 || (ai.timecount/ai.timegap-i) < (ai.time-2)/ai.timegap+1 {
 			step := i/ai.framegap - 1
-			ai.palfx[step].remap = sd.fx.remap
+			ai.palfx[step].remap = sd.pfx.remap
 			sprs.add(&SprData{
 				anim:         img.anim,
-				fx:           ai.palfx[step],
+				pfx:           ai.palfx[step],
 				pos:          img.pos,
 				scl:          img.scl,
 				trans:        ai.trans,
@@ -1261,7 +1259,6 @@ func (ai *AfterImage) recAndCue(sd *SprData, rec bool, hitpause bool, layer int3
 				rot:          img.rot,
 				screen:       false,
 				undarken:     sd.undarken,
-				oldVer:       sd.oldVer,
 				facing:       sd.facing,
 				airOffsetFix: sd.airOffsetFix,
 				projection:   img.projection,
@@ -1734,7 +1731,7 @@ func (e *Explod) update(playerNo int) {
 	// Add sprite to draw list
 	sd := &SprData{
 		anim:         e.anim,
-		fx:           pfx,
+		pfx:          pfx,
 		pos:          drawpos,
 		scl:          drawscale,
 		trans:        e.trans,
@@ -1743,7 +1740,6 @@ func (e *Explod) update(playerNo int) {
 		rot:          rot,
 		screen:       e.space == Space_screen,
 		undarken:     parent != nil && parent.ignoreDarkenTime > 0,
-		oldVer:       oldVer,
 		facing:       facing,
 		airOffsetFix: [2]float32{1, 1},
 		projection:   int32(e.projection),
@@ -2394,7 +2390,7 @@ func (p *Projectile) cueDraw() {
 		// Add sprite to draw list
 		sd := &SprData{
 			anim:         p.ani,
-			fx:           p.palfx,
+			pfx:          p.palfx,
 			pos:          pos,
 			scl:          drawscale,
 			trans:        TT_default,
@@ -2403,7 +2399,6 @@ func (p *Projectile) cueDraw() {
 			rot:          rot,
 			screen:       false,
 			undarken:     sys.chars[p.playerno][0] != nil && sys.chars[p.playerno][0].ignoreDarkenTime > 0, //p.playerno == sys.superplayerno,
-			oldVer:       sys.cgi[p.playerno].mugenver[0] != 1,
 			facing:       p.facing,
 			airOffsetFix: [2]float32{1, 1},
 			projection:   int32(p.projection),
@@ -11314,7 +11309,7 @@ func (c *Char) cueDraw() {
 		// Define sprite data
 		sd := &SprData{
 			anim:         anim,
-			fx:           c.getPalfx(),
+			pfx:          c.getPalfx(),
 			pos:          pos,
 			scl:          drawscale,
 			trans:        c.trans,
@@ -11323,7 +11318,6 @@ func (c *Char) cueDraw() {
 			rot:          rot,
 			screen:       false,
 			undarken:     c.ignoreDarkenTime > 0,
-			oldVer:       c.gi().mugenver[0] != 1,
 			facing:       c.facing,
 			airOffsetFix: airOffsetFix,
 			projection:   int32(c.projection),

--- a/src/char.go
+++ b/src/char.go
@@ -2748,8 +2748,8 @@ type Char struct {
 	ownclsnscale      bool
 	pushPriority      int32
 	prevfallflag      bool
-	dustOldPos        [3]float32
-	dustTime          int
+	makeDustSpacing   int
+	//dustOldPos        [3]float32
 }
 
 // Add a new char to the game
@@ -2838,7 +2838,7 @@ func (c *Char) clearState() {
 	c.counterHit = false
 	c.hitdefContact = false
 	c.fallTime = 0
-	c.dustTime = 0
+	c.makeDustSpacing = 0
 }
 
 func (c *Char) clsnOverlapTrigger(box1, pid, box2 int32) bool {
@@ -7989,21 +7989,25 @@ func (c *Char) makeDust(x, y, z float32, spacing int) {
 	if c.asf(ASF_nomakedust) {
 		return
 	}
+
 	if spacing < 1 {
 		sys.appendToConsole(c.warn() + "invalid MakeDust spacing")
 		spacing = 1
 	}
-	if c.dustTime >= spacing {
-		c.dustTime = 0
+
+	if c.makeDustSpacing >= spacing {
+		c.makeDustSpacing = 0
 	} else {
 		return
 	}
+
 	if e, i := c.spawnExplod(); e != nil {
 		e.animNo = 120
 		e.anim_ffx = "f"
 		e.sprpriority = math.MaxInt32
 		e.layerno = c.layerNo
 		e.ownpal = true
+		e.postype = PT_P1
 		e.relativePos = [...]float32{x, y, z}
 		e.setPos(c)
 		c.commitExplod(i)
@@ -9947,6 +9951,7 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 				e.layerno = 1 // e.ontop = true
 				e.sprpriority = math.MinInt32
 				e.ownpal = true
+				e.postype = PT_P1
 				e.relativePos = [3]float32{off[0], off[1], off[2]}
 				e.supermovetime = -1
 				e.pausemovetime = -1
@@ -10520,7 +10525,7 @@ func (c *Char) actionRun() {
 		if c.helperIndex == 0 && c.gi().pctime >= 0 {
 			c.gi().pctime++
 		}
-		c.dustTime++
+		c.makeDustSpacing++
 	}
 	c.xScreenBound()
 	c.zDepthBound()
@@ -10672,11 +10677,12 @@ func (c *Char) update() {
 				}
 			}
 			// Engine dust effects
-			if sys.supertime == 0 && sys.pausetime == 0 &&
-				((c.ss.moveType == MT_H && (c.ss.stateType == ST_S || c.ss.stateType == ST_C)) || c.ss.no == 52) &&
-				c.pos[1] == 0 && (AbsF(c.pos[0]-c.dustOldPos[0]) >= 1 || AbsF(c.pos[2]-c.dustOldPos[2]) >= 1) {
-				c.makeDust(0, 0, 0, 3) // Default spacing of 3
-			}
+			// Moved to system.zss
+			//if sys.supertime == 0 && sys.pausetime == 0 &&
+			//	((c.ss.moveType == MT_H && (c.ss.stateType == ST_S || c.ss.stateType == ST_C)) || c.ss.no == 52) &&
+			//	c.pos[1] == 0 && (AbsF(c.pos[0]-c.dustOldPos[0]) >= 1 || AbsF(c.pos[2]-c.dustOldPos[2]) >= 1) {
+			//	c.makeDust(0, 0, 0, 3) // Default spacing of 3
+			//}
 		}
 		if c.ss.moveType == MT_H {
 			// Set opposing team's First Attack flag
@@ -11332,7 +11338,7 @@ func (c *Char) cueDraw() {
 	if sys.tickNextFrame() {
 		c.minus = 2
 		c.oldPos = c.pos
-		c.dustOldPos = c.pos // We need this one separated because PosAdd and such change oldPos
+		//c.dustOldPos = c.pos // We need this one separated because PosAdd and such change oldPos
 	}
 }
 

--- a/src/char.go
+++ b/src/char.go
@@ -1065,7 +1065,7 @@ func newAfterImage() *AfterImage {
 	for i := range ai.palfx {
 		ai.palfx[i] = newPalFX()
 		ai.palfx[i].enable = true
-		ai.palfx[i].negType = true
+		ai.palfx[i].allowNeg = true
 	}
 
 	ai.clear()
@@ -2314,7 +2314,7 @@ func (p *Projectile) tick() {
 	}
 }
 
-func (p *Projectile) cueDraw(oldVer bool) {
+func (p *Projectile) cueDraw() {
 	notpause := p.hitpause <= 0 && !p.paused(p.playerno)
 	if sys.tickFrame() && p.ani != nil && notpause {
 		p.ani.UpdateSprite()
@@ -10095,7 +10095,7 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 			}
 		}
 		if hd.palfx.time > 0 && getter.palfx != nil {
-			getter.palfx.clear2(true)
+			getter.palfx.clearWithNeg(true)
 			getter.palfx.PalFXDef = hd.palfx
 		}
 		if hd.envshake_time > 0 {

--- a/src/char.go
+++ b/src/char.go
@@ -1056,15 +1056,20 @@ type AfterImage struct {
 }
 
 func newAfterImage() *AfterImage {
+	maxFrames := Max(0, sys.cfg.Config.AfterImageMax)
+
 	ai := &AfterImage{
-		palfx: make([]*PalFX, sys.cfg.Config.AfterImageMax),
+		palfx: make([]*PalFX, maxFrames),
 	}
+
 	for i := range ai.palfx {
 		ai.palfx[i] = newPalFX()
 		ai.palfx[i].enable = true
 		ai.palfx[i].negType = true
 	}
+
 	ai.clear()
+
 	return ai
 }
 
@@ -5814,8 +5819,8 @@ func (c *Char) destroySelf(recursive, removeexplods, removetexts bool) bool {
 
 // Make a new helper before reading the bytecode parameters
 func (c *Char) newHelper() (h *Char) {
-	// If any existing helper entry is valid for overwriting, use that one
-	i := int32(0)
+	// If any existing helper entry is valid for overwriting, use it
+	i := int32(1)
 	for ; int(i) < len(sys.chars[c.playerNo]); i++ {
 		if sys.chars[c.playerNo][i].helperIndex < 0 {
 			h = sys.chars[c.playerNo][i]
@@ -5823,9 +5828,10 @@ func (c *Char) newHelper() (h *Char) {
 			break
 		}
 	}
+
 	// Otherwise append to the end
 	if int(i) >= len(sys.chars[c.playerNo]) {
-		if i >= sys.cfg.Config.HelperMax {
+		if i > sys.cfg.Config.HelperMax { // Do not count index 0
 			return
 		}
 		h = newChar(c.playerNo, i)

--- a/src/common.go
+++ b/src/common.go
@@ -1069,7 +1069,7 @@ func (l *Layout) DrawAnim(r *[4]int32, x, y, scl, xscl, yscl float32, ln int16, 
 		a.Draw(r, x+l.offset[0]-xsoffset, y+l.offset[1]+float32(sys.gameHeight-240),
 			scl, scl, (l.scale[0]*xscl)*float32(l.facing), (l.scale[0]*xscl)*float32(l.facing),
 			(l.scale[1]*yscl)*float32(l.vfacing), xshear, Rotation{l.angle, 0, 0},
-			float32(sys.gameWidth-320)/2, palfx, false, 1, [2]float32{1, 1}, 0, 0, 0, false)
+			float32(sys.gameWidth-320)/2, palfx, 1, [2]float32{1, 1}, 0, 0, 0, false)
 	}
 }
 

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -6584,8 +6584,8 @@ func (c *Compiler) statementEnd(line *string) error {
 	return nil
 }
 
-func (c *Compiler) readKeyValue(is IniSection, end string,
-	line *string) error {
+func (c *Compiler) readKeyValue(is IniSection, end string, line *string) error {
+	// Read the key (parameter name)
 	name := c.scan(line)
 	if name == "" || name == ":" {
 		return c.wrongClosureToken()
@@ -6593,15 +6593,27 @@ func (c *Compiler) readKeyValue(is IniSection, end string,
 	if name == end {
 		return nil
 	}
+
+	// Check for duplicate keys
+	if _, exists := is[name]; exists {
+		return Error(fmt.Sprintf("Duplicate key found: %s", name))
+	}
+
+	// Check separator
 	c.scan(line)
 	if err := c.needToken(":"); err != nil {
 		return err
 	}
+
+	// Read the value
 	data, _, err := c.readSentence(line)
 	if err != nil {
 		return err
 	}
+
+	// Store the pair
 	is[name] = data
+
 	return nil
 }
 

--- a/src/config.go
+++ b/src/config.go
@@ -130,6 +130,7 @@ type Config struct {
 		HelperMax        int32    `ini:"HelperMax"`
 		ProjectileMax    int      `ini:"ProjectileMax"`
 		PaletteMax       int      `ini:"PaletteMax"`
+		TextMax          int      `ini:"TextMax"`
 		ZoomActive       bool     `ini:"ZoomActive"`
 		EscOpensMenu     bool     `ini:"EscOpensMenu"`
 		FirstRun         bool     `ini:"FirstRun"`
@@ -302,14 +303,20 @@ func (c *Config) initStruct() {
 
 // Normalize values
 func (c *Config) normalize() {
+	c.SetValueUpdate("Config.Framerate", int(Clamp(int32(c.Config.Framerate), 1, 840)))
+	c.SetValueUpdate("Config.Players", int(Clamp(int32(c.Config.Players), 1, int32(MaxSimul)*2)))
 	c.SetValueUpdate("Options.GameSpeed", int(Clamp(int32(c.Options.GameSpeed), -9, 9)))
 	c.SetValueUpdate("Options.GameSpeedStep", int(Clamp(int32(c.Options.GameSpeedStep), 1, 60)))
-	c.SetValueUpdate("Options.Simul.Min", int(Clamp(int32(c.Options.Simul.Min), 2, int32(MaxSimul))))
 	c.SetValueUpdate("Options.Simul.Max", int(Clamp(int32(c.Options.Simul.Max), int32(c.Options.Simul.Min), int32(MaxSimul))))
-	c.SetValueUpdate("Options.Tag.Min", int(Clamp(int32(c.Options.Tag.Min), 2, int32(MaxSimul))))
+	c.SetValueUpdate("Options.Simul.Min", int(Clamp(int32(c.Options.Simul.Min), 2, int32(MaxSimul))))
 	c.SetValueUpdate("Options.Tag.Max", int(Clamp(int32(c.Options.Tag.Max), int32(c.Options.Tag.Min), int32(MaxSimul))))
-	c.SetValueUpdate("Config.Players", int(Clamp(int32(c.Config.Players), 1, int32(MaxSimul)*2)))
-	c.SetValueUpdate("Config.Framerate", int(Clamp(int32(c.Config.Framerate), 1, 840)))
+	c.SetValueUpdate("Options.Tag.Min", int(Clamp(int32(c.Options.Tag.Min), 2, int32(MaxSimul))))
+
+	// Options that determine allocation sizes should not be negative
+	if c.Config.AfterImageMax < 0 {
+		c.SetValueUpdate("Config.AfterImageMax", 0)
+	}
+
 	path := strings.TrimSpace(c.Config.ScreenshotFolder)
 	if path != "" {
 		path = strings.ReplaceAll(path, "\\", "/")
@@ -320,16 +327,19 @@ func (c *Config) normalize() {
 			c.SetValueUpdate("Config.ScreenshotFolder", path)
 		}
 	}
+
 	switch c.Sound.SampleRate {
 	case 22050, 44100, 48000:
 	default:
 		c.SetValueUpdate("Sound.SampleRate", 44100)
 	}
-	c.SetValueUpdate("Sound.PanningRange", ClampF(c.Sound.PanningRange, 0, 100))
-	c.SetValueUpdate("Sound.WavChannels", Clamp(c.Sound.WavChannels, 1, 256))
-	c.SetValueUpdate("Sound.PauseMasterVolume", int(Clamp(int32(c.Sound.PauseMasterVolume), 0, 100)))
-	c.SetValueUpdate("Sound.MaxBGMVolume", int(Clamp(int32(c.Sound.MaxBGMVolume), 100, 250)))
+
 	c.SetValueUpdate("Input.SOCDResolution", int(Clamp(int32(c.Input.SOCDResolution), 0, 4)))
+	c.SetValueUpdate("Sound.MaxBGMVolume", int(Clamp(int32(c.Sound.MaxBGMVolume), 100, 250)))
+	c.SetValueUpdate("Sound.PanningRange", ClampF(c.Sound.PanningRange, 0, 100))
+	c.SetValueUpdate("Sound.PauseMasterVolume", int(Clamp(int32(c.Sound.PauseMasterVolume), 0, 100)))
+	c.SetValueUpdate("Sound.WavChannels", Clamp(c.Sound.WavChannels, 1, 256))
+
 	switch c.Video.MSAA {
 	case 0, 2, 4, 6, 8, 16, 32:
 	default:

--- a/src/image.go
+++ b/src/image.go
@@ -57,10 +57,10 @@ func newPalFXDef() *PalFXDef {
 type PalFX struct {
 	PalFXDef
 	remap        []int
-	negType      bool
+	allowNeg     bool // Can use negative color math
 	sintime      [4]int32
 	enable       bool
-	eNegType     bool
+	eAllowNeg    bool
 	eInvertall   bool
 	eInvertblend int32
 	eAdd         [3]int32
@@ -79,16 +79,16 @@ func newPalFX() *PalFX {
 	return &PalFX{}
 }
 
-func (pf *PalFX) clear2(nt bool) {
+func (pf *PalFX) clearWithNeg(neg bool) {
 	pf.PalFXDef = *newPalFXDef()
-	pf.negType = nt
+	pf.allowNeg = neg
 	for i := 0; i < len(pf.sintime); i++ {
 		pf.sintime[i] = 0
 	}
 }
 
 func (pf *PalFX) clear() {
-	pf.clear2(false)
+	pf.clearWithNeg(false)
 }
 
 func (pf *PalFX) getSynFx(alpha [2]int32) *PalFX {
@@ -120,7 +120,7 @@ func (pf *PalFX) getFxPal(pal []uint32, neg bool) []uint32 {
 	if !p.enable {
 		return pal
 	}
-	if !p.eNegType {
+	if !p.eAllowNeg {
 		neg = false
 	}
 	var m [3]int32
@@ -185,7 +185,7 @@ func (pf *PalFX) getFcPalFx(transNeg bool, alpha [2]int32) (neg bool, grayscale 
 	grayscale = 1 - p.eColor
 	invblend = p.eInvertblend
 	hue = -(p.eHue * 180.0) * (math.Pi / 180.0)
-	if !p.eNegType {
+	if !p.eAllowNeg {
 		transNeg = false
 	}
 	for i, v := range p.eAdd {
@@ -287,7 +287,7 @@ func (pf *PalFX) step() {
 		} else {
 			pf.eInvertblend = pf.invertblend
 		}
-		pf.eNegType = pf.negType
+		pf.eAllowNeg = pf.allowNeg
 		pf.sinAdd(&pf.eAdd)
 		pf.sinMul(&pf.eMul)
 		pf.sinColor(&pf.eColor)

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -3578,6 +3578,12 @@ func (rt *LifeBarRoundTransition) Step() {
 		rt.fadeoutTimer--
 	}
 	if rt.shutterTimer > 0 {
+		// Signal system to skip intros when shutter is about to be fully closed
+		// This ensures the intros will skip even if/when the shutter updates at a different rate than characters
+		// https://github.com/ikemen-engine/Ikemen-GO/issues/2720
+		if rt.shutterTimer == (rt.shutter_time + 1) {
+			sys.introSkipCall = true
+		}
 		rt.shutterTimer--
 	}
 }

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -4915,19 +4915,23 @@ func (l *Lifebar) step() {
 		l.mo[sys.gameMode].step()
 	}
 	// Text sctrl
-	for i := 0; i < len(l.textsprite); i++ {
-		if l.textsprite[i].removetime == 0 {
-			l.textsprite = append(l.textsprite[:i], l.textsprite[i+1:]...)
-			i-- // -1 as the slice just got shorter
-		} else {
-			l.textsprite[i].Draw()
+	l.UpdateText()
+}
+
+func (l *Lifebar) UpdateText() {
+	tempSlice := l.textsprite[:0]
+
+	for _, ts := range l.textsprite {
+		if ts.removetime > 0 { // No infinite time at the moment since text sprites are not very efficient
+			ts.Draw()
 			if sys.tickNextFrame() {
-				if l.textsprite[i].removetime > 0 {
-					l.textsprite[i].removetime--
-				}
+				ts.removetime--
 			}
+			tempSlice = append(tempSlice, ts)
 		}
 	}
+
+	l.textsprite = tempSlice
 }
 
 func (l *Lifebar) RemoveText(id, ownerid int32) {

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -117,19 +117,22 @@ Framerate           = 60
 ; Leave blank to automatically detect the system language.
 Language            = en
 ; Number of simultaneous afterimage effects allowed.
-; Set to a lower number to save memory (minimum 1).
+; Set to a lower number to save memory.
 AfterImageMax       = 128
-; Maximum number of explods allowed in total. Hitsparks also count as explods.
-; Set to a lower number to save memory (minimum 8).
+; Maximum number of explods allowed per player. Hitsparks also count as explods.
+; Set to a lower number to save memory.
 ExplodMax           = 512
 ; Maximum number of helpers allowed per player.
-; Set to a lower number to save memory (minimum 4).
+; Set to a lower number to save memory.
 HelperMax           = 56
 ; Maximum number of projectiles allowed per player.
-; Set to a lower number to save memory (minimum 5).
+; Set to a lower number to save memory.
 ProjectileMax       = 256
 ; Maximum number of palettes allowed per player.
 PaletteMax          = 100
+; Maximum number of lifebar texts allowed in total.
+; Set to a lower number to save memory.
+TextMax = 256
 ; Zoom toggle (0 disables zoom for stages coded to have it).
 ZoomActive          = 1
 ; Toggles if Esc key should open Pause menu.

--- a/src/script.go
+++ b/src/script.go
@@ -3285,7 +3285,7 @@ func triggerFunctions(l *lua.LState) {
 	})
 	luaRegister(l, "playerid", func(*lua.LState) int {
 		ret := false
-		if c := sys.playerID(int32(numArg(l, 1))); c != nil {
+		if c := sys.debugWC.playerIDTrigger(int32(numArg(l, 1))); c != nil {
 			sys.debugWC, ret = c, true
 		}
 		l.Push(lua.LBool(ret))
@@ -3293,7 +3293,7 @@ func triggerFunctions(l *lua.LState) {
 	})
 	luaRegister(l, "playerindex", func(*lua.LState) int {
 		ret := false
-		if c := sys.playerIndexRedirect(int32(numArg(l, 1))); c != nil {
+		if c := sys.debugWC.playerIndexTrigger(int32(numArg(l, 1))); c != nil {
 			sys.debugWC, ret = c, true
 		}
 		l.Push(lua.LBool(ret))
@@ -3316,11 +3316,11 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "helperindex", func(*lua.LState) int {
-		ret, id := false, int32(0)
+		ret, idx := false, int32(0)
 		if !nilArg(l, 1) {
-			id = int32(numArg(l, 1))
+			idx = int32(numArg(l, 1))
 		}
-		if c := sys.debugWC.helperIndexTrigger(id, true); c != nil {
+		if c := sys.debugWC.helperIndexTrigger(idx); c != nil {
 			sys.debugWC, ret = c, true
 		}
 		l.Push(lua.LBool(ret))
@@ -5684,7 +5684,7 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "helperindexexist", func(*lua.LState) int {
-		l.Push(lua.LBool(sys.debugWC.helperByIndexExist(
+		l.Push(lua.LBool(sys.debugWC.helperIndexExist(
 			BytecodeInt(int32(numArg(l, 1)))).ToB()))
 		return 1
 	})

--- a/src/script.go
+++ b/src/script.go
@@ -6166,7 +6166,7 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "gamespeed", func(*lua.LState) int {
-		l.Push(lua.LNumber(100 * float32(sys.gameLogicSpeed()) / float32(sys.gameRenderSpeed())))
+		l.Push(lua.LNumber(100 * sys.gameLogicSpeed() / 60))
 		return 1
 	})
 	luaRegister(l, "lasthitter", func(*lua.LState) int {

--- a/src/stage.go
+++ b/src/stage.go
@@ -1849,7 +1849,7 @@ func (s *Stage) action() {
 			b.palfx.eHue = sys.bgPalFX.eHue
 			b.palfx.eInvertall = sys.bgPalFX.eInvertall
 			b.palfx.eInvertblend = sys.bgPalFX.eInvertblend
-			b.palfx.eNegType = sys.bgPalFX.eNegType
+			b.palfx.eAllowNeg = sys.bgPalFX.eAllowNeg
 		}
 		if b.enabled && !paused {
 			s.bg[i].bga.action()
@@ -1882,7 +1882,7 @@ func (s *Stage) action() {
 			s.model.pfx.eHue = sys.bgPalFX.eHue
 			s.model.pfx.eInvertall = sys.bgPalFX.eInvertall
 			s.model.pfx.eInvertblend = sys.bgPalFX.eInvertblend
-			s.model.pfx.eNegType = sys.bgPalFX.eNegType
+			s.model.pfx.eAllowNeg = sys.bgPalFX.eAllowNeg
 		}
 	}
 }

--- a/src/stage.go
+++ b/src/stage.go
@@ -691,7 +691,7 @@ func (bg backGround) draw(pos [2]float32, drawscl, bgscl, stglscl float32,
 			bg.xscale[0]*bgscl*(scalestartX+xs)*xs3,
 			xbs*bgscl*(scalestartX+xs)*xs3,
 			ys*ys3, xras*x/(AbsF(ys*ys3)*lscl[1]*float32(bg.anim.spr.Size[1])*bg.scalestart[1])*sclx_recip*bg.scalestart[1]-bg.xshear,
-			bg.rot, rcx, bg.palfx, true, 1, [2]float32{1, 1}, int32(bg.projection), bg.fLength, 0, false)
+			bg.rot, rcx, bg.palfx, 1, [2]float32{1, 1}, int32(bg.projection), bg.fLength, 0, false)
 	}
 }
 

--- a/src/state.go
+++ b/src/state.go
@@ -249,7 +249,7 @@ type GameState struct {
 
 	// 11/5/2022
 	fight        Fight
-	introSkipped bool
+	introSkipCall bool
 	preFightTime int32
 
 	commandLists []*CommandList
@@ -473,8 +473,7 @@ func (gs *GameState) LoadState(stateID int) {
 		sys.rollback.currentFight = gs.fight.Clone(a, gsp)
 	}
 
-	sys.introSkipped = gs.introSkipped
-
+	sys.introSkipCall = gs.introSkipCall
 	sys.preFightTime = gs.preFightTime
 
 	sys.loopBreak = gs.loopBreak
@@ -682,7 +681,7 @@ func (gs *GameState) SaveState(stateID int) {
 		gs.fight = sys.rollback.currentFight.Clone(a, gsp)
 	}
 
-	gs.introSkipped = sys.introSkipped
+	gs.introSkipCall = sys.introSkipCall
 	gs.preFightTime = sys.preFightTime
 
 	gs.loopBreak = sys.loopBreak

--- a/src/system.go
+++ b/src/system.go
@@ -787,10 +787,29 @@ func (s *System) anyChar() *Char {
 }
 
 func (s *System) playerID(id int32) *Char {
-	return s.charList.getCharWithID(id)
+	if id < 0 {
+		return nil
+	}
+
+	// Invalid ID
+	ch, ok := s.charList.idMap[id]
+	if !ok {
+		return nil
+	}
+
+	// Mugen skips DestroySelf helpers here
+	if ch.csf(CSF_destroy) {
+		return nil
+	}
+
+	return ch
 }
 
-func (s *System) playerIndexRedirect(idx int32) *Char {
+func (s *System) playerIndex(idx int32) *Char {
+	if idx < 0 || int(idx) >= len(sys.charList.runOrder) {
+		return nil
+	}
+
 	// We will ignore destroyed helpers here, like Mugen redirections
 	var searchIdx int32
 	for _, p := range sys.charList.runOrder {
@@ -828,7 +847,7 @@ func (s *System) playerIndexExist(idx BytecodeValue) BytecodeValue {
 	if idx.IsSF() {
 		return BytecodeSF()
 	}
-	return BytecodeBool(s.playerIndexRedirect(idx.ToI()) != nil)
+	return BytecodeBool(s.playerIndex(idx.ToI()) != nil)
 }
 
 func (s *System) playerNoExist(no BytecodeValue) BytecodeValue {

--- a/src/system.go
+++ b/src/system.go
@@ -1685,7 +1685,7 @@ func (s *System) action() {
 	for i := range s.projs {
 		for j := range s.projs[i] {
 			if s.projs[i][j].id >= 0 {
-				s.projs[i][j].cueDraw(s.cgi[i].mugenver[0] != 1)
+				s.projs[i][j].cueDraw()
 			}
 		}
 	}


### PR DESCRIPTION
Fix:
- Intro skipping will now always happen even if shutter and characters are updated at different times
- Fixed off by 1 error in HelperMax
- Fixed oversight that allowed a negative AfterimageMax to crash Ikemen
- Fixed oversight that made characters push each other slower than intended
- Fixed game speed value being incorrect when framerate is not 60
- Fixed reflection alpha when not using Trans sctrl
- Fixes #2720

Feature:
- Maximum text sprites can now be configured in config.ini

Refactor:
- Dust effects are no longer hardcoded. Moved to system.zss
- PlayerID and PlayerIndex will now print errors when retrieving invalid players, like most redirections
- The compiler will now crash with an error message if it finds duplicate parameters in a ZSS state controller