### PR TITLE
refactor: migrate AIR indices to int32

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -11258,8 +11258,7 @@ func (sc remapSprite) Run(c *Char, _ []int32) bool {
 	if crun == nil {
 		return false
 	}
-	nullSpr := uint16(0xFFFF)
-	src := [...]uint16{nullSpr, nullSpr}
+	src := [...]int32{-1, -1}
 
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
@@ -11270,14 +11269,14 @@ func (sc remapSprite) Run(c *Char, _ []int32) bool {
 		case remapSprite_preset:
 			crun.remapSpritePreset(string(*(*[]byte)(unsafe.Pointer(&exp[0]))))
 		case remapSprite_source:
-			src[0] = uint16(exp[0].evalI(c))
+			src[0] = int32(exp[0].evalI(c))
 			if len(exp) > 1 {
-				src[1] = uint16(exp[1].evalI(c))
+				src[1] = int32(exp[1].evalI(c))
 			}
 		case remapSprite_dest:
-			dst := [...]uint16{uint16(exp[0].evalI(c)), nullSpr}
+			dst := [...]int32{int32(exp[0].evalI(c)), -1}
 			if len(exp) > 1 {
-				dst[1] = uint16(exp[1].evalI(c))
+				dst[1] = int32(exp[1].evalI(c))
 			}
 			crun.remapSprite(src, dst)
 		}
@@ -13556,8 +13555,8 @@ func (sc modifyStageBG) Run(c *Char, _ []int32) bool {
 				eachBg(func(bg *backGround) {
 					if bg._type == BG_Normal {
 						bg.anim.frames = []AnimFrame{*newAnimFrame()}
-						bg.anim.frames[0].Group = I32ToU16(gr)
-						bg.anim.frames[0].Number = I32ToU16(im)
+						bg.anim.frames[0].Group = gr
+						bg.anim.frames[0].Number = im
 					}
 				})
 			case modifyStageBG_start_x:

--- a/src/char.go
+++ b/src/char.go
@@ -3637,10 +3637,12 @@ func (c *Char) load(def string) error {
 							if len(k) == 2 {
 								var v [2]int32
 								is.ReadI32(key, &v[0], &v[1])
-								if _, ok := gi.remapPreset[subname][uint16(Atoi(k[0]))]; !ok {
-									gi.remapPreset[subname][uint16(Atoi(k[0]))] = make(RemapTable)
+								g0 := int32(Atoi(k[0]))
+								n0 := int32(Atoi(k[1]))
+								if _, ok := gi.remapPreset[subname][g0]; !ok {
+									gi.remapPreset[subname][g0] = make(RemapTable)
 								}
-								gi.remapPreset[subname][uint16(Atoi(k[0]))][uint16(Atoi(k[1]))] = [...]uint16{uint16(v[0]), uint16(v[1])}
+								gi.remapPreset[subname][g0][n0] = v
 							}
 						}
 					}
@@ -8399,25 +8401,24 @@ func (c *Char) drawPal() [2]int32 {
 	return c.getDrawPal(palMap[0])
 }
 
-type RemapTable map[uint16][2]uint16
-type RemapPreset map[uint16]RemapTable
+type RemapTable map[int32][2]int32
+type RemapPreset map[int32]RemapTable
 
-func (c *Char) remapSprite(src [2]uint16, dst [2]uint16) {
-	nullSpr := uint16(0xFFFF)
-	if src[0] == nullSpr || src[1] == nullSpr || dst[0] == nullSpr || dst[1] == nullSpr {
+func (c *Char) remapSprite(src [2]int32, dst [2]int32) {
+	if src[0] == -1 || src[1] == -1 || dst[0] == -1 || dst[1] == -1 {
 		return
 	}
 	if _, ok := c.remapSpr[src[0]]; !ok {
 		c.remapSpr[src[0]] = make(RemapTable)
 	}
-	c.remapSpr[src[0]][src[1]] = [...]uint16{dst[0], dst[1]}
+	c.remapSpr[src[0]][src[1]] = [...]int32{dst[0], dst[1]}
 }
 
 func (c *Char) remapSpritePreset(preset string) {
 	if _, ok := c.gi().remapPreset[preset]; !ok {
 		return
 	}
-	var src, dst [2]uint16
+	var src, dst [2]int32
 	for src[0] = range c.gi().remapPreset[preset] {
 		for src[1], dst = range c.gi().remapPreset[preset][src[0]] {
 			c.remapSprite(src, dst)

--- a/src/common.go
+++ b/src/common.go
@@ -1118,7 +1118,7 @@ func (al *AnimLayout) Read(pre string, is IniSection, at AnimationTable, ln int1
 	var g, n int32
 	if is.ReadI32(pre+"spr", &g, &n) {
 		al.anim.frames = []AnimFrame{*newAnimFrame()}
-		al.anim.frames[0].Group, al.anim.frames[0].Number = I32ToU16(g), I32ToU16(n)
+		al.anim.frames[0].Group, al.anim.frames[0].Number = g, n
 		al.anim.mask = 0
 		al.lay = *newLayout(ln)
 	}

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -1649,7 +1649,7 @@ func readLifeBarFace(pre string, is IniSection, sff *Sff, at AnimationTable) *Li
 
 func (fa *LifeBarFace) step(ref int, far *LifeBarFace) {
 	refChar := sys.chars[ref][0]
-	group, number := uint16(fa.face_spr[0]), uint16(fa.face_spr[1])
+	group, number := fa.face_spr[0], fa.face_spr[1]
 	if refChar != nil && refChar.anim != nil {
 		if mg, ok := refChar.anim.remap[group]; ok {
 			if mn, ok := mg[number]; ok {
@@ -1657,10 +1657,10 @@ func (fa *LifeBarFace) step(ref int, far *LifeBarFace) {
 			}
 		}
 	}
-	if far.old_spr[0] != int32(group) || far.old_spr[1] != int32(number) ||
+	if far.old_spr[0] != group || far.old_spr[1] != number ||
 		far.old_pal[0] != sys.cgi[ref].remappedpal[0] || far.old_pal[1] != sys.cgi[ref].remappedpal[1] {
-		far.face = sys.cgi[ref].sff.getOwnPalSprite(group, number, &sys.cgi[ref].palettedata.palList)
-		far.old_spr = [...]int32{int32(group), int32(number)}
+		far.face = sys.cgi[ref].sff.getOwnPalSprite(uint16(group), uint16(number), &sys.cgi[ref].palettedata.palList)
+		far.old_spr = [...]int32{group, number}
 		far.old_pal = [...]int32{sys.cgi[ref].remappedpal[0], sys.cgi[ref].remappedpal[1]}
 	}
 	fa.bg.Action()

--- a/src/script.go
+++ b/src/script.go
@@ -288,7 +288,7 @@ func systemScriptInit(l *lua.LState) {
 		return 2
 	})
 	luaRegister(l, "animGetPreloadedCharData", func(l *lua.LState) int {
-		if anim := sys.sel.GetChar(int(numArg(l, 1))).anims.get(uint16(numArg(l, 2)), uint16(numArg(l, 3))); anim != nil {
+		if anim := sys.sel.GetChar(int(numArg(l, 1))).anims.get(int32(numArg(l, 2)), int32(numArg(l, 3))); anim != nil {
 			pfx := newPalFX()
 			pfx.clear()
 			pfx.time = -1
@@ -303,7 +303,7 @@ func systemScriptInit(l *lua.LState) {
 		return 0
 	})
 	luaRegister(l, "animGetPreloadedStageData", func(l *lua.LState) int {
-		if anim := sys.sel.GetStage(int(numArg(l, 1))).anims.get(uint16(numArg(l, 2)), uint16(numArg(l, 3))); anim != nil {
+		if anim := sys.sel.GetStage(int(numArg(l, 1))).anims.get(int32(numArg(l, 2)), int32(numArg(l, 3))); anim != nil {
 			pfx := newPalFX()
 			pfx.clear()
 			pfx.time = -1
@@ -796,7 +796,10 @@ func systemScriptInit(l *lua.LState) {
 			copyAnim := CopyAnim(a)
 			char := sys.sel.GetChar(int(numArg(l, 2)))
 			for _, c := range copyAnim.anim.frames {
-				spr, ok := copyAnim.anim.sff.sprites[[...]uint16{c.Group, c.Number}]
+				if c.Group < 0 || c.Number < 0 {
+					continue
+				}
+				spr, ok := copyAnim.anim.sff.sprites[[2]uint16{uint16(c.Group), uint16(c.Number)}]
 				if !ok || spr == nil {
 					continue
 				}

--- a/src/stage.go
+++ b/src/stage.go
@@ -299,8 +299,7 @@ func readBackGround(is IniSection, link *backGround,
 			var g, n int32
 			if is.readI32ForStage("spriteno", &g, &n) {
 				bg.anim.frames = []AnimFrame{*newAnimFrame()}
-				bg.anim.frames[0].Group, bg.anim.frames[0].Number =
-					I32ToU16(g), I32ToU16(n)
+				bg.anim.frames[0].Group, bg.anim.frames[0].Number = g, n
 			}
 			if is.ReadI32("mask", &tmp) {
 				if tmp != 0 {
@@ -413,10 +412,13 @@ func readBackGround(is IniSection, link *backGround,
 		is.ReadI32("tilespacing", &bg.anim.tile.xspacing, &bg.anim.tile.yspacing)
 		//bg.anim.tile.yspacing = bg.anim.tile.xspacing
 		if bg.actionno < 0 && len(bg.anim.frames) > 0 {
-			if spr := sff.GetSprite(
-				bg.anim.frames[0].Group, bg.anim.frames[0].Number); spr != nil {
-				bg.anim.tile.xspacing += int32(spr.Size[0])
-				bg.anim.tile.yspacing += int32(spr.Size[1])
+			group := bg.anim.frames[0].Group
+			number := bg.anim.frames[0].Number
+			if group >= 0 && number >= 0 {
+				if spr := sff.GetSprite(uint16(group), uint16(number)); spr != nil {
+					bg.anim.tile.xspacing += int32(spr.Size[0])
+					bg.anim.tile.yspacing += int32(spr.Size[1])
+				}
 			}
 		} else {
 			if bg.anim.tile.xspacing == 0 {

--- a/src/system.go
+++ b/src/system.go
@@ -3608,7 +3608,10 @@ func (s *Select) addChar(defLine string) {
 				if animation := at.get(v_anim); animation != nil {
 					sc.anims.addAnim(animation, v_anim)
 					for _, fr := range animation.frames {
-						listSpr[[2]uint16{fr.Group, fr.Number}] = true
+						if fr.Group < 0 || fr.Number < 0 {
+							continue
+						}
+						listSpr[[2]uint16{uint16(fr.Group), uint16(fr.Number)}] = true
 					}
 				}
 			}
@@ -3861,7 +3864,9 @@ func (s *Select) AddStage(def string) error {
 			if anim := at.get(v); anim != nil {
 				ss.anims.addAnim(anim, v)
 				for _, fr := range anim.frames {
-					listSpr[[...]uint16{fr.Group, fr.Number}] = true
+					if fr.Group >= 0 && fr.Number >= 0 {
+						listSpr[[2]uint16{uint16(fr.Group), uint16(fr.Number)}] = true
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fixes:

- Fix unsafe conversions that caused -1 to become 65535, leading to incorrect sprite access.
- Fix debug console and related triggers that were incorrectly displaying 65535 instead of -1 when -1 was used in AIR