### PR TITLE
fix: Reduce memory usage spike in sff loading

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -3805,7 +3805,7 @@ func (c *Char) load(def string) error {
 		sprite_resolved := resolvePathRelativeToDef(sprite)
 		if err := LoadFile(&sprite_resolved, []string{gi.def, "", sys.motif.Def, "data/"}, func(filename string) error {
 			var err_sff error
-			gi.sff, err_sff = loadSff(filename, true) // loadSff uses OpenFile
+			gi.sff, err_sff = loadSff(filename, true, false) // loadSff uses OpenFile
 			return err_sff
 		}); err != nil {
 			return err

--- a/src/font.go
+++ b/src/font.go
@@ -365,7 +365,7 @@ func loadDefInfo(f *Fnt, filename string, is IniSection, height int32) {
 
 func LoadFntSff(f *Fnt, fontfile string, filename string) {
 	fileDir := SearchFile(filename, []string{fontfile, "font/", sys.motif.Def, "", "data/"})
-	sff, err := loadSff(fileDir, false)
+	sff, err := loadSff(fileDir, false, false)
 
 	if err != nil {
 		panic(err)

--- a/src/image.go
+++ b/src/image.go
@@ -1322,7 +1322,7 @@ func removeSFFCache(filename string) {
 	}
 }
 
-func loadSff(filename string, char bool) (*Sff, error) {
+func loadSff(filename string, char bool, isMainThread bool) (*Sff, error) {
 	// If this SFF is already in the cache, just return a copy
 	if cached, ok := SffCache[filename]; ok {
 		cached.refCount++
@@ -1453,6 +1453,9 @@ func loadSff(filename string, char bool) (*Sff, error) {
 			shofs = int64(xofs)
 		} else {
 			shofs += 28
+		}
+		if isMainThread {
+			sys.runMainThreadTask()
 		}
 	}
 	SffCache[filename] = &SffCacheEntry{*s, 1}

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -123,7 +123,7 @@ func loadFightFx(def string, isGlobal bool) error {
 				files = false
 				if is.LoadFile("sff", []string{def, sys.motif.Def, "", "data/"},
 					func(filename string) error {
-						s, err := loadSff(filename, false)
+						s, err := loadSff(filename, false, true)
 						if err != nil {
 							return err
 						}
@@ -4276,7 +4276,7 @@ func loadLifebar(def string) (*Lifebar, error) {
 				filesflg = false
 				if is.LoadFile("sff", []string{def, sys.motif.Def, "", "data/"},
 					func(filename string) error {
-						s, err := loadSff(filename, false)
+						s, err := loadSff(filename, false, true)
 						if err != nil {
 							return err
 						}
@@ -4298,7 +4298,7 @@ func loadLifebar(def string) (*Lifebar, error) {
 				}
 				if is.LoadFile("fightfx.sff", []string{def, sys.motif.Def, "", "data/"},
 					func(filename string) error {
-						s, err := loadSff(filename, false)
+						s, err := loadSff(filename, false, true)
 						if err != nil {
 							return err
 						}

--- a/src/motif.go
+++ b/src/motif.go
@@ -1993,7 +1993,7 @@ func (m *Motif) loadBgDefProperties(bgDef *BgDefProperties, bgname, spr string) 
 		LoadFile(&bgDef.Spr, []string{bgDef.Spr, m.Def, "", "data/"}, func(filename string) error {
 			if filename != "" {
 				var err error
-				bgDef.Sff, err = loadSff(filename, false)
+				bgDef.Sff, err = loadSff(filename, false, true)
 				if err != nil {
 					sys.errLog.Printf("Failed to load %v: %v", filename, err)
 				}
@@ -2021,7 +2021,7 @@ func (m *Motif) loadFiles() {
 	LoadFile(&m.Files.Spr, []string{m.Files.Spr}, func(filename string) error {
 		if filename != "" {
 			var err error
-			m.Sff, err = loadSff(filename, false)
+			m.Sff, err = loadSff(filename, false, true)
 			if err != nil {
 				sys.errLog.Printf("Failed to load %v: %v", filename, err)
 			}
@@ -2036,7 +2036,7 @@ func (m *Motif) loadFiles() {
 	LoadFile(&m.Files.Glyphs, []string{m.Files.Glyphs}, func(filename string) error {
 		if filename != "" {
 			var err error
-			m.GlyphsSff, err = loadSff(filename, false)
+			m.GlyphsSff, err = loadSff(filename, false, true)
 			if err != nil {
 				sys.errLog.Printf("Failed to load %v: %v", filename, err)
 			}

--- a/src/render_vk.go
+++ b/src/render_vk.go
@@ -779,6 +779,7 @@ type Renderer_VK struct {
 	minUniformBufferOffsetAlignment uint32
 	maxImageArrayLayers             uint32
 	memoryTypeMap                   map[vk.MemoryPropertyFlagBits]uint32
+	allocatedImageMemory            uint64
 
 	VKState
 }
@@ -4680,6 +4681,7 @@ func (r *Renderer_VK) CreatePipelineCache() error {
 // Render initialization.
 // Creates the default shaders, the framebuffer and enables MSAA.
 func (r *Renderer_VK) Init() {
+	r.allocatedImageMemory = 0
 	r.enableModel = sys.cfg.Video.EnableModel
 	r.enableShadow = sys.cfg.Video.EnableModelShadow
 	r.memoryTypeMap = make(map[vk.MemoryPropertyFlagBits]uint32)
@@ -7564,6 +7566,7 @@ func (r *Renderer_VK) AllocateImageMemory(img vk.Image, memoryProperty vk.Memory
 		memoryTypeIndex, _ = vk.FindMemoryTypeIndex(r.gpuDevices[r.gpuIndex], memReq.MemoryTypeBits, memoryProperty)
 		r.memoryTypeMap[memoryProperty] = memoryTypeIndex
 	}
+	r.allocatedImageMemory += uint64(memReq.Size)
 	allocInfo := vk.MemoryAllocateInfo{
 		SType:           vk.StructureTypeMemoryAllocateInfo,
 		AllocationSize:  memReq.Size,

--- a/src/script.go
+++ b/src/script.go
@@ -3,8 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	lua "github.com/yuin/gopher-lua"
-	"gopkg.in/ini.v1"
 	"io"
 	"math"
 	"math/rand"
@@ -16,6 +14,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	lua "github.com/yuin/gopher-lua"
+	"gopkg.in/ini.v1"
 )
 
 // ExecFunc executes a Lua function by name and returns its boolean result.
@@ -3497,7 +3498,7 @@ func systemScriptInit(l *lua.LState) {
 	})
 	luaRegister(l, "sffNew", func(l *lua.LState) int {
 		if !nilArg(l, 1) {
-			sff, err := loadSff(strArg(l, 1), false)
+			sff, err := loadSff(strArg(l, 1), false, true)
 			if err != nil {
 				l.RaiseError("\nCan't load %v: %v\n", strArg(l, 1), err.Error())
 			}

--- a/src/stage.go
+++ b/src/stage.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"gopkg.in/ini.v1"
 	"image"
 	"image/draw"
 	_ "image/jpeg"
@@ -20,6 +19,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"gopkg.in/ini.v1"
 
 	_ "github.com/lukegb/dds"
 	"github.com/mdouchement/hdr"
@@ -1302,7 +1303,7 @@ func loadStage(def string, maindef bool) (*Stage, error) {
 	if sectionExists {
 		sectionExists = false
 		if sec[0].LoadFile("spr", []string{def, "", sys.motif.Def, "data/"}, func(filename string) error {
-			sff, err := loadSff(filename, false)
+			sff, err := loadSff(filename, false, false)
 			if err != nil {
 				return err
 			}

--- a/src/storyboard.go
+++ b/src/storyboard.go
@@ -302,7 +302,7 @@ func (s *Storyboard) loadFiles() {
 	LoadFile(&s.SceneDef.Spr, []string{s.SceneDef.Spr}, func(filename string) error {
 		if filename != "" {
 			var err error
-			s.Sff, err = loadSff(filename, false)
+			s.Sff, err = loadSff(filename, false, true)
 			if err != nil {
 				sys.errLog.Printf("Failed to load %v: %v", filename, err)
 			}


### PR DESCRIPTION
Add runMainThreadTask call in loadsff so that the decoded images can be released as soon as possible.
fix #265 