### PR TITLE
feat: prefer runtime defaultConfig.ini, fallback to embedded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Ikemen_GO_x86.exe
 Ikemen_GO.command
 external/script/.idea/*
 *.manifest
+resources/*
 
 # Ikemen_GO-Elecbyte-Screenpack
 ScreenpackLicense.txt

--- a/src/config.go
+++ b/src/config.go
@@ -248,16 +248,23 @@ func loadConfig(def string) (*Config, error) {
 		//AllowDuplicateShadowValues: true,
 	}
 
-	// Load the INI file
+	// Choose default config source: prefer physical file, else embedded bytes.
+	var defaultSrc interface{}
+	if fp := FileExist("resources/defaultConfig.ini"); len(fp) != 0 {
+		defaultSrc = fp
+	} else {
+		defaultSrc = defaultConfig
+	}
+	// Load the INI file(s)
 	var iniFile *ini.File
 	var err error
 	if fp := FileExist(def); len(fp) == 0 {
-		iniFile, err = ini.LoadSources(options, defaultConfig)
+		iniFile, err = ini.LoadSources(options, defaultSrc)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read data: %v", err)
 		}
 	} else {
-		iniFile, err = ini.LoadSources(options, defaultConfig, def)
+		iniFile, err = ini.LoadSources(options, defaultSrc, def)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read data: %v", err)
 		}


### PR DESCRIPTION
Load resources/defaultConfig.ini at runtime when present; otherwise use embedded bytes. Implements #1145