### PR TITLE
fix: screenpack parsing crash

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -12117,6 +12117,10 @@ func (cl *CharList) commandUpdate() {
 				// Update Forward/Back flipping flag
 				c.updateFBFlip()
 
+				// Safety guard: prevent indexing cmd slices when they may be empty.
+				if len(c.cmd) == 0 || (c.helperIndex > 0 && len(root.cmd) == 0) {
+					continue
+				}
 				if (c.helperIndex == 0 || c.helperIndex > 0 && &c.cmd[0] != &root.cmd[0]) &&
 					c.cmd[0].InputUpdate(c, c.controller, sys.aiLevel[i], false) {
 					// Clear input buffers and skip the rest of the loop

--- a/src/iniutils.go
+++ b/src/iniutils.go
@@ -2754,7 +2754,7 @@ func resolveInlineFonts(iniFile *ini.File, baseDef string, fnt map[int]*Fnt, ind
 			}
 			// treat as filename; derive height from last element when present
 			h := int32(-1)
-			if len(parts) >= 7 {
+			if len(parts) > 7 {
 				hvStr := strings.TrimSpace(parts[7])
 				if IsInt(hvStr) {
 					h = Atoi(hvStr)


### PR DESCRIPTION
* Fix out of bound font parameter crash in screenpack parser
https://discord.com/channels/233345562261323776/282927929548210177/1449919963572994239
* Safety guard to prevent indexing cmd slices when they may be empty (unrelated to recent changes)
https://discord.com/channels/233345562261323776/282927929548210177/1449790918168416280
