### PR TITLE
fix: explods, player ID, PalFX, AfterImageMax; refactoring

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6532,7 +6532,7 @@ func (sc afterImage) Run(c *Char, _ []int32) bool {
 		return false
 	}
 
-	crun.aimg.clear()
+	crun.aimg.setDefault()
 	if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 &&
 		c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 {
 		crun.aimg.palfx[0].invertblend = -2

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5724,7 +5724,7 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 			if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
 				e.palfxdef.invertblend = -2
 			}
-			afterImage(sc).runSub(c, &e.aimg, paramID, exp)
+			afterImage(sc).runSub(c, crun, &e.aimg, paramID, exp)
 			palFX(sc).runSub(c, &e.palfxdef, paramID, exp)
 
 			explod(sc).setInterpolation(c, e, paramID, exp, &e.palfxdef)
@@ -6338,7 +6338,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 					if e.ownpal {
 						palFX(sc).runSub(c, &e.palfx.PalFXDef, paramID, exp)
 					}
-					afterImage(sc).runSub(c, &e.aimg, paramID, exp)
+					afterImage(sc).runSub(c, crun, &e.aimg, paramID, exp)
 				})
 			}
 		}
@@ -6444,7 +6444,7 @@ const (
 	afterImage_redirectid
 )
 
-func (sc afterImage) runSub(c *Char, ai *AfterImage, paramID byte, exp []BytecodeExp) {
+func (sc afterImage) runSub(c, crun *Char, ai *AfterImage, paramID byte, exp []BytecodeExp) {
 	switch paramID {
 	case afterImage_trans:
 		src := Clamp(int32(exp[0].evalI(c)), 0, 255)
@@ -6524,6 +6524,10 @@ func (sc afterImage) runSub(c *Char, ai *AfterImage, paramID byte, exp []Bytecod
 	case afterImage_ignorehitpause:
 		ai.ignorehitpause = exp[0].evalB(c)
 	}
+
+	// Check for errors
+	// This placement is not ideal, but it's a little cleaner than doing it in every sctrl that has afterimage parameters
+	ai.validateParams(crun)
 }
 
 func (sc afterImage) Run(c *Char, _ []int32) bool {
@@ -6543,7 +6547,7 @@ func (sc afterImage) Run(c *Char, _ []int32) bool {
 		if paramID == afterImage_redirectid {
 			return true // Already handled. Avoid runSub
 		}
-		sc.runSub(c, &crun.aimg, paramID, exp)
+		sc.runSub(c, crun, &crun.aimg, paramID, exp)
 		return true
 	})
 
@@ -7394,7 +7398,7 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 			return true // Already handled. Avoid runSub
 		default:
 			if !hitDef(sc).runSub(c, &p.hitdef, paramID, exp) {
-				afterImage(sc).runSub(c, &p.aimg, paramID, exp)
+				afterImage(sc).runSub(c, crun, &p.aimg, paramID, exp)
 			}
 		}
 		return true
@@ -8485,7 +8489,7 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 			default:
 				eachProj(func(p *Projectile) {
 					if !hitDef(sc).runSub(c, &p.hitdef, paramID, exp) {
-						afterImage(sc).runSub(c, &p.aimg, paramID, exp)
+						afterImage(sc).runSub(c, crun, &p.aimg, paramID, exp)
 					}
 				})
 			}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5897,9 +5897,6 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				// What possibly happens in Mugen is that all parameters are read first then only applied if PosType is defined
 				if paramlock() {
 					eachExpl(func(e *Explod) {
-						if e.facing*e.relativef >= 0 { // See below
-							e.relativef = 1
-						}
 						e.offset = [3]float32{0, 0, 0}
 						e.setAllPosX(e.offset[0])
 						e.setAllPosY(e.offset[1])
@@ -5912,6 +5909,10 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 							e.bindtime = 1
 						}
 						e.space = Space_none
+						// Defaulting facing too makes some explods face the wrong way
+						//if e.facing*e.relativef >= 0 { // See below
+						//	e.relativef = 1
+						//}
 					})
 				}
 				// Flag PosType as found

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3093,7 +3093,7 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_deg:
 		be.deg(sys.bcStack.Top())
 	case OC_ex_lastplayerid:
-		sys.bcStack.PushI(sys.nextCharId - 1)
+		sys.bcStack.PushI(sys.lastCharId)
 	case OC_ex_lerp:
 		v3 := sys.bcStack.Pop()
 		v2 := sys.bcStack.Pop()

--- a/src/char.go
+++ b/src/char.go
@@ -11754,8 +11754,23 @@ type CharList struct {
 }
 
 func (cl *CharList) clear() {
+	// Reset CharList
 	*cl = CharList{idMap: make(map[int32]*Char)}
-	sys.nextCharId = sys.cfg.Config.HelperMax
+
+	// Reset player ID tracker to baseline
+	// ID's start from HelperMax in Mugen. We don't strictly need to do the same but it might improve backward compatibility
+	// TODO: Mugen codes that rely on this fact already don't work correctly in Mugen, so it may be pointless to do the same
+	sys.lastCharId = Max(0, sys.cfg.Config.HelperMax - 1)
+
+	// Clear all player ID's to avoid false conflicts with stale players
+	// TODO: Maybe stale players should be cleared better
+	for _, p := range sys.chars {
+		for _, c := range p {
+			if c != nil {
+				c.id = -1
+			}
+		}
+	}
 }
 
 func (cl *CharList) add(c *Char) {

--- a/src/char.go
+++ b/src/char.go
@@ -6076,8 +6076,10 @@ func (c *Char) destroySelf(recursive, removeexplods, removetexts bool) bool {
 
 // Make a new helper before reading the bytecode parameters
 func (c *Char) newHelper() (h *Char) {
-	// If any existing helper entry is valid for overwriting, use it
+	// Start at index 1, skipping the root
 	i := int32(1)
+
+	// If any existing helper entry is available for overwriting, use it
 	for ; int(i) < len(sys.chars[c.playerNo]); i++ {
 		if sys.chars[c.playerNo][i].helperIndex < 0 {
 			h = sys.chars[c.playerNo][i]
@@ -6088,9 +6090,14 @@ func (c *Char) newHelper() (h *Char) {
 
 	// Otherwise append to the end
 	if int(i) >= len(sys.chars[c.playerNo]) {
+		// Check helper limit
 		if i > sys.cfg.Config.HelperMax { // Do not count index 0
+			root := sys.chars[c.playerNo][0]
+			sys.appendToConsole(root.warn() + fmt.Sprintf("Reached limit of %v helpers. Helper creation skipped", sys.cfg.Config.HelperMax))
 			return
 		}
+
+		// Add helper if allowed
 		h = newChar(c.playerNo, i)
 		sys.chars[c.playerNo] = append(sys.chars[c.playerNo], h)
 	}
@@ -6626,7 +6633,15 @@ func (c *Char) spawnProjectile() *Projectile {
 	}
 
 	// If no inactive projectile was found, append a new one within the max limit
-	if p == nil && len(*playerProjs) < sys.cfg.Config.ProjectileMax {
+	if p == nil {
+		// Check projectile limit
+		if len(*playerProjs) >= sys.cfg.Config.ProjectileMax {
+			root := sys.chars[c.playerNo][0]
+			sys.appendToConsole(root.warn() + fmt.Sprintf("Reached limit of %v projectiles. New projectile creation skipped", sys.cfg.Config.ProjectileMax))
+			return nil
+		}
+
+		// Add projectile if allowed
 		newP := newProjectile()
 		*playerProjs = append(*playerProjs, newP)
 		p = newP

--- a/src/char.go
+++ b/src/char.go
@@ -1090,12 +1090,12 @@ func newAfterImage() *AfterImage {
 		ai.palfx[i].allowNeg = true
 	}
 
-	ai.clear()
+	ai.setDefault()
 
 	return ai
 }
 
-func (ai *AfterImage) clear() {
+func (ai *AfterImage) setDefault() {
 	ai.time = 0
 	ai.length = 20
 	if len(ai.palfx) > 0 {
@@ -1249,6 +1249,14 @@ func (ai *AfterImage) recAndCue(sd *SprData, rec bool, hitpause bool, layer int3
 		ai.framegap < 1 || ai.framegap > 32767 {
 		ai.time = 0
 		ai.reccount, ai.timecount, ai.timegap = 0, 0, 0
+		// Clear animation and PalFX data
+		// This makes afterimages lighter in save states
+		for i := range ai.imgs {
+			ai.imgs[i].anim = nil
+		}
+		for i := range ai.palfx {
+			ai.palfx[i] = nil
+		}
 		return
 	}
 

--- a/src/char.go
+++ b/src/char.go
@@ -1631,7 +1631,7 @@ func (e *Explod) update(playerNo int) {
 
 	if sys.tickFrame() {
 		if e.removetime >= 0 && e.time >= e.removetime ||
-			act && e.removetime < -1 && e.anim.loopend {
+			act && e.removetime <= -2 && e.anim.loopend {
 			e.id, e.anim = IErr, nil
 			return
 		}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -5974,12 +5974,14 @@ func (c *Compiler) paramTrans(is IniSection, sc *StateControllerBase,
 			defsrc, defdst = 255, 128
 		case "addalpha":
 			tt = TT_add
-			defsrc, defdst = 255, 0 // In Mugen it defaults to this before reading the alpha
+			defsrc, defdst = 255, 0
+			// In Mugen it defaults to this before reading the alpha
+			// Older Mugen versions have a bug where AddAlpha defaults to no change if the animation also uses AddAlpha (AS_D_). This is fixed in 1.1
 		case "sub":
 			tt = TT_sub
 			defsrc, defdst = 255, 255
 		default:
-			// In Mugen, cns ignore invalid parameter names
+			// In Mugen, CNS ignores invalid parameter names
 			if !cnsParam || c.zssMode || !sys.ignoreMostErrors {
 				return Error("Invalid trans type: " + data)
 			} else {

--- a/src/config.go
+++ b/src/config.go
@@ -324,9 +324,10 @@ func (c *Config) normalize() {
 	c.SetValueUpdate("Options.Tag.Min", int(Clamp(int32(c.Options.Tag.Min), 2, int32(MaxSimul))))
 
 	// Options that determine allocation sizes should not be negative
-	if c.Config.AfterImageMax < 0 {
-		c.SetValueUpdate("Config.AfterImageMax", 0)
-	}
+	// Update: AfterImageMax no longer does, but it's good to keep it in mind
+	//if c.Config.AfterImageMax < 0 {
+	///	c.SetValueUpdate("Config.AfterImageMax", 0)
+	//}
 
 	path := strings.TrimSpace(c.Config.ScreenshotFolder)
 	if path != "" {

--- a/src/net.go
+++ b/src/net.go
@@ -151,17 +151,18 @@ func NewLoopTimer(fps uint32, framesToSpread uint32) LoopTimer {
 }
 
 func (lt *LoopTimer) OnGGPOTimeSyncEvent(framesAhead float32) {
+	lt.waitTotal = time.Duration(float32(time.Second/60) * framesAhead)
+	lt.lastAdvantage = float32(time.Second/60) * framesAhead
+
 	if sys.intro > 0 && sys.tickCount == 0 {
-		lt.waitTotal = time.Duration(float32(time.Second/60) * framesAhead)
-		lt.lastAdvantage = float32(time.Second/60) * framesAhead
-		if lt.lastAdvantage < float32(0) {
+		// Wait longer during the start of each round, allowing both players to load assets
+		if lt.lastAdvantage < 0 {
 			lt.timeWait = time.Duration(lt.lastAdvantage) / time.Duration(lt.framesToSpreadWait)
 			lt.waitCount = time.Duration(lt.framesToSpreadWait)
 		}
 	} else {
-		lt.waitTotal = time.Duration(float32(time.Second/60) * framesAhead)
-		lt.lastAdvantage = float32(time.Second/60) * framesAhead
-		lt.lastAdvantage = lt.lastAdvantage / 4
+		// Normal waiting time
+		lt.lastAdvantage /= 4
 		lt.timeWait = time.Duration(lt.lastAdvantage) / time.Duration(lt.framesToSpreadWait)
 		lt.waitCount = time.Duration(lt.framesToSpreadWait)
 	}

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -116,9 +116,9 @@ Framerate           = 60
 ; See http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
 ; Leave blank to automatically detect the system language.
 Language            = en
-; Number of simultaneous afterimage effects allowed per player.
+; Maximum number of afterimage sprites allowed per player.
 ; Set to a lower number to save memory.
-AfterImageMax       = 128
+AfterImageMax       = 512
 ; Maximum number of explods allowed per player. Hitsparks also count as explods.
 ; Set to a lower number to save memory.
 ExplodMax           = 512

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -116,7 +116,7 @@ Framerate           = 60
 ; See http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
 ; Leave blank to automatically detect the system language.
 Language            = en
-; Number of simultaneous afterimage effects allowed.
+; Number of simultaneous afterimage effects allowed per player.
 ; Set to a lower number to save memory.
 AfterImageMax       = 128
 ; Maximum number of explods allowed per player. Hitsparks also count as explods.

--- a/src/state.go
+++ b/src/state.go
@@ -166,7 +166,7 @@ type GameState struct {
 	numSimul, numTurns      [2]int32    // UIT
 	esc                     bool
 	envcol_under            bool
-	nextCharId              int32
+	lastCharId              int32
 	tickCount               int
 	oldTickCount            int
 	tickCountF              float32
@@ -339,7 +339,7 @@ func (gs *GameState) LoadState(stateID int) {
 	sys.winskipped = gs.winskipped
 
 	sys.intro = gs.intro
-	sys.nextCharId = gs.nextCharId
+	sys.lastCharId = gs.lastCharId
 
 	sys.scrrect = gs.scrrect
 	sys.gameWidth = gs.gameWidth
@@ -391,7 +391,7 @@ func (gs *GameState) LoadState(stateID int) {
 	sys.numTurns = gs.numTurns
 	sys.esc = gs.esc
 	sys.envcol_under = gs.envcol_under
-	sys.nextCharId = gs.nextCharId
+	sys.lastCharId = gs.lastCharId
 	sys.tickCount = gs.tickCount
 	sys.oldTickCount = gs.oldTickCount
 	sys.tickCountF = gs.tickCountF
@@ -553,7 +553,7 @@ func (gs *GameState) SaveState(stateID int) {
 	gs.slowtime = sys.slowtime
 	gs.winskipped = sys.winskipped
 	gs.intro = sys.intro
-	gs.nextCharId = sys.nextCharId
+	gs.lastCharId = sys.lastCharId
 
 	gs.scrrect = sys.scrrect
 	gs.gameWidth = sys.gameWidth
@@ -604,7 +604,7 @@ func (gs *GameState) SaveState(stateID int) {
 	gs.numTurns = sys.numTurns
 	gs.esc = sys.esc
 	gs.envcol_under = sys.envcol_under
-	gs.nextCharId = sys.nextCharId
+	gs.lastCharId = sys.lastCharId
 	gs.tickCount = sys.tickCount
 	gs.oldTickCount = sys.oldTickCount
 	gs.tickCountF = sys.tickCountF

--- a/src/state.go
+++ b/src/state.go
@@ -177,7 +177,6 @@ type GameState struct {
 	screenright             float32
 	xmin, xmax              float32
 	winskipped              bool
-	paused, frameStepFlag   bool
 	roundResetFlg           bool
 	reloadFlg               bool
 	reloadStageFlg          bool
@@ -403,8 +402,6 @@ func (gs *GameState) LoadState(stateID int) {
 	sys.xmin = gs.xmin
 	sys.xmax = gs.xmax
 	sys.winskipped = gs.winskipped
-	sys.paused = gs.paused
-	sys.frameStepFlag = gs.frameStepFlag
 	sys.roundResetFlg = gs.roundResetFlg
 	sys.reloadFlg = gs.reloadFlg
 	sys.reloadStageFlg = gs.reloadStageFlg
@@ -616,8 +613,6 @@ func (gs *GameState) SaveState(stateID int) {
 	gs.xmin = sys.xmin
 	gs.xmax = sys.xmax
 	gs.winskipped = sys.winskipped
-	gs.paused = sys.paused
-	gs.frameStepFlag = sys.frameStepFlag
 	gs.roundResetFlg = sys.roundResetFlg
 	gs.reloadFlg = sys.reloadFlg
 	gs.reloadStageFlg = sys.reloadStageFlg

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -271,8 +271,13 @@ func (c *Char) Clone(a *arena.Arena, gsp *GameStatePool) (result Char) {
 	// Since curFrame is desynced from anim's state, we must save it as well
 	if c.curFrame != nil {
 		result.curFrame = c.curFrame.Clone(a)
-	} else {
-		result.curFrame = nil
+	}
+
+	if c.shadowAnim != nil {
+		result.shadowAnim = c.shadowAnim.Clone(a, gsp)
+	}
+	if c.reflectAnim != nil {
+		result.reflectAnim = c.reflectAnim.Clone(a, gsp)
 	}
 
 	// TODO: Profiling shows this is hotter than it should be

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -216,6 +216,8 @@ func (e *Explod) Clone(a *arena.Arena, gsp *GameStatePool) *Explod {
 		result.palfx = e.palfx.Clone(a)
 	}
 
+	result.aimg = e.aimg.Clone(a, gsp)
+
 	return result
 }
 
@@ -231,16 +233,11 @@ func (p *Projectile) clone(a *arena.Arena, gsp *GameStatePool) *Projectile {
 		result.ani = p.ani.Clone(a, gsp)
 	}
 
-	if p.aimg.palfx != nil {
-		result.aimg.palfx = arena.MakeSlice[*PalFX](a, len(p.aimg.palfx), len(p.aimg.palfx))
-		for i := range p.aimg.palfx {
-			result.aimg.palfx[i] = p.aimg.palfx[i].Clone(a)
-		}
-	}
-
 	if p.palfx != nil {
 		result.palfx = p.palfx.Clone(a)
 	}
+
+	result.aimg = p.aimg.Clone(a, gsp)
 
 	return result
 }
@@ -281,7 +278,12 @@ func (c *Char) Clone(a *arena.Arena, gsp *GameStatePool) (result Char) {
 	}
 
 	// TODO: Profiling shows this is hotter than it should be
+	// Maybe we ought to clear animation data from them when their timer expires
 	result.aimg = c.aimg.Clone(a, gsp)
+
+	if c.palfx != nil {
+		result.palfx = c.palfx.Clone(a)
+	}
 
 	// Manually copy references that shallow copy poorly, as needed
 	// Pointers, slices, maps, functions, channels etc
@@ -305,10 +307,12 @@ func (c *Char) Clone(a *arena.Arena, gsp *GameStatePool) (result Char) {
 	result.p2EnemyList = arena.MakeSlice[*Char](a, len(c.p2EnemyList), len(c.p2EnemyList))
 	copy(result.p2EnemyList, c.p2EnemyList)
 
-	if c.p2EnemyBackup != nil {
-		tmp := *c.p2EnemyBackup
-		result.p2EnemyBackup = &tmp
-	}
+	//if c.p2EnemyBackup != nil {
+	//	tmp := *c.p2EnemyBackup
+	//	result.p2EnemyBackup = &tmp
+	//}
+	// This ought to be enough
+	result.p2EnemyBackup = c.p2EnemyBackup
 
 	result.inputShift = arena.MakeSlice[[2]int](a, len(c.inputShift), len(c.inputShift))
 	copy(result.inputShift, c.inputShift)
@@ -365,8 +369,6 @@ func (c *Char) Clone(a *arena.Arena, gsp *GameStatePool) (result Char) {
 func (cl *CharList) Clone(a *arena.Arena, gsp *GameStatePool) (result CharList) {
 	result = *cl
 
-	// Manually copy references that shallow copy poorly, as needed
-	// Pointers, slices, maps, functions, channels etc
 	result.runOrder = arena.MakeSlice[*Char](a, len(cl.runOrder), len(cl.runOrder))
 	copy(result.runOrder, cl.runOrder)
 
@@ -375,6 +377,7 @@ func (cl *CharList) Clone(a *arena.Arena, gsp *GameStatePool) (result CharList) 
 	for k, v := range cl.idMap {
 		result.idMap[k] = v
 	}
+
 	return
 }
 
@@ -383,10 +386,12 @@ func (pf *PalFX) Clone(a *arena.Arena) *PalFX {
 		return nil
 	}
 	result := *pf
+
 	if pf.remap != nil {
 		result.remap = arena.MakeSlice[int](a, len(pf.remap), len(pf.remap))
 		copy(result.remap, pf.remap)
 	}
+
 	return &result
 }
 

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -279,6 +279,7 @@ func (c *Char) Clone(a *arena.Arena, gsp *GameStatePool) (result Char) {
 
 	// TODO: Profiling shows this is hotter than it should be
 	// Maybe we ought to clear animation data from them when their timer expires
+	// Update: Done already but copying 60 PalFX's is still a problem
 	result.aimg = c.aimg.Clone(a, gsp)
 
 	if c.palfx != nil {

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -188,12 +188,9 @@ func (ai AfterImage) Clone(a *arena.Arena, gsp *GameStatePool) (result AfterImag
 	}
 
 	// Deep copy PalFX
-	if ai.palfx != nil {
-		result.palfx = arena.MakeSlice[*PalFX](a, len(ai.palfx), len(ai.palfx))
-		for i := range ai.palfx {
-			if ai.palfx[i] != nil {
-				result.palfx[i] = ai.palfx[i].Clone(a)
-			}
+	for i := range ai.palfx {
+		if ai.palfx[i] != nil {
+			result.palfx[i] = ai.palfx[i].Clone(a)
 		}
 	}
 

--- a/src/system.go
+++ b/src/system.go
@@ -216,6 +216,7 @@ type System struct {
 	wintime                 int32
 	projs                   [MaxPlayerNo][]*Projectile
 	explods                 [MaxPlayerNo][]*Explod
+	activeAfterImages       [MaxPlayerNo]int32
 	changeStateNest         int32
 	spritesLayerN1          DrawList
 	spritesLayerU           DrawList
@@ -1915,14 +1916,18 @@ func (s *System) runIntroSkip() {
 	}
 }
 
-func (s *System) action() {
-	// Clear sprite data
+func (s *System) clearSpriteData() {
+	// Main sprites
 	s.spritesLayerN1 = s.spritesLayerN1[:0]
 	s.spritesLayerU = s.spritesLayerU[:0]
 	s.spritesLayer0 = s.spritesLayer0[:0]
 	s.spritesLayer1 = s.spritesLayer1[:0]
+
+	// Shadows and reflections
 	s.shadows = s.shadows[:0]
 	s.reflections = s.reflections[:0]
+
+	// Debug sprites
 	s.debugc1hit = s.debugc1hit[:0]
 	s.debugc1rev = s.debugc1rev[:0]
 	s.debugc1not = s.debugc1not[:0]
@@ -1934,6 +1939,15 @@ func (s *System) action() {
 	s.debugcsize = s.debugcsize[:0]
 	s.debugch = s.debugch[:0]
 	s.clsnText = nil
+
+	// Reset afterimage tracker
+	for i := range s.activeAfterImages {
+		s.activeAfterImages[i] = 0
+	}
+}
+
+func (s *System) action() {
+	s.clearSpriteData()
 
 	var x, y, scl float32 = s.cam.Pos[0], s.cam.Pos[1], s.cam.Scale / s.cam.BaseScale()
 	s.cam.ResetTracking()

--- a/src/system.go
+++ b/src/system.go
@@ -178,7 +178,7 @@ type System struct {
 	stageLoopNo             int
 	stageLocalcoords        map[string][2]float32
 	wireframeDisplay        bool
-	nextCharId              int32
+	lastCharId              int32
 	tickCount               int
 	oldTickCount            int
 	tickCountF              float32
@@ -1468,28 +1468,85 @@ func (s *System) clsnOverlap(clsn1 [][4]float32, scl1, pos1 [2]float32, facing1 
 	return false
 }
 
+// Assign starting player ID's in a way similar to Mugen
+// This isn't strictly necessary but might improve backward compatibility
+// TODO: We may be going through too much work for nothing here. A natural ID order of each loaded player having "ID + 1" would probably be better
+func (s *System) initPlayerID() {
+	// Assign a new player ID only if needed
+	assignID := func(i int) {
+		if i < 0 || i >= len(sys.chars) || len(sys.chars[i]) == 0 || sys.chars[i][0] == nil {
+			return
+		}
+
+		c := sys.chars[i][0]
+
+		if sys.round == 1 || c.roundsExisted() == 0 {
+			c.id = sys.newCharId()
+		}
+	}
+
+	// Free some ID's in subsequent rounds
+	if sys.round > 1 {
+		sys.pruneCharId()
+	}
+
+	// Odd player number ID's
+	for i := 0; i < MaxSimul*2; i += 2 {
+		assignID(i)
+	}
+
+	// Even player number ID's
+	for i := 1; i < MaxSimul*2; i += 2 {
+		assignID(i)
+	}
+
+	// Extra player ID's
+	for i := MaxSimul * 2; i < MaxPlayerNo; i++ {
+		assignID(i)
+	}
+}
+
+// Prune player ID's above the last active root ID
+// Mugen doesn't do this, but it avoids having to work with very high ID's in later rounds
+func (s *System) pruneCharId() {
+	s.lastCharId = Max(0, sys.cfg.Config.HelperMax - 1)
+
+	for _, p := range s.chars {
+		if len(p) > 0 && p[0] != nil && p[0].id > s.lastCharId {
+			s.lastCharId = p[0].id
+		}
+		// At this point we're still checking the previous round's player ID's
+		// However that works out well for Turns mode because it means a joining player won't reuse the ID of a defeated player
+	}
+}
+
+// Determine the next available character ID while keeping track of the last number used
 func (s *System) newCharId() int32 {
-	// Check if the next ID is already being used by a helper with "preserve"
-	// We specifically check for preserved helpers because otherwise this also detects the players from the previous match that are being replaced
-	newid := s.nextCharId
-	taken := true
-	for taken {
-		taken = false
+	newid := s.lastCharId + 1
+
+	// Check if the next ID is already being used
+	// This is needed because helpers may be preserved between rounds
+	for {
+		conflict := false
 		for _, p := range s.chars {
 			for _, c := range p {
-				//if c.id == newid && c.preserve != 0 && !c.csf(CSF_destroy) {
-				if c.id == newid && c.preserve && !c.csf(CSF_destroy) {
-					taken = true
+				if c != nil && c.id == newid && !c.csf(CSF_destroy) {
+					// Note: We only recycle destroyed helper ID's because the ID's refresh each round, unlike Mugen
+					conflict = true
 					newid++
 					break
 				}
 			}
-			if taken {
-				break // Skip outer loop
+			if conflict {
+				break
 			}
 		}
+		if !conflict {
+			break
+		}
 	}
-	s.nextCharId = newid + 1
+
+	s.lastCharId = newid
 	return newid
 }
 
@@ -1621,15 +1678,21 @@ func (s *System) resetRoundState() {
 	s.winskipped = false
 	s.intro = s.lifebar.ro.start_waittime + s.lifebar.ro.ctrl_time + 1
 	s.curRoundTime = s.maxRoundTime
-	s.nextCharId = s.cfg.Config.HelperMax
+
+	// Mugen resets the starting ID between matches but not between rounds
+	// Previously Ikemen reset it between rounds, but that creates the odd scenario where a new player in Turns mode will have the same ID as a previous player
+	//s.nextCharId = s.cfg.Config.HelperMax
+
 	if (s.tmode[0] == TM_Turns && s.wins[1] >= s.numTurns[0]-1) ||
 		(s.tmode[0] != TM_Turns && s.wins[1] >= s.lifebar.ro.match_wins[0]-1) {
 		s.decisiveRound[0] = true
 	}
+
 	if (s.tmode[1] == TM_Turns && s.wins[0] >= s.numTurns[1]-1) ||
 		(s.tmode[1] != TM_Turns && s.wins[0] >= s.lifebar.ro.match_wins[1]-1) {
 		s.decisiveRound[1] = true
 	}
+
 	var roundRef int32
 	if s.round == 1 {
 		s.stageLoopNo = 0
@@ -1678,7 +1741,6 @@ func (s *System) resetRoundState() {
 		if len(p) == 0 {
 			continue
 		}
-		s.nextCharId = Max(s.nextCharId, p[0].id+1)
 		s.clearPlayerAssets(i, false)
 		p[0].posReset()
 		p[0].setCtrl(false)
@@ -3935,6 +3997,7 @@ func newLoader() *Loader {
 	return &Loader{state: LS_NotYet, loadExit: make(chan LoaderState, 1)}
 }
 
+/*
 func (l *Loader) loadPlayerChar(pn int) int {
 	return l.loadCharacter(pn, false)
 }
@@ -3942,6 +4005,7 @@ func (l *Loader) loadPlayerChar(pn int) int {
 func (l *Loader) loadAttachedChar(pn int) int {
 	return l.loadCharacter(pn, true)
 }
+*/
 
 func (l *Loader) loadCharacter(pn int, attached bool) int {
 	if !attached && sys.roundsExisted[pn&1] > 0 {
@@ -4141,6 +4205,7 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 			}
 		}
 	}
+
 	return 1
 }
 

--- a/src/system.go
+++ b/src/system.go
@@ -216,7 +216,6 @@ type System struct {
 	wintime                 int32
 	projs                   [MaxPlayerNo][]*Projectile
 	explods                 [MaxPlayerNo][]*Explod
-	activeAfterImages       [MaxPlayerNo]int32
 	changeStateNest         int32
 	spritesLayerN1          DrawList
 	spritesLayerU           DrawList
@@ -224,6 +223,7 @@ type System struct {
 	spritesLayer1           DrawList
 	shadows                 ShadowList
 	reflections             ReflectionList
+	afterImageCount         [MaxPlayerNo]int32
 	debugc1hit              ClsnRect
 	debugc1rev              ClsnRect
 	debugc1not              ClsnRect
@@ -1941,8 +1941,8 @@ func (s *System) clearSpriteData() {
 	s.clsnText = nil
 
 	// Reset afterimage tracker
-	for i := range s.activeAfterImages {
-		s.activeAfterImages[i] = 0
+	for i := range s.afterImageCount {
+		s.afterImageCount[i] = 0
 	}
 }
 


### PR DESCRIPTION
Fixes:
- Fixed ModifyExplod making some Mugen explods face the wrong way
- Added missing char PalFX to save states
- Added the new explod afterimages as well
- AfterImageMax now controls the maximum allowed afterimage sprites per player instead of essentially doing nothing

Refactor:
- Adjusted how player ID's are attributed, making it a bit more robust. In Turns mode, a joining player will no longer occupy the same ID as a defeated player
- Afterimages now drop animation data when it's no longer needed, making them a bit lighter in save states
- Reaching helper or projectile limits now prints debug warnings
- Loading a state no longer changes the game's paused state

Fixes #2856 
Fixes https://discord.com/channels/233345562261323776/282927929548210177/1436595067426050138
Fixes https://discord.com/channels/233345562261323776/233363722934943744/1437262823699906660