### PR TITLE
feat: Avoid repeats for random select 

### DIFF
--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -20,7 +20,7 @@ local t_aiRamp = {}
 local t_gameStats = {}
 local t_recordText = {}
 local t_reservedChars = {{}, {}}
-local t_unchosenChars = {{}, {}}
+local t_unchosenRandChars = {{}, {}}
 local timerSelect = 0
 local cursorActive = {}
 local cursorDone = {}
@@ -1367,38 +1367,38 @@ end
 
 -- Resets the unchosen character pool for a player
 local function f_resetUnchosenChars(pn, allowReserved)
-	t_unchosenChars[pn] = {}
+	t_unchosenRandChars[pn] = {}
 	if allowReserved then
 		for _, v in ipairs(main.t_randomChars) do
-			table.insert(t_unchosenChars[pn], v)
+			table.insert(t_unchosenRandChars[pn], v)
 		end
 		return
 	end
 
 	for _, v in ipairs(main.t_randomChars) do
 		if not t_reservedChars[pn][v] then
-			table.insert(t_unchosenChars[pn], v)
+			table.insert(t_unchosenRandChars[pn], v)
 		end
 	end
 
 	-- If we still have no characters, allow reserved characters
 	-- This is similar to the way the old code worked
-	if #t_unchosenChars[pn] == 0 then
+	if #t_unchosenRandChars[pn] == 0 then
 		f_resetUnchosenChars(pn, true)
 	end
 end
 
 -- Selects a random character and removes it from the unchosen pool
 local function f_useUnchosenChar(pn)
-	if #t_unchosenChars[pn] == 0 then
+	if #t_unchosenRandChars[pn] == 0 then
 		return nil
 	end
-	local randomIndex = math.random(1, #t_unchosenChars[pn])
-	local selectedChar = t_unchosenChars[pn][randomIndex]
+	local randomIndex = math.random(1, #t_unchosenRandChars[pn])
+	local selectedChar = t_unchosenRandChars[pn][randomIndex]
 
 	-- Remove selected character from pool (swap with last and remove)
-	t_unchosenChars[pn][randomIndex] = t_unchosenChars[pn][#t_unchosenChars[pn]]
-	table.remove(t_unchosenChars[pn])
+	t_unchosenRandChars[pn][randomIndex] = t_unchosenRandChars[pn][#t_unchosenRandChars[pn]]
+	table.remove(t_unchosenRandChars[pn])
 
 	return selectedChar
 end
@@ -1409,7 +1409,7 @@ function start.f_randomChar(pn)
 		return nil
 	end
 
-	if #t_unchosenChars[pn] == 0 then
+	if #t_unchosenRandChars[pn] == 0 then
 		if gameOption('Options.Team.Duplicates') then
 			f_resetUnchosenChars(pn, true)
 		else

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -20,6 +20,7 @@ local t_aiRamp = {}
 local t_gameStats = {}
 local t_recordText = {}
 local t_reservedChars = {{}, {}}
+local t_unchosenChars = {{}, {}}
 local timerSelect = 0
 local cursorActive = {}
 local cursorDone = {}
@@ -1364,24 +1365,59 @@ function start.f_excludeChar(t, ref)
 	return t
 end
 
+-- Resets the unchosen character pool for a player
+local function f_resetUnchosenChars(pn, allowReserved)
+	t_unchosenChars[pn] = {}
+	if allowReserved then
+		for _, v in ipairs(main.t_randomChars) do
+			table.insert(t_unchosenChars[pn], v)
+		end
+		return
+	end
+
+	for _, v in ipairs(main.t_randomChars) do
+		if not t_reservedChars[pn][v] then
+			table.insert(t_unchosenChars[pn], v)
+		end
+	end
+
+	-- If we still have no characters, allow reserved characters
+	-- This is similar to the way the old code worked
+	if #t_unchosenChars[pn] == 0 then
+		f_resetUnchosenChars(pn, true)
+	end
+end
+
+-- Selects a random character and removes it from the unchosen pool
+local function f_useUnchosenChar(pn)
+	if #t_unchosenChars[pn] == 0 then
+		return nil
+	end
+	local randomIndex = math.random(1, #t_unchosenChars[pn])
+	local selectedChar = t_unchosenChars[pn][randomIndex]
+
+	-- Remove selected character from pool (swap with last and remove)
+	t_unchosenChars[pn][randomIndex] = t_unchosenChars[pn][#t_unchosenChars[pn]]
+	table.remove(t_unchosenChars[pn])
+
+	return selectedChar
+end
+
 --returns random char ref
 function start.f_randomChar(pn)
 	if #main.t_randomChars == 0 then
 		return nil
 	end
-	if gameOption('Options.Team.Duplicates') then
-		return main.t_randomChars[math.random(1, #main.t_randomChars)]
-	end
-	local t = {}
-	for k, v in ipairs(main.t_randomChars) do
-		if not t_reservedChars[pn][v] then
-			table.insert(t, v)
+
+	if #t_unchosenChars[pn] == 0 then
+		if gameOption('Options.Team.Duplicates') then
+			f_resetUnchosenChars(pn, true)
+		else
+			f_resetUnchosenChars(pn, false)
 		end
 	end
-	if #t > 0 then
-		return t[math.random(1, #t)]
-	end
-	return main.t_randomChars[math.random(1, #main.t_randomChars)]
+
+	return f_useUnchosenChar(pn)
 end
 
 --return true if slot is selected, update start.t_grid

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -21,6 +21,7 @@ local t_gameStats = {}
 local t_recordText = {}
 local t_reservedChars = {{}, {}}
 local t_unchosenRandChars = {{}, {}}
+local t_lastRandChar = {}
 local timerSelect = 0
 local cursorActive = {}
 local cursorDone = {}
@@ -1396,9 +1397,20 @@ local function f_useUnchosenChar(pn)
 	local randomIndex = math.random(1, #t_unchosenRandChars[pn])
 	local selectedChar = t_unchosenRandChars[pn][randomIndex]
 
+	-- Just making sure we don't select the same character twice in a row
+	if selectedChar == t_lastRandChar[pn] and #t_unchosenRandChars[pn] > 1 then
+		if randomIndex == 1 then
+			randomIndex = #t_unchosenRandChars[pn]
+		else
+			randomIndex = randomIndex - 1
+		end
+		selectedChar = t_unchosenRandChars[pn][randomIndex]
+	end
+
 	-- Remove selected character from pool (swap with last and remove)
 	t_unchosenRandChars[pn][randomIndex] = t_unchosenRandChars[pn][#t_unchosenRandChars[pn]]
 	table.remove(t_unchosenRandChars[pn])
+	t_lastRandChar[pn] = selectedChar
 
 	return selectedChar
 end

--- a/src/system.go
+++ b/src/system.go
@@ -3933,6 +3933,8 @@ func (s *Select) AddStage(def string) error {
 	return nil
 }
 
+// Not sure where to run this
+// Should be run after s.charlist has been set 
 func (s *Select) InitRandomPools(numTeams int) {
 	s.unchosenIndices = make([][]int, numTeams)
 	for i := 0; i < numTeams; i++ {
@@ -3984,7 +3986,8 @@ func (s *Select) AddSelectedChar(tn, cn, pl int) bool {
 		return false
 	}
 	/*
-		Old Version
+		Old Version, should be used when the proper config.ini setting is used
+		Not sure how to retrieve it
 		m := 0
 		for s.charlist[n].def == "randomselect" || len(s.charlist[n].def) == 0 {
 			m++
@@ -3997,7 +4000,7 @@ func (s *Select) AddSelectedChar(tn, cn, pl int) bool {
 	*/
 
 	if s.charlist[n].def == "randomselect" {
-		n = s.GetRandomUnchosen(tn) // Pass team number
+		n = s.GetRandomUnchosen(tn)
 		if n < 0 {
 			return false
 		}

--- a/src/system.go
+++ b/src/system.go
@@ -3308,6 +3308,8 @@ type Select struct {
 	cdefOverwrite      map[int]string
 	sdefOverwrite      string
 	ocd                [3][]OverrideCharData
+
+	unchosenIndices [][]int // Used to track unchosen characters for random select
 }
 
 func newSelect() *Select {
@@ -3931,19 +3933,77 @@ func (s *Select) AddStage(def string) error {
 	return nil
 }
 
+func (s *Select) InitRandomPools(numTeams int) {
+	s.unchosenIndices = make([][]int, numTeams)
+	for i := 0; i < numTeams; i++ {
+		s.ResetUnchosen(i)
+	}
+}
+
+func (s *Select) ResetUnchosen(tn int) {
+	if tn < 0 || tn >= len(s.unchosenIndices) {
+		return
+	}
+
+	s.unchosenIndices[tn] = make([]int, 0, len(s.charlist))
+	for i := range s.charlist {
+		// only add non randomselect characters to possible options
+		if s.charlist[i].def != "randomselect" && len(s.charlist[i].def) > 0 {
+			s.unchosenIndices[tn] = append(s.unchosenIndices[tn], i)
+		}
+	}
+}
+
+func (s *Select) GetRandomUnchosen(tn int) int {
+	if tn < 0 || tn >= len(s.unchosenIndices) {
+		return -1
+	}
+
+	if len(s.unchosenIndices[tn]) == 0 {
+		s.ResetUnchosen(tn)
+	}
+
+	if len(s.unchosenIndices[tn]) == 0 {
+		return -1
+	}
+
+	pool := s.unchosenIndices[tn]
+	randomPos := int(Rand(0, int32(len(pool))-1))
+	chosen := pool[randomPos]
+
+	lastIdx := len(pool) - 1
+	pool[randomPos] = pool[lastIdx]
+	s.unchosenIndices[tn] = pool[:lastIdx]
+
+	return chosen
+}
+
 func (s *Select) AddSelectedChar(tn, cn, pl int) bool {
-	m, n := 0, s.GetCharNo(cn)
+	n := s.GetCharNo(cn)
 	if len(s.charlist) == 0 || len(s.charlist[n].def) == 0 {
 		return false
 	}
-	for s.charlist[n].def == "randomselect" || len(s.charlist[n].def) == 0 {
-		m++
-		if m > 100000 {
+	/*
+		Old Version
+		m := 0
+		for s.charlist[n].def == "randomselect" || len(s.charlist[n].def) == 0 {
+			m++
+			if m > 100000 {
+				return false
+			}
+			n = int(Rand(0, int32(len(s.charlist))-1))
+			pl = int(Rand(1, int32(sys.cfg.Config.PaletteMax)))
+		}
+	*/
+
+	if s.charlist[n].def == "randomselect" {
+		n = s.GetRandomUnchosen(tn) // Pass team number
+		if n < 0 {
 			return false
 		}
-		n = int(Rand(0, int32(len(s.charlist))-1))
 		pl = int(Rand(1, int32(sys.cfg.Config.PaletteMax)))
 	}
+
 	sys.loadMutex.Lock()
 	s.selected[tn] = append(s.selected[tn], [...]int{n, pl})
 	s.ocd[tn] = append(s.ocd[tn], *newOverrideCharData())

--- a/src/system.go
+++ b/src/system.go
@@ -3309,7 +3309,7 @@ type Select struct {
 	sdefOverwrite      string
 	ocd                [3][]OverrideCharData
 
-	unchosenIndices [][]int // Used to track unchosen characters for random select
+	validCharIndices []int
 }
 
 func newSelect() *Select {
@@ -3933,52 +3933,14 @@ func (s *Select) AddStage(def string) error {
 	return nil
 }
 
-// Not sure where to run this
-// Should be run after s.charlist has been set 
-func (s *Select) InitRandomPools(numTeams int) {
-	s.unchosenIndices = make([][]int, numTeams)
-	for i := 0; i < numTeams; i++ {
-		s.ResetUnchosen(i)
-	}
-}
-
-func (s *Select) ResetUnchosen(tn int) {
-	if tn < 0 || tn >= len(s.unchosenIndices) {
-		return
-	}
-
-	s.unchosenIndices[tn] = make([]int, 0, len(s.charlist))
+func (s *Select) ResetValidCharIndices() {
+	s.validCharIndices = make([]int, 0, len(s.charlist))
 	for i := range s.charlist {
 		// only add non randomselect characters to possible options
 		if s.charlist[i].def != "randomselect" && len(s.charlist[i].def) > 0 {
-			s.unchosenIndices[tn] = append(s.unchosenIndices[tn], i)
+			s.validCharIndices = append(s.validCharIndices, i)
 		}
 	}
-}
-
-func (s *Select) GetRandomUnchosen(tn int) int {
-	if tn < 0 || tn >= len(s.unchosenIndices) {
-		return -1
-	}
-
-	if len(s.unchosenIndices[tn]) == 0 {
-		s.ResetUnchosen(tn)
-	}
-
-	// If all items in charlist are randomselect or nonexistant, the list will be empty after resetting
-	if len(s.unchosenIndices[tn]) == 0 {
-		return -1
-	}
-
-	pool := s.unchosenIndices[tn]
-	randomPos := int(Rand(0, int32(len(pool))-1))
-	chosen := pool[randomPos]
-
-	lastIdx := len(pool) - 1
-	pool[randomPos] = pool[lastIdx]
-	s.unchosenIndices[tn] = pool[:lastIdx]
-
-	return chosen
 }
 
 func (s *Select) AddSelectedChar(tn, cn, pl int) bool {
@@ -4001,7 +3963,12 @@ func (s *Select) AddSelectedChar(tn, cn, pl int) bool {
 	*/
 
 	if s.charlist[n].def == "randomselect" {
-		n = s.GetRandomUnchosen(tn)
+		if len(s.validCharIndices) == 0 {
+			return false
+		}
+		randomPos := int(Rand(0, int32(len(s.validCharIndices))-1))
+
+		n = s.validCharIndices[randomPos]
 		if n < 0 {
 			return false
 		}
@@ -4021,6 +3988,7 @@ func (s *Select) ClearSelected() {
 	s.ocd = [3][]OverrideCharData{}
 	sys.loadMutex.Unlock()
 	s.selectedStageNo = -1
+	s.ResetValidCharIndices()
 }
 
 type LoaderState int32

--- a/src/system.go
+++ b/src/system.go
@@ -3965,6 +3965,7 @@ func (s *Select) GetRandomUnchosen(tn int) int {
 		s.ResetUnchosen(tn)
 	}
 
+	// If all items in charlist are randomselect or nonexistant, the list will be empty after resetting
 	if len(s.unchosenIndices[tn]) == 0 {
 		return -1
 	}

--- a/src/system.go
+++ b/src/system.go
@@ -3967,11 +3967,7 @@ func (s *Select) AddSelectedChar(tn, cn, pl int) bool {
 			return false
 		}
 		randomPos := int(Rand(0, int32(len(s.validCharIndices))-1))
-
 		n = s.validCharIndices[randomPos]
-		if n < 0 {
-			return false
-		}
 		pl = int(Rand(1, int32(sys.cfg.Config.PaletteMax)))
 	}
 


### PR DESCRIPTION
Related to #2771 

# Help Needed
- @potsmugen mentioned that there should be an option in the `config.ini`, I don't know where that is. I saved the old code for that though
- Looks like most of the random select is handled in Lua so I'm not sure if the Go code is necessary. We can remove it since statistically choosing randomselect that many times is unlikely.


# Changes
## Go
- Creates a list of valid characters to choose from when resetting
- When randomselect is chosen for a character, choose from the valid characters

## Lua
- Created unchosen and lastchosen tables
- when choosing random
  - if the lastchosen table for a user is empty, it gets created. I've tried to keep the old reservedChars logic
  - we then choose a random item from the table and remove it
    - if the item is the same as the last item chosen, we try to choose the item before it. This avoids showing the same character more than once is a bit of an eyesore
    

