### PR TITLE
feat: attackmul and defencemul triggers; fix: Persistent parameter Behavior to Match MUGEN

### DIFF
--- a/src/anim.go
+++ b/src/anim.go
@@ -1070,10 +1070,6 @@ func (dl DrawList) draw(cameraX, cameraY, cameraScl float32) {
 		if dl[i].priority != dl[j].priority {
 			return dl[i].priority > dl[j].priority
 		}
-		// Then by SyncID to group synchronized sprites together
-		if dl[i].syncId != dl[j].syncId {
-			return dl[i].syncId < dl[j].syncId
-		}
 		// Sort by syncLayer to ensure proper layering within a sync group
 		return dl[i].syncLayer > dl[j].syncLayer
 	})

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -2877,7 +2877,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_spriteplayerno:
 		sys.bcStack.PushI(int32(c.spritePN) + 1)
 	case OC_ex_attack:
-		sys.bcStack.PushF(float32(c.gi().attackBase) * c.ocd().attackRatio)
+		base := float32(c.gi().attackBase) * c.ocd().attackRatio / 100
+		sys.bcStack.PushF(base * c.attackMul[0] * 100)
 	case OC_ex_clsnoverlap:
 		c2 := sys.bcStack.Pop().ToI()
 		id := sys.bcStack.Pop().ToI()
@@ -2890,7 +2891,7 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_decisiveround:
 		sys.bcStack.PushB(sys.decisiveRound[^c.playerNo&1])
 	case OC_ex_defence:
-		sys.bcStack.PushF(float32(c.gi().defenceBase))
+		sys.bcStack.PushF(float32(c.finalDefense * 100))
 	case OC_ex_dizzy:
 		sys.bcStack.PushB(c.scf(SCF_dizzy))
 	case OC_ex_dizzypoints:

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -2201,12 +2201,12 @@ func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 		hitDef_unhittabletime, VT_Int, 2, false); err != nil {
 		return err
 	}
-	if err := c.paramValue(is, sc, "p2stand.friction",
-		hitDef_p2stand_friction, VT_Float, 1, false); err != nil {
+	if err := c.paramValue(is, sc, "stand.friction",
+		hitDef_stand_friction, VT_Float, 1, false); err != nil {
 		return err
 	}
-	if err := c.paramValue(is, sc, "p2crouch.friction",
-		hitDef_p2crouch_friction, VT_Float, 1, false); err != nil {
+	if err := c.paramValue(is, sc, "crouch.friction",
+		hitDef_crouch_friction, VT_Float, 1, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "missonreversaldef",

--- a/src/script.go
+++ b/src/script.go
@@ -3386,7 +3386,8 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "attack", func(*lua.LState) int {
-		l.Push(lua.LNumber(float32(sys.debugWC.gi().attackBase) * sys.debugWC.ocd().attackRatio))
+		base := float32(sys.debugWC.gi().attackBase) * sys.debugWC.ocd().attackRatio / 100
+		l.Push(lua.LNumber(base * sys.debugWC.attackMul[0] * 100))
 		return 1
 	})
 	luaRegister(l, "attackmul", func(*lua.LState) int {
@@ -3839,7 +3840,7 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "defence", func(*lua.LState) int {
-		l.Push(lua.LNumber(float32(sys.debugWC.gi().defenceBase)))
+		l.Push(lua.LNumber(sys.debugWC.finalDefense * 100))
 		return 1
 	})
 	luaRegister(l, "defencemul", func(*lua.LState) int {

--- a/src/script.go
+++ b/src/script.go
@@ -3386,8 +3386,11 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "attack", func(*lua.LState) int {
-		base := float32(sys.debugWC.gi().attackBase) * sys.debugWC.ocd().attackRatio / 100
-		l.Push(lua.LNumber(base * sys.debugWC.attackMul[0] * 100))
+		l.Push(lua.LNumber(float32(sys.debugWC.gi().attackBase) * sys.debugWC.ocd().attackRatio))
+		return 1
+	})
+	luaRegister(l, "attackmul", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.attackMul[0]))
 		return 1
 	})
 	luaRegister(l, "authorname", func(*lua.LState) int {
@@ -3836,7 +3839,11 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "defence", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.finalDefense * 100))
+		l.Push(lua.LNumber(float32(sys.debugWC.gi().defenceBase)))
+		return 1
+	})
+	luaRegister(l, "defencemul", func(*lua.LState) int {
+		l.Push(lua.LNumber(float32(sys.debugWC.finalDefense / float64(sys.debugWC.gi().defenceBase) * 100)))
 		return 1
 	})
 	luaRegister(l, "drawgame", func(*lua.LState) int {


### PR DESCRIPTION
・Corrects the behavior of the persistent SCTRL parameter to accurately replicate MUGEN's specifications, especially during hitpause. persistent counters are inherited across ChangeState during hitpause, just like in MUGEN.

Fixes https://kamekaze.world/neo/

・Implemented MUGEN's quirk where a ChangeState in hitpause disables the SCTRL at the same index in the destination state until the hitpause ends.

(These behaviors are not reproduced when ikemenversion is set)

・Add attackmul trigger and defencemul trigger
These separate the attackmul and defencemul values from the before attack and defence triggers. Accordingly, the attack and defence triggers will no longer include attackmul and defencemul in their calculations. To output the same value as the before triggers, use something like attack * attackmul

・Renamed p2stand.friction and p2crouch.friction to stand.friction and crouch.friction.

・Removed grouping by syncId in draw sort, as it's probably unnecessary (syncLayer is sufficient)
Fixes #2840