### PR TITLE
fix: versus co-op crashwhen Engine Players are set to 2

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -3384,6 +3384,9 @@ function main.f_start()
 			elseif c == 'storymode' and #main.t_selStoryMode == 0 then --skip story mode if there are no story arc declared
 				t_skipGroup[c] = true
 				break
+			elseif c == 'versuscoop' and gameOption('Config.Players') < 4 then --skip versus coop if there are not enough players
+				t_skipGroup[c] = true
+				break
 			end
 			--appending the menu table
 			if j == 1 then --first string after menu.itemname (either reserved one or custom submenu assignment)


### PR DESCRIPTION
disables versus coop mode if there are not enough players. Fixes #2495