### PR TITLE
refactor: update vulkan binding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 )
 
 require (
-	github.com/Eiton/vulkan v0.0.0-20251024132427-732131af8682 // indirect
+	github.com/Eiton/vulkan v0.0.0-20251123130526-85ddf7d0854d // indirect
 	github.com/icza/bitio v1.1.0 // indirect
 	github.com/mewkiz/flac v1.0.12 // indirect
 	github.com/mewkiz/pkg v0.0.0-20230226050401-4010bf0fec14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/Eiton/vulkan v0.0.0-20250730113011-bf42e2273c75 h1:i5crUn2IysHQBe/8+z
 github.com/Eiton/vulkan v0.0.0-20250730113011-bf42e2273c75/go.mod h1:3O9afAqFWBxgbKHanYAoOT1bkRkxyWxB7qfIoYJrm+g=
 github.com/Eiton/vulkan v0.0.0-20251024132427-732131af8682 h1:QAKWmR+/eg63syQ2ASI4KlRrBxnSLQ1r/WWGnnxSrbA=
 github.com/Eiton/vulkan v0.0.0-20251024132427-732131af8682/go.mod h1:3O9afAqFWBxgbKHanYAoOT1bkRkxyWxB7qfIoYJrm+g=
+github.com/Eiton/vulkan v0.0.0-20251123130526-85ddf7d0854d h1:VW/3rhljmIihyvTLuilJAiza2VSURxUtfqiAS33yGPQ=
+github.com/Eiton/vulkan v0.0.0-20251123130526-85ddf7d0854d/go.mod h1:3O9afAqFWBxgbKHanYAoOT1bkRkxyWxB7qfIoYJrm+g=
 github.com/TheTitanrain/w32 v0.0.0-20180517000239-4f5cfb03fabf/go.mod h1:peYoMncQljjNS6tZwI9WVyQB3qZS6u79/N3mBOcnd3I=
 github.com/TheTitanrain/w32 v0.0.0-20200114052255-2654d97dbd3d h1:2xp1BQbqcDDaikHnASWpVZRjibOxu7y9LhAv04whugI=
 github.com/TheTitanrain/w32 v0.0.0-20200114052255-2654d97dbd3d/go.mod h1:peYoMncQljjNS6tZwI9WVyQB3qZS6u79/N3mBOcnd3I=


### PR DESCRIPTION
Regenerated the Vulkan binding using a modified c-for-go build. Number of C memory allocation is reduced.
Fix index out of range error in Vulkan SetVertexData()