### PR TITLE
fix: Fixes Zoom processing when CameraBound is enabled

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -12870,6 +12870,7 @@ func (sc modifyPlayer) Run(c *Char, _ []int32) bool {
 				crun.unsetSCF(SCF_ctrl)
 			} else {
 				crun.unsetSCF(SCF_ko)
+				crun.unsetSCF(SCF_over_alive | SCF_over_ko)
 			}
 		case modifyPlayer_ailevel:
 			crun.setAILevel(exp[0].evalF(c))

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -5892,7 +5892,7 @@ func (c *Compiler) paramSaveData(is IniSection, sc *StateControllerBase, id byte
 
 // Parse trans and alpha together
 func (c *Compiler) paramTrans(is IniSection, sc *StateControllerBase,
-	prefix string, id byte, afterImage bool) error {
+	prefix string, id byte, cnsParam bool) error {
 
 	return c.stateParam(is, prefix+"trans", false, func(data string) error {
 		if len(data) == 0 {
@@ -5925,8 +5925,8 @@ func (c *Compiler) paramTrans(is IniSection, sc *StateControllerBase,
 			tt = TT_sub
 			defsrc, defdst = 255, 255
 		default:
-			// In Mugen, afterimages ignore invalid parameter names
-			if !afterImage || c.zssMode || !sys.ignoreMostErrors {
+			// In Mugen, cns ignore invalid parameter names
+			if !cnsParam || c.zssMode || !sys.ignoreMostErrors {
 				return Error("Invalid trans type: " + data)
 			} else {
 				sys.appendToConsole("WARNING: " + sys.cgi[c.playerNo].nameLow + fmt.Sprintf(": Invalid trans type: "+data+" in state %v ", c.stateNo))

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -645,7 +645,11 @@ func (c *Compiler) helper(is IniSection, sc *StateControllerBase, _ int8) (State
 		}
 		if err := c.stateParam(is, "name", false, func(data string) error {
 			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
-				return Error("Helper name not enclosed in \"")
+				if c.zssMode {
+					return Error("Helper name not enclosed in \"")
+				}
+				sys.appendToConsole("WARNING: " + sys.cgi[c.playerNo].nameLow + fmt.Sprintf(": Helper name not enclosed in \" : in state %v ", c.stateNo))
+				return nil
 			}
 			sc.add(helper_name, sc.beToExp(BytecodeExp(data[1:len(data)-1])))
 			return nil
@@ -927,7 +931,7 @@ func (c *Compiler) explodSub(is IniSection,
 		explod_removeonchangestate, VT_Bool, 1, false); err != nil {
 		return err
 	}
-	if err := c.paramTrans(is, sc, "", explod_trans, false); err != nil {
+	if err := c.paramTrans(is, sc, "", explod_trans, true); err != nil {
 		return err
 	}
 	if err := c.palFXSub(is, sc, "palfx."); err != nil {
@@ -3430,7 +3434,7 @@ func (c *Compiler) trans(is IniSection, sc *StateControllerBase, _ int8) (StateC
 			trans_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.paramTrans(is, sc, "", trans_trans, false); err != nil {
+		if err := c.paramTrans(is, sc, "", trans_trans, true); err != nil {
 			return err
 		}
 		return nil

--- a/src/stage.go
+++ b/src/stage.go
@@ -1253,7 +1253,7 @@ func loadStage(def string, maindef bool) (*Stage, error) {
 	}
 	if sectionExists {
 		sectionExists = false
-		s.bgmusic = sec[0]["bgmusic"]
+		s.bgmusic = decodeShiftJIS(sec[0]["bgmusic"])
 		sec[0].ReadI32("bgmvolume", &s.bgmvolume)
 		sec[0].ReadI32("bgmloopstart", &s.bgmloopstart)
 		sec[0].ReadI32("bgmloopend", &s.bgmloopend)

--- a/src/system.go
+++ b/src/system.go
@@ -600,7 +600,11 @@ func (s *System) renderFrame() {
 			if s.zoomStageBound {
 				dscl = MaxF(s.cam.MinScale, s.drawScale/s.cam.BaseScale())
 				if s.zoomCameraBound {
-					dx = x + ClampF(s.zoomPosXLag/scl, -s.cam.halfWidth/scl*2*(1-1/s.zoomScale), s.cam.halfWidth/scl*2*(1-1/s.zoomScale))
+					zoomedViewWidth := float32(s.gameWidth) / s.drawScale
+					minCamX := x - (s.cam.halfWidth/scl - zoomedViewWidth/2)
+					maxCamX := x + (s.cam.halfWidth/scl - zoomedViewWidth/2)
+					intermediateTargetX := x + s.zoomPosXLag/scl
+					dx = ClampF(intermediateTargetX, minCamX, maxCamX)
 				} else {
 					dx = x + s.zoomPosXLag/scl
 				}


### PR DESCRIPTION
・Fixes #2569 Zoom processing when CameraBound is enabled. 
・Fixes it so that chars properly revive when ModifyPlayer alive is set to 1. 
・Add support for Shift-JIS in stage BGM file names. 
・Ensured that invalid Helper name parameters and Explod/Trans trans parameters do not cause crashes in CNS. Matches MUGEN's specification.