### PR TITLE
refactor: dummyproof lua random

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -4,6 +4,18 @@ main = {}
 --;===========================================================
 --; INITIALIZE DATA
 --;===========================================================
+math.randomseed = function(seed)
+	if type(seed) ~= "number" then
+		error("number expected, got " .. type(seed))
+	end
+	if seed % 1 ~= 0 then
+		error("seed must be an integer")
+	end
+	if seed < 0 or seed >= 2^31 then
+		error("seed out of range, must be between 0 and 2^31 - 1")
+	end
+	sszRandomSeed(seed)
+end
 math.random = function(min, max)
 	-- should return a float between 0 and 1
 	if min == nil then

--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -4,6 +4,34 @@ main = {}
 --;===========================================================
 --; INITIALIZE DATA
 --;===========================================================
+math.random = function(min, max)
+	-- should return a float between 0 and 1
+	if min == nil then
+		-- int32 maximum is (2^31 - 1)
+		-- using 2^31 should make 1 impossible
+		-- lua's max integer apparently is 2^63 - 1
+		return sszRandom() / 2^31
+	end
+	-- supports math.random(2)
+	if max == nil then
+		max = min
+		min = 1
+	end
+
+	local range = max - min + 1
+	if range <= 0 then
+		error("max must be greater than or equal to min")
+	end
+	if range == 1 then
+		return min
+	end
+	-- sszRandom doesn't support values greater than 2^31
+	-- might as well fail so users don't run into unexpected behaviour
+	if range > 2^31 then
+		error("range must be less than or equal to 2^31")
+	end
+	return min + (sszRandom() % range)
+end
 math.randomseed(os.time())
 
 main.flags = getCommandLineFlags()

--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -3865,7 +3865,7 @@ local function getUniquePalette(ch, prev)
 	local pals = charData and charData.pal or {1}
 
 	if not prev or ch ~= prev.ch then
-		return pals[sszRandom() % #pals + 1]
+		return pals[math.random(#pals)]
 	end
 
 	local available = {}
@@ -3876,7 +3876,7 @@ local function getUniquePalette(ch, prev)
 	end
 
 	if #available > 0 then
-		return available[sszRandom() % #available + 1]
+		return available[math.random(#available)]
 	else
 		return prev.pal
 	end

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -1403,13 +1403,13 @@ end
 --shuffles a table in-place (using synced RNG)
 function start.shuffleTable(t, last)
 	for i = #t, 2, -1 do
-		local j = (sszRandom() % i) + 1
+		local j = math.random(i)
 		t[i], t[j] = t[j], t[i]
 	end
 	-- prevent first element from repeating the last of previous cycle
 	if last and #t > 1 and t[#t] == last then
 		-- swap the first element with a random other position
-		local swap = (sszRandom() % (#t - 1)) + 1
+		local swap = math.random(#t - 1)
 		t[#t], t[swap] = t[swap], t[#t]
 	end
 end
@@ -1494,7 +1494,7 @@ function start.f_slotSelected(cell, side, cmd, player, x, y)
 								sndPlay(motif.files.snd_data, motif.select_info['p' .. side .. '_swap_snd'][1], motif.select_info['p' .. side .. '_swap_snd'][2])
 							end
 						else --select
-							main.t_selGrid[cell].slot = v[(sszRandom() % #v) + 1]
+							main.t_selGrid[cell].slot = v[math.random(#v)]
 							start.c[player].selRef = start.f_selGrid(cell).char_ref
 						end
 						start.t_grid[y + 1][x + 1].char = start.f_selGrid(cell).char

--- a/src/script.go
+++ b/src/script.go
@@ -2886,6 +2886,10 @@ func systemScriptInit(l *lua.LState) {
 		l.Push(lua.LNumber(Random()))
 		return 1
 	})
+	luaRegister(l, "sszRandomSeed", func(l *lua.LState) int {
+		Srand(int32(numArg(l, 1)))
+		return 0
+	})
 	luaRegister(l, "frameStep", func(*lua.LState) int {
 		sys.frameStepFlag = true
 		return 0


### PR DESCRIPTION
While local, the original math.random is fine.
However, if someone wants to use math.random over net play, it should come from sszRandom. instead of trying to explain to new moders that they should use sszRandom, this just replaces it so they don't have to learn about it.