### PR TITLE
build: add Docker-based Android build to pipeline

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,8 @@
 *.mod text eol=lf
 *.sum text eol=lf
 *.ini text eol=lf
+*.yml text eol=lf
+Dockerfile text eol=lf
 
 # Syntax
 *.def linguist-language=ini

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [ develop ]
+    branches: [ develop, ci-test ]
   workflow_dispatch:
     inputs:
       tag:
@@ -28,6 +28,11 @@ on:
         type: string
         required: false
         default: ''
+      buildAndroidApk:
+        description: 'Build Android APK.'
+        type: boolean
+        required: false
+        default: true
 
 permissions:
   checks: write
@@ -93,6 +98,14 @@ jobs:
             glibc: ''
             target: '10.7'
             build_target: MacOSARM # MacOS
+          - runner_os: android
+            os: ubuntu-22.04
+            goos: android
+            goarch: arm64
+            bin: ikemen-go.apk
+            glibc: ''
+            target: ''
+            build_target: Android
     runs-on: ${{ matrix.cfg.os }}
     steps:
       - uses: actions/checkout@v6
@@ -130,6 +143,7 @@ jobs:
           vulkan-components: Vulkan-Headers, Vulkan-Loader
           vulkan-use-cache: true
       - name: Install dependencies
+        if: ${{ matrix.cfg.runner_os != 'android' }}
         shell: bash
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
@@ -149,8 +163,78 @@ jobs:
             )
           fi
 
+      - name: Generate LICENSES.txt
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # One LICENSES.txt for ALL platforms (including Android).
+          # Must exist BEFORE Android Docker Compose runs so it is visible in the bind-mounted workspace.
+          FFMPEG_REV="${FFMPEG_REV:-release/7.1}"
+
+          SCREENPACK_LIC_MAIN="https://raw.githubusercontent.com/ikemen-engine/Ikemen_GO-Elecbyte-Screenpack/main/LICENCE.txt"
+          SCREENPACK_LIC_MASTER="https://raw.githubusercontent.com/ikemen-engine/Ikemen_GO-Elecbyte-Screenpack/master/LICENCE.txt"
+
+          FFMPEG_LGPL="https://raw.githubusercontent.com/FFmpeg/FFmpeg/${FFMPEG_REV}/COPYING.LGPLv2.1"
+          FFMPEG_LICENSE_MD="https://raw.githubusercontent.com/FFmpeg/FFmpeg/${FFMPEG_REV}/LICENSE.md"
+          FFMPEG_CREDITS="https://raw.githubusercontent.com/FFmpeg/FFmpeg/${FFMPEG_REV}/CREDITS"
+
+          LIBXMP_README="https://raw.githubusercontent.com/libxmp/libxmp/master/README"
+          SDL2_LICENSE="https://raw.githubusercontent.com/libsdl-org/SDL/main/LICENSE.txt"
+
+          {
+            echo "============================="
+            echo " Ikemen GO - LICENSES.txt"
+            echo "============================="
+            echo
+            echo "Section 1: Ikemen GO (MIT)"
+            echo "--------------------------"
+            cat LICENCE.txt
+            echo
+            echo "Section 2: Bundled Assets (Creative Commons)"
+            echo "-------------------------------------------"
+            echo "Screenpack license from Ikemen_GO-Elecbyte-Screenpack/LICENCE.txt:"
+            echo
+            ( curl -fsSL "$SCREENPACK_LIC_MAIN" || curl -fsSL "$SCREENPACK_LIC_MASTER" )
+            echo
+            echo "Section 3: FFmpeg (LGPL v2.1) and Notices"
+            echo "-----------------------------------------"
+            echo "This program dynamically links FFmpeg under the GNU Lesser General Public License v2.1."
+            echo "The exact corresponding FFmpeg source is attached to the release page as:"
+            echo "  src_ffmpeg.tar.gz"
+            echo
+            echo "3.1 Full LGPL v2.1 license text:"
+            echo "--------------------------------"
+            curl -fsSL "$FFMPEG_LGPL"
+            echo
+            echo "3.2 FFmpeg LICENSE.md:"
+            echo "----------------------"
+            curl -fsSL "$FFMPEG_LICENSE_MD"
+            echo
+            echo "3.3 FFmpeg CREDITS:"
+            echo "-------------------"
+            curl -fsSL "$FFMPEG_CREDITS"
+            echo
+            echo "Section 4: libxmp and Notices"
+            echo "-----------------------------"
+            echo "Upstream: https://github.com/libxmp/libxmp"
+            echo
+            echo "libxmp README (contains license info):"
+            echo "-------------------------------------"
+            curl -fsSL "$LIBXMP_README"
+            echo
+            echo "Section 5: SDL2 and Notices"
+            echo "---------------------------"
+            echo "Upstream: https://github.com/libsdl-org/SDL"
+            echo
+            echo "SDL2 LICENSE (zlib):"
+            echo "--------------------"
+            curl -fsSL "$SDL2_LICENSE"
+            echo
+          } > LICENSES.txt
+
       - name: Build (POSIX)
-        if: ${{ runner.os != 'Windows' }}
+        if: ${{ runner.os != 'Windows' && matrix.cfg.runner_os != 'android' }}
         shell: bash
         env:
           BUILD_FFMPEG: "yes"
@@ -167,6 +251,29 @@ jobs:
           if [ "$RUNNER_OS" = "macOS" ]; then
             make appbundle BINNAME=bin/${{ matrix.cfg.bin }}
           fi
+
+      - name: Build Android (Docker Compose)
+        if: ${{ matrix.cfg.runner_os == 'android' && (github.event_name != 'workflow_dispatch' || github.event.inputs.buildAndroidApk != 'false') }}
+        shell: bash
+        env:
+          # Build APK is optional but enabled by default. If disabled, we skip this entire step.
+          BUILD_ANDROID_APK: ${{ (github.event_name != 'workflow_dispatch' || github.event.inputs.buildAndroidApk != 'false') && '1' || '0' }}
+          APP_VERSION: ${{ needs.tag.outputs.version }}
+          APP_BUILDTIME: ${{ needs.tag.outputs.buildTime }}
+        run: |
+          set -euo pipefail
+          echo "==> Docker sanity:"
+          docker version
+          docker compose version
+          echo
+          echo "==> Building Android (APK via Docker Compose)..."
+          chmod +x build/build_android.sh
+          ./build/build_android.sh
+          echo
+          echo "==> Outputs:"
+          ls -lah bin/ lib/ || true
+          test -f bin/libmain.so
+          test -f bin/ikemen-go.apk
 
       - name: Build (MSYS2)
         if: ${{ runner.os == 'Windows' }}
@@ -185,10 +292,12 @@ jobs:
           ./build/build.sh ${{ matrix.cfg.build_target }}
 
       - name: Prepare FFmpeg artifacts
-        # if: ${{ matrix.cfg.runner_os == 'windows' }}
+        if: ${{ matrix.cfg.runner_os == 'linux' }}
         id: artifacts_ffmpeg
         shell: bash
         run: |
+          # Android build runs in Docker and may create root-owned git dirs; allow them.
+          git config --global --add safe.directory "$GITHUB_WORKSPACE/build/ffmpeg-src" >/dev/null 2>&1 || true
           mkdir -p FFmpeg-CS
           # Export the *exact* tree
           ( cd build/ffmpeg-src && git archive --format=tar HEAD ) | tar -x -C FFmpeg-CS
@@ -199,11 +308,36 @@ jobs:
           echo "artifact_ffsrc=src_ffmpeg.tar.gz" >> "$GITHUB_OUTPUT"
 
       - name: Prepare release artifacts
+        if: ${{ matrix.cfg.runner_os != 'android' || (github.event_name != 'workflow_dispatch' || github.event.inputs.buildAndroidApk != 'false') }}
         id: artifacts
         shell: bash
         run: |
           echo "Preparing files for deployment"
           mkdir -p deploy
+
+          if [ "${{ matrix.cfg.runner_os }}" = "android" ]; then
+            echo "==> Preparing Android release artifact"
+            mkdir -p deploy/lib
+            cp -av bin/ikemen-go.apk deploy/ || true
+            cp -av bin/libmain.so bin/libmain.h deploy/ 2>/dev/null || true
+            cp -av lib/*.so* deploy/lib/ 2>/dev/null || true
+            cp README.md deploy/ 2>/dev/null || true
+
+            cp -av LICENSES.txt deploy/ 2>/dev/null || true
+
+            cd deploy
+            if [ "${{ github.event.inputs.tag }}" = "" ]; then
+              ARTIFACT_NAME=Ikemen_GO-dev-android.zip
+              echo "artifact=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
+            else
+              ARTIFACT_NAME=Ikemen_GO-${{ needs.tag.outputs.version }}-android.zip
+              echo "artifact=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
+            fi
+            zip -r ../$ARTIFACT_NAME *
+            echo "Successfully prepared Android assets for deployment"
+            exit 0
+          fi
+
           mkdir -p deploy/data
 
           # 1) Put binary and shared libs generated by build.sh
@@ -233,73 +367,8 @@ jobs:
           # 3) Include readme
           cp README.md deploy/
 
-          # 4) Build a single LICENSES.txt dynamically
-          {
-            echo "============================="
-            echo " Ikemen GO - LICENSES.txt"
-            echo "============================="
-            echo
-            echo "Section 1: Ikemen GO (MIT)"
-            echo "--------------------------"
-            cat LICENCE.txt
-            echo
-            echo "Section 2: Bundled Assets (Creative Commons)"
-            echo "-------------------------------------------"
-            echo "Screenpack license from Ikemen_GO-Elecbyte-Screenpack/LICENCE.txt:"
-            echo
-            cat Ikemen_GO-Elecbyte-Screenpack/LICENCE.txt
-            echo
-            echo "Note: Some assets in the engine repo are under CC-BY 3.0 as noted in the MIT section above."
-            echo
-            echo "Section 3: FFmpeg (LGPL v2.1) and Notices"
-            echo "-----------------------------------------"
-            echo "This program dynamically links FFmpeg under the GNU Lesser General Public License v2.1."
-            echo "The FFmpeg shared libraries are included in this archive so the app runs out of the box."
-            echo "The exact corresponding FFmpeg source is attached to the release page as:"
-            echo "  src_ffmpeg.tar.gz"
-            echo
-            echo "3.1 Full LGPL v2.1 license text (from FFmpeg/COPYING.LGPLv2.1):"
-            echo "----------------------------------------------------------------"
-            cat build/ffmpeg-src/COPYING.LGPLv2.1
-            echo
-            echo "3.2 FFmpeg LICENSE.md:"
-            echo "----------------------"
-            cat build/ffmpeg-src/LICENSE.md
-            echo
-            echo "3.3 FFmpeg CREDITS:"
-            echo "-------------------"
-            cat build/ffmpeg-src/CREDITS
-            echo
-            echo "3.4 FFmpeg shared objects shipped in this archive:"
-            echo "-----------------------------------------------"
-            if [ "$RUNNER_OS" = "Windows" ]; then
-              ( cd deploy/lib 2>/dev/null && ls -1 *.dll 2>/dev/null || true )
-            elif [ "$RUNNER_OS" = "Linux" ]; then
-              ( cd deploy/lib 2>/dev/null && ls -1 *.so* 2>/dev/null || true )
-            else
-              ( cd deploy/I.K.E.M.E.N-Go.app/Contents/Frameworks 2>/dev/null && ls -1 *.dylib 2>/dev/null || true )
-            fi
-            echo
-            echo "Section 4: libxmp and Notices"
-            echo "-----------------------------"
-            echo "This program dynamically links libxmp for module music playback."
-            echo "Upstream: https://github.com/libxmp/libxmp"
-            echo
-            echo "libxmp LICENSE (fetched from upstream README at build time):"
-            echo "-----------------------------------------------------------"
-            set -o pipefail
-            curl -fsSL https://raw.githubusercontent.com/libxmp/libxmp/master/README | awk '/^LICENSE$/{p=1} p'
-            echo
-            echo "Section 5: SDL2 and Notices"
-            echo "---------------------------"
-            echo "This program uses SDL2 for windowing, input, controller support."
-            echo "Upstream: https://github.com/libsdl-org/SDL"
-            echo
-            echo "SDL2 LICENSE (zlib, fetched from upstream LICENSE.txt):"
-            echo "-------------------------------------------------------"
-            curl -fsSL https://raw.githubusercontent.com/libsdl-org/SDL/main/LICENSE.txt
-            echo
-          } > deploy/LICENSES.txt
+          # 4) Single LICENSES.txt
+          cp -av LICENSES.txt deploy/ 2>/dev/null || true
 
           # 5) Extra runtime db
           GAMEPAD_DB_URL="https://raw.githubusercontent.com/mdqinc/SDL_GameControllerDB/refs/heads/master/gamecontrollerdb.txt"
@@ -347,13 +416,13 @@ jobs:
           echo "Successfully prepared assets for deployment"
 
       - name: Update dev release
-        if: "${{ github.event.inputs.tag == '' }}"
+        if: "${{ github.event.inputs.tag == '' && steps.artifacts.outputs.artifact != '' }}"
         uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.IKEMEN_TOKEN }}
           allowUpdates: true
           artifactErrorsFailBuild: true
-          artifacts: "${{ steps.artifacts.outputs.artifact }},${{ steps.artifacts_ffmpeg.outputs.artifact_ffsrc }}"
+          artifacts: "${{ steps.artifacts.outputs.artifact }}${{ matrix.cfg.runner_os == 'linux' && format(',{0}', steps.artifacts_ffmpeg.outputs.artifact_ffsrc) || '' }}"
           body: |
             The nightly release, or more precisely, the latest development version, is generated after each commit and always represents the most up-to-date iteration of the source code. It features the newest development version of the engine and screenpack files, making it ready for testing straightaway. Using it can eliminate the need to compile the source code for the latest, cutting-edge updates. However, as a consequence, it may sometimes contain regressions that were not yet discovered and/or outpace the documentation that corresponds to stable releases with version numbers like v x.x.x.
           discussionCategory: ""
@@ -375,13 +444,13 @@ jobs:
           updateOnlyUnreleased: false
 
       - name: Create Release
-        if: "${{ github.event.inputs.tag != '' }}"
+        if: "${{ github.event.inputs.tag != '' && steps.artifacts.outputs.artifact != '' }}"
         uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.IKEMEN_TOKEN }}
           allowUpdates: true
           artifactErrorsFailBuild: true
-          artifacts: "${{ steps.artifacts.outputs.artifact }},${{ steps.artifacts_ffmpeg.outputs.artifact_ffsrc }}"
+          artifacts: "${{ steps.artifacts.outputs.artifact }}${{ matrix.cfg.runner_os == 'linux' && format(',{0}', steps.artifacts_ffmpeg.outputs.artifact_ffsrc) || '' }}"
           # body: |
           #   ${{ needs.tag.outputs.changelog }}
           discussionCategory: ${{ github.event.inputs.discussionCategory }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@ vendor/*
 *.log
 *.cmd
 *.bat
-*.sh
+/*.sh
+!build/**/*.sh
 *.png
 save/*
 Ikemen_GO.exe
@@ -45,6 +46,14 @@ external/script/wip/*
 .vscode/*
 .vs/*
 .idea/*
+
+# Android build outputs (generated)
+bin/*.apk
+bin/libmain.so
+bin/libmain.h
+lib/*.so
+lib/*.so.*
+build/android-apk/
 
 # Binaries
 build/android-deps/

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -20,9 +20,11 @@ pacman -S --noconfirm \
   mingw-w64-x86_64-tools-git mingw-w64-x86_64-libxmp \
   mingw-w64-x86_64-SDL2
 ```
+
 > On MSYS2 we auto-fix "trimmed" Go by setting `GOROOT=/mingw64/lib/go` if needed.
 
 ### Build 64-bit (Ikemen_GO.exe)
+
 ```bash
 git clone https://github.com/ikemen-engine/Ikemen-GO.git
 cd Ikemen-GO
@@ -33,8 +35,10 @@ make Ikemen_GO.exe
 ```
 
 ### Build 32-bit (Ikemen_GO_x86.exe)
+
 > Requires 32-bit MinGW cross tools in addition to the above:
 > `pacman -S --noconfirm mingw-w64-i686-toolchain mingw-w64-i686-pkg-config mingw-w64-i686-nasm mingw-w64-i686-yasm mingw-w64-i686-libxmp mingw-w64-i686-SDL2`
+
 ```bash
 # build.sh
 ./build/build.sh Win32
@@ -43,13 +47,16 @@ make Ikemen_GO_x86.exe
 ```
 
 ### Run (Windows)
+
 ```bash
 ./Ikemen_GO.exe          # 64-bit
 ./Ikemen_GO_x86.exe      # 32-bit
 ```
 
 ### Use system FFmpeg instead (optional)
+
 Install `mingw-w64-x86_64-ffmpeg` (and/or i686 variant for 32-bit), then:
+
 ```bash
 BUILD_FFMPEG=no ./build/build.sh Win64   # or Win32
 ```
@@ -59,6 +66,7 @@ BUILD_FFMPEG=no ./build/build.sh Win64   # or Win32
 ## Linux
 
 ### Dependencies (Debian/Ubuntu)
+
 ```bash
 sudo apt update && sudo apt install -y \
   golang-go git pkg-config make nasm yasm build-essential \
@@ -66,6 +74,7 @@ sudo apt update && sudo apt install -y \
 ```
 
 ### Build x86-64 (Ikemen_GO_Linux)
+
 ```bash
 git clone https://github.com/ikemen-engine/Ikemen-GO.git
 cd Ikemen-GO
@@ -76,25 +85,31 @@ make Ikemen_GO_Linux
 ```
 
 ### Build ARM64 on an ARM host (Ikemen_GO_LinuxARM)
+
 > On an **ARM64 (aarch64) machine**, the same dependencies apply.
+
 ```bash
 # build.sh
 ./build/build.sh LinuxARM
 # or make
 make Ikemen_GO_LinuxARM
 ```
+
 > Cross-compiling x86→ARM with CGO/FFmpeg requires an ARM cross toolchain and is not covered here.
 
 ### Run (Linux)
+
 ```bash
 ./Ikemen_GO_Linux        # x86-64
 ./Ikemen_GO_LinuxARM     # ARM64
 # If you need a GL fallback on some drivers:
 MESA_GL_VERSION_OVERRIDE=2.1 ./Ikemen_GO_Linux
 ```
+
 You can also double-click **`build/Ikemen_GO.command`** on Linux.
 
 ### Use system FFmpeg instead (optional)
+
 ```bash
 sudo apt install -y ffmpeg libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libswresample-dev libavfilter-dev
 BUILD_FFMPEG=no ./build/build.sh Linux      # or LinuxARM
@@ -105,12 +120,14 @@ BUILD_FFMPEG=no ./build/build.sh Linux      # or LinuxARM
 ## macOS (Apple Silicon by default; Intel supported)
 
 ### Dependencies (Homebrew)
+
 ```bash
 brew update && brew install git go pkg-config nasm libxmp sdl2 molten-vk
 # Optional: brew install yasm
 ```
 
 ### Build (Apple Silicon default)
+
 ```bash
 git clone https://github.com/ikemen-engine/Ikemen-GO.git
 cd Ikemen-GO
@@ -121,6 +138,7 @@ make Ikemen_GO_MacOSARM
 ```
 
 ### Build (Intel)
+
 ```bash
 ./build/build.sh MacOS
 # or
@@ -128,19 +146,23 @@ make Ikemen_GO_MacOS
 ```
 
 ### App bundle (optional)
+
 ```bash
 make appbundle BINNAME=bin/Ikemen_GO_MacOSARM   # or BINNAME=bin/Ikemen_GO_MacOS
 open I.K.E.M.E.N-Go.app
 ```
+
 You can also double-click **`build/Ikemen_GO.command`**; it starts the bundle or the binary.
 
 ### Run (raw binary)
+
 ```bash
 ./bin/Ikemen_GO_MacOSARM   # Apple Silicon
 ./bin/Ikemen_GO_MacOS      # Intel
 ```
 
 ### Use system FFmpeg instead (optional)
+
 ```bash
 brew install ffmpeg
 BUILD_FFMPEG=no ./build/build.sh MacOSARM   # or MacOS
@@ -148,47 +170,69 @@ BUILD_FFMPEG=no ./build/build.sh MacOSARM   # or MacOS
 
 ---
 
-## Android (from Linux or macOS host)
-Android NDK r27d is required. ***YOU MUST SET THE `ANDROID_NDK_HOME` ENVIRONMENT VARIABLE PRIOR TO BUILDING TO YOUR NDK PATH OR THIS WILL NOT WORK!!!***
+## Android (APK via Docker)
+
+This builds the engine **and** produces a ready-to-install **APK** inside Docker. No Android Studio required.
+
+### Requirements
+
+* Docker (Docker Desktop on Windows/macOS, or Docker Engine on Linux)
+
+### Build (from repo root)
+
+#### Option A: one-liner helper script
 
 ```bash
-export ANDROID_NDK_HOME=/path/to/androidndk
-./build/build.sh android
+./build/build_android.sh
 ```
 
-This will create the necessary .so files to place in `src/main/jniLibs/arm64-v8a` in both the `lib/` folder and `bin/libmain.so` file.
-To run it on Android, an APK must be created.
+This script wraps the docker compose commands and runs the Android build inside the container.
 
-### Creating the APK
-Android Studio is required to make the APK.
-1. Run `git clone https://github.com/Jesuszilla/ikemen-droid.git`
-2. Place all the lib .so files from the `lib/` folder and the `build/libmain.so` into `src/main/jniLibs/arm64-v8a/` folder inside the repository.
-3. Place all the engine assets in `src/main/assets` exactly as defined in `src/main/assets/manifest.txt`. You may wish to generate your own manifest.txt for your own game files, but a default is included in the above repository.
-4. Open a terminal to the root of the ikemen-droid project in Android Studio.
-5. Run `./gradlew clean assembleDebug`
-6. The APK is now in `app/build/outputs/apk/debug/app-debug.apk`.
-7. (Optional) Install to your Android device by running the command `adb install -r app/build/outputs/apk/app-debug.apk`.
+### Option B: run Docker Compose directly
 
-After running step 7, you can select I.K.E.M.E.N-Go from the Android list of apps as usual, or you could run:
 ```bash
-adb shell am start -n org.ikemen_engine.ikemen_go/org.libsdl.app.SDLActivity`
+docker compose -f build/docker/android/docker-compose.yml build
+docker compose -f build/docker/android/docker-compose.yml run --rm android-build
 ```
 
-### Adding additional content (Android)
-The default assets should be included in the APK and extracted on first run. For additional content, you can either hook up your Android device in File Transfer mode, or you could run:
+### Outputs
+
+After a successful run, these will exist in your repo:
+
+* `bin/ikemen-go.apk` (the APK)
+* `bin/libmain.so` and `bin/libmain.h` (engine shared library + header)
+* `lib/*.so` (Android runtime dependencies: SDL2, FFmpeg libs, libxmp, etc.)
+* `build/android-apk/ikemen-droid` (cloned Android wrapper project)
+
+### Configuration knobs (optional)
+
+You can override build metadata and wrapper source:
+
 ```bash
-adb push /path/to/src/file /sdcard/Android/data/org.ikemen_engine.ikemen_go/files/path/to/dst/file
+APP_VERSION=my-build APP_BUILDTIME=2026.01.13 \
+ANDROID_APK_REPO=https://github.com/Jesuszilla/ikemen-droid.git \
+ANDROID_APK_REF=main \
+docker compose -f build/docker/android/docker-compose.yml run --rm android-build
 ```
 
-e.g. to push a new options.lua from the `assets` folder from the root of the Android project, you'd do:
+To skip APK packaging (only build `.so` + deps):
+
 ```bash
-adb push app/src/main/assets/external/script/options.lua /sdcard/Android/data/org.ikemen_engine.ikemen_go/files/external/script/options.lua
+BUILD_ANDROID_APK=0 docker compose -f build/docker/android/docker-compose.yml run --rm android-build
 ```
 
+### Customizing the Android wrapper (package name, manifest, icons, etc.)
+
+The APK is built from the `ikemen-droid` wrapper project, which is cloned into:
+`build/android-apk/ikemen-droid`
+
+If you need changes in that wrapper, fork it and point the build to your fork via:
+`ANDROID_APK_REPO` and `ANDROID_APK_REF` (shown above).
 
 ---
 
-## Assets required to run
+## Assets required to run (desktop builds)
+
 Place these folders **next to the executable or app bundle**:
 `data`, `external`, `font`, and a screenpack (see our Elecbyte screenpack repo).
 The release CI bundles these automatically.
@@ -196,17 +240,19 @@ The release CI bundles these automatically.
 ---
 
 ## Notes & licensing
-- The minimal FFmpeg we build matches CI: shared libs only; `file` protocol; Matroska/WebM demuxers;
+
+* The minimal FFmpeg we build matches CI: shared libs only; `file` protocol; Matroska/WebM demuxers;
   VP9/Opus/Vorbis decoders and parsers; no FFmpeg CLI tools.
-- FFmpeg is used under **LGPL v2.1**; releases attach the corresponding source snapshot.
-- Ikemen GO sources are MIT; bundled screenpack assets have their own licenses.
+* FFmpeg is used under **LGPL v2.1**; releases attach the corresponding source snapshot.
+* Ikemen GO sources are MIT; bundled screenpack assets have their own licenses.
 
 ---
 
 ## Troubleshooting
-- **Missing tools**: re-run the dependency commands for your OS/arch.
-- **FFmpeg link errors**: use the default `build.sh` (auto-builds FFmpeg), or install system FFmpeg dev packages and run with `BUILD_FFMPEG=no`.
-- **libxmp not found**: install libxmp-dev (Linux), libxmp (macOS/Homebrew), or the MSYS2 package mingw-w64-*-libxmp on Windows.
-- **SDL2 not found / pkg-config errors**: if you see an error mentioning that the sdl2 package is missing from the pkg-config search path, install SDL2 development files.
-- **Windows DLLs**: verify `.\lib\*.dll` exists (local build places FFmpeg DLLs there).
-- **Linux GL compatibility**: try `MESA_GL_VERSION_OVERRIDE=2.1` for a fallback.
+
+* **Missing tools**: re-run the dependency commands for your OS/arch.
+* **FFmpeg link errors**: use the default `build.sh` (auto-builds FFmpeg), or install system FFmpeg dev packages and run with `BUILD_FFMPEG=no`.
+* **libxmp not found**: install libxmp-dev (Linux), libxmp (macOS/Homebrew), or the MSYS2 package mingw-w64-*-libxmp on Windows.
+* **SDL2 not found / pkg-config errors**: if you see an error mentioning that the sdl2 package is missing from the pkg-config search path, install SDL2 development files.
+* **Windows DLLs**: verify `.\lib\*.dll` exists (local build places FFmpeg DLLs there).
+* **Linux GL compatibility**: try `MESA_GL_VERSION_OVERRIDE=2.1` for a fallback.

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SHELL=/bin/bash
 # /src files
 srcFiles=src/resources/defaultConfig.ini \
 	src/anim.go \
+	src/audio_sdl.go \
 	src/bgdef.go \
 	src/bytecode.go \
 	src/camera.go \
@@ -15,28 +16,45 @@ srcFiles=src/resources/defaultConfig.ini \
 	src/config.go \
 	src/dllsearch_windows.go \
 	src/font.go \
+	src/font_gl21.go \
+	src/font_gl32.go \
+	src/font_gles32.go \
+	src/font_vk.go \
+	src/hiscore_rank.go \
 	src/image.go \
 	src/iniutils.go \
 	src/input.go \
-	src/input_glfw.go \
+	src/input_sdl.go \
 	src/lifebar.go \
 	src/main.go \
+	src/motif.go \
+	src/music.go \
 	src/net.go \
+	src/rect.go \
 	src/render.go \
 	src/render_gl.go \
 	src/render_gl_gl32.go \
+	src/render_gl_gles32.go \
+	src/render_vk.go \
 	src/rollback.go \
 	src/script.go \
+	src/select_params.go \
 	src/sound.go \
+	src/sound_xm.go \
 	src/stage.go \
 	src/state.go \
 	src/state_clone.go \
+	src/stats.go \
 	src/stdout_windows.go \
+	src/storyboard.go \
 	src/system.go \
-	src/system_glfw.go \
+	src/system_sdl.go \
+	src/util_android.go \
+	src/util_darwin.go \
 	src/util_desktop.go \
-	src/util_js.go \
+	src/util_linux.go \
 	src/util_raw.go \
+	src/util_windows.go \
 	src/video_ffmpeg.go
 	
 
@@ -85,6 +103,10 @@ appbundle:
 	iconutil -c icns build/icontmp/icon.iconset -o build/icontmp/icon.icns
 	cp build/icontmp/icon.icns I.K.E.M.E.N-Go.app/Contents/Resources/icon.icns
 	rm -rf build/icontmp
+
+.PHONY: android-apk
+android-apk:
+	bash ./build/build_android.sh
 
 clean_appbundle:
 	rm -rf I.K.E.M.E.N-Go.app

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ These instructions are for those interested in developing the Ikemen GO engine i
 
 ### Building
 For setup and platform-specific steps, see [BUILDING.md](./BUILDING.md).
-It covers Windows, Linux (including ARM64), and macOS (Apple Silicon and Intel).
+It covers Windows, Linux (including ARM64), macOS (Apple Silicon and Intel), and Android (APK via Docker).
 
 ### Debugging
 In order to run the compiled Ikemen GO executable, you will need to download the [engine dependencies](https://github.com/ikemen-engine/Ikemen_GO-Elecbyte-Screenpack) and unpack them into the Ikemen-GO source directory. After that, you can use [Goland](https://www.jetbrains.com/go/) or [Visual Studio Code](https://code.visualstudio.com/) to debug.

--- a/build/build_android.sh
+++ b/build/build_android.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build Android APK via Docker Compose.
+# Usage:
+#   ./build/build_android.sh
+#   ./build/build_android.sh --no-build
+#   APP_VERSION=my-build APP_BUILDTIME=2026.01.13 ./build/build_android.sh
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd -P)"
+cd "$REPO_ROOT"
+
+COMPOSE_FILE="$REPO_ROOT/build/docker/android/docker-compose.yml"
+
+pause_always_windows() {
+  local status="${1:-0}"
+  case "$OSTYPE" in
+    msys|cygwin)
+      # Don't pause in CI environments (prevents hanging GitHub Actions).
+      if [[ -n "${CI:-}" || -n "${GITHUB_ACTIONS:-}" ]]; then
+        return 0
+      fi
+      # If stdin/stdout are terminals, wait for a keypress so the window doesn't auto-close.
+      if [[ -t 0 && -t 1 ]]; then
+        echo
+        if [[ "$status" -eq 0 ]]; then
+          printf "Done. Press any key to close..."
+        else
+          printf "Failed (exit %s). Press any key to close..." "$status"
+        fi
+        IFS= read -r -n1 _ || true
+        echo
+      fi
+    ;;
+  esac
+}
+trap 'st=$?; pause_always_windows "$st"' EXIT
+
+DO_BUILD=1
+DO_RUN=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-build)
+      DO_BUILD=0
+      shift
+      ;;
+    --build-only)
+      DO_RUN=0
+      shift
+      ;;
+    -h|--help)
+      cat <<'EOF'
+Usage: ./build/build_android.sh [--no-build] [--build-only]
+
+Builds the Docker image and runs the android-build container to produce:
+  - bin/ikemen-go.apk
+  - bin/libmain.so, bin/libmain.h
+  - lib/*.so
+
+Environment overrides (optional):
+  APP_VERSION, APP_BUILDTIME, ANDROID_APK_REPO, ANDROID_APK_REF, BUILD_ANDROID_APK
+EOF
+      exit 0
+      ;;
+    *)
+      echo "ERROR: Unknown argument: $1" >&2
+      echo "Run with --help for usage." >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Prefer "docker compose" but fall back to legacy "docker-compose" if present.
+if docker compose version >/dev/null 2>&1; then
+  DC=(docker compose -f "$COMPOSE_FILE")
+elif command -v docker-compose >/dev/null 2>&1; then
+  DC=(docker-compose -f "$COMPOSE_FILE")
+else
+  echo "ERROR: docker compose not found. Install Docker / Docker Compose." >&2
+  exit 1
+fi
+
+if [[ "$DO_BUILD" == "1" ]]; then
+  "${DC[@]}" build android-build
+fi
+
+if [[ "$DO_RUN" == "1" ]]; then
+  "${DC[@]}" run --rm android-build
+fi

--- a/build/docker/android/Dockerfile
+++ b/build/docker/android/Dockerfile
@@ -1,0 +1,84 @@
+ARG UBUNTU_VERSION=22.04
+# Default uses Docker Hub; override BASE_IMAGE to use another registry (e.g. ECR Public)
+ARG BASE_IMAGE=ubuntu:22.04
+FROM ${BASE_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG GO_VERSION=1.20.14
+ARG ANDROID_NDK_VERSION=r27d
+ARG ANDROID_NDK_ZIP=android-ndk-${ANDROID_NDK_VERSION}-linux.zip
+ARG ANDROID_NDK_URL=https://dl.google.com/android/repository/${ANDROID_NDK_ZIP}
+
+# Android SDK cmdline tools (can be overridden at build time if Google revs it)
+ARG ANDROID_CMDLINE_TOOLS_ZIP=commandlinetools-linux-11076708_latest.zip
+ARG ANDROID_CMDLINE_TOOLS_URL=https://dl.google.com/android/repository/${ANDROID_CMDLINE_TOOLS_ZIP}
+ARG ANDROID_PLATFORM=android-34
+ARG ANDROID_BUILD_TOOLS=34.0.0
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    ca-certificates \
+    curl \
+    git \
+    unzip \
+    xz-utils \
+    zip \
+    file \
+    binutils \
+    openjdk-17-jdk-headless \
+    build-essential \
+    make \
+    pkg-config \
+    cmake \
+    ninja-build \
+    nasm \
+    yasm \
+    python3 \
+  && rm -rf /var/lib/apt/lists/*
+
+# Go (match CI's ~1.20)
+RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o /tmp/go.tgz \
+  && rm -rf /usr/local/go \
+  && tar -C /usr/local -xzf /tmp/go.tgz \
+  && rm -f /tmp/go.tgz
+
+ENV PATH=/usr/local/go/bin:${PATH}
+ENV GOPATH=/go
+ENV GOMODCACHE=/go/pkg/mod
+
+# Android SDK (for Gradle APK build)
+ENV ANDROID_SDK_ROOT=/opt/android-sdk
+ENV ANDROID_HOME=/opt/android-sdk
+
+RUN mkdir -p "${ANDROID_SDK_ROOT}/cmdline-tools" \
+  && curl -fsSL "${ANDROID_CMDLINE_TOOLS_URL}" -o /tmp/cmdline-tools.zip \
+  && unzip -q /tmp/cmdline-tools.zip -d "${ANDROID_SDK_ROOT}/cmdline-tools" \
+  && rm -f /tmp/cmdline-tools.zip \
+  && if [ -d "${ANDROID_SDK_ROOT}/cmdline-tools/cmdline-tools" ]; then \
+       mv "${ANDROID_SDK_ROOT}/cmdline-tools/cmdline-tools" "${ANDROID_SDK_ROOT}/cmdline-tools/latest"; \
+     fi
+
+ENV PATH=${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin:${ANDROID_SDK_ROOT}/platform-tools:${PATH}
+
+RUN yes | sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" --licenses >/dev/null \
+  && sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" \
+      "platform-tools" \
+      "platforms;${ANDROID_PLATFORM}" \
+      "build-tools;${ANDROID_BUILD_TOOLS}"
+
+# Android NDK r27d
+RUN mkdir -p /opt \
+  && curl -fsSL "${ANDROID_NDK_URL}" -o /tmp/ndk.zip \
+  && unzip -q /tmp/ndk.zip -d /opt \
+  && rm -f /tmp/ndk.zip \
+  && test -d "/opt/android-ndk-${ANDROID_NDK_VERSION}"
+
+ENV ANDROID_NDK_HOME=/opt/android-ndk-r27d
+
+# Workspace (repo is mounted here via docker compose)
+WORKDIR /work
+
+# Avoid "dubious ownership" errors when the repo is volume-mounted
+RUN git config --system --add safe.directory /work || true
+
+CMD ["/bin/bash"]

--- a/build/docker/android/docker-compose.yml
+++ b/build/docker/android/docker-compose.yml
@@ -1,0 +1,54 @@
+services:
+  android-build:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        UBUNTU_VERSION: "22.04"
+        GO_VERSION: "1.20.14"
+        ANDROID_NDK_VERSION: "r27d"
+        #BASE_IMAGE: "${BASE_IMAGE:-public.ecr.aws/docker/library/ubuntu:22.04}"
+        BASE_IMAGE: "${BASE_IMAGE:-ubuntu:22.04}"
+    image: ikemen-go-android-builder:ubuntu-22.04
+    working_dir: /work
+    volumes:
+      # Mount the repo root (this compose file lives in build/docker/android)
+      - ../../..:/work
+      # Cache Go modules/build to speed up rebuilds
+      - go-mod-cache:/go/pkg/mod
+      - go-build-cache:/root/.cache/go-build
+      # Cache Gradle to speed up APK rebuilds
+      - gradle-cache:/root/.gradle
+    environment:
+      # build.sh requires this for Android
+      ANDROID_NDK_HOME: /opt/android-ndk-r27d
+      # These are optional but match CI intent
+      CGO_ENABLED: "1"
+      GOEXPERIMENT: "arenas"
+      APP_VERSION: "${APP_VERSION:-docker-test}"
+      APP_BUILDTIME: "${APP_BUILDTIME:-2026.01.13}"
+      # Build APK automatically (default is 1, but make it explicit in compose)
+      BUILD_ANDROID_APK: "${BUILD_ANDROID_APK:-1}"
+    command: >
+      bash -lc "
+        set -euo pipefail;
+        go env -w GO111MODULE=on;
+        go mod download;
+        ./build/build.sh Android;
+        echo;
+        echo '==> Outputs:';
+        ls -lah bin/ lib/ || true;
+        echo;
+        echo '==> Sanity checks:';
+        test -f bin/libmain.so;
+        file bin/libmain.so || true;
+        (command -v readelf >/dev/null && readelf -d bin/libmain.so | sed -n 's/.*(NEEDED).*/&/p') || true;
+        echo;
+        echo '==> APK:';
+        ls -lah bin/*.apk 2>/dev/null || true;
+      "
+
+volumes:
+  go-mod-cache:
+  go-build-cache:
+  gradle-cache:


### PR DESCRIPTION
Pipeline now builds Android using docker compose, making builds OS-agnostic.
Run build/build_android.sh to build locally.