### PR TITLE
fix: palette select crashes from empty frames and unloaded slots

### DIFF
--- a/data/system.base.def
+++ b/data/system.base.def
@@ -958,6 +958,10 @@
 	p2.teammenu.ratio7.icon.facing = 1
 	p2.teammenu.ratio7.icon.scale = 1.0, 1.0
 
+	; 0 - Palette select disabled
+	; 1 - Initial selected palette is 1
+	; 2 - Initial selected palette corresponds to key pressed(a = 1, b = 2)
+	; 3 - Initial selected palette corresponds to key pressed + keymap (a = 4, x = 1 on kfm)
 	paletteselect = 0
 	;p<pn>.member<num>.palmenu.number.offset = 0, 0
 	;p<pn>.member<num>.palmenu.number.font = -1, 0, 0

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -3157,6 +3157,7 @@ function start.f_selectMenu(side, cmd, player, member, selectState)
 
 					start.p[side].t_selTemp[member].ref = start.c[player].selRef
 					local charRef = start.p[side].t_selTemp[member].ref
+					local charData = start.f_getCharData(charRef)
 					local pal = start.p[side].t_selTemp[member].pal
 					local finalPal
 
@@ -3172,6 +3173,10 @@ function start.f_selectMenu(side, cmd, player, member, selectState)
 
 					-- resolve visual palette conflict
 					finalPal = resolvePalConflict(side, charRef, finalPal)
+
+					if finalPal > #charData.pal then
+						finalPal = #charData.pal
+					end
 
 					if motif.select_info.paletteselect > 0 then
 						start.p[side].t_selTemp[member].pal = finalPal


### PR DESCRIPTION
Fix:
- Palette select crashing when done/preview animations have invalid/empty frames
- Prevents navigation through inexistent indexes
- Enforce PaletteMax limit in loadCharPalettes
- Skip invalid or linked palettes that point to unloaded slots
- Avoid creating "phantom" palette entries
- Fixes: #2745 
  - Note: Ikemen no longer crashes with this kind of case, but for the sprites to become visible again with the palette select, a fix in the char's SFF is still necessary