### PR TITLE
feat: ProjID and GuardKO GetHitVar, NoCornerPush; refactoring

### DIFF
--- a/data/functions.zss
+++ b/data/functions.zss
@@ -208,7 +208,7 @@ ignoreHitPause{
 ignoreHitPause{
 	let ret = 0;
 	if receivedDamage != map(_iksys_receivedDamageCurr) {
-		if receivedDamage > 0 && getHitVar(playerNo) != 0 && playerId(getHitVar(id)),teamSide != teamSide {
+		if receivedDamage > 0 && getHitVar(playerNo) != 0 && playerId(getHitVar(playerId)),teamSide != teamSide {
 			map(_iksys_receivedDamageRet) := receivedDamage - map(_iksys_receivedDamageCurr);
 			map(_iksys_receivedDamageFlag) := gameTime;
 		}

--- a/data/score.zss
+++ b/data/score.zss
@@ -83,7 +83,7 @@ ignoreHitPause if !const(Default.Enable.Score) || teamSide = 0 {
 			let dmgMul = 8;
 		}
 		if $dmgMul > 0 {
-			scoreAdd{value: round($ret * $dmgMul, -2); redirectid: getHitVar(id)}
+			scoreAdd{value: round($ret * $dmgMul, -2); redirectid: getHitVar(playerId)}
 		}
 	}	
 	# code executed only by P1 and P2

--- a/src/anim.go
+++ b/src/anim.go
@@ -380,7 +380,7 @@ func (a *Animation) isBlank() bool {
 
 func (a *Animation) isCommonFX() bool {
 	for _, fx := range sys.ffx {
-		if fx.fsff == a.sff {
+		if fx.sff == a.sff { // TODO: This may be a problem in the very unlikely scenario that the same SFF is used in a char and in common FX
 			return true
 		}
 	}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -4373,7 +4373,8 @@ func (sc stateDef) Run(c *Char) {
 			}
 		case stateDef_hitdefpersist:
 			if !exp[0].evalB(c) {
-				c.clearHitDef()
+				//c.clearHitDef()
+				c.hitdef.reset(c, nil)
 				// Reset AttackDist
 				c.hitdef.guard_dist_x = [2]float32{c.size.attack.dist.width[0], c.size.attack.dist.width[1]}
 				c.hitdef.guard_dist_y = [2]float32{c.size.attack.dist.height[0], c.size.attack.dist.height[1]}
@@ -7267,8 +7268,7 @@ func (sc hitDef) Run(c *Char, _ []int32) bool {
 		return false
 	}
 
-	crun.hitdef.clear(crun, crun.localscl)
-	crun.hitdef.playerno = sys.workingState.playerNo
+	crun.hitdef.reset(crun, nil)
 
 	// Mugen 1.1 behavior if invertblend param is omitted
 	if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
@@ -7293,7 +7293,8 @@ func (sc hitDef) Run(c *Char, _ []int32) bool {
 	//	return false
 	//}
 
-	crun.setHitdefDefault(&crun.hitdef)
+	crun.hitdef.finalizeParams(crun, nil)
+
 	return false
 }
 
@@ -7312,8 +7313,7 @@ func (sc reversalDef) Run(c *Char, _ []int32) bool {
 		return false
 	}
 
-	crun.hitdef.clear(crun, crun.localscl)
-	crun.hitdef.playerno = sys.workingState.playerNo
+	crun.hitdef.reset(crun, nil)
 
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
@@ -7331,7 +7331,7 @@ func (sc reversalDef) Run(c *Char, _ []int32) bool {
 		return true
 	})
 
-	crun.setHitdefDefault(&crun.hitdef)
+	crun.hitdef.finalizeParams(crun, nil)
 
 	return false
 }
@@ -7582,7 +7582,7 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 		return true
 	})
 
-	crun.setHitdefDefault(&p.hitdef)
+	p.hitdef.finalizeParams(crun, p)
 
 	if p.hitanim == -1 {
 		p.hitanim_ffx = p.anim_ffx

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -649,7 +649,7 @@ const (
 	OC_ex_inputtime_w
 	OC_ex_inputtime_m
 	OC_ex_movehitvar_frame
-	OC_ex_movehitvar_cornerpush
+	OC_ex_movehitvar_cornerpush_veloff
 	OC_ex_movehitvar_id
 	OC_ex_movehitvar_overridden
 	OC_ex_movehitvar_playerno
@@ -3102,8 +3102,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_min:
 		v2 := sys.bcStack.Pop()
 		be.min(sys.bcStack.Top(), v2)
-	case OC_ex_movehitvar_cornerpush:
-		sys.bcStack.PushF(c.mhv.cornerpush)
+	case OC_ex_movehitvar_cornerpush_veloff:
+		sys.bcStack.PushF(c.mhv.cornerpush_veloff)
 	case OC_ex_movehitvar_frame:
 		sys.bcStack.PushB(c.mhv.frame)
 	case OC_ex_movehitvar_id:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -558,7 +558,7 @@ const (
 	OC_ex_gethitvar_attr
 	OC_ex_gethitvar_dizzypoints
 	OC_ex_gethitvar_guardpoints
-	OC_ex_gethitvar_id
+	OC_ex_gethitvar_playerid
 	OC_ex_gethitvar_playerno
 	OC_ex_gethitvar_redlife
 	OC_ex_gethitvar_score
@@ -966,6 +966,7 @@ const (
 	OC_ex2_numstagebg
 	OC_ex2_envshakevar_dir
 	OC_ex2_gethitvar_fall_envshake_dir
+	OC_ex2_gethitvar_projid
 	OC_ex2_xshear
 	OC_ex2_zoomvar_scale
 	OC_ex2_zoomvar_pos_x
@@ -2816,10 +2817,10 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(c.ghv.dizzypoints)
 	case OC_ex_gethitvar_guardpoints:
 		sys.bcStack.PushI(c.ghv.guardpoints)
-	case OC_ex_gethitvar_id:
-		sys.bcStack.PushI(c.ghv.playerId)
+	case OC_ex_gethitvar_playerid:
+		sys.bcStack.PushI(c.ghv.playerid)
 	case OC_ex_gethitvar_playerno:
-		sys.bcStack.PushI(int32(c.ghv.playerNo) + 1)
+		sys.bcStack.PushI(int32(c.ghv.playerno) + 1)
 	case OC_ex_gethitvar_redlife:
 		sys.bcStack.PushI(c.ghv.redlife)
 	case OC_ex_gethitvar_score:
@@ -3106,11 +3107,11 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_movehitvar_frame:
 		sys.bcStack.PushB(c.mhv.frame)
 	case OC_ex_movehitvar_id:
-		sys.bcStack.PushI(c.mhv.playerId)
+		sys.bcStack.PushI(c.mhv.playerid)
 	case OC_ex_movehitvar_overridden:
 		sys.bcStack.PushB(c.mhv.overridden)
 	case OC_ex_movehitvar_playerno:
-		sys.bcStack.PushI(int32(c.mhv.playerNo))
+		sys.bcStack.PushI(int32(c.mhv.playerno) + 1)
 	case OC_ex_movehitvar_spark_x:
 		sys.bcStack.PushF(c.mhv.sparkxy[0] * (c.localscl / oc.localscl))
 	case OC_ex_movehitvar_spark_y:
@@ -3888,6 +3889,8 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(sys.envShake.dir / float32(math.Pi) * 180)
 	case OC_ex2_gethitvar_fall_envshake_dir:
 		sys.bcStack.PushF(c.ghv.fall_envshake_dir)
+	case OC_ex2_gethitvar_projid: // TODO: Move these next to other gethitvar
+		sys.bcStack.PushI(c.ghv.projid)
 	case OC_ex2_xshear:
 		sys.bcStack.PushF(c.xshear)
 	case OC_ex2_zoomvar_scale:
@@ -7265,7 +7268,7 @@ func (sc hitDef) Run(c *Char, _ []int32) bool {
 	}
 
 	crun.hitdef.clear(crun, crun.localscl)
-	crun.hitdef.playerNo = sys.workingState.playerNo
+	crun.hitdef.playerno = sys.workingState.playerNo
 
 	// Mugen 1.1 behavior if invertblend param is omitted
 	if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
@@ -7310,7 +7313,7 @@ func (sc reversalDef) Run(c *Char, _ []int32) bool {
 	}
 
 	crun.hitdef.clear(crun, crun.localscl)
-	crun.hitdef.playerNo = sys.workingState.playerNo
+	crun.hitdef.playerno = sys.workingState.playerNo
 
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
@@ -13702,9 +13705,9 @@ func (sc getHitVarSet) Run(c *Char, _ []int32) bool {
 		case getHitVarSet_hitshaketime:
 			crun.ghv.hitshaketime = exp[0].evalI(c)
 		case getHitVarSet_id:
-			crun.ghv.playerId = exp[0].evalI(c)
+			crun.ghv.playerid = exp[0].evalI(c)
 		case getHitVarSet_playerno:
-			crun.ghv.playerNo = int(exp[0].evalI(c))
+			crun.ghv.playerno = int(exp[0].evalI(c))
 		case getHitVarSet_redlife:
 			crun.ghv.redlife = exp[0].evalI(c)
 		case getHitVarSet_slidetime:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -555,11 +555,13 @@ const (
 	OC_ex_gethitvar_fall_envshake_ampl
 	OC_ex_gethitvar_fall_envshake_phase
 	OC_ex_gethitvar_fall_envshake_mul
+	OC_ex_gethitvar_fall_envshake_dir
 	OC_ex_gethitvar_attr
 	OC_ex_gethitvar_dizzypoints
 	OC_ex_gethitvar_guardpoints
 	OC_ex_gethitvar_playerid
 	OC_ex_gethitvar_playerno
+	OC_ex_gethitvar_projid
 	OC_ex_gethitvar_redlife
 	OC_ex_gethitvar_score
 	OC_ex_gethitvar_hitdamage
@@ -593,6 +595,7 @@ const (
 	OC_ex_gethitvar_stand_friction
 	OC_ex_gethitvar_crouch_friction
 	OC_ex_gethitvar_keepstate
+	OC_ex_gethitvar_guardko
 	OC_ex_ailevelf
 	OC_ex_animelemvar_alphadest
 	OC_ex_animelemvar_angle
@@ -713,6 +716,7 @@ const (
 	OC_ex_envshakevar_time
 	OC_ex_envshakevar_freq
 	OC_ex_envshakevar_ampl
+	OC_ex_envshakevar_dir
 	OC_ex_angle
 	OC_ex_scale_x
 	OC_ex_scale_y
@@ -722,22 +726,23 @@ const (
 	OC_ex_alpha_s
 	OC_ex_alpha_d
 	OC_ex_selfcommand
-	OC_ex_fightscreenvar_info_author
-	OC_ex_fightscreenvar_info_localcoord_x
-	OC_ex_fightscreenvar_info_localcoord_y
-	OC_ex_fightscreenvar_info_name
-	OC_ex_fightscreenvar_round_ctrl_time
-	OC_ex_fightscreenvar_round_over_hittime
-	OC_ex_fightscreenvar_round_over_time
-	OC_ex_fightscreenvar_round_over_waittime
-	OC_ex_fightscreenvar_round_over_wintime
-	OC_ex_fightscreenvar_round_slow_time
-	OC_ex_fightscreenvar_round_start_waittime
-	OC_ex_fightscreenvar_round_callfight_time
-	OC_ex_fightscreenvar_time_framespercount
+
 )
 const (
 	OC_ex2_index OpCode = iota
+	OC_ex2_fightscreenvar_info_author
+	OC_ex2_fightscreenvar_info_localcoord_x
+	OC_ex2_fightscreenvar_info_localcoord_y
+	OC_ex2_fightscreenvar_info_name
+	OC_ex2_fightscreenvar_round_ctrl_time
+	OC_ex2_fightscreenvar_round_over_hittime
+	OC_ex2_fightscreenvar_round_over_time
+	OC_ex2_fightscreenvar_round_over_waittime
+	OC_ex2_fightscreenvar_round_over_wintime
+	OC_ex2_fightscreenvar_round_slow_time
+	OC_ex2_fightscreenvar_round_start_waittime
+	OC_ex2_fightscreenvar_round_callfight_time
+	OC_ex2_fightscreenvar_time_framespercount
 	OC_ex2_groundlevel
 	OC_ex2_layerno
 	OC_ex2_runorder
@@ -964,9 +969,6 @@ const (
 	OC_ex2_stagebgvar_velocity_x
 	OC_ex2_stagebgvar_velocity_y
 	OC_ex2_numstagebg
-	OC_ex2_envshakevar_dir
-	OC_ex2_gethitvar_fall_envshake_dir
-	OC_ex2_gethitvar_projid
 	OC_ex2_xshear
 	OC_ex2_zoomvar_scale
 	OC_ex2_zoomvar_pos_x
@@ -978,15 +980,16 @@ const (
 	OC_ex2_defencemul
 	OC_ex2_guardcount
 	OC_ex2_airjumpcount
-	OC_ex2_analog_leftx
-	OC_ex2_analog_lefty
-	OC_ex2_analog_rightx
-	OC_ex2_analog_righty
-	OC_ex2_analog_lefttrigger
-	OC_ex2_analog_righttrigger
+
 )
 const (
-	OC_ex3_helpervar_clsnproxy OpCode = iota
+	OC_ex3_analog_leftx OpCode = iota
+	OC_ex3_analog_lefty
+	OC_ex3_analog_rightx
+	OC_ex3_analog_righty
+	OC_ex3_analog_lefttrigger
+	OC_ex3_analog_righttrigger
+	OC_ex3_helpervar_clsnproxy
 	OC_ex3_helpervar_helpertype
 	OC_ex3_helpervar_id
 	OC_ex3_helpervar_keyctrl
@@ -2700,6 +2703,7 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		*sys.bcStack.Top() = c.constp(1280, sys.bcStack.Top().ToF())
 	case OC_ex_const1080p:
 		*sys.bcStack.Top() = c.constp(1920, sys.bcStack.Top().ToF())
+	// GetHitVar
 	case OC_ex_gethitvar_animtype:
 		sys.bcStack.PushI(int32(c.ghv.animtype))
 	case OC_ex_gethitvar_air_animtype:
@@ -2808,6 +2812,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.ghv.fall_envshake_phase)
 	case OC_ex_gethitvar_fall_envshake_mul:
 		sys.bcStack.PushF(c.ghv.fall_envshake_mul)
+	case OC_ex_gethitvar_fall_envshake_dir:
+		sys.bcStack.PushF(c.ghv.fall_envshake_dir)
 	case OC_ex_gethitvar_attr:
 		attr := (*(*int32)(unsafe.Pointer(&be[*i])))
 		// same as c.hitDefAttr()
@@ -2821,6 +2827,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(c.ghv.playerid)
 	case OC_ex_gethitvar_playerno:
 		sys.bcStack.PushI(int32(c.ghv.playerno) + 1)
+	case OC_ex_gethitvar_projid:
+		sys.bcStack.PushI(c.ghv.projid)
 	case OC_ex_gethitvar_redlife:
 		sys.bcStack.PushI(c.ghv.redlife)
 	case OC_ex_gethitvar_score:
@@ -2883,6 +2891,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		*i += 4
 	case OC_ex_gethitvar_keepstate:
 		sys.bcStack.PushB(c.ghv.keepstate)
+	case OC_ex_gethitvar_guardko:
+		sys.bcStack.PushB(c.ghv.guardko)
 	case OC_ex_ailevelf:
 		if c.asf(ASF_noailevel) {
 			sys.bcStack.PushI(0)
@@ -2969,36 +2979,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(sys.envShake.freq / float32(math.Pi) * 180)
 	case OC_ex_envshakevar_ampl:
 		sys.bcStack.PushF(float32(math.Abs(float64(sys.envShake.ampl / oc.localscl))))
-	case OC_ex_fightscreenvar_info_author:
-		sys.bcStack.PushB(sys.lifebar.authorLow ==
-			sys.stringPool[sys.workingState.playerNo].List[*(*int32)(unsafe.Pointer(&be[*i]))])
-		*i += 4
-	case OC_ex_fightscreenvar_info_localcoord_x:
-		sys.bcStack.PushI(sys.lifebar.localcoord[0])
-	case OC_ex_fightscreenvar_info_localcoord_y:
-		sys.bcStack.PushI(sys.lifebar.localcoord[1])
-	case OC_ex_fightscreenvar_info_name:
-		sys.bcStack.PushB(sys.lifebar.nameLow ==
-			sys.stringPool[sys.workingState.playerNo].List[*(*int32)(unsafe.Pointer(&be[*i]))])
-		*i += 4
-	case OC_ex_fightscreenvar_round_ctrl_time:
-		sys.bcStack.PushI(sys.lifebar.ro.ctrl_time)
-	case OC_ex_fightscreenvar_round_over_hittime:
-		sys.bcStack.PushI(sys.lifebar.ro.over_hittime)
-	case OC_ex_fightscreenvar_round_over_time:
-		sys.bcStack.PushI(sys.lifebar.ro.over_time)
-	case OC_ex_fightscreenvar_round_over_waittime:
-		sys.bcStack.PushI(sys.lifebar.ro.over_waittime)
-	case OC_ex_fightscreenvar_round_over_wintime:
-		sys.bcStack.PushI(sys.lifebar.ro.over_wintime)
-	case OC_ex_fightscreenvar_round_slow_time:
-		sys.bcStack.PushI(sys.lifebar.ro.slow_time)
-	case OC_ex_fightscreenvar_round_start_waittime:
-		sys.bcStack.PushI(sys.lifebar.ro.start_waittime)
-	case OC_ex_fightscreenvar_round_callfight_time:
-		sys.bcStack.PushI(sys.lifebar.ro.callfight_time)
-	case OC_ex_fightscreenvar_time_framespercount:
-		sys.bcStack.PushI(sys.lifebar.ti.framespercount)
+	case OC_ex_envshakevar_dir:
+		sys.bcStack.PushF(sys.envShake.dir / float32(math.Pi) * 180)
 	case OC_ex_fighttime:
 		sys.bcStack.PushI(sys.matchTime)
 	case OC_ex_firstattack:
@@ -3267,6 +3249,36 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	switch opc {
 	case OC_ex2_index:
 		sys.bcStack.PushI(c.indexTrigger())
+	case OC_ex2_fightscreenvar_info_author:
+		sys.bcStack.PushB(sys.lifebar.authorLow ==
+			sys.stringPool[sys.workingState.playerNo].List[*(*int32)(unsafe.Pointer(&be[*i]))])
+		*i += 4
+	case OC_ex2_fightscreenvar_info_localcoord_x:
+		sys.bcStack.PushI(sys.lifebar.localcoord[0])
+	case OC_ex2_fightscreenvar_info_localcoord_y:
+		sys.bcStack.PushI(sys.lifebar.localcoord[1])
+	case OC_ex2_fightscreenvar_info_name:
+		sys.bcStack.PushB(sys.lifebar.nameLow ==
+			sys.stringPool[sys.workingState.playerNo].List[*(*int32)(unsafe.Pointer(&be[*i]))])
+		*i += 4
+	case OC_ex2_fightscreenvar_round_ctrl_time:
+		sys.bcStack.PushI(sys.lifebar.ro.ctrl_time)
+	case OC_ex2_fightscreenvar_round_over_hittime:
+		sys.bcStack.PushI(sys.lifebar.ro.over_hittime)
+	case OC_ex2_fightscreenvar_round_over_time:
+		sys.bcStack.PushI(sys.lifebar.ro.over_time)
+	case OC_ex2_fightscreenvar_round_over_waittime:
+		sys.bcStack.PushI(sys.lifebar.ro.over_waittime)
+	case OC_ex2_fightscreenvar_round_over_wintime:
+		sys.bcStack.PushI(sys.lifebar.ro.over_wintime)
+	case OC_ex2_fightscreenvar_round_slow_time:
+		sys.bcStack.PushI(sys.lifebar.ro.slow_time)
+	case OC_ex2_fightscreenvar_round_start_waittime:
+		sys.bcStack.PushI(sys.lifebar.ro.start_waittime)
+	case OC_ex2_fightscreenvar_round_callfight_time:
+		sys.bcStack.PushI(sys.lifebar.ro.callfight_time)
+	case OC_ex2_fightscreenvar_time_framespercount:
+		sys.bcStack.PushI(sys.lifebar.ti.framespercount)
 	case OC_ex2_groundlevel:
 		sys.bcStack.PushF(c.groundLevel * (c.localscl / oc.localscl))
 	case OC_ex2_layerno:
@@ -3885,12 +3897,6 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		}
 	case OC_ex2_numstagebg:
 		*sys.bcStack.Top() = c.numStageBG(*sys.bcStack.Top())
-	case OC_ex2_envshakevar_dir:
-		sys.bcStack.PushF(sys.envShake.dir / float32(math.Pi) * 180)
-	case OC_ex2_gethitvar_fall_envshake_dir:
-		sys.bcStack.PushF(c.ghv.fall_envshake_dir)
-	case OC_ex2_gethitvar_projid: // TODO: Move these next to other gethitvar
-		sys.bcStack.PushI(c.ghv.projid)
 	case OC_ex2_xshear:
 		sys.bcStack.PushF(c.xshear)
 	case OC_ex2_zoomvar_scale:
@@ -3916,18 +3922,6 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(c.guardCount)
 	case OC_ex2_airjumpcount:
 		sys.bcStack.PushI(c.airJumpCount)
-	case OC_ex2_analog_leftx:
-		sys.bcStack.PushF(c.analogAxes[0])
-	case OC_ex2_analog_lefty:
-		sys.bcStack.PushF(c.analogAxes[1])
-	case OC_ex2_analog_rightx:
-		sys.bcStack.PushF(c.analogAxes[2])
-	case OC_ex2_analog_righty:
-		sys.bcStack.PushF(c.analogAxes[3])
-	case OC_ex2_analog_lefttrigger:
-		sys.bcStack.PushF(c.analogAxes[4])
-	case OC_ex2_analog_righttrigger:
-		sys.bcStack.PushF(c.analogAxes[5])
 	default:
 		sys.errLog.Printf("%v\n", be[*i-1])
 		c.panic()
@@ -3938,6 +3932,18 @@ func (be BytecodeExp) run_ex3(c *Char, i *int, oc *Char) {
 	(*i)++
 	opc := be[*i-1]
 	switch opc {
+	case OC_ex3_analog_leftx:
+		sys.bcStack.PushF(c.analogAxes[0])
+	case OC_ex3_analog_lefty:
+		sys.bcStack.PushF(c.analogAxes[1])
+	case OC_ex3_analog_rightx:
+		sys.bcStack.PushF(c.analogAxes[2])
+	case OC_ex3_analog_righty:
+		sys.bcStack.PushF(c.analogAxes[3])
+	case OC_ex3_analog_lefttrigger:
+		sys.bcStack.PushF(c.analogAxes[4])
+	case OC_ex3_analog_righttrigger:
+		sys.bcStack.PushF(c.analogAxes[5])
 	// HelperVar
 	case OC_ex3_helpervar_clsnproxy, OC_ex3_helpervar_id, OC_ex3_helpervar_helpertype,
 		OC_ex3_helpervar_keyctrl, OC_ex3_helpervar_ownclsnscale, OC_ex3_helpervar_ownpal,

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3272,7 +3272,7 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	case OC_ex2_layerno:
 		sys.bcStack.PushI(c.layerNo)
 	case OC_ex2_runorder:
-		sys.bcStack.PushI(c.runorder)
+		sys.bcStack.PushI(c.runOrderTrigger())
 	case OC_ex2_palfxvar_time:
 		sys.bcStack.PushI(c.palfxvar(0))
 	case OC_ex2_palfxvar_addr:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -653,8 +653,8 @@ const (
 	OC_ex_inputtime_m
 	OC_ex_movehitvar_frame
 	OC_ex_movehitvar_cornerpush_veloff
-	OC_ex_movehitvar_id
 	OC_ex_movehitvar_overridden
+	OC_ex_movehitvar_playerid
 	OC_ex_movehitvar_playerno
 	OC_ex_movehitvar_spark_x
 	OC_ex_movehitvar_spark_y
@@ -3088,7 +3088,7 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.mhv.cornerpush_veloff)
 	case OC_ex_movehitvar_frame:
 		sys.bcStack.PushB(c.mhv.frame)
-	case OC_ex_movehitvar_id:
+	case OC_ex_movehitvar_playerid:
 		sys.bcStack.PushI(c.mhv.playerid)
 	case OC_ex_movehitvar_overridden:
 		sys.bcStack.PushB(c.mhv.overridden)

--- a/src/char.go
+++ b/src/char.go
@@ -5917,8 +5917,8 @@ func (c *Char) playSound(ffx string, lowpriority bool, loopCount int32, g, n, ch
 			s = c.gi().snd.Get([...]int32{g, n})
 		}
 	} else {
-		if sys.ffx[current_ffx] != nil && sys.ffx[current_ffx].fsnd != nil {
-			s = sys.ffx[current_ffx].fsnd.Get([...]int32{g, n})
+		if sys.ffx[current_ffx] != nil && sys.ffx[current_ffx].snd != nil {
+			s = sys.ffx[current_ffx].snd.Get([...]int32{g, n})
 		}
 	}
 	if s == nil {
@@ -6684,8 +6684,8 @@ func (c *Char) getAnim(n int32, ffx string, fx bool) (a *Animation) {
 	}
 
 	if current_ffx != "" && current_ffx != "s" {
-		if sys.ffx[current_ffx] != nil && sys.ffx[current_ffx].fat != nil {
-			a = sys.ffx[current_ffx].fat.get(n)
+		if sys.ffx[current_ffx] != nil && sys.ffx[current_ffx].animTable != nil {
+			a = sys.ffx[current_ffx].animTable.get(n)
 		}
 	} else {
 		a = c.gi().animTable.get(n)
@@ -6734,7 +6734,7 @@ func (c *Char) animSpriteSetup(a *Animation, spritePN int, ffx string, ownpal bo
 
 	if a.isCommonFX() {
 		for _, fx := range sys.ffx { // A little redundant since isCommonFX also does this loop, but easier to read
-			if fx.fsff == a.sff {
+			if fx.sff == a.sff {
 				// Calculate scale
 				// With the addition of variable viewport, we should now calculate the scale each time instead of precomputing it
 				scale := fx.fx_scale
@@ -8661,8 +8661,8 @@ func (c *Char) appendLifebarAction(text, s_ffx, a_ffx string, snd, spr [2]int32,
 
 	// Play sound
 	if snd[0] != -1 && snd[1] != -1 {
-		if s_ffx != "" && s_ffx != "s" && sys.ffx[s_ffx] != nil && sys.ffx[s_ffx].fsnd != nil {
-			s := sys.ffx[s_ffx].fsnd.Get(snd) //Common FX
+		if s_ffx != "" && s_ffx != "s" && sys.ffx[s_ffx] != nil && sys.ffx[s_ffx].snd != nil {
+			s := sys.ffx[s_ffx].snd.Get(snd) //Common FX
 			if s != nil {
 				sys.soundChannels.Play(s, snd[0], snd[1], 100, 0, 0, 0, 0)
 			}
@@ -8732,12 +8732,12 @@ func (c *Char) appendLifebarAction(text, s_ffx, a_ffx string, snd, spr [2]int32,
 		teammsg.is[fmt.Sprintf("team%v.front.spr", c.teamside+1)] = fmt.Sprintf("%v,%v", spr[0], spr[1])
 	}
 	// Read background
-	msg.bg = ReadAnimLayout(fmt.Sprintf("team%v.bg.", c.teamside+1), teammsg.is, sys.lifebar.sff, sys.lifebar.at, 2)
+	msg.bg = ReadAnimLayout(fmt.Sprintf("team%v.bg.", c.teamside+1), teammsg.is, sys.lifebar.sff, sys.lifebar.animTable, 2)
 	// Read front
 	if a_ffx != "" && a_ffx != "s" { //Common FX
-		msg.front = ReadAnimLayout(fmt.Sprintf("team%v.front.", c.teamside+1), teammsg.is, sys.ffx[a_ffx].fsff, sys.ffx[a_ffx].fat, 2)
+		msg.front = ReadAnimLayout(fmt.Sprintf("team%v.front.", c.teamside+1), teammsg.is, sys.ffx[a_ffx].sff, sys.ffx[a_ffx].animTable, 2)
 	} else {
-		msg.front = ReadAnimLayout(fmt.Sprintf("team%v.front.", c.teamside+1), teammsg.is, sys.lifebar.sff, sys.lifebar.at, 2)
+		msg.front = ReadAnimLayout(fmt.Sprintf("team%v.front.", c.teamside+1), teammsg.is, sys.lifebar.sff, sys.lifebar.animTable, 2)
 	}
 
 	// Insert new message

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2567,7 +2567,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			opc = OC_ex_gethitvar_dizzypoints
 		case "guardpoints":
 			opc = OC_ex_gethitvar_guardpoints
-		case "playerid", "id":
+		case "playerid", "id": // "ID" is deprecated
 			opc = OC_ex_gethitvar_playerid
 		case "playerno":
 			opc = OC_ex_gethitvar_playerno
@@ -4847,8 +4847,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.append(OC_ex_movehitvar_cornerpush_veloff)
 		case "frame":
 			out.append(OC_ex_movehitvar_frame)
-		case "id":
-			out.append(OC_ex_movehitvar_id)
+		case "playerid", "id": // "ID" is deprecated
+			out.append(OC_ex_movehitvar_playerid)
 		case "overridden":
 			out.append(OC_ex_movehitvar_overridden)
 		case "playerno":

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -4645,6 +4645,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nobrake))
 		case "nocombodisplay":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nocombodisplay))
+		case "nocornerpush":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nocornerpush))
 		case "nocrouch":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nocrouch))
 		case "nodizzypointsdamage":
@@ -4845,8 +4847,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		}
 		out.append(OC_ex_)
 		switch c.token {
-		case "cornerpush":
-			out.append(OC_ex_movehitvar_cornerpush)
+		case "cornerpush.veloff":
+			out.append(OC_ex_movehitvar_cornerpush_veloff)
 		case "frame":
 			out.append(OC_ex_movehitvar_frame)
 		case "id":

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1692,17 +1692,17 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 
 		switch c.token {
 		case "leftx":
-			opc = OC_ex2_analog_leftx
+			opc = OC_ex3_analog_leftx
 		case "lefty":
-			opc = OC_ex2_analog_lefty
+			opc = OC_ex3_analog_lefty
 		case "rightx":
-			opc = OC_ex2_analog_rightx
+			opc = OC_ex3_analog_rightx
 		case "righty":
-			opc = OC_ex2_analog_righty
+			opc = OC_ex3_analog_righty
 		case "lefttrigger":
-			opc = OC_ex2_analog_lefttrigger
+			opc = OC_ex3_analog_lefttrigger
 		case "righttrigger":
-			opc = OC_ex2_analog_righttrigger
+			opc = OC_ex3_analog_righttrigger
 		default:
 			return bvNone(), Error(fmt.Sprintf("Invalid Analog axis: %s", c.token))
 		}
@@ -1712,7 +1712,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		if err := c.checkClosingParenthesis(); err != nil {
 			return bvNone(), err
 		}
-		out.append(OC_ex2_, opc)
+		out.append(OC_ex3_, opc)
 	case "anim":
 		out.append(OC_anim)
 	case "animelemno":
@@ -2464,7 +2464,6 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		if err := c.checkOpeningParenthesis(in); err != nil {
 			return bvNone(), err
 		}
-		opct := OC_ex_
 		isFlag := 0
 		switch c.token {
 		case "animtype":
@@ -2560,8 +2559,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "fall.envshake.mul":
 			opc = OC_ex_gethitvar_fall_envshake_mul
 		case "fall.envshake.dir":
-			opct = OC_ex2_
-			opc = OC_ex2_gethitvar_fall_envshake_dir
+			opc = OC_ex_gethitvar_fall_envshake_dir
 		case "attr":
 			opc = OC_ex_gethitvar_attr
 			isFlag = 1
@@ -2633,8 +2631,9 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "keepstate":
 			opc = OC_ex_gethitvar_keepstate
 		case "projid":
-			opct = OC_ex2_
-			opc = OC_ex2_gethitvar_projid
+			opc = OC_ex_gethitvar_projid
+		case "guardko":
+			opc = OC_ex_gethitvar_guardko
 		default:
 			return bvNone(), Error("Invalid GetHitVar argument: " + c.token)
 		}
@@ -2649,7 +2648,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				if attr, err := c.trgAttr(in); err != nil {
 					return err
 				} else {
-					out.append(opct)
+					out.append(OC_ex_)
 					out.appendI32Op(opc, attr)
 				}
 				return nil
@@ -2663,7 +2662,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				if flg, err := flagSub(); err != nil {
 					return err
 				} else {
-					out.append(opct)
+					out.append(OC_ex_)
 					out.appendI32Op(opc, flg)
 					return nil
 				}
@@ -2673,9 +2672,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			}
 		case 0:
 			// no flag
-			out.append(opct, opc)
+			out.append(OC_ex_, opc)
 		}
-		// no-op (for y/xveladd and fall.envshake.dir)
 	case "groundlevel":
 		out.append(OC_ex2_, OC_ex2_groundlevel)
 	case "guardcount":
@@ -4378,7 +4376,6 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		if err := c.checkOpeningParenthesis(in); err != nil {
 			return bvNone(), err
 		}
-		opct := OC_ex_
 		switch c.token {
 		case "time":
 			opc = OC_ex_envshakevar_time
@@ -4387,12 +4384,11 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		case "ampl":
 			opc = OC_ex_envshakevar_ampl
 		case "dir":
-			opct = OC_ex2_
-			opc = OC_ex2_envshakevar_dir
+			opc = OC_ex_envshakevar_dir
 		default:
 			return bvNone(), Error("Invalid EnvShakeVar argument: " + c.token)
 		}
-		out.append(opct, opc)
+		out.append(OC_ex_, opc)
 		c.token = c.tokenizer(in)
 		if err := c.checkClosingParenthesis(); err != nil {
 			return bvNone(), err
@@ -4432,42 +4428,42 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		isStr := false
 		switch fsvname {
 		case "info.author":
-			opc = OC_ex_fightscreenvar_info_author
+			opc = OC_ex2_fightscreenvar_info_author
 			isStr = true
 		case "info.localcoord.x":
-			opc = OC_ex_fightscreenvar_info_localcoord_x
+			opc = OC_ex2_fightscreenvar_info_localcoord_x
 		case "info.localcoord.y":
-			opc = OC_ex_fightscreenvar_info_localcoord_y
+			opc = OC_ex2_fightscreenvar_info_localcoord_y
 		case "info.name":
-			opc = OC_ex_fightscreenvar_info_name
+			opc = OC_ex2_fightscreenvar_info_name
 			isStr = true
 		case "round.ctrl.time":
-			opc = OC_ex_fightscreenvar_round_ctrl_time
+			opc = OC_ex2_fightscreenvar_round_ctrl_time
 		case "round.over.hittime":
-			opc = OC_ex_fightscreenvar_round_over_hittime
+			opc = OC_ex2_fightscreenvar_round_over_hittime
 		case "round.over.time":
-			opc = OC_ex_fightscreenvar_round_over_time
+			opc = OC_ex2_fightscreenvar_round_over_time
 		case "round.over.waittime":
-			opc = OC_ex_fightscreenvar_round_over_waittime
+			opc = OC_ex2_fightscreenvar_round_over_waittime
 		case "round.over.wintime":
-			opc = OC_ex_fightscreenvar_round_over_wintime
+			opc = OC_ex2_fightscreenvar_round_over_wintime
 		case "round.slow.time":
-			opc = OC_ex_fightscreenvar_round_slow_time
+			opc = OC_ex2_fightscreenvar_round_slow_time
 		case "round.start.waittime":
-			opc = OC_ex_fightscreenvar_round_start_waittime
+			opc = OC_ex2_fightscreenvar_round_start_waittime
 		case "round.callfight.time":
-			opc = OC_ex_fightscreenvar_round_callfight_time
+			opc = OC_ex2_fightscreenvar_round_callfight_time
 		case "time.framespercount":
-			opc = OC_ex_fightscreenvar_time_framespercount
+			opc = OC_ex2_fightscreenvar_time_framespercount
 		default:
 			return bvNone(), Error("Invalid FightScreenVar argument: " + fsvname)
 		}
 		if isStr {
-			if err := nameSub(OC_ex_, opc); err != nil {
+			if err := nameSub(OC_ex2_, opc); err != nil {
 				return bvNone(), err
 			}
 		} else {
-			out.append(OC_ex_)
+			out.append(OC_ex2_)
 			out.append(opc)
 		}
 	case "fighttime":

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2569,8 +2569,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			opc = OC_ex_gethitvar_dizzypoints
 		case "guardpoints":
 			opc = OC_ex_gethitvar_guardpoints
-		case "id":
-			opc = OC_ex_gethitvar_id
+		case "playerid", "id":
+			opc = OC_ex_gethitvar_playerid
 		case "playerno":
 			opc = OC_ex_gethitvar_playerno
 		case "redlife":
@@ -2632,6 +2632,9 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			isFlag = 2
 		case "keepstate":
 			opc = OC_ex_gethitvar_keepstate
+		case "projid":
+			opct = OC_ex2_
+			opc = OC_ex2_gethitvar_projid
 		default:
 			return bvNone(), Error("Invalid GetHitVar argument: " + c.token)
 		}

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -203,6 +203,8 @@ func (c *Compiler) assertSpecial(is IniSection, sc *StateControllerBase, _ int8)
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nobrake)))
 			case "nocombodisplay":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nocombodisplay)))
+			case "nocornerpush":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nocornerpush)))
 			case "nocrouch":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nocrouch)))
 			case "nodizzypointsdamage":

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -49,10 +49,10 @@ func (wt *WinType) SetPerfect() {
 }
 
 type FightFx struct {
-	fat        AnimationTable
+	animTable  AnimationTable
 	fileName   string
-	fsff       *Sff
-	fsnd       *Snd
+	sff        *Sff
+	snd        *Snd
 	fx_scale   float32
 	localcoord [2]float32
 	refCount   int
@@ -61,7 +61,7 @@ type FightFx struct {
 
 func newFightFx() *FightFx {
 	return &FightFx{
-		fsff:       &Sff{},
+		sff:       &Sff{},
 		fx_scale:   1.0,
 		localcoord: [2]float32{float32(sys.lifebar.localcoord[0]), float32(sys.lifebar.localcoord[1])},
 	}
@@ -127,7 +127,7 @@ func loadFightFx(def string, isGlobal bool, isMainThread bool) error {
 						if err != nil {
 							return err
 						}
-						*ffx.fsff = *s
+						*ffx.sff = *s
 						return nil
 					}); err != nil {
 					return err
@@ -139,14 +139,14 @@ func loadFightFx(def string, isGlobal bool, isMainThread bool) error {
 							return err
 						}
 						lines, i := SplitAndTrim(str, "\n"), 0
-						ffx.fat = ReadAnimationTable(ffx.fsff, &ffx.fsff.palList, lines, &i)
+						ffx.animTable = ReadAnimationTable(ffx.sff, &ffx.sff.palList, lines, &i)
 						return nil
 					}); err != nil {
 					return err
 				}
 				if is.LoadFile("snd", []string{def, sys.motif.Def, "", "data/"},
 					func(filename string) error {
-						ffx.fsnd, err = LoadSnd(filename)
+						ffx.snd, err = LoadSnd(filename)
 						return err
 					}); err != nil {
 					return err
@@ -156,7 +156,7 @@ func loadFightFx(def string, isGlobal bool, isMainThread bool) error {
 	}
 	// Set fx scale to anims
 	// Now calculated in each animation call
-	//for _, a := range ffx.fat {
+	//for _, a := range ffx.animTable {
 	//	a.start_scale = [...]float32{ffx.fx_scale, ffx.fx_scale}
 	//}
 	// Adding used prefixes to a list is no longer necessary
@@ -4152,7 +4152,7 @@ type Lifebar struct {
 	offsetY       float32
 	scale         float32
 	portraitScale float32
-	at            AnimationTable
+	animTable     AnimationTable
 	sff           *Sff
 	snd           *Snd
 	fnt           map[int]*Fnt
@@ -4246,7 +4246,7 @@ func loadLifebar(def string) (*Lifebar, error) {
 		}
 	}
 	lines, i := SplitAndTrim(str, "\n"), 0
-	l.at = ReadAnimationTable(l.sff, &l.sff.palList, lines, &i)
+	l.animTable = ReadAnimationTable(l.sff, &l.sff.palList, lines, &i)
 	i = 0
 	filesflg := true
 
@@ -4331,7 +4331,7 @@ func loadLifebar(def string) (*Lifebar, error) {
 						if err != nil {
 							return err
 						}
-						*ffx.fsff = *s
+						*ffx.sff = *s
 						return nil
 					}); err != nil {
 					return nil, err
@@ -4343,14 +4343,14 @@ func loadLifebar(def string) (*Lifebar, error) {
 							return err
 						}
 						lines, i := SplitAndTrim(str, "\n"), 0
-						ffx.fat = ReadAnimationTable(ffx.fsff, &ffx.fsff.palList, lines, &i)
+						ffx.animTable = ReadAnimationTable(ffx.sff, &ffx.sff.palList, lines, &i)
 						return nil
 					}); err != nil {
 					return nil, err
 				}
 				if is.LoadFile("common.snd", []string{def, sys.motif.Def, "", "data/"},
 					func(filename string) error {
-						ffx.fsnd, err = LoadSnd(filename)
+						ffx.snd, err = LoadSnd(filename)
 						return err
 					}); err != nil {
 					return nil, err
@@ -4426,90 +4426,90 @@ func loadLifebar(def string) (*Lifebar, error) {
 			is.ReadF32("scale", &ffx.fx_scale)
 		case "lifebar":
 			if l.hb[0][0] == nil {
-				l.hb[0][0] = readHealthBar("p1.", is, l.sff, l.at, l.fnt)
+				l.hb[0][0] = readHealthBar("p1.", is, l.sff, l.animTable, l.fnt)
 			}
 			if l.hb[0][1] == nil {
-				l.hb[0][1] = readHealthBar("p2.", is, l.sff, l.at, l.fnt)
+				l.hb[0][1] = readHealthBar("p2.", is, l.sff, l.animTable, l.fnt)
 			}
 		case "powerbar":
 			if l.pb[0][0] == nil {
-				l.pb[0][0] = readPowerBar("p1.", is, l.sff, l.at, l.fnt)
+				l.pb[0][0] = readPowerBar("p1.", is, l.sff, l.animTable, l.fnt)
 			}
 			if l.pb[0][1] == nil {
-				l.pb[0][1] = readPowerBar("p2.", is, l.sff, l.at, l.fnt)
+				l.pb[0][1] = readPowerBar("p2.", is, l.sff, l.animTable, l.fnt)
 			}
 		case "guardbar":
 			if l.gb[0][0] == nil {
-				l.gb[0][0] = readGuardBar("p1.", is, l.sff, l.at, l.fnt)
+				l.gb[0][0] = readGuardBar("p1.", is, l.sff, l.animTable, l.fnt)
 			}
 			if l.gb[0][1] == nil {
-				l.gb[0][1] = readGuardBar("p2.", is, l.sff, l.at, l.fnt)
+				l.gb[0][1] = readGuardBar("p2.", is, l.sff, l.animTable, l.fnt)
 			}
 		case "stunbar":
 			if l.sb[0][0] == nil {
-				l.sb[0][0] = readStunBar("p1.", is, l.sff, l.at, l.fnt)
+				l.sb[0][0] = readStunBar("p1.", is, l.sff, l.animTable, l.fnt)
 			}
 			if l.sb[0][1] == nil {
-				l.sb[0][1] = readStunBar("p2.", is, l.sff, l.at, l.fnt)
+				l.sb[0][1] = readStunBar("p2.", is, l.sff, l.animTable, l.fnt)
 			}
 		case "face":
 			if l.fa[0][0] == nil {
-				l.fa[0][0] = readLifeBarFace("p1.", is, l.sff, l.at)
+				l.fa[0][0] = readLifeBarFace("p1.", is, l.sff, l.animTable)
 			}
 			if l.fa[0][1] == nil {
-				l.fa[0][1] = readLifeBarFace("p2.", is, l.sff, l.at)
+				l.fa[0][1] = readLifeBarFace("p2.", is, l.sff, l.animTable)
 			}
 		case "name":
 			if l.nm[0][0] == nil {
-				l.nm[0][0] = readLifeBarName("p1.", is, l.sff, l.at, l.fnt)
+				l.nm[0][0] = readLifeBarName("p1.", is, l.sff, l.animTable, l.fnt)
 			}
 			if l.nm[0][1] == nil {
-				l.nm[0][1] = readLifeBarName("p2.", is, l.sff, l.at, l.fnt)
+				l.nm[0][1] = readLifeBarName("p2.", is, l.sff, l.animTable, l.fnt)
 			}
 		case "turns ":
 			subname = strings.ToLower(subname)
 			switch {
 			case len(subname) >= 7 && subname[:7] == "lifebar":
 				if l.hb[2][0] == nil {
-					l.hb[2][0] = readHealthBar("p1.", is, l.sff, l.at, l.fnt)
+					l.hb[2][0] = readHealthBar("p1.", is, l.sff, l.animTable, l.fnt)
 				}
 				if l.hb[2][1] == nil {
-					l.hb[2][1] = readHealthBar("p2.", is, l.sff, l.at, l.fnt)
+					l.hb[2][1] = readHealthBar("p2.", is, l.sff, l.animTable, l.fnt)
 				}
 			case len(subname) >= 8 && subname[:8] == "powerbar":
 				if l.pb[2][0] == nil {
-					l.pb[2][0] = readPowerBar("p1.", is, l.sff, l.at, l.fnt)
+					l.pb[2][0] = readPowerBar("p1.", is, l.sff, l.animTable, l.fnt)
 				}
 				if l.pb[2][1] == nil {
-					l.pb[2][1] = readPowerBar("p2.", is, l.sff, l.at, l.fnt)
+					l.pb[2][1] = readPowerBar("p2.", is, l.sff, l.animTable, l.fnt)
 				}
 			case len(subname) >= 8 && subname[:8] == "guardbar":
 				if l.gb[2][0] == nil {
-					l.gb[2][0] = readGuardBar("p1.", is, l.sff, l.at, l.fnt)
+					l.gb[2][0] = readGuardBar("p1.", is, l.sff, l.animTable, l.fnt)
 				}
 				if l.gb[2][1] == nil {
-					l.gb[2][1] = readGuardBar("p2.", is, l.sff, l.at, l.fnt)
+					l.gb[2][1] = readGuardBar("p2.", is, l.sff, l.animTable, l.fnt)
 				}
 			case len(subname) >= 7 && subname[:7] == "stunbar":
 				if l.sb[2][0] == nil {
-					l.sb[2][0] = readStunBar("p1.", is, l.sff, l.at, l.fnt)
+					l.sb[2][0] = readStunBar("p1.", is, l.sff, l.animTable, l.fnt)
 				}
 				if l.sb[2][1] == nil {
-					l.sb[2][1] = readStunBar("p2.", is, l.sff, l.at, l.fnt)
+					l.sb[2][1] = readStunBar("p2.", is, l.sff, l.animTable, l.fnt)
 				}
 			case len(subname) >= 4 && subname[:4] == "face":
 				if l.fa[2][0] == nil {
-					l.fa[2][0] = readLifeBarFace("p1.", is, l.sff, l.at)
+					l.fa[2][0] = readLifeBarFace("p1.", is, l.sff, l.animTable)
 				}
 				if l.fa[2][1] == nil {
-					l.fa[2][1] = readLifeBarFace("p2.", is, l.sff, l.at)
+					l.fa[2][1] = readLifeBarFace("p2.", is, l.sff, l.animTable)
 				}
 			case len(subname) >= 4 && subname[:4] == "name":
 				if l.nm[2][0] == nil {
-					l.nm[2][0] = readLifeBarName("p1.", is, l.sff, l.at, l.fnt)
+					l.nm[2][0] = readLifeBarName("p1.", is, l.sff, l.animTable, l.fnt)
 				}
 				if l.nm[2][1] == nil {
-					l.nm[2][1] = readLifeBarName("p2.", is, l.sff, l.at, l.fnt)
+					l.nm[2][1] = readLifeBarName("p2.", is, l.sff, l.animTable, l.fnt)
 				}
 			}
 		case "simul ", "simul_3p ", "simul_4p ", "tag ", "tag_3p ", "tag_4p ":
@@ -4530,191 +4530,191 @@ func loadLifebar(def string) (*Lifebar, error) {
 			switch {
 			case len(subname) >= 7 && subname[:7] == "lifebar":
 				if l.hb[i][0] == nil {
-					l.hb[i][0] = readHealthBar("p1.", is, l.sff, l.at, l.fnt)
+					l.hb[i][0] = readHealthBar("p1.", is, l.sff, l.animTable, l.fnt)
 				}
 				if l.hb[i][1] == nil {
-					l.hb[i][1] = readHealthBar("p2.", is, l.sff, l.at, l.fnt)
+					l.hb[i][1] = readHealthBar("p2.", is, l.sff, l.animTable, l.fnt)
 				}
 				if l.hb[i][2] == nil {
-					l.hb[i][2] = readHealthBar("p3.", is, l.sff, l.at, l.fnt)
+					l.hb[i][2] = readHealthBar("p3.", is, l.sff, l.animTable, l.fnt)
 				}
 				if l.hb[i][3] == nil {
-					l.hb[i][3] = readHealthBar("p4.", is, l.sff, l.at, l.fnt)
+					l.hb[i][3] = readHealthBar("p4.", is, l.sff, l.animTable, l.fnt)
 				}
 				if l.hb[i][4] == nil {
-					l.hb[i][4] = readHealthBar("p5.", is, l.sff, l.at, l.fnt)
+					l.hb[i][4] = readHealthBar("p5.", is, l.sff, l.animTable, l.fnt)
 				}
 				if l.hb[i][5] == nil {
-					l.hb[i][5] = readHealthBar("p6.", is, l.sff, l.at, l.fnt)
+					l.hb[i][5] = readHealthBar("p6.", is, l.sff, l.animTable, l.fnt)
 				}
 				if i != 4 && i != 6 {
 					if l.hb[i][6] == nil {
-						l.hb[i][6] = readHealthBar("p7.", is, l.sff, l.at, l.fnt)
+						l.hb[i][6] = readHealthBar("p7.", is, l.sff, l.animTable, l.fnt)
 					}
 					if l.hb[i][7] == nil {
-						l.hb[i][7] = readHealthBar("p8.", is, l.sff, l.at, l.fnt)
+						l.hb[i][7] = readHealthBar("p8.", is, l.sff, l.animTable, l.fnt)
 					}
 				}
 			case len(subname) >= 8 && subname[:8] == "powerbar":
 				if l.pb[i][0] == nil {
-					l.pb[i][0] = readPowerBar("p1.", is, l.sff, l.at, l.fnt)
+					l.pb[i][0] = readPowerBar("p1.", is, l.sff, l.animTable, l.fnt)
 				}
 				if l.pb[i][1] == nil {
-					l.pb[i][1] = readPowerBar("p2.", is, l.sff, l.at, l.fnt)
+					l.pb[i][1] = readPowerBar("p2.", is, l.sff, l.animTable, l.fnt)
 				}
 				if l.pb[i][2] == nil {
-					l.pb[i][2] = readPowerBar("p3.", is, l.sff, l.at, l.fnt)
+					l.pb[i][2] = readPowerBar("p3.", is, l.sff, l.animTable, l.fnt)
 				}
 				if l.pb[i][3] == nil {
-					l.pb[i][3] = readPowerBar("p4.", is, l.sff, l.at, l.fnt)
+					l.pb[i][3] = readPowerBar("p4.", is, l.sff, l.animTable, l.fnt)
 				}
 				if l.pb[i][4] == nil {
-					l.pb[i][4] = readPowerBar("p5.", is, l.sff, l.at, l.fnt)
+					l.pb[i][4] = readPowerBar("p5.", is, l.sff, l.animTable, l.fnt)
 				}
 				if l.pb[i][5] == nil {
-					l.pb[i][5] = readPowerBar("p6.", is, l.sff, l.at, l.fnt)
+					l.pb[i][5] = readPowerBar("p6.", is, l.sff, l.animTable, l.fnt)
 				}
 				if i != 4 && i != 6 {
 					if l.pb[i][6] == nil {
-						l.pb[i][6] = readPowerBar("p7.", is, l.sff, l.at, l.fnt)
+						l.pb[i][6] = readPowerBar("p7.", is, l.sff, l.animTable, l.fnt)
 					}
 					if l.pb[i][7] == nil {
-						l.pb[i][7] = readPowerBar("p8.", is, l.sff, l.at, l.fnt)
+						l.pb[i][7] = readPowerBar("p8.", is, l.sff, l.animTable, l.fnt)
 					}
 				}
 			case len(subname) >= 8 && subname[:8] == "guardbar":
 				if l.gb[i][0] == nil {
-					l.gb[i][0] = readGuardBar("p1.", is, l.sff, l.at, l.fnt)
+					l.gb[i][0] = readGuardBar("p1.", is, l.sff, l.animTable, l.fnt)
 				}
 				if l.gb[i][1] == nil {
-					l.gb[i][1] = readGuardBar("p2.", is, l.sff, l.at, l.fnt)
+					l.gb[i][1] = readGuardBar("p2.", is, l.sff, l.animTable, l.fnt)
 				}
 				if l.gb[i][2] == nil {
-					l.gb[i][2] = readGuardBar("p3.", is, l.sff, l.at, l.fnt)
+					l.gb[i][2] = readGuardBar("p3.", is, l.sff, l.animTable, l.fnt)
 				}
 				if l.gb[i][3] == nil {
-					l.gb[i][3] = readGuardBar("p4.", is, l.sff, l.at, l.fnt)
+					l.gb[i][3] = readGuardBar("p4.", is, l.sff, l.animTable, l.fnt)
 				}
 				if l.gb[i][4] == nil {
-					l.gb[i][4] = readGuardBar("p5.", is, l.sff, l.at, l.fnt)
+					l.gb[i][4] = readGuardBar("p5.", is, l.sff, l.animTable, l.fnt)
 				}
 				if l.gb[i][5] == nil {
-					l.gb[i][5] = readGuardBar("p6.", is, l.sff, l.at, l.fnt)
+					l.gb[i][5] = readGuardBar("p6.", is, l.sff, l.animTable, l.fnt)
 				}
 				if i != 4 && i != 6 {
 					if l.gb[i][6] == nil {
-						l.gb[i][6] = readGuardBar("p7.", is, l.sff, l.at, l.fnt)
+						l.gb[i][6] = readGuardBar("p7.", is, l.sff, l.animTable, l.fnt)
 					}
 					if l.gb[i][7] == nil {
-						l.gb[i][7] = readGuardBar("p8.", is, l.sff, l.at, l.fnt)
+						l.gb[i][7] = readGuardBar("p8.", is, l.sff, l.animTable, l.fnt)
 					}
 				}
 			case len(subname) >= 7 && subname[:7] == "stunbar":
 				if l.sb[i][0] == nil {
-					l.sb[i][0] = readStunBar("p1.", is, l.sff, l.at, l.fnt)
+					l.sb[i][0] = readStunBar("p1.", is, l.sff, l.animTable, l.fnt)
 				}
 				if l.sb[i][1] == nil {
-					l.sb[i][1] = readStunBar("p2.", is, l.sff, l.at, l.fnt)
+					l.sb[i][1] = readStunBar("p2.", is, l.sff, l.animTable, l.fnt)
 				}
 				if l.sb[i][2] == nil {
-					l.sb[i][2] = readStunBar("p3.", is, l.sff, l.at, l.fnt)
+					l.sb[i][2] = readStunBar("p3.", is, l.sff, l.animTable, l.fnt)
 				}
 				if l.sb[i][3] == nil {
-					l.sb[i][3] = readStunBar("p4.", is, l.sff, l.at, l.fnt)
+					l.sb[i][3] = readStunBar("p4.", is, l.sff, l.animTable, l.fnt)
 				}
 				if l.sb[i][4] == nil {
-					l.sb[i][4] = readStunBar("p5.", is, l.sff, l.at, l.fnt)
+					l.sb[i][4] = readStunBar("p5.", is, l.sff, l.animTable, l.fnt)
 				}
 				if l.sb[i][5] == nil {
-					l.sb[i][5] = readStunBar("p6.", is, l.sff, l.at, l.fnt)
+					l.sb[i][5] = readStunBar("p6.", is, l.sff, l.animTable, l.fnt)
 				}
 				if i != 4 && i != 6 {
 					if l.sb[i][6] == nil {
-						l.sb[i][6] = readStunBar("p7.", is, l.sff, l.at, l.fnt)
+						l.sb[i][6] = readStunBar("p7.", is, l.sff, l.animTable, l.fnt)
 					}
 					if l.sb[i][7] == nil {
-						l.sb[i][7] = readStunBar("p8.", is, l.sff, l.at, l.fnt)
+						l.sb[i][7] = readStunBar("p8.", is, l.sff, l.animTable, l.fnt)
 					}
 				}
 			case len(subname) >= 4 && subname[:4] == "face":
 				if l.fa[i][0] == nil {
-					l.fa[i][0] = readLifeBarFace("p1.", is, l.sff, l.at)
+					l.fa[i][0] = readLifeBarFace("p1.", is, l.sff, l.animTable)
 				}
 				if l.fa[i][1] == nil {
-					l.fa[i][1] = readLifeBarFace("p2.", is, l.sff, l.at)
+					l.fa[i][1] = readLifeBarFace("p2.", is, l.sff, l.animTable)
 				}
 				if l.fa[i][2] == nil {
-					l.fa[i][2] = readLifeBarFace("p3.", is, l.sff, l.at)
+					l.fa[i][2] = readLifeBarFace("p3.", is, l.sff, l.animTable)
 				}
 				if l.fa[i][3] == nil {
-					l.fa[i][3] = readLifeBarFace("p4.", is, l.sff, l.at)
+					l.fa[i][3] = readLifeBarFace("p4.", is, l.sff, l.animTable)
 				}
 				if l.fa[i][4] == nil {
-					l.fa[i][4] = readLifeBarFace("p5.", is, l.sff, l.at)
+					l.fa[i][4] = readLifeBarFace("p5.", is, l.sff, l.animTable)
 				}
 				if l.fa[i][5] == nil {
-					l.fa[i][5] = readLifeBarFace("p6.", is, l.sff, l.at)
+					l.fa[i][5] = readLifeBarFace("p6.", is, l.sff, l.animTable)
 				}
 				if i != 4 && i != 6 {
 					if l.fa[i][6] == nil {
-						l.fa[i][6] = readLifeBarFace("p7.", is, l.sff, l.at)
+						l.fa[i][6] = readLifeBarFace("p7.", is, l.sff, l.animTable)
 					}
 					if l.fa[i][7] == nil {
-						l.fa[i][7] = readLifeBarFace("p8.", is, l.sff, l.at)
+						l.fa[i][7] = readLifeBarFace("p8.", is, l.sff, l.animTable)
 					}
 				}
 			case len(subname) >= 4 && subname[:4] == "name":
 				if l.nm[i][0] == nil {
-					l.nm[i][0] = readLifeBarName("p1.", is, l.sff, l.at, l.fnt)
+					l.nm[i][0] = readLifeBarName("p1.", is, l.sff, l.animTable, l.fnt)
 				}
 				if l.nm[i][1] == nil {
-					l.nm[i][1] = readLifeBarName("p2.", is, l.sff, l.at, l.fnt)
+					l.nm[i][1] = readLifeBarName("p2.", is, l.sff, l.animTable, l.fnt)
 				}
 				if l.nm[i][2] == nil {
-					l.nm[i][2] = readLifeBarName("p3.", is, l.sff, l.at, l.fnt)
+					l.nm[i][2] = readLifeBarName("p3.", is, l.sff, l.animTable, l.fnt)
 				}
 				if l.nm[i][3] == nil {
-					l.nm[i][3] = readLifeBarName("p4.", is, l.sff, l.at, l.fnt)
+					l.nm[i][3] = readLifeBarName("p4.", is, l.sff, l.animTable, l.fnt)
 				}
 				if l.nm[i][4] == nil {
-					l.nm[i][4] = readLifeBarName("p5.", is, l.sff, l.at, l.fnt)
+					l.nm[i][4] = readLifeBarName("p5.", is, l.sff, l.animTable, l.fnt)
 				}
 				if l.nm[i][5] == nil {
-					l.nm[i][5] = readLifeBarName("p6.", is, l.sff, l.at, l.fnt)
+					l.nm[i][5] = readLifeBarName("p6.", is, l.sff, l.animTable, l.fnt)
 				}
 				if i != 4 && i != 6 {
 					if l.nm[i][6] == nil {
-						l.nm[i][6] = readLifeBarName("p7.", is, l.sff, l.at, l.fnt)
+						l.nm[i][6] = readLifeBarName("p7.", is, l.sff, l.animTable, l.fnt)
 					}
 					if l.nm[i][7] == nil {
-						l.nm[i][7] = readLifeBarName("p8.", is, l.sff, l.at, l.fnt)
+						l.nm[i][7] = readLifeBarName("p8.", is, l.sff, l.animTable, l.fnt)
 					}
 				}
 			}
 		case "winicon":
 			if l.wi[0] == nil {
-				l.wi[0] = readLifeBarWinIcon("p1.", is, l.sff, l.at, l.fnt)
+				l.wi[0] = readLifeBarWinIcon("p1.", is, l.sff, l.animTable, l.fnt)
 			}
 			if l.wi[1] == nil {
-				l.wi[1] = readLifeBarWinIcon("p2.", is, l.sff, l.at, l.fnt)
+				l.wi[1] = readLifeBarWinIcon("p2.", is, l.sff, l.animTable, l.fnt)
 			}
 		case "time":
 			if l.ti == nil {
-				l.ti = readLifeBarTime(is, l.sff, l.at, l.fnt)
+				l.ti = readLifeBarTime(is, l.sff, l.animTable, l.fnt)
 			}
 		case "combo":
 			if l.co[0] == nil {
 				if _, ok := is["team1.pos"]; ok {
-					l.co[0] = readLifeBarCombo("team1.", is, l.sff, l.at, l.fnt, 0)
+					l.co[0] = readLifeBarCombo("team1.", is, l.sff, l.animTable, l.fnt, 0)
 				} else {
-					l.co[0] = readLifeBarCombo("", is, l.sff, l.at, l.fnt, 0)
+					l.co[0] = readLifeBarCombo("", is, l.sff, l.animTable, l.fnt, 0)
 				}
 			}
 			if l.co[1] == nil {
 				if _, ok := is["team2.pos"]; ok {
-					l.co[1] = readLifeBarCombo("team2.", is, l.sff, l.at, l.fnt, 1)
+					l.co[1] = readLifeBarCombo("team2.", is, l.sff, l.animTable, l.fnt, 1)
 				} else {
-					l.co[1] = readLifeBarCombo("", is, l.sff, l.at, l.fnt, 1)
+					l.co[1] = readLifeBarCombo("", is, l.sff, l.animTable, l.fnt, 1)
 				}
 			}
 		case "action":
@@ -4726,47 +4726,47 @@ func loadLifebar(def string) (*Lifebar, error) {
 			}
 		case "round":
 			if l.ro == nil {
-				l.ro = readLifeBarRound(is, l.sff, l.at, l.snd, l.fnt)
+				l.ro = readLifeBarRound(is, l.sff, l.animTable, l.snd, l.fnt)
 			}
 		case "ratio":
 			if l.ra[0] == nil {
-				l.ra[0] = readLifeBarRatio("p1.", is, l.sff, l.at)
+				l.ra[0] = readLifeBarRatio("p1.", is, l.sff, l.animTable)
 			}
 			if l.ra[1] == nil {
-				l.ra[1] = readLifeBarRatio("p2.", is, l.sff, l.at)
+				l.ra[1] = readLifeBarRatio("p2.", is, l.sff, l.animTable)
 			}
 		case "timer":
 			if l.tr == nil {
-				l.tr = readLifeBarTimer(is, l.sff, l.at, l.fnt)
+				l.tr = readLifeBarTimer(is, l.sff, l.animTable, l.fnt)
 			}
 		case "score":
 			if l.sc[0] == nil {
-				l.sc[0] = readLifeBarScore("p1.", is, l.sff, l.at, l.fnt)
+				l.sc[0] = readLifeBarScore("p1.", is, l.sff, l.animTable, l.fnt)
 			}
 			if l.sc[1] == nil {
-				l.sc[1] = readLifeBarScore("p2.", is, l.sff, l.at, l.fnt)
+				l.sc[1] = readLifeBarScore("p2.", is, l.sff, l.animTable, l.fnt)
 			}
 		case "match":
 			if l.ma == nil {
-				l.ma = readLifeBarMatch(is, l.sff, l.at, l.fnt)
+				l.ma = readLifeBarMatch(is, l.sff, l.animTable, l.fnt)
 			}
 		case "ailevel":
 			if l.ai[0] == nil {
-				l.ai[0] = readLifeBarAiLevel("p1.", is, l.sff, l.at, l.fnt)
+				l.ai[0] = readLifeBarAiLevel("p1.", is, l.sff, l.animTable, l.fnt)
 			}
 			if l.ai[1] == nil {
-				l.ai[1] = readLifeBarAiLevel("p2.", is, l.sff, l.at, l.fnt)
+				l.ai[1] = readLifeBarAiLevel("p2.", is, l.sff, l.animTable, l.fnt)
 			}
 		case "wincount":
 			if l.wc[0] == nil {
-				l.wc[0] = readLifeBarWinCount("p1.", is, l.sff, l.at, l.fnt)
+				l.wc[0] = readLifeBarWinCount("p1.", is, l.sff, l.animTable, l.fnt)
 			}
 			if l.wc[1] == nil {
-				l.wc[1] = readLifeBarWinCount("p2.", is, l.sff, l.at, l.fnt)
+				l.wc[1] = readLifeBarWinCount("p2.", is, l.sff, l.animTable, l.fnt)
 			}
 		case "mode":
 			if l.mo == nil {
-				l.mo = readLifeBarMode(is, l.sff, l.at, l.fnt)
+				l.mo = readLifeBarMode(is, l.sff, l.animTable, l.fnt)
 			}
 		}
 	}
@@ -4776,7 +4776,7 @@ func loadLifebar(def string) (*Lifebar, error) {
 	//	sys.ffx["f"].fx_scale = float32(l.localcoord[0]) / 320
 	//}
 	// Now calculated in each animation call
-	//for _, a := range sys.ffx["f"].fat {
+	//for _, a := range sys.ffx["f"].animTable {
 	//	a.start_scale = [...]float32{sys.ffx["f"].fx_scale, sys.ffx["f"].fx_scale}
 	//}
 	// Iterate over map in a stable iteration order

--- a/src/main.go
+++ b/src/main.go
@@ -9,9 +9,6 @@ import (
 	"strconv"
 	"strings"
 
-	"net/http"
-	_ "net/http/pprof"
-
 	"github.com/veandco/go-sdl2/sdl"
 	lua "github.com/yuin/gopher-lua"
 )
@@ -57,11 +54,6 @@ func closeLog(f *os.File) {
 }
 
 func main() {
-
-	go func() {
-		fmt.Println(http.ListenAndServe("localhost:6060", nil))
-	}()
-
 	realMain()
 }
 

--- a/src/script.go
+++ b/src/script.go
@@ -6465,8 +6465,8 @@ func triggerFunctions(l *lua.LState) {
 		c := sys.debugWC
 		var ln lua.LNumber
 		switch strings.ToLower(strArg(l, 1)) {
-		case "cornerpush":
-			ln = lua.LNumber(c.mhv.cornerpush)
+		case "cornerpush.veloff":
+			ln = lua.LNumber(c.mhv.cornerpush_veloff)
 		case "frame":
 			ln = lua.LNumber(Btoi(c.mhv.frame))
 		case "id":
@@ -7879,6 +7879,8 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_nobrake)))
 		case "nocombodisplay":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_nocombodisplay)))
+		case "nocornerpush":
+			l.Push(lua.LBool(sys.debugWC.asf(ASF_nocornerpush)))
 		case "nocrouch":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_nocrouch)))
 		case "nodizzypointsdamage":

--- a/src/script.go
+++ b/src/script.go
@@ -5905,87 +5905,90 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "explodvar", func(*lua.LState) int {
-		ln := lua.LNumber(math.NaN())
+		var lv lua.LValue
 		id := int32(numArg(l, 1))
 		idx := int(numArg(l, 2))
 		vname := strArg(l, 3)
-
-		for i, e := range sys.debugWC.getExplods(id) {
-			if i == idx {
-				switch strings.ToLower(vname) {
-				case "accel x":
-					ln = lua.LNumber(e.accel[0])
-				case "accel y":
-					ln = lua.LNumber(e.accel[1])
-				case "accel z":
-					ln = lua.LNumber(e.accel[2])
-				case "anim":
-					ln = lua.LNumber(e.animNo)
-				case "angle":
-					ln = lua.LNumber(e.anglerot[0] + e.interpolate_angle[0])
-				case "angle x":
-					ln = lua.LNumber(e.anglerot[1] + e.interpolate_angle[1])
-				case "angle y":
-					ln = lua.LNumber(e.anglerot[2] + e.interpolate_angle[2])
-				case "animelem":
-					ln = lua.LNumber(e.anim.curelem + 1)
-				case "animelemtime":
-					ln = lua.LNumber(e.anim.curelemtime)
-				case "animplayerno":
-					ln = lua.LNumber(e.animPN + 1)
-				case "spriteplayerno":
-					ln = lua.LNumber(e.spritePN + 1)
-				case "bindtime":
-					ln = lua.LNumber(e.bindtime)
-				case "drawpal group":
-					ln = lua.LNumber(sys.debugWC.explodDrawPal(e)[0])
-				case "drawpal index":
-					ln = lua.LNumber(sys.debugWC.explodDrawPal(e)[1])
-				case "facing":
-					ln = lua.LNumber(e.facing)
-				case "friction x":
-					ln = lua.LNumber(e.friction[0])
-				case "friction y":
-					ln = lua.LNumber(e.friction[1])
-				case "friction z":
-					ln = lua.LNumber(e.friction[2])
-				case "id":
-					ln = lua.LNumber(e.id)
-				case "layerno":
-					ln = lua.LNumber(e.layerno)
-				case "pausemovetime":
-					ln = lua.LNumber(e.pausemovetime)
-				case "pos x":
-					ln = lua.LNumber(e.pos[0] + e.offset[0] + e.relativePos[0] + e.interpolate_pos[0])
-				case "pos y":
-					ln = lua.LNumber(e.pos[1] + e.offset[1] + e.relativePos[1] + e.interpolate_pos[1])
-				case "pos z":
-					ln = lua.LNumber(e.pos[2] + e.offset[2] + e.relativePos[2] + e.interpolate_pos[2])
-				case "removetime":
-					ln = lua.LNumber(e.removetime)
-				case "scale x":
-					ln = lua.LNumber(e.scale[0] * e.interpolate_scale[0])
-				case "scale y":
-					ln = lua.LNumber(e.scale[1] * e.interpolate_scale[1])
-				case "sprpriority":
-					ln = lua.LNumber(e.sprpriority)
-				case "time":
-					ln = lua.LNumber(e.time)
-				case "vel x":
-					ln = lua.LNumber(e.velocity[0])
-				case "vel y":
-					ln = lua.LNumber(e.velocity[1])
-				case "vel z":
-					ln = lua.LNumber(e.velocity[2])
-				case "xshear":
-					ln = lua.LNumber(e.xshear)
-				default:
-					l.RaiseError("\nInvalid argument: %v\n", vname)
-				}
-				break
+		// Get explod
+		explods := sys.debugWC.getExplods(id)
+		var e *Explod
+		if idx >= 0 && idx < len(explods) {
+			e = explods[idx]
+		}
+		// Handle returns
+		if e != nil {
+			switch strings.ToLower(vname) {
+			case "accel x":
+				lv = lua.LNumber(e.accel[0])
+			case "accel y":
+				lv = lua.LNumber(e.accel[1])
+			case "accel z":
+				lv = lua.LNumber(e.accel[2])
+			case "anim":
+				lv = lua.LNumber(e.animNo)
+			case "angle":
+				lv = lua.LNumber(e.anglerot[0] + e.interpolate_angle[0])
+			case "angle x":
+				lv = lua.LNumber(e.anglerot[1] + e.interpolate_angle[1])
+			case "angle y":
+				lv = lua.LNumber(e.anglerot[2] + e.interpolate_angle[2])
+			case "animelem":
+				lv = lua.LNumber(e.anim.curelem + 1)
+			case "animelemtime":
+				lv = lua.LNumber(e.anim.curelemtime)
+			case "animplayerno":
+				lv = lua.LNumber(e.animPN + 1)
+			case "spriteplayerno":
+				lv = lua.LNumber(e.spritePN + 1)
+			case "bindtime":
+				lv = lua.LNumber(e.bindtime)
+			case "drawpal group":
+				lv = lua.LNumber(sys.debugWC.explodDrawPal(e)[0])
+			case "drawpal index":
+				lv = lua.LNumber(sys.debugWC.explodDrawPal(e)[1])
+			case "facing":
+				lv = lua.LNumber(e.facing)
+			case "friction x":
+				lv = lua.LNumber(e.friction[0])
+			case "friction y":
+				lv = lua.LNumber(e.friction[1])
+			case "friction z":
+				lv = lua.LNumber(e.friction[2])
+			case "id":
+				lv = lua.LNumber(e.id)
+			case "layerno":
+				lv = lua.LNumber(e.layerno)
+			case "pausemovetime":
+				lv = lua.LNumber(e.pausemovetime)
+			case "pos x":
+				lv = lua.LNumber(e.pos[0] + e.offset[0] + e.relativePos[0] + e.interpolate_pos[0])
+			case "pos y":
+				lv = lua.LNumber(e.pos[1] + e.offset[1] + e.relativePos[1] + e.interpolate_pos[1])
+			case "pos z":
+				lv = lua.LNumber(e.pos[2] + e.offset[2] + e.relativePos[2] + e.interpolate_pos[2])
+			case "removetime":
+				lv = lua.LNumber(e.removetime)
+			case "scale x":
+				lv = lua.LNumber(e.scale[0] * e.interpolate_scale[0])
+			case "scale y":
+				lv = lua.LNumber(e.scale[1] * e.interpolate_scale[1])
+			case "sprpriority":
+				lv = lua.LNumber(e.sprpriority)
+			case "time":
+				lv = lua.LNumber(e.time)
+			case "vel x":
+				lv = lua.LNumber(e.velocity[0])
+			case "vel y":
+				lv = lua.LNumber(e.velocity[1])
+			case "vel z":
+				lv = lua.LNumber(e.velocity[2])
+			case "xshear":
+				lv = lua.LNumber(e.xshear)
+			default:
+				l.RaiseError("\nInvalid argument: %v\n", vname)
 			}
 		}
-		l.Push(ln)
+		l.Push(lv)
 		return 1
 	})
 	luaRegister(l, "facing", func(*lua.LState) int {
@@ -6080,198 +6083,194 @@ func triggerFunctions(l *lua.LState) {
 	})
 	luaRegister(l, "gethitvar", func(*lua.LState) int {
 		c := sys.debugWC
-		var ln lua.LNumber
+		var lv lua.LValue
 		switch strings.ToLower(strArg(l, 1)) {
 		case "fall.envshake.dir":
-			ln = lua.LNumber(c.ghv.fall_envshake_dir)
+			lv = lua.LNumber(c.ghv.fall_envshake_dir)
 		case "animtype":
-			ln = lua.LNumber(c.gethitAnimtype())
+			lv = lua.LNumber(c.gethitAnimtype())
 		case "air.animtype":
-			ln = lua.LNumber(c.ghv.airanimtype)
+			lv = lua.LNumber(c.ghv.airanimtype)
 		case "ground.animtype":
-			ln = lua.LNumber(c.ghv.groundanimtype)
+			lv = lua.LNumber(c.ghv.groundanimtype)
 		case "fall.animtype":
-			ln = lua.LNumber(c.ghv.fall_animtype)
+			lv = lua.LNumber(c.ghv.fall_animtype)
 		case "type":
-			ln = lua.LNumber(c.ghv._type)
+			lv = lua.LNumber(c.ghv._type)
 		case "airtype":
-			ln = lua.LNumber(c.ghv.airtype)
+			lv = lua.LNumber(c.ghv.airtype)
 		case "groundtype":
-			ln = lua.LNumber(c.ghv.groundtype)
+			lv = lua.LNumber(c.ghv.groundtype)
 		case "damage":
-			ln = lua.LNumber(c.ghv.damage)
+			lv = lua.LNumber(c.ghv.damage)
 		case "guardcount":
-			ln = lua.LNumber(c.ghv.guardcount)
+			lv = lua.LNumber(c.ghv.guardcount)
 		case "hitcount":
-			ln = lua.LNumber(c.ghv.hitcount)
+			lv = lua.LNumber(c.ghv.hitcount)
 		case "fallcount":
-			ln = lua.LNumber(c.ghv.fallcount)
+			lv = lua.LNumber(c.ghv.fallcount)
 		case "hitshaketime":
-			ln = lua.LNumber(c.ghv.hitshaketime)
+			lv = lua.LNumber(c.ghv.hitshaketime)
 		case "hittime":
-			ln = lua.LNumber(c.ghv.hittime)
+			lv = lua.LNumber(c.ghv.hittime)
 		case "stand.friction":
 			sf := c.ghv.standfriction
 			if math.IsNaN(float64(sf)) {
 				sf = c.gi().movement.stand.friction
 			}
-			ln = lua.LNumber(sf)
+			lv = lua.LNumber(sf)
 		case "crouch.friction":
 			cf := c.ghv.crouchfriction
 			if math.IsNaN(float64(cf)) {
 				cf = c.gi().movement.crouch.friction
 			}
-			ln = lua.LNumber(cf)
+			lv = lua.LNumber(cf)
 		case "slidetime":
-			ln = lua.LNumber(c.ghv.slidetime)
+			lv = lua.LNumber(c.ghv.slidetime)
 		case "ctrltime":
-			ln = lua.LNumber(c.ghv.ctrltime)
+			lv = lua.LNumber(c.ghv.ctrltime)
 		case "recovertime", "down.recovertime": // Added second term for consistency
-			ln = lua.LNumber(c.ghv.down_recovertime)
+			lv = lua.LNumber(c.ghv.down_recovertime)
 		case "xoff":
-			ln = lua.LNumber(c.ghv.xoff)
+			lv = lua.LNumber(c.ghv.xoff)
 		case "yoff":
-			ln = lua.LNumber(c.ghv.yoff)
+			lv = lua.LNumber(c.ghv.yoff)
 		case "zoff":
-			ln = lua.LNumber(c.ghv.zoff)
+			lv = lua.LNumber(c.ghv.zoff)
 		case "xvel":
-			ln = lua.LNumber(c.ghv.xvel)
+			lv = lua.LNumber(c.ghv.xvel)
 		case "yvel":
-			ln = lua.LNumber(c.ghv.yvel)
+			lv = lua.LNumber(c.ghv.yvel)
 		case "zvel":
-			ln = lua.LNumber(c.ghv.zvel)
+			lv = lua.LNumber(c.ghv.zvel)
 		case "xaccel":
-			ln = lua.LNumber(c.ghv.xaccel)
+			lv = lua.LNumber(c.ghv.xaccel)
 		case "yaccel":
-			ln = lua.LNumber(c.ghv.yaccel)
+			lv = lua.LNumber(c.ghv.yaccel)
 		case "zaccel":
-			ln = lua.LNumber(c.ghv.zaccel)
+			lv = lua.LNumber(c.ghv.zaccel)
 		case "xveladd":
-			ln = lua.LNumber(c.ghv.xveladd)
+			lv = lua.LNumber(c.ghv.xveladd)
 		case "yveladd":
-			ln = lua.LNumber(c.ghv.yveladd)
+			lv = lua.LNumber(c.ghv.yveladd)
 		case "hitid", "chainid":
-			ln = lua.LNumber(c.ghv.chainId())
+			lv = lua.LNumber(c.ghv.chainId())
 		case "guarded":
-			ln = lua.LNumber(Btoi(c.ghv.guarded))
+			lv = lua.LBool(c.ghv.guarded)
 		case "isbound":
-			ln = lua.LNumber(Btoi(c.isTargetBound()))
+			lv = lua.LBool(c.isTargetBound())
 		case "fall":
-			ln = lua.LNumber(Btoi(c.ghv.fallflag))
+			lv = lua.LBool(c.ghv.fallflag)
 		case "fall.damage":
-			ln = lua.LNumber(c.ghv.fall_damage)
+			lv = lua.LNumber(c.ghv.fall_damage)
 		case "fall.xvel":
 			if math.IsNaN(float64(c.ghv.fall_xvelocity)) {
-				ln = lua.LNumber(-32760) // Winmugen behavior
+				lv = lua.LNumber(-32760) // Winmugen behavior
 			} else {
-				ln = lua.LNumber(c.ghv.fall_xvelocity)
+				lv = lua.LNumber(c.ghv.fall_xvelocity)
 			}
 		case "fall.yvel":
-			ln = lua.LNumber(c.ghv.fall_yvelocity)
+			lv = lua.LNumber(c.ghv.fall_yvelocity)
 		case "fall.zvel":
 			if math.IsNaN(float64(c.ghv.fall_zvelocity)) {
-				ln = lua.LNumber(-32760) // Winmugen behavior
+				lv = lua.LNumber(-32760) // Winmugen behavior
 			} else {
-				ln = lua.LNumber(c.ghv.fall_zvelocity)
+				lv = lua.LNumber(c.ghv.fall_zvelocity)
 			}
 		case "fall.recover":
-			ln = lua.LNumber(Btoi(c.ghv.fall_recover))
+			lv = lua.LBool(c.ghv.fall_recover)
 		case "fall.time":
-			ln = lua.LNumber(c.fallTime)
+			lv = lua.LNumber(c.fallTime)
 		case "fall.recovertime":
-			ln = lua.LNumber(c.ghv.fall_recovertime)
+			lv = lua.LNumber(c.ghv.fall_recovertime)
 		case "fall.kill":
-			ln = lua.LNumber(Btoi(c.ghv.fall_kill))
+			lv = lua.LBool(c.ghv.fall_kill)
 		case "fall.envshake.time":
-			ln = lua.LNumber(c.ghv.fall_envshake_time)
+			lv = lua.LNumber(c.ghv.fall_envshake_time)
 		case "fall.envshake.freq":
-			ln = lua.LNumber(c.ghv.fall_envshake_freq)
+			lv = lua.LNumber(c.ghv.fall_envshake_freq)
 		case "fall.envshake.ampl":
-			ln = lua.LNumber(c.ghv.fall_envshake_ampl)
+			lv = lua.LNumber(c.ghv.fall_envshake_ampl)
 		case "fall.envshake.phase":
-			ln = lua.LNumber(c.ghv.fall_envshake_phase)
+			lv = lua.LNumber(c.ghv.fall_envshake_phase)
 		case "fall.envshake.mul":
-			ln = lua.LNumber(c.ghv.fall_envshake_mul)
+			lv = lua.LNumber(c.ghv.fall_envshake_mul)
 		case "attr":
-			// return here, because ln is a
-			// LNumber (we have a LString)
-			l.Push(attrLStr(c.ghv.attr))
-			return 1
+			lv = attrLStr(c.ghv.attr)
 		case "dizzypoints":
-			ln = lua.LNumber(c.ghv.dizzypoints)
+			lv = lua.LNumber(c.ghv.dizzypoints)
 		case "guardpoints":
-			ln = lua.LNumber(c.ghv.guardpoints)
+			lv = lua.LNumber(c.ghv.guardpoints)
 		case "id":
-			ln = lua.LNumber(c.ghv.playerid)
+			lv = lua.LNumber(c.ghv.playerid)
 		case "playerno":
-			ln = lua.LNumber(c.ghv.playerno + 1)
+			lv = lua.LNumber(c.ghv.playerno + 1)
 		case "redlife":
-			ln = lua.LNumber(c.ghv.redlife)
+			lv = lua.LNumber(c.ghv.redlife)
 		case "score":
-			ln = lua.LNumber(c.ghv.score)
+			lv = lua.LNumber(c.ghv.score)
 		case "hitdamage":
-			ln = lua.LNumber(c.ghv.hitdamage)
+			lv = lua.LNumber(c.ghv.hitdamage)
 		case "guarddamage":
-			ln = lua.LNumber(c.ghv.guarddamage)
+			lv = lua.LNumber(c.ghv.guarddamage)
 		case "power":
-			ln = lua.LNumber(c.ghv.power)
+			lv = lua.LNumber(c.ghv.power)
 		case "hitpower":
-			ln = lua.LNumber(c.ghv.hitpower)
+			lv = lua.LNumber(c.ghv.hitpower)
 		case "guardpower":
-			ln = lua.LNumber(c.ghv.guardpower)
+			lv = lua.LNumber(c.ghv.guardpower)
 		case "kill":
-			ln = lua.LNumber(Btoi(c.ghv.kill))
+			lv = lua.LBool(c.ghv.kill)
 		case "priority":
-			ln = lua.LNumber(c.ghv.priority)
+			lv = lua.LNumber(c.ghv.priority)
 		case "facing":
-			ln = lua.LNumber(c.ghv.facing)
+			lv = lua.LNumber(c.ghv.facing)
 		case "ground.velocity.x":
-			ln = lua.LNumber(c.ghv.ground_velocity[0])
+			lv = lua.LNumber(c.ghv.ground_velocity[0])
 		case "ground.velocity.y":
-			ln = lua.LNumber(c.ghv.ground_velocity[1])
+			lv = lua.LNumber(c.ghv.ground_velocity[1])
 		case "ground.velocity.z":
-			ln = lua.LNumber(c.ghv.ground_velocity[2])
+			lv = lua.LNumber(c.ghv.ground_velocity[2])
 		case "air.velocity.x":
-			ln = lua.LNumber(c.ghv.air_velocity[0])
+			lv = lua.LNumber(c.ghv.air_velocity[0])
 		case "air.velocity.y":
-			ln = lua.LNumber(c.ghv.air_velocity[1])
+			lv = lua.LNumber(c.ghv.air_velocity[1])
 		case "air.velocity.z":
-			ln = lua.LNumber(c.ghv.air_velocity[2])
+			lv = lua.LNumber(c.ghv.air_velocity[2])
 		case "down.velocity.x":
-			ln = lua.LNumber(c.ghv.down_velocity[0])
+			lv = lua.LNumber(c.ghv.down_velocity[0])
 		case "down.velocity.y":
-			ln = lua.LNumber(c.ghv.down_velocity[1])
+			lv = lua.LNumber(c.ghv.down_velocity[1])
 		case "down.velocity.z":
-			ln = lua.LNumber(c.ghv.down_velocity[2])
+			lv = lua.LNumber(c.ghv.down_velocity[2])
 		case "guard.velocity.x":
-			ln = lua.LNumber(c.ghv.guard_velocity[0])
+			lv = lua.LNumber(c.ghv.guard_velocity[0])
 		case "guard.velocity.y":
-			ln = lua.LNumber(c.ghv.guard_velocity[1])
+			lv = lua.LNumber(c.ghv.guard_velocity[1])
 		case "guard.velocity.z":
-			ln = lua.LNumber(c.ghv.guard_velocity[2])
+			lv = lua.LNumber(c.ghv.guard_velocity[2])
 		case "airguard.velocity.x":
-			ln = lua.LNumber(c.ghv.airguard_velocity[0])
+			lv = lua.LNumber(c.ghv.airguard_velocity[0])
 		case "airguard.velocity.y":
-			ln = lua.LNumber(c.ghv.airguard_velocity[1])
+			lv = lua.LNumber(c.ghv.airguard_velocity[1])
 		case "airguard.velocity.z":
-			ln = lua.LNumber(c.ghv.airguard_velocity[2])
+			lv = lua.LNumber(c.ghv.airguard_velocity[2])
 		case "frame":
-			ln = lua.LNumber(Btoi(c.ghv.frame))
+			lv = lua.LBool(c.ghv.frame)
 		case "down.recover":
-			ln = lua.LNumber(Btoi(c.ghv.down_recover))
+			lv = lua.LBool(c.ghv.down_recover)
 		case "guardflag":
-			// return here, because ln is a
-			// LNumber (we have a LString)
-			l.Push(flagLStr(c.ghv.guardflag))
-			return 1
+			lv = flagLStr(c.ghv.guardflag)
 		case "keepstate":
-			ln = lua.LNumber(Btoi(c.ghv.keepstate))
+			lv = lua.LBool(c.ghv.keepstate)
 		case "projid":
-			ln = lua.LNumber(c.ghv.projid)
+			lv = lua.LNumber(c.ghv.projid)
+		case "guardko":
+			lv = lua.LBool(c.ghv.guardko)
 		default:
 			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}
-		l.Push(ln)
+		l.Push(lv)
 		return 1
 	})
 	luaRegister(l, "groundlevel", func(*lua.LState) int {
@@ -6463,28 +6462,28 @@ func triggerFunctions(l *lua.LState) {
 	})
 	luaRegister(l, "movehitvar", func(*lua.LState) int {
 		c := sys.debugWC
-		var ln lua.LNumber
+		var lv lua.LValue
 		switch strings.ToLower(strArg(l, 1)) {
 		case "cornerpush.veloff":
-			ln = lua.LNumber(c.mhv.cornerpush_veloff)
+			lv = lua.LNumber(c.mhv.cornerpush_veloff)
 		case "frame":
-			ln = lua.LNumber(Btoi(c.mhv.frame))
+			lv = lua.LBool(c.mhv.frame)
 		case "id":
-			ln = lua.LNumber(c.mhv.playerid)
+			lv = lua.LNumber(c.mhv.playerid)
 		case "overridden":
-			ln = lua.LNumber(Btoi(c.mhv.overridden))
+			lv = lua.LBool(c.mhv.overridden)
 		case "playerno":
-			ln = lua.LNumber(c.mhv.playerno + 1)
+			lv = lua.LNumber(c.mhv.playerno + 1)
 		case "sparkx":
-			ln = lua.LNumber(c.mhv.sparkxy[0])
+			lv = lua.LNumber(c.mhv.sparkxy[0])
 		case "sparky":
-			ln = lua.LNumber(c.mhv.sparkxy[1])
+			lv = lua.LNumber(c.mhv.sparkxy[1])
 		case "uniqhit":
-			ln = lua.LNumber(len(c.hitdefTargets))
+			lv = lua.LNumber(len(c.hitdefTargets))
 		default:
 			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}
-		l.Push(ln)
+		l.Push(lv)
 		return 1
 	})
 	luaRegister(l, "movetype", func(*lua.LState) int {
@@ -7528,45 +7527,45 @@ func triggerFunctions(l *lua.LState) {
 	})
 	luaRegister(l, "animelemvar", func(l *lua.LState) int {
 		vname := strings.ToLower(strArg(l, 1))
-		var ln lua.LNumber
+		var lv lua.LValue
 		// Because the char's animation steps at the end of each frame, before the scripts run,
 		// AnimElemVar Lua version uses curFrame instead of anim.CurrentFrame()
 		f := sys.debugWC.curFrame
 		if f != nil {
 			switch vname {
 			case "alphadest":
-				ln = lua.LNumber(f.DstAlpha)
+				lv = lua.LNumber(f.DstAlpha)
 			case "alphasource":
-				ln = lua.LNumber(f.SrcAlpha)
+				lv = lua.LNumber(f.SrcAlpha)
 			case "angle":
-				ln = lua.LNumber(f.Angle)
+				lv = lua.LNumber(f.Angle)
 			case "group":
-				ln = lua.LNumber(f.Group)
+				lv = lua.LNumber(f.Group)
 			case "hflip":
-				ln = lua.LNumber(Btoi(f.Hscale < 0))
+				lv = lua.LBool(f.Hscale < 0)
 			case "image":
-				ln = lua.LNumber(f.Number)
+				lv = lua.LNumber(f.Number)
 			case "numclsn1":
-				ln = lua.LNumber(len(f.Clsn1))
+				lv = lua.LNumber(len(f.Clsn1))
 			case "numclsn2":
-				ln = lua.LNumber(len(f.Clsn2))
+				lv = lua.LNumber(len(f.Clsn2))
 			case "time":
-				ln = lua.LNumber(f.Time)
+				lv = lua.LNumber(f.Time)
 			case "vflip":
-				ln = lua.LNumber(Btoi(f.Vscale < 0))
+				lv = lua.LBool(f.Vscale < 0)
 			case "xoffset":
-				ln = lua.LNumber(f.Xoffset)
+				lv = lua.LNumber(f.Xoffset)
 			case "xscale":
-				ln = lua.LNumber(f.Xscale)
+				lv = lua.LNumber(f.Xscale)
 			case "yoffset":
-				ln = lua.LNumber(f.Yoffset)
+				lv = lua.LNumber(f.Yoffset)
 			case "yscale":
-				ln = lua.LNumber(f.Yscale)
+				lv = lua.LNumber(f.Yscale)
 			default:
 				l.RaiseError("\nInvalid argument: %v\n", vname)
 			}
 		}
-		l.Push(ln)
+		l.Push(lv)
 		return 1
 	})
 	luaRegister(l, "animlength", func(*lua.LState) int {
@@ -7763,7 +7762,7 @@ func triggerFunctions(l *lua.LState) {
 			case "preserve":
 				lv = lua.LBool(c.preserve)
 			default:
-				l.RaiseError("\nInvalid helpervar property: %v\n", vname)
+				l.RaiseError("\nInvalid argument: %v\n", vname)
 			}
 		}
 		l.Push(lv)

--- a/src/script.go
+++ b/src/script.go
@@ -6997,7 +6997,7 @@ func triggerFunctions(l *lua.LState) {
 	//	return 1
 	//})
 	luaRegister(l, "runorder", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.runorder))
+		l.Push(lua.LNumber(sys.debugWC.runOrderTrigger()))
 		return 1
 	})
 	luaRegister(l, "reversaldefattr", func(*lua.LState) int {

--- a/src/script.go
+++ b/src/script.go
@@ -6201,7 +6201,7 @@ func triggerFunctions(l *lua.LState) {
 			lv = lua.LNumber(c.ghv.dizzypoints)
 		case "guardpoints":
 			lv = lua.LNumber(c.ghv.guardpoints)
-		case "id":
+		case "playerid":
 			lv = lua.LNumber(c.ghv.playerid)
 		case "playerno":
 			lv = lua.LNumber(c.ghv.playerno + 1)
@@ -6468,7 +6468,7 @@ func triggerFunctions(l *lua.LState) {
 			lv = lua.LNumber(c.mhv.cornerpush_veloff)
 		case "frame":
 			lv = lua.LBool(c.mhv.frame)
-		case "id":
+		case "playerid":
 			lv = lua.LNumber(c.mhv.playerid)
 		case "overridden":
 			lv = lua.LBool(c.mhv.overridden)

--- a/src/script.go
+++ b/src/script.go
@@ -6202,9 +6202,9 @@ func triggerFunctions(l *lua.LState) {
 		case "guardpoints":
 			ln = lua.LNumber(c.ghv.guardpoints)
 		case "id":
-			ln = lua.LNumber(c.ghv.playerId)
+			ln = lua.LNumber(c.ghv.playerid)
 		case "playerno":
-			ln = lua.LNumber(c.ghv.playerNo)
+			ln = lua.LNumber(c.ghv.playerno + 1)
 		case "redlife":
 			ln = lua.LNumber(c.ghv.redlife)
 		case "score":
@@ -6266,6 +6266,8 @@ func triggerFunctions(l *lua.LState) {
 			return 1
 		case "keepstate":
 			ln = lua.LNumber(Btoi(c.ghv.keepstate))
+		case "projid":
+			ln = lua.LNumber(c.ghv.projid)
 		default:
 			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}
@@ -6468,11 +6470,11 @@ func triggerFunctions(l *lua.LState) {
 		case "frame":
 			ln = lua.LNumber(Btoi(c.mhv.frame))
 		case "id":
-			ln = lua.LNumber(c.mhv.playerId)
+			ln = lua.LNumber(c.mhv.playerid)
 		case "overridden":
 			ln = lua.LNumber(Btoi(c.mhv.overridden))
 		case "playerno":
-			ln = lua.LNumber(c.mhv.playerNo)
+			ln = lua.LNumber(c.mhv.playerno + 1)
 		case "sparkx":
 			ln = lua.LNumber(c.mhv.sparkxy[0])
 		case "sparky":

--- a/src/system.go
+++ b/src/system.go
@@ -4529,8 +4529,8 @@ func (l *Loader) load() {
 			continue
 		}
 		if ffx.refCount <= 0 {
-			if ffx.fsff != nil {
-				removeSFFCache(ffx.fsff.filename)
+			if ffx.sff != nil {
+				removeSFFCache(ffx.sff.filename)
 			}
 			delete(sys.ffx, prefix)
 			//sys.errLog.Printf("Unloaded CommonFX: %s (prefix: %s)", ffx.fileName, prefix)


### PR DESCRIPTION
Features:
- GetHitVar(projid). Returns the ID of the projectile that hit the player
- AssertSpecial flag NoCornerPush. Self-explanatory
- GetHitVar(guardko). Exposes the internal variable used to flag that a KO happened by guard damage

Fixes:
- Fixed projectiles setting the enemy's getHitVar(ID) to the player that called the projectile instead of its actual owner (root)
- Fixed player number index offset in some triggers
- Fixed negative projID being allowed
- Adjusted syncID feature to still respect the natural drawing order of things instead of taking over it

Refactor:
- Centralized the checks for who owns a projectile
- GetHitVar(id) now accepts GetHitVar(playerID) as optional syntax, since there are many ID parameters. MoveHitVar as well
- Refactored some HitDef functions to be more straightforward
- Adjusted cornerpush code
- MoveHitVar(cornerpush) renamed to MoveHitVar(cornerpush.veloff) in order to match HitDef parameters
- The runOrder slice now updates itself with the actual char run orders instead of serving as a flatter sys.chars. This makes most char things obey the same processing order
- RunOrder trigger now retrieves the order dynamically
- Some Lua triggers changed to return LValue