### PR TITLE
fix: rollback sys.sel cloning,  inputAxes

### DIFF
--- a/src/net.go
+++ b/src/net.go
@@ -494,7 +494,8 @@ func (rs *RollbackSession) InitP2(numPlayers int, localPort int, remotePort int,
 	}
 
 	var inputBits InputBits = 0
-	var inputSize int = len(encodeInputs(inputBits))
+	var inputAxes [6]int8 = [6]int8{}
+	var inputSize int = len(encodeInputs(inputBits)) + len(inputAxes)
 
 	player := ggpo.NewRemotePlayer(20, 1, remoteIp, remotePort)
 	player2 := ggpo.NewLocalPlayer(20, 2)
@@ -543,7 +544,8 @@ func (rs *RollbackSession) InitSyncTest(numPlayers int) {
 	}
 
 	var inputBits InputBits = 0
-	var inputSize int = len(encodeInputs(inputBits))
+	var inputAxes [6]int8 = [6]int8{}
+	var inputSize int = len(encodeInputs(inputBits)) + len(inputAxes)
 
 	player := ggpo.NewLocalPlayer(20, 1)
 	player2 := ggpo.NewLocalPlayer(20, 2)

--- a/src/resources/defaultMotif.ini
+++ b/src/resources/defaultMotif.ini
@@ -2145,7 +2145,7 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	no.active.localcoord = 320, 240
 
 	; If set to 0, stops all player sounds and prevents new ones from starting.
-	sounds.enabled = 1
+	sounds.enabled = 0
 	; Enables legacy (Mugen) bare bones continue screen functionality.
 	legacymode.enabled = 1
 	; Enables [Game Over Screen] storyboard after not continuing.
@@ -2413,7 +2413,7 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 
 [Win Screen]
 	enabled = 1
-	sounds.enabled = 1
+	sounds.enabled = 0
 
 	fadein.time = 32
 	fadein.col = 0, 0, 0
@@ -2482,7 +2482,7 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 
 [Survival Results Screen]
 	enabled = 1
-	sounds.enabled = 1
+	sounds.enabled = 0
 
 	roundstowin = 5
 
@@ -2538,7 +2538,7 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 
 [Time Attack Results Screen]
 	enabled = 1
-	sounds.enabled = 1
+	sounds.enabled = 0
 
 	fadein.time = 32
 	fadein.col = 0, 0, 0

--- a/src/state.go
+++ b/src/state.go
@@ -432,7 +432,7 @@ func (gs *GameState) LoadState(stateID int) {
 
 	sys.decisiveRound = gs.decisiveRound
 
-	sys.sel = gs.sel.Clone(a)
+	//sys.sel = gs.sel.Clone(a)
 	for i := 0; i < len(sys.stringPool); i++ {
 		sys.stringPool[i] = gs.stringPool[i].Clone(a, gsp)
 	}
@@ -649,7 +649,7 @@ func (gs *GameState) SaveState(stateID int) {
 	gs.scoreRounds = arena.MakeSlice[[2]float32](a, len(sys.scoreRounds), len(sys.scoreRounds))
 	copy(gs.scoreRounds, sys.scoreRounds)
 	gs.decisiveRound = sys.decisiveRound
-	gs.sel = sys.sel.Clone(a)
+	//gs.sel = sys.sel.Clone(a)
 	for i := 0; i < len(sys.stringPool); i++ {
 		gs.stringPool[i] = sys.stringPool[i].Clone(a, gsp)
 	}

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -672,6 +672,56 @@ func (s *Stage) Clone(a *arena.Arena, gsp *GameStatePool) *Stage {
 	return result
 }
 
-func (s Select) Clone(a *arena.Arena) (result Select) {
-	return
-}
+/*func (s Select) Clone(a *arena.Arena) (result Select) {
+	result = s
+
+	// Copy selected (mutable; slices)
+	for side := 0; side < len(s.selected); side++ {
+		if s.selected[side] == nil {
+			result.selected[side] = nil
+			continue
+		}
+		if a != nil {
+			result.selected[side] = arena.MakeSlice[[2]int](a, len(s.selected[side]), len(s.selected[side]))
+		} else {
+			result.selected[side] = make([][2]int, len(s.selected[side]))
+		}
+		copy(result.selected[side], s.selected[side])
+	}
+
+	// Copy overwrite map headers (maps are reference types)
+	if s.cdefOverwrite != nil {
+		result.cdefOverwrite = make(map[int]string, len(s.cdefOverwrite))
+		for k, v := range s.cdefOverwrite {
+			result.cdefOverwrite[k] = v
+		}
+	}
+
+	// Copy music map header and candidate slices.
+	// The *bgMusic entries themselves are treated as immutable; copying pointers is enough.
+	if s.music != nil {
+		result.music = make(Music, len(s.music))
+		for k, lst := range s.music {
+			if lst == nil {
+				result.music[k] = nil
+			continue
+			}
+			var nlst []*bgMusic
+			if a != nil {
+				nlst = arena.MakeSlice[*bgMusic](a, len(lst), len(lst))
+			} else {
+				nlst = make([]*bgMusic, len(lst))
+			}
+			copy(nlst, lst)
+			result.music[k] = nlst
+		}
+	}
+
+	// gameParams should never be nil during fight code paths.
+	// Keep the existing pointer (stable), but defensively initialize if needed.
+	if result.gameParams == nil {
+		result.gameParams = newGameParams()
+	}
+
+	return result
+}*/


### PR DESCRIPTION
- post-match sounds are now disabled by default (as in mugen)
- in net.go only InitP1 function was taking inputAxes into account
- nothing in Select struct needs rolling back, unless I'm missing something. Commented out.