### PR TITLE
fix: palette select not skipping invalid indexes

### DIFF
--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -578,6 +578,13 @@ function start.f_setStage(num, assigned)
 			num = start.stageShuffleBag('includeStage', main.t_includeStage[1])
 		end
 	end
+	if not num then -- extra fallback to prevent rare cases of nil num
+		if main.t_selectableStages and #main.t_selectableStages > 0 then
+			num = main.t_selectableStages[1]
+		else
+			num = 1
+		end
+	end
 	selectStage(num)
 	return num
 end

--- a/src/script.go
+++ b/src/script.go
@@ -674,6 +674,13 @@ func systemScriptInit(l *lua.LState) {
 		l.Push(lua.LBool(false))
 		return 1
 	})
+	luaRegister(l, "ValidatePal", func(l *lua.LState) int {
+		palReq := int(numArg(l, 1))
+		charRef := int(numArg(l, 2))
+		valid := sys.sel.ValidatePalette(charRef, palReq)
+		l.Push(lua.LNumber(valid))
+		return 1
+	})
 	luaRegister(l, "changeColorPalette", func(*lua.LState) int {
 		//Changes the actual color of the palette
 		a, _ := toUserData(l, 1).(*Anim)
@@ -778,8 +785,8 @@ func systemScriptInit(l *lua.LState) {
 		sys.sel.ClearSelected()
 		return 0
 	})
-	luaRegister(l, "colorPortrait", func(l *lua.LState) int {
-		// Creates a duplicate animation to avoid palette sharing across players
+	luaRegister(l, "prepareAnim", func(l *lua.LState) int {
+		// Prepares an animation copy so each player can apply their own palette
 		a, ok := toUserData(l, 1).(*Anim)
 		if !ok {
 			userDataError(l, 1, a)

--- a/src/system.go
+++ b/src/system.go
@@ -3390,6 +3390,31 @@ func (s *Select) GetChar(i int) *SelectChar {
 	return &s.charlist[n]
 }
 
+// Validates a palette index for the palette select
+func (s *Select) ValidatePalette(charRef, requested int) int {
+    if charRef < 0 || charRef >= len(s.charlist) {
+        return 1
+    }
+    sc := &s.charlist[charRef]
+    if len(sc.pal) == 0 {
+        return 1
+    }
+    // If the requested index exists, return it
+    for _, real := range sc.pal {
+        if int(real) == requested {
+            return requested
+        }
+    }
+    // Otherwise, return the next valid one (circular)
+    for _, real := range sc.pal {
+        if int(real) > requested {
+            return int(real)
+        }
+    }
+    // Fallback: return the first available
+    return int(sc.pal[0])
+}
+
 func (s *Select) SelectStage(n int) { s.selectedStageNo = n }
 
 func (s *Select) GetStage(n int) *SelectStage {


### PR DESCRIPTION
Fix: 
- Fixes: #2787 
- Fixes: #2782 
- Palette select only navigate through and picks actually valid indexes, empty slots are skipped. Picking directly a invalid slot (start+key), jumps to the next valid slot

Refactor:
- The function name``colorPortrait`` was changed to ``prepareAnim`` to better reflect its purpose.