### PR TITLE
refactor: parse menu.item.bg.spacing as float32

### DIFF
--- a/src/motif.go
+++ b/src/motif.go
@@ -130,7 +130,7 @@ type AnimationProperties struct {
 
 type BgAnimationProperties struct {
 	AnimationProperties
-	Spacing [2]int32 `ini:"spacing"`
+	Spacing [2]float32 `ini:"spacing"`
 }
 
 type AnimationTextProperties struct {


### PR DESCRIPTION
This PR changes the type of `menu.item.bg.spacing` to `float32`, to be consistent with the existing `menu.item.spacing` parameter.