### PR TITLE
feat: add getStoryboardScene() and scene jump support to storyboards

### DIFF
--- a/src/resources/defaultStoryboard.ini
+++ b/src/resources/defaultStoryboard.ini
@@ -2,3 +2,4 @@
 key.skip = s
 key.cancel = a, b, c, x, y, z, m
 stopmusic = 1
+disablecancel = 0

--- a/src/script.go
+++ b/src/script.go
@@ -4120,6 +4120,14 @@ func systemScriptInit(l *lua.LState) {
 		l.Push(lua.LBool(sys.storyboard.active))
 		return 1
 	})
+	luaRegister(l, "getStoryboardScene", func(l *lua.LState) int {
+		if sys.storyboard.active {
+			l.Push(lua.LNumber(sys.storyboard.currentSceneIndex))
+		} else {
+			l.Push(lua.LNil)
+		}
+		return 1
+	})
 	luaRegister(l, "runHiscore", func(*lua.LState) int {
 		if !sys.paused || sys.frameStepFlag {
 			if !sys.motif.hi.initialized {

--- a/src/storyboard.go
+++ b/src/storyboard.go
@@ -108,6 +108,7 @@ type Storyboard struct {
 			Cancel []string `ini:"cancel"`
 		} `ini:"key"`
 		StopMusic bool `ini:"stopmusic"`
+		DisableCancel bool `ini:"disablecancel"`
 	} `ini:"scenedef"`
 	Scene         map[string]*SceneProperties `ini:"map:^(?i)scene_?[0-9]+$" lua:"scene"`
 	fntIndexByKey map[string]int
@@ -599,9 +600,9 @@ func (s *Storyboard) step() {
 	}
 
 	// Cancel handling
-	if sys.esc ||
+	if !s.SceneDef.DisableCancel && (sys.esc ||
 		(!sys.motif.AttractMode.Enabled && sys.button(s.SceneDef.Key.Cancel, -1)) ||
-		(!sys.gameRunning && sys.motif.AttractMode.Enabled && sys.credits > 0) {
+		(!sys.gameRunning && sys.motif.AttractMode.Enabled && sys.credits > 0)) {
 		sys.esc = false
 		s.cancel = true
 	}
@@ -723,6 +724,8 @@ func (s *Storyboard) step() {
 		if sys.motif.fadeOut != nil {
 			sys.motif.fadeOut.reset()
 		}
+		s.counter = 0
+		s.endTimer = -1
 		if s.cancel {
 			s.currentSceneIndex = len(s.sceneKeys)
 		} else {
@@ -732,8 +735,6 @@ func (s *Storyboard) step() {
 				s.currentSceneIndex++
 			}
 		}
-		s.counter = 0
-		s.endTimer = -1
 		if s.currentSceneIndex >= len(s.sceneKeys) {
 			if s.musicPlaying && s.SceneDef.StopMusic {
 				sys.bgm.Stop()

--- a/src/storyboard.go
+++ b/src/storyboard.go
@@ -85,6 +85,7 @@ type SceneProperties struct {
 	} `ini:"bg"`
 	Bgm   BgmProperties `ini:"bgm"`
 	Music Music
+	Jump *int `ini:"jump"`
 }
 
 type Storyboard struct {
@@ -725,7 +726,11 @@ func (s *Storyboard) step() {
 		if s.cancel {
 			s.currentSceneIndex = len(s.sceneKeys)
 		} else {
-			s.currentSceneIndex++
+			if sceneProps.Jump != nil && *sceneProps.Jump != s.currentSceneIndex {
+				s.currentSceneIndex = *sceneProps.Jump
+			} else {
+				s.currentSceneIndex++
+			}
 		}
 		s.counter = 0
 		s.endTimer = -1


### PR DESCRIPTION
Add getStoryboardScene() lua function to expose the currently active storyboard scene.
This allows lua scripts to make decisions based on the current scene, like handling vn choice results and dynamic scene jumps.

The change is fully compatible with existing storyboards.
