### PR TITLE
feat: per row/column spacing; fix

### DIFF
--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -2161,21 +2161,21 @@ function start.updateDrawList()
 
 			if t.skip ~= 1 then
 				local charData = start.f_selGrid(cellIndex)
-				local function getTransforms(defaultFacing)
+				local function getTransforms(base)
 					return {
-						facing      = getCellFacing(defaultFacing, c, r),
-						scale       = getCellTransform(c, r, "scale", nil),
-						xshear      = getCellTransform(c, r, "xshear", nil),
-						angle       = getCellTransform(c, r, "angle", nil),
-						xangle      = getCellTransform(c, r, "xangle", nil),
-						yangle      = getCellTransform(c, r, "yangle", nil),
-						projection  = getCellTransform(c, r, "projection", nil),
-						focallength = getCellTransform(c, r, "focallength", nil)
+						facing      = getCellFacing(base.facing, c, r),
+						scale       = getCellTransform(c, r, "scale", base.scale),
+						xshear      = getCellTransform(c, r, "xshear", base.xshear),
+						angle       = getCellTransform(c, r, "angle", base.angle),
+						xangle      = getCellTransform(c, r, "xangle", base.xangle),
+						yangle      = getCellTransform(c, r, "yangle", base.yangle),
+						projection  = getCellTransform(c, r, "projection", base.projection),
+						focallength = getCellTransform(c, r, "focallength", base.focallength)
 					}
 				end
 
 				if (charData and charData.char ~= nil and (charData.hidden == 0 or charData.hidden == 3)) or motif.select_info.showemptyboxes then
-					local item = getTransforms(motif.select_info.cell.bg.facing)
+					local item = getTransforms(motif.select_info.cell.bg)
 					item.anim = motif.select_info.cell.bg.AnimData
 					item.x = motif.select_info.pos[1] + t.x
 					item.y = motif.select_info.pos[2] + t.y
@@ -2183,7 +2183,7 @@ function start.updateDrawList()
 				end
 
 				if charData and (charData.char == 'randomselect' or charData.hidden == 3) then
-					local item = getTransforms(motif.select_info.cell.random.facing)
+					local item = getTransforms(motif.select_info.cell.random)
 					item.anim = motif.select_info.cell.random.AnimData
 					item.x = motif.select_info.pos[1] + t.x + motif.select_info.portrait.offset[1]
 					item.y = motif.select_info.pos[2] + t.y + motif.select_info.portrait.offset[2]
@@ -2191,7 +2191,7 @@ function start.updateDrawList()
 				end
 
 				if charData and charData.char_ref ~= nil and charData.hidden == 0 then
-					local item = getTransforms(motif.select_info.portrait.facing)
+					local item = getTransforms(motif.select_info.portrait)
 					item.anim = charData.cell_data
 					item.x = motif.select_info.pos[1] + t.x + motif.select_info.portrait.offset[1]
 					item.y = motif.select_info.pos[2] + t.y + motif.select_info.portrait.offset[2]

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -1139,7 +1139,7 @@ function start.f_drawCursor(pn, x, y, param, done)
 	local baseX, baseY
 
 	if cellData then
-		-- cellData already includes all spacing accumulations and offsets
+		-- cellData already includes all spacing and offsets
 		baseX = motif.select_info.pos[1] + cellData.x
 		baseY = motif.select_info.pos[2] + cellData.y
 	end

--- a/src/motif.go
+++ b/src/motif.go
@@ -354,6 +354,7 @@ type InfoBoxProperties struct {
 
 type CellOverrideProperties struct {
 	Offset      [2]float32 `ini:"offset"`
+	Spacing     [2]float32 `ini:"spacing"`
 	Facing      int32      `ini:"facing" default:"1"`
 	Skip        bool       `ini:"skip"`
 	Scale       [2]float32 `ini:"scale"`


### PR DESCRIPTION
Feat: 
- Add support for editing spacing per row/column

```ini
cell.0-*.spacing = 4, 4
```
If y isn’t defined, it uses the same value as x

Fix: 
- Fix a bug where, even without defining cell overrides, ``cell.bg`` and ``cell.random`` couldn’t use transformations on their own