### PR TITLE
fix: camel-case convention: *SetfLength, -> *SetFocalLength, ValidatePal -> validatePal

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -1172,7 +1172,7 @@ function main.f_addChar(line, playable, loading, slot)
 					animSetXAngle(a, params.xangle)
 					animSetYAngle(a, params.yangle)
 					animSetProjection(a, params.projection)
-					animSetfLength(a, params.focallength)
+					animSetFocalLength(a, params.focallength)
 					animSetWindow(a, params.window[1], params.window[2], params.window[3], params.window[4])
 					animUpdate(a)
 					main.t_selChars[row].cell_data = a
@@ -1265,7 +1265,7 @@ function main.f_addStage(file, hidden, line)
 					animSetXAngle(a, params.xangle)
 					animSetYAngle(a, params.yangle)
 					animSetProjection(a, params.projection)
-					animSetfLength(a, params.focallength)
+					animSetFocalLength(a, params.focallength)
 					if params.window == nil or #params.window < 4 then
 						params.window = {0, 0, motif.info.localcoord[1], motif.info.localcoord[2]}
 					end

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -760,7 +760,7 @@ function start.f_animGet(ref, side, member, paramsSide, params, loop, srcAnim)
 				animSetXAngle(a, params.xangle)
 				animSetYAngle(a, params.yangle)
 				animSetProjection(a, params.projection)
-				animSetfLength(a, params.focallength)
+				animSetFocalLength(a, params.focallength)
 				animSetWindow(a, params.window[1], params.window[2], params.window[3], params.window[4])
 				if srcAnim ~= nil then
 					animApplyVel(a, srcAnim)
@@ -1179,7 +1179,7 @@ function start.f_drawCursor(pn, x, y, param, done)
 		animSetXAngle(a, getCellTransform(x, y, "xangle", params.xangle))
 		animSetYAngle(a, getCellTransform(x, y, "yangle", params.yangle))
 		animSetProjection(a, getCellTransform(x, y, "projection", params.projection))
-		animSetfLength(a, getCellTransform(x, y, "focallength", params.focallength))
+		animSetFocalLength(a, getCellTransform(x, y, "focallength", params.focallength))
 		animUpdate(a)
 	end
 	main.f_animPosDraw(
@@ -2848,22 +2848,22 @@ local function resolvePalConflict(side, charRef, pal)
 	end
 	-- if the chosen palette is not used, keep it
 	if not usedPals[pal] then
-		return ValidatePal(pal, charRef)
+		return validatePal(pal, charRef)
 	end
 	-- if it's in use, try to find the next free one
 	local maxPal = gameOption('Config.PaletteMax')
 	for i = pal + 1, maxPal do
 	if not usedPals[i] then
-			return ValidatePal(i, charRef)
+			return validatePal(i, charRef)
 		end
 	end
 	for i = 1, pal - 1 do
 		if not usedPals[i] then
-			return ValidatePal(i, charRef)
+			return validatePal(i, charRef)
 		end
 	end
 
-	return ValidatePal(pal, charRef)
+	return validatePal(pal, charRef)
 end
 
 local function applyPalette(sel, charData, palIndex)
@@ -2885,10 +2885,10 @@ function start.f_palMenu(side, cmd, player, member, selectState)
 	local pn = 2 * (member - 1) + side
 	-- initialize palette list and index if character changed or not yet set
 	if st.validPalsCharRef ~= charRef or not st.validPals then
-		local valid, seen, cur = {}, {}, ValidatePal(1, charRef)
+		local valid, seen, cur = {}, {}, validatePal(1, charRef)
 		valid[1], seen[cur] = cur, true
 		for i = 1, #charData.pal do
-			local nextp = ValidatePal(cur + 1, charRef)
+			local nextp = validatePal(cur + 1, charRef)
 			if seen[nextp] then break end
 			table.insert(valid, nextp)
 			seen[nextp], cur = true, nextp

--- a/src/iniutils.go
+++ b/src/iniutils.go
@@ -2062,7 +2062,7 @@ func SetAnim(obj interface{}, fVal, structVal, parent reflect.Value, sffOverride
 	a.rot.yangle = yangle
 	// animSetProjection
 	a.projection = projection
-	// animSetfLength
+	// animSetFocalLength
 	a.fLength = focallength
 	// animSetWindow
 	a.SetWindow(window)
@@ -2260,9 +2260,9 @@ func SetTextSprite(obj interface{}, fVal, structVal, parent reflect.Value) {
 	ts.rot.xangle = xangle
 	// textImgSetYAngle
 	ts.rot.yangle = yangle
-	// textSetProjection
+	// textImgSetProjection
 	ts.projection = projection
-	// textSetfLength
+	// textImgSetFocalLength
 	ts.fLength = focallength
 	// textImgSetWindow
 	ts.SetWindow(window)

--- a/src/script.go
+++ b/src/script.go
@@ -1208,7 +1208,7 @@ func systemScriptInit(l *lua.LState) {
 		}
 		return 0
 	})
-	luaRegister(l, "animSetfLength", func(*lua.LState) int {
+	luaRegister(l, "animSetFocalLength", func(*lua.LState) int {
 		a, ok := toUserData(l, 1).(*Anim)
 		if !ok {
 			userDataError(l, 1, a)
@@ -1415,7 +1415,7 @@ func systemScriptInit(l *lua.LState) {
 		l.Push(lua.LBool(false))
 		return 1
 	})
-	luaRegister(l, "ValidatePal", func(l *lua.LState) int {
+	luaRegister(l, "validatePal", func(l *lua.LState) int {
 		palReq := int(numArg(l, 1))
 		charRef := int(numArg(l, 2))
 		valid := sys.sel.ValidatePalette(charRef, palReq)
@@ -4670,7 +4670,7 @@ func systemScriptInit(l *lua.LState) {
 		}
 		return 0
 	})
-	luaRegister(l, "textImgSetfLength", func(*lua.LState) int {
+	luaRegister(l, "textImgSetFocalLength", func(*lua.LState) int {
 		ts, ok := toUserData(l, 1).(*TextSprite)
 		if !ok {
 			userDataError(l, 1, ts)


### PR DESCRIPTION
script.go functions renaming to follow existing conventions (camel casing)
* animSetfLength -> animSetFocalLength
* textImgSetfLength -> textImgSetFocalLength
* ValidatePal -> validatePal