### PR TITLE
fix: non-deterministic math/rand usage

### DIFF
--- a/src/motif.go
+++ b/src/motif.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/fs"
 	"math"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -3883,7 +3882,8 @@ func (di *MotifDialogue) getDialogueLines() ([]string, int, error) {
 			}
 		}
 		if len(validPlayers) > 0 {
-			pn = validPlayers[rand.Int()%len(validPlayers)]
+			idx := int(RandI(0, int32(len(validPlayers)-1)))
+			pn = validPlayers[idx]
 		}
 	}
 	lines := []string{}
@@ -5554,7 +5554,8 @@ func (vi *MotifVictory) getVictoryQuote(m *Motif, p *Char) string {
 
 		// Select a random available quote if any exist
 		if len(availableQuotes) > 0 {
-			quoteIndex = availableQuotes[rand.Intn(len(availableQuotes))]
+			idx := int(RandI(0, int32(len(availableQuotes)-1)))
+			quoteIndex = availableQuotes[idx]
 		} else {
 			quoteIndex = -1
 		}

--- a/src/script.go
+++ b/src/script.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -2494,8 +2493,8 @@ func systemScriptInit(l *lua.LState) {
 	luaRegister(l, "getCharRandomPalette", func(*lua.LState) int {
 		c := sys.sel.GetChar(int(numArg(l, 1)))
 		if len(c.pal) > 0 {
-			n := rand.Int() % len(c.pal)
-			l.Push(lua.LNumber(c.pal[n]))
+			idx := int(RandI(0, int32(len(c.pal)-1)))
+			l.Push(lua.LNumber(c.pal[idx]))
 		} else {
 			l.Push(lua.LNumber(1))
 		}


### PR DESCRIPTION
Replace math/rand with synced engine RNG for victory quotes, dialogue, and random palette to prevent netplay desync.