### PR TITLE
fix: victory screen, darken and spacing

### DIFF
--- a/src/resources/defaultMotif.ini
+++ b/src/resources/defaultMotif.ini
@@ -2870,8 +2870,8 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	p1.lose.spr = -1, 0
 	p1.lose.anim = -1
 	; Can be used to darken the defeated character's portrait. Useful when the character does not have a dedicated defeated portrait.
-	; 0 = disabled, 256 = completely black
-	p1.lose.darken = 0
+	; 256 = normal, 0 = completely black
+	p1.lose.brightness = 256
 
 	p1.velocity = 0, 0
 	p1.maxdist = 0, 0
@@ -2902,7 +2902,7 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	p1.face2.draworder = 0
 	p1.face2.lose.spr = -1, 0
 	p1.face2.lose.anim = -1
-	p1.face2.lose.darken = 0
+	p1.face2.lose.brightness = 256
 
 	p1.face2.velocity = 0, 0
 	p1.face2.maxdist = 0, 0
@@ -2948,7 +2948,7 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	p2.draworder = 0
 	p2.lose.spr = -1, 0
 	p2.lose.anim = -1
-	p2.lose.darken = 0
+	p2.lose.brightness = 256
 
 	p2.velocity = 0, 0
 	p2.maxdist = 0, 0
@@ -2977,7 +2977,7 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	p2.face2.draworder = 0
 	p2.face2.lose.spr = -1, 0
 	p2.face2.lose.anim = -1
-	p2.face2.lose.darken = 0
+	p2.face2.lose.brightness = 256
 
 	p2.face2.velocity = 0, 0
 	p2.face2.maxdist = 0, 0


### PR DESCRIPTION
Fix:
- The ``pn.lose.darken / pn.face2.lose.darken`` parameter was changed to ``pn.lose.brightness / pn.face2.lose.brightness``  (256 = normal, 0 = completely black) to better match the engine’s syntax. darken was always treated as a bool, not a int.

- Fixes: #3032 
- Fixes: #3030 