### PR TITLE
fix: Prevent same random from being chosen twice in a row after refreshing pool

### DIFF
--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -536,11 +536,13 @@ function start.stageShuffleBag(id, pool)
 		end
 		start.shuffleTable(t)
 		start.shuffleBags[id] = t
+
 		-- prevent same stage from being chosen twice in a row
-		if start.previousRandStage[id] == t[#t] then
+		if #t > 1 and start.previousRandStage[id] == t[#t] then
 			local tmp = t[#t]
-			t[#t] = t[1]
-			t[1] = tmp
+			newLast = math.random(1, #t - 1)
+			t[#t] = t[newLast]
+			t[newLast] = tmp
 		end
 		start.previousRandStage[id] = t[1]
 	end
@@ -1431,10 +1433,11 @@ function start.f_randomChar(pn)
 		start.shuffleBags[pn] = t
 
 		-- prevent same character from being chosen twice in a row
-		if start.previousRandChar[pn] == t[#t] then
+		if #t > 1 and start.previousRandChar[pn] == t[#t] then
 			local tmp = t[#t]
-			t[#t] = t[1]
-			t[1] = tmp
+			newLast = math.random(1, #t - 1)
+			t[#t] = t[newLast]
+			t[newLast] = tmp
 		end
 		start.previousRandChar[pn] = t[1]
 	end
@@ -2987,10 +2990,11 @@ function start.f_randomPal(charRef)
 		start.shufflePals[charRef] = t
 
 		-- prevent same palette from being chosen twice in a row
-		if start.previousRandPal[charRef] == t[#t] then
+		if #t > 1 and start.previousRandPal[charRef] == t[#t] then
 			local tmp = t[#t]
-			t[#t] = t[1]
-			t[1] = tmp
+			newLast = math.random(1, #t - 1)
+			t[#t] = t[newLast]
+			t[newLast] = tmp
 		end
 		start.previousRandPal[charRef] = t[1]
 	end

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -527,6 +527,7 @@ function start.stageShuffleBag(id, pool)
 	id = id or 'defaultStageBag'
 	start.shuffleBags = start.shuffleBags or {}
 	start.shuffleBags[id] = start.shuffleBags[id] or {}
+	start.previousRandStage = start.previousRandStage or {}
 
 	if #start.shuffleBags[id] == 0 then
 		local t = {}
@@ -535,6 +536,13 @@ function start.stageShuffleBag(id, pool)
 		end
 		start.shuffleTable(t)
 		start.shuffleBags[id] = t
+		-- prevent same stage from being chosen twice in a row
+		if start.previousRandStage[id] == t[#t] then
+			local tmp = t[#t]
+			t[#t] = t[1]
+			t[1] = tmp
+		end
+		start.previousRandStage[id] = t[1]
 	end
 
 	local idx = table.remove(start.shuffleBags[id])
@@ -1409,6 +1417,7 @@ function start.f_randomChar(pn)
 		return nil
 	end
 	start.shuffleBags = start.shuffleBags or {}
+	start.previousRandChar = start.previousRandChar or {}
 
 	if not start.shuffleBags[pn] or #start.shuffleBags[pn] == 0 then
 		start.shuffleBags[pn] = {}
@@ -1420,6 +1429,14 @@ function start.f_randomChar(pn)
 		end
 		start.shuffleTable(t)
 		start.shuffleBags[pn] = t
+
+		-- prevent same character from being chosen twice in a row
+		if start.previousRandChar[pn] == t[#t] then
+			local tmp = t[#t]
+			t[#t] = t[1]
+			t[1] = tmp
+		end
+		start.previousRandChar[pn] = t[1]
 	end
 	--draws one char from the bag
 	local result = table.remove(start.shuffleBags[pn])
@@ -2953,6 +2970,7 @@ end
 function start.f_randomPal(charRef)
 	start.shufflePals = start.shufflePals or {}
 	start.shufflePals[charRef] = start.shufflePals[charRef] or {}
+	start.previousRandPal = start.previousRandPal or {}
 
 	local charData = start.f_getCharData(charRef)
 	local pals = charData and charData.pal
@@ -2967,6 +2985,14 @@ function start.f_randomPal(charRef)
 		end
 		start.shuffleTable(t)
 		start.shufflePals[charRef] = t
+
+		-- prevent same palette from being chosen twice in a row
+		if start.previousRandPal[charRef] == t[#t] then
+			local tmp = t[#t]
+			t[#t] = t[1]
+			t[1] = tmp
+		end
+		start.previousRandPal[charRef] = t[1]
 	end
 	--draws one pal from the bag
 	local result = table.remove(start.shufflePals[charRef])

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -1402,17 +1402,34 @@ function start.f_excludeChar(t, ref)
 	return t
 end
 
+function start.sszRandomFromRange(min, max)
+	if max == nil then
+		max = min
+		min = 1
+	end
+
+	local range = max - min + 1
+	if range <= 0 then
+		error("sszRandomFromRange: max must be greater than or equal to min")
+	end
+	if range == 1 then
+		return min
+	end
+	local randomInt = sszRandom()
+	return min + (randomInt % range)
+end
+
 --shuffles a table in-place
 function start.shuffleTable(t)
 	for i = #t, 2, -1 do
-		local j = math.random(i)
+		local j = start.sszRandomFromRange(i)
 		t[i], t[j] = t[j], t[i]
 	end
 end
 
 function start.shuffleLastElement(t)
 	local tmp = t[#t]
-	local newLast = math.random(1, #t - 1)
+	local newLast = start.sszRandomFromRange(1, #t - 1)
 	t[#t] = t[newLast]
 	t[newLast] = tmp
 end

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -540,7 +540,7 @@ function start.stageShuffleBag(id, pool)
 		-- prevent same stage from being chosen twice in a row
 		if #t > 1 and start.previousRandStage[id] == t[#t] then
 			local tmp = t[#t]
-			newLast = math.random(1, #t - 1)
+			local newLast = math.random(1, #t - 1)
 			t[#t] = t[newLast]
 			t[newLast] = tmp
 		end
@@ -1435,7 +1435,7 @@ function start.f_randomChar(pn)
 		-- prevent same character from being chosen twice in a row
 		if #t > 1 and start.previousRandChar[pn] == t[#t] then
 			local tmp = t[#t]
-			newLast = math.random(1, #t - 1)
+			local newLast = math.random(1, #t - 1)
 			t[#t] = t[newLast]
 			t[newLast] = tmp
 		end
@@ -2992,7 +2992,7 @@ function start.f_randomPal(charRef)
 		-- prevent same palette from being chosen twice in a row
 		if #t > 1 and start.previousRandPal[charRef] == t[#t] then
 			local tmp = t[#t]
-			newLast = math.random(1, #t - 1)
+			local newLast = math.random(1, #t - 1)
 			t[#t] = t[newLast]
 			t[newLast] = tmp
 		end

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -539,10 +539,7 @@ function start.stageShuffleBag(id, pool)
 
 		-- prevent same stage from being chosen twice in a row
 		if #t > 1 and start.previousRandStage[id] == t[#t] then
-			local tmp = t[#t]
-			local newLast = math.random(1, #t - 1)
-			t[#t] = t[newLast]
-			t[newLast] = tmp
+			start.shuffleLastElement(t)
 		end
 		start.previousRandStage[id] = t[1]
 	end
@@ -1413,6 +1410,13 @@ function start.shuffleTable(t)
 	end
 end
 
+function start.shuffleLastElement(t)
+	local tmp = t[#t]
+	local newLast = math.random(1, #t - 1)
+	t[#t] = t[newLast]
+	t[newLast] = tmp
+end
+
 --returns random char ref
 function start.f_randomChar(pn)
 	if #main.t_randomChars == 0 then
@@ -1434,10 +1438,7 @@ function start.f_randomChar(pn)
 
 		-- prevent same character from being chosen twice in a row
 		if #t > 1 and start.previousRandChar[pn] == t[#t] then
-			local tmp = t[#t]
-			local newLast = math.random(1, #t - 1)
-			t[#t] = t[newLast]
-			t[newLast] = tmp
+			start.shuffleLastElement(t)
 		end
 		start.previousRandChar[pn] = t[1]
 	end
@@ -2991,10 +2992,7 @@ function start.f_randomPal(charRef)
 
 		-- prevent same palette from being chosen twice in a row
 		if #t > 1 and start.previousRandPal[charRef] == t[#t] then
-			local tmp = t[#t]
-			local newLast = math.random(1, #t - 1)
-			t[#t] = t[newLast]
-			t[newLast] = tmp
+			start.shuffleLastElement(t)
 		end
 		start.previousRandPal[charRef] = t[1]
 	end


### PR DESCRIPTION
After a pool is empty, its recreated and shuffled. While this works fine, sometimes the last item of the previous pool is the same item of the next pool. This causes a character to show up for 2 frames which is the purpose of a newly merged commit.

This double selection is most obvious on select screens with only 2 available items.
