### PR TITLE
fix: keyboard input not working straight away on menus due to > 0 main.analogDeadTime initialization

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -203,7 +203,7 @@ end
 local ANALOG_DEAD_TIME = 20 -- dead time to limit scrolling behavior
 main.playerInput = 1
 main.lastAxis = nil
-main.analogDeadTime = ANALOG_DEAD_TIME
+main.analogDeadTime = 0
 function main.f_input(p, b)
 	for _, pn in ipairs(p) do
 		for _, btn in ipairs(b) do


### PR DESCRIPTION
Whoops