### PR TITLE
fix: screenpack textdelay, language overrides, BGM interrupt, stage format, custom res

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -1587,6 +1587,12 @@ function main.f_storyboard(path)
 	if s == nil then
 		return
 	end
+	if main.debugLog then
+		-- get filename without extension from full path
+		local name = path:match("([^/\\]+)$") or "unknown" -- last path segment
+		name = name:gsub("%.[^%.]+$", "") -- strip last extension
+		main.f_printTable(s, 'debug/loadStoryboard_' .. name .. '.txt')
+	end
 	while true do
 		if not runStoryboard() then
 			break

--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -2445,7 +2445,7 @@ function main.f_createMenu(tbl, bool_bgreset, bool_main, bool_f1, bool_del)
 		if bool_bgreset then
 			if not motif.attract_mode.enabled then
 				bgReset(motif[main.background].BGDef)
-				playBgm({source = "motif.title"})
+				playBgm({source = "motif.title", interrupt = true})
 			end
 			main.f_fadeReset('fadein', motif[main.group])
 		end
@@ -2720,7 +2720,7 @@ function main.f_replay()
 		if main.close and not main.fadeActive then
 			bgReset(motif[main.background].BGDef)
 			main.f_fadeReset('fadein', motif[main.group])
-			playBgm({source = "motif.title"})
+			playBgm({source = "motif.title", interrupt = true})
 			main.close = false
 			break
 		elseif esc() or main.f_input(main.t_players, motif[main.group].menu.cancel.key) or (t[item].itemname == 'back' and main.f_input(main.t_players, motif[main.group].menu.done.key)) then
@@ -2854,7 +2854,7 @@ function main.f_hiscoreDisplay(itemname)
 	sndPlay(motif.Snd, motif[main.group].cursor.done.snd[1], motif[main.group].cursor.done.snd[2])
 	main.f_hiscore(itemname, -1)
 	--main.f_fadeReset('fadein', motif[main.group])
-	playBgm({source = "motif.title"})
+	playBgm({source = "motif.title", interrupt = true})
 	return true
 end
 
@@ -2871,7 +2871,7 @@ function main.f_attractStart()
 	bgReset(motif.attractbgdef.BGDef)
 	main.f_fadeReset('fadein', motif.attract_mode)
 	local fadeOutStarted = false
-	playBgm({source = "motif.title"})
+	playBgm({source = "motif.title", interrupt = true})
 	local creditsCnt = credits()
 	while true do
 		counter = counter + 1

--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -690,6 +690,41 @@ function main.f_countSubstring(s1, s2)
 	return select(2, s1:gsub(s2, ""))
 end
 
+-- formats using %s / %i in the order they appear in fmt
+function main.f_formatBySpec(fmt, specMap)
+	if fmt == nil then return "" end
+	if type(fmt) ~= "string" then fmt = tostring(fmt) end
+	local args = {}
+	local pos = 1
+	while true do
+		local p = fmt:find("%%", pos)
+		if not p then break end
+		local nextc = fmt:sub(p + 1, p + 1)
+		if nextc == "%" then
+			-- literal %%
+			pos = p + 2
+		else
+			-- match a printf-like directive
+			local _, e, verb = fmt:find("%%[%-%+ #0]*%d*%.?%d*([A-Za-z])", p)
+			if not e then break end
+			if verb == "s" then
+				args[#args + 1] = tostring(specMap.s or "")
+			elseif verb == "i" or verb == "d" or verb == "u" then
+				args[#args + 1] = tonumber(specMap.i) or 0
+			end
+			pos = e + 1
+		end
+	end
+	if #args == 0 then return fmt end
+	local fmt2 = fmt
+	local ok, out = pcall(string.format, fmt2, unpack(args))
+	if not ok then
+		print("main.f_formatBySpec ERROR: " .. tostring(out))
+		return fmt
+	end
+	return out
+end
+
 --update rounds to win variables
 main.roundsNumSingle = {}
 main.roundsNumSimul = {}

--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -1431,7 +1431,7 @@ function options.f_createMenu(tbl, bool_main)
 			if main.close and not main.fadeActive then
 				bgReset(motif[main.background].BGDef)
 				main.f_fadeReset('fadein', motif[main.group])
-				playBgm({source = "motif.title"})
+				playBgm({source = "motif.title", interrupt = true})
 				main.close = false
 				break
 			elseif esc() or main.f_input(main.t_players, motif.option_info.menu.cancel.key) then

--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -850,7 +850,7 @@ options.t_itemname = {
 				sndPlay(motif.Snd, motif.option_info.cursor.move.snd[1], motif.option_info.cursor.move.snd[2])
 				local resheight = tonumber(main.f_drawInput(
 					motif.option_info.textinput.TextSpriteData,
-					motif.option_info.textinput.resheight.reswidth,
+					motif.option_info.textinput.text.resheight,
 					motif.option_info,
 					motif.optionbgdef,
 					motif.option_info.textinput.overlay.RectData

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -1566,7 +1566,7 @@ function start.f_selectMode()
 			sndPlay(motif.Snd, motif.select_info.cancel.snd[1], motif.select_info.cancel.snd[2])
 			bgReset(motif[main.background].BGDef)
 			main.f_fadeReset('fadein', motif[main.group])
-			playBgm({source = "motif.title"})
+			playBgm({source = "motif.title", interrupt = true})
 			return
 		end
 		--first match
@@ -1635,7 +1635,7 @@ function start.f_selectMode()
 			if start.exit then
 				bgReset(motif[main.background].BGDef)
 				main.f_fadeReset('fadein', motif[main.group])
-				playBgm({source = "motif.title"})
+				playBgm({source = "motif.title", interrupt = true})
 				start.exit = false
 				return
 			end
@@ -2086,7 +2086,7 @@ function start.f_selectScreen()
 	bgReset(motif.selectbgdef.BGDef)
 	main.f_fadeReset('fadein', motif.select_info)
 	local fadeOutStarted = false
-	playBgm({source = "motif.select"})
+	playBgm({source = "motif.select", interrupt = true})
 	start.f_resetTempData(motif.select_info, 'face')
 	f_snapCursor()
 	local stageActiveCount = 0

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -2316,7 +2316,7 @@ function start.f_selectScreen()
 				--draw stage name
 				local stage_text = motif.select_info.stage.random.text
 				if stageListNo ~= 0 then
-					stage_text = string.format(motif.select_info.stage.text, stageListNo, main.t_selStages[main.t_selectableStages[stageListNo]].name)
+					stage_text = main.f_formatBySpec(motif.select_info.stage.text, {i = stageListNo, s = main.t_selStages[main.t_selectableStages[stageListNo]].name})
 				end
 				textImgReset(motif.select_info.stage.TextSpriteData)
 				textImgSetText(motif.select_info.stage.TextSpriteData, stage_text)
@@ -3367,7 +3367,8 @@ function start.f_selectVersus(active, t_orderSelect)
 		--draw stage name
 		if selStageNo and main.t_selStages[selStageNo] then
 			textImgReset(motif.vs_screen.stage.TextSpriteData)
-			textImgSetText(motif.vs_screen.stage.TextSpriteData, string.format(motif.vs_screen.stage.text, main.t_selStages[selStageNo].name))
+			local stage_text = main.f_formatBySpec(motif.vs_screen.stage.text, {i = selStageNo, s = main.t_selStages[selStageNo].name})
+			textImgSetText(motif.vs_screen.stage.TextSpriteData, stage_text)
 			textImgDraw(motif.vs_screen.stage.TextSpriteData)
 		end
 		--draw match counter

--- a/src/font.go
+++ b/src/font.go
@@ -1046,10 +1046,20 @@ func StepTypewriter(fullLine string, typedLen *int, charDelayCounter *int32,
 	if fullLine == "" {
 		*typedLen = 0
 		*lineFullyRendered = true
+		*charDelayCounter = 0
 		return
 	}
 
 	totalRunes := utf8.RuneCountInString(fullLine)
+
+	// textdelay <= 0 means "show everything immediately"
+	if delay <= 0 {
+		*typedLen = totalRunes
+		*charDelayCounter = 0
+		*lineFullyRendered = true
+		return
+	}
+
 	if *typedLen > totalRunes {
 		*typedLen = totalRunes
 	}

--- a/src/motif.go
+++ b/src/motif.go
@@ -1533,7 +1533,10 @@ func loadMotif(def string) (*Motif, error) {
 				continue
 			}
 			lang, base, has := splitLangPrefix(raw)
-			logical := base
+			logical := raw
+			if has {
+				logical = base
+			}
 			// Backgrounds and [Begin Action] blocks are skipped (case-insensitive).
 			lb := strings.ToLower(logical)
 			// Skip raw BG sections which are handled by loadBGDef.
@@ -1560,9 +1563,7 @@ func loadMotif(def string) (*Motif, error) {
 			}
 			// Route by language.
 			if has {
-				if lang == "en" {
-					baseSecs = append(baseSecs, secPair{s, logical})
-				} else if lang == curLang {
+				if lang == curLang {
 					langSecs = append(langSecs, secPair{s, logical})
 				}
 			} else {
@@ -1654,7 +1655,7 @@ func loadMotif(def string) (*Motif, error) {
 	m.populateDataPointers()
 	m.applyPostParsePosAdjustments()
 
-	m.Music = parseMusicSection(pickLangSection(iniFile, "Music"))
+	m.Music = parseMusicSection(pickLangSectionMerged(iniFile, "Music"))
 	m.Music.DebugDump("Motif [Music]")
 
 	return &m, nil

--- a/src/script.go
+++ b/src/script.go
@@ -2492,16 +2492,18 @@ func systemScriptInit(l *lua.LState) {
 				return
 			}
 			// Choose the language-appropriate section name transparently.
-			secName := ResolveLangSectionName(file, sec, SelectedLanguage())
-			s, err := file.GetSection(secName)
-			if err != nil || s == nil {
-				return
-			}
 			lp := strings.ToLower(pref)
-			for _, k := range s.Keys() {
-				n := k.Name()
-				if strings.HasPrefix(strings.ToLower(n), lp) {
-					fn(n[len(pref):], k.Value())
+			// Overlay semantics: [Section] then [<lang>.Section]
+			for _, secName := range ResolveLangSectionNames(file, sec, SelectedLanguage()) {
+				s, err := file.GetSection(secName)
+				if err != nil || s == nil {
+					continue
+				}
+				for _, k := range s.Keys() {
+					n := k.Name()
+					if strings.HasPrefix(strings.ToLower(n), lp) {
+						fn(n[len(pref):], k.Value())
+					}
 				}
 			}
 		}
@@ -2566,26 +2568,48 @@ func systemScriptInit(l *lua.LState) {
 				if file == nil || sec == "" {
 					return
 				}
-				s, err := file.GetSection(ResolveLangSectionName(file, sec, SelectedLanguage()))
-				if err != nil || s == nil {
-					return
-				}
 				lp := strings.ToLower(pref)
-				for _, k := range s.Keys() {
-					n := k.Name()
-					if !strings.HasPrefix(strings.ToLower(n), lp) {
+				// Build effective entries per overlay semantics:
+				// [Section] then [<lang>.Section] overwriting values/disabled flags.
+				byFlat := map[string]entry{}
+				var order []string
+
+				addFrom := func(s *ini.Section) {
+					if s == nil {
+						return
+					}
+					for _, k := range s.Keys() {
+						n := k.Name()
+						if !strings.HasPrefix(strings.ToLower(n), lp) {
+							continue
+						}
+						p := n[len(pref):]
+						base := p
+						if i := strings.LastIndex(base, "."); i >= 0 {
+							base = base[i+1:]
+						}
+						e := entry{
+							flat:     strings.ReplaceAll(p, ".", "_"),
+							base:     strings.ToLower(base),
+							disabled: isEmpty(k.Value()),
+						}
+						if _, ok := byFlat[e.flat]; !ok {
+							order = append(order, e.flat)
+						}
+						byFlat[e.flat] = e
+					}
+				}
+
+				for _, secName := range ResolveLangSectionNames(file, sec, SelectedLanguage()) {
+					s, err := file.GetSection(secName)
+					if err != nil || s == nil {
 						continue
 					}
-					p := n[len(pref):] // e.g. "menuversus.back"
-					base := p
-					if i := strings.LastIndex(base, "."); i >= 0 {
-						base = base[i+1:]
-					}
-					out = append(out, entry{
-						flat:     strings.ReplaceAll(p, ".", "_"), // e.g. "menuversus_back"
-						base:     strings.ToLower(base),           // e.g. "back"
-						disabled: isEmpty(k.Value()),
-					})
+					addFrom(s)
+				}
+
+				for _, flat := range order {
+					out = append(out, byFlat[flat])
 				}
 				return
 			}
@@ -2652,29 +2676,50 @@ func systemScriptInit(l *lua.LState) {
 				if file == nil || sec == "" {
 					return
 				}
-				s, err := file.GetSection(ResolveLangSectionName(file, sec, SelectedLanguage()))
-				if err != nil || s == nil {
-					return
-				}
 				const pref = "teammenu.itemname."
 				lp := strings.ToLower(pref)
-				for _, k := range s.Keys() {
-					n := k.Name()
-					ln := strings.ToLower(n)
-					if !strings.HasPrefix(ln, lp) {
+				// Overlay semantics: [Section] then [<lang>.Section]
+				byKey := map[string]entry{} // key = elem|field
+				var order []string
+
+				addFrom := func(s *ini.Section) {
+					if s == nil {
+						return
+					}
+					for _, k := range s.Keys() {
+						n := k.Name()
+						ln := strings.ToLower(n)
+						if !strings.HasPrefix(ln, lp) {
+							continue
+						}
+						rest := n[len(pref):]
+						ps := strings.Split(rest, ".")
+						elem := "default"
+						field := ""
+						if len(ps) == 1 {
+							field = strings.ToLower(ps[0])
+						} else {
+							elem = strings.ToLower(ps[0])
+							field = strings.ToLower(ps[len(ps)-1])
+						}
+						e := entry{elem: elem, field: field, disabled: isEmpty(k.Value())}
+						key := elem + "|" + field
+						if _, ok := byKey[key]; !ok {
+							order = append(order, key)
+						}
+						byKey[key] = e
+					}
+				}
+
+				for _, secName := range ResolveLangSectionNames(file, sec, SelectedLanguage()) {
+					s, err := file.GetSection(secName)
+					if err != nil || s == nil {
 						continue
 					}
-					rest := n[len(pref):] // e.g. "simul" or "teamarcade.simul"
-					ps := strings.Split(rest, ".")
-					elem := "default"
-					field := ""
-					if len(ps) == 1 {
-						field = strings.ToLower(ps[0])
-					} else {
-						elem = strings.ToLower(ps[0])
-						field = strings.ToLower(ps[len(ps)-1])
-					}
-					out = append(out, entry{elem: elem, field: field, disabled: isEmpty(k.Value())})
+					addFrom(s)
+				}
+				for _, k := range order {
+					out = append(out, byKey[k])
 				}
 				return
 			}

--- a/src/storyboard.go
+++ b/src/storyboard.go
@@ -179,17 +179,15 @@ func loadStoryboard(def string) (*Storyboard, error) {
 				continue
 			}
 			lang, base, has := splitLangPrefix(raw)
-			logical := base
-			if !has {
-				logical = raw
+			logical := raw
+			if has {
+				logical = base
 			}
 			if !interesting(logical) {
 				continue
 			}
 			if has {
-				if lang == "en" {
-					baseSecs = append(baseSecs, secPair{s, logical})
-				} else if lang == curLang {
+				if lang == curLang {
 					langSecs = append(langSecs, secPair{s, logical})
 				}
 			} else {
@@ -291,7 +289,7 @@ func loadStoryboard(def string) (*Storyboard, error) {
 
 	for scene, sceneProps := range s.Scene {
 		sceneName := strings.Replace(scene, "scene_", "scene ", 1)
-		sceneProps.Music = parseMusicSection(pickLangSection(iniFile, sceneName))
+		sceneProps.Music = parseMusicSection(pickLangSectionMerged(iniFile, sceneName))
 		sceneProps.Music.DebugDump(fmt.Sprintf("Storyboard %s [%s]", def, sceneName))
 	}
 


### PR DESCRIPTION
Fixes:
* textdelay: treat <= 0 as intended (0 no longer behaves like 1).
  Fixes https://discord.com/channels/233345562261323776/233363722934943744/1450171092747419739
* language-prefixed sections: ensure they correctly override base section values.
   Fixes https://discord.com/channels/233345562261323776/233363722934943744/1450186212697575647
* playBgm interrupt: when interrupt is requested, stop currently playing music even if the new BGM is empty/undefined; only persist when the resolved file matches the currently playing one.
   Fixes: https://discord.com/channels/233345562261323776/233363722934943744/1450165360484421665
* stage text formatting: support %i and/or %s in any order via a helper that maps args to specifier order.
   Fixes: https://discord.com/channels/233345562261323776/233363722934943744/1450194676333154525
* custom resolution crash: fix a typo that caused a crash when setting a custom resolution.
   Fixes: https://discord.com/channels/233345562261323776/233363722934943744/1450277636743106710