### PR TITLE
fix: portraits inheriting cell scaling incorrectly

### DIFF
--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -2144,6 +2144,20 @@ function start.updateDrawList()
 					item.anim = charData.cell_data
 					item.x = motif.select_info.pos[1] + t.x + motif.select_info.portrait.offset[1]
 					item.y = motif.select_info.pos[2] + t.y + motif.select_info.portrait.offset[2]
+					-- apply cell scale override while preserving portrait resolution factor
+					if item.scale ~= nil then
+						local charInfo = main.t_selChars[charData.char_ref + 1]
+						if charInfo then
+							local portraitScale = charInfo.portraitscale or 1
+							local charLocalcoord = charInfo.localcoord or motif.info.localcoord[1]
+							-- recompute resolution compensation factor
+							local resFix = portraitScale * motif.info.localcoord[1] / charLocalcoord
+							item.scale = {
+								item.scale[1] * resFix,
+								item.scale[2] * resFix
+							}
+						end
+					end
 					table.insert(drawList, item)
 				end
 			end

--- a/src/resources/defaultMotif.ini
+++ b/src/resources/defaultMotif.ini
@@ -673,6 +673,7 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 
 	; <col>-<row> cell variants replace standard ones on per cell basis.
 	; Asterisk <col-*> or <*-row> can be used as a wildcard to apply changes to entire columns or rows.
+	; <*-*> can be used to aplly changes to all cells.
 	; Portraits, cell backgrounds, and cursors inherit all cell transformations.
 	;cell.<col>-<row>.offset = 0, 0
 	;cell.<col>-<row>.facing = 0


### PR DESCRIPTION
Fix:
- Fixed an issue where defining scale per cell/row/column caused portrait scaling to be divided instead of overridden