### PR TITLE
fix: replays, projectile PalFX, save state text

### DIFF
--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -962,51 +962,51 @@ func (c *Compiler) explodSub(is IniSection,
 func (c *Compiler) explodInterpolate(is IniSection,
 	sc *StateControllerBase) error {
 	if err := c.paramValue(is, sc, "interpolation.time",
-		explod_interpolate_time, VT_Int, 1, false); err != nil {
+		explod_interpolation_time, VT_Int, 1, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "interpolation.animelem",
-		explod_interpolate_animelem, VT_Int, 1, false); err != nil {
+		explod_interpolation_animelem, VT_Int, 1, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "interpolation.scale",
-		explod_interpolate_scale, VT_Float, 2, false); err != nil {
+		explod_interpolation_scale, VT_Float, 2, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "interpolation.angle",
-		explod_interpolate_angle, VT_Float, 3, false); err != nil {
+		explod_interpolation_angle, VT_Float, 3, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "interpolation.alpha",
-		explod_interpolate_alpha, VT_Float, 2, false); err != nil {
+		explod_interpolation_alpha, VT_Float, 2, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "interpolation.offset",
-		explod_interpolate_pos, VT_Float, 3, false); err != nil {
+		explod_interpolation_pos, VT_Float, 3, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "interpolation.focallength",
-		explod_interpolate_focallength, VT_Float, 1, false); err != nil {
+		explod_interpolation_focallength, VT_Float, 1, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "interpolation.xshear",
-		explod_interpolate_xshear, VT_Float, 1, false); err != nil {
+		explod_interpolation_xshear, VT_Float, 1, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "interpolation.palfx.mul",
-		explod_interpolate_pfx_mul, VT_Int, 3, false); err != nil {
+		explod_interpolation_pfx_mul, VT_Int, 3, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "interpolation.palfx.add",
-		explod_interpolate_pfx_add, VT_Int, 3, false); err != nil {
+		explod_interpolation_pfx_add, VT_Int, 3, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "interpolation.palfx.color",
-		explod_interpolate_pfx_color, VT_Float, 1, false); err != nil {
+		explod_interpolation_pfx_color, VT_Float, 1, false); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "interpolation.palfx.hue",
-		explod_interpolate_pfx_hue, VT_Float, 1, false); err != nil {
+		explod_interpolation_pfx_hue, VT_Float, 1, false); err != nil {
 		return err
 	}
 	return nil

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -601,6 +601,26 @@ func (l *Lifebar) Clone(a *arena.Arena) (result Lifebar) {
 		}
 	}
 
+	// TextSprite
+	if l.textsprite != nil {
+		result.textsprite = make([]*TextSprite, len(l.textsprite))
+		for i, ts := range l.textsprite {
+			if ts != nil {
+				result.textsprite[i] = &TextSprite{}
+				*result.textsprite[i] = *ts
+
+				if ts.params != nil {
+					result.textsprite[i].params = make([]interface{}, len(ts.params))
+					copy(result.textsprite[i].params, ts.params)
+				}
+
+				if ts.palfx != nil {
+					result.textsprite[i].palfx = ts.palfx.Clone(a)
+				}
+			}
+		}
+	}
+
 	return
 }
 


### PR DESCRIPTION
Fixes:
- Fixed projectiles not being able to inflict a PalFX when they hit the enemy
- Adjusted replay code so they can be used again
- Added texts (from the Text sctrl) to save states
- Fixes #2917
- Fixes #2927
- Fixes #2928