### PR TITLE
fix: persistent value when changestate during hitpause

### DIFF
--- a/data/system.zss
+++ b/data/system.zss
@@ -3,12 +3,20 @@
 #===============================================================================
 [StateDef -4]
 
-# For backward compatibility, x and z-axis get hit acceleration must be handled here
-# TODO: These cases should maybe use the state number constants
-# TODO: These patches could be done by appending sctrl's to the common1.cns states
 if pauseTime = 0 {
+	# For backward compatibility, x and z-axis get hit acceleration must be handled here
+	# TODO: These cases should maybe use the state number constants
+	# TODO: These patches could be done by appending sctrl's to the common1.cns states
 	if time > 0 && (stateNo = 5030 || stateNo = 5035 || stateNo = 5040 || stateNo = 5050 || stateNo = 5071 || stateNo = 5200) {
 		velAdd{x: getHitVar(xAccel); z: getHitVar(zAccel)}
+	}
+	# When keepstate attack, pause at hitshaketime are handled here
+	# TODO: will change the pause process from hitpause to a new pause SCTRL
+	if gethitvar(keepstate) && gethitvar(hitshaketime)>0 && hitpausetime=0 && !HitOverridden {
+		ModifyPlayer{hitpausetime:gethitvar(hitshaketime)}
+		ignorehitpause{
+		GetHitVarSet{hitshaketime:0}
+		}
 	}
 }
 

--- a/src/char.go
+++ b/src/char.go
@@ -5934,6 +5934,8 @@ func (c *Char) stateChange1(no int32, pn int) bool {
 			// If changing state during hitpause, restore (carry over) persistent from the before state
 			c.ss.sb.ctrlsps = make([]int32, len(c.ss.sb.ctrlsps))
 			copy(c.ss.sb.ctrlsps, ctrlsps_backup)
+			// Apply special persistent counter behavior for state changes during hitpause
+			c.persistentChangeStateHitpauseCorrection(&c.ss.sb)
 
 			// Get the index of the currently executing SCTRL block
 			c.hitStateChangeIdx = c.currentSctrlIndex
@@ -5947,6 +5949,31 @@ func (c *Char) stateChange1(no int32, pn int) bool {
 	return true
 }
 
+// Correction process to reproduce MUGEN's persistent behavior
+// This is called during a ChangeState while in hitpause
+func (c *Char) persistentChangeStateHitpauseCorrection(sbc *StateBytecode) {
+	// Nested structures do not need to be considered
+	for _, sctrl := range sbc.block.ctrls {
+		if sctrlBlock, ok := sctrl.(StateBlock); ok {
+			idx := sctrlBlock.persistentIndex
+			if idx >= 0 && int(idx) < len(sbc.ctrlsps) {
+				// If the destination SCTRL is persistent=0 (run-once)
+				if sctrlBlock.persistent == math.MaxInt32 {
+					// If the carried-over counter is > 1 (waiting),it is considered "already executed" and locked
+					if sbc.ctrlsps[idx] > 1 {
+						sbc.ctrlsps[idx] = math.MaxInt32
+					}
+				} else { // If the destination SCTRL is persistent > 0
+					// If the carried-over counter was from a p=0 SCTRL and was already executed (locked state)
+					// reset the counter with the new persistent value, making it executable again
+					if sbc.ctrlsps[idx] == math.MaxInt32 {
+						sbc.ctrlsps[idx] = sctrlBlock.persistent
+					}
+				}
+			}
+		}
+	}
+}
 func (c *Char) stateChange2() bool {
 	if c.stchtmp && !c.hitPause() {
 		c.ss.sb.init(c)
@@ -9903,8 +9930,11 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 		}
 		if hd.KeepState && ghvset {
 			getter.ghv.keepstate = hd.KeepState
-			getter.hitPauseTime = Max(0, hd.guard_pausetime[1])
-			getter.ghv.hitshaketime = 0
+			if hitResult == 2 {
+				getter.ghv.hitshaketime = Max(0, hd.guard_pausetime[1])
+			} else {
+				getter.ghv.hitshaketime = Max(0, hd.pausetime[1])
+			}
 		} else if ghvset {
 			ghv := &getter.ghv
 			cmb := (getter.ss.moveType == MT_H || getter.csf(CSF_gethit)) && !ghv.guarded
@@ -10859,25 +10889,25 @@ func (c *Char) actionRun() {
 			c.updateCurFrame()
 		}
 		if c.ghv.damage != 0 {
-			if c.ss.moveType == MT_H || c.ghv.keepstate {
+			if c.ss.moveType == MT_H || (c.ghv.keepstate && c.hoverIdx == -1) {
 				c.lifeAdd(-float64(c.ghv.damage), true, true)
 			}
 			c.ghv.damage = 0
 		}
 		if c.ghv.redlife != 0 {
-			if c.ss.moveType == MT_H || c.ghv.keepstate {
+			if c.ss.moveType == MT_H || (c.ghv.keepstate && c.hoverIdx == -1) {
 				c.redLifeAdd(-float64(c.ghv.redlife), true)
 			}
 			c.ghv.redlife = 0
 		}
 		if c.ghv.dizzypoints != 0 {
-			if c.ss.moveType == MT_H || c.ghv.keepstate {
+			if c.ss.moveType == MT_H || (c.ghv.keepstate && c.hoverIdx == -1) {
 				c.dizzyPointsAdd(-float64(c.ghv.dizzypoints), true)
 			}
 			c.ghv.dizzypoints = 0
 		}
 		if c.ghv.guardpoints != 0 {
-			if c.ss.moveType == MT_H || c.ghv.keepstate {
+			if c.ss.moveType == MT_H || (c.ghv.keepstate && c.hoverIdx == -1) {
 				c.guardPointsAdd(-float64(c.ghv.guardpoints), true)
 			}
 			c.ghv.guardpoints = 0
@@ -10887,6 +10917,7 @@ func (c *Char) actionRun() {
 		c.ghv.power = 0
 		c.ghv.hitpower = 0
 		c.ghv.guardpower = 0
+		c.ghv.keepstate = false
 		// The following block used to be in char.update()
 		// That however caused a breaking difference with Mugen when checking these variables between different players
 		// https://github.com/ikemen-engine/Ikemen-GO/issues/1540

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2605,6 +2605,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "guardflag":
 			opc = OC_ex_gethitvar_guardflag
 			isFlag = 2
+		case "keepstate":
+			opc = OC_ex_gethitvar_keepstate
 		default:
 			return bvNone(), Error("Invalid GetHitVar argument: " + c.token)
 		}
@@ -4232,7 +4234,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 	case "ailevelf":
 		out.append(OC_ex_, OC_ex_ailevelf)
 	case "airjumpcount":
-		out.append(OC_ex_, OC_ex_airjumpcount)
+		out.append(OC_ex2_, OC_ex2_airjumpcount)
 	case "animelemvar":
 		if err := c.checkOpeningParenthesis(in); err != nil {
 			return bvNone(), err

--- a/src/script.go
+++ b/src/script.go
@@ -4212,6 +4212,8 @@ func triggerFunctions(l *lua.LState) {
 			// LNumber (we have a LString)
 			l.Push(flagLStr(c.ghv.guardflag))
 			return 1
+		case "keepstate":
+			ln = lua.LNumber(Btoi(c.ghv.keepstate))
 		default:
 			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}


### PR DESCRIPTION
・Fix #2881 persistent value when changestate during hitpause

1.Carrying Over a Counter to a persistent = 0 SCTRL: 
When a SCTRL with persistent = 0 inherits a persistent counter from a previous state that was still counting down (value was > 0), the new SCTRL will now be treated as if it has already been executed. Its counter is immediately set to a locked state (math.MaxInt32), preventing it from running until the character's persistent counters are next reset. If the inherited counter was already ≤ 0 (ready to execute), the SCTRL remains executable.

2.Carrying Over an Executed persistent = 0 Counter to a persistent > 0 SCTRL:
 Conversely, when an SCTRL with a repeating persistent value (e.g., persistent = 32) inherits a locked counter (math.MaxInt32) from a persistent = 0 SCTRL that had already run, the counter is now reset to the new SCTRL's persistent value. This unlocks the SCTRL.

・Fix Hitdef keepstate
Damage handling for HitOverride
Moved the process of pausing the opponent to system.zss