### PR TITLE
feat: victory screen, keepside and winname; fix

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -1284,6 +1284,10 @@ function main.f_addStage(file, hidden, line)
 					animSetFacing(a, params.facing)
 					animSetXShear(a, params.xshear)
 					animSetAngle(a, params.angle)
+					animSetXAngle(a, params.xangle)
+					animSetYAngle(a, params.yangle)
+					animSetProjection(a, params.projection)
+					animSetfLength(a, params.focallength)
 					if params.window == nil or #params.window < 4 then
 						params.window = {0, 0, motif.info.localcoord[1], motif.info.localcoord[2]}
 					end

--- a/src/motif.go
+++ b/src/motif.go
@@ -927,7 +927,10 @@ type StoryboardProperties struct {
 
 type VictoryScreenProperties struct {
 	Enabled bool `ini:"enabled"`
-	Sounds  struct {
+	KeepSide struct {
+		Enabled bool `ini:"enabled"`
+	} `ini:"keepside`
+	Sounds struct {
 		Enabled bool `ini:"enabled"`
 	} `ini:"sounds"`
 	Cpu struct {
@@ -944,6 +947,7 @@ type VictoryScreenProperties struct {
 	FadeIn   FadeProperties `ini:"fadein"`
 	FadeOut  FadeProperties `ini:"fadeout"`
 	Time     int32          `ini:"time"`
+	WinName  TextProperties `ini:"winname"`
 	WinQuote struct {
 		TextProperties
 		TextSpacing float32 `ini:"textspacing"`
@@ -5620,7 +5624,7 @@ func (vi *MotifVictory) init(m *Motif) {
 	winnerSide := int(sys.winnerTeam() - 1)
 	loserSide := winnerSide ^ 1
 	maxW := int(Clamp(m.VictoryScreen.P1.Num, 0, 4))
-	maxL := int(Clamp(m.VictoryScreen.P2.Num, 0, 4))
+	maxL := int(Clamp(m.VictoryScreen.P2.Num, 1, 4))
 	wEntries := vi.buildSideOrder(winnerSide, m.VictoryScreen.Winner.TeamKo.Enabled, maxW)
 	lEntries := vi.buildSideOrder(loserSide, true, maxL) // losers always allow KO display
 
@@ -5643,6 +5647,11 @@ func (vi *MotifVictory) init(m *Motif) {
 	lSlots := []*PlayerVictoryProperties{&m.VictoryScreen.P2, &m.VictoryScreen.P4, &m.VictoryScreen.P6, &m.VictoryScreen.P8}
 	wNames := []string{"P1", "P3", "P5", "P7"}
 	lNames := []string{"P2", "P4", "P6", "P8"}
+
+	if m.VictoryScreen.KeepSide.Enabled && sys.winnerTeam() == 2 {
+		wSlots, lSlots = lSlots, wSlots
+	}
+
 	for i := 0; i < len(wEntries) && i < len(wSlots); i++ {
 		vi.applyEntry(m, wSlots[i], wEntries[i], wNames[i])
 	}
@@ -5655,6 +5664,12 @@ func (vi *MotifVictory) init(m *Motif) {
 		leader = wEntries[0].c
 	}
 	vi.text = vi.getVictoryQuote(m, leader)
+
+	m.VictoryScreen.WinName.TextSpriteData.text = ""
+	if leader != nil {
+		// Displays only the winner’s name regardless of team side or player number
+		m.VictoryScreen.WinName.TextSpriteData.text = leader.gi().displayname
+	}
 	m.VictoryBgDef.BGDef.Reset()
 
 	//fmt.Printf("[Victory] init done. Winners=%d entries, Losers=%d entries. WinQuote=%q\n", len(wEntries), len(lEntries), vi.text)
@@ -5805,6 +5820,8 @@ func (vi *MotifVictory) draw(m *Motif, layerno int16) {
 	m.VictoryScreen.P7.Name.TextSpriteData.Draw(layerno)
 	m.VictoryScreen.P8.Name.TextSpriteData.Draw(layerno)
 
+	// Winner Name
+	m.VictoryScreen.WinName.TextSpriteData.Draw(layerno)
 	// Winquote
 	m.VictoryScreen.WinQuote.TextSpriteData.Draw(layerno)
 }

--- a/src/resources/defaultMotif.ini
+++ b/src/resources/defaultMotif.ini
@@ -2761,6 +2761,9 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	cpu.enabled = 1
 	; Enables victory screen in versus mode.
 	vs.enabled = 1
+	; If set to 1, characters keep their original match sides on the victory screen.
+	; (P1 stays on the left, P2 stays on the right, even if P2 wins).
+	keepside.enabled = 0
 	; Enables including defeated team members portraits of the winner team.
 	winner.teamko.enabled = 0
 
@@ -2795,6 +2798,21 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	winquote.textwrap = w
 
 	winquote.displaytime = 0
+
+	; If defined, displays only the winner’s name regardless of team side or player number
+	; winname.font = -1, 0, 1, 255, 255, 255, 255, -1
+	; winname.offset = 0, 0
+	; winname.scale = 1.0, 1.0
+	; winname.xshear = 0
+	; winname.angle = 0
+	; winname.xangle = 0
+	; winname.yangle = 0
+	; winname.projection = orthographic
+	; winname.focallength = 2048
+	;;winname.text = 
+	; winname.layerno = 1
+	; winname.window = 
+	; winname.localcoord = 320, 240
 
 	overlay.col = 0, 0, 0
 	overlay.alpha = 0, 128


### PR DESCRIPTION
Feat:
- Added two new optional parameters to the victory screen:
- ``keepside.enabled``: If set to 1, characters keep their original match sides on the victory screen (P1 stays on the left, P2 stays on the right, even if P2 wins).
``winname``: Accepts all standard text parameters. If defined, it displays only the winner’s name, regardless of team side or player number.

With these new parameters, it’s now possible to recreate SF-style victory screens where the winner’s and loser’s portraits do not swap sides, and optionally show only the winner’s name.

Fix:
- Fixed projection not working with stage.portraits.
- Fixed an issue where P2 portraits on victory screen required ``p2.num = 1`` to work even when using only a single portrait