### PR TITLE
feat: shadow/reflection x scale; fix: win poses, stage time; refactoring

### DIFF
--- a/src/anim.go
+++ b/src/anim.go
@@ -1290,9 +1290,12 @@ func (sl ShadowList) draw(x, y, scl float32) {
 			yscale = sys.stage.sdw.yscale
 		}
 
-		xshear := -s.xshear
-		if xshear == 0 {
-			xshear = sys.stage.sdw.xshear + s.shadowXshear
+		// Stack original sprite xshear with stage or custom xshear
+		var xshear float32
+		if s.shadowXshear != 0 {
+			xshear = -s.xshear + s.shadowXshear
+		} else {
+			xshear = -s.xshear + sys.stage.sdw.xshear
 		}
 
 		// Invert xshear if sprite is flipped vertically
@@ -1315,6 +1318,7 @@ func (sl ShadowList) draw(x, y, scl float32) {
 			return 0
 		}
 
+		// TODO: These should probably stack with "s" rotation instead of overriding it
 		rot := Rotation{
 			angle:  rotVal(s.shadowRot.angle, sys.stage.sdw.rot.angle, s.rot.angle),
 			xangle: rotVal(s.shadowRot.xangle, sys.stage.sdw.rot.xangle, s.rot.xangle),
@@ -1532,9 +1536,12 @@ func (rl ReflectionList) draw(x, y, scl float32) {
 			yscale = sys.stage.reflection.yscale
 		}
 
-		xshear := -s.xshear
-		if xshear == 0 {
-			xshear = sys.stage.reflection.xshear + s.reflectXshear
+		// Stack original sprite xshear with stage or custom xshear
+		var xshear float32
+		if s.reflectXshear != 0 {
+			xshear = -s.xshear + s.reflectXshear
+		} else {
+			xshear = -s.xshear + sys.stage.reflection.xshear
 		}
 
 		// Invert xshear if sprite is flipped vertically
@@ -1557,6 +1564,7 @@ func (rl ReflectionList) draw(x, y, scl float32) {
 			return 0
 		}
 
+		// TODO: These should probably stack with "s" rotation instead of overriding it
 		rot := Rotation{
 			angle:  rotVal(s.reflectRot.angle, sys.stage.reflection.rot.angle, s.rot.angle),
 			xangle: rotVal(s.reflectRot.xangle, sys.stage.reflection.rot.xangle, s.rot.xangle),

--- a/src/anim.go
+++ b/src/anim.go
@@ -1280,29 +1280,24 @@ func (sl ShadowList) draw(x, y, scl float32) {
 
 		color = color&0xff*alpha<<8&0xff0000 | color&0xff00*alpha>>8&0xff00 | color&0xff0000*alpha>>24&0xff
 
-		var xshear float32
-		if s.xshear != 0 {
-			xshear = -s.xshear
-		} else {
-			xshear = sys.stage.sdw.xshear + s.shadowXshear
-		}
-
-		var xscale float32
-		if s.shadowXscale != 0 {
-			xscale = sys.stage.sdw.xscale * s.shadowXscale
-		} else {
+		xscale := s.shadowXscale
+		if xscale == 0 {
 			xscale = sys.stage.sdw.xscale
 		}
 
-		var yscale float32
-		if s.shadowYscale != 0 {
-			yscale = sys.stage.sdw.yscale * s.shadowYscale
-		} else {
+		yscale := s.shadowYscale
+		if yscale == 0 {
 			yscale = sys.stage.sdw.yscale
 		}
 
+		xshear := -s.xshear
+		if xshear == 0 {
+			xshear = sys.stage.sdw.xshear + s.shadowXshear
+		}
+
+		// Invert xshear if sprite is flipped vertically
 		if yscale > 0 {
-			xshear = -xshear // Invert if sprite is flipped
+			xshear = -xshear
 		}
 
 		offsetX := s.shadowOffset[0] + sys.stage.sdw.offset[0]
@@ -1404,6 +1399,7 @@ type ReflectionSprite struct {
 	reflectIntensity  int32
 	reflectOffset     [2]float32
 	reflectWindow     [4]float32
+	reflectXscale     float32
 	reflectXshear     float32
 	reflectYscale     float32
 	reflectRot        Rotation
@@ -1526,22 +1522,24 @@ func (rl ReflectionList) draw(x, y, scl float32) {
 			refPosY = s.groundLevel + (refPosY-s.groundLevel)*sys.stage.reflection.ydelta
 		}
 
-		var xshear float32
-		if s.xshear != 0 {
-			xshear = -s.xshear
-		} else {
-			xshear = sys.stage.reflection.xshear + s.reflectXshear
+		xscale := s.reflectXscale
+		if xscale == 0 {
+			xscale = sys.stage.reflection.xscale
 		}
 
-		var yscale float32
-		if s.reflectYscale != 0 {
-			yscale = sys.stage.reflection.yscale * s.reflectYscale
-		} else {
+		yscale := s.reflectYscale
+		if yscale == 0 {
 			yscale = sys.stage.reflection.yscale
 		}
 
+		xshear := -s.xshear
+		if xshear == 0 {
+			xshear = sys.stage.reflection.xshear + s.reflectXshear
+		}
+
+		// Invert xshear if sprite is flipped vertically
 		if yscale > 0 {
-			xshear = -xshear // Invert if sprite is flipped
+			xshear = -xshear
 		}
 
 		offsetX := s.reflectOffset[0] + sys.stage.reflection.offset[0]
@@ -1631,7 +1629,8 @@ func (rl ReflectionList) draw(x, y, scl float32) {
 		s.anim.Draw(drawwindow,
 			(sys.cam.Offset[0]-shake[0])/scl-(x-s.pos[0]-offsetX),
 			(sys.cam.GroundLevel()+sys.cam.Offset[1]-shake[1])/scl-y/scl-(refPosY*yscale-offsetY),
-			scl, scl, s.scl[0], s.scl[0],
+			scl, scl,
+			s.scl[0]*xscale, s.scl[0] * xscale,
 			-s.scl[1]*yscale, xshear, rot, float32(sys.gameWidth)/2,
 			s.pfx, s.facing, s.airOffsetFix, projection, fLength, color, true)
 

--- a/src/anim.go
+++ b/src/anim.go
@@ -1172,6 +1172,7 @@ type ShadowSprite struct {
 	shadowIntensity  int32
 	shadowOffset     [2]float32
 	shadowWindow     [4]float32
+	shadowXscale     float32
 	shadowXshear     float32
 	shadowYscale     float32
 	shadowRot        Rotation
@@ -1286,6 +1287,13 @@ func (sl ShadowList) draw(x, y, scl float32) {
 			xshear = sys.stage.sdw.xshear + s.shadowXshear
 		}
 
+		var xscale float32
+		if s.shadowXscale != 0 {
+			xscale = sys.stage.sdw.xscale * s.shadowXscale
+		} else {
+			xscale = sys.stage.sdw.xscale
+		}
+
 		var yscale float32
 		if s.shadowYscale != 0 {
 			yscale = sys.stage.sdw.yscale * s.shadowYscale
@@ -1383,7 +1391,7 @@ func (sl ShadowList) draw(x, y, scl float32) {
 		s.anim.ShadowDraw(drawwindow,
 			(sys.cam.Offset[0]-shake[0])-((x-s.pos[0]-offsetX)*scl),
 			sys.cam.GroundLevel()+(sys.cam.Offset[1]-shake[1])-y-(sdwPosY*yscale-offsetY)*scl,
-			scl*s.scl[0], scl*-s.scl[1],
+			scl*s.scl[0]*xscale, scl*-s.scl[1],
 			yscale, xshear, rot,
 			s.pfx, uint32(color), intensity, s.facing, s.airOffsetFix, projection, fLength)
 	}

--- a/src/anim.go
+++ b/src/anim.go
@@ -1309,20 +1309,27 @@ func (sl ShadowList) draw(x, y, scl float32) {
 		// Rotation offset. Only shadow scale sign
 		xrotoff := xshear * SignF(yscale) * (float32(s.anim.spr.Offset[1]) * s.scl[1])
 
-		rotVal := func(vals ...float32) float32 {
-			for _, v := range vals {
-				if v != 0 {
-					return v
-				}
+		// Add custom or stage shadow rotation to original sprite rotation
+		addRot := func(baseAngle float32, customAngle float32, stageAngle float32) float32 {
+			if customAngle != 0 {
+				return baseAngle + customAngle
 			}
-			return 0
+			return baseAngle + stageAngle
 		}
 
-		// TODO: These should probably stack with "s" rotation instead of overriding it
 		rot := Rotation{
-			angle:  rotVal(s.shadowRot.angle, sys.stage.sdw.rot.angle, s.rot.angle),
-			xangle: rotVal(s.shadowRot.xangle, sys.stage.sdw.rot.xangle, s.rot.xangle),
-			yangle: rotVal(s.shadowRot.yangle, sys.stage.sdw.rot.yangle, s.rot.yangle),
+			angle:  addRot(s.rot.angle, s.shadowRot.angle, sys.stage.sdw.rot.angle),
+			xangle: addRot(s.rot.xangle, s.shadowRot.xangle, sys.stage.sdw.rot.xangle),
+			yangle: addRot(s.rot.yangle, s.shadowRot.yangle, sys.stage.sdw.rot.yangle),
+		}
+
+		// If sprite is flipped horizontally, invert the added rotation part
+		// TODO: This is possibly not ideal. Maybe the original sprite's facing should be used instead of checking angle sign
+		if s.rot.angle < 0 {
+			rot.angle = s.rot.angle - (rot.angle - s.rot.angle)
+		}
+		if s.rot.yangle < 0 {
+			rot.yangle = s.rot.yangle - (rot.yangle - s.rot.yangle)
 		}
 
 		if rot.angle != 0 {
@@ -1555,20 +1562,26 @@ func (rl ReflectionList) draw(x, y, scl float32) {
 		// Rotation offset
 		xrotoff := xshear * yscale * (float32(s.anim.spr.Offset[1]) * s.scl[1] * scl)
 
-		rotVal := func(vals ...float32) float32 {
-			for _, v := range vals {
-				if v != 0 {
-					return v
-				}
+		// Add custom or stage reflection rotation to original sprite rotation
+		addRot := func(baseAngle float32, customAngle float32, stageAngle float32) float32 {
+			if customAngle != 0 {
+				return baseAngle + customAngle
 			}
-			return 0
+			return baseAngle + stageAngle
 		}
 
-		// TODO: These should probably stack with "s" rotation instead of overriding it
 		rot := Rotation{
-			angle:  rotVal(s.reflectRot.angle, sys.stage.reflection.rot.angle, s.rot.angle),
-			xangle: rotVal(s.reflectRot.xangle, sys.stage.reflection.rot.xangle, s.rot.xangle),
-			yangle: rotVal(s.reflectRot.yangle, sys.stage.reflection.rot.yangle, s.rot.yangle),
+			angle:  addRot(s.rot.angle, s.reflectRot.angle, sys.stage.reflection.rot.angle),
+			xangle: addRot(s.rot.xangle, s.reflectRot.xangle, sys.stage.reflection.rot.xangle),
+			yangle: addRot(s.rot.yangle, s.reflectRot.yangle, sys.stage.reflection.rot.yangle),
+		}
+
+		// If sprite is flipped horizontally, invert the added rotation part
+		if s.rot.angle < 0 {
+			rot.angle = s.rot.angle - (rot.angle - s.rot.angle)
+		}
+		if s.rot.yangle < 0 {
+			rot.yangle = s.rot.yangle - (rot.yangle - s.rot.yangle)
 		}
 
 		if rot.angle != 0 {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -433,6 +433,7 @@ const (
 	OC_const_stagevar_scaling_botscale
 	OC_const_stagevar_bound_screenleft
 	OC_const_stagevar_bound_screenright
+	OC_const_stagevar_stageinfo_autoturn
 	OC_const_stagevar_stageinfo_localcoord_x
 	OC_const_stagevar_stageinfo_localcoord_y
 	OC_const_stagevar_stageinfo_resetbg
@@ -2488,6 +2489,8 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(int32(float32(sys.stage.screenleft) * sys.stage.localscl / oc.localscl))
 	case OC_const_stagevar_bound_screenright:
 		sys.bcStack.PushI(int32(float32(sys.stage.screenright) * sys.stage.localscl / oc.localscl))
+	case OC_const_stagevar_stageinfo_autoturn:
+		sys.bcStack.PushB(sys.stage.autoturn)
 	case OC_const_stagevar_stageinfo_localcoord_x:
 		sys.bcStack.PushI(sys.stage.stageCamera.localcoord[0])
 	case OC_const_stagevar_stageinfo_localcoord_y:
@@ -12661,6 +12664,7 @@ const (
 	modifyStageVar_scaling_botscale
 	modifyStageVar_bound_screenleft
 	modifyStageVar_bound_screenright
+	modifyStageVar_stageinfo_autoturn
 	modifyStageVar_stageinfo_resetbg
 	modifyStageVar_stageinfo_xscale
 	modifyStageVar_stageinfo_yscale
@@ -12819,6 +12823,8 @@ func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 			s.screenright = int32(exp[0].evalF(c) * scaleratio)
 			shouldResetCamera = true
 		// StageInfo group
+		case modifyStageVar_stageinfo_autoturn:
+			s.autoturn = exp[0].evalB(c)
 		case modifyStageVar_stageinfo_resetbg:
 			s.resetbg = exp[0].evalB(c)
 		case modifyStageVar_stageinfo_xscale:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -13622,18 +13622,19 @@ func (sc modifyStageBG) Run(c *Char, _ []int32) bool {
 type modifyShadow StateControllerBase
 
 const (
-	modifyShadow_anim byte = iota
+	modifyShadow_angle byte = iota
+	modifyShadow_anim
 	modifyShadow_color
+	modifyShadow_focallength
 	modifyShadow_intensity
 	modifyShadow_offset
-	modifyShadow_window
-	modifyShadow_xshear
-	modifyShadow_yscale
-	modifyShadow_angle
-	modifyShadow_xangle
-	modifyShadow_yangle
-	modifyShadow_focallength
 	modifyShadow_projection
+	modifyShadow_window
+	modifyShadow_xangle
+	modifyShadow_xscale
+	modifyShadow_xshear
+	modifyShadow_yangle
+	modifyShadow_yscale
 	modifyShadow_redirectid
 )
 
@@ -13675,6 +13676,8 @@ func (sc modifyShadow) Run(c *Char, _ []int32) bool {
 			}
 		case modifyShadow_window:
 			crun.shadowWindow = [4]float32{exp[0].evalF(c), exp[1].evalF(c), exp[2].evalF(c), exp[3].evalF(c)}
+		case modifyShadow_xscale:
+			crun.shadowXscale = exp[0].evalF(c)
 		case modifyShadow_xshear:
 			crun.shadowXshear = exp[0].evalF(c)
 		case modifyShadow_yscale:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -435,6 +435,7 @@ const (
 	OC_const_stagevar_bound_screenright
 	OC_const_stagevar_stageinfo_localcoord_x
 	OC_const_stagevar_stageinfo_localcoord_y
+	OC_const_stagevar_stageinfo_resetbg
 	OC_const_stagevar_stageinfo_xscale
 	OC_const_stagevar_stageinfo_yscale
 	OC_const_stagevar_stageinfo_zoffset
@@ -2491,6 +2492,8 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(sys.stage.stageCamera.localcoord[0])
 	case OC_const_stagevar_stageinfo_localcoord_y:
 		sys.bcStack.PushI(sys.stage.stageCamera.localcoord[1])
+	case OC_const_stagevar_stageinfo_resetbg:
+		sys.bcStack.PushB(sys.stage.resetbg)
 	case OC_const_stagevar_stageinfo_xscale:
 		sys.bcStack.PushF(sys.stage.scale[0])
 	case OC_const_stagevar_stageinfo_yscale:
@@ -12658,10 +12661,11 @@ const (
 	modifyStageVar_scaling_botscale
 	modifyStageVar_bound_screenleft
 	modifyStageVar_bound_screenright
-	modifyStageVar_stageinfo_zoffset
-	modifyStageVar_stageinfo_zoffsetlink
+	modifyStageVar_stageinfo_resetbg
 	modifyStageVar_stageinfo_xscale
 	modifyStageVar_stageinfo_yscale
+	modifyStageVar_stageinfo_zoffset
+	modifyStageVar_stageinfo_zoffsetlink
 	modifyStageVar_shadow_intensity
 	modifyStageVar_shadow_color
 	modifyStageVar_shadow_yscale
@@ -12815,15 +12819,17 @@ func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 			s.screenright = int32(exp[0].evalF(c) * scaleratio)
 			shouldResetCamera = true
 		// StageInfo group
+		case modifyStageVar_stageinfo_resetbg:
+			s.resetbg = exp[0].evalB(c)
+		case modifyStageVar_stageinfo_xscale:
+			s.scale[0] = exp[0].evalF(c)
+		case modifyStageVar_stageinfo_yscale:
+			s.scale[1] = exp[0].evalF(c)
 		case modifyStageVar_stageinfo_zoffset:
 			s.stageCamera.zoffset = int32(exp[0].evalF(c) * scaleratio)
 			shouldResetCamera = true
 		case modifyStageVar_stageinfo_zoffsetlink:
 			s.zoffsetlink = exp[0].evalI(c)
-		case modifyStageVar_stageinfo_xscale:
-			s.scale[0] = exp[0].evalF(c)
-		case modifyStageVar_stageinfo_yscale:
-			s.scale[1] = exp[0].evalF(c)
 		// Shadow group
 		case modifyStageVar_shadow_intensity:
 			s.sdw.intensity = Clamp(exp[0].evalI(c), 0, 255)

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -13706,6 +13706,7 @@ const (
 	modifyReflection_intensity
 	modifyReflection_offset
 	modifyReflection_window
+	modifyReflection_xscale
 	modifyReflection_xshear
 	modifyReflection_yscale
 	modifyReflection_angle
@@ -13753,6 +13754,8 @@ func (sc modifyReflection) Run(c *Char, _ []int32) bool {
 			}
 		case modifyReflection_window:
 			crun.reflectWindow = [4]float32{exp[0].evalF(c), exp[1].evalF(c), exp[2].evalF(c), exp[3].evalF(c)}
+		case modifyReflection_xscale:
+			crun.reflectXscale = exp[0].evalF(c)
 		case modifyReflection_xshear:
 			crun.reflectXshear = exp[0].evalF(c)
 		case modifyReflection_yscale:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -12800,21 +12800,13 @@ func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 			s.p[1].facing = exp[0].evalI(c)
 		// Scaling group
 		case modifyStageVar_scaling_topz:
-			if s.mugenver[0] != 1 { // mugen 1.0+ removed support for topz
-				s.stageCamera.topz = exp[0].evalF(c)
-			}
+			s.stageCamera.topz = exp[0].evalF(c)
 		case modifyStageVar_scaling_botz:
-			if s.mugenver[0] != 1 { // mugen 1.0+ removed support for botz
-				s.stageCamera.botz = exp[0].evalF(c)
-			}
+			s.stageCamera.botz = exp[0].evalF(c)
 		case modifyStageVar_scaling_topscale:
-			if s.mugenver[0] != 1 { // mugen 1.0+ removed support for topscale
-				s.stageCamera.ztopscale = exp[0].evalF(c)
-			}
+			s.stageCamera.ztopscale = exp[0].evalF(c)
 		case modifyStageVar_scaling_botscale:
-			if s.mugenver[0] != 1 { // mugen 1.0+ removed support for botscale
-				s.stageCamera.zbotscale = exp[0].evalF(c)
-			}
+			s.stageCamera.zbotscale = exp[0].evalF(c)
 		// Bound group
 		case modifyStageVar_bound_screenleft:
 			s.screenleft = int32(exp[0].evalF(c) * scaleratio)

--- a/src/char.go
+++ b/src/char.go
@@ -2805,6 +2805,7 @@ type Char struct {
 	shadowIntensity   int32
 	shadowOffset      [2]float32
 	shadowWindow      [4]float32
+	shadowXscale      float32
 	shadowXshear      float32
 	shadowYscale      float32
 	shadowRot         Rotation
@@ -10608,6 +10609,7 @@ func (c *Char) actionPrepare() {
 		c.shadowIntensity = -1
 		c.shadowOffset = [2]float32{}
 		c.shadowWindow = [4]float32{}
+		c.shadowXscale = 0
 		c.shadowXshear = 0
 		c.shadowYscale = 0
 		c.shadowRot = Rotation{0, 0, 0}
@@ -11678,6 +11680,7 @@ func (c *Char) cueDraw() {
 						(c.size.shadowoffset+c.shadowOffset[1])*c.localscl + sdwYscale*drawZoff + drawZoff,
 					},
 					shadowWindow:     c.shadowWindow,
+					shadowXscale:     c.shadowXscale,
 					shadowXshear:     c.shadowXshear,
 					shadowYscale:     c.shadowYscale,
 					shadowRot:        c.shadowRot,

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -3679,6 +3679,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			opc = OC_const_stagevar_bound_screenleft
 		case "bound.screenright":
 			opc = OC_const_stagevar_bound_screenright
+		case "stageinfo.autoturn":
+			opc = OC_const_stagevar_stageinfo_autoturn
 		case "stageinfo.localcoord.x":
 			opc = OC_const_stagevar_stageinfo_localcoord_x
 		case "stageinfo.localcoord.y":

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -3683,6 +3683,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			opc = OC_const_stagevar_stageinfo_localcoord_x
 		case "stageinfo.localcoord.y":
 			opc = OC_const_stagevar_stageinfo_localcoord_y
+		case "stageinfo.resetbg":
+			opc = OC_const_stagevar_stageinfo_resetbg
 		case "stageinfo.zoffset":
 			opc = OC_const_stagevar_stageinfo_zoffset
 		case "stageinfo.zoffsetlink":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -5820,12 +5820,8 @@ func (c *Compiler) modifyStageVar(is IniSection, sc *StateControllerBase, _ int8
 			modifyStageVar_bound_screenright, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.paramValue(is, sc, "stageinfo.zoffset",
-			modifyStageVar_stageinfo_zoffset, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "stageinfo.zoffsetlink",
-			modifyStageVar_stageinfo_zoffsetlink, VT_Int, 1, false); err != nil {
+		if err := c.paramValue(is, sc, "stageinfo.resetbg",
+			modifyStageVar_stageinfo_resetbg, VT_Bool, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "stageinfo.xscale",
@@ -5834,6 +5830,14 @@ func (c *Compiler) modifyStageVar(is IniSection, sc *StateControllerBase, _ int8
 		}
 		if err := c.paramValue(is, sc, "stageinfo.yscale",
 			modifyStageVar_stageinfo_yscale, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "stageinfo.zoffset",
+			modifyStageVar_stageinfo_zoffset, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "stageinfo.zoffsetlink",
+			modifyStageVar_stageinfo_zoffsetlink, VT_Int, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "shadow.intensity",

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1360,6 +1360,10 @@ func (c *Compiler) modifyReflection(is IniSection, sc *StateControllerBase, _ in
 			modifyReflection_window, VT_Float, 4, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "xscale",
+			modifyReflection_xscale, VT_Float, 1, false); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "xshear",
 			modifyReflection_xshear, VT_Float, 1, false); err != nil {
 			return err

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -5820,6 +5820,10 @@ func (c *Compiler) modifyStageVar(is IniSection, sc *StateControllerBase, _ int8
 			modifyStageVar_bound_screenright, VT_Int, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "stageinfo.autoturn",
+			modifyStageVar_stageinfo_autoturn, VT_Bool, 1, false); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "stageinfo.resetbg",
 			modifyStageVar_stageinfo_resetbg, VT_Bool, 1, false); err != nil {
 			return err

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1294,6 +1294,10 @@ func (c *Compiler) modifyShadow(is IniSection, sc *StateControllerBase, _ int8) 
 			modifyShadow_window, VT_Float, 4, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "xscale",
+			modifyShadow_xscale, VT_Float, 1, false); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "xshear",
 			modifyShadow_xshear, VT_Float, 1, false); err != nil {
 			return err

--- a/src/script.go
+++ b/src/script.go
@@ -5331,14 +5331,16 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LNumber(sys.stage.stageCamera.localcoord[0]))
 		case "stageinfo.localcoord.y":
 			l.Push(lua.LNumber(sys.stage.stageCamera.localcoord[1]))
-		case "stageinfo.zoffset":
-			l.Push(lua.LNumber(sys.stage.stageCamera.zoffset))
-		case "stageinfo.zoffsetlink":
-			l.Push(lua.LNumber(sys.stage.zoffsetlink))
+		case "stageinfo.resetbg":
+			l.Push(lua.LBool(sys.stage.resetbg))
 		case "stageinfo.xscale":
 			l.Push(lua.LNumber(sys.stage.scale[0]))
 		case "stageinfo.yscale":
 			l.Push(lua.LNumber(sys.stage.scale[1]))
+		case "stageinfo.zoffset":
+			l.Push(lua.LNumber(sys.stage.stageCamera.zoffset))
+		case "stageinfo.zoffsetlink":
+			l.Push(lua.LNumber(sys.stage.zoffsetlink))
 		case "shadow.intensity":
 			l.Push(lua.LNumber(sys.stage.sdw.intensity))
 		case "shadow.color.r":

--- a/src/script.go
+++ b/src/script.go
@@ -5331,6 +5331,8 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LNumber(sys.stage.stageCamera.localcoord[0]))
 		case "stageinfo.localcoord.y":
 			l.Push(lua.LNumber(sys.stage.stageCamera.localcoord[1]))
+		case "stageinfo.autoturn":
+			l.Push(lua.LBool(sys.stage.autoturn))
 		case "stageinfo.resetbg":
 			l.Push(lua.LBool(sys.stage.resetbg))
 		case "stageinfo.xscale":

--- a/src/stage.go
+++ b/src/stage.go
@@ -861,6 +861,7 @@ func (bgc *bgCtrl) yEnable() bool {
 type stageShadow struct {
 	intensity  int32
 	color      uint32
+	xscale     float32
 	yscale     float32
 	fadeend    int32
 	fadebgn    int32
@@ -953,8 +954,9 @@ func newStage(def string) *Stage {
 	}
 	s.sdw.intensity = 128
 	s.sdw.color = 0x000000 // https://github.com/ikemen-engine/Ikemen-GO/issues/2150
-	s.sdw.yscale = 0.4
+	s.sdw.xscale = 1.0
 	s.sdw.ydelta = 1.0
+	s.sdw.yscale = 0.4
 	s.reflection.color = 0xFFFFFF
 	s.reflection.ydelta = 1.0
 	s.p[0].startx = -70
@@ -1399,6 +1401,7 @@ func loadStage(def string, maindef bool) (*Stage, error) {
 			r, g, b = 0, 0, 0
 		}
 		s.sdw.color = uint32(r<<16 | g<<8 | b)
+		sec[0].ReadF32("xscale", &s.sdw.xscale)
 		sec[0].ReadF32("yscale", &s.sdw.yscale)
 		sec[0].readI32ForStage("fade.range", &s.sdw.fadeend, &s.sdw.fadebgn)
 		sec[0].ReadF32("xshear", &s.sdw.xshear)

--- a/src/stage.go
+++ b/src/stage.go
@@ -958,7 +958,9 @@ func newStage(def string) *Stage {
 	s.sdw.ydelta = 1.0
 	s.sdw.yscale = 0.4
 	s.reflection.color = 0xFFFFFF
+	s.reflection.xscale = 1.0
 	s.reflection.ydelta = 1.0
+	s.reflection.yscale = 1.0 // Default scale is 1. It's normally off because default intensity is 0
 	s.p[0].startx = -70
 	s.p[1].startx = 70
 	s.stageprops = newStageProps()
@@ -1438,8 +1440,6 @@ func loadStage(def string, maindef bool) (*Stage, error) {
 	}
 	if sectionExists {
 		sectionExists = false
-		s.reflection.yscale = 1.0
-		s.reflection.xshear = 0
 		s.reflection.color = 0xFFFFFF
 		var tmp int32
 		//sec[0].ReadBool("reflect", &reflect) // This parameter is documented in Mugen but doesn't do anything
@@ -1453,6 +1453,7 @@ func loadStage(def string, maindef bool) (*Stage, error) {
 		if sec[0].ReadI32("layerno", &tmp) {
 			s.reflection.layerno = Clamp(tmp, -1, 0)
 		}
+		sec[0].ReadF32("xscale", &s.reflection.xscale)
 		sec[0].ReadF32("yscale", &s.reflection.yscale)
 		sec[0].readI32ForStage("fade.range", &s.reflection.fadeend, &s.reflection.fadebgn)
 		sec[0].ReadF32("xshear", &s.reflection.xshear)

--- a/src/system.go
+++ b/src/system.go
@@ -1872,10 +1872,6 @@ func (s *System) action() {
 	var x, y, scl float32 = s.cam.Pos[0], s.cam.Pos[1], s.cam.Scale / s.cam.BaseScale()
 	s.cam.ResetTracking()
 
-	// Update round state
-	// This is also reflected on characters (intros, win poses)
-	s.stepRoundState()
-
 	// Run "tick frame"
 	if s.tickFrame() {
 		// X axis player limits
@@ -1935,6 +1931,11 @@ func (s *System) action() {
 	// This function runs every tick
 	// It should be placed between "tick frame" and "tick next frame"
 	s.charUpdate()
+
+	// Update round state
+	// This is also reflected on characters (intros, win poses)
+	// It's important that this is placed after the tickFrame logic, or characters will not see every step of the sys.intro timer
+	s.stepRoundState()
 
 	// Update lifebars
 	// This must happen before hit detection for accurate display


### PR DESCRIPTION
Features:
- Stage shadows and ModifyShadow can now also use an x component for scale
- Stage reflections and ModifyReflection can now also use an x component for scale
- Added missing resetBG and autoturn to (Modify)StageVar

Fixes:
- Fixed characters randomly not standing up before performing their win poses
- Fixed stagetime incrementing during pauses
- Fixes #2850 

Refactor:
- Removed mugenversion restriction when modifying stage z scaling parameters
- The shadow/reflection xshear now stacks with the sprite's instead of being overridden
- The shadow/reflection angle now stacks with the sprite's instead of overriding it