### PR TITLE
fix: dialogue apect, default itemname, dialogue active portrait, default training values, fade anim length, font palettes, music values defaults

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -497,8 +497,8 @@ function main.f_fadeAnim(fadeGroup)
 	--draw fade anim
 	if main.fadeCnt > 0 then
 		if fadeGroup[main.fadeType].AnimData ~= nil then
-			animUpdate(fadeGroup[main.fadeType].AnimData)
 			animDraw(fadeGroup[main.fadeType].AnimData)
+			animUpdate(fadeGroup[main.fadeType].AnimData)
 		end
 		main.fadeCnt = main.fadeCnt - 1
 	end
@@ -526,8 +526,8 @@ function main.f_fadeReset(fadeType, fadeGroup)
 	main.fadeCnt = 0
 	if fadeGroup[fadeType].AnimData ~= nil then
 		animReset(fadeGroup[fadeType].AnimData)
-		--animUpdate(fadeGroup[fadeType].AnimData)
-		main.fadeCnt = animGetLength(fadeGroup[fadeType].AnimData)
+		animUpdate(fadeGroup[fadeType].AnimData)
+		main.fadeCnt = animGetLength(fadeGroup[fadeType].AnimData) - 1
 		if fadeType == 'fadeout' and main.fadeCnt > fadeGroup[fadeType].time then
 			main.fadeStart = main.fadeStart + main.fadeCnt - fadeGroup[fadeType].time
 		end

--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -949,10 +949,10 @@ options.t_itemname = {
 			local currentWidth = gameOption('Video.FightAspectWidth')
 			local currentHeight = gameOption('Video.FightAspectHeight')
 			for k, v in ipairs(t.submenu[t.items[item].itemname].items) do
-				if v.itemname == 'default' and currentWidth == 0 and currentHeight == 0 then
+				if v.itemname == 'defaultaspect' and currentWidth == 0 and currentHeight == 0 then
 					v.selected = true
 					ok = true
-				elseif v.itemname == 'stage' and currentWidth == -1 and currentHeight == -1 then
+				elseif v.itemname == 'stageaspect' and currentWidth == -1 and currentHeight == -1 then
 					v.selected = true
 					ok = true
 				else
@@ -1468,6 +1468,15 @@ end
 
 options.t_vardisplayPointers = {}
 
+local function findItemnameBySuffix(sfx)
+	for _, k in ipairs(motif.option_info.menu.itemname_order) do
+		if k:match(sfx) then
+			return motif.option_info.menu.itemname[k]
+		end
+	end
+	return ''
+end
+
 -- Associative elements table storing functions returning current setting values
 -- rendered alongside menu item name. Can be appended via external module.
 options.t_vardisplay = {
@@ -1489,9 +1498,9 @@ options.t_vardisplay = {
 		if width > 0 and height > 0 then
 			return width .. ':' .. height
 		elseif width < 0 and height < 0 then
-			return 'Stage'
+			return findItemnameBySuffix('stageaspect$')
 		else
-			return 'Default'
+			return findItemnameBySuffix('defaultaspect$')
 		end
 	end,
 	['audioducking'] = function()
@@ -1773,8 +1782,8 @@ function options.f_start()
 		-- aspect ratio
 		elseif v:match('_aspectratio_') then
 			-- aspect ratio default
-			if v:match('_aspectratio_default$') then
-				options.t_itemname['default'] = function(t, item, cursorPosY, moveTxt)
+			if v:match('_aspectratio_defaultaspect$') then
+				options.t_itemname['defaultaspect'] = function(t, item, cursorPosY, moveTxt)
 					if main.f_input(main.t_players, motif.option_info.menu.done.key) then
 						sndPlay(motif.Snd, motif.option_info.cursor.done.snd[1], motif.option_info.cursor.done.snd[2])
 						modifyGameOption('Video.FightAspectWidth', 0)
@@ -1785,8 +1794,8 @@ function options.f_start()
 					return true
 				end
 			-- aspect ratio stage
-			elseif v:match('_aspectratio_stage$') then
-				options.t_itemname['stage'] = function(t, item, cursorPosY, moveTxt)
+			elseif v:match('_aspectratio_stageaspect$') then
+				options.t_itemname['stageaspect'] = function(t, item, cursorPosY, moveTxt)
 					if main.f_input(main.t_players, motif.option_info.menu.done.key) then
 						sndPlay(motif.Snd, motif.option_info.cursor.done.snd[1], motif.option_info.cursor.done.snd[2])
 						modifyGameOption('Video.FightAspectWidth', -1)

--- a/src/motif.go
+++ b/src/motif.go
@@ -2884,7 +2884,9 @@ func (me *MotifMenu) reset(m *Motif) {
 	me.active = false
 	me.initialized = false
 	me.endTimer = -1
-	sys.applyFightAspect()
+	if !m.di.active {
+		sys.applyFightAspect()
+	}
 }
 
 func (me *MotifMenu) init(m *Motif) {

--- a/src/motif.go
+++ b/src/motif.go
@@ -1983,6 +1983,9 @@ func (m *Motif) overrideParams() {
 		{SrcSec: "Victory Screen", SrcPrefix: "p2.", DstSec: "Victory Screen", DstPrefix: "p4."},
 		{SrcSec: "Victory Screen", SrcPrefix: "p2.", DstSec: "Victory Screen", DstPrefix: "p6."},
 		{SrcSec: "Victory Screen", SrcPrefix: "p2.", DstSec: "Victory Screen", DstPrefix: "p8."},
+		// [Dialogue Info]
+		{SrcSec: "Dialogue Info", SrcPrefix: "p1.face.", DstSec: "Dialogue Info", DstPrefix: "p1.face.active."},
+		{SrcSec: "Dialogue Info", SrcPrefix: "p2.face.", DstSec: "Dialogue Info", DstPrefix: "p2.face.active."},
 	}
 	m.mergeWithInheritance(specs)
 	// Inheritance may add new font filenames; rerun resolver to map them to deduped font indices.

--- a/src/resources/defaultMotif.ini
+++ b/src/resources/defaultMotif.ini
@@ -2883,8 +2883,8 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	menu.itemname.menuvideo.vsync = VSync
 	menu.itemname.menuvideo.aspectratio = Aspect Ratio
 	; Aspect ratio is assigned based on values used in itemname suffix (e.g. 4:3)
-	menu.itemname.menuvideo.aspectratio.default = Default
-	menu.itemname.menuvideo.aspectratio.stage = Stage
+	menu.itemname.menuvideo.aspectratio.defaultaspect = Default
+	menu.itemname.menuvideo.aspectratio.stageaspect = Stage
 	menu.itemname.menuvideo.aspectratio.4x3 = 4:3
 	menu.itemname.menuvideo.aspectratio.16x9 = 16:9
 	menu.itemname.menuvideo.aspectratio.customaspect = Custom

--- a/src/resources/defaultMotif.ini
+++ b/src/resources/defaultMotif.ini
@@ -3658,6 +3658,267 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 
 [Training Info]
 	; If not overridden, values used for [Menu Info] are shared with this group.
+
+	enabled = 1
+
+	fadein.time = 0
+	fadein.col = 0, 0, 0
+	fadein.anim = -1
+	fadein.snd = -1, 0
+
+	fadeout.time = 0
+	fadeout.col = 0, 0, 0
+	fadeout.anim = -1
+	fadeout.snd = -1, 0
+
+	title.font = f-6x9.def, 0, 0, 255, 255, 255, 255, -1
+	title.offset = 159, 19
+	title.scale = 1.0, 1.0
+	title.xshear = 0
+	title.angle = 0
+	title.text = PAUSE
+	title.layerno = 1
+	title.window = 
+	title.localcoord = 320, 240
+
+	menu.pos = 85, 33
+
+	menu.tween.factor = 0.5
+	menu.tween.wrap.snap = 0
+
+	menu.item.font = f-6x9.def, 0, 1, 191, 191, 191, 255, -1
+	menu.item.offset = 0, 0
+	menu.item.scale = 1.0, 1.0
+	menu.item.xshear = 0
+	menu.item.angle = 0
+	;;menu.item.text = 
+	menu.item.layerno = 1
+	menu.item.window = 
+	menu.item.localcoord = 320, 240
+
+	menu.item.uppercase = 0
+	menu.item.spacing = 0, 14
+	menu.item.tween.factor = 0.5
+
+	menu.item.bg.anim = -1
+	menu.item.bg.spr = -1, 0
+	menu.item.bg.offset = 0, 0
+	menu.item.bg.facing = 1
+	menu.item.bg.scale = 1.0, 1.0
+	menu.item.bg.xshear = 0
+	menu.item.bg.angle = 0
+	menu.item.bg.layerno = 1
+	menu.item.bg.window = 
+	menu.item.bg.localcoord = 320, 240
+
+	;menu.item.bg.<itemname>.anim = -1
+	;menu.item.bg.<itemname>.spr = -1, 0
+	;menu.item.bg.<itemname>.offset = 0, 0
+	;menu.item.bg.<itemname>.facing = 1
+	;menu.item.bg.<itemname>.scale = 1.0, 1.0
+	;menu.item.bg.<itemname>.xshear = 0
+	;menu.item.bg.<itemname>.angle = 0
+	;menu.item.bg.<itemname>.layerno = 1
+	;menu.item.bg.<itemname>.window = 
+	;menu.item.bg.<itemname>.localcoord = 320, 240
+
+	menu.item.active.font = f-6x9.def, 0, 1, 255, 255, 255, 255, -1
+	menu.item.active.offset = 0, 0
+	menu.item.active.scale = 1.0, 1.0
+	menu.item.active.xshear = 0
+	menu.item.active.angle = 0
+	;;menu.item.active.text = 
+	menu.item.active.layerno = 1
+	menu.item.active.window = 
+	menu.item.active.localcoord = 320, 240
+
+	menu.item.active.bg.anim = -1
+	menu.item.active.bg.spr = -1, 0
+	menu.item.active.bg.offset = 0, 0
+	menu.item.active.bg.facing = 1
+	menu.item.active.bg.scale = 1.0, 1.0
+	menu.item.active.bg.xshear = 0
+	menu.item.active.bg.angle = 0
+	menu.item.active.bg.layerno = 1
+	menu.item.active.bg.window = 
+	menu.item.active.bg.localcoord = 320, 240
+
+	;menu.item.active.bg.<itemname>.anim = -1
+	;menu.item.active.bg.<itemname>.spr = -1, 0
+	;menu.item.active.bg.<itemname>.offset = 0, 0
+	;menu.item.active.bg.<itemname>.facing = 1
+	;menu.item.active.bg.<itemname>.scale = 1.0, 1.0
+	;menu.item.active.bg.<itemname>.xshear = 0
+	;menu.item.active.bg.<itemname>.angle = 0
+	;menu.item.active.bg.<itemname>.layerno = 1
+	;menu.item.active.bg.<itemname>.window = 
+	;menu.item.active.bg.<itemname>.localcoord = 320, 240
+
+	menu.item.selected.font = f-6x9.def, 0, 1, 0, 247, 247, 255, -1
+	menu.item.selected.offset = 0, 0
+	menu.item.selected.scale = 1.0, 1.0
+	menu.item.selected.xshear = 0
+	menu.item.selected.angle = 0
+	;;menu.item.selected.text = 
+	menu.item.selected.layerno = 1
+	menu.item.selected.window = 
+	menu.item.selected.localcoord = 320, 240
+
+	menu.item.selected.active.font = f-6x9.def, 0, 1, 0, 247, 247, 255, -1
+	menu.item.selected.active.offset = 0, 0
+	menu.item.selected.active.scale = 1.0, 1.0
+	menu.item.selected.active.xshear = 0
+	menu.item.selected.active.angle = 0
+	;;menu.item.selected.active.text = 
+	menu.item.selected.active.layerno = 1
+	menu.item.selected.active.window = 
+	menu.item.selected.active.localcoord = 320, 240
+
+	menu.item.value.font = f-6x9.def, 0, -1, 255, 255, 255, 255, -1
+	menu.item.value.offset = 150, 0
+	menu.item.value.scale = 1.0, 1.0
+	menu.item.value.xshear = 0
+	menu.item.value.angle = 0
+	;;menu.item.value.text = 
+	menu.item.value.layerno = 1
+	menu.item.value.window = 
+	menu.item.value.localcoord = 320, 240
+
+	menu.item.value.active.font = f-6x9.def, 0, -1, 255, 255, 255, 255, -1
+	menu.item.value.active.offset = 150, 0
+	menu.item.value.active.scale = 1.0, 1.0
+	menu.item.value.active.xshear = 0
+	menu.item.value.active.angle = 0
+	;;menu.item.value.active.text = 
+	menu.item.value.active.layerno = 1
+	menu.item.value.active.window = 
+	menu.item.value.active.localcoord = 320, 240
+
+	menu.window.margins.y = 0, 0
+	menu.window.visibleitems = 13
+
+	menu.boxcursor.visible = 1
+	menu.boxcursor.coords = -5, -10, 154, 3
+	menu.boxcursor.col = 255, 255, 255
+	menu.boxcursor.layerno = 1
+	menu.boxcursor.localcoord = 320, 240
+	menu.boxcursor.pulse = 30, 20, 30
+	menu.boxcursor.tween.factor = 0.5
+	menu.boxcursor.tween.snap = 0
+	menu.boxcursor.tween.wrap.snap = 0
+
+	menu.boxbg.visible = 1
+	menu.boxbg.col = 0, 0, 0
+	menu.boxbg.alpha = 0, 128
+	menu.boxbg.layerno = 1
+	menu.boxbg.localcoord = 320, 240
+
+	menu.arrow.up.anim = -1
+	menu.arrow.up.spr = -1, 0
+	menu.arrow.up.offset = 0, 0
+	menu.arrow.up.facing = 1
+	menu.arrow.up.scale = 1.0, 1.0
+	menu.arrow.up.xshear = 0
+	menu.arrow.up.angle = 0
+	menu.arrow.up.layerno = 1
+	menu.arrow.up.window = 
+	menu.arrow.up.localcoord = 320, 240
+
+	menu.arrow.down.anim = -1
+	menu.arrow.down.spr = -1, 0
+	menu.arrow.down.offset = 0, 0
+	menu.arrow.down.facing = 1
+	menu.arrow.down.scale = 1.0, 1.0
+	menu.arrow.down.xshear = 0
+	menu.arrow.down.angle = 0
+	menu.arrow.down.layerno = 1
+	menu.arrow.down.window = 
+	menu.arrow.down.localcoord = 320, 240
+
+	menu.title.uppercase = 1
+
+	menu.next.key = $D, LS_Y+
+	menu.previous.key = $U, LS_Y-
+	menu.add.key = $F, LS_X+
+	menu.subtract.key = $B, LS_X-
+	menu.done.key = a, b, c, x, y, z, s
+	menu.cancel.key = m
+
+	hidebars = 1
+
+	cursor.move.snd = 100, 0
+	cursor.done.snd = 100, 1
+	cancel.snd = 100, 2
+	enter.snd = -1, 0
+
+	overlay.col = 0, 0, 0
+	overlay.alpha = 0, 128
+	overlay.window = 
+	overlay.localcoord = 320, 240
+
+	movelist.pos = 10, 20
+
+	movelist.title.font = Open_Sans.def, 0, 0, 255, 255, 255, 255, -1
+	movelist.title.offset = 150, 0
+	movelist.title.scale = 0.4, 0.4
+	movelist.title.xshear = 0
+	movelist.title.angle = 0
+	movelist.title.text = %s
+	movelist.title.layerno = 1
+	movelist.title.window = 
+	movelist.title.localcoord = 320, 240
+
+	movelist.title.uppercase = 0
+
+	movelist.text.font = Open_Sans.def, 0, 1, 255, 255, 255, 255, -1
+	movelist.text.offset = 0, 12
+	movelist.text.scale = 0.4, 0.4
+	movelist.text.xshear = 0
+	movelist.text.angle = 0
+	movelist.text.text = Command List not found.
+	movelist.text.layerno = 1
+	movelist.text.window = 
+	movelist.text.localcoord = 320, 240
+
+	movelist.text.spacing = 1, 1
+
+	movelist.glyphs.offset = 0, 2
+	movelist.glyphs.scale = 1.0, 1.0
+	movelist.glyphs.layerno = 1
+	movelist.glyphs.localcoord = 320, 240
+	movelist.glyphs.spacing = 2, 0
+
+	movelist.window.margins.y = 20, 1
+	movelist.window.visibleitems = 18
+	movelist.window.width = 300
+
+	movelist.overlay.col = 0, 0, 0
+	movelist.overlay.alpha = 0, 128
+	movelist.overlay.window = 
+	movelist.overlay.localcoord = 320, 240
+
+	movelist.arrow.up.anim = -1
+	movelist.arrow.up.spr = -1, 0
+	movelist.arrow.up.offset = 0, 0
+	movelist.arrow.up.facing = 1
+	movelist.arrow.up.scale = 1.0, 1.0
+	movelist.arrow.up.xshear = 0
+	movelist.arrow.up.angle = 0
+	movelist.arrow.up.layerno = 1
+	movelist.arrow.up.window = 
+	movelist.arrow.up.localcoord = 320, 240
+
+	movelist.arrow.down.anim = -1
+	movelist.arrow.down.spr = -1, 0
+	movelist.arrow.down.offset = 0, 0
+	movelist.arrow.down.facing = 1
+	movelist.arrow.down.scale = 1.0, 1.0
+	movelist.arrow.down.xshear = 0
+	movelist.arrow.down.angle = 0
+	movelist.arrow.down.layerno = 1
+	movelist.arrow.down.window = 
+	movelist.arrow.down.localcoord = 320, 240
+
 	; Training specific parameters:
 	menu.valuename.dummycontrol_cooperative = Cooperative
 	menu.valuename.dummycontrol_ai = AI

--- a/src/script.go
+++ b/src/script.go
@@ -2628,12 +2628,11 @@ func systemScriptInit(l *lua.LState) {
 						disabledFlat[e.flat] = true
 						continue
 					}
-					// Allow duplicates for separators (empty, empty1, empty2, ...).
+					// Allow duplicates for separators (spacer, spacer1, spacer2, ...).
 					if disabledFlat[e.flat] || (seenFlat[e.flat] && !isSpacerKey(e.base)) {
 						continue
 					}
-					// For defaults, suppress items whose leaf was already added from user entries (or earlier),
-					// but DO NOT suppress "back" or empty* so each submenu can have its own back/separators.
+					// For defaults, suppress items whose leaf was already added from user entries (or earlier), but do not suppress back or spacer*
 					if isDefault && e.base != "back" && !isSpacerKey(e.base) && seenBase[e.base] {
 						continue
 					}


### PR DESCRIPTION
Fixes:
* pausing the game during dialogue makes the image stretch
  https://discord.com/channels/233345562261323776/233363722934943744/1450987130049269770
* default itemname missing in options menu
  https://discord.com/channels/233345562261323776/233363722934943744/1451016619609292942
* dialogue active portrait variants inherit values from standard portraits.
  https://discord.com/channels/233345562261323776/233363722934943744/1450987021517717534
* default training menu values missing
  https://discord.com/channels/233345562261323776/233363722934943744/1450967142441816198
  Partially reverts #2979
* fade anim length
https://discord.com/channels/233345562261323776/233363722934943744/1450951366267764756
Previous attempt to fix it in #2975
* fonts with multiple palettes
  https://discord.com/channels/233345562261323776/233363722934943744/1450476101758353553
  while keeping the optimization gains from https://github.com/ikemen-engine/Ikemen-GO/commit/42c425aaa2929025e52c0b98df762d3f297d1616
* motif music values defaulting
  https://discord.com/channels/233345562261323776/233363722934943744/1451057915774636144