### PR TITLE
fix: sff loading regression

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -4091,14 +4091,14 @@ func (c *Char) loadFx(def string) error {
 						resolved_path := resolvePathRelativeToDef(fx_path)
 
 						if found_path := FileExist(resolved_path); found_path != "" {
-							if err := loadFightFx(found_path, false); err != nil {
+							if err := loadFightFx(found_path, false, false); err != nil {
 								sys.errLog.Printf("Could not load CommonFX %s for char %s: %v", found_path, def, err)
 							} else {
 								gi.fxPath = append(gi.fxPath, found_path)
 							}
 						} else {
 							if found_path_fallback := SearchFile(fx_path, []string{def, "", sys.motif.Def, "data/"}); found_path_fallback != "" {
-								if err := loadFightFx(found_path_fallback, false); err != nil {
+								if err := loadFightFx(found_path_fallback, false, false); err != nil {
 									sys.errLog.Printf("Could not load CommonFX %s for char %s: %v", found_path_fallback, def, err)
 								} else {
 									gi.fxPath = append(gi.fxPath, found_path_fallback)
@@ -4122,7 +4122,7 @@ func (c *Char) loadFx(def string) error {
 						}
 						resolved_fx_path := resolvePathRelativeToDef(fx_path)
 						if resolved_fx_path != "" {
-							if err := loadFightFx(resolved_fx_path, false); err != nil {
+							if err := loadFightFx(resolved_fx_path, false, false); err != nil {
 								sys.errLog.Printf("Could not load CommonFX %s for char %s: %v", resolved_fx_path, def, err)
 							} else {
 								gi.fxPath = append(gi.fxPath, resolved_fx_path)

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -67,7 +67,7 @@ func newFightFx() *FightFx {
 	}
 }
 
-func loadFightFx(def string, isGlobal bool) error {
+func loadFightFx(def string, isGlobal bool, isMainThread bool) error {
 	str, err := LoadText(def)
 	if err != nil {
 		return err
@@ -123,7 +123,7 @@ func loadFightFx(def string, isGlobal bool) error {
 				files = false
 				if is.LoadFile("sff", []string{def, sys.motif.Def, "", "data/"},
 					func(filename string) error {
-						s, err := loadSff(filename, false, true)
+						s, err := loadSff(filename, false, isMainThread)
 						if err != nil {
 							return err
 						}
@@ -4246,7 +4246,7 @@ func loadLifebar(def string) (*Lifebar, error) {
 	for _, key := range SortedKeys(sys.cfg.Common.Fx) {
 		for _, v := range sys.cfg.Common.Fx[key] {
 			if err := LoadFile(&v, []string{def, sys.motif.Def, "", "data/"}, func(filename string) error {
-				if err := loadFightFx(filename, true); err != nil {
+				if err := loadFightFx(filename, true, true); err != nil {
 					return err
 				}
 				return nil
@@ -4331,7 +4331,7 @@ func loadLifebar(def string) (*Lifebar, error) {
 				for i := 1; i <= l.fx_limit; i++ {
 					if err := is.LoadFile(fmt.Sprintf("fx%v", i), []string{def, sys.motif.Def, "", "data/"},
 						func(filename string) error {
-							if err := loadFightFx(filename, true); err != nil {
+							if err := loadFightFx(filename, true, true); err != nil {
 								return err
 							}
 							return nil


### PR DESCRIPTION
fix the problem where loading characters using "fightfx.prefix" and "FX" will crash the engine
fix #2997 and #3001