### PR TITLE
fix: BGMVar(Position) not updating when BGMRAMBuffer is 1, rumble remapping

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -10907,8 +10907,8 @@ func (sc forceFeedback) Run(c *Char, _ []int32) bool {
 		}
 		return true
 	})
-	if crun.controller >= 0 && crun.controller < len(sys.ffbparams) {
-		joy := crun.controller
+	if crun.controller >= 0 && sys.inputRemap[crun.controller] < len(sys.ffbparams) {
+		joy := sys.inputRemap[crun.controller]
 		if newAPI { // New API: just rumble straight away on the ultimately redirected character
 			input.RumbleController(joy, lo, hi, time)
 		} else { // Old API: fill out FFB params
@@ -10917,7 +10917,7 @@ func (sc forceFeedback) Run(c *Char, _ []int32) bool {
 				if crun = crun.p2(); crun == nil {
 					return false
 				}
-				joy = crun.controller
+				joy = sys.inputRemap[crun.controller]
 			}
 			// Don't rumble helpers.
 			if joy >= 0 && joy < len(sys.ffbparams) && crun.helperIndex == 0 {

--- a/src/sound.go
+++ b/src/sound.go
@@ -398,6 +398,7 @@ func (bgm *Bgm) Open(filename string, loop, bgmVolume, bgmLoopStart, bgmLoopEnd,
 	}
 	bgm.startPos = startPosition
 	sw := newSwapSeeker(bgm.streamer)
+	bgm.streamer = sw // fix pos not updating after swapping
 	streamer := newStreamLooper(sw, lc, bgmLoopStart, bgmLoopEnd)
 	// we're going to continue to use our own modified streamLooper because beep doesn't allow
 	// negative values for loopcount (no forever case)


### PR DESCRIPTION
* Fixes an issue where BGMVar(Position) would always return 0 after swapping the buffer when BGMRAMBuffer is 1.
* Fixes #3135