### PR TITLE
fix: the behavior of EnvShake

### DIFF
--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -1236,8 +1236,8 @@ function start.f_drawCursor(pn, x, y, param, done)
 		cd.slideOffset[2] = cd.startPos[2] - baseY
 	end
 	local t_factor = {
-		motif.select_info['p' .. pn .. '_cursor_tween_factor'][1],
-		motif.select_info['p' .. pn .. '_cursor_tween_factor'][2]
+		motif.select_info['p' .. 2-pn%2 .. '_cursor_tween_factor'][1],
+		motif.select_info['p' .. 2-pn%2 .. '_cursor_tween_factor'][2]
 	}
 	-- apply tween if enabled, otherwise snap to target
 	if not done and t_factor[1] > 0 and t_factor[2] > 0 then

--- a/src/anim.go
+++ b/src/anim.go
@@ -1070,6 +1070,10 @@ func (dl DrawList) draw(cameraX, cameraY, cameraScl float32) {
 		if dl[i].priority != dl[j].priority {
 			return dl[i].priority > dl[j].priority
 		}
+		// Then by SyncID to group synchronized sprites together
+		if dl[i].syncId != dl[j].syncId && dl[i].syncId > 0 && dl[j].syncId > 0 {
+			return dl[i].syncId < dl[j].syncId
+		}
 		// Sort by syncLayer to ensure proper layering within a sync group
 		return dl[i].syncLayer > dl[j].syncLayer
 	})

--- a/src/char.go
+++ b/src/char.go
@@ -1350,6 +1350,7 @@ type Explod struct {
 	palfx               *PalFX
 	palfxdef            PalFXDef
 	window              [4]float32
+	syncParams          bool
 	syncLayer           int32
 	syncId              int32
 	aimg                AfterImage
@@ -1407,6 +1408,7 @@ func (e *Explod) initFromChar(c *Char) *Explod {
 		alpha:             [2]int32{-1, 0},
 		bindId:            -2,
 		syncId:            -1,
+		syncParams:        true,
 		syncLayer:         0,
 		ignorehitpause:    true,
 		interpolate_scale: [4]float32{1, 1, 0, 0},
@@ -1659,8 +1661,8 @@ func (e *Explod) update(playerNo int) {
 			e.pos[i] = e.newPos[i] - (e.newPos[i]-e.oldPos[i])*(1-spd)
 		}
 	}
-	if e.syncId >= 0 {
-		if syncChar := sys.playerID(e.syncId); syncChar != nil {
+	if e.syncId > 0 {
+		if syncChar := sys.playerID(e.syncId); syncChar != nil && e.syncParams {
 			e.sprpriority = syncChar.sprPriority
 			e.scale = [2]float32{syncChar.size.xscale * syncChar.angleDrawScale[0], syncChar.size.yscale * syncChar.angleDrawScale[1]}
 			if syncChar.csf(CSF_angledraw) {
@@ -1668,7 +1670,15 @@ func (e *Explod) update(playerNo int) {
 			} else {
 				e.anglerot = [3]float32{0, 0, 0}
 			}
+			e.window = syncChar.window
+			e.xshear = syncChar.xshear
+			e.projection = syncChar.projection
+			e.fLength = syncChar.fLength
+
 			e.trans = syncChar.trans
+			e.alpha = syncChar.alpha
+			e.palfx = syncChar.getPalfx()
+			e.facing = syncChar.facing
 			if syncChar.aimg.time != 0 {
 				// Copy Afterimage settings, but not the state
 				e.aimg.time = syncChar.aimg.time
@@ -1686,9 +1696,6 @@ func (e *Explod) update(playerNo int) {
 				e.aimg.ignorehitpause = syncChar.aimg.ignorehitpause
 				e.aimg.palfx[0] = syncChar.aimg.palfx[0] // Settings are in the first element
 			}
-			e.alpha = syncChar.alpha
-			e.palfx = syncChar.getPalfx()
-			e.facing = syncChar.facing
 		}
 	}
 	off := e.relativePos
@@ -1808,7 +1815,7 @@ func (e *Explod) update(playerNo int) {
 		window:       ewin,
 		xshear:       xshear,
 	}
-	if e.syncId >= 0 {
+	if e.syncId > 0 {
 		sd.syncId = e.syncId
 		sd.syncLayer = e.syncLayer
 	}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2468,6 +2468,10 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			opc = OC_ex_gethitvar_hitshaketime
 		case "hittime":
 			opc = OC_ex_gethitvar_hittime
+		case "stand.friction":
+			opc = OC_ex_gethitvar_stand_friction
+		case "crouch.friction":
+			opc = OC_ex_gethitvar_crouch_friction
 		case "slidetime":
 			opc = OC_ex_gethitvar_slidetime
 		case "ctrltime":
@@ -2645,7 +2649,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 	case "groundlevel":
 		out.append(OC_ex2_, OC_ex2_groundlevel)
 	case "guardcount":
-		out.append(OC_ex_, OC_ex_guardcount)
+		out.append(OC_ex2_, OC_ex2_guardcount)
 	case "helperindexexist":
 		if _, err := c.oneArg(out, in, rd, true); err != nil {
 			return bvNone(), err

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -883,6 +883,10 @@ func (c *Compiler) explodSub(is IniSection,
 		explod_synclayer, VT_Int, 1, false); err != nil {
 		return err
 	}
+	if err := c.paramValue(is, sc, "syncparams",
+		explod_syncparams, VT_Bool, 1, false); err != nil {
+		return err
+	}
 	if err := c.paramValue(is, sc, "syncid",
 		explod_syncid, VT_Int, 1, false); err != nil {
 		return err
@@ -6182,6 +6186,10 @@ func (c *Compiler) getHitVarSet(is IniSection, sc *StateControllerBase, _ int8) 
 			getHitVarSet_chainid, VT_Int, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "crouch.friction",
+			getHitVarSet_crouchfriction, VT_Float, 1, false); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "ctrltime",
 			getHitVarSet_ctrltime, VT_Int, 1, false); err != nil {
 			return err
@@ -6300,6 +6308,10 @@ func (c *Compiler) getHitVarSet(is IniSection, sc *StateControllerBase, _ int8) 
 		}
 		if err := c.paramValue(is, sc, "redlife",
 			getHitVarSet_redlife, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "stand.friction",
+			getHitVarSet_standfriction, VT_Float, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "slidetime",

--- a/src/script.go
+++ b/src/script.go
@@ -4074,6 +4074,18 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(c.ghv.hitshaketime)
 		case "hittime":
 			ln = lua.LNumber(c.ghv.hittime)
+		case "stand.friction":
+			sf := c.ghv.standfriction
+			if math.IsNaN(float64(sf)) {
+				sf = c.gi().movement.stand.friction
+			}
+			ln = lua.LNumber(sf)
+		case "crouch.friction":
+			cf := c.ghv.crouchfriction
+			if math.IsNaN(float64(cf)) {
+				cf = c.gi().movement.crouch.friction
+			}
+			ln = lua.LNumber(cf)
 		case "slidetime":
 			ln = lua.LNumber(c.ghv.slidetime)
 		case "ctrltime":

--- a/src/system.go
+++ b/src/system.go
@@ -4353,7 +4353,7 @@ func (es *EnvShake) next() {
 
 func (es *EnvShake) getOffset() [2]float32 {
 	if es.time > 0 {
-		offset := -(es.ampl * float32(math.Sin(float64(es.phase))))
+		offset := (es.ampl * float32(math.Sin(float64(es.phase))))
 		return [2]float32{offset * float32(math.Sin(float64(-es.dir))),
 			offset * float32(math.Cos(float64(-es.dir)))}
 	}


### PR DESCRIPTION
・Fix #2661 the behavior of EnvShake.
Corrected the lower limit of phase to match MUGEN. Fixed the inversion of ampl.

・Fixes a bug that caused crashes in Versus CO-OP mode.

・Add stand.friction and crouch.friction to GetHitVar.

・Add the syncParams parameter to Explod, allowing selection of whether to copy the image state.

・Disabled the processing for hitPauseExecutionToggleFlags, as it was causing issues.
Fixes #2360