### PR TITLE
fix: missing aspectratio option, remove legacy stagefit

### DIFF
--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -217,7 +217,6 @@ options.t_itemname = {
 			--modifyGameOption('Video.WindowCentered', true)
 			modifyGameOption('Video.ExternalShaders', {})
 			modifyGameOption('Video.WindowScaleMode', true)
-			--modifyGameOption('Video.StageFit', true)
 			modifyGameOption('Video.FightAspectWidth', -1)
 			modifyGameOption('Video.FightAspectHeight', -1)
 			modifyGameOption('Video.KeepAspect', true)
@@ -941,23 +940,6 @@ options.t_itemname = {
 		end
 		return true
 	end,
-	--[[
-	--StageFit
-	['stagefit'] = function(t, item, cursorPosY, moveTxt)
-		if main.f_input(main.t_players, motif.option_info.menu.add.key, motif.option_info.menu.subtract.key, motif.option_info.menu.done.key) then
-			sndPlay(motif.Snd, motif.option_info.cursor.move.snd[1], motif.option_info.cursor.move.snd[2])
-			if gameOption('Video.StageFit') then
-				modifyGameOption('Video.StageFit', false)
-			else
-				modifyGameOption('Video.StageFit', true)
-			end
-			t.items[item].vardisplay = options.f_boolDisplay(gameOption('Video.StageFit'), motif.option_info.menu.valuename.enabled, motif.option_info.menu.valuename.disabled)
-			options.modified = true
-			options.needReload = true
-		end
-		return true
-	end,
-	]]
 	-- Match Aspect Ratio (submenu)
 	['aspectratio'] = function(t, item, cursorPosY, moveTxt)
 		if main.f_input(main.t_players, motif.option_info.menu.add.key, motif.option_info.menu.subtract.key, motif.option_info.menu.done.key) then
@@ -1557,11 +1539,6 @@ options.t_vardisplay = {
 	['helpermax'] = function()
 		return gameOption('Config.HelperMax')
 	end,
-	--[[
-	['stagefit'] = function()
-		return options.f_boolDisplay(gameOption('Video.StageFit'), motif.option_info.menu.valuename.enabled, motif.option_info.menu.valuename.disabled)
-	end,
-	]]
 	['keepaspect'] = function()
 		return options.f_boolDisplay(gameOption('Video.KeepAspect'), motif.option_info.menu.valuename.enabled, motif.option_info.menu.valuename.disabled)
 	end,

--- a/src/resources/defaultMotif.ini
+++ b/src/resources/defaultMotif.ini
@@ -2871,7 +2871,15 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	menu.itemname.menuvideo.resolution.back = Back
 	menu.itemname.menuvideo.fullscreen = Fullscreen
 	menu.itemname.menuvideo.vsync = VSync
-	menu.itemname.menuvideo.stagefit = StageFit
+	menu.itemname.menuvideo.aspectratio = Aspect Ratio
+	; Aspect ratio is assigned based on values used in itemname suffix (e.g. 4:3)
+	menu.itemname.menuvideo.aspectratio.default = Default
+	menu.itemname.menuvideo.aspectratio.stage = Stage
+	menu.itemname.menuvideo.aspectratio.4x3 = 4:3
+	menu.itemname.menuvideo.aspectratio.16x9 = 16:9
+	menu.itemname.menuvideo.aspectratio.customaspect = Custom
+	menu.itemname.menuvideo.aspectratio.spacer1 = -
+	menu.itemname.menuvideo.aspectratio.back = Back
 	menu.itemname.menuvideo.keepaspect = Keep Aspect Ratio
 	menu.itemname.menuvideo.windowscalemode = Window Scale Mode
 	menu.itemname.menuvideo.msaa = MSAA


### PR DESCRIPTION
stagefit hasn't been available as an option for quite some time; it was replaced by the aspect ratio option. defaultMotif.ini didn’t include those parameters.
https://discord.com/channels/233345562261323776/282927929548210177/1449718233602195591