### PR TITLE
fix: Vulkan and bg tiling fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 )
 
 require (
-	github.com/Eiton/vulkan v0.0.0-20250730113011-bf42e2273c75 // indirect
+	github.com/Eiton/vulkan v0.0.0-20251024132427-732131af8682 // indirect
 	github.com/icza/bitio v1.1.0 // indirect
 	github.com/mewkiz/flac v1.0.12 // indirect
 	github.com/mewkiz/pkg v0.0.0-20230226050401-4010bf0fec14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/Eiton/glfont v0.0.0-20241204103952-50dc7762af2b h1:RR9huEiJHKkCejLpMf
 github.com/Eiton/glfont v0.0.0-20241204103952-50dc7762af2b/go.mod h1:jVuoVdx3TcsRWwr4YXahY0NiENpBIHSnr21efpK5h38=
 github.com/Eiton/vulkan v0.0.0-20250730113011-bf42e2273c75 h1:i5crUn2IysHQBe/8+znnxXJxOnJi8pwZ5HtZFcM+FAY=
 github.com/Eiton/vulkan v0.0.0-20250730113011-bf42e2273c75/go.mod h1:3O9afAqFWBxgbKHanYAoOT1bkRkxyWxB7qfIoYJrm+g=
+github.com/Eiton/vulkan v0.0.0-20251024132427-732131af8682 h1:QAKWmR+/eg63syQ2ASI4KlRrBxnSLQ1r/WWGnnxSrbA=
+github.com/Eiton/vulkan v0.0.0-20251024132427-732131af8682/go.mod h1:3O9afAqFWBxgbKHanYAoOT1bkRkxyWxB7qfIoYJrm+g=
 github.com/TheTitanrain/w32 v0.0.0-20180517000239-4f5cfb03fabf/go.mod h1:peYoMncQljjNS6tZwI9WVyQB3qZS6u79/N3mBOcnd3I=
 github.com/TheTitanrain/w32 v0.0.0-20200114052255-2654d97dbd3d h1:2xp1BQbqcDDaikHnASWpVZRjibOxu7y9LhAv04whugI=
 github.com/TheTitanrain/w32 v0.0.0-20200114052255-2654d97dbd3d/go.mod h1:peYoMncQljjNS6tZwI9WVyQB3qZS6u79/N3mBOcnd3I=

--- a/src/anim.go
+++ b/src/anim.go
@@ -780,9 +780,10 @@ func (a *Animation) Draw(window *[4]int32, x, y, xcs, ycs, xs, xbs, ys,
 			//}
 		}
 		if a.tile.xflag == 1 {
-			space := xs * float32(a.tile.xspacing)
+			space := xs / h * float32(a.tile.xspacing)
 			if a.tile.xspacing <= 0 {
-				space += xs * float32(a.spr.Size[0])
+				space += xs / h * float32(a.spr.Size[0])
+				space += float32(a.spr.Size[0])
 			}
 			if space != 0 {
 				x -= float32(int(x/space)) * space

--- a/src/render_vk.go
+++ b/src/render_vk.go
@@ -4968,12 +4968,11 @@ func (r *Renderer_VK) BeginFrame(clearColor bool) {
 	r.spriteProgram.uniformOffsetMap = make(map[interface{}]uint32)
 	r.spriteProgram.uniformBufferOffset = 0
 	r.currentSpriteTexture.spriteTexture = r.dummyTexture
-	r.currentSpriteTexture.palTexture = r.palTexture.textures[0]
+	r.currentSpriteTexture.palTexture = r.dummyTexture
 	r.VKState.spriteTexture = r.dummyTexture
 	r.VKState.palTexture = r.dummyTexture
 	r.modelProgram.uniformOffsetMap = make(map[interface{}]uint32)
 	r.modelProgram.uniformBufferOffset = 0
-	//r.spriteProgram.descriptorSetCache.ClearAccessFlag()
 }
 
 func (r *Renderer_VK) BlendReset() {
@@ -6176,7 +6175,7 @@ func (r *Renderer_VK) RenderQuad() {
 	}
 	// MacOS MoltenVK workaround: push constants need to be set every draw call
 	if switchedProgram || r.VKState.palTexture != r.currentSpriteTexture.palTexture || runtime.GOOS == "darwin" {
-		if switchedProgram || r.VKState.palTexture.offset[0] != r.currentSpriteTexture.palTexture.offset[0] || r.VKState.palTexture.offset[1] != r.currentSpriteTexture.palTexture.offset[1] || runtime.GOOS == "darwin" {
+		if switchedProgram || r.VKState.palTexture.img != r.currentSpriteTexture.palTexture.img || r.VKState.palTexture.offset[0] != r.currentSpriteTexture.palTexture.offset[0] || r.VKState.palTexture.offset[1] != r.currentSpriteTexture.palTexture.offset[1] || runtime.GOOS == "darwin" {
 			uvst := r.VKState.palTexture.uvst
 			vk.CmdPushConstants(r.commandBuffers[0], r.spriteProgram.pipelineLayout, vk.ShaderStageFlags(vk.ShaderStageFragmentBit), 0, 16, unsafe.Pointer(&uvst))
 		}


### PR DESCRIPTION
fix the problem where sometimes shadow is not rendered properly in Vulkan
fix the problem where resource is potentially freed before it is used in Vulkan vkCmdPipelineBarrier.
fix the problem where scale in bg animation will affect tilespacing. fix #2476 