### PR TITLE
fix: optimize building ffmpeg

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -115,11 +115,11 @@ check_deps() {
 			need gcc
 			need g++
 			need nasm
-			need yasm
 			need go
 			need gendef
 			need dlltool
 			if ((${#missing[@]})); then
+				echo "Missing package: ${missing[@]}" >&2
 				echo "Install from the MINGW64 shell:" >&2
 				echo "  pacman -Syu --noconfirm" >&2
 				echo "  pacman -S --noconfirm \\" >&2
@@ -404,7 +404,7 @@ function build_ffmpeg() {
 	echo "==> Building minimal FFmpeg to $FFMPEG_PREFIX (sources in $FFMPEG_SRCDIR)"
 	mkdir -p "$BUILDDIR"
 	rm -rf "$FFMPEG_SRCDIR"
-	git clone https://github.com/FFmpeg/FFmpeg.git "$FFMPEG_SRCDIR"
+	git clone --depth=1 -b "$FFMPEG_REV" https://github.com/FFmpeg/FFmpeg.git "$FFMPEG_SRCDIR"
 	pushd "$FFMPEG_SRCDIR" >/dev/null
 	git checkout "$FFMPEG_REV"
 


### PR DESCRIPTION
Now building ffmpeg from source is much faster.
Instead of downloading 450MB from ffmpeg repo, now it only downloads 17MB.

```
$ BUILD_FFMPEG=yes ./build/build.sh Win64
==> Embedding Windows resources (icon + manifest) with windres...
==> BUILD_FFMPEG=yes: forcing local FFmpeg build
==> Building minimal FFmpeg to /f/Projects/ikemen-go-leon-dev-update/build/ffmpeg (sources in build/ffmpeg-src)
Cloning into 'build/ffmpeg-src'...
remote: Enumerating objects: 8495, done.
remote: Counting objects: 100% (8495/8495), done.
remote: Compressing objects: 100% (6382/6382), done.
remote: Total 8495 (delta 2401), reused 4727 (delta 1778), pack-reused 0 (from 0)
Receiving objects: 100% (8495/8495), 17.94 MiB | 2.68 MiB/s, done.
```