### PR TITLE
fix: random cycle restarting from the last used index, mirrored palettes in demo mode mirror match

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -3806,6 +3806,14 @@ function main.f_demo()
 	main.menu.f = main.t_itemname.demo()
 end
 
+local function getUniquePalette(ch, prev)
+	local pal
+	repeat
+		pal = getCharRandomPalette(ch)
+	until not prev or ch ~= prev.ch or pal ~= prev.pal
+	return pal
+end
+
 function main.f_demoStart()
 	main.f_default()
 	main.lifebar.bars = motif.demo_mode.fight_bars_display == 1
@@ -3814,7 +3822,10 @@ function main.f_demoStart()
 		setCom(i, 8)
 		setTeamMode(i, 0, 1)
 		local ch = main.t_randomChars[math.random(1, #main.t_randomChars)]
-		selectChar(i, ch, getCharRandomPalette(ch))
+		local pal = getUniquePalette(ch, prev)
+
+		selectChar(i, ch, pal)
+		prev = {ch = ch, pal = pal}
 	end
 	local stage = start.f_setStage()
 	start.f_setMusic(stage)

--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -3805,13 +3805,13 @@ function main.f_demo()
 	main.f_fadeReset('fadeout', motif.demo_mode)
 	main.menu.f = main.t_itemname.demo()
 end
-
+--prevents mirrored palette in demo mode mirror matches
 local function getUniquePalette(ch, prev)
 	local charData = start.f_getCharData(ch)
 	local pals = charData and charData.pal or {1}
 
 	if not prev or ch ~= prev.ch then
-		return pals[math.random(1, #pals)]
+		return pals[sszRandom() % #pals + 1]
 	end
 
 	local available = {}
@@ -3822,7 +3822,7 @@ local function getUniquePalette(ch, prev)
 	end
 
 	if #available > 0 then
-		return available[math.random(1, #available)]
+		return available[sszRandom() % #available + 1]
 	else
 		return prev.pal
 	end

--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -3807,11 +3807,25 @@ function main.f_demo()
 end
 
 local function getUniquePalette(ch, prev)
-	local pal
-	repeat
-		pal = getCharRandomPalette(ch)
-	until not prev or ch ~= prev.ch or pal ~= prev.pal
-	return pal
+	local charData = start.f_getCharData(ch)
+	local pals = charData and charData.pal or {1}
+
+	if not prev or ch ~= prev.ch then
+		return pals[math.random(1, #pals)]
+	end
+
+	local available = {}
+	for _, p in ipairs(pals) do
+		if p ~= prev.pal then
+			table.insert(available, p)
+		end
+	end
+
+	if #available > 0 then
+		return available[math.random(1, #available)]
+	else
+		return prev.pal
+	end
 end
 
 function main.f_demoStart()


### PR DESCRIPTION
Fix: 
- Change the random methods to use sszRandom instead of math.random to keep them synced during netplay