### PR TITLE
feat: disable players + shadow rendering on motif screen; fix: gamemode typo; restore title music + fade on exit from randomtest; team mode selection after returning to select screen

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -3129,6 +3129,9 @@ function main.f_randomtest()
 		game()
 		refresh()
 		if winnerteam() == -1 then
+			bgReset(motif[main.background].BGDef)
+			playBgm({source = "motif.title", interrupt = true})
+			main.f_fadeReset('fadein', motif[main.group])
 			break
 		end
 	end

--- a/external/script/menu.lua
+++ b/external/script/menu.lua
@@ -248,6 +248,7 @@ menu.t_itemname = {
 			endMatch()
 			start.characterchange = true
 			main.pauseMenu = false
+			start.f_selectReset(false)
 			return false
 		end
 		return true

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -404,7 +404,7 @@ function start.f_prefightHUD()
 	local acc = start.f_accStats(prev)
 	local t_score = {acc.score.total[1], acc.score.total[2]}
 	local timer = acc.time.total
-	if start.challenger > 0 and gamemode('teamversus') then
+	if start.challenger > 0 and gamemode('versus') then
 		return 0, {0, 0}
 	end
 	-- emulate resetScore-on-loss behavior for the next match HUD

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -1748,6 +1748,7 @@ end
 --resets various data
 function start.f_selectReset(hardReset)
 	esc(false)
+	main.f_cmdBufReset()
 	resetGameStats()
 	setMatchNo(1)
 	setConsecutiveWins(1, 0)

--- a/src/motif.go
+++ b/src/motif.go
@@ -2741,7 +2741,14 @@ func (m *Motif) Save(file string) error {
 
 func (mo *Motif) processStateChange(c *Char, states []int32) bool {
 	for _, stateNo := range states {
+		// Negative state numbers are treated as hide/disable this character.
+		if stateNo < 0 {
+			c.setSCF(SCF_disabled)
+			return true
+		}
 		if c.selfStatenoExist(BytecodeInt(stateNo)) == BytecodeBool(true) {
+			// If the character was previously hidden/disabled, re-enable it when a valid state transition is requested.
+			c.unsetSCF(SCF_disabled)
 			c.changeState(int32(stateNo), -1, -1, "")
 			return true
 		}

--- a/src/system.go
+++ b/src/system.go
@@ -2755,6 +2755,13 @@ func (s *System) draw(x, y, scl float32) {
 		// Draw character sprites with special under flag
 		s.spritesLayerU.draw(x, y, scl*s.cam.BaseScale())
 
+		// Draw lifebar layers -1 and 0
+		s.lifebar.draw(-1)
+		s.lifebar.draw(0)
+
+		// Draw motif layer 0
+		s.motif.draw(0)
+
 		// Draw shadows
 		// Draw reflections on layer 0
 		// TODO: Make shadows render in same layers as their sources?
@@ -2798,12 +2805,6 @@ func (s *System) draw(x, y, scl float32) {
 		//	rect[0] = s.scrrect[2] - rect[2]
 		//	fade(rect, 0, 255)
 		//}
-
-		// Draw lifebar layers -1 and 0
-		s.lifebar.draw(-1)
-		s.lifebar.draw(0)
-		// Draw motif layer 0
-		s.motif.draw(0)
 	}
 	// Draw EnvColor effect
 	if s.envcol_time != 0 {


### PR DESCRIPTION
Feats:
* disable players on motif screen via state parameters set to -1
* motif background on first layer will be rendered not only on top of stage and players but also below shadow/reflections

Fixes:
* restore title music + fade on exit from randomtest
Fixes: https://discord.com/channels/233345562261323776/233363722934943744/1466067442244518170
* team mode selection after returning to select screen
Fixes: https://discord.com/channels/233345562261323776/233363722934943744/1466017154397634696
* gamemode typo