### PR TITLE
feat: unhardcoded win pose safety timeout; fix: StateDef anim; refactor: afterimages

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -4269,7 +4269,10 @@ func (sc stateDef) Run(c *Char) {
 		case stateDef_anim:
 			ffx := string(*(*[]byte)(unsafe.Pointer(&exp[0])))
 			animNo := exp[1].evalI(c)
-			c.changeAnim(animNo, c.playerNo, -1, ffx)
+			// "anim = -1" in this case means no change
+			if animNo != -1 {
+				c.changeAnim(animNo, c.playerNo, -1, ffx)
+			}
 		case stateDef_ctrl:
 			c.setCtrl(exp[0].evalB(c))
 		case stateDef_poweradd:

--- a/src/char.go
+++ b/src/char.go
@@ -6074,12 +6074,16 @@ func (c *Char) changeStateEx(no int32, pn int, anim, ctrl int32, ffx string) {
 		(c.ss.stateType == ST_S || c.ss.stateType == ST_C) && !c.asf(ASF_nofacep2) {
 		c.autoTurn()
 	}
+
+	// "anim = -1" in this case means no change
 	if anim != -1 {
 		c.changeAnim(anim, c.playerNo, -1, ffx)
 	}
+
 	if ctrl >= 0 {
 		c.setCtrl(ctrl != 0)
 	}
+
 	if c.stateChange1(no, pn) && sys.changeStateNest == 0 && c.minus == 0 {
 		for c.stchtmp && sys.changeStateNest < MaxLoop {
 			c.stateChange2()
@@ -6521,10 +6525,13 @@ func (c *Char) getShadowReflectionSprite(animNo int32, animPlayerNo, spritePlaye
 
 // Same old getAnim, but now without the FFX scale adjustment
 func (c *Char) getAnim(n int32, ffx string, fx bool) (a *Animation) {
+	// Return empty but valid animation
 	if n == -2 {
 		return &Animation{}
 	}
 
+	// In most cases, -1 means no animation. So we return nothing but do not log an error
+	// In ChangeState and StateDef, however, it means no change in animation (handled in respective places)
 	if n == -1 {
 		return nil
 	}

--- a/src/char.go
+++ b/src/char.go
@@ -8418,7 +8418,7 @@ func (c *Char) inputWait() bool {
 		return true
 	}
 	// If after round "over.waittime" and the win poses have not started
-	if sys.intro <= -sys.lifebar.ro.over_waittime && sys.wintime >= 0 {
+	if sys.intro <= -sys.lifebar.ro.over_waittime && sys.winposetime >= 0 {
 		return true
 	}
 	return false

--- a/src/char.go
+++ b/src/char.go
@@ -4642,6 +4642,15 @@ func (c *Char) alive() bool {
 	return !c.scf(SCF_ko)
 }
 
+// Check if a player should care about winning or losing
+// Used to enter win/lose states
+func (c *Char) activelyFighting() bool {
+	if c.teamside < 0 || c.scf(SCF_standby) || c.scf(SCF_disabled) {
+		return false
+	}
+	return true
+}
+
 func (c *Char) animElemNo(time int32) BytecodeValue {
 	if c.anim != nil && time >= -c.anim.curtime {
 		return BytecodeInt(c.anim.AnimElemNo(time))

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -2535,8 +2535,8 @@ type LifeBarRound struct {
 	over_waittime       int32
 	over_hittime        int32
 	over_wintime        int32
+	over_forcewintime   int32
 	over_time           int32
-	over_cancelwintime  int32
 	win_time            int32
 	win_sndtime         int32
 	win, win2           [2]AnimTextSnd
@@ -2577,8 +2577,8 @@ func newLifeBarRound(snd *Snd) *LifeBarRound {
 		over_waittime:      45,
 		over_hittime:       10,
 		over_wintime:       45,
+		over_forcewintime:  900, // Hardcoded in Mugen
 		over_time:          210,
-		over_cancelwintime: 900, // Hardcoded in Mugen
 		callfight_time:     60,
 	}
 }
@@ -2670,13 +2670,13 @@ func readLifeBarRound(is IniSection,
 	if ro.over_wintime < 1 {
 		ro.over_wintime = 1
 	}
+	is.ReadI32("over.forcewintime", &ro.over_forcewintime)
+	if ro.over_forcewintime < 1 {
+		ro.over_forcewintime = 1
+	}
 	is.ReadI32("over.time", &ro.over_time)
 	if ro.over_time < 1 {
 		ro.over_time = 1
-	}
-	is.ReadI32("over.cancelwintime", &ro.over_cancelwintime)
-	if ro.over_cancelwintime < 1 {
-		ro.over_cancelwintime = 1
 	}
 	is.ReadI32("win.time", &ro.win_time)
 	ro.win_sndtime = ro.win_time

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -2536,6 +2536,7 @@ type LifeBarRound struct {
 	over_hittime        int32
 	over_wintime        int32
 	over_time           int32
+	over_cancelwintime  int32
 	win_time            int32
 	win_sndtime         int32
 	win, win2           [2]AnimTextSnd
@@ -2577,6 +2578,7 @@ func newLifeBarRound(snd *Snd) *LifeBarRound {
 		over_hittime:       10,
 		over_wintime:       45,
 		over_time:          210,
+		over_cancelwintime: 900, // Hardcoded in Mugen
 		callfight_time:     60,
 	}
 }
@@ -2584,13 +2586,13 @@ func newLifeBarRound(snd *Snd) *LifeBarRound {
 func readLifeBarRound(is IniSection,
 	sff *Sff, at AnimationTable, snd *Snd, f []*Fnt) *LifeBarRound {
 	ro := newLifeBarRound(snd)
-	var tmp int32
-	var ftmp float32
+
 	is.ReadI32("pos", &ro.pos[0], &ro.pos[1])
 	is.ReadI32("match.wins", &ro.match_wins[0], &ro.match_wins[1])
 	is.ReadI32("match.maxdrawgames", &ro.match_maxdrawgames[0], &ro.match_maxdrawgames[1])
-	if is.ReadI32("start.waittime", &tmp) {
-		ro.start_waittime = Max(1, tmp)
+	is.ReadI32("start.waittime", &ro.start_waittime)
+	if ro.start_waittime < 1 {
+		ro.start_waittime = 1
 	}
 	is.ReadI32("round.time", &ro.round_time)
 	ro.round_sndtime = ro.round_time
@@ -2623,8 +2625,9 @@ func readLifeBarRound(is IniSection,
 	for i := range ro.fight_bg {
 		ro.fight_bg[i] = ReadAnimLayout(fmt.Sprintf("fight.bg%v.", i), is, sff, at, 2)
 	}
-	if is.ReadI32("ctrl.time", &tmp) {
-		ro.ctrl_time = Max(1, tmp)
+	is.ReadI32("ctrl.time", &ro.ctrl_time)
+	if ro.ctrl_time < 1 {
+		ro.ctrl_time = 1
 	}
 	is.ReadI32("ko.time", &ro.ko_time)
 	ro.ko_sndtime = ro.ko_time
@@ -2644,30 +2647,41 @@ func readLifeBarRound(is IniSection,
 	for i := range ro.to_bg {
 		ro.to_bg[i] = ReadAnimLayout(fmt.Sprintf("to.bg%v.", i), is, sff, at, 2)
 	}
+
 	is.ReadI32("slow.time", &ro.slow_time)
-	if is.ReadI32("slow.fadetime", &tmp) {
-		ro.slow_fadetime = Min(ro.slow_time, tmp)
-	} else {
-		ro.slow_fadetime = int32(float32(ro.slow_time) * 0.75)
+	ro.slow_fadetime = int32(float32(ro.slow_time) * 0.75) // Default fadetime
+	is.ReadI32("slow.fadetime", &ro.slow_fadetime)
+	if ro.slow_fadetime > ro.slow_time {
+		ro.slow_fadetime = ro.slow_time
 	}
-	if is.ReadF32("slow.speed", &ftmp) {
-		ro.slow_speed = MinF(1, ftmp)
+	is.ReadF32("slow.speed", &ro.slow_speed)
+	if ro.slow_speed > 1 {
+		ro.slow_speed = 1
 	}
-	if is.ReadI32("over.hittime", &tmp) {
-		ro.over_hittime = Max(1, tmp)
+	is.ReadI32("over.hittime", &ro.over_hittime)
+	if ro.over_hittime < 1 {
+		ro.over_hittime = 1
 	}
-	if is.ReadI32("over.waittime", &tmp) {
-		ro.over_waittime = Max(1, tmp)
+	is.ReadI32("over.waittime", &ro.over_waittime)
+	if ro.over_waittime < 1 {
+		ro.over_waittime = 1
 	}
-	if is.ReadI32("over.wintime", &tmp) {
-		ro.over_wintime = Max(1, tmp)
+	is.ReadI32("over.wintime", &ro.over_wintime)
+	if ro.over_wintime < 1 {
+		ro.over_wintime = 1
 	}
-	if is.ReadI32("over.time", &tmp) {
-		ro.over_time = Max(1, tmp)
+	is.ReadI32("over.time", &ro.over_time)
+	if ro.over_time < 1 {
+		ro.over_time = 1
+	}
+	is.ReadI32("over.cancelwintime", &ro.over_cancelwintime)
+	if ro.over_cancelwintime < 1 {
+		ro.over_cancelwintime = 1
 	}
 	is.ReadI32("win.time", &ro.win_time)
 	ro.win_sndtime = ro.win_time
 	is.ReadI32("win.sndtime", &ro.win_sndtime)
+
 	for i := 0; i < 2; i++ {
 		var ok, bg bool
 		// win

--- a/src/state.go
+++ b/src/state.go
@@ -257,7 +257,7 @@ type GameState struct {
 
 	loopBreak    bool
 	loopContinue bool
-	wintime      int32
+	winposetime  int32
 
 	// Rollback
 	netTime int32
@@ -477,7 +477,7 @@ func (gs *GameState) LoadState(stateID int) {
 	sys.loopBreak = gs.loopBreak
 	sys.loopContinue = gs.loopContinue
 
-	sys.wintime = gs.wintime
+	sys.winposetime = gs.winposetime
 
 	// Log state load
 	if sys.rollback.session == nil {
@@ -683,7 +683,7 @@ func (gs *GameState) SaveState(stateID int) {
 	gs.loopBreak = sys.loopBreak
 	gs.loopContinue = sys.loopContinue
 
-	gs.wintime = sys.wintime
+	gs.winposetime = sys.winposetime
 
 	// Log save state
 	if sys.rollback.session == nil {

--- a/src/state.go
+++ b/src/state.go
@@ -192,7 +192,7 @@ type GameState struct {
 	zoomCameraBound         bool
 	zoomPos                 [2]float32
 	finishType              FinishType // UIT
-	waitdown                int32
+	winwaittime             int32
 	slowtime                int32
 
 	changeStateNest int32
@@ -332,7 +332,7 @@ func (gs *GameState) LoadState(stateID int) {
 	sys.winType = gs.winType
 	sys.winTrigger = gs.winTrigger
 	sys.lastHitter = gs.lastHitter
-	sys.waitdown = gs.waitdown
+	sys.winwaittime = gs.winwaittime
 	sys.slowtime = gs.slowtime
 
 	sys.winskipped = gs.winskipped
@@ -546,7 +546,7 @@ func (gs *GameState) SaveState(stateID int) {
 	gs.winType = sys.winType
 	gs.winTrigger = sys.winTrigger
 	gs.lastHitter = sys.lastHitter
-	gs.waitdown = sys.waitdown
+	gs.winwaittime = sys.winwaittime
 	gs.slowtime = sys.slowtime
 	gs.winskipped = sys.winskipped
 	gs.intro = sys.intro

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -177,8 +177,13 @@ func (ghv *GetHitVar) Clone(a *arena.Arena) (result *GetHitVar) {
 	return
 }
 
-func (ai AfterImage) Clone(a *arena.Arena, gsp *GameStatePool) (result AfterImage) {
-	result = ai
+func (ai *AfterImage) Clone(a *arena.Arena, gsp *GameStatePool) *AfterImage {
+	if ai == nil {
+		return nil
+	}
+
+	result := &AfterImage{}
+	*result = *ai
 
 	// Deep copy Animations
 	for i := range ai.imgs {
@@ -194,7 +199,7 @@ func (ai AfterImage) Clone(a *arena.Arena, gsp *GameStatePool) (result AfterImag
 		}
 	}
 
-	return
+	return result
 }
 
 func (e *Explod) Clone(a *arena.Arena, gsp *GameStatePool) *Explod {
@@ -213,7 +218,9 @@ func (e *Explod) Clone(a *arena.Arena, gsp *GameStatePool) *Explod {
 		result.palfx = e.palfx.Clone(a)
 	}
 
-	result.aimg = e.aimg.Clone(a, gsp)
+	if e.aimg != nil {
+		result.aimg = e.aimg.Clone(a, gsp)
+	}
 
 	return result
 }
@@ -234,7 +241,9 @@ func (p *Projectile) clone(a *arena.Arena, gsp *GameStatePool) *Projectile {
 		result.palfx = p.palfx.Clone(a)
 	}
 
-	result.aimg = p.aimg.Clone(a, gsp)
+	if p.aimg != nil {
+		result.aimg = p.aimg.Clone(a, gsp)
+	}
 
 	return result
 }
@@ -277,7 +286,9 @@ func (c *Char) Clone(a *arena.Arena, gsp *GameStatePool) (result Char) {
 	// TODO: Profiling shows this is hotter than it should be
 	// Maybe we ought to clear animation data from them when their timer expires
 	// Update: Done already but copying 60 PalFX's is still a problem
-	result.aimg = c.aimg.Clone(a, gsp)
+	if c.aimg != nil {
+		result.aimg = c.aimg.Clone(a, gsp)
+	}
 
 	if c.palfx != nil {
 		result.palfx = c.palfx.Clone(a)


### PR DESCRIPTION
Features:
- Added lifebar  over.forcewintime parameter, which exposes the previously hardcoded 900 frames after which players are forced into their win poses
- Implements #2890 

Fixes:
- Fixed oversight that made StateDef anim -1 act like an invalid animation instead of resulting in no change
- Fixes #2898 

Refactor:
- AfterImages now use pointers and are consequentially removed from memory when disabled, making them lighter in savestates
- Afterimage memory allocation is now only as large as necessary
- A character that is currently uninvested in the match won't be forced into some match related states, such as state 0 at round start or state 180 upon winning. This means attached characters and characters in standby