### PR TITLE
feat: victory screen lose portraits param; fixes

### DIFF
--- a/src/motif.go
+++ b/src/motif.go
@@ -5616,8 +5616,9 @@ func (vi *MotifVictory) applyEntry(m *Motif, dst *PlayerVictoryProperties, e vic
 		m, sc, slotName+".main",
 		targetAnim, targetSpr,
 		dst.Localcoord, dst.Layerno, dst.Facing,
-		dst.Scale, dst.Window,
-		mainX, mainY,
+		dst.Scale, dst.Xshear, dst.Angle, dst.XAngle, 
+		dst.YAngle, dst.Projection, dst.Focallength, 
+		dst.Window, mainX, mainY,
 		dst.ApplyPal || e.c == nil,
 		e.pal, e.c,
 	)
@@ -5628,8 +5629,9 @@ func (vi *MotifVictory) applyEntry(m *Motif, dst *PlayerVictoryProperties, e vic
 		m, sc, slotName+".face2",
 		targetFace2Anim, targetFace2Spr,
 		dst.Face2.Localcoord, dst.Face2.Layerno, dst.Face2.Facing,
-		dst.Face2.Scale, dst.Face2.Window,
-		face2X, face2Y,
+		dst.Face2.Scale, dst.Face2.Xshear, dst.Face2.Angle, dst.Face2.XAngle, 
+		dst.Face2.YAngle, dst.Face2.Projection, dst.Face2.Focallength, 
+		dst.Face2.Window, face2X, face2Y,
 		dst.Face2.ApplyPal || e.c == nil,
 		e.pal, e.c,
 	)
@@ -5907,7 +5909,8 @@ func tryGetPortrait(sc *SelectChar, ownerC *Char, pairs [][2]int32) (anim *Anima
 func victoryPortraitAnim(m *Motif, sc *SelectChar, slot string,
 	animNo int32, spr [2]int32,
 	localcoord [2]int32, layerno int16, facing int32,
-	scale [2]float32, window [4]int32,
+	scale [2]float32, xshear float32, angle float32, xangle float32, 
+	yangle float32, projection string, fLength float32, window [4]int32,
 	x, y float32, applyPal bool, pal int, ownerC *Char) *Anim {
 
 	//fmt.Printf("[Victory] buildPortrait slot=%s scNil=%v animNo=%d spr=(%d,%d) pos=(%.1f,%.1f) scale=(%.3f,%.3f) localcoord=(%d,%d) window=(%d,%d,%d,%d) applyPal=%v pal=%d\n", slot, sc == nil, animNo, spr[0], spr[1], x, y, scale[0], scale[1], localcoord[0], localcoord[1], window[0], window[1], window[2], window[3], applyPal, pal)
@@ -5975,6 +5978,26 @@ func victoryPortraitAnim(m *Motif, sc *SelectChar, slot string,
 	if sx == 0 || sy == 0 {
 		//fmt.Printf("[Victory] slot=%s -> WARNING: zero scale sx=%.4f sy=%.4f (check portraitscale/localcoord)\n", slot, sx, sy)
 	}
+	// Transformations
+	a.xshear = xshear
+	a.rot.angle = angle
+	a.rot.xangle = xangle
+	a.rot.yangle = yangle
+	a.projection = int32(Projection_Orthographic) // Default
+	v := strings.ToLower(strings.TrimSpace(projection))
+	switch v {
+	case "perspective":
+		a.projection = int32(Projection_Perspective)
+	case "perspective2":
+		a.projection = int32(Projection_Perspective2)
+	case "orthographic":
+		// default, we don't need to do nothing
+	default:
+		if i, err := strconv.Atoi(v); err == nil {
+			a.projection = int32(i)
+		}
+	}
+	a.fLength = fLength
 	// Palette for non-loaded (or force-apply if requested)
 	if applyPal && pal > 0 && a.anim != nil && a.anim.sff != nil {
 		if len(a.anim.sff.palList.paletteMap) > 0 {

--- a/src/motif.go
+++ b/src/motif.go
@@ -5978,6 +5978,7 @@ func victoryPortraitAnim(m *Motif, sc *SelectChar, slot string,
 	// Palette for non-loaded (or force-apply if requested)
 	if applyPal && pal > 0 && a.anim != nil && a.anim.sff != nil {
 		if len(a.anim.sff.palList.paletteMap) > 0 {
+			a = a.Copy()
 			a.anim.sff.palList.paletteMap[0] = pal - 1
 		}
 		//fmt.Printf("[Victory] slot=%s -> applied palette %d\n", slot, pal)

--- a/src/resources/defaultMotif.ini
+++ b/src/resources/defaultMotif.ini
@@ -2858,6 +2858,11 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	; Set 1 to apply selected palette to Portraits
 	p1.applypal = 0
 	p1.draworder = 0
+	; Replaces the character portrait with the one defined below when the character loses the match.
+	; Useful for displaying "defeated" / "beaten" versions of the character.
+	; If not defined, the standard victory portrait is used instead.
+	p1.lose.spr = -1, 0
+	p1.lose.anim = -1
 
 	p1.velocity = 0, 0
 	p1.maxdist = 0, 0
@@ -2886,6 +2891,8 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	p1.face2.localcoord = 320, 240
 	p1.face2.applypal = 0
 	p1.face2.draworder = 0
+	p1.face2.lose.spr = -1, 0
+	p1.face2.lose.anim = -1
 
 	p1.face2.velocity = 0, 0
 	p1.face2.maxdist = 0, 0
@@ -2929,13 +2936,15 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	p2.localcoord = 320, 240
 	p2.applypal = 0
 	p2.draworder = 0
+	p2.lose.spr = -1, 0
+	p2.lose.anim = -1
 
 	p2.velocity = 0, 0
 	p2.maxdist = 0, 0
 	p2.accel = 0, 0
 	p2.friction = 1, 1
 	p2.pos = 0, 0
-	p2.num = 0
+	p2.num = 1
 	p2.spacing = 0, 0
 	p2.padding = 0
 
@@ -2955,6 +2964,8 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	p2.face2.localcoord = 320, 240
 	p2.face2.applypal = 0
 	p2.face2.draworder = 0
+	p2.face2.lose.spr = -1, 0
+	p2.face2.lose.anim = -1
 
 	p2.face2.velocity = 0, 0
 	p2.face2.maxdist = 0, 0

--- a/src/resources/defaultMotif.ini
+++ b/src/resources/defaultMotif.ini
@@ -2863,6 +2863,9 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	; If not defined, the standard victory portrait is used instead.
 	p1.lose.spr = -1, 0
 	p1.lose.anim = -1
+	; Can be used to darken the defeated character's portrait. Useful when the character does not have a dedicated defeated portrait.
+	; 0 = disabled, 256 = completely black
+	p1.lose.darken = 0
 
 	p1.velocity = 0, 0
 	p1.maxdist = 0, 0
@@ -2893,6 +2896,7 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	p1.face2.draworder = 0
 	p1.face2.lose.spr = -1, 0
 	p1.face2.lose.anim = -1
+	p1.face2.lose.darken = 0
 
 	p1.face2.velocity = 0, 0
 	p1.face2.maxdist = 0, 0
@@ -2938,6 +2942,7 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	p2.draworder = 0
 	p2.lose.spr = -1, 0
 	p2.lose.anim = -1
+	p2.lose.darken = 0
 
 	p2.velocity = 0, 0
 	p2.maxdist = 0, 0
@@ -2966,6 +2971,7 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	p2.face2.draworder = 0
 	p2.face2.lose.spr = -1, 0
 	p2.face2.lose.anim = -1
+	p2.face2.lose.darken = 0
 
 	p2.face2.velocity = 0, 0
 	p2.face2.maxdist = 0, 0


### PR DESCRIPTION
Feat:
- New Victory Screen optional parameters:
``pn.lose.anim``, ``pn.lose.spr``, ``pn.face2.lose.anim``, ``pn.face2.lose.spr``, ``pn.lose.darken``, ``pn.face2.lose.darken``

Replaces the character portrait with the one defined when the character loses the match.
Useful for displaying "defeated" / "beaten" versions of the character. 
If not defined, the standard victory portrait is used instead.

``pn.lose.darken`` Can be used to darken the defeated character's portrait. Useful when the character does not have a dedicated defeated portrait.
0 = disabled, 256 = completely black

- Implements: #3026 

Fix:
- Victory Screen portraits not using palettes with applypal = 1
- Fixes: #3027 