### PR TITLE
fix: Fixes a bug in the default AttackMul

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -12870,7 +12870,7 @@ func (sc modifyPlayer) Run(c *Char, _ []int32) bool {
 				crun.unsetSCF(SCF_ctrl)
 			} else {
 				crun.unsetSCF(SCF_ko)
-				crun.unsetSCF(SCF_over_alive | SCF_over_ko)
+				crun.unsetSCF(SCF_over_ko)
 			}
 		case modifyPlayer_ailevel:
 			crun.setAILevel(exp[0].evalF(c))

--- a/src/char.go
+++ b/src/char.go
@@ -2867,7 +2867,7 @@ func (c *Char) enemyNearP2Clear() {
 func (c *Char) prepareNextRound() {
 	c.sysVarRangeSet(0, math.MaxInt32, 0)
 	c.sysFvarRangeSet(0, math.MaxInt32, 0)
-	atk := float32(c.gi().data.attack) * c.ocd().attackRatio / 100
+	atk := c.ocd().attackRatio
 	c.CharSystemVar = CharSystemVar{
 		bindToId:              -1,
 		angleDrawScale:        [2]float32{1, 1},
@@ -5601,7 +5601,7 @@ func (c *Char) playSound(ffx string, lowpriority bool, loopCount int32, g, n, ch
 }
 
 func (c *Char) autoTurn() {
-	if c.helperIndex == 0 && !c.asf(ASF_noautoturn) && sys.stage.autoturn && c.shouldFaceP2() {
+	if c.helperIndex == 0 && !c.asf(ASF_noautoturn) && sys.stage.autoturn && c.shouldFaceP2() && (c.ss.no != 52 || c.animTime() == 0) {
 		switch c.ss.stateType {
 		case ST_S:
 			if c.animNo != 5 {

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -3434,7 +3434,7 @@ func (c *Compiler) trans(is IniSection, sc *StateControllerBase, _ int8) (StateC
 			trans_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.paramTrans(is, sc, "", trans_trans, true); err != nil {
+		if err := c.paramTrans(is, sc, "", trans_trans, false); err != nil {
 			return err
 		}
 		return nil

--- a/src/script.go
+++ b/src/script.go
@@ -3813,7 +3813,7 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "defence", func(*lua.LState) int {
-		l.Push(lua.LNumber(float32(sys.debugWC.finalDefense * 100)))
+		l.Push(lua.LNumber(sys.debugWC.finalDefense * 100))
 		return 1
 	})
 	luaRegister(l, "drawgame", func(*lua.LState) int {
@@ -5520,10 +5520,6 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.debugWC.animPN + 1))
 		return 1
 	})
-	luaRegister(l, "attack", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.attackMul[0] * 100))
-		return 1
-	})
 	luaRegister(l, "clamp", func(*lua.LState) int {
 		v1, v2, v3, retv := float32(numArg(l, 1)), float32(numArg(l, 2)), float32(numArg(l, 3)), float32(0)
 		retv = MaxF(v2, MinF(v1, v3))
@@ -5559,11 +5555,6 @@ func triggerFunctions(l *lua.LState) {
 	})
 	luaRegister(l, "decisiveround", func(*lua.LState) int {
 		l.Push(lua.LBool(sys.decisiveRound[^sys.debugWC.playerNo&1]))
-		return 1
-	})
-	// deg (dedicated functionality already exists in Lua)
-	luaRegister(l, "defence", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.finalDefense * 100))
 		return 1
 	})
 	luaRegister(l, "displayname", func(*lua.LState) int {


### PR DESCRIPTION
・Fixes a bug in the default AttackMul where Const values were being calculated twice.
・Fixes so that the turn-around animation in stateno=52 is performed after the existing animation is completed. 
・Fixes Trans's trans parameter to crash on invalid syntax. 
・Removed unnecessary SCF operations in ModifyPlayer's alive. 
・Removed duplicates in script.go.