### PR TITLE
feat: modifyText

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -5964,7 +5964,7 @@ func (c *Char) destroySelf(recursive, removeexplods, removetexts bool) bool {
 	}
 
 	if removetexts {
-		sys.lifebar.RemoveText(-1, c.id)
+		sys.lifebar.removeText(-1, -1, c.id)
 	}
 
 	if recursive {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -161,6 +161,7 @@ func newCompiler() *Compiler {
 		"modifysnd":            c.modifySnd,
 		"modifystagebg":        c.modifyStageBG,
 		"modifystagevar":       c.modifyStageVar,
+		"modifytext":           c.modifyText,
 		"overrideclsn":         c.overrideClsn,
 		"parentmapadd":         c.parentMapAdd,
 		"parentmapset":         c.parentMapSet,

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -5434,6 +5434,125 @@ func (c *Compiler) text(is IniSection, sc *StateControllerBase, _ int8) (StateCo
 	return *ret, err
 }
 
+func (c *Compiler) modifyText(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+	ret, err := (*modifyText)(sc), c.stateSec(is, func() error {
+		if err := c.paramValue(is, sc, "redirectid", 
+			modifytext_redirectid, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "index", 
+			modifytext_index, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "id", 
+			text_id, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "removetime", 
+			text_removetime, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "layerno", 
+			text_layerno, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "params", false, func(data string) error {
+			bes, err := c.exprs(data, VT_SFalse, 100000)
+			if err != nil {
+				return err
+			}
+			sc.add(text_params, bes)
+			return nil
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "text", false, func(data string) error {
+			_else := false
+			if len(data) >= 2 && data[0] == '"' {
+				if i := strings.Index(data[1:], "\""); i >= 0 {
+					data, _ = strconv.Unquote(data)
+				} else {
+					_else = true
+				}
+			} else {
+				_else = true
+			}
+			if _else {
+				return Error("Text not enclosed in \"")
+			}
+			sc.add(text_text, sc.iToExp(int32(sys.stringPool[c.playerNo].Add(data))))
+			return nil
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "font", false, func(data string) error {
+			prefix := c.getDataPrefix(&data, false)
+			fflg := prefix == "f"
+			return c.scAdd(sc, text_font, data, VT_Int, 1, 
+				sc.iToExp(Btoi(fflg))...)
+		}); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "localcoord", 
+			text_localcoord, VT_Float, 2, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "bank", 
+			text_bank, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "align", 
+			text_align, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "linespacing", 
+			text_linespacing, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "textdelay", 
+			text_textdelay, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "pos", 
+			text_pos, VT_Float, 2, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "velocity", 
+			text_velocity, VT_Float, 2, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "friction", 
+			text_friction, VT_Float, 2, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "accel", 
+			text_accel, VT_Float, 2, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "scale", 
+			text_scale, VT_Float, 2, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "angle", 
+			text_angle, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.palFXSub(is, sc, "palfx."); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "color", 
+			text_color, VT_Int, 3, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "xshear", 
+			text_xshear, VT_Float, 1, false); err != nil {
+			return err
+		}
+		return nil
+	})
+	return *ret, err
+}
+
 func (c *Compiler) removeText(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*removeText)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -5444,6 +5563,11 @@ func (c *Compiler) removeText(is IniSection, sc *StateControllerBase, _ int8) (S
 		if err := c.stateParam(is, "id", false, func(data string) error {
 			b = true
 			return c.scAdd(sc, removetext_id, data, VT_Int, 1)
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "index", false, func(data string) error {
+			return c.scAdd(sc, removetext_index, data, VT_Int, 1)
 		}); err != nil {
 			return err
 		}

--- a/src/font.go
+++ b/src/font.go
@@ -635,25 +635,27 @@ type TextSprite struct {
 	ownerid          int32
 	id               int32
 	text             string
+	template         string
+	params           []interface{}
 	fnt              *Fnt
 	bank, align      int32
 	x, y, xscl, yscl float32
-	window           [4]int32
-	palfx            *PalFX
-	frgba            [4]float32 // ttf fonts
-	removetime       int32      // text sctrl
-	layerno          int16      // text sctrl
+	xshear           float32
+	angle            float32
 	localScale       float32    // text sctrl
 	offsetX          int32      // text sctrl
 	lineSpacing      float32
+	layerno          int16      // text sctrl
+	palfx            *PalFX
+	frgba            [4]float32 // ttf fonts
+	forcecolor       bool
+	removetime       int32      // text sctrl
 	elapsedTicks     float32
 	textDelay        float32
 	velocity         [2]float32
 	friction         [2]float32
 	accel            [2]float32
-	forcecolor       bool
-	xshear           float32
-	angle            float32
+	window           [4]int32
 }
 
 func NewTextSprite() *TextSprite {

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -4996,13 +4996,30 @@ func (l *Lifebar) UpdateText() {
 	}
 }
 
-func (l *Lifebar) RemoveText(id, ownerid int32) {
-	for i := len(l.textsprite) - 1; i >= 0; i-- {
-		if (id == -1 && l.textsprite[i].ownerid == ownerid) ||
-			(id != -1 && l.textsprite[i].id == id && l.textsprite[i].ownerid == ownerid) {
-			l.textsprite = append(l.textsprite[:i], l.textsprite[i+1:]...)
+func (l *Lifebar) removeText(id, index, ownerid int32) {
+	n := int32(0)
+
+	// Mark matching texts invalid
+	for _, ts := range l.textsprite {
+		if (id == -1 && ts.ownerid == ownerid) || (id != -1 && ts.id == id && ts.ownerid == ownerid) {
+			if index < 0 || index == n {
+				ts.id = IErr
+				if index == n {
+					break
+				}
+			}
+			n++
 		}
 	}
+
+	// Compact the slice to remove invalid texts
+	tempSlice := l.textsprite[:0] // Reuse backing array
+	for _, ts := range l.textsprite {
+		if ts.id != IErr {
+			tempSlice = append(tempSlice, ts)
+		}
+	}
+	l.textsprite = tempSlice
 }
 
 // Resets lifebar as well as prepares team mode configuration for each player


### PR DESCRIPTION
Feat
- Added `modifyText` sctrl, allowing modification of parameters of an existing text created by the `text` sctrl

Fix
- Corrected `palfx` timings in `text` sctrl so that effects match expected durations

Refactor
- Updated `removeText` to support indexes.
- Reorganized `TextSprite` struct to improve readability