### PR TITLE
fix: audio stuttering, remove unnecessary gl.flush command

### DIFF
--- a/src/audio_sdl.go
+++ b/src/audio_sdl.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"sync"
+	"time"
 
 	"github.com/gopxl/beep/v2"
 	"github.com/veandco/go-sdl2/sdl"
@@ -59,6 +60,15 @@ func (s *SDLSpeaker) Init(sampleRate beep.SampleRate, bufferSize int) error {
 	s.dev = dev
 	sdl.ClearQueuedAudio(s.dev)
 	sdl.PauseAudioDevice(s.dev, false)
+
+	// Start the audio pushing thread
+	go func() {
+		for true {
+			s.FillAudio()
+			time.Sleep(time.Millisecond * 17) // prevents fans from going crazy on Android handhelds
+		}
+	}()
+
 	return nil
 }
 

--- a/src/render_gl_gles32.go
+++ b/src/render_gl_gles32.go
@@ -387,7 +387,7 @@ func (t *Texture_GLES32) SetSubDataStride(data []byte, x, y, width, height, stri
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
 
 	gl.PixelStorei(gl.UNPACK_ROW_LENGTH, 0)
-	gl.Flush()
+	// gl.Flush()
 }
 func (t *Texture_GLES32) SetDataG(data []byte, mag, min, ws, wt TextureSamplingParam) {
 

--- a/src/system.go
+++ b/src/system.go
@@ -642,7 +642,6 @@ func (s *System) eventUpdate() bool {
 		v.Activate = false
 	}
 	s.window.pollEvents()
-	speaker.FillAudio() // fill the SDL audio buffer
 	s.gameEnd = s.window.shouldClose()
 	return !s.gameEnd
 }


### PR DESCRIPTION
Moved audio to its own thread for filling the SDL audio sink. Fixes https://discord.com/channels/233345562261323776/233363722934943744/1464701691604500594

gl.flush for render_gl_gles32.go seems unnecessary after weeks of testing without it