### PR TITLE
feat(script.go): add animPaletteSet, animPaletteGet and sffCacheDelete

### DIFF
--- a/src/script.go
+++ b/src/script.go
@@ -1279,6 +1279,7 @@ func systemScriptInit(l *lua.LState) {
 		return 0
 	})
     luaRegister(l, "animPaletteGet", func(*lua.LState) int {
+		// Userdata
         a, ok := toUserData(l, 1).(*Anim)
         if !ok {
             userDataError(l, 1, a)
@@ -1298,6 +1299,7 @@ func systemScriptInit(l *lua.LState) {
         return 1
     })
     luaRegister(l, "animPaletteSet", func(*lua.LState) int {
+		// Userdata
         a, ok := toUserData(l, 1).(*Anim)
         if !ok {
             userDataError(l, 1, a)


### PR DESCRIPTION
For my color edit module to work, 3 new golang embedded lua functions were created:
- animPaletteSet: Sets a specific color of a loaded animation
- animPaletteGet: Retrieves the color table of a loaded animation
- sffCacheDelete: Clears the sff cache for preloaded animations, allowing for the changes of an animation's color to be visible.
Nothing else is required, just those functions, and no existing functions were changed.