### PR TITLE
feat: menu.item.bgspacing

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -3365,10 +3365,8 @@ function main.f_menuCommonDraw(t, item, cursorPosY, moveTxt, sec, bg, skipClear,
 		-- draw background
 		main.f_animPosDraw(
 			params.AnimData,
-			-- TODO: pre 1.0 skipped spacing calc for bg elements, consider adding it
-			-- posX, posY
-			offx,
-			offy
+			(sec.menu.item.bgspacing == true) and (params.offset[1] + posX) or offx,
+			(sec.menu.item.bgspacing == true) and (params.offset[2] + posY) or offy
 		)
 		-- text sprite for label
 		local labelSprite

--- a/src/motif.go
+++ b/src/motif.go
@@ -291,10 +291,11 @@ type MenuProperties struct {
 	Tween TweenProperties `ini:"tween"`
 	Item  struct {
 		TextProperties
-		Uppercase bool                            `ini:"uppercase"`
-		Spacing   [2]float32                      `ini:"spacing"`
-		Tween     TweenProperties                 `ini:"tween"`
-		Bg        map[string]*AnimationProperties `ini:"bg" flatten:"true"`
+		Uppercase bool                             `ini:"uppercase"`
+		BgSpacing bool                             `ini:"bgspacing"`
+		Spacing   [2]float32                       `ini:"spacing"`
+		Tween     TweenProperties                  `ini:"tween"`
+		Bg        map[string]*AnimationProperties  `ini:"bg" flatten:"true"`
 		Active    struct {
 			TextProperties
 			Bg map[string]*AnimationProperties `ini:"bg" flatten:"true"`

--- a/src/resources/defaultMotif.ini
+++ b/src/resources/defaultMotif.ini
@@ -251,6 +251,9 @@
 	menu.item.spacing = 0, 13
 	menu.item.tween.factor = 0.5
 
+	; Applies menu.item.spacing to all background elements
+	menu.item.bgspacing = 1
+
 	menu.item.bg.anim = -1
 	menu.item.bg.spr = -1, 0
 	menu.item.bg.offset = 0, 0
@@ -685,6 +688,7 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	p1.cursor.tween.factor = 0.5, 0.5
 	; Snaps the cursor when wrapping
 	p1.cursor.tween.wrap.snap = 0
+	; Reset the cursor animation when selecting a new cell
 	p1.cursor.reset = 0
 
 	p1.cursor.active.anim = -1

--- a/src/resources/defaultMotif.ini
+++ b/src/resources/defaultMotif.ini
@@ -252,7 +252,7 @@
 	menu.item.tween.factor = 0.5
 
 	; Applies menu.item.spacing to all background elements
-	menu.item.bgspacing = 1
+	menu.item.bgspacing = 0
 
 	menu.item.bg.anim = -1
 	menu.item.bg.spr = -1, 0


### PR DESCRIPTION
This PR adds a new parameter to the motif called `menu.item.bgspacing`.
It applies spacing specified in `menu.item.spacing` to the menu item background elements.