### PR TITLE
feat: modifyShadow/Reflection keepTransform and animelem; fix

### DIFF
--- a/src/anim.go
+++ b/src/anim.go
@@ -1177,18 +1177,19 @@ func (dl DrawList) draw(cameraX, cameraY, cameraScl float32) {
 
 type ShadowSprite struct {
 	*SprData
-	groundLevel      float32
-	shadowColor      int32
-	shadowAlpha      int32
-	shadowIntensity  int32
-	shadowOffset     [2]float32
-	shadowWindow     [4]float32
-	shadowXscale     float32
-	shadowXshear     float32
-	shadowYscale     float32
-	shadowRot        Rotation
-	shadowProjection int32
-	shadowfLength    float32
+	groundLevel         float32
+	shadowColor         int32
+	shadowAlpha         int32
+	shadowIntensity     int32
+	shadowKeeptransform bool
+	shadowOffset        [2]float32
+	shadowWindow        [4]float32
+	shadowXscale        float32
+	shadowXshear        float32
+	shadowYscale        float32
+	shadowRot           Rotation
+	shadowProjection    int32
+	shadowfLength       float32
 }
 
 type ShadowList []*ShadowSprite
@@ -1305,6 +1306,8 @@ func (sl ShadowList) draw(x, y, scl float32) {
 		var xshear float32
 		if s.shadowXshear != 0 {
 			xshear = -s.xshear + s.shadowXshear
+		} else if !s.shadowKeeptransform { // Do not stack original sprite xshear in this case
+			xshear = s.shadowXshear
 		} else {
 			xshear = -s.xshear + sys.stage.sdw.xshear
 		}
@@ -1322,6 +1325,9 @@ func (sl ShadowList) draw(x, y, scl float32) {
 
 		// Add custom or stage shadow rotation to original sprite rotation
 		addRot := func(baseAngle float32, customAngle float32, stageAngle float32) float32 {
+			if !s.shadowKeeptransform {
+				return customAngle // Raw modifyShadow angle
+			}
 			if customAngle != 0 {
 				return baseAngle + customAngle
 			}
@@ -1336,11 +1342,13 @@ func (sl ShadowList) draw(x, y, scl float32) {
 
 		// If sprite is flipped horizontally, invert the added rotation part
 		// TODO: This is possibly not ideal. Maybe the original sprite's facing should be used instead of checking angle sign
-		if s.rot.angle < 0 {
-			rot.angle = s.rot.angle - (rot.angle - s.rot.angle)
-		}
-		if s.rot.yangle < 0 {
-			rot.yangle = s.rot.yangle - (rot.yangle - s.rot.yangle)
+		if s.shadowKeeptransform {
+			if s.rot.angle < 0 {
+				rot.angle = s.rot.angle - (rot.angle - s.rot.angle)
+			}
+			if s.rot.yangle < 0 {
+				rot.yangle = s.rot.yangle - (rot.yangle - s.rot.yangle)
+			}
 		}
 
 		if rot.angle != 0 {
@@ -1417,17 +1425,18 @@ func (sl ShadowList) draw(x, y, scl float32) {
 
 type ReflectionSprite struct {
 	*SprData
-	groundLevel       float32
-	reflectColor      int32
-	reflectIntensity  int32
-	reflectOffset     [2]float32
-	reflectWindow     [4]float32
-	reflectXscale     float32
-	reflectXshear     float32
-	reflectYscale     float32
-	reflectRot        Rotation
-	reflectProjection int32
-	reflectfLength    float32
+	groundLevel          float32
+	reflectColor         int32
+	reflectIntensity     int32
+	reflectKeeptransform bool
+	reflectOffset        [2]float32
+	reflectWindow        [4]float32
+	reflectXscale        float32
+	reflectXshear        float32
+	reflectYscale        float32
+	reflectRot           Rotation
+	reflectProjection    int32
+	reflectfLength       float32
 }
 
 type ReflectionList []*ReflectionSprite
@@ -1559,6 +1568,8 @@ func (rl ReflectionList) draw(x, y, scl float32) {
 		var xshear float32
 		if s.reflectXshear != 0 {
 			xshear = -s.xshear + s.reflectXshear
+		} else if !s.reflectKeeptransform {
+			xshear = s.reflectXshear
 		} else {
 			xshear = -s.xshear + sys.stage.reflection.xshear
 		}
@@ -1576,6 +1587,9 @@ func (rl ReflectionList) draw(x, y, scl float32) {
 
 		// Add custom or stage reflection rotation to original sprite rotation
 		addRot := func(baseAngle float32, customAngle float32, stageAngle float32) float32 {
+			if !s.reflectKeeptransform {
+				return customAngle
+			}
 			if customAngle != 0 {
 				return baseAngle + customAngle
 			}
@@ -1589,11 +1603,13 @@ func (rl ReflectionList) draw(x, y, scl float32) {
 		}
 
 		// If sprite is flipped horizontally, invert the added rotation part
-		if s.rot.angle < 0 {
-			rot.angle = s.rot.angle - (rot.angle - s.rot.angle)
-		}
-		if s.rot.yangle < 0 {
-			rot.yangle = s.rot.yangle - (rot.yangle - s.rot.yangle)
+		if s.reflectKeeptransform {
+			if s.rot.angle < 0 {
+				rot.angle = s.rot.angle - (rot.angle - s.rot.angle)
+			}
+			if s.rot.yangle < 0 {
+				rot.yangle = s.rot.yangle - (rot.yangle - s.rot.yangle)
+			}
 		}
 
 		if rot.angle != 0 {

--- a/src/anim.go
+++ b/src/anim.go
@@ -191,6 +191,7 @@ type Animation struct {
 	interpolate_blend_dstalpha float32
 	remap                      RemapPreset
 	start_scale                [2]float32
+	isParallax                 bool
 	isVideo                    bool // Because videos are rendered through Animation.Draw()
 }
 
@@ -785,10 +786,18 @@ func (a *Animation) Draw(window *[4]int32, x, y, xcs, ycs, xs, xbs, ys,
 			//}
 		}
 		if a.tile.xflag == 1 {
-			space := xs / h * float32(a.tile.xspacing)
-			if a.tile.xspacing <= 0 {
-				space += xs / h * float32(a.spr.Size[0])
-				space += float32(a.spr.Size[0])
+			var space float32
+			if a.isParallax {
+				space = xs * float32(a.tile.xspacing)
+				if a.tile.xspacing <= 0 {
+					space += xs * float32(a.spr.Size[0])
+				}
+			} else {
+				space = xs/h * float32(a.tile.xspacing)
+				if a.tile.xspacing <= 0 {
+					space += xs/h * float32(a.spr.Size[0])
+					space += float32(a.spr.Size[0])
+				}
 			}
 			if space != 0 {
 				x -= float32(int(x/space)) * space

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -13635,9 +13635,11 @@ const (
 	modifyShadow_anim
 	modifyShadow_animplayerno
 	modifyShadow_spriteplayerno
+	modifyShadow_animelem
 	modifyShadow_color
 	modifyShadow_focallength
 	modifyShadow_intensity
+	modifyShadow_keeptransform
 	modifyShadow_offset
 	modifyShadow_projection
 	modifyShadow_window
@@ -13656,11 +13658,14 @@ func (sc modifyShadow) Run(c *Char, _ []int32) bool {
 	}
 
 	redirscale := c.localscl / crun.localscl
-	animPN := crun.playerNo
-	spritePN := crun.playerNo
+	animPN := -1
+	spritePN := -1
 
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
+		case modifyShadow_animelem:
+			crun.shadowAnimelem = exp[0].evalI(c)
+			crun.setAnimElemTo(crun.shadowAnim, &crun.shadowAnimelem)
 		case modifyShadow_animplayerno:
 			animPN = int(exp[0].evalI(c)) - 1
 		case modifyShadow_spriteplayerno:
@@ -13668,7 +13673,7 @@ func (sc modifyShadow) Run(c *Char, _ []int32) bool {
 		case modifyShadow_anim:
 			ffx := string(*(*[]byte)(unsafe.Pointer(&exp[0])))
 			animNo := exp[1].evalI(c)
-			anim := c.getAnimSprite(animNo, animPN, spritePN, ffx, true, false)
+			anim := c.getShadowReflectionSprite(animNo, animPN, spritePN, ffx, true, false, "ModifyShadow")
 			if anim != nil {
 				anim.Action() // Need to step for it to appear
 				crun.shadowAnim = anim
@@ -13685,6 +13690,8 @@ func (sc modifyShadow) Run(c *Char, _ []int32) bool {
 			crun.shadowColor = [3]int32{r, g, b}
 		case modifyShadow_intensity:
 			crun.shadowIntensity = Clamp(exp[0].evalI(c), 0, 255)
+		case modifyShadow_keeptransform:
+			crun.shadowKeeptransform = exp[0].evalB(c)
 		case modifyShadow_offset:
 			crun.shadowOffset[0] = exp[0].evalF(c) * redirscale
 			if len(exp) > 1 {
@@ -13720,8 +13727,10 @@ const (
 	modifyReflection_anim byte = iota
 	modifyReflection_animplayerno
 	modifyReflection_spriteplayerno
+	modifyReflection_animelem
 	modifyReflection_color
 	modifyReflection_intensity
+	modifyReflection_keeptransform
 	modifyReflection_offset
 	modifyReflection_window
 	modifyReflection_xscale
@@ -13742,11 +13751,14 @@ func (sc modifyReflection) Run(c *Char, _ []int32) bool {
 	}
 
 	redirscale := c.localscl / crun.localscl
-	animPN := crun.playerNo
-	spritePN := crun.playerNo
+	animPN := -1
+	spritePN := -1
 
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
+		case modifyReflection_animelem:
+			crun.reflectAnimelem = exp[0].evalI(c)
+			crun.setAnimElemTo(crun.reflectAnim, &crun.reflectAnimelem)
 		case modifyReflection_animplayerno:
 			animPN = int(exp[0].evalI(c)) - 1
 		case modifyReflection_spriteplayerno:
@@ -13754,7 +13766,7 @@ func (sc modifyReflection) Run(c *Char, _ []int32) bool {
 		case modifyReflection_anim:
 			ffx := string(*(*[]byte)(unsafe.Pointer(&exp[0])))
 			animNo := exp[1].evalI(c)
-			anim := c.getAnimSprite(animNo, animPN, spritePN, ffx, true, false)
+			anim := c.getShadowReflectionSprite(animNo, animPN, spritePN, ffx, true, false, "ModifyReflection")
 			if anim != nil {
 				anim.Action() // Need to step for it to appear
 				crun.reflectAnim = anim
@@ -13771,6 +13783,8 @@ func (sc modifyReflection) Run(c *Char, _ []int32) bool {
 			crun.reflectColor = [3]int32{r, g, b}
 		case modifyReflection_intensity:
 			crun.reflectIntensity = Clamp(exp[0].evalI(c), 0, 255)
+		case modifyReflection_keeptransform:
+			crun.reflectKeeptransform = exp[0].evalB(c)
 		case modifyReflection_offset:
 			crun.reflectOffset[0] = exp[0].evalF(c) * redirscale
 			if len(exp) > 1 {

--- a/src/char.go
+++ b/src/char.go
@@ -10734,7 +10734,7 @@ func (c *Char) actionPrepare() {
 		c.shadowAnim = nil
 		c.shadowColor = [3]int32{-1, -1, -1}
 		c.shadowIntensity = -1
-		c.shadowKeeptransform = false
+		c.shadowKeeptransform = true
 		c.shadowOffset = [2]float32{}
 		c.shadowWindow = [4]float32{}
 		c.shadowXscale = 0
@@ -10748,7 +10748,7 @@ func (c *Char) actionPrepare() {
 		c.reflectAnim = nil
 		c.reflectColor = [3]int32{-1, -1, -1}
 		c.reflectIntensity = -1
-		c.reflectKeeptransform = false
+		c.reflectKeeptransform = true
 		c.reflectOffset = [2]float32{}
 		c.reflectWindow = [4]float32{}
 		c.reflectXscale = 0
@@ -11776,10 +11776,6 @@ func (c *Char) cueDraw() {
 				if c.shadowAnim != nil {
 					shadowSDcopy := *shadowSD
 					shadowSDcopy.anim = c.shadowAnim
-					if c.shadowKeeptransform {
-						shadowSDcopy.rot = c.shadowRot
-						shadowSDcopy.xshear = c.shadowXshear
-					}
 					shadowSDcopy.anim.curelem = c.shadowAnimelem
 					shadowSD = &shadowSDcopy
 				}
@@ -11810,12 +11806,18 @@ func (c *Char) cueDraw() {
 					refYscale = c.reflectYscale
 				}
 
+				sdwKeeptransform := c.shadowKeeptransform 
+				if !c.shadowKeeptransform {
+					sdwKeeptransform = false
+				}
+
 				// Add shadow to shadow list
 				sys.shadows.add(&ShadowSprite{
 					SprData:         shadowSD,
 					shadowColor:     sdwclr,
 					shadowAlpha:     sdwalp,
 					shadowIntensity: c.shadowIntensity,
+					shadowKeeptransform: sdwKeeptransform,
 					shadowOffset: [2]float32{
 						c.shadowOffset[0] * c.localscl,
 						(c.size.shadowoffset+c.shadowOffset[1])*c.localscl + sdwYscale*drawZoff + drawZoff,
@@ -11837,10 +11839,6 @@ func (c *Char) cueDraw() {
 				if c.reflectAnim != nil {
 					reflectSDcopy := *reflectSD
 					reflectSDcopy.anim = c.reflectAnim
-					if c.reflectKeeptransform {
-						reflectSDcopy.rot = c.reflectRot
-						reflectSDcopy.xshear = c.reflectXshear
-					}
 					reflectSDcopy.anim.curelem = c.reflectAnimelem
 					reflectSD = &reflectSDcopy
 				}
@@ -11848,11 +11846,17 @@ func (c *Char) cueDraw() {
 				// Reflection modifiers
 				reflectclr := c.reflectColor[0]<<16 | c.reflectColor[1]<<8 | c.reflectColor[2]
 
+				reflectKeeptransform := c.reflectKeeptransform 
+				if !c.reflectKeeptransform {
+					reflectKeeptransform = false
+				}
+
 				// Add reflection to reflection list
 				sys.reflections.add(&ReflectionSprite{
 					SprData:          reflectSD,
 					reflectColor:     reflectclr,
 					reflectIntensity: c.reflectIntensity,
+					reflectKeeptransform: reflectKeeptransform,
 					reflectOffset: [2]float32{
 						c.reflectOffset[0] * c.localscl,
 						(c.size.shadowoffset+c.reflectOffset[1])*c.localscl + refYscale*drawZoff + drawZoff,

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1286,12 +1286,20 @@ func (c *Compiler) modifyShadow(is IniSection, sc *StateControllerBase, _ int8) 
 		}); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "animelem",
+			modifyShadow_animelem, VT_Int, 1, false); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "color",
 			modifyShadow_color, VT_Int, 3, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "intensity",
 			modifyShadow_intensity, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "keeptransform",
+			modifyShadow_keeptransform, VT_Bool, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "offset",
@@ -1360,12 +1368,20 @@ func (c *Compiler) modifyReflection(is IniSection, sc *StateControllerBase, _ in
 		}); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "animelem",
+			modifyReflection_animelem, VT_Int, 1, false); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "color",
 			modifyReflection_color, VT_Int, 3, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "intensity",
 			modifyReflection_intensity, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "keeptransform",
+			modifyReflection_keeptransform, VT_Bool, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "offset",

--- a/src/stage.go
+++ b/src/stage.go
@@ -535,6 +535,7 @@ func (bg backGround) draw(pos [2]float32, drawscl, bgscl, stglscl float32,
 		bg.xscale[1] = float32(bg.width[1]) / float32(bg.anim.spr.Size[0])
 		scalestartX = AbsF(scalestartX)
 		bg.xofs = scalestartX * ((-float32(bg.width[0]) / 2) + float32(bg.anim.spr.Offset[0])*bg.xscale[0])
+		bg.anim.isParallax = true
 	}
 
 	// Calculate raster x ratio and base x scale


### PR DESCRIPTION
Feat: 
- Added the ``keepTransform`` parameter to modifyShadow and Reflection. When set to 0, shadows and reflections keep their original transformations (angle and xshear) unchanged and use only the values from the modify Sctrl's without stacking. Defaults to 1.

Fix:
- Fixed a bug where a Parallax BG element using tiles would get offset when zoom was applied.