### PR TITLE
fix: tween always snaping on wrap

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -3212,7 +3212,7 @@ function main.f_menuCommonCalc(t, item, cursorPosY, moveTxt, sec, cursorParams, 
 			item = item + 1
 		end
 		cursorPosY = item
-		if sec.menu.tween.wrap.snap then
+		if sec.menu.tween.wrap.snap == 1 then
 			main.menuSnap = true
 		end
 		main.menuWrapped = true
@@ -3227,7 +3227,7 @@ function main.f_menuCommonCalc(t, item, cursorPosY, moveTxt, sec, cursorParams, 
 		else
 			cursorPosY = item
 		end
-		if sec.menu.tween.wrap.snap then
+		if sec.menu.tween.wrap.snap == 1 then
 			main.menuSnap = true
 		end
 		main.menuWrapped = true
@@ -3422,7 +3422,7 @@ function main.f_menuCommonDraw(t, item, cursorPosY, moveTxt, sec, bg, skipClear,
 		sec.boxCursorData.init = true
 		sec.boxCursorData.snap = -1
 	end
-	if sec.menu.boxcursor.tween.wrap.snap and main.menuWrapped then
+	if sec.menu.boxcursor.tween.wrap.snap == 1 and main.menuWrapped then
 		sec.boxCursorData.offsetY = targetY
 	end
 	--apply tween if enabled, otherwise snap to target

--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -3212,7 +3212,7 @@ function main.f_menuCommonCalc(t, item, cursorPosY, moveTxt, sec, cursorParams, 
 			item = item + 1
 		end
 		cursorPosY = item
-		if sec.menu.tween.wrap.snap == 1 then
+		if sec.menu.tween.wrap.snap ~= 0 then
 			main.menuSnap = true
 		end
 		main.menuWrapped = true
@@ -3227,7 +3227,7 @@ function main.f_menuCommonCalc(t, item, cursorPosY, moveTxt, sec, cursorParams, 
 		else
 			cursorPosY = item
 		end
-		if sec.menu.tween.wrap.snap == 1 then
+		if sec.menu.tween.wrap.snap ~= 0 then
 			main.menuSnap = true
 		end
 		main.menuWrapped = true
@@ -3422,7 +3422,7 @@ function main.f_menuCommonDraw(t, item, cursorPosY, moveTxt, sec, bg, skipClear,
 		sec.boxCursorData.init = true
 		sec.boxCursorData.snap = -1
 	end
-	if sec.menu.boxcursor.tween.wrap.snap == 1 and main.menuWrapped then
+	if sec.menu.boxcursor.tween.wrap.snap ~= 0 and main.menuWrapped then
 		sec.boxCursorData.offsetY = targetY
 	end
 	--apply tween if enabled, otherwise snap to target

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -1092,7 +1092,7 @@ function start.f_drawCursor(pn, x, y, param, done)
 		cd.slideOffset[1], cd.slideOffset[2] = 0, 0
 	end
 
-	if motif.select_info['p' .. pn].cursor.tween.wrap.snap == 1 then
+	if motif.select_info['p' .. pn].cursor.tween.wrap.snap ~= 0 then
 		local dx = cd.targetPos[1] - cd.startPos[1]
 		local dy = cd.targetPos[2] - cd.startPos[2]
 		if math.abs(dx) > motif.select_info.cell.size[1] * (motif.select_info.columns - 1) or math.abs(dy) > motif.select_info.cell.size[2] * (motif.select_info.rows - 1) then

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -1092,7 +1092,7 @@ function start.f_drawCursor(pn, x, y, param, done)
 		cd.slideOffset[1], cd.slideOffset[2] = 0, 0
 	end
 
-	if motif.select_info['p' .. pn].cursor.tween.wrap.snap then
+	if motif.select_info['p' .. pn].cursor.tween.wrap.snap == 1 then
 		local dx = cd.targetPos[1] - cd.startPos[1]
 		local dy = cd.targetPos[2] - cd.startPos[2]
 		if math.abs(dx) > motif.select_info.cell.size[1] * (motif.select_info.columns - 1) or math.abs(dy) > motif.select_info.cell.size[2] * (motif.select_info.rows - 1) then


### PR DESCRIPTION
Fix:
- Fixes an issue where tween.wrap.snap was always active even when set to 0 (which is the default value).