### PR TITLE
fix: keymenu bg.anim element, warning overlay rendered on top of text

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -1538,7 +1538,6 @@ end
 --returns table storing menu window coordinates
 function main.f_menuWindow(t, offset)
 	local offset = offset or {0, 0}
-	-- If margins are set, keep legacy vertical-only clamp.
 	if t.window.margins.y[1] ~= 0 or t.window.margins.y[2] ~= 0 then
 		return {
 			0,
@@ -1547,17 +1546,7 @@ function main.f_menuWindow(t, offset)
 			t.pos[2] + offset[2] + (t.window.visibleitems - 1) * t.item.spacing[2] + t.window.margins.y[2]
 		}
 	end
-	-- Margins 0,0 => clamp tightly to the menu box (both axes).
-	local x1 = t.pos[1] + offset[1] + t.boxcursor.coords[1]
-	local y1 = t.pos[2] + offset[2] + t.boxcursor.coords[2]
-	local w  = t.boxcursor.coords[3] - t.boxcursor.coords[1] + 1
-	local h  = t.boxcursor.coords[4] - t.boxcursor.coords[2] + 1
-	-- Height grows with visible rows; using visibleitems is enough for clipping.
-	local winLeft   = math.max(0, x1)
-	local winTop    = math.max(0, y1)
-	local winRight  = math.min(x1 + w, motif.info.localcoord[1])
-	local winBottom = math.min(y1 + h + (t.window.visibleitems - 1) * t.item.spacing[2], motif.info.localcoord[2])
-	return {winLeft, winTop, winRight, winBottom}
+	return {0, 0, motif.info.localcoord[1], motif.info.localcoord[2]}
 end
 
 function main.f_storyboard(path)

--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -2156,6 +2156,7 @@ end
 
 function options.f_keyCfg(cfgType, controller, bg, skipClear)
 	local t = t_keyCfg
+	local side_before = side
 	-- Dynamically add/remove the "Rumble" option based on type
 	if motif.option_info.keymenu.menu.itemname.rumble ~= nil then
 		if cfgType ~= 'Joystick' then
@@ -2411,6 +2412,19 @@ function options.f_keyCfg(cfgType, controller, bg, skipClear)
 		end
 		resetKey()
 	end
+
+	-- Reset active background animation when switching side
+	if side_before ~= side and t ~= nil and t[item] ~= nil then
+		local bgTable = motif.option_info.keymenu.menu.item.active.bg
+		if bgTable ~= nil then
+			local params = bgTable[t[item].paramname] or bgTable.default
+			if params ~= nil and params.AnimData ~= nil then
+				animReset(params.AnimData)
+				animUpdate(params.AnimData)
+			end
+		end
+	end
+
 	-- standard / forced menu movement (up/down)
 	-- When Config all is active, movement is driven by forcedDir (0 = locked, 1 = down).
 	cursorPosY, moveTxt, item = main.f_menuCommonCalc(t, item, cursorPosY, moveTxt, motif.option_info.keymenu, motif.option_info.cursor, forcedDir)

--- a/src/resources/defaultMotif.ini
+++ b/src/resources/defaultMotif.ini
@@ -5975,7 +5975,7 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 
 	overlay.col = 0, 0, 0
 	overlay.alpha = 0, 128
-	overlay.layerno = 1
+	overlay.layerno = 0
 	overlay.window = 
 	overlay.localcoord = 320, 240
 


### PR DESCRIPTION
menu.window.margins.y = 0,0 means render all, not auto clip.
Fixes: https://discord.com/channels/233345562261323776/282927929548210177/1465486189154009287
Fixes: https://discord.com/channels/233345562261323776/282927929548210177/1465494903806099668
Fixes: https://discord.com/channels/233345562261323776/233363722934943744/1465483512499933276