### PR TITLE
fix: Fix PlaySnd volume

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -4445,7 +4445,7 @@ func (sc playSnd) Run(c *Char, _ []int32) bool {
 
 	x := &crun.pos[0]
 	ls := crun.localscl
-	f, lw, lp, stopgh, stopcs := "", false, false, false, false
+	f, lw, lp, stopgh, stopcs, vscaleflg := "", false, false, false, false, false
 	var g, n, ch, vo, pri, lc int32 = -1, 0, -1, 100, 0, 0
 	var loopstart, loopend, startposition = 0, 0, 0
 	var p, fr float32 = 0, 1
@@ -4472,9 +4472,10 @@ func (sc playSnd) Run(c *Char, _ []int32) bool {
 			ls = 1
 			p = exp[0].evalF(c)
 		case playSnd_volume:
-			vo = vo + int32(float64(exp[0].evalI(c))*(25.0/64.0))
+			vo = vo + int32(float64(exp[0].evalI(c))*(25.0/128.0))
 		case playSnd_volumescale:
 			vo = exp[0].evalI(c)
+			vscaleflg = true
 		case playSnd_freqmul:
 			fr = ClampF(exp[0].evalF(c), 0.01, 5)
 		case playSnd_loop:
@@ -4499,6 +4500,10 @@ func (sc playSnd) Run(c *Char, _ []int32) bool {
 	// Read the loop parameter if loopcount not specified
 	if lc == 0 {
 		if lp {
+			// WINMUGEN has a bug where the volume parameter is disabled when loop is specified
+			if !vscaleflg && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
+				vo = 100
+			}
 			crun.playSound(f, lw, -1, g, n, ch, vo, p, fr, ls, x, true, pri, loopstart, loopend, startposition, stopgh, stopcs)
 		} else {
 			crun.playSound(f, lw, 0, g, n, ch, vo, p, fr, ls, x, true, pri, loopstart, loopend, startposition, stopgh, stopcs)

--- a/src/char.go
+++ b/src/char.go
@@ -1243,7 +1243,7 @@ func (ai *AfterImage) recAfterImg(sd *SprData, hitpause bool) {
 	ai.timecount++
 }
 
-func (ai *AfterImage) recAndCue(sd *SprData, rec bool, hitpause bool, layer int32) {
+func (ai *AfterImage) recAndCue(sd *SprData, rec bool, hitpause bool, layer int32, screen_space bool) {
 	if ai.time == 0 || (ai.timecount >= ai.timegap*ai.length+ai.time-1 && ai.time > 0) ||
 		ai.timegap < 1 || ai.timegap > 32767 ||
 		ai.framegap < 1 || ai.framegap > 32767 {
@@ -1280,7 +1280,7 @@ func (ai *AfterImage) recAndCue(sd *SprData, rec bool, hitpause bool, layer int3
 				alpha:        ai.alpha,
 				priority:     img.priority - step, // Afterimages decrease in sprpriority over time
 				rot:          img.rot,
-				screen:       false,
+				screen:       screen_space,
 				undarken:     sd.undarken,
 				facing:       sd.facing,
 				airOffsetFix: sd.airOffsetFix,
@@ -1820,7 +1820,7 @@ func (e *Explod) update(playerNo int) {
 		sd.syncLayer = e.syncLayer
 	}
 	// Record afterimage
-	e.aimg.recAndCue(sd, sys.tickNextFrame() && act, sys.tickNextFrame() && e.ignorehitpause && (e.supermovetime != 0 || e.pausemovetime != 0), e.layerno)
+	e.aimg.recAndCue(sd, sys.tickNextFrame() && act, sys.tickNextFrame() && e.ignorehitpause && (e.supermovetime != 0 || e.pausemovetime != 0), e.layerno, e.space == Space_screen)
 
 	sprs.add(sd)
 
@@ -2489,7 +2489,7 @@ func (p *Projectile) cueDraw() {
 			xshear:       p.xshear,
 		}
 
-		p.aimg.recAndCue(sd, sys.tickNextFrame() && notpause, false, p.layerno)
+		p.aimg.recAndCue(sd, sys.tickNextFrame() && notpause, false, p.layerno, false)
 		sprs.add(sd)
 
 		// Add a shadow if color is not 0
@@ -11628,7 +11628,7 @@ func (c *Char) cueDraw() {
 		charSD.syncLayer = 0 // Character body is always at layer 0
 
 		// Record afterimage
-		c.aimg.recAndCue(charSD, rec, sys.tickNextFrame() && c.hitPause(), c.layerNo)
+		c.aimg.recAndCue(charSD, rec, sys.tickNextFrame() && c.hitPause(), c.layerNo, false)
 		// Hitshake effect
 		if c.ghv.hitshaketime > 0 && c.ss.time&1 != 0 {
 			charSD.pos[0] -= c.facing


### PR DESCRIPTION
Fixes #2854
・WINMUGEN has a bug where the volume parameter is disabled when loop is specified. (volumescale is not affected by this).

・Change the range of values accepted by PlaySnd volume parameter from [-256 to 256] to [-512 to 512]
This is just temporarily widening the range of values that volume accepts, and it does not accurately reproduce WinMUGEN's behavior. In WINMUGEN , the playsnd volume parameter is affected by const [Data]volume, but that logic seems different from the current IKEMEN GO implementation. but I'm not sure if it needs to be perfectly replicated.

・Fixes the pos of Afterimage for Explod with space=screen.