### PR TITLE
refactor: centralized input read for both Lua and motif.button()

### DIFF
--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -249,7 +249,6 @@ options.t_itemname = {
 			--modifyGameOption('Input.SOCDResolution', 4)
 			--modifyGameOption('Input.ControllerStickSensitivity', 0.4)
 			--modifyGameOption('Input.XinputTriggerSensitivity', 0.5)
-			--modifyGameOption('Input.AnalogDeadTime', 20)
 
 			loadLifebar(motif.files.fight)
 			main.timeFramesPerCount = fightscreenvar("time.framespercount")

--- a/src/config.go
+++ b/src/config.go
@@ -224,7 +224,6 @@ type Config struct {
 		SOCDResolution             int     `ini:"SOCDResolution"`
 		ControllerStickSensitivity float32 `ini:"ControllerStickSensitivity"`
 		XinputTriggerSensitivity   float32 `ini:"XinputTriggerSensitivity"`
-		AnalogDeadTime             int32   `ini:"AnalogDeadTime"`
 	} `ini:"Input"`
 	Keys     map[string]*KeysProperties `ini:"map:^(?i)Keys_P[0-9]+$" lua:"Keys"`
 	Joystick map[string]*KeysProperties `ini:"map:^(?i)Joystick_P[0-9]+$" lua:"Joystick"`

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -372,8 +372,6 @@ SOCDResolution             = 4
 ControllerStickSensitivity = 0.5
 ; XInput trigger sensitivity
 XinputTriggerSensitivity   = 0.5
-; Dead time (in ms) used to limit gamepad analog-axis scrolling behavior.
-AnalogDeadTime = 20
 
 ; -------------------------------------------------------------------------------
 [Keys_P1]

--- a/src/system.go
+++ b/src/system.go
@@ -75,6 +75,7 @@ var sys = System{
 	arenaSaveMap:     make(map[int]*arena.Arena),
 	arenaLoadMap:     make(map[int]*arena.Arena),
 	debugAccel:       1, // TODO: We probably shouldn't rely on this being initialized to 1
+	lastInputController: -1,
 }
 
 type TeamMode int32
@@ -318,6 +319,9 @@ type System struct {
 
 	luaDrawPreOps   []func()
 	luaDrawLayerOps [3][]func()
+
+	lastInputController int
+	uiLastInputToken string
 
 	// For Android support
 	baseDir string


### PR DESCRIPTION
Remove AnalogDeadTime config setting. Instead of duplicating the same code in Lua and Go, both origins use the same motif.button() function.