### PR TITLE
feat: Add ZoomVar Trigger

### DIFF
--- a/src/anim.go
+++ b/src/anim.go
@@ -1017,6 +1017,8 @@ type SprData struct {
 	projection   int32
 	fLength      float32
 	window       [4]float32
+	syncId       int32 // Synchronization target ID
+	syncLayer    int32 // Layer for synchronized drawing
 	xshear       float32
 }
 
@@ -1067,7 +1069,12 @@ func (dl DrawList) draw(cameraX, cameraY, cameraScl float32) {
 		if dl[i].priority != dl[j].priority {
 			return dl[i].priority > dl[j].priority
 		}
-		return false
+		// Then by SyncID to group synchronized sprites together
+		if dl[i].syncId != dl[j].syncId {
+			return dl[i].syncId < dl[j].syncId
+		}
+		// Sort by syncLayer to ensure proper layering within a sync group
+		return dl[i].syncLayer > dl[j].syncLayer
 	})
 
 	// Common variables

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -469,6 +469,7 @@ var triggerMap = map[string]int{
 	"winhyper":           1,
 	"winspecial":         1,
 	"xshear":             1,
+	"zoomvar":            1,
 }
 
 func (c *Compiler) tokenizer(in *string) string {
@@ -4905,6 +4906,33 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		}
 	case "xshear":
 		out.append(OC_ex2_, OC_ex2_xshear)
+	case "zoomvar":
+		if err := c.checkOpeningParenthesis(in); err != nil {
+			return bvNone(), err
+		}
+		opct := OC_ex2_
+		switch c.token {
+		case "scale":
+			opc = OC_ex2_zoomvar_scale
+		case "pos.x":
+			opc = OC_ex2_zoomvar_pos_x
+		case "pos.y":
+			opc = OC_ex2_zoomvar_pos_y
+		case "lag":
+			opc = OC_ex2_zoomvar_lag
+		case "time":
+			opc = OC_ex2_zoomvar_time
+		default:
+			return bvNone(), Error("Invalid ZoomVar argument: " + c.token)
+		}
+		out.append(opct, opc)
+		c.token = c.tokenizer(in)
+		if err := c.checkClosingParenthesis(); err != nil {
+			return bvNone(), err
+		}
+		if rd {
+			out.append(OC_rdreset)
+		}
 	case "=", "!=", ">", ">=", "<", "<=", "&", "&&", "^", "^^", "|", "||",
 		"+", "*", "**", "/", "%":
 		if !sys.ignoreMostErrors || len(c.previousOperator) > 0 {

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -818,7 +818,7 @@ func (c *Compiler) ctrlSet(is IniSection, sc *StateControllerBase, _ int8) (Stat
 }
 
 func (c *Compiler) explodSub(is IniSection,
-	sc *StateControllerBase) error {
+	sc *StateControllerBase, ihp int8) error {
 	if err := c.paramValue(is, sc, "remappal",
 		explod_remappal, VT_Int, 2, false); err != nil {
 		return err
@@ -877,6 +877,14 @@ func (c *Compiler) explodSub(is IniSection,
 	}
 	if err := c.paramValue(is, sc, "scale",
 		explod_scale, VT_Float, 2, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "synclayer",
+		explod_synclayer, VT_Int, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "syncid",
+		explod_syncid, VT_Int, 1, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "bindid",
@@ -939,6 +947,9 @@ func (c *Compiler) explodSub(is IniSection,
 	}
 	if err := c.paramValue(is, sc, "window",
 		explod_window, VT_Float, 4, false); err != nil {
+		return err
+	}
+	if err := c.afterImageSub(is, sc, ihp, "afterimage."); err != nil {
 		return err
 	}
 	return nil
@@ -1023,7 +1034,7 @@ func (c *Compiler) explod(is IniSection, sc *StateControllerBase,
 			explod_ownpal, VT_Bool, 1, false); err != nil {
 			return err
 		}
-		if err := c.explodSub(is, sc); err != nil {
+		if err := c.explodSub(is, sc, ihp); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "animelem",
@@ -1080,7 +1091,7 @@ func (c *Compiler) modifyExplod(is IniSection, sc *StateControllerBase,
 			modifyexplod_index, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.explodSub(is, sc); err != nil {
+		if err := c.explodSub(is, sc, ihp); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "animplayerno",
@@ -1729,6 +1740,10 @@ func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 		hitDef_fall_kill, VT_Bool, 1, false); err != nil {
 		return err
 	}
+	if err := c.paramValue(is, sc, "keepstate",
+		hitDef_keepstate, VT_Bool, 1, false); err != nil {
+		return err
+	}
 	if err := c.paramValue(is, sc, "hitonce",
 		hitDef_hitonce, VT_Bool, 1, false); err != nil {
 		return err
@@ -2186,6 +2201,19 @@ func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 		hitDef_unhittabletime, VT_Int, 2, false); err != nil {
 		return err
 	}
+	if err := c.paramValue(is, sc, "p2stand.friction",
+		hitDef_p2stand_friction, VT_Float, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "p2crouch.friction",
+		hitDef_p2crouch_friction, VT_Float, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "missonreversaldef",
+		hitDef_missonreversaldef, VT_Bool, 1, false); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/src/script.go
+++ b/src/script.go
@@ -6261,6 +6261,25 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(winp))
 		return 1
 	})
+	luaRegister(l, "zoomvar", func(*lua.LState) int {
+		var ln lua.LNumber
+		switch strings.ToLower(strArg(l, 1)) {
+		case "scale":
+			ln = lua.LNumber(sys.drawScale)
+		case "pos.x":
+			ln = lua.LNumber(sys.zoomPosXLag)
+		case "pos.y":
+			ln = lua.LNumber(sys.zoomPosYLag)
+		case "lag":
+			ln = lua.LNumber(sys.zoomlag)
+		case "time":
+			ln = lua.LNumber(sys.enableZoomtime)
+		default:
+			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
+		}
+		l.Push(ln)
+		return 1
+	})
 }
 
 // Legacy functions that may be removed in future, once script refactoring is finished


### PR DESCRIPTION
New Features:

Trigger:
ZoomVar(): Get the current state of a Zoom SCTRL. It can retrieve the current zoom scale, pos.x, pos.y, lag, time.

Hitdef parameters:
missonreversaldef: Allows an attack to ignore the opponent's ReversalDef. 
p2stand.friction / p2crouch.friction: Temporarily set the opponent's friction coefficient upon being hit.
keepstate: Apply damage and hitpause to an opponent without changing their state, similar to HitOverride's keepstate.

Explod parameters:
syncid / synclayer: Synchronize an Explod's rendering state (scale, angle, trans, etc.) with a target character in real-time. synclayer controls whether the Explod is drawn above (1), below (-1), or at the same layer (0) as the target.
afterimage: Added Afterimage functionality to Explod, just like Projectile.