### PR TITLE
fix: crash that could happen in FFB due to Player-type Helpers

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -10826,13 +10826,16 @@ func (sc forceFeedback) Run(c *Char, _ []int32) bool {
 				}
 				joy = crun.controller
 			}
-			sys.ffbparams[sys.inputRemap[sys.joystickConfig[joy].Joy]] = ForceFeedbackParams{
-				timer:    time,
-				start:    ampl[0],
-				d1:       ampl[1],
-				d2:       ampl[2],
-				d3:       ampl[3],
-				waveform: waveform,
+			// Don't rumble helpers.
+			if joy >= 0 && joy < len(sys.joystickConfig) && crun.helperIndex == 0 {
+				sys.ffbparams[sys.inputRemap[sys.joystickConfig[joy].Joy]] = ForceFeedbackParams{
+					timer:    time,
+					start:    ampl[0],
+					d1:       ampl[1],
+					d2:       ampl[2],
+					d3:       ampl[3],
+					waveform: waveform,
+				}
 			}
 		}
 	}

--- a/src/input.go
+++ b/src/input.go
@@ -3286,7 +3286,7 @@ func (cl *CommandList) InputUpdate(owner *Char, controller int, aiLevel float32,
 				buttons = cl.Buffer.InputReader.LocalInput(sys.inputRemap[controller], script)
 			}
 			if controller < len(sys.joystickConfig) {
-				axes = input.GetJoystickAxes(sys.joystickConfig[controller].Joy)
+				axes = input.GetJoystickAxes(sys.joystickConfig[controller].Joy) // THIS IS INTENTIONAL TO PREVENT ANALOG SWAPPING ON MACOS, DO NOT CHANGE THIS
 			}
 		}
 	}


### PR DESCRIPTION
Crash was reported with Player-type Helpers in ForceFeedback so now FFB is disabled if it detects the redirected character is a helper.

Also added a comment in input.go so everyone knows why the axes retrieval is different.