### PR TITLE
feat:(motif) tween.wrap.snap; palmenu fixes

### DIFF
--- a/data/system.base.def
+++ b/data/system.base.def
@@ -193,7 +193,8 @@
 
 	; Enables Mugen menu tween (if > 0.0) and allows adjusting its factor
 	menu.tween.factor = 0.3
-
+	; Snaps menu when wrapping
+	menu.tween.wrap.snap = 0
 	; Title text rendered in main menu
 	title.offset = 159, 19
 	title.font = -1, 0, 0, 255, 255, 255, -1
@@ -307,7 +308,8 @@
 	menu.boxcursor.tween.snap = 0
 	; Enables boxcursor tween (if > 0.0) and allows adjusting its factor
 	menu.boxcursor.tween.factor = 0.3
-
+	; Snaps boxcursor when the menu is wrapping
+	menu.boxcursor.tween.snap = 0
 	; boxbg is an automatically generated overlay around itemnames, based on
 	; values assigned to menu.pos and menu.boxcursor.coords parameters.
 	menu.boxbg.visible = 0
@@ -622,11 +624,13 @@
 	p2.cursor.switchtime = 3
 
 	; Enables the Mugen 1.1 cursor tween (if > 0) and allows adjusting its x and y tween factors
-	p1.cursor.tween.factor = 0.0, 0.0
+	p1.cursor.tween.factor = 0.5, 0.5
+	; Snaps the cursor when wrapping
+	p1.cursor.tween.wrap.snap = 0
 	; Resets cursor animation when moving to a new cell
 	p1.cursor.reset = 0
 
-	p2.cursor.tween.factor = 0.0, 0.0
+	p2.cursor.tween.factor = 0.5, 0.5
 	p2.cursor.reset = 0
 
 	; cursor parameters defaults to p1 and p2 values, if not specified
@@ -968,32 +972,32 @@
 	;p<pn>.member<num>.palmenu.text.offset = 0, 0
 	;p<pn>.member<num>.palmenu.text.font = -1, 0, 0
 	;p<pn>.member<num>.palmenu.text.scale = 1.0, 1.0
-	;p<pn>.member<num>_palmenu.text.xshear = 1.0
-	;p<pn>.member<num>_palmenu.text.angle = 1
+	;p<pn>.member<num>.palmenu.text.xshear = 1.0
+	;p<pn>.member<num>.palmenu.text.angle = 1
 	;p<pn>.palmenu.text.offset = 0, 0
 	;p<pn>.palmenu.text.font = -1, 0, 0
 	;p<pn>.palmenu.text.scale = 1.0, 1.0
 	;p<pn>.palmenu.text.xshear = 1.0
 	;p<pn>.palmenu.text.angle = 1
 	;p<pn>.palmenu.text.text = ""
-	p1.palmenu.bg.pos = 0, 0
+	p1.palmenu.pos = 0, 0
 	p1.palmenu.bg.anim = -1
 	p1.palmenu.bg.spr =
 	p1.palmenu.bg.offset = 0, 0
 	p1.palmenu.bg.facing = 1
 	p1.palmenu.bg.scale = 1.0, 1.0
-	p2.palmenu.bg.pos = 0, 0
-	p2.palmenu.bg.anim = -1
-	p2.palmenu.bg.spr = 
-	p2.palmenu.bg_offset = 0, 0
-	p2.palmenu.bg_facing = 1
-	p2.palmenu.bg_scale = 1.0, 1.0
 	p1.palmenu.next.key = "$F"
 	p1.palmenu.previous.key = "$B"
 	p1.palmenu.accept.key = "a&b&c"
 	p1.palmenu.cancel.key = "x&y&z"
 	p1.palmenu.random.key = "s"
 	p1.palmenu.random.text = "Random"
+	p2.palmenu.pos = 0, 0
+	p2.palmenu.bg.anim = -1
+	p2.palmenu.bg.spr = 
+	p2.palmenu.bg.offset = 0, 0
+	p2.palmenu.bg.facing = 1
+	p2.palmenu.bg.scale = 1.0, 1.0
 	p2.palmenu.next.key = "$F"
 	p2.palmenu.previous.key = "$B"
 	p2.palmenu.accept.key = "a&b&c"
@@ -1618,6 +1622,7 @@
 	menu.pos = 85, 33
 
 	menu.tween.factor = 0.3
+	menu.tween.wrap.snap = 0
 
 	;menu.bg.<itemname>.anim = -1
 	;menu.bg.<itemname>.spr = 
@@ -1703,6 +1708,7 @@
 	menu.boxcursor.alpharange = 10, 40, 2, 255, 255, 0
 	menu.boxcursor.tween.snap = 0
 	menu.boxcursor.tween.factor = 0.3
+	menu.boxcursor.tween.wrap.snap = 0
 
 	menu.boxbg.visible = 1
 	menu.boxbg.col = 0, 0, 0
@@ -1963,6 +1969,7 @@
 	menu.pos = 85, 33
 
 	menu.tween.factor = 0.3
+	menu.tween.wrap.snap = 0
 
 	;menu.bg.<itemname>.anim = -1
 	;menu.bg.<itemname>.spr = 
@@ -2009,6 +2016,7 @@
 	menu.boxcursor.alpharange = 10, 40, 2, 255, 255, 0
 	menu.boxcursor.tween.snap = 0
 	menu.boxcursor.tween.factor = 0.3
+	menu.boxcursor.tween.wrap.snap = 0
 
 	menu.boxbg.visible = 1
 	menu.boxbg.col = 0, 0, 0
@@ -2062,6 +2070,7 @@
 	menu.pos = 85, 33
 
 	menu.tween.factor = 0.3
+	menu.tween.wrap.snap = 0
 
 	;menu.bg.<itemname>.anim = -1
 	;menu.bg.<itemname>.spr = 
@@ -2132,6 +2141,7 @@
 	menu.boxcursor.alpharange = 10, 40, 2, 255, 255, 0
 	menu.boxcursor.tween.snap = 0
 	menu.boxcursor.tween.factor = 0.3
+	menu.boxcursor.tween.wrap.snap = 0
 
 	menu.boxbg.visible = 1
 	menu.boxbg.col = 0, 0, 0
@@ -2350,6 +2360,7 @@
 	menu.pos = 159, 158
 
 	menu.tween.factor = 0.3
+	menu.tween.wrap.snap = 0
 
 	;menu.bg.<itemname>.anim = -1
 	;menu.bg.<itemname>.spr = 

--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -3934,6 +3934,7 @@ function main.f_menuCommonCalc(t, item, cursorPosY, moveTxt, section, keyPrev, k
 			end
 		end
 	end
+	main.menuWrapped = false
 	if item > #t or (item == 1 and t[item].itemname == 'empty') then
 		item = 1
 		while true do
@@ -3941,6 +3942,10 @@ function main.f_menuCommonCalc(t, item, cursorPosY, moveTxt, section, keyPrev, k
 			item = item + 1
 		end
 		cursorPosY = item
+		if motif[section].menu_tween_wrap_snap == 1 then
+			main.menuSnap = true
+		end
+		main.menuWrapped = true
 	elseif item < 1 then
 		item = #t
 		while true do
@@ -3952,6 +3957,10 @@ function main.f_menuCommonCalc(t, item, cursorPosY, moveTxt, section, keyPrev, k
 		else
 			cursorPosY = item
 		end
+		if motif[section].menu_tween_wrap_snap == 1 then
+			main.menuSnap = true
+		end
+		main.menuWrapped = true
 	end
 	-- compute target: determine first visible item to keep cursor at row `cursorPosY`, clamp to valid range, and convert to pixel offset
 	local visible = motif[section].menu_window_visibleitems
@@ -4227,7 +4236,9 @@ function main.f_menuCommonDraw(t, item, cursorPosY, moveTxt, section, bgdef, tit
 		bcd.init = true
 		bcd.snap = -1
 	end
-
+	if motif[section].menu_boxcursor_tween_wrap_snap == 1 and main.menuWrapped then
+		bcd.offsetY = targetY
+	end
 	--apply tween if enabled, otherwise snap to target
 	if t_factor > 0 then
 		bcd.offsetY = f_tweenStep(bcd.offsetY, targetY, t_factor)

--- a/external/script/motif.lua
+++ b/external/script/motif.lua
@@ -166,6 +166,7 @@ local motif =
 		menu_hiscore_key = 's', --Ikemen feature
 		menu_pos = {159, 158},
 		menu_tween_factor = 0.3, --Ikemen feature
+		menu_tween_wrap_snap = 0 --Ikemen feature
 		--menu_bg_<itemname>_anim = -1, --Ikemen feature
 		--menu_bg_<itemname>_spr = {}, --Ikemen feature
 		--menu_bg_<itemname>_offset = {0, 0}, --Ikemen feature
@@ -200,6 +201,7 @@ local motif =
 		menu_boxcursor_visible = 1,
 		menu_boxcursor_tween_snap = 0, --Ikemen feature
 		menu_boxcursor_tween_factor = 0.3, --Ikemen feature
+		menu_boxcursor_tween_wrap_snap = 0 --Ikemen feature
 		menu_boxcursor_coords = {-40, -10, 39, 2},
 		menu_boxcursor_col = {255, 255, 255}, --Ikemen feature
 		menu_boxcursor_alpharange = {10, 40, 2, 255, 255, 0}, --Ikemen feature
@@ -305,7 +307,8 @@ local motif =
 		--cell_<col>_<row>_offset = {0, 0}, --Ikemen feature
 		--cell_<col>_<row>_facing = 1, --Ikemen feature
 		--cell_<col>_<row>_skip = 0, --Ikemen feature
-		p1_cursor_tween_factor = {0.3, 0.3}, --Ikemen feature
+		p1_cursor_tween_factor = {0.5, 0.5}, --Ikemen feature
+		p1_cursor_tween_wrap_snap = 0, --Ikemen feature
 		p1_cursor_startcell = {0, 0},
 		p1_cursor_active_anim = -1,
 		p1_cursor_active_spr = {},
@@ -321,7 +324,8 @@ local motif =
 		p1_cursor_done_snd = {100, 1},
 		p1_cursor_reset = 0, --Ikemen feature
 		p1_random_move_snd = {100, 0},
-		p2_cursor_tween_factor = {0.3, 0.3}, --Ikemen feature
+		p2_cursor_tween_factor = {0.5, 0.5}, --Ikemen feature
+		p2_cursor_tween_wrap_snap = 0 --Ikemen feature
 		p2_cursor_startcell = {0, 4},
 		p2_cursor_active_anim = -1,
 		p2_cursor_active_spr = {},
@@ -754,19 +758,12 @@ local motif =
 		--p<pn>_palmenu_text_scale = {1.0, 1.0}, --Ikemen feature
 		--p<pn>_palmenu_text_xshear = 1.0, --Ikemen feature
 		--p<pn>_palmenu_text_angle = 1, --Ikemen feature
-		--p<pn>_palmenu_text_text = '' --Ikemen feature
-		p1_palmenu_bg_pos = {0, 0}, --Ikemen feature
+		p1_palmenu_pos = {0, 0}, --Ikemen feature
 		p1_palmenu_bg_anim = -1, --Ikemen feature
 		p1_palmenu_bg_spr = {}, --Ikemen feature
 		p1_palmenu_bg_offset = {0, 0}, --Ikemen feature
 		p1_palmenu_bg_facing = 1, --Ikemen feature
 		p1_palmenu_bg_scale = {1.0, 1.0}, --Ikemen feature
-		p2_palmenu_bg_pos = {0, 0}, --Ikemen feature
-		p2_palmenu_bg_anim = -1, --Ikemen feature
-		p2_palmenu_bg_spr = {}, --Ikemen feature
-		p2_palmenu_bg_offset = {0, 0}, --Ikemen feature
-		p2_palmenu_bg_facing = 1, --Ikemen feature
-		p2_palmenu_bg_scale = {1.0, 1.0}, --Ikemen feature
 		p1_palmenu_next_key = '$F', --Ikemen feature
 		p1_palmenu_previous_key = '$B', --Ikemen feature
 		p1_palmenu_accept_key = 'a&b&c', --Ikemen feature
@@ -779,6 +776,12 @@ local motif =
 		p2_palmenu_cancel_key = 'x&y&z', --Ikemen feature
 		p2_palmenu_random_key = 's', --Ikemen feature
 		p2_palmenu_random_text = 'Random', --Ikemen feature
+		p2_palmenu_pos = {0, 0}, --Ikemen feature
+		p2_palmenu_bg_anim = -1, --Ikemen feature
+		p2_palmenu_bg_spr = {}, --Ikemen feature
+		p2_palmenu_bg_offset = {0, 0}, --Ikemen feature
+		p2_palmenu_bg_facing = 1, --Ikemen feature
+		p2_palmenu_bg_scale = {1.0, 1.0}, --Ikemen feature
 		palmenu_move_snd = {-1, 0}, --Ikemen feature
 		palmenu_done_snd = {-1, 0}, --Ikemen feature
 		palmenu_cancel_snd = {-1, 0}, --Ikemen feature
@@ -1247,6 +1250,7 @@ local motif =
 		menu_uselocalcoord = 0, --Ikemen feature
 		menu_pos = {85, 33}, --Ikemen feature
 		menu_tween_factor = 0.3, --Ikemen feature
+		menu_tween_wrap_snap = 0 --Ikemen feature
 		--menu_bg_<itemname>_anim = -1, --Ikemen feature
 		--menu_bg_<itemname>_spr = {}, --Ikemen feature
 		--menu_bg_<itemname>_offset = {0, 0}, --Ikemen feature
@@ -1316,6 +1320,7 @@ local motif =
 		menu_boxcursor_visible = 1, --Ikemen feature
 		menu_boxcursor_tween_snap = 0, --Ikemen feature
 		menu_boxcursor_tween_factor = 0.3, --Ikemen feature
+		menu_boxcursor_tween_wrap_snap = 0 --Ikemen feature
 		menu_boxcursor_coords = {-5, -10, 154, 3}, --Ikemen feature
 		menu_boxcursor_col = {255, 255, 255}, --Ikemen feature
 		menu_boxcursor_alpharange = {10, 40, 2, 255, 255, 0}, --Ikemen feature
@@ -1503,6 +1508,7 @@ local motif =
 		menu_uselocalcoord = 0, --Ikemen feature
 		menu_pos = {85, 33}, --Ikemen feature
 		menu_tween_factor = 0.3, --Ikemen feature
+		menu_tween_wrap_snap = 0 --Ikemen feature
 		--menu_bg_<itemname>_anim = -1, --Ikemen feature
 		--menu_bg_<itemname>_spr = {}, --Ikemen feature
 		--menu_bg_<itemname>_offset = {0, 0}, --Ikemen feature
@@ -1537,6 +1543,7 @@ local motif =
 		menu_boxcursor_visible = 1, --Ikemen feature
 		menu_boxcursor_tween_snap = 0, --Ikemen feature
 		menu_boxcursor_tween_factor = 0.3, --Ikemen feature
+		menu_boxcursor_tween_wrap_snap = 0 --Ikemen feature
 		menu_boxcursor_coords = {-5, -10, 154, 3}, --Ikemen feature
 		menu_boxcursor_col = {255, 255, 255}, --Ikemen feature
 		menu_boxcursor_alpharange = {10, 40, 2, 255, 255, 0}, --Ikemen feature
@@ -1581,6 +1588,7 @@ local motif =
 		menu_uselocalcoord = 0, --Ikemen feature
 		menu_pos = {85, 33}, --Ikemen feature
 		menu_tween_factor = 0.3, --Ikemen feature
+		menu_tween_wrap_snap = 0 --Ikemen feature
 		--menu_bg_<itemname>_anim = -1, --Ikemen feature
 		--menu_bg_<itemname>_spr = {}, --Ikemen feature
 		--menu_bg_<itemname>_offset = {0, 0}, --Ikemen feature
@@ -1635,6 +1643,7 @@ local motif =
 		menu_boxcursor_visible = 1, --Ikemen feature
 		menu_boxcursor_tween_snap = 0, --Ikemen feature
 		menu_boxcursor_tween_factor = 0.3, --Ikemen feature
+		menu_boxcursor_tween_wrap_snap = 0 --Ikemen feature
 		menu_boxcursor_coords = {-5, -10, 154, 3}, --Ikemen feature
 		menu_boxcursor_col = {255, 255, 255}, --Ikemen feature
 		menu_boxcursor_alpharange = {10, 40, 2, 255, 255, 0}, --Ikemen feature
@@ -1819,6 +1828,7 @@ local motif =
 		menu_accept_key = 'a&b&c&x&y&z&s', --Ikemen feature
 		menu_pos = {159, 158}, --Ikemen feature
 		menu_tween_factor = 0.3, --Ikemen feature
+		menu_tween_tween_wrap_snap = 0 --Ikemen feature
 		--menu_bg_<itemname>_anim = -1, --Ikemen feature
 		--menu_bg_<itemname>_spr = {}, --Ikemen feature
 		--menu_bg_<itemname>_offset = {0, 0}, --Ikemen feature
@@ -1853,6 +1863,7 @@ local motif =
 		menu_boxcursor_visible = 1, --Ikemen feature
 		menu_boxcursor_tween_snap = 0, --Ikemen feature
 		menu_boxcursor_tween_factor = 0.3, --Ikemen feature
+		menu_boxcursor_tween_wrap_snap = 0 --Ikemen feature
 		menu_boxcursor_coords = {-40, -10, 39, 2},
 		menu_boxcursor_col = {255, 255, 255}, --Ikemen feature
 		menu_boxcursor_alpharange = {10, 40, 2, 255, 255, 0}, --Ikemen feature
@@ -3074,7 +3085,7 @@ for _, v in ipairs({
 	{s = 'p1_teammenu_ratio5_icon_',      x = t_pos.p1_teammenu_pos[1] + t_pos.p1_teammenu_item_offset[1], y = t_pos.p1_teammenu_pos[2] + t_pos.p1_teammenu_item_offset[2]},
 	{s = 'p1_teammenu_ratio6_icon_',      x = t_pos.p1_teammenu_pos[1] + t_pos.p1_teammenu_item_offset[1], y = t_pos.p1_teammenu_pos[2] + t_pos.p1_teammenu_item_offset[2]},
 	{s = 'p1_teammenu_ratio7_icon_',      x = t_pos.p1_teammenu_pos[1] + t_pos.p1_teammenu_item_offset[1], y = t_pos.p1_teammenu_pos[2] + t_pos.p1_teammenu_item_offset[2]},
-	{s = 'p1_palmenu_bg_',                x = t_pos.p1_palmenu_bg_pos[1],                                  y = t_pos.p1_palmenu_bg_pos[2]},
+	{s = 'p1_palmenu_bg_',                x = t_pos.p1_palmenu_pos[1],                                     y = t_pos.p1_palmenu_pos[2]},
 	{s = 'p2_teammenu_bg_',               x = t_pos.p2_teammenu_pos[1],                                    y = t_pos.p2_teammenu_pos[2]},
 	{s = 'p2_teammenu_selftitle_',        x = t_pos.p2_teammenu_pos[1],                                    y = t_pos.p2_teammenu_pos[2]},
 	{s = 'p2_teammenu_enemytitle_',       x = t_pos.p2_teammenu_pos[1],                                    y = t_pos.p2_teammenu_pos[2]},
@@ -3088,7 +3099,7 @@ for _, v in ipairs({
 	{s = 'p2_teammenu_ratio5_icon_',      x = t_pos.p2_teammenu_pos[1] + t_pos.p2_teammenu_item_offset[1], y = t_pos.p2_teammenu_pos[2] + t_pos.p2_teammenu_item_offset[2]},
 	{s = 'p2_teammenu_ratio6_icon_',      x = t_pos.p2_teammenu_pos[1] + t_pos.p2_teammenu_item_offset[1], y = t_pos.p2_teammenu_pos[2] + t_pos.p2_teammenu_item_offset[2]},
 	{s = 'p2_teammenu_ratio7_icon_',      x = t_pos.p2_teammenu_pos[1] + t_pos.p2_teammenu_item_offset[1], y = t_pos.p2_teammenu_pos[2] + t_pos.p2_teammenu_item_offset[2]},
-	{s = 'p2_palmenu_bg_',                x = t_pos.p2_palmenu_bg_pos[1],                                  y = t_pos.p2_palmenu_bg_pos[2]},
+	{s = 'p2_palmenu_bg_',                x = t_pos.p2_palmenu_pos[1],                                     y = t_pos.p2_palmenu_pos[2]},
 	{s = 'stage_portrait_random_',        x = t_pos.stage_pos[1],                                          y = t_pos.stage_pos[2]},
 	{s = 'stage_portrait_bg_',            x = t_pos.stage_pos[1],                                          y = t_pos.stage_pos[2]},
 }) do


### PR DESCRIPTION
Feat:
- Added ``tween.wrap.snap`` when enabled, snaps the cursor or the menu directly when wrapping

Fixes:
- Duplicate palettes when two players confirmed at the same time
- Using the menu key on ``px.palmenu.cancel.key`` no longer exits the select screen
- ``px.palmenu.bg.pos`` renamed to ``px.palmenu.pos``, and the menu's overall position is now based on this parameter

updated screenpacks defaults: https://github.com/ikemen-engine/Ikemen_GO-Elecbyte-Screenpack/pull/36