### PR TITLE
fix: stage selection, randomtest closing window and teams support, normalize dialogue tokens, charparam music, team leader music, post-challenger input remapping, winscreen crash, backgrounds reset, bg elements spacing

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -3116,6 +3116,7 @@ function main.f_randomtest()
 		start.f_setStage()
 		loadStart()
 		game()
+		refresh()
 		if winnerteam() == -1 then
 			break
 		end

--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -3369,9 +3369,9 @@ function main.f_menuCommonDraw(t, item, cursorPosY, moveTxt, sec, bg, skipClear,
 		-- draw background
 		local bgPosX = offx 
 		local bgPosY = offy
-		if params.spacing[1] ~= 0 or params.spacing[2] ~= 0 then
-			bgPosX = bgPosX + (i - 1) * params.spacing[1]
-			bgPosY = bgPosY + (i - 1) * params.spacing[2] - moveTxt
+		if bgTable.default.spacing[1] ~= 0 or bgTable.default.spacing[2] ~= 0 then
+			bgPosX = bgPosX + (i - 1) * bgTable.default.spacing[1]
+			bgPosY = bgPosY + (i - 1) * bgTable.default.spacing[2] - moveTxt
 		end
 		main.f_animPosDraw(params.AnimData, bgPosX, bgPosY)
 		-- text sprite for label

--- a/external/script/menu.lua
+++ b/external/script/menu.lua
@@ -277,6 +277,10 @@ end
 function menu.f_createMenu(tbl, sec, bg, bool_main)
 	return function()
 		hook.run("menu.menu.loop")
+		if menu._lastMenuTbl ~= tbl then
+			menu._lastMenuTbl = tbl
+			main.f_menuItemBgAnimReset(sec)
+		end
 		local t = tbl.items
 		if tbl.reset then
 			tbl.reset = false

--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -1434,6 +1434,7 @@ function options.f_createMenu(tbl, bool_main)
 		local item = 1
 		local t = tbl.items
 		main.f_menuSnap(motif.option_info)
+		main.f_menuItemBgAnimReset(motif.option_info)
 		if bool_main then
 			bgReset(motif.optionbgdef.BGDef)
 			main.f_fadeReset('fadein', motif.option_info)
@@ -1479,6 +1480,7 @@ function options.f_createMenu(tbl, bool_main)
 					sndPlay(motif.Snd, motif.option_info.cursor.done.snd[1], motif.option_info.cursor.done.snd[2])
 					tbl.submenu[f].loop()
 					main.f_menuSnap(motif.option_info)
+					main.f_menuItemBgAnimReset(motif.option_info)
 				elseif not options.t_itemname[f](tbl, item, cursorPosY, moveTxt) then
 					break
 				end

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -3562,6 +3562,13 @@ function start.f_selectLoading(musicParams)
 		if v == nil then return end
 		parts[#parts + 1] = k .. "=" .. tostring(v)
 	end
+	addParam("charparam.ai", main.charparam.ai)
+	addParam("charparam.arcadepath", main.charparam.arcadepath)
+	addParam("charparam.music", main.charparam.music)
+	addParam("charparam.rounds", main.charparam.rounds)
+	addParam("charparam.single", main.charparam.single)
+	addParam("charparam.stage", main.charparam.stage)
+	addParam("charparam.time", main.charparam.time)
 	for side = 1, 2 do
 		for member, v in ipairs(start.p[side].t_selected) do
 			if not v.loading then

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -2252,6 +2252,7 @@ function start.f_selectScreen()
 	textImgSetText(motif.select_info.record.TextSpriteData, start.f_getRecordText())
 
 	local staticDrawList = start.updateDrawList()
+	local stageResetInput = false
 	start.needUpdateDrawList = false
 
 	while not selScreenEnd do
@@ -2391,6 +2392,10 @@ function start.f_selectScreen()
 		if start.p[1].selEnd and start.p[2].selEnd and start.p[1].teamEnd and start.p[2].teamEnd then
 			restoreCursor = true
 			if main.stageMenu and not stageEnd then --Stage select
+				if not stageResetInput then
+					main.f_cmdBufReset()
+					stageResetInput = true
+				end
 				start.f_stageMenu()
 				if not timerReset then
 					timerSelect = motif.select_info.timer.displaytime

--- a/src/motif.go
+++ b/src/motif.go
@@ -10,7 +10,6 @@ import (
 	"reflect"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 	"unicode/utf8"
 
@@ -2024,7 +2023,8 @@ func (m *Motif) mergeWithInheritance(specs []InheritSpec) {
 			// palmenu.preview only inherits when palmenu.preview.anim is defined
 			if isPreviewAnim(dstKey) {
 				if v, ok := get(user, sp.DstSec, dstKey); ok {
-					if iv, err := strconv.Atoi(strings.TrimSpace(v)); err != nil || iv < 0 {
+					tv := strings.TrimSpace(v)
+					if !IsInt(tv) || Atoi(tv) < 0 {
 						continue
 					}
 				} else {
@@ -3731,11 +3731,11 @@ func (di *MotifDialogue) dialogueRedirection(redirect string) int {
 
 func (di *MotifDialogue) parseTag(tag string) []DialogueToken {
 	tag = strings.TrimSpace(tag)
-	pOnlyRe := regexp.MustCompile(`^p(\d+)$`)
+	pOnlyRe := regexp.MustCompile(`(?i)^p(\d+)$`)
 	if pOnlyRe.MatchString(tag) {
 		matches := pOnlyRe.FindStringSubmatch(tag)
 		if len(matches) == 2 {
-			pnValue, _ := strconv.Atoi(matches[1])
+			pnValue := int(Atoi(matches[1]))
 			return []DialogueToken{{
 				param: "p",
 				side:  -1,
@@ -3747,31 +3747,34 @@ func (di *MotifDialogue) parseTag(tag string) []DialogueToken {
 	if equalIndex == -1 {
 		return nil
 	}
-	paramPart := tag[:equalIndex]
-	valuePart := tag[equalIndex+1:]
+	paramPart := strings.TrimSpace(tag[:equalIndex])
+	valuePart := strings.TrimSpace(tag[equalIndex+1:])
 	side := -1
 	param := paramPart
 	redirection := ""
 	pn := -1
 	numValues := []interface{}{}
-	pPrefixRe := regexp.MustCompile(`^p(\d+)([a-zA-Z]+)$`)
+	pPrefixRe := regexp.MustCompile(`(?i)^p(\d+)([a-zA-Z]+)$`)
 	if pPrefixRe.MatchString(paramPart) {
 		subMatches := pPrefixRe.FindStringSubmatch(paramPart)
 		if len(subMatches) == 3 {
-			s, _ := strconv.Atoi(subMatches[1])
-			side = s
+			side = int(Atoi(subMatches[1]))
 			param = subMatches[2]
 		}
 	}
+	param = strings.ToLower(strings.TrimSpace(param))
 	parts := strings.Split(valuePart, ",")
 	if len(parts) > 0 {
-		if _, err := strconv.Atoi(parts[0]); err != nil {
-			redirection = parts[0]
+		head := strings.TrimSpace(parts[0])
+		parts[0] = head
+		if !IsInt(head) {
+			redirection = head
 			parts = parts[1:]
 		}
 		for _, p := range parts {
-			if val, err := strconv.ParseFloat(p, 32); err == nil {
-				numValues = append(numValues, float32(val))
+			p = strings.TrimSpace(p)
+			if IsNumeric(p) {
+				numValues = append(numValues, float32(Atof(p)))
 			} else {
 				numValues = append(numValues, p)
 			}
@@ -3839,7 +3842,7 @@ func (di *MotifDialogue) parseAll(lines []string) []DialogueParsedLine {
 
 func (di *MotifDialogue) preprocessNames(lines []string) []string {
 	result := make([]string, len(lines))
-	nameRe := regexp.MustCompile(`<(displayname|name)=([^>]+)>`)
+	nameRe := regexp.MustCompile(`(?i)<(displayname|name)=([^>]+)>`)
 	for i, line := range lines {
 		newLine := line
 		for {
@@ -3848,7 +3851,7 @@ func (di *MotifDialogue) preprocessNames(lines []string) []string {
 				break
 			}
 			fullMatch := newLine[loc[0]:loc[1]]
-			paramType := newLine[loc[2]:loc[3]]
+			paramType := strings.ToLower(newLine[loc[2]:loc[3]])
 			redirectionValue := newLine[loc[4]:loc[5]]
 			resolvedPn := di.dialogueRedirection(redirectionValue)
 			replacementText := ""
@@ -4178,8 +4181,8 @@ func (di *MotifDialogue) buildFaceAnim(m *Motif, side, pn, grp, idx int, faceCfg
 	case "orthographic":
 		// default, we don't need to do nothing
 	default:
-		if i, err := strconv.Atoi(v); err == nil {
-			a.projection = int32(i)
+		if IsInt(v) {
+			a.projection = Atoi(v)
 		}
 	}
 	a.fLength = faceCfg.Focallength
@@ -6150,8 +6153,8 @@ func victoryPortraitAnim(m *Motif, sc *SelectChar, slot string,
 	case "orthographic":
 		// default, we don't need to do nothing
 	default:
-		if i, err := strconv.Atoi(v); err == nil {
-			a.projection = int32(i)
+		if IsInt(v) {
+			a.projection = Atoi(v)
 		}
 	}
 	a.fLength = fLength

--- a/src/motif.go
+++ b/src/motif.go
@@ -6471,7 +6471,7 @@ func (wi *MotifWin) draw(m *Motif, layerno int16) {
 			rs.WinsText.TextSpriteData.Draw(layerno)
 		}
 		// Top background
-		if bg.BGDef != nil && layerno == 2 {
+		if bg != nil && bg.BGDef != nil && layerno == 2 {
 			bg.BGDef.Draw(int32(layerno), 0, 0, 1)
 		}
 		return

--- a/src/music.go
+++ b/src/music.go
@@ -398,6 +398,7 @@ func (m Music) act() {
 
 			// Round Start
 			if c.teamside == sys.home &&
+				c.playerNo == c.teamLeader()-1 &&
 				(sys.stage.bgmState == BGMStateIdle || sys.tickCount == 0) &&
 				sys.tickCount == 0 {
 				switch {

--- a/src/script.go
+++ b/src/script.go
@@ -3455,13 +3455,15 @@ func systemScriptInit(l *lua.LState) {
 		if sys.sel.selectedStageNo == -1 {
 			l.RaiseError("\nStage not selected for load\n")
 		}
+		// Always reset per-launch params; they must not leak across matches/modes.
+		if sys.sel.gameParams == nil {
+			sys.sel.gameParams = newGameParams()
+		} else {
+			sys.sel.gameParams.Reset()
+		}
+		sys.sel.music = make(Music)
 		if !nilArg(l, 1) {
 			entries := SplitAndTrim(strArg(l, 1), ",")
-			if sys.sel.gameParams == nil {
-				sys.sel.gameParams = newGameParams()
-			} else {
-				sys.sel.gameParams.Reset()
-			}
 			sys.sel.gameParams.AppendParams(entries)
 			// Feed normalized music params to Music.
 			sys.sel.music.AppendParams(sys.sel.gameParams.MusicEntries())

--- a/src/script.go
+++ b/src/script.go
@@ -4431,7 +4431,13 @@ func systemScriptInit(l *lua.LState) {
 		return 0
 	})
 	luaRegister(l, "setLastInputController", func(l *lua.LState) int {
-		sys.lastInputController = int(numArg(l, 1))
+		// Lua-facing controller indices are 1-based
+		n := int(numArg(l, 1))
+		if n >= 1 {
+			sys.lastInputController = n - 1
+		} else {
+			sys.lastInputController = -1
+		}
 		return 0
 	})
 	luaRegister(l, "setLife", func(*lua.LState) int {

--- a/src/select_params.go
+++ b/src/select_params.go
@@ -56,6 +56,9 @@ func parseBoolLoose(s string) (bool, bool) {
 
 func isMusicKey(key string) bool {
 	kl := strings.ToLower(strings.TrimSpace(key))
+	if strings.HasPrefix(kl, "charparam") {
+		return false
+	}
 	return strings.HasPrefix(kl, "music") ||
 		strings.Contains(kl, ".music") ||
 		strings.Contains(kl, ".bgm") ||
@@ -345,6 +348,13 @@ type GameParams struct {
 	PersistLife   bool     `ini:"persistlife"`
 	PersistMusic  bool     `ini:"persistmusic"`
 	PersistRounds bool     `ini:"persistrounds"`
+	CharParamAI         bool `ini:"charparam.ai"`
+	CharParamArcadePath bool `ini:"charparam.arcadepath"`
+	CharParamMusic      bool `ini:"charparam.music"`
+	CharParamRounds     bool `ini:"charparam.rounds"`
+	CharParamSingle     bool `ini:"charparam.single"`
+	CharParamStage      bool `ini:"charparam.stage"`
+	CharParamTime       bool `ini:"charparam.time"`
 	ocd           [3][]OverrideCharData
 	Raw           []string
 }
@@ -426,6 +436,34 @@ func (p *GameParams) AppendParams(entries []string) {
 		}
 
 		switch kl {
+		case "charparam.ai":
+			if b, ok := parseBoolLoose(val); ok {
+				p.CharParamAI = b
+			}
+		case "charparam.arcadepath":
+			if b, ok := parseBoolLoose(val); ok {
+				p.CharParamArcadePath = b
+			}
+		case "charparam.music":
+			if b, ok := parseBoolLoose(val); ok {
+				p.CharParamMusic = b
+			}
+		case "charparam.rounds":
+			if b, ok := parseBoolLoose(val); ok {
+				p.CharParamRounds = b
+			}
+		case "charparam.single":
+			if b, ok := parseBoolLoose(val); ok {
+				p.CharParamSingle = b
+			}
+		case "charparam.stage":
+			if b, ok := parseBoolLoose(val); ok {
+				p.CharParamStage = b
+			}
+		case "charparam.time":
+			if b, ok := parseBoolLoose(val); ok {
+				p.CharParamTime = b
+			}
 		case "continue":
 			if b, ok := parseBoolLoose(val); ok {
 				p.Continue = b

--- a/src/system.go
+++ b/src/system.go
@@ -1899,7 +1899,16 @@ func (s *System) resetRoundState() {
 		// Append select.def stage music parameters
 		s.cgi[i].music.Append(sys.stage.si().music)
 		// Override with select.def char music parameters
-		s.cgi[i].music.Override(p[0].si().music)
+		useCharMusic := false
+		if sys.sel.gameParams != nil {
+			useCharMusic = sys.sel.gameParams.CharParamMusic
+		}
+		// In Versus modes, round/final/life music shouldn't override stage music; victory.music still can.
+		if useCharMusic {
+			s.cgi[i].music.Override(p[0].si().music)
+		} else if v, ok := p[0].si().music[normalizeMusicPrefix("victory")]; ok {
+			s.cgi[i].music.Override(Music{normalizeMusicPrefix("victory"): v})
+		}
 		// Override with music with launchFight parameters
 		s.cgi[i].music.Override(sys.sel.music)
 		// Debug dump of merged music.


### PR DESCRIPTION
* Skip stage selection when starting Survival mode.
Fixes #3186
* Fix hang on X window close and Alt+F4 in randomtest.
Fixes: https://discord.com/channels/233345562261323776/233363722934943744/1464929580753096820
Fixes: https://discord.com/channels/233345562261323776/233363722934943744/1464933257798750410
* Extend randomtest to support random team modes and variable team sizes
Fixes: https://discord.com/channels/233345562261323776/233363722934943744/1464930710669492472
* Normalize dialogue tokens for consistent parsing; remove strconv usage from motif.go.
Fixes: https://discord.com/channels/233345562261323776/233363722934943744/1465105910199226409
* Fix per mode select.def charparam music support
Fixes: https://discord.com/channels/233345562261323776/233363722934943744/1464633888029544458
* Fix team leader music trigger logic
Fixes: https://discord.com/channels/233345562261323776/233363722934943744/1464633981801730121
* Fix off-by-one in setLastInputController causing incorrect post-challenger input remapping
* Win screen: prevent background crash
Fixes https://github.com/ikemen-engine/modules/issues/7
* Fix background parameter reset behavior
Fixes: https://discord.com/channels/233345562261323776/282927929548210177/1464353409204355329
* Fix background element spacing calculations
Fixes: https://discord.com/channels/233345562261323776/282927929548210177/1464393503030251716

