### PR TITLE
fix: Text rendering

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -12239,6 +12239,7 @@ func (cl *CharList) pushDetection(getter *Char) {
 				// Update position interpolation
 				// TODO: Interpolation still looks wrong when framerate is above 60fps
 				c.setPosX(c.pos[0], true)
+				getter.setPosX(getter.pos[0], true)
 			}
 
 			// TODO: Z axis push might need some decision for who stays in the corner, like X axis
@@ -12265,6 +12266,7 @@ func (cl *CharList) pushDetection(getter *Char) {
 
 				// Update position interpolation
 				c.setPosZ(c.pos[2], true)
+				getter.setPosZ(getter.pos[2], true)
 			}
 		}
 	}

--- a/src/font.go
+++ b/src/font.go
@@ -671,50 +671,56 @@ func (ts *TextSprite) SetTextVel() {
 }
 
 func (ts *TextSprite) Draw() {
-	if !sys.frameSkip && ts.fnt != nil {
-		tabSize := 4
-		tabSpaces := strings.Repeat(" ", tabSize)
+	if sys.frameSkip || ts.fnt == nil || len(ts.text) == 0 {
+		return
+	}
 
-		if sys.tickFrame() {
-			if ts.textDelay > 0 { // If textDelay is greater than 0, it controls the maximum number of characters
-				ts.elapsedTicks++
-			}
-			ts.SetTextVel()
-			if ts.palfx != nil && !ts.forcecolor {
-				ts.palfx.step()
-			}
+	// Replace each tab with 4 spaces
+	// We do this first so that length checks are accurate
+	text := strings.ReplaceAll(ts.text, "\t", "    ")
+
+	maxChars := int32(len(text))
+
+	// If textDelay is greater than 0, it controls the maximum number of characters
+	if ts.textDelay > 0 {
+		// Offset the delay so that we show the first character immediately
+		elapsed := ts.elapsedTicks + ts.textDelay
+		maxChars = int32(elapsed / ts.textDelay)
+	}
+
+	maxChars = Clamp(maxChars, 0, int32(len(text)))
+
+	// Control of total displayed characters
+	totalCharsShown := 0
+
+	lines := strings.Split(text, "\n")
+
+	for i, line := range lines {
+		lineLength := len(line)
+
+		// Shows the characters progressively
+		charsToShow := int(Min(int32(lineLength), maxChars-int32(totalCharsShown)))
+		if charsToShow <= 0 {
+			continue
 		}
 
-		maxChars := int32(ts.elapsedTicks / ts.textDelay)
-		totalCharsShown := 0 // Control of total displayed characters
+		newY := ts.y + float32(i)*ts.yscl*ts.lineSpacing
 
-		lines := strings.Split(ts.text, "\n")
-		for i, line := range lines {
-			line = strings.ReplaceAll(line, "\t", tabSpaces)
-			newY := ts.y + float32(i)*ts.yscl*ts.lineSpacing
-			lineLength := len(line)
+		// Xshear offset correction
+		xshear := -ts.xshear
+		xsoffset := xshear * (float32(ts.fnt.offset[1]) * ts.yscl)
 
-			// Shows the characters progressively
-			charsToShow := lineLength // Default to show the entire line
-			if ts.textDelay > 0 {
-				charsToShow = int(Min(int32(lineLength), maxChars-int32(totalCharsShown)))
-				totalCharsShown += charsToShow
-			}
+		// Draw the visible line
+		if ts.fnt.Type == "truetype" {
+			ts.fnt.DrawTtf(line[:charsToShow], ts.x, newY, ts.xscl, ts.yscl, ts.align, true, &ts.window, ts.frgba)
+		} else {
+			ts.fnt.DrawText(line[:charsToShow], ts.x-xsoffset, newY, ts.xscl, ts.yscl,
+				xshear, Rotation{ts.angle, 0, 0}, ts.bank, ts.align, &ts.window, ts.palfx)
+		}
 
-			// Xshear offset correction
-			xshear := -ts.xshear
-			xsoffset := xshear * (float32(ts.fnt.offset[1]) * ts.yscl)
-
-			// Draws the visible line
-			if ts.fnt.Type == "truetype" {
-				ts.fnt.DrawTtf(line[:charsToShow], ts.x, newY, ts.xscl, ts.yscl, ts.align, true, &ts.window, ts.frgba)
-			} else {
-				ts.fnt.DrawText(line[:charsToShow], ts.x-xsoffset, newY, ts.xscl, ts.yscl, xshear, Rotation{ts.angle, 0, 0}, ts.bank, ts.align, &ts.window, ts.palfx)
-			}
-
-			if ts.textDelay > 0 && totalCharsShown >= int(maxChars) {
-				break
-			}
+		totalCharsShown += charsToShow
+		if totalCharsShown >= int(maxChars) {
+			break
 		}
 	}
 }

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -4919,19 +4919,29 @@ func (l *Lifebar) step() {
 }
 
 func (l *Lifebar) UpdateText() {
-	tempSlice := l.textsprite[:0]
+	// Explod timers update at this time, so we'll do the same here
+	if sys.tickNextFrame() {
+		tempSlice := l.textsprite[:0]
 
-	for _, ts := range l.textsprite {
-		if ts.removetime > 0 { // No infinite time at the moment since text sprites are not very efficient
-			ts.Draw()
-			if sys.tickNextFrame() {
-				ts.removetime--
+		for _, ts := range l.textsprite {
+			ts.elapsedTicks++
+
+			ts.SetTextVel()
+
+			if ts.palfx != nil && !ts.forcecolor {
+				ts.palfx.step()
 			}
-			tempSlice = append(tempSlice, ts)
-		}
-	}
 
-	l.textsprite = tempSlice
+			if ts.removetime != 0 {
+				tempSlice = append(tempSlice, ts) // Keep this text
+				if ts.removetime > 0 {
+					ts.removetime--
+				}
+			}
+		}
+
+		l.textsprite = tempSlice
+	}
 }
 
 func (l *Lifebar) RemoveText(id, ownerid int32) {


### PR DESCRIPTION
- Removed duplicate draw call for texts
- Clearer separation of concerns between Text Update() and Draw()
- When using textdelay the first letter is now shown immediately instead of also having delay
- Re-added support for infinite removetime
- Fixes #2759 