### PR TITLE
feat: animNew accepts *Animation as second argument; add animSetAnimation

### DIFF
--- a/src/anim.go
+++ b/src/anim.go
@@ -1844,6 +1844,16 @@ func (a *Anim) Copy() *Anim {
 	return newAnim
 }
 
+// Returns a shallow copy of an Animation.
+func (a *Animation) ShallowCopy() *Animation {
+	if a == nil {
+		return nil
+	}
+	ret := &Animation{}
+	*ret = *a
+	return ret
+}
+
 func (a *Anim) SetTile(x, y, sx, sy int32) {
 	a.anim.tile.xflag, a.anim.tile.yflag, a.anim.tile.xspacing, a.anim.tile.yspacing = x, y, sx, sy
 }

--- a/src/iniutils.go
+++ b/src/iniutils.go
@@ -1893,7 +1893,7 @@ func getFieldFromHierarchy(primary, parent reflect.Value, name string) (reflect.
 	return reflect.Value{}, false
 }
 
-// SetAnim sets the Anim field generically for any struct that contains At and Sff fields.
+// SetAnim sets the Anim field generically for any struct that contains AnimTable and Sff fields.
 func SetAnim(obj interface{}, fVal, structVal, parent reflect.Value, sffOverride *Sff) {
 	anim := int32(-1)
 	spr := [2]int32{-1, 0}
@@ -2009,7 +2009,7 @@ func SetAnim(obj interface{}, fVal, structVal, parent reflect.Value, sffOverride
 
 	// Access obj fields generically
 	objVal := reflect.ValueOf(obj).Elem()
-	atField := objVal.FieldByName("At")
+	atField := objVal.FieldByName("AnimTable")
 
 	// Resolve SFF to use: override if provided, else obj.Sff
 	var sffPtr *Sff
@@ -2024,13 +2024,13 @@ func SetAnim(obj interface{}, fVal, structVal, parent reflect.Value, sffOverride
 	}
 
 	if !atField.IsValid() {
-		fmt.Println("Error: object does not have required At or Sff fields")
+		fmt.Println("Error: object does not have required AnimTable or Sff fields")
 		return
 	}
 
 	animMap, ok := atField.Interface().(AnimationTable)
 	if !ok {
-		fmt.Println("Error: At field is not of type AnimationTable")
+		fmt.Println("Error: AnimTable field is not of type AnimationTable")
 		return
 	}
 

--- a/src/motif.go
+++ b/src/motif.go
@@ -1305,7 +1305,7 @@ type Motif struct {
 	IniFile         *ini.File
 	UserIniFile     *ini.File
 	DefaultOnlyIni  *ini.File
-	At              AnimationTable
+	AnimTable       AnimationTable
 	Sff             *Sff
 	Snd             *Snd
 	Fnt             map[int]*Fnt
@@ -1767,7 +1767,7 @@ func loadMotif(def string) (*Motif, error) {
 		return nil, err
 	}
 	lines, i := SplitAndTrim(str, "\n"), 0
-	m.At = ReadAnimationTable(m.Sff, &m.Sff.palList, lines, &i)
+	m.AnimTable = ReadAnimationTable(m.Sff, &m.Sff.palList, lines, &i)
 	i = 0
 
 	m.overrideParams()

--- a/src/storyboard.go
+++ b/src/storyboard.go
@@ -88,15 +88,15 @@ type SceneProperties struct {
 }
 
 type Storyboard struct {
-	IniFile  *ini.File
-	At       AnimationTable
-	Sff      *Sff
-	Snd      *Snd
-	Fnt      map[int]*Fnt
-	Model    *Model
-	Def      string         `ini:"def"`
-	Info     InfoProperties `ini:"info"`
-	SceneDef struct {
+	IniFile   *ini.File
+	AnimTable AnimationTable
+	Sff       *Sff
+	Snd       *Snd
+	Fnt       map[int]*Fnt
+	Model     *Model
+	Def       string         `ini:"def"`
+	Info      InfoProperties `ini:"info"`
+	SceneDef  struct {
 		Spr        string                     `ini:"spr" lookup:"def,,data/"`
 		Snd        string                     `ini:"snd" lookup:"def,,data/"`
 		Font       map[string]*FontProperties `ini:"map:^(?i)font[0-9]+$" lua:"font"`
@@ -294,13 +294,13 @@ func loadStoryboard(def string) (*Storyboard, error) {
 		return nil, err
 	}
 	lines, i := SplitAndTrim(str, "\n"), 0
-	s.At = ReadAnimationTable(s.Sff, &s.Sff.palList, lines, &i)
+	s.AnimTable = ReadAnimationTable(s.Sff, &s.Sff.palList, lines, &i)
 	i = 0
 
 	// Storyboard-specific quirk:
 	// enable phantom pixel adjustment on all storyboard animations so that
 	// frames flipped via H or V get an extra pixel of offset.
-	for _, anim := range s.At {
+	for _, anim := range s.AnimTable {
 		if anim != nil {
 			anim.phantomPixel = true
 		}


### PR DESCRIPTION
* Extend Lua `animNew` to accept either AIR string or `*Animation` userdata..
* Add `animSetAnimatio`n with the same dual input to swap an `*Anim`’s underlying `*Animation`.