### PR TITLE
fix: stage BG anim sharing

### DIFF
--- a/src/bgdef.go
+++ b/src/bgdef.go
@@ -14,7 +14,7 @@ type BGDef struct {
 	def          string
 	localcoord   [2]float32
 	sff          *Sff
-	at           AnimationTable
+	animTable    AnimationTable
 	bg           []*backGround
 	bgc          []bgCtrl
 	bga          bgAction
@@ -77,13 +77,13 @@ func loadBGDef(sff *Sff, model *Model, def string, bgname string) (*BGDef, error
 	}
 	s.sff = sff
 	s.model = model
-	s.at = ReadAnimationTable(s.sff, &s.sff.palList, lines, &i)
+	s.animTable = ReadAnimationTable(s.sff, &s.sff.palList, lines, &i)
 	var bglink *backGround
 	for _, bgsec := range defmap[bgname] {
 		if len(s.bg) > 0 && s.bg[len(s.bg)-1].positionlink {
 			bglink = s.bg[len(s.bg)-1]
 		}
-		bg, err := readBackGround(bgsec, bglink, s.sff, s.at, s.stageprops, def)
+		bg, err := readBackGround(bgsec, bglink, s.sff, s.animTable, s.stageprops, def)
 		if err != nil {
 			return nil, err
 		}
@@ -153,12 +153,9 @@ func (s *BGDef) getBg(id int32) (bg []*backGround) {
 func (s *BGDef) runBgCtrl(bgc *bgCtrl) {
 	switch bgc._type {
 	case BT_Anim:
-		a := s.at.get(bgc.v[0])
-		if a != nil {
-			for i := range bgc.bg {
-				bgc.bg[i].actionno = bgc.v[0]
-				bgc.bg[i].anim = a
-			}
+		animNo := bgc.v[0]
+		for i := range bgc.bg {
+			bgc.bg[i].changeAnim(animNo, s.animTable)
 		}
 	case BT_Visible:
 		for i := range bgc.bg {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -13445,16 +13445,15 @@ func (sc modifyStageBG) Run(c *Char, _ []int32) bool {
 			// Start modifying
 			switch paramID {
 			case modifyStageBG_actionno:
-				val := exp[0].evalI(c)
-				a := sys.stage.at.get(val) // Check if stage has that animation
-				if a != nil {
-					eachBg(func(bg *backGround) {
-						if bg._type == BG_Anim {
-							bg.changeAnim(val, a)
-							bg.anim.Action() // This step is necessary because stages update before characters
-						}
-					})
-				}
+				animNo := exp[0].evalI(c)
+				// Getting an animation first and then applying it to multiple objects can cause shared pointer issues
+				// a := sys.stage.animTable.get(val)
+				eachBg(func(bg *backGround) {
+					if bg._type == BG_Anim {
+						bg.changeAnim(animNo, sys.stage.animTable)
+						bg.anim.Action() // This step is necessary because stages update before characters
+					}
+				})
 			case modifyStageBG_angle:
 				val := exp[0].evalF(c)
 				eachBg(func(bg *backGround) {

--- a/src/char.go
+++ b/src/char.go
@@ -2535,7 +2535,7 @@ type CharGlobalInfo struct {
 	sff                     *Sff
 	palettedata             *Palette
 	snd                     *Snd
-	anim                    AnimationTable
+	animTable               AnimationTable
 	palInfo                 map[int]PalInfo
 	palno                   int32
 	ikemenver               [3]uint16
@@ -3051,7 +3051,7 @@ func (c *Char) load(def string) error {
 	gi := &sys.cgi[c.playerNo]
 	gi.def, gi.displayname, gi.lifebarname, gi.author = def, "", "", ""
 	gi.sff, gi.palettedata, gi.snd, gi.quotes = nil, nil, nil, [MaxQuotes]string{}
-	gi.anim = NewAnimationTable()
+	gi.animTable = NewAnimationTable()
 	gi.fnt = [10]*Fnt{}
 	for i := 0; i < sys.cfg.Config.PaletteMax; i++ {
 		pal := gi.palInfo[i]
@@ -3686,7 +3686,7 @@ func (c *Char) load(def string) error {
 		}
 	}
 	lines, i = SplitAndTrim(str, "\n"), 0
-	gi.anim = ReadAnimationTable(gi.sff, &gi.palettedata.palList, lines, &i)
+	gi.animTable = ReadAnimationTable(gi.sff, &gi.palettedata.palList, lines, &i)
 	if len(sound) > 0 {
 		sound_resolved := resolvePathRelativeToDef(sound)
 		if LoadFile(&sound_resolved, []string{def, "", sys.motifDir, "data/"}, func(filename string) error {
@@ -5507,7 +5507,7 @@ func (c *Char) selfAnimExist(anim BytecodeValue) BytecodeValue {
 	if anim.IsSF() {
 		return BytecodeSF()
 	}
-	return BytecodeBool(c.gi().anim.get(anim.ToI()) != nil)
+	return BytecodeBool(c.gi().animTable.get(anim.ToI()) != nil)
 }
 
 func (c *Char) selfStatenoExist(stateno BytecodeValue) BytecodeValue {
@@ -6321,7 +6321,7 @@ func (c *Char) getAnim(n int32, ffx string, fx bool) (a *Animation) {
 			a = sys.ffx[current_ffx].fat.get(n)
 		}
 	} else {
-		a = c.gi().anim.get(n)
+		a = c.gi().animTable.get(n)
 	}
 
 	// Log invalid animations

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -600,10 +600,10 @@ func (s *Stage) Clone(a *arena.Arena, gsp *GameStatePool) *Stage {
 	}
 
 	// Clone animation table
-	result.at = *gsp.Get(s.at).(*AnimationTable)
-	maps.Clear(result.at)
-	for k, v := range s.at {
-		result.at[k] = v.Clone(a, gsp)
+	result.animTable = *gsp.Get(s.animTable).(*AnimationTable)
+	maps.Clear(result.animTable)
+	for k, v := range s.animTable {
+		result.animTable[k] = v.Clone(a, gsp)
 	}
 
 	// Clone backgrounds and rebuild mapping

--- a/src/system.go
+++ b/src/system.go
@@ -1703,8 +1703,8 @@ func (s *System) resetRoundState() {
 		// Select anim 0
 		firstAnim := int32(0)
 		// Default to first anim in .AIR if 0 was not found
-		if p[0].gi().anim[0] == nil {
-			for k := range p[0].gi().anim {
+		if p[0].gi().animTable[0] == nil {
+			for k := range p[0].gi().animTable {
 				firstAnim = k
 				break
 			}


### PR DESCRIPTION
- Fixed animation data potentially becoming shared when an "anim" BGCtrl is used on multiple elements
- Standardized AnimationTable variable names so they're less ambiguous
- Fixes #2830