### PR TITLE
refactor: optimize rendering, memory recycling; fixes

### DIFF
--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -182,7 +182,7 @@ options.t_itemname = {
 			modifyGameOption('Config.HelperMax', 56)
 			modifyGameOption('Config.ProjectileMax', 256)
 			modifyGameOption('Config.PaletteMax', 100)
-			modifyGameOption('Config.TextMax', 256)
+			modifyGameOption('Config.TextMax', 128)
 			--modifyGameOption('Config.ZoomActive', true)
 			--modifyGameOption('Config.EscOpensMenu', true)
 			--modifyGameOption('Config.BackgroundLoading', false) --TODO: not implemented

--- a/src/anim.go
+++ b/src/anim.go
@@ -1039,12 +1039,14 @@ func (at AnimationTable) readAction(sff *Sff, pal *PaletteList,
 	}
 	return nil
 }
+
 func ReadAnimationTable(sff *Sff, pal *PaletteList, lines []string, i *int) AnimationTable {
 	at := NewAnimationTable()
 	for at.readAction(sff, pal, lines, i) != nil {
 	}
 	return at
 }
+
 func (at AnimationTable) get(no int32) *Animation {
 	a := at[no]
 	if a == nil {
@@ -1237,7 +1239,7 @@ func (dl DrawList) draw(cameraX, cameraY, cameraScl float32) {
 		// Restore system brightness
 		sys.brightness = oldBright
 	}
-	BlendReset()
+	//BlendReset()
 }
 
 type ShadowSprite struct {

--- a/src/anim.go
+++ b/src/anim.go
@@ -973,7 +973,7 @@ func (a *Animation) ShadowDraw(window *[4]int32, x, y, xscl, yscl, vscl, rxadd f
 	//			}
 	//		}
 	//	}
-	//	rp.paltex = PaletteToTexture(pal[:])
+	//	rp.paltex = NewTextureFromPalette(pal[:])
 	//}
 
 	if a.spr.coldepth <= 8 && (color != 0 || intensity > 0) {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -12457,13 +12457,13 @@ func (sc text) Run(c *Char, _ []int32) bool {
 	}
 
 	// Do nothing if text limit reached
-	if len(sys.motif.textsprite) >= sys.cfg.Config.TextMax {
+	if len(sys.chartexts) >= sys.cfg.Config.TextMax {
 		return false
 	}
 
 	ts := NewTextSprite()
 	ts.ownerid = crun.id
-	ts.SetLocalcoord(float32(sys.scrrect[2]), float32(sys.scrrect[3]))
+	ts.SetLocalcoord(float32(sys.scrrect[2]), float32(sys.scrrect[3])) // TODO: Default to char localcoord instead
 	ts.params = []interface{}{}
 	var x, y, xscl, yscl, xvel, yvel, xmaxdist, ymaxdist, xacc, yacc float32 = 0, 0, 1, 1, 0, 0, 0, 0, 0, 0
 	var fnt int = -1
@@ -12614,7 +12614,7 @@ func (sc text) Run(c *Char, _ []int32) bool {
 	if ts.text == "" {
 		ts.text = OldSprintf("%v", ts.params...)
 	}
-	sys.motif.textsprite = append(sys.motif.textsprite, ts)
+	sys.chartexts = append(sys.chartexts, ts)
 	return false
 }
 
@@ -12729,7 +12729,7 @@ func (sc modifyText) Run(c *Char, _ []int32) bool {
 			return true
 		default:
 			if len(texts) == 0 {
-				for _, ts := range sys.motif.textsprite {
+				for _, ts := range sys.chartexts {
 					if ts.ownerid != crun.id {
 						continue
 					}
@@ -12973,6 +12973,7 @@ func (sc removeText) Run(c *Char, _ []int32) bool {
 
 	tid := int32(-1)
 	idx := int32(-1)
+
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
 		case removetext_id:
@@ -12982,7 +12983,8 @@ func (sc removeText) Run(c *Char, _ []int32) bool {
 		}
 		return true
 	})
-	sys.motif.removeText(tid, idx, crun.id)
+
+	sys.removeCharText(tid, idx, crun.id)
 	return false
 }
 

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5579,7 +5579,7 @@ func (sc bgPalFX) Run(c *Char, _ []int32) bool {
 		sys.bgPalFX.invertblend = -3
 	} else {
 		// Apply to specific elements
-		backgrounds := c.getMultipleStageBg(bgid, bgidx, false)
+		backgrounds := c.getMultipleStageBg(bgid, bgidx, true)
 		for _, bg := range backgrounds {
 			bg.palfx.clear()
 			bg.palfx.PalFXDef = pfx
@@ -6056,7 +6056,8 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 			return true // Already handled. Avoid default
 		default:
 			if len(expls) == 0 {
-				expls = crun.getMultipleExplods(eid, idx, false) // We could print a warning here but Mugen doesn't
+				logMissing := c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0
+				expls = crun.getMultipleExplods(eid, idx, logMissing)
 				if len(expls) == 0 {
 					return false
 				}
@@ -6085,7 +6086,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 						}
 						e.space = Space_none
 						// Defaulting facing too makes some explods face the wrong way
-						//if e.facing*e.relativef >= 0 { // See below
+						//if e.trueFacing() >= 0 { // See below
 						//	e.relativef = 1
 						//}
 					})
@@ -6113,7 +6114,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 						// There's a bug in Mugen 1.1 where an explod that is facing left can't be flipped
 						// https://github.com/ikemen-engine/Ikemen-GO/issues/1252
 						// Ikemen chars just work as supposed to
-						if c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 || e.facing*e.relativef >= 0 {
+						if c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 || e.trueFacing() >= 0 {
 							e.relativef = rf
 						}
 					})
@@ -13934,7 +13935,7 @@ func (sc modifyStageBG) Run(c *Char, _ []int32) bool {
 		default:
 			// Get BG's to modify
 			if len(backgrounds) == 0 {
-				backgrounds = c.getMultipleStageBg(bgid, bgidx, false)
+				backgrounds = c.getMultipleStageBg(bgid, bgidx, true)
 				if len(backgrounds) == 0 {
 					return false
 				}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -12457,15 +12457,15 @@ func (sc text) Run(c *Char, _ []int32) bool {
 	}
 
 	// Do nothing if text limit reached
-	if len(sys.chartexts[crun.playerNo]) >= sys.cfg.Config.TextMax {
+	ts := crun.spawnText()
+	if ts == nil {
 		return false
 	}
 
-	ts := NewTextSprite()
 	ts.ownerid = crun.id
 	ts.SetLocalcoord(float32(sys.scrrect[2]), float32(sys.scrrect[3]))
 	//ts.SetLocalcoord(c.stWgi().localcoord[0], c.stWgi().localcoord[1]) // Not crun here // TODO: No point in making this change until localcoord is fixed
-	ts.params = []interface{}{}
+	//ts.params = []interface{}{} // Handled in loadDefaults
 
 	var x, y, xscl, yscl, xvel, yvel, xmaxdist, ymaxdist, xacc, yacc float32 = 0, 0, 1, 1, 0, 0, 0, 0, 0, 0
 	var fnt int = -1
@@ -12617,7 +12617,6 @@ func (sc text) Run(c *Char, _ []int32) bool {
 		ts.text = OldSprintf("%v", ts.params...)
 	}
 
-	sys.chartexts[crun.playerNo] = append(sys.chartexts[crun.playerNo], ts)
 	return false
 }
 

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6011,7 +6011,6 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 	redirscale := c.localscl / crun.localscl
 	eid := int32(-1)
 	idx := int(-1)
-	var expls []*Explod
 	rp := [2]int32{-1, 0}
 	remap := false
 	ptexists := false
@@ -6024,15 +6023,10 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 		return c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 && !ptexists
 	}
 
+	var expls []*Explod
 	eachExpl := func(f func(e *Explod)) {
-		if idx < 0 {
-			for _, e := range expls {
-				if idx < 0 {
-					f(e)
-				}
-			}
-		} else if idx < len(expls) {
-			f(expls[idx])
+		for _, e := range expls {
+			f(e)
 		}
 	}
 
@@ -7721,15 +7715,11 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 	redirscale := c.localscl / crun.localscl
 	mpid := int32(-1)
 	mpidx := int(-1)
-	var projs []*Projectile
 
+	var projs []*Projectile
 	eachProj := func(f func(p *Projectile)) {
-		if mpidx < 0 {
-			for _, p := range projs {
-				f(p)
-			}
-		} else if mpidx < len(projs) {
-			f(projs[mpidx])
+		for _, p := range projs {
+			f(p)
 		}
 	}
 
@@ -12709,16 +12699,12 @@ func (sc modifyText) Run(c *Char, _ []int32) bool {
 	}
 
 	tid := int32(-1)
-	idx := int32(-1)
-	var texts []*TextSprite
+	idx := int(-1)
 
+	var texts []*TextSprite
 	eachText := func(f func(ts *TextSprite)) {
-		if idx < 0 {
-			for _, ts := range texts {
-				f(ts)
-			}
-		} else if idx >= 0 && idx < int32(len(texts)) {
-			f(texts[idx])
+		for _, ts := range texts {
+			f(ts)
 		}
 	}
 
@@ -12727,19 +12713,12 @@ func (sc modifyText) Run(c *Char, _ []int32) bool {
 		case text_id:
 			tid = exp[0].evalI(c)
 		case modifytext_index:
-			idx = exp[0].evalI(c)
+			idx = int(exp[0].evalI(c))
 		case modifytext_redirectid:
 			return true
 		default:
 			if len(texts) == 0 {
-				for _, ts := range sys.chartexts[crun.playerNo] {
-					if ts.ownerid != crun.id {
-						continue
-					}
-					if tid == -1 || ts.id == tid {
-						texts = append(texts, ts)
-					}
-				}
+				texts = crun.getMultipleTexts(tid, idx, true)
 				if len(texts) == 0 {
 					return false
 				}
@@ -13917,9 +13896,9 @@ const (
 func (sc modifyStageBG) Run(c *Char, _ []int32) bool {
 	bgid := int32(-1)
 	bgidx := int(-1)
-	var backgrounds []*backGround
 
 	// Helper function to modify each BG
+	var backgrounds []*backGround
 	eachBg := func(f func(bg *backGround)) {
 		for _, bg := range backgrounds {
 			f(bg)

--- a/src/char.go
+++ b/src/char.go
@@ -5383,7 +5383,7 @@ func (c *Char) numText(textid BytecodeValue) BytecodeValue {
 		return BytecodeSF()
 	}
 	var id, n int32 = textid.ToI(), 0
-	for _, ts := range sys.motif.textsprite {
+	for _, ts := range sys.chartexts {
 		if ts.id == id && ts.ownerid == c.id {
 			n++
 		}
@@ -6331,7 +6331,7 @@ func (c *Char) destroySelf(recursive, removeexplods, removetexts bool) bool {
 	}
 
 	if removetexts {
-		sys.motif.removeText(-1, -1, c.id)
+		sys.removeCharText(-1, -1, c.id)
 	}
 
 	if recursive {

--- a/src/char.go
+++ b/src/char.go
@@ -4258,6 +4258,7 @@ func (c *Char) loadPalette() {
 
 	gi.remappedpal = [2]int32{1, gi.palno}
 }
+
 func (c *Char) loadFx(def string) error {
 	gi := c.gi()
 	gi.fxPath = []string{} // Always initialize before loading.
@@ -4366,6 +4367,7 @@ func (c *Char) loadFx(def string) error {
 	}
 	return nil
 }
+
 func (c *Char) clearHitCount() {
 	c.hitCount = 0
 	c.uniqHitCount = 0
@@ -6220,6 +6222,7 @@ func (c *Char) persistentChangeStateHitpauseCorrection(sbc *StateBytecode) {
 		}
 	}
 }
+
 func (c *Char) stateChange2() bool {
 	if c.stchtmp && !c.hitPause() {
 		c.ss.sb.init(c)
@@ -6554,16 +6557,9 @@ func (c *Char) spawnExplod() (*Explod, int) {
 		return nil, -1
 	}
 
-	// Check if we have any ghosted explods sitting outside the current slice length
-	e := GetGhostPointer(*playerExplods)
+	// Recover a ghosted explod or make a new one
+	e := RecoverOrAppend(playerExplods, func(e *Explod) { e.clear() }, newExplod)
 
-	if e != nil {
-		e.clear()
-	} else {
-		e = newExplod()
-	}
-
-	*playerExplods = append(*playerExplods, e)
 	idx := len(*playerExplods) - 1
 
 	e.initFromChar(c)
@@ -6753,16 +6749,8 @@ func (c *Char) spawnText() *TextSprite {
 		return nil
 	}
 
-	// Check if we have any ghosted texts sitting outside the current slice length
-	ts := GetGhostPointer(*playerTexts)
-
-	if ts != nil {
-		ts.Clear()
-	} else {
-		ts = NewTextSprite()
-	}
-
-	*playerTexts = append(*playerTexts, ts)
+	// Recover a ghosted text or make a new one
+	ts := RecoverOrAppend(playerTexts, func(ts *TextSprite) { ts.Clear() }, NewTextSprite)
 
 	return ts
 }
@@ -7072,16 +7060,8 @@ func (c *Char) spawnProjectile() *Projectile {
 		return nil
 	}
 
-	// Check if we have any ghosted projectiles sitting outside the current slice length
-	p := GetGhostPointer(*playerProjs)
-
-	if p != nil {
-		p.clear()
-	} else {
-		p = newProjectile()
-	}
-
-	*playerProjs = append(*playerProjs, p)
+	// Recover a ghosted projectile or make a new one
+	p := RecoverOrAppend(playerProjs, func(p *Projectile) { p.clear() }, newProjectile)
 
 	p.initFromChar(c)
 

--- a/src/char.go
+++ b/src/char.go
@@ -1198,10 +1198,10 @@ func (ghv GetHitVar) getJuggle(id, defaultJuggle int32) int32 {
 	return defaultJuggle
 }
 
-func (ghv *GetHitVar) dropId(id int32) {
+func (ghv *GetHitVar) dropPlayerId(id int32) {
 	for i, v := range ghv.targetedBy {
 		if v[0] == id {
-			ghv.targetedBy = append(ghv.targetedBy[:i], ghv.targetedBy[i+1:]...)
+			ghv.targetedBy = SliceDelete(ghv.targetedBy, i)
 			return
 		}
 	}
@@ -1209,7 +1209,7 @@ func (ghv *GetHitVar) dropId(id int32) {
 
 func (ghv *GetHitVar) addId(id, juggle int32) {
 	juggle = ghv.getJuggle(id, juggle)
-	ghv.dropId(id)
+	ghv.dropPlayerId(id)
 	ghv.targetedBy = append(ghv.targetedBy, [...]int32{id, juggle})
 }
 
@@ -6286,7 +6286,7 @@ func (c *Char) destroy() {
 	// Remove ID from target's GetHitVars
 	for _, tid := range c.targets {
 		if t := sys.playerID(tid); t != nil {
-			t.ghv.dropId(c.id)
+			t.ghv.dropPlayerId(c.id)
 		}
 	}
 
@@ -6960,6 +6960,7 @@ func (c *Char) spawnProjectile() *Projectile {
 	playerProjs := &sys.projs[c.playerNo]
 
 	// Reuse inactive projectile slot if available
+	// TODO: We could keep this slice compact like with explods
 	for i := range *playerProjs {
 		if (*playerProjs)[i].id < 0 {
 			p = (*playerProjs)[i]
@@ -7833,7 +7834,7 @@ func (c *Char) targetDrop(excludeid int32, excludechar int32, keepone bool) {
 					tg = append(tg, tid)
 				} else {
 					t.gethitBindClear()
-					t.ghv.dropId(c.id)
+					t.ghv.dropPlayerId(c.id)
 				}
 			}
 		}
@@ -7850,7 +7851,7 @@ func (c *Char) targetDrop(excludeid int32, excludechar int32, keepone bool) {
 					tg = append(tg, tid)
 				} else {
 					t.gethitBindClear()
-					t.ghv.dropId(c.id)
+					t.ghv.dropPlayerId(c.id)
 				}
 			}
 		}
@@ -7872,7 +7873,7 @@ func (c *Char) targetDrop(excludeid int32, excludechar int32, keepone bool) {
 					}
 					t.setBindTime(0)
 				}
-				t.ghv.dropId(c.id)
+				t.ghv.dropPlayerId(c.id)
 			}
 		}
 	} else {
@@ -9266,7 +9267,7 @@ func (c *Char) dropTargets() {
 func (c *Char) removeTarget(pid int32) {
 	for i, t := range c.targets {
 		if t == pid {
-			c.targets = append(c.targets[:i], c.targets[i+1:]...)
+			c.targets = SliceDelete(c.targets, i)
 			return
 		}
 	}
@@ -9398,7 +9399,7 @@ func (c *Char) getClsn(group int32) [][4]float32 {
 			if mod.index == -1 {
 				final = final[:0]
 			} else if mod.index >= 0 && mod.index < len(final) {
-				final = append(final[:mod.index], final[mod.index+1:]...)
+				final = SliceDelete(final, mod.index)
 			}
 
 		// Modify all existing boxes
@@ -10733,7 +10734,7 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 					jg = v[1]
 				}
 			}
-			getter.ghv.dropId(origin.id)
+			getter.ghv.dropPlayerId(origin.id)
 			getter.ghv.targetedBy = append(getter.ghv.targetedBy, [...]int32{origin.id, jg - c.juggle})
 		}
 		if c.inheritJuggle == 1 && c.parent(false) != nil {

--- a/src/char.go
+++ b/src/char.go
@@ -12384,7 +12384,7 @@ func (cl *CharList) commandUpdate() {
 					continue
 				}
 				if (c.helperIndex == 0 || c.helperIndex > 0 && &c.cmd[0] != &root.cmd[0]) &&
-					c.cmd[0].InputUpdate(c, c.controller, sys.aiLevel[i], false) {
+					c.cmd[0].InputUpdate(c, c.controller) {
 					// Clear input buffers and skip the rest of the loop
 					// This used to apply only to the root, but that caused some issues with helper-based custom input systems
 					if c.inputWait() || c.asf(ASF_noinput) {

--- a/src/char.go
+++ b/src/char.go
@@ -6715,6 +6715,7 @@ func (c *Char) explodBindTime(id, time int32) {
 // Marks matching explods invalid and prunes the slice immediately
 func (c *Char) removeExplod(id, idx int32) {
 	playerExplods := &sys.explods[c.playerNo]
+	removedAny := false
 	n := int32(0)
 
 	// Mark matching explods as invalid
@@ -6722,6 +6723,8 @@ func (c *Char) removeExplod(id, idx int32) {
 		if e.matchId(id, c.id) {
 			if idx < 0 || idx == n {
 				e.id = IErr
+
+				removedAny = true
 				if idx == n {
 					break
 				}
@@ -6730,14 +6733,10 @@ func (c *Char) removeExplod(id, idx int32) {
 		}
 	}
 
-	// Compact the slice to remove invalid explods
-	tempSlice := (*playerExplods)[:0] // Reuse backing array
-	for _, e := range *playerExplods {
-		if e.id != IErr {
-			tempSlice = append(tempSlice, e)
-		}
+	// Remove invalid explods right away
+	if removedAny {
+		sys.explodPrune(c.playerNo)
 	}
-	*playerExplods = tempSlice
 }
 
 // Always appends to preserve insertion order
@@ -6765,6 +6764,7 @@ func (c *Char) spawnText() *TextSprite {
 
 func (c *Char) removeText(id, index int32) {
 	playerTexts := &sys.chartexts[c.playerNo]
+	removedAny := false
 	n := int32(0)
 
 	// Mark matching texts as invalid
@@ -6774,7 +6774,10 @@ func (c *Char) removeText(id, index int32) {
 		}
 		if id < 0 || ts.id == id {
 			if index < 0 || index == n {
-				ts.id = IErr
+				ts.id = IErr // Texts are filtered by removetime but we might as well do this too
+				ts.removetime = 0
+
+				removedAny = true
 				if index == n {
 					break
 				}
@@ -6783,14 +6786,10 @@ func (c *Char) removeText(id, index int32) {
 		}
 	}
 
-	// Compact the slice to remove invalid texts
-	tempSlice := (*playerTexts)[:0] 
-	for _, ts := range *playerTexts {
-		if ts.id != IErr {
-			tempSlice = append(tempSlice, ts)
-		}
+	// Remove invalid texts right away
+	if removedAny {
+		sys.charTextsPrune(c.playerNo)
 	}
-	*playerTexts = tempSlice
 }
 
 // Get animation and apply sprite owner properties to it

--- a/src/char.go
+++ b/src/char.go
@@ -291,8 +291,8 @@ func (cd *CharData) init() {
 	cd.guardsound_channel = -1
 	cd.ko.echo = 0
 	cd.volume = 256
-	cd.intpersistindex = int32(math.MaxInt32)
-	cd.floatpersistindex = int32(math.MaxInt32)
+	cd.intpersistindex = math.MaxInt32
+	cd.floatpersistindex = math.MaxInt32
 }
 
 type CharSize struct {
@@ -6705,6 +6705,29 @@ func (c *Char) removeExplod(id, idx int32) {
 		}
 	}
 	*playerExplods = tempSlice
+}
+
+// Always appends to preserve insertion order
+func (c *Char) spawnText() *TextSprite {
+	playerTexts := &sys.chartexts[c.playerNo]
+
+	// Do nothing if text limit reached
+	if len(*playerTexts) >= sys.cfg.Config.TextMax {
+		return nil
+	}
+
+	// Check if we have any ghosted texts sitting outside the current slice length
+	ts := GetGhostPointer(*playerTexts)
+
+	if ts != nil {
+		ts.Clear()
+	} else {
+		ts = NewTextSprite()
+	}
+
+	*playerTexts = append(*playerTexts, ts)
+
+	return ts
 }
 
 func (c *Char) removeText(id, index int32) {

--- a/src/char.go
+++ b/src/char.go
@@ -5383,7 +5383,7 @@ func (c *Char) numText(textid BytecodeValue) BytecodeValue {
 		return BytecodeSF()
 	}
 	var id, n int32 = textid.ToI(), 0
-	for _, ts := range sys.chartexts {
+	for _, ts := range sys.chartexts[c.playerNo] {
 		if ts.id == id && ts.ownerid == c.id {
 			n++
 		}
@@ -6331,7 +6331,7 @@ func (c *Char) destroySelf(recursive, removeexplods, removetexts bool) bool {
 	}
 
 	if removetexts {
-		sys.removeCharText(-1, -1, c.id)
+		c.removeText(-1, -1)
 	}
 
 	if recursive {
@@ -6668,7 +6668,7 @@ func (c *Char) removeExplod(id, idx int32) {
 	playerExplods := &sys.explods[c.playerNo]
 	n := int32(0)
 
-	// Mark matching explods invalid
+	// Mark matching explods as invalid
 	for _, e := range *playerExplods {
 		if e.matchId(id, c.id) {
 			if idx < 0 || idx == n {
@@ -6689,6 +6689,36 @@ func (c *Char) removeExplod(id, idx int32) {
 		}
 	}
 	*playerExplods = tempSlice
+}
+
+func (c *Char) removeText(id, index int32) {
+	playerTexts := &sys.chartexts[c.playerNo]
+	n := int32(0)
+
+	// Mark matching texts as invalid
+	for _, ts := range *playerTexts {
+		if ts.ownerid != c.id {
+			continue
+		}
+		if id < 0 || ts.id == id {
+			if index < 0 || index == n {
+				ts.id = IErr
+				if index == n {
+					break
+				}
+			}
+			n++
+		}
+	}
+
+	// Compact the slice to remove invalid texts
+	tempSlice := (*playerTexts)[:0] 
+	for _, ts := range *playerTexts {
+		if ts.id != IErr {
+			tempSlice = append(tempSlice, ts)
+		}
+	}
+	*playerTexts = tempSlice
 }
 
 // Get animation and apply sprite owner properties to it

--- a/src/char.go
+++ b/src/char.go
@@ -202,12 +202,12 @@ func (cr *ClsnRect) Add(clsn [][4]float32, x, y, xs, ys, angle float32) {
 	}
 }
 
+// Draw the whole list of a specific type of debug Clsn
 func (cr ClsnRect) draw(blendAlpha [2]int32) {
-	paltex := PaletteToTexture(sys.clsnSpr.Pal)
 	for _, c := range cr {
 		params := RenderParams{
 			tex:            sys.clsnSpr.Tex,
-			paltex:         paltex,
+			paltex:         sys.clsnSpr.PalTex,
 			size:           sys.clsnSpr.Size,
 			x:              -c[0] * sys.widthScale,
 			y:              -c[1] * sys.heightScale,
@@ -4159,7 +4159,7 @@ func (c *Char) loadPalette() {
 					copy(newSlice, gi.palettedata.palList.PalTex)
 					gi.palettedata.palList.PalTex = newSlice
 				}
-				gi.palettedata.palList.PalTex[i] = PaletteToTexture(pl)
+				gi.palettedata.palList.PalTex[i] = NewTextureFromPalette(pl)
 				tmp = i + 1
 			} else {
 				pal.exists = false
@@ -4179,7 +4179,7 @@ func (c *Char) loadPalette() {
 		}
 		for i := 0; i < numPals; i++ {
 			if pData := gi.sff.palList.Get(i); pData != nil {
-				gi.palettedata.palList.PalTex[i] = PaletteToTexture(pData)
+				gi.palettedata.palList.PalTex[i] = NewTextureFromPalette(pData)
 			}
 		}
 
@@ -4190,13 +4190,13 @@ func (c *Char) loadPalette() {
 			if pl, ok := readAct(&pal); ok {
 				if existsInSff && pIdx >= 0 {
 					// Overwrite existing SFFv2 slot with ACT data
-					gi.palettedata.palList.PalTex[pIdx] = PaletteToTexture(pl)
+					gi.palettedata.palList.PalTex[pIdx] = NewTextureFromPalette(pl)
 				} else {
 					// Create a new isolated index for the ACT to prevent crashes
 					newIdx := len(gi.palettedata.palList.palettes)
 					gi.palettedata.palList.palettes = append(gi.palettedata.palList.palettes, pl)
 					gi.palettedata.palList.paletteMap = append(gi.palettedata.palList.paletteMap, newIdx)
-					gi.palettedata.palList.PalTex = append(gi.palettedata.palList.PalTex, PaletteToTexture(pl))
+					gi.palettedata.palList.PalTex = append(gi.palettedata.palList.PalTex, NewTextureFromPalette(pl))
 					gi.palettedata.palList.PalTable[[...]uint16{1, uint16(i + 1)}] = newIdx
 				}
 				pal.exists = true

--- a/src/char.go
+++ b/src/char.go
@@ -2001,7 +2001,7 @@ func (e *Explod) update(playerNo int) {
 		}
 	}
 
-	var trueFacing float32 = e.facing * e.relativef
+	facing := e.trueFacing()
 	//if e.lockSpriteFacing {
 	//	facing = -1
 	//}
@@ -2039,7 +2039,7 @@ func (e *Explod) update(playerNo int) {
 	if alp[0] < 0 {
 		alp[0] = -1
 	}
-	if (trueFacing < 0) != (e.vfacing < 0) {
+	if (facing < 0) != (e.vfacing < 0) {
 		anglerot[0] *= -1
 		anglerot[2] *= -1
 	}
@@ -2101,7 +2101,7 @@ func (e *Explod) update(playerNo int) {
 		rot:          rot,
 		screen:       e.space == Space_screen,
 		undarken:     parent != nil && parent.ignoreDarkenTime > 0,
-		facing:       trueFacing,
+		facing:       facing,
 		airOffsetFix: [2]float32{1, 1},
 		projection:   int32(e.projection),
 		fLength:      fLength,
@@ -2271,6 +2271,10 @@ func (e *Explod) resetInterpolation(pfd *PalFXDef) {
 		e.interpolate_fLength[i] = e.fLength
 		e.interpolate_xshear[i] = e.xshear
 	}
+}
+
+func (e *Explod) trueFacing() float32 {
+	return e.facing * e.relativef
 }
 
 type Projectile struct {
@@ -5442,7 +5446,7 @@ func (c *Char) explodVar(eid BytecodeValue, idx BytecodeValue, vtype OpCode) Byt
 		case OC_ex2_explodvar_drawpal_index:
 			v = BytecodeInt(c.explodDrawPal(e)[1])
 		case OC_ex2_explodvar_facing:
-			v = BytecodeInt(int32(e.facing * e.relativef))
+			v = BytecodeInt(int32(e.trueFacing()))
 		case OC_ex2_explodvar_friction_x:
 			v = BytecodeFloat(e.friction[0])
 		case OC_ex2_explodvar_friction_y:

--- a/src/char.go
+++ b/src/char.go
@@ -6568,11 +6568,11 @@ func (c *Char) spawnExplod() (*Explod, int) {
 
 // Get multiple explods for ModifyExplod, etc
 func (c *Char) getMultipleExplods(id int32, idx int, log bool) (expls []*Explod) {
-	// Filter explods with the specified ID
-	if idx < len(sys.explods[c.playerNo]) { // Includes negative indexes (all)
+	// No use searching if index is impossible
+	if len(sys.explods[c.playerNo]) > 0 && idx < len(sys.explods[c.playerNo]) {
+		// Filter explods with the specified ID
 		matchCount := 0
-		for i := range sys.explods[c.playerNo] {
-			e := sys.explods[c.playerNo][i]
+		for _, e := range sys.explods[c.playerNo] {
 			if e.matchId(id, c.id) {
 				if idx >= 0 {
 					// Count the matches but only return one
@@ -6586,10 +6586,10 @@ func (c *Char) getMultipleExplods(id int32, idx int, log bool) (expls []*Explod)
 				matchCount++
 			}
 		}
-	}
 
-	if len(expls) > 0 {
-		return expls
+		if len(expls) > 0 {
+			return expls
+		}
 	}
 
 	// No valid explods found
@@ -6753,6 +6753,40 @@ func (c *Char) spawnText() *TextSprite {
 	ts := RecoverOrAppend(playerTexts, func(ts *TextSprite) { ts.Clear() }, NewTextSprite)
 
 	return ts
+}
+
+// Get multiple text sprites for ModifyText
+func (c *Char) getMultipleTexts(id int32, idx int, log bool) (texts []*TextSprite) {
+	// No use searching if index is impossible
+	if len(sys.chartexts[c.playerNo]) > 0 && idx < len(sys.chartexts[c.playerNo]) {
+		// Filter texts with the specified ID
+		matchCount := 0
+		for _, ts := range sys.chartexts[c.playerNo] {
+			// Check owner and ID match
+			if ts.ownerid == c.id && (id == -1 || ts.id == id) {
+				if idx >= 0 {
+					// Count the matches but only return the specific one
+					if matchCount == idx {
+						return []*TextSprite{ts}
+					}
+				} else {
+					// Append all matches
+					texts = append(texts, ts)
+				}
+				matchCount++
+			}
+		}
+
+		if len(texts) > 0 {
+			return texts
+		}
+	}
+
+	// No valid texts found
+	if log {
+		sys.appendToConsole(c.warn() + fmt.Sprintf("found no texts with ID %v and index %v", id, idx))
+	}
+	return nil
 }
 
 func (c *Char) removeText(id, index int32) {
@@ -7143,8 +7177,9 @@ func (c *Char) projDrawPal(p *Projectile) [2]int32 {
 
 // Get multiple projectiles for ModifyProjectile, etc
 func (c *Char) getMultipleProjs(id int32, idx int, log bool) (projs []*Projectile) {
-	// Filter projectiles with the specified ID
-	if idx < len(sys.projs[c.playerNo]) { // Includes negative indexes (all)
+	// No use searching if index is impossible
+	if len(sys.projs[c.playerNo]) > 0 && idx < len(sys.projs[c.playerNo]) {
+		// Filter projectiles with the specified ID
 		matchCount := 0
 		for _, p := range sys.projs[c.playerNo] {
 			if id < 0 || p.id == id {
@@ -7160,11 +7195,11 @@ func (c *Char) getMultipleProjs(id int32, idx int, log bool) (projs []*Projectil
 				matchCount++
 			}
 		}
-	}
 
-	// Return all matches
-	if len(projs) > 0 {
-		return projs
+		// Return all matches
+		if len(projs) > 0 {
+			return projs
+		}
 	}
 
 	// No valid projectiles found
@@ -7590,8 +7625,9 @@ func (c *Char) setFacing(f float32) {
 
 // Get multiple stage BG elements for ModifyStageBG sctrl
 func (c *Char) getMultipleStageBg(id int32, idx int, log bool) (filteredBg []*backGround) {
-	// Filter background elements with the specified ID
-	if idx < len(sys.stage.bg) { // Includes negative indexes (all)
+	// No use searching if index is impossible
+	if len(sys.stage.bg) > 0 && idx < len(sys.stage.bg) {
+		// Filter background elements with the specified ID
 		matchCount := 0
 		for _, bg := range sys.stage.bg {
 			if id < 0 || id == bg.id {
@@ -7601,17 +7637,17 @@ func (c *Char) getMultipleStageBg(id int32, idx int, log bool) (filteredBg []*ba
 						return []*backGround{bg}
 					}
 				} else {
-					// Append all matches (wildcard mode)
+					// Append all matches
 					filteredBg = append(filteredBg, bg)
 				}
 				matchCount++
 			}
 		}
-	}
 
-	// Return all matches
-	if len(filteredBg) > 0 {
-		return filteredBg
+		// Return all matches
+		if len(filteredBg) > 0 {
+			return filteredBg
+		}
 	}
 
 	// No valid background element found

--- a/src/char.go
+++ b/src/char.go
@@ -2492,8 +2492,8 @@ func (p *Projectile) update() {
 			if p.anim != nil && (p.anim.totaltime <= 0 || p.anim.AnimTime() == 0) {
 				p.anim = nil
 			}
-			if p.anim == nil && p.id >= 0 {
-				p.id = ^p.id
+			if p.anim == nil { // && p.id >= 0 {
+				p.id = IErr // ^p.id
 			}
 		}
 	}
@@ -2563,7 +2563,7 @@ func (p *Projectile) tradeDetection(playerNo, index int) {
 
 	// Skip if this projectile can't trade at all
 	// Projectiles can trade even if they are spawned with 0 hits
-	if p.remflag || p.hits < 0 || p.id < 0 {
+	if p.hits < 0 || p.remflag {
 		return
 	}
 
@@ -5617,7 +5617,7 @@ func (c *Char) numProj() int32 {
 	n := int32(0)
 
 	for _, p := range sys.projs[c.playerNo] {
-		if p.id >= 0 && !((p.hits < 0 && p.remove) || p.remflag) {
+		if !((p.hits < 0 && p.remove) || p.remflag) {
 			n++
 		}
 	}
@@ -7100,8 +7100,7 @@ func (c *Char) getMultipleProjs(id int32, idx int, log bool) (projs []*Projectil
 	if idx < len(sys.projs[c.playerNo]) { // Includes negative indexes (all)
 		matchCount := 0
 		for _, p := range sys.projs[c.playerNo] {
-			// Only check active projectiles (p.id >= 0)
-			if p.id >= 0 && (id < 0 || p.id == id) {
+			if id < 0 || p.id == id {
 				if idx >= 0 {
 					// Count the matches but only return one
 					if matchCount == idx {
@@ -12676,7 +12675,7 @@ func (cl *CharList) hitDetectionProjectile(getter *Char) {
 			p := sys.projs[i][j]
 
 			// Skip if projectile can't hit
-			if p.id < 0 || p.hits <= 0 {
+			if p.hits <= 0 {
 				continue
 			}
 

--- a/src/char.go
+++ b/src/char.go
@@ -2888,6 +2888,7 @@ type CharGlobalInfo struct {
 	music                   Music
 	attackBase              int32
 	defenceBase             int32
+	canMutateStage          bool // Determines if the stage should be included in save states
 }
 
 func (cgi *CharGlobalInfo) clearPCTime() {

--- a/src/common.go
+++ b/src/common.go
@@ -691,7 +691,7 @@ func OldSprintf(f string, a ...interface{}) (s string) {
 			b[i] = 'd'
 		}
 		for i := len(lIdx) - 1; i >= 0; i-- {
-			b = append(b[:lIdx[i]], b[lIdx[i]+1:]...)
+			b = SliceDelete(b, lIdx[i])
 		}
 		f = string(b)
 	}
@@ -1553,12 +1553,22 @@ func LowercaseNoExtension(filename string) string {
 	return strings.ToLower(nameOnly)
 }
 
-// Similar to slice.delete but more thorough because it also nils the removed item
-func SliceDelete[T any](slice []*T, i int) []*T {
+// Similar to slices.delete but more thorough because it also nils/zeroes the removed item
+func SliceDelete[T any](slice []T, i int) []T {
 	if i < 0 || i >= len(slice) {
 		return slice
 	}
 	copy(slice[i:], slice[i+1:])
-	slice[len(slice)-1] = nil
+	var zero T
+	slice[len(slice)-1] = zero // This only matters for pointers
 	return slice[:len(slice)-1]
+}
+
+// Nils out all elements and returns a zero-length slice while preserving the underlying capacity
+// This is better than plain [:0] because we ensure data from previous characters is GC'd
+func PointerSliceReset[T any](slice []*T) []*T {
+	for i := range slice {
+		slice[i] = nil
+	}
+	return slice[:0]
 }

--- a/src/common.go
+++ b/src/common.go
@@ -1552,3 +1552,13 @@ func LowercaseNoExtension(filename string) string {
 	}
 	return strings.ToLower(nameOnly)
 }
+
+// Similar to slice.delete but more thorough because it also nils the removed item
+func SliceDelete[T any](slice []*T, i int) []*T {
+	if i < 0 || i >= len(slice) {
+		return slice
+	}
+	copy(slice[i:], slice[i+1:])
+	slice[len(slice)-1] = nil
+	return slice[:len(slice)-1]
+}

--- a/src/common.go
+++ b/src/common.go
@@ -1572,3 +1572,11 @@ func PointerSliceReset[T any](slice []*T) []*T {
 	}
 	return slice[:0]
 }
+
+// Pull a pointer from outside the slice's current length but within its capacity
+func GetGhostPointer[T any](s []*T) *T {
+	if len(s) < cap(s) {
+		return s[:len(s)+1][len(s)]
+	}
+	return nil
+}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -4850,10 +4850,10 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.append(OC_ex_movehitvar_cornerpush_veloff)
 		case "frame":
 			out.append(OC_ex_movehitvar_frame)
-		case "playerid", "id": // "ID" is deprecated
-			out.append(OC_ex_movehitvar_playerid)
 		case "overridden":
 			out.append(OC_ex_movehitvar_overridden)
+		case "playerid", "id": // "ID" is deprecated
+			out.append(OC_ex_movehitvar_playerid)
 		case "playerno":
 			out.append(OC_ex_movehitvar_playerno)
 		case "sparkx":

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -7782,14 +7782,16 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 	lines, i = SplitAndTrim(str, "\n"), 0
 
 	// Initialize command list data
-	if sys.chars[pn][0].cmd == nil {
-		sys.chars[pn][0].cmd = make([]CommandList, MaxPlayerNo)
-		b := NewInputBuffer()
-		for i := range sys.chars[pn][0].cmd {
-			sys.chars[pn][0].cmd[i] = *NewCommandList(b, -1)
+	char := sys.chars[pn][0]
+	if char.cmd == nil {
+		char.cmd = make([]CommandList, MaxPlayerNo)
+		// Create one single input buffer and link it to all command lists
+		buffer := NewInputBuffer()
+		for i := range char.cmd {
+			char.cmd[i] = *NewCommandList(buffer)
 		}
 	}
-	c.cmdl = &sys.chars[pn][0].cmd[pn]
+	c.cmdl = &char.cmd[pn]
 	remap, defaults, ckr := true, true, NewCommandKeyRemap()
 
 	var cmds []IniSection

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -4670,6 +4670,7 @@ func (c *Compiler) loadFile(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	})
 	return *ret, err
 }
+
 func (c *Compiler) loadState(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*loadState)(sc), c.stateSec(is, func() error {
 		sc.add(loadState_, nil)
@@ -6126,6 +6127,7 @@ func (c *Compiler) modifyStageVar(is IniSection, sc *StateControllerBase, _ int8
 		}
 		return nil
 	})
+	sys.cgi[c.playerNo].canMutateStage = true
 	return *ret, err
 }
 
@@ -6762,6 +6764,7 @@ func (c *Compiler) modifyStageBG(is IniSection, sc *StateControllerBase, _ int8)
 		}
 		return nil
 	})
+	sys.cgi[c.playerNo].canMutateStage = true
 	return *ret, err
 }
 

--- a/src/font.go
+++ b/src/font.go
@@ -1191,7 +1191,7 @@ func (ts *TextSprite) Update() {
 }
 
 func (ts *TextSprite) Draw(ln int16) {
-	if sys.frameSkip || ts.fnt == nil || len(ts.text) == 0 || ts.layerno != ln {
+	if sys.frameSkip || ts.layerno != ln || ts.fnt == nil || len(ts.text) == 0 {
 		return
 	}
 

--- a/src/font.go
+++ b/src/font.go
@@ -726,21 +726,42 @@ type TextSprite struct {
 }
 
 func NewTextSprite() *TextSprite {
-	ts := &TextSprite{
+	ts := &TextSprite{}
+	ts.loadDefaults()
+	return ts
+}
+
+// More like a reset but that name is taken
+func (ts *TextSprite) Clear() {
+	ts.loadDefaults()
+}
+
+func (ts *TextSprite) loadDefaults() {
+	pfx := ts.palfx
+	prm := ts.params[:0]
+
+	*ts = TextSprite{
 		id:         -1,
 		align:      1,
 		xscl:       1,
 		yscl:       1,
 		window:     sys.scrrect,
-		palfx:      newPalFX(),
 		frgba:      [...]float32{1.0, 1.0, 1.0, 1.0},
 		removetime: 1,
 		localScale: 1,
 		friction:   [2]float32{1.0, 1.0},
 		scaleInit:  [2]float32{1.0, 1.0},
 	}
+
+	ts.params = prm
+
+	if pfx == nil {
+		ts.palfx = newPalFX()
+	} else {
+		ts.palfx = pfx
+		ts.palfx.clear()
+	}
 	ts.palfx.setColor(255, 255, 255)
-	return ts
 }
 
 // Creates a shallow copy with independent palette mapping

--- a/src/font.go
+++ b/src/font.go
@@ -530,7 +530,7 @@ func (f *Fnt) drawChar(
 			f.lastPalBase = base
 		} else {
 			// first time seeing this palette: upload once and reuse
-			f.paltex = PaletteToTexture(pal)
+			f.paltex = NewTextureFromPalette(pal)
 			f.paltexCache[base] = f.paltex
 			f.lastPalBase = base
 		}

--- a/src/font_gl21.go
+++ b/src/font_gl21.go
@@ -94,6 +94,7 @@ func (f *Font_GL21) UpdateResolution(windowWidth int, windowHeight int) {
 func (f *Font_GL21) Printf(x, y float32, scale float32, spacingXAdd float32, align int32, blend bool, window [4]int32, fs string, argv ...interface{}) error {
 
 	indices := []rune(fmt.Sprintf(fs, argv...))
+	r := gfx.(*Renderer_GL21)
 
 	if len(indices) == 0 {
 		return nil
@@ -102,11 +103,9 @@ func (f *Font_GL21) Printf(x, y float32, scale float32, spacingXAdd float32, ali
 	// Buffer to store vertex data for multiple glyphs
 	batchSize := Min(250, int32(len(indices)))
 	batchVertices := make([]float32, 0, batchSize*6*4)
+
 	//setup blending mode
-	gl.Enable(gl.BLEND)
-	if blend {
-		gl.BlendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA)
-	}
+	r.SetBlending(blend, BlendAdd, BlendSrcAlpha, BlendOneMinusSrcAlpha)
 
 	//restrict drawing to a certain part of the window
 	gl.Enable(gl.SCISSOR_TEST)
@@ -114,7 +113,7 @@ func (f *Font_GL21) Printf(x, y float32, scale float32, spacingXAdd float32, ali
 
 	// Activate corresponding render state
 	program := gfxFont.(*FontRenderer_GL21).shaderProgram
-	gl.UseProgram(program.program)
+	r.UseProgram(program.program)
 	//set text color
 	gl.Uniform4f(program.u["textColor"], f.color.r, f.color.g, f.color.b, f.color.a)
 	//set screen resolution
@@ -194,8 +193,8 @@ func (f *Font_GL21) Printf(x, y float32, scale float32, spacingXAdd float32, ali
 	//clear opengl textures and programs
 	gl.BindVertexArray(0)
 	gl.BindTexture(gl.TEXTURE_2D, 0)
-	gl.UseProgram(0)
-	gl.Disable(gl.BLEND)
+	//gl.UseProgram(0)
+	//gl.Disable(gl.BLEND)
 	gl.Disable(gl.SCISSOR_TEST)
 
 	return nil

--- a/src/font_gl32.go
+++ b/src/font_gl32.go
@@ -97,6 +97,7 @@ func (f *Font_GL32) UpdateResolution(windowWidth int, windowHeight int) {
 func (f *Font_GL32) Printf(x, y float32, scale float32, spacingXAdd float32, align int32, blend bool, window [4]int32, fs string, argv ...interface{}) error {
 
 	indices := []rune(fmt.Sprintf(fs, argv...))
+	r := gfx.(*Renderer_GL32)
 
 	if len(indices) == 0 {
 		return nil
@@ -105,11 +106,9 @@ func (f *Font_GL32) Printf(x, y float32, scale float32, spacingXAdd float32, ali
 	// Buffer to store vertex data for multiple glyphs
 	batchSize := Min(250, int32(len(indices)))
 	batchVertices := make([]float32, 0, batchSize*6*4)
+
 	//setup blending mode
-	gl.Enable(gl.BLEND)
-	if blend {
-		gl.BlendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA)
-	}
+	r.SetBlending(blend, BlendAdd, BlendSrcAlpha, BlendOneMinusSrcAlpha)
 
 	//restrict drawing to a certain part of the window
 	gl.Enable(gl.SCISSOR_TEST)
@@ -117,7 +116,7 @@ func (f *Font_GL32) Printf(x, y float32, scale float32, spacingXAdd float32, ali
 
 	// Activate corresponding render state
 	program := gfxFont.(*FontRenderer_GL32).shaderProgram
-	gl.UseProgram(program.program)
+	r.UseProgram(program.program)
 	//set text color
 	gl.Uniform4f(program.u["textColor"], f.color.r, f.color.g, f.color.b, f.color.a)
 	//set screen resolution
@@ -197,8 +196,8 @@ func (f *Font_GL32) Printf(x, y float32, scale float32, spacingXAdd float32, ali
 	//clear opengl textures and programs
 	gl.BindVertexArray(0)
 	gl.BindTexture(gl.TEXTURE_2D, 0)
-	gl.UseProgram(0)
-	gl.Disable(gl.BLEND)
+	//gl.UseProgram(0)
+	//gl.Disable(gl.BLEND)
 	gl.Disable(gl.SCISSOR_TEST)
 
 	return nil

--- a/src/font_gles32.go
+++ b/src/font_gles32.go
@@ -90,8 +90,8 @@ func (f *Font_GLES32) UpdateResolution(windowWidth int, windowHeight int) {
 
 // Printf draws a string to the screen, takes a list of arguments like printf
 func (f *Font_GLES32) Printf(x, y float32, scale float32, spacingXAdd float32, align int32, blend bool, window [4]int32, fs string, argv ...interface{}) error {
-
 	indices := []rune(fmt.Sprintf(fs, argv...))
+	r := gfx.(*Renderer_GL32)
 
 	if len(indices) == 0 {
 		return nil
@@ -101,10 +101,7 @@ func (f *Font_GLES32) Printf(x, y float32, scale float32, spacingXAdd float32, a
 	batchSize := Min(250, int32(len(indices)))
 	batchVertices := make([]float32, 0, batchSize*6*4)
 	//setup blending mode
-	gl.Enable(gl.BLEND)
-	if blend {
-		gl.BlendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA)
-	}
+	r.SetBlending(blend, BlendAdd, BlendSrcAlpha, BlendOneMinusSrcAlpha)
 
 	//restrict drawing to a certain part of the window
 	// gl.Enable(gl.SCISSOR_TEST)
@@ -112,7 +109,7 @@ func (f *Font_GLES32) Printf(x, y float32, scale float32, spacingXAdd float32, a
 
 	// Activate corresponding render state
 	program := gfxFont.(*FontRenderer_GLES32).shaderProgram
-	gl.UseProgram(program.program)
+	r.UseProgram(program.program)
 
 	// Set texture location
 	texLoc := gl.GetUniformLocation(program.program, gl.Str("tex\x00"))
@@ -199,8 +196,8 @@ func (f *Font_GLES32) Printf(x, y float32, scale float32, spacingXAdd float32, a
 	//clear opengl textures and programs
 	gl.BindVertexArray(0)
 	gl.BindTexture(gl.TEXTURE_2D, 0)
-	gl.UseProgram(0)
-	gl.Disable(gl.BLEND)
+	//gl.UseProgram(0)
+	//gl.Disable(gl.BLEND)
 	gl.Disable(gl.SCISSOR_TEST)
 
 	return nil

--- a/src/image.go
+++ b/src/image.go
@@ -704,13 +704,17 @@ func (s *Sprite) shareCopy(src *Sprite) {
 	//s.PalTex = src.PalTex
 }
 
+// Returns the raw palette colors
 func (s *Sprite) GetPal(pl *PaletteList) []uint32 {
 	if len(s.Pal) > 0 || s.coldepth > 8 {
+		// Use the sprite's own palette
 		return s.Pal
 	}
-	return pl.Get(int(s.palidx)) //pl.palettes[pl.paletteMap[int(s.palidx)]]
+	// Fetch from the global palette list
+	return pl.Get(int(s.palidx)) 
 }
 
+// Returns the shared global texture
 func (s *Sprite) GetPalTex(pl *PaletteList) Texture {
 	if s.coldepth > 8 {
 		return nil
@@ -1211,23 +1215,45 @@ func (s *Sprite) readV2(f io.ReadSeeker, offset int64, datasize uint32) error {
 // Compare current palette to previous one and reuse if possible
 // This saves a lot of palette operations when the same player has many sprites on screen
 func (s *Sprite) CachePalette(pal []uint32) Texture {
-	hasPalette := true
+	match := true
 	if s.PalTex == nil || len(pal) != len(s.paltemp) {
-		hasPalette = false
+		match = false
 	} else {
 		for i := range pal {
 			if pal[i] != s.paltemp[i] {
-				hasPalette = false
+				match = false
 				break
 			}
 		}
 	}
-	// If cached texture is invalid, generate a new one and cache it
-	if !hasPalette {
-		s.PalTex = PaletteToTexture(pal)
+	// If cached texture is invalid, update or replace it
+	if !match {
+		// Previously we were always generating a new texture in this branch
+		//s.PalTex = PaletteToTexture(pal)
+		s.PalTex = s.updatePaletteTexture(pal)
 		s.paltemp = append([]uint32{}, pal...)
 	}
 	return s.PalTex
+}
+
+// Update existing texture if provided. Create a new one if not
+func (s *Sprite) updatePaletteTexture(pal []uint32) Texture {
+    // If we already have a texture, just update the pixels
+    if s.PalTex != nil {
+        if len(pal) > 0 {
+            s.PalTex.SetData(unsafe.Slice((*byte)(unsafe.Pointer(&pal[0])), len(pal)*4))
+        } else {
+            s.PalTex.SetData(nil)
+        }
+        return s.PalTex
+    }
+
+    // Otherwise create a new one
+    tx := gfx.newPaletteTexture()
+    if len(pal) > 0 {
+        tx.SetData(unsafe.Slice((*byte)(unsafe.Pointer(&pal[0])), len(pal)*4))
+    }
+    return tx
 }
 
 func (s *Sprite) Draw(x, y, xscale, yscale float32, rxadd float32, rot Rotation, projectionMode int32, fLength float32, fx *PalFX, window *[4]int32) {

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -3686,7 +3686,7 @@ func (ro *LifeBarRound) draw(layerno int16, f map[int]*Fnt) {
 			ro.fadeIn.drawRect(rect, ro.shutter_col, 255)
 		}
 	}
-	BlendReset()
+	//BlendReset()
 }
 
 type LifeBarRatio struct {
@@ -5286,7 +5286,7 @@ func (l *Lifebar) draw(layerno int16) {
 		// LifeBarRound
 		l.ro.draw(layerno, l.fnt)
 	}
-	BlendReset()
+	//BlendReset()
 }
 
 func (l *Lifebar) setLifebarScale() {

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -1742,12 +1742,17 @@ func (fa *LifeBarFace) draw(layerno int16, ref int, far *LifeBarFace) {
 
 		// Get texture
 		if far.face.coldepth <= 8 {
-			far.face.Pal = nil
-			if far.face.PalTex != nil {
-				far.face.PalTex = far.face.GetPalTex(&sys.cgi[ref].palettedata.palList)
-			} else {
-				far.face.Pal = far.face.GetPal(&sys.cgi[ref].palettedata.palList)
-			}
+			// This method created a large hot spot in the profile
+			// It was throwing away good textures because of bad GetPalTex returns
+			//far.face.Pal = nil
+			//if far.face.PalTex != nil {
+			//	far.face.PalTex = far.face.GetPalTex(&sys.cgi[ref].palettedata.palList)
+			//} else {
+			//	far.face.Pal = far.face.GetPal(&sys.cgi[ref].palettedata.palList)
+			//}
+
+			// Now we just update the palette data and let the engine figure it out
+			far.face.Pal = far.face.GetPal(&sys.cgi[ref].palettedata.palList)
 		}
 
 		// Revert palette maps to initial state

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -2413,7 +2413,7 @@ func insertLbMsg(array []*LbMsg, value *LbMsg, index int) []*LbMsg {
 }
 
 func removeLbMsg(array []*LbMsg, index int) []*LbMsg {
-	return append(array[:index], array[index+1:]...)
+	return SliceDelete(array, index)
 }
 
 type LifeBarAction struct {

--- a/src/motif.go
+++ b/src/motif.go
@@ -4256,7 +4256,7 @@ func (di *MotifDialogue) applyTokens(m *Motif, line *DialogueParsedLine) {
 				applied := di.applyToken(m, line, token, i)
 				if applied {
 					// remove token
-					tokenList = append(tokenList[:idx], tokenList[idx+1:]...)
+					tokenList = SliceDelete(tokenList, idx)
 				}
 			}
 			line.tokens[i] = tokenList

--- a/src/motif.go
+++ b/src/motif.go
@@ -2707,7 +2707,7 @@ func (m *Motif) drawLoading() {
 		FillRect(sys.scrrect, 0x000000, [2]int32{255, 0})
 
 		ts.Draw(ts.layerno)
-		BlendReset()
+		//BlendReset()
 
 		// Submit and present
 		gfx.EndFrame()
@@ -2991,7 +2991,7 @@ func (m *Motif) draw(layerno int16) {
 			m.fadeIn.draw()
 		}
 	}
-	BlendReset()
+	//BlendReset()
 }
 
 func (m *Motif) isDialogueSet() bool {

--- a/src/render.go
+++ b/src/render.go
@@ -32,7 +32,7 @@ type Renderer interface {
 	IsModelEnabled() bool
 	IsShadowEnabled() bool
 
-	BlendReset()
+	//BlendReset()
 	SetPipeline(eq BlendEquation, src, dst BlendFunc)
 	ReleasePipeline()
 	prepareShadowMapPipeline(bufferIndex uint32)
@@ -489,9 +489,12 @@ func initRenderSpriteQuad(rp *RenderParams) {
 	rp.y += rp.rcy
 }
 
+// We relied too much on this, which hurt performance a little
+/*
 func BlendReset() {
 	gfx.BlendReset()
 }
+*/
 
 func RenderSprite(rp RenderParams) {
 	if !rp.IsValid() {
@@ -702,6 +705,7 @@ func CreateTextureAtlas(width, height int32, depth int32, filter bool) *TextureA
 	ta.skyline.PushBack([2]int32{0, 0})
 	return ta
 }
+
 func (ta *TextureAtlas) AddImage(width, height int32, data []byte) ([4]float32, bool) {
 	const maxWidth = 4096
 	if ta.resize {
@@ -727,6 +731,7 @@ func (ta *TextureAtlas) AddImage(width, height int32, data []byte) ([4]float32, 
 	ta.texture.SetSubData(data, x, y, width, height)
 	return [4]float32{float32(x) / float32(ta.width), float32(y) / float32(ta.height), float32(x+width) / float32(ta.width), float32(y+height) / float32(ta.height)}, true
 }
+
 func (ta *TextureAtlas) AddImageStride(width, height, stride int32, data []byte) ([4]float32, bool) {
 	const maxWidth = 4096
 	if ta.resize {
@@ -756,6 +761,7 @@ func (ta *TextureAtlas) AddImageStride(width, height, stride int32, data []byte)
 	}
 	return [4]float32{float32(x) / float32(ta.width), float32(y) / float32(ta.height), float32(x+width) / float32(ta.width), float32(y+height) / float32(ta.height)}, true
 }
+
 func (ta *TextureAtlas) FindPlaceToInsert(width, height int32) (int32, int32, bool) {
 	//leave 1px space
 	space := int32(1)

--- a/src/render_gl_gl32.go
+++ b/src/render_gl_gl32.go
@@ -63,9 +63,11 @@ func (r *Renderer_GL32) newShaderProgram(vert, frag, geo, id string, crashWhenFa
 	s.t = make(map[string]int)
 	return s, nil
 }
+
 func (r *ShaderProgram_GL32) glStr(s string) *uint8 {
 	return gl.Str(s + "\x00")
 }
+
 func (s *ShaderProgram_GL32) RegisterAttributes(names ...string) {
 	for _, name := range names {
 		s.a[name] = gl.GetAttribLocation(s.program, s.glStr(name))
@@ -205,6 +207,7 @@ func (r *Renderer_GL32) newDataTexture(width, height int32) (t Texture) {
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
 	return
 }
+
 func (r *Renderer_GL32) newHDRTexture(width, height int32) (t Texture) {
 	var h uint32
 	gl.ActiveTexture(gl.TEXTURE0)
@@ -223,6 +226,7 @@ func (r *Renderer_GL32) newHDRTexture(width, height int32) (t Texture) {
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.MIRRORED_REPEAT)
 	return
 }
+
 func (r *Renderer_GL32) newCubeMapTexture(widthHeight int32, mipmap bool, lowestMipLevel int32) (t Texture) {
 	var h uint32
 	gl.ActiveTexture(gl.TEXTURE0)
@@ -272,6 +276,7 @@ func (t *Texture_GL32) SetData(data []byte) {
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
 }
+
 func (t *Texture_GL32) SetSubData(data []byte, x, y, width, height int32) {
 	var interp int32 = gl.NEAREST
 	if t.filter {
@@ -293,9 +298,11 @@ func (t *Texture_GL32) SetSubData(data []byte, x, y, width, height int32) {
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
 }
+
 func (t *Texture_GL32) SetSubDataStride(textureData []byte, x, y, width, height, stride int32) {
 
 }
+
 func (t *Texture_GL32) SetDataG(data []byte, mag, min, ws, wt TextureSamplingParam) {
 
 	format := t.MapInternalFormat(Max(t.depth, 8))
@@ -309,6 +316,7 @@ func (t *Texture_GL32) SetDataG(data []byte, mag, min, ws, wt TextureSamplingPar
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, t.MapTextureSamplingParam(ws))
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, t.MapTextureSamplingParam(wt))
 }
+
 func (t *Texture_GL32) SetPixelData(data []float32) {
 	format := t.MapInternalFormat(Max(t.depth/4, 8))
 	internalFormat := t.MapInternalFormat(Max(t.depth, 8))
@@ -397,11 +405,14 @@ type Renderer_GL32 struct {
 	enableShadow bool
 	GL32State
 }
+
 type GL32State struct {
+	program             uint32
 	depthTest           bool
 	depthMask           bool
 	invertFrontFace     bool
 	doubleSided         bool
+	blendEnabled        bool
 	blendEquation       BlendEquation
 	blendSrc            BlendFunc
 	blendDst            BlendFunc
@@ -718,9 +729,9 @@ func (r *Renderer_GL32) BeginFrame(clearColor bool) {
 }
 
 func (r *Renderer_GL32) BlendReset() {
-	gl.BlendEquation(r.MapBlendEquation(BlendAdd))
-	gl.BlendFunc(r.MapBlendFunction(BlendSrcAlpha), r.MapBlendFunction(BlendOneMinusSrcAlpha))
+	r.SetBlending(true, BlendAdd, BlendSrcAlpha, BlendOneMinusSrcAlpha)
 }
+
 func (r *Renderer_GL32) EndFrame() {
 	if len(r.fbo_pp) == 0 {
 		return
@@ -761,7 +772,7 @@ func (r *Renderer_GL32) EndFrame() {
 	}
 
 	// disable blending
-	gl.Disable(gl.BLEND)
+	r.SetBlending(false, 0, 0, 0)
 
 	for i := 0; i < len(r.postShaderSelect); i++ {
 		postShader := r.postShaderSelect[i]
@@ -797,7 +808,7 @@ func (r *Renderer_GL32) EndFrame() {
 		}
 
 		// tell GL we want to use our shader program
-		gl.UseProgram(postShader.program)
+		r.UseProgram(postShader.program)
 
 		// set post-processing parameters
 		gl.Uniform1i(postShader.u["Texture_GL32"], 0)
@@ -886,6 +897,7 @@ func (r *Renderer_GL32) SetFrontFace(invertFrontFace bool) {
 		}
 	}
 }
+
 func (r *Renderer_GL32) SetCullFace(doubleSided bool) {
 	if doubleSided != r.doubleSided {
 		r.doubleSided = doubleSided
@@ -897,25 +909,43 @@ func (r *Renderer_GL32) SetCullFace(doubleSided bool) {
 		}
 	}
 }
-func (r *Renderer_GL32) SetBlending(eq BlendEquation, src, dst BlendFunc) {
-	if eq != r.blendEquation {
-		r.blendEquation = eq
-		gl.BlendEquation(r.MapBlendEquation(eq))
+
+func (r *Renderer_GL32) UseProgram(program uint32) {
+	if r.program != program {
+		gl.UseProgram(program)
+		r.program = program
 	}
-	if src != r.blendSrc || dst != r.blendDst {
-		r.blendSrc = src
-		r.blendDst = dst
-		gl.BlendFunc(r.MapBlendFunction(src), r.MapBlendFunction(dst))
+}
+
+func (r *Renderer_GL32) SetBlending(enable bool, eq BlendEquation, src, dst BlendFunc) {
+	if enable != r.blendEnabled {
+		if enable {
+			r.blendEnabled = true
+			gl.Enable(gl.BLEND)
+		} else {
+			r.blendEnabled = false
+			gl.Disable(gl.BLEND)
+		}
+	}
+
+	if enable {
+		if eq != r.blendEquation {
+			r.blendEquation = eq
+			gl.BlendEquation(r.MapBlendEquation(eq))
+		}
+		if src != r.blendSrc || dst != r.blendDst {
+			r.blendSrc = src
+			r.blendDst = dst
+			gl.BlendFunc(r.MapBlendFunction(src), r.MapBlendFunction(dst))
+		}
 	}
 }
 
 func (r *Renderer_GL32) SetPipeline(eq BlendEquation, src, dst BlendFunc) {
 	gl.BindVertexArray(r.vao)
-	gl.UseProgram(r.spriteShader.program)
 
-	gl.BlendEquation(r.MapBlendEquation(eq))
-	gl.BlendFunc(r.MapBlendFunction(src), r.MapBlendFunction(dst))
-	gl.Enable(gl.BLEND)
+	r.UseProgram(r.spriteShader.program)
+	r.SetBlending(true, eq, src, dst)
 
 	// Must bind buffer before enabling attributes
 	gl.BindBuffer(gl.ARRAY_BUFFER, r.vertexBuffer)
@@ -932,11 +962,11 @@ func (r *Renderer_GL32) ReleasePipeline() {
 	gl.DisableVertexAttribArray(uint32(loc))
 	loc = r.spriteShader.a["uv"]
 	gl.DisableVertexAttribArray(uint32(loc))
-	gl.Disable(gl.BLEND)
+	//gl.Disable(gl.BLEND)
 }
 
 func (r *Renderer_GL32) prepareShadowMapPipeline(bufferIndex uint32) {
-	gl.UseProgram(r.shadowMapShader.program)
+	r.UseProgram(r.shadowMapShader.program)
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_shadow)
 	gl.Viewport(0, 0, 1024, 1024)
 	gl.Enable(gl.TEXTURE_2D)
@@ -969,6 +999,7 @@ func (r *Renderer_GL32) prepareShadowMapPipeline(bufferIndex uint32) {
 	gl.FramebufferTexture(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, r.fbo_shadow_cube_texture, 0)
 	gl.Clear(gl.DEPTH_BUFFER_BIT)
 }
+
 func (r *Renderer_GL32) setShadowMapPipeline(doubleSided, invertFrontFace, useUV, useNormal, useTangent, useVertColor, useJoint0, useJoint1 bool, numVertices, vertAttrOffset uint32) {
 	r.SetFrontFace(invertFrontFace)
 	r.SetCullFace(doubleSided)
@@ -1089,8 +1120,9 @@ func (r *Renderer_GL32) ReleaseShadowPipeline() {
 	r.useJoint0 = false
 	r.useJoint1 = false
 }
+
 func (r *Renderer_GL32) prepareModelPipeline(bufferIndex uint32, env *Environment) {
-	gl.UseProgram(r.modelShader.program)
+	r.UseProgram(r.modelShader.program)
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo)
 	gl.Viewport(0, 0, sys.scrrect[2], sys.scrrect[3])
 	gl.Clear(gl.DEPTH_BUFFER_BIT)
@@ -1167,12 +1199,14 @@ func (r *Renderer_GL32) prepareModelPipeline(bufferIndex uint32, env *Environmen
 		gl.Uniform1f(loc, 0)
 	}
 }
-func (r *Renderer_GL32) SetModelPipeline(eq BlendEquation, src, dst BlendFunc, depthTest, depthMask, doubleSided, invertFrontFace, useUV, useNormal, useTangent, useVertColor, useJoint0, useJoint1, useOutlineAttribute bool, numVertices, vertAttrOffset uint32) {
+
+func (r *Renderer_GL32) SetModelPipeline(eq BlendEquation, src, dst BlendFunc, depthTest, depthMask, doubleSided, invertFrontFace,
+	useUV, useNormal, useTangent, useVertColor, useJoint0, useJoint1, useOutlineAttribute bool, numVertices, vertAttrOffset uint32) {
 	r.SetDepthTest(depthTest)
 	r.SetDepthMask(depthMask)
 	r.SetFrontFace(invertFrontFace)
 	r.SetCullFace(doubleSided)
-	r.SetBlending(eq, src, dst)
+	r.SetBlending(true, eq, src, dst)
 
 	loc := r.modelShader.a["inVertexId"]
 	gl.EnableVertexAttribArray(uint32(loc))
@@ -1289,6 +1323,7 @@ func (r *Renderer_GL32) SetModelPipeline(eq BlendEquation, src, dst BlendFunc, d
 		gl.VertexAttrib4f(uint32(loc), 0, 0, 0, 0)
 	}
 }
+
 func (r *Renderer_GL32) SetMeshOulinePipeline(invertFrontFace bool, meshOutline float32) {
 	r.SetFrontFace(invertFrontFace)
 	r.SetDepthTest(true)
@@ -1297,6 +1332,7 @@ func (r *Renderer_GL32) SetMeshOulinePipeline(invertFrontFace bool, meshOutline 
 	loc := r.modelShader.u["meshOutline"]
 	gl.Uniform1f(loc, meshOutline)
 }
+
 func (r *Renderer_GL32) ReleaseModelPipeline() {
 	loc := r.modelShader.a["inVertexId"]
 	gl.DisableVertexAttribArray(uint32(loc))
@@ -1420,6 +1456,7 @@ func (r *Renderer_GL32) SetModelUniformF(name string, values ...float32) {
 		gl.Uniform4f(loc, values[0], values[1], values[2], values[3])
 	}
 }
+
 func (r *Renderer_GL32) SetModelUniformFv(name string, values []float32) {
 	loc := r.modelShader.u[name]
 	switch len(values) {
@@ -1433,6 +1470,7 @@ func (r *Renderer_GL32) SetModelUniformFv(name string, values []float32) {
 		gl.Uniform4fv(loc, 2, &values[0])
 	}
 }
+
 func (r *Renderer_GL32) SetModelUniformMatrix(name string, value []float32) {
 	loc := r.modelShader.u[name]
 	gl.UniformMatrix4fv(loc, 1, false, &value[0])
@@ -1469,6 +1507,7 @@ func (r *Renderer_GL32) SetShadowMapUniformF(name string, values ...float32) {
 		gl.Uniform4f(loc, values[0], values[1], values[2], values[3])
 	}
 }
+
 func (r *Renderer_GL32) SetShadowMapUniformFv(name string, values []float32) {
 	loc := r.shadowMapShader.u[name]
 	switch len(values) {
@@ -1482,6 +1521,7 @@ func (r *Renderer_GL32) SetShadowMapUniformFv(name string, values []float32) {
 		gl.Uniform4fv(loc, 2, &values[0])
 	}
 }
+
 func (r *Renderer_GL32) SetShadowMapUniformMatrix(name string, value []float32) {
 	loc := r.shadowMapShader.u[name]
 	gl.UniformMatrix4fv(loc, 1, false, &value[0])
@@ -1513,10 +1553,12 @@ func (r *Renderer_GL32) SetVertexData(values ...float32) {
 	gl.BindBuffer(gl.ARRAY_BUFFER, r.vertexBuffer)
 	gl.BufferData(gl.ARRAY_BUFFER, len(data), unsafe.Pointer(&data[0]), gl.STATIC_DRAW)
 }
+
 func (r *Renderer_GL32) SetModelVertexData(bufferIndex uint32, values []byte) {
 	gl.BindBuffer(gl.ARRAY_BUFFER, r.modelVertexBuffer[bufferIndex])
 	gl.BufferData(gl.ARRAY_BUFFER, len(values), unsafe.Pointer(&values[0]), gl.STATIC_DRAW)
 }
+
 func (r *Renderer_GL32) SetModelIndexData(bufferIndex uint32, values ...uint32) {
 	data := new(bytes.Buffer)
 	binary.Write(data, binary.LittleEndian, values)
@@ -1528,9 +1570,11 @@ func (r *Renderer_GL32) SetModelIndexData(bufferIndex uint32, values ...uint32) 
 func (r *Renderer_GL32) RenderQuad() {
 	gl.DrawArrays(gl.TRIANGLE_STRIP, 0, 4)
 }
+
 func (r *Renderer_GL32) RenderElements(mode PrimitiveMode, count, offset int) {
 	gl.DrawElementsWithOffset(r.MapPrimitiveMode(mode), int32(count), gl.UNSIGNED_INT, uintptr(offset))
 }
+
 func (r *Renderer_GL32) RenderShadowMapElements(mode PrimitiveMode, count, offset int) {
 	r.RenderElements(mode, count, offset)
 }
@@ -1541,7 +1585,7 @@ func (r *Renderer_GL32) RenderCubeMap(envTex Texture, cubeTex Texture) {
 	textureSize := cubeTexture.width
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_env)
 	gl.Viewport(0, 0, textureSize, textureSize)
-	gl.UseProgram(r.panoramaToCubeMapShader.program)
+	r.UseProgram(r.panoramaToCubeMapShader.program)
 	loc := r.panoramaToCubeMapShader.a["VertCoord"]
 	gl.EnableVertexAttribArray(uint32(loc))
 	gl.VertexAttribPointerWithOffset(uint32(loc), 2, gl.FLOAT, false, 0, 0)
@@ -1565,6 +1609,7 @@ func (r *Renderer_GL32) RenderCubeMap(envTex Texture, cubeTex Texture) {
 	gl.BindTexture(gl.TEXTURE_CUBE_MAP, cubeTexture.handle)
 	gl.GenerateMipmap(gl.TEXTURE_CUBE_MAP)
 }
+
 func (r *Renderer_GL32) RenderFilteredCubeMap(distribution int32, cubeTex Texture, filteredTex Texture, mipmapLevel, sampleCount int32, roughness float32) {
 	cubeTexture := cubeTex.(*Texture_GL32)
 	filteredTexture := filteredTex.(*Texture_GL32)
@@ -1572,7 +1617,7 @@ func (r *Renderer_GL32) RenderFilteredCubeMap(distribution int32, cubeTex Textur
 	currentTextureSize := textureSize >> mipmapLevel
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_env)
 	gl.Viewport(0, 0, currentTextureSize, currentTextureSize)
-	gl.UseProgram(r.cubemapFilteringShader.program)
+	r.UseProgram(r.cubemapFilteringShader.program)
 	loc := r.cubemapFilteringShader.a["VertCoord"]
 	gl.EnableVertexAttribArray(uint32(loc))
 	gl.VertexAttribPointerWithOffset(uint32(loc), 2, gl.FLOAT, false, 0, 0)
@@ -1606,13 +1651,14 @@ func (r *Renderer_GL32) RenderFilteredCubeMap(distribution int32, cubeTex Textur
 	}
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo)
 }
+
 func (r *Renderer_GL32) RenderLUT(distribution int32, cubeTex Texture, lutTex Texture, sampleCount int32) {
 	cubeTexture := cubeTex.(*Texture_GL32)
 	lutTexture := lutTex.(*Texture_GL32)
 	textureSize := lutTexture.width
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_env)
 	gl.Viewport(0, 0, textureSize, textureSize)
-	gl.UseProgram(r.cubemapFilteringShader.program)
+	r.UseProgram(r.cubemapFilteringShader.program)
 	loc := r.cubemapFilteringShader.a["VertCoord"]
 	gl.EnableVertexAttribArray(uint32(loc))
 	gl.VertexAttribPointerWithOffset(uint32(loc), 2, gl.FLOAT, false, 0, 0)

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -130,9 +130,9 @@ HelperMax           = 56
 ProjectileMax       = 256
 ; Maximum number of palettes allowed per player.
 PaletteMax          = 100
-; Maximum number of lifebar texts allowed in total.
+; Maximum number of texts allowed per player.
 ; Set to a lower number to save memory.
-TextMax = 256
+TextMax = 128
 ; Zoom toggle (0 disables zoom for stages coded to have it).
 ZoomActive          = 1
 ; Toggles if Esc key should open Pause menu.

--- a/src/script.go
+++ b/src/script.go
@@ -6068,7 +6068,7 @@ func triggerFunctions(l *lua.LState) {
 			case "drawpal index":
 				lv = lua.LNumber(sys.debugWC.explodDrawPal(e)[1])
 			case "facing":
-				lv = lua.LNumber(e.facing * e.relativef)
+				lv = lua.LNumber(e.trueFacing())
 			case "friction x":
 				lv = lua.LNumber(e.friction[0])
 			case "friction y":
@@ -6589,10 +6589,10 @@ func triggerFunctions(l *lua.LState) {
 			lv = lua.LNumber(c.mhv.cornerpush_veloff)
 		case "frame":
 			lv = lua.LBool(c.mhv.frame)
-		case "playerid":
-			lv = lua.LNumber(c.mhv.playerid)
 		case "overridden":
 			lv = lua.LBool(c.mhv.overridden)
+		case "playerid":
+			lv = lua.LNumber(c.mhv.playerid)
 		case "playerno":
 			lv = lua.LNumber(c.mhv.playerno + 1)
 		case "sparkx":

--- a/src/script.go
+++ b/src/script.go
@@ -1773,8 +1773,8 @@ func systemScriptInit(l *lua.LState) {
 		if cl.Buffer != nil {
 			buf = cl.Buffer
 		}
-		fmt.Printf("%s *CommandList=%p ControllerNo=%d Names=%d Groups=%d Buffer=%p\n",
-			str, cl, cl.ControllerNo, len(cl.Names), len(cl.Commands), buf)
+		fmt.Printf("%s *CommandList=%p Names=%d Groups=%d Buffer=%p\n",
+			str, cl, len(cl.Names), len(cl.Commands), buf)
 		for name, idx := range cl.Names {
 			if idx < 0 || idx >= len(cl.Commands) {
 				fmt.Printf("%s  %q idx=%d (out of range)\n", str, name, idx)
@@ -1811,19 +1811,19 @@ func systemScriptInit(l *lua.LState) {
 			return 0 // Attempt to fix a rare registry overflow error while the window is unfocused
 		}
 		controller := int(numArg(l, 2)) - 1
-		if cl.InputUpdate(nil, controller, 0, true) {
+		if cl.InputUpdate(nil, controller) {
 			cl.Step(false, false, false, false, 0)
 		}
 		return 0
 	})
 	luaRegister(l, "commandNew", func(l *lua.LState) int {
-		var controllerNo int32
+		var controllerNo int
 		if !nilArg(l, 1) {
-			controllerNo = int32(numArg(l, 1))
+			controllerNo = int(numArg(l, 1))
 		}
-		cl := NewCommandList(NewInputBuffer(), controllerNo)
+		cl := NewCommandList(NewInputBuffer())
 		if controllerNo > 0 {
-			idx := int(controllerNo - 1) // 0-based index
+			idx := controllerNo - 1 // 0-based index
 			// Grow sys.commandLists if needed
 			if idx >= len(sys.commandLists) {
 				tmp := make([]*CommandList, idx+1)

--- a/src/script.go
+++ b/src/script.go
@@ -1319,7 +1319,7 @@ func systemScriptInit(l *lua.LState) {
 			}
 		})
 		a.anim.palettedata.SetSource(pal, palData)
-		a.anim.palettedata.PalTex[pal] = PaletteToTexture(palData)
+		a.anim.palettedata.PalTex[pal] = NewTextureFromPalette(palData)
 		return 0
 	})
 	luaRegister(l, "animSetScale", func(*lua.LState) int {

--- a/src/script.go
+++ b/src/script.go
@@ -3984,11 +3984,11 @@ func systemScriptInit(l *lua.LState) {
 		if !sys.frameSkip {
 			sys.luaFlushDrawQueue()
 			if sys.motif.fadeIn.isActive() {
-				BlendReset()
+				//BlendReset()
 				sys.motif.fadeIn.step()
 				sys.motif.fadeIn.draw()
 			} else if sys.motif.fadeOut.isActive() {
-				BlendReset()
+				//BlendReset()
 				sys.motif.fadeOut.step()
 				sys.motif.fadeOut.draw()
 			}

--- a/src/stage.go
+++ b/src/stage.go
@@ -4233,6 +4233,7 @@ func drawNodeShadow(mdl *Model, scene *Scene, n *Node, camOffset [3]float32, dra
 		}
 	}
 }
+
 func (model *Model) drawShadow(bufferIndex uint32, sceneNumber int, offset [3]float32) {
 	scene := model.scenes[sceneNumber]
 	gfx.prepareShadowMapPipeline(bufferIndex)
@@ -4369,6 +4370,7 @@ func (model *Model) drawShadow(bufferIndex uint32, sceneNumber int, offset [3]fl
 	}
 	gfx.ReleaseShadowPipeline()
 }
+
 func (model *Model) draw(bufferIndex uint32, sceneNumber int, layerNumber int, defaultLayerNumber int, offset [3]float32, proj, view, viewProjMatrix mgl.Mat4, outlineConst float32) {
 	if sceneNumber < 0 || sceneNumber >= len(model.scenes) {
 		return

--- a/src/stage.go
+++ b/src/stage.go
@@ -2022,7 +2022,7 @@ func (s *Stage) draw(layer int32, x, y, scl float32) {
 			b.draw(pos, scl, bgscl, s.localscl, s.scale, ofs[1], true)
 		}
 	}
-	BlendReset()
+	//BlendReset()
 }
 
 func (s *Stage) reset() {

--- a/src/state.go
+++ b/src/state.go
@@ -224,7 +224,7 @@ type GameState struct {
 	scoreRounds     [][2]float32
 	decisiveRound   [2]bool
 	sel             Select
-	stringPool      [MaxPlayerNo]StringPool
+	//stringPool      [MaxPlayerNo]StringPool // Only mutated while compiling
 	dialogueFlg     bool
 	gameMode        string
 	consecutiveWins [2]int32
@@ -453,9 +453,9 @@ func (gs *GameState) LoadState(stateID int) {
 	sys.decisiveRound = gs.decisiveRound
 
 	//sys.sel = gs.sel.Clone(a)
-	for i := 0; i < len(sys.stringPool); i++ {
-		sys.stringPool[i] = gs.stringPool[i].Clone(a, gsp)
-	}
+	// for i := 0; i < len(sys.stringPool); i++ {
+	// 	sys.stringPool[i] = gs.stringPool[i].Clone(a, gsp)
+	// }
 
 	sys.motif.di.active = gs.dialogueFlg
 	sys.gameMode = gs.gameMode
@@ -681,10 +681,11 @@ func (gs *GameState) SaveState(stateID int) {
 	gs.scoreRounds = arena.MakeSlice[[2]float32](a, len(sys.scoreRounds), len(sys.scoreRounds))
 	copy(gs.scoreRounds, sys.scoreRounds)
 	gs.decisiveRound = sys.decisiveRound
+
 	//gs.sel = sys.sel.Clone(a)
-	for i := 0; i < len(sys.stringPool); i++ {
-		gs.stringPool[i] = sys.stringPool[i].Clone(a, gsp)
-	}
+	// for i := 0; i < len(sys.stringPool); i++ {
+	//		gs.stringPool[i] = sys.stringPool[i].Clone(a, gsp)
+	// }
 
 	gs.dialogueFlg = sys.motif.di.active
 	gs.gameMode = sys.gameMode

--- a/src/state.go
+++ b/src/state.go
@@ -117,6 +117,7 @@ type GameState struct {
 	charData   [MaxPlayerNo][]Char
 	projs      [MaxPlayerNo][]*Projectile
 	explods    [MaxPlayerNo][]*Explod
+	chartexts  []*TextSprite
 	aiInput    [MaxPlayerNo]AiInput
 	ffbParams  [MaxPlayerNo]ForceFeedbackParams
 	inputRemap [MaxPlayerNo]int
@@ -295,14 +296,15 @@ func (gs *GameState) LoadState(stateID int) {
 	sys.curPlayTime = gs.curPlayTime
 
 	gs.loadCharData(a, gsp)
+	gs.loadProjectileData(a, gsp)
 	gs.loadExplodData(a, gsp)
+	gs.loadCharTextData(a, gsp)
 	sys.cam = gs.cam
 
 	gs.loadPauseData()
 	gs.loadSuperPauseData()
 
 	gs.loadPalFX(a)
-	gs.loadProjectileData(a, gsp)
 	sys.aiLevel = gs.aiLevel
 	sys.envShake = gs.envShake
 	sys.envcol_time = gs.envcol_time
@@ -536,14 +538,15 @@ func (gs *GameState) SaveState(stateID int) {
 	gs.curPlayTime = sys.curPlayTime
 
 	gs.saveCharData(a, gsp)
+	gs.saveProjectileData(a, gsp)
 	gs.saveExplodData(a, gsp)
+	gs.saveCharTextData(a)
 	gs.cam = sys.cam
 
 	gs.savePauseData()
 	gs.saveSuperPauseData()
 
 	gs.savePalFX(a)
-	gs.saveProjectileData(a, gsp)
 
 	gs.aiLevel = sys.aiLevel
 	gs.envShake = sys.envShake
@@ -813,6 +816,13 @@ func (gs *GameState) saveExplodData(a *arena.Arena, gsp *GameStatePool) {
 	}
 }
 
+func (gs *GameState) saveCharTextData(a *arena.Arena) {
+	gs.chartexts = arena.MakeSlice[*TextSprite](a, len(sys.chartexts), len(sys.chartexts))
+	for i := range sys.chartexts {
+		gs.chartexts[i] = cloneTextSprite(a, sys.chartexts[i])
+	}
+}
+
 func (gs *GameState) loadPalFX(a *arena.Arena) {
 	sys.allPalFX = gs.allPalFX.Clone(a)
 	sys.bgPalFX = gs.bgPalFX.Clone(a)
@@ -865,6 +875,15 @@ func (gs *GameState) loadPauseData() {
 	sys.pauseplayerno = gs.pauseplayerno
 }
 
+func (gs *GameState) loadProjectileData(a *arena.Arena, gsp *GameStatePool) {
+	for i := range gs.projs {
+		sys.projs[i] = arena.MakeSlice[*Projectile](a, len(gs.projs[i]), len(gs.projs[i]))
+		for j := range gs.projs[i] {
+			sys.projs[i][j] = gs.projs[i][j].clone(a, gsp)
+		}
+	}
+}
+
 func (gs *GameState) loadExplodData(a *arena.Arena, gsp *GameStatePool) {
 	for i := range gs.explods {
 		sys.explods[i] = arena.MakeSlice[*Explod](a, len(gs.explods[i]), len(gs.explods[i]))
@@ -874,12 +893,10 @@ func (gs *GameState) loadExplodData(a *arena.Arena, gsp *GameStatePool) {
 	}
 }
 
-func (gs *GameState) loadProjectileData(a *arena.Arena, gsp *GameStatePool) {
-	for i := range gs.projs {
-		sys.projs[i] = arena.MakeSlice[*Projectile](a, len(gs.projs[i]), len(gs.projs[i]))
-		for j := range gs.projs[i] {
-			sys.projs[i][j] = gs.projs[i][j].clone(a, gsp)
-		}
+func (gs *GameState) loadCharTextData(a *arena.Arena, gsp *GameStatePool) {
+	sys.chartexts = arena.MakeSlice[*TextSprite](a, len(gs.chartexts), len(gs.chartexts))
+	for i := range gs.chartexts {
+		sys.chartexts[i] = cloneTextSprite(a, gs.chartexts[i])
 	}
 }
 

--- a/src/state.go
+++ b/src/state.go
@@ -28,7 +28,7 @@ func (cs Char) String() string {
 	Id                  :%d
 	HelperId            :%d
 	HelperIndex         :%d
-	ParentIndex         :%d
+	ParentId            :%d
 	PlayerNo            :%d
 	Teamside            :%d
 	AnimPN              :%d
@@ -42,7 +42,7 @@ func (cs Char) String() string {
 	HoIdx               :%d
 	Mctime              :%d
 	Targets             :%v
-	TargetsOfHitdef     :%v
+	HitdefTargets       :%v
 	Atktmp              :%d
 	Hittmp              :%d
 	Acttmp              :%d
@@ -55,9 +55,9 @@ func (cs Char) String() string {
 	Offset              :%v`,
 		cs.name, cs.redLife, cs.juggle, cs.life, cs.controller, cs.localcoord,
 		cs.localscl, cs.pos, cs.interPos, cs.oldPos, cs.vel, cs.facing,
-		cs.id, cs.helperId, cs.helperIndex, cs.parentIndex, cs.playerNo,
+		cs.id, cs.helperId, cs.helperIndex, cs.parentId, cs.playerNo,
 		cs.teamside, cs.animPN, cs.animNo, cs.lifeMax, cs.powerMax, cs.dizzyPoints,
-		cs.guardPoints, cs.fallTime, cs.clsnScale, cs.hoverIdx, cs.mctime, cs.targets, cs.hitdefTargetsBuffer,
+		cs.guardPoints, cs.fallTime, cs.clsnScale, cs.hoverIdx, cs.mctime, cs.targets, cs.hitdefTargets,
 		cs.atktmp, cs.hittmp, cs.acttmp, cs.minus, cs.groundAngle, cs.inheritJuggle,
 		cs.preserve, cs.cnsvar, cs.cnsfvar, cs.offset)
 	return str

--- a/src/state.go
+++ b/src/state.go
@@ -117,7 +117,7 @@ type GameState struct {
 	charData   [MaxPlayerNo][]Char
 	projs      [MaxPlayerNo][]*Projectile
 	explods    [MaxPlayerNo][]*Explod
-	chartexts  []*TextSprite
+	chartexts  [MaxPlayerNo][]*TextSprite
 	aiInput    [MaxPlayerNo]AiInput
 	ffbParams  [MaxPlayerNo]ForceFeedbackParams
 	inputRemap [MaxPlayerNo]int
@@ -298,7 +298,7 @@ func (gs *GameState) LoadState(stateID int) {
 	gs.loadCharData(a, gsp)
 	gs.loadProjectileData(a, gsp)
 	gs.loadExplodData(a, gsp)
-	gs.loadCharTextData(a, gsp)
+	gs.loadCharTextData(a)
 	sys.cam = gs.cam
 
 	gs.loadPauseData()
@@ -817,9 +817,11 @@ func (gs *GameState) saveExplodData(a *arena.Arena, gsp *GameStatePool) {
 }
 
 func (gs *GameState) saveCharTextData(a *arena.Arena) {
-	gs.chartexts = arena.MakeSlice[*TextSprite](a, len(sys.chartexts), len(sys.chartexts))
 	for i := range sys.chartexts {
-		gs.chartexts[i] = cloneTextSprite(a, sys.chartexts[i])
+		gs.chartexts[i] = arena.MakeSlice[*TextSprite](a, len(sys.chartexts[i]), len(sys.chartexts[i]))
+		for j := range sys.chartexts[i] {
+			gs.chartexts[i][j] = cloneTextSprite(a, sys.chartexts[i][j])
+		}
 	}
 }
 
@@ -893,10 +895,12 @@ func (gs *GameState) loadExplodData(a *arena.Arena, gsp *GameStatePool) {
 	}
 }
 
-func (gs *GameState) loadCharTextData(a *arena.Arena, gsp *GameStatePool) {
-	sys.chartexts = arena.MakeSlice[*TextSprite](a, len(gs.chartexts), len(gs.chartexts))
+func (gs *GameState) loadCharTextData(a *arena.Arena) {
 	for i := range gs.chartexts {
-		sys.chartexts[i] = cloneTextSprite(a, gs.chartexts[i])
+		sys.chartexts[i] = arena.MakeSlice[*TextSprite](a, len(gs.chartexts[i]), len(gs.chartexts[i]))
+		for j := range gs.chartexts[i] {
+			sys.chartexts[i][j] = cloneTextSprite(a, gs.chartexts[i][j])
+		}
 	}
 }
 

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -119,6 +119,7 @@ func (af *AnimFrame) Clone(a *arena.Arena) (result *AnimFrame) {
 	return
 }
 
+/*
 func (sp StringPool) Clone(a *arena.Arena, gsp *GameStatePool) (result StringPool) {
 	result = sp
 	result.List = arena.MakeSlice[string](a, len(sp.List), len(sp.List))
@@ -131,6 +132,7 @@ func (sp StringPool) Clone(a *arena.Arena, gsp *GameStatePool) (result StringPoo
 	}
 	return
 }
+*/
 
 func (b *StateBlock) Clone(a *arena.Arena) (result StateBlock) {
 	result = *b

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -912,14 +912,6 @@ func (m *Motif) Clone(a *arena.Arena) (result Motif) {
 		result.wi = sys.motif.wi
 	}
 
-	// TextSprite
-	if m.textsprite != nil {
-		result.textsprite = arena.MakeSlice[*TextSprite](a, len(m.textsprite), len(m.textsprite))
-		for i := 0; i < len(m.textsprite); i++ {
-			result.textsprite[i] = cloneTextSprite(a, m.textsprite[i])
-		}
-	}
-
 	return
 }
 

--- a/src/system.go
+++ b/src/system.go
@@ -2379,6 +2379,13 @@ func (s *System) charTextsUpdate() {
 		return
 	}
 
+	// With texts we run the cleanup first. Otherwise a removetime of 1 disappears immediately
+	// The reason this is different from explods is that texts don't use a DrawList to buffer the sprites
+	for i := range s.chartexts {
+		s.charTextsPrune(i)
+	}
+
+	// Logic
 	for i := range s.chartexts {
 		for _, ts := range s.chartexts[i] {
 			ts.Update()
@@ -2386,11 +2393,6 @@ func (s *System) charTextsUpdate() {
 				ts.removetime--
 			}
 		}
-	}
-
-	// Cleanup
-	for i := range s.chartexts {
-		s.charTextsPrune(i)
 	}
 }
 
@@ -2956,7 +2958,7 @@ func (s *System) drawCharTexts(layerno int16) {
 }
 
 func (s *System) drawTop() {
-	BlendReset()
+	//BlendReset()
 
 	s.brightness = s.brightnessOld
 	// Draw Clsn boxes

--- a/src/system.go
+++ b/src/system.go
@@ -1134,9 +1134,9 @@ func (s *System) playerIndex(idx int32) *Char {
 		return nil
 	}
 
-	// We will ignore destroyed helpers here, like Mugen redirections
+	// We will ignore destroyed helpers here, like Mugen redirections do
 	var searchIdx int32
-	for _, p := range sys.charList.runOrder {
+	for _, p := range sys.charList.creationOrder {
 		if p != nil && !p.csf(CSF_destroy) {
 			if searchIdx == idx {
 				return p

--- a/src/system.go
+++ b/src/system.go
@@ -1769,12 +1769,10 @@ func (s *System) clearPlayerAssets(pn int, forceDestroy bool) {
 		if forceDestroy {
 			p.children = p.children[:0]
 		} else {
-			for i, ch := range p.children {
-				if ch != nil {
-					//if ch.preserve == 0 || (s.roundResetFlg && ch.preserve == s.round) {
-					if !ch.preserve {
-						p.children[i] = nil
-					}
+			for i := len(p.children) - 1; i >= 0; i-- {
+				//if ch.preserve == 0 || (s.roundResetFlg && ch.preserve == s.round) {
+				if p.children[i] != nil && !p.children[i].preserve {
+					p.children = SliceDelete(p.children, i)
 				}
 			}
 		}

--- a/src/system.go
+++ b/src/system.go
@@ -1084,7 +1084,8 @@ func (s *System) stepCommandLists() {
 		if i >= 0 && i < len(s.commandInputSource) {
 			controller = s.commandInputSource[i]
 		}
-		if cl.InputUpdate(nil, controller, 0, true) {
+		// Step commands only if the buffer has already stepped. Prevents rapid fire inputs
+		if cl.InputUpdate(nil, controller) {
 			cl.Step(false, false, false, false, 0)
 		}
 	}

--- a/src/system.go
+++ b/src/system.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"unsafe"
 
 	"github.com/gopxl/beep/v2"
 
@@ -446,7 +445,7 @@ func (s *System) init(w, h int32) *lua.LState {
 		whitepal[i] = 0xffffffff // White (and full alpha)
 	}
 	s.whitePalTex = gfx.newPaletteTexture()
-	s.whitePalTex.SetData(pal32ToBytes(whitepal))
+	s.whitePalTex.SetData(Pal32ToBytes(whitepal))
 
 	systemScriptInit(l)
 	s.shortcutScripts = make(map[ShortcutKey]*ShortcutScript)
@@ -2961,28 +2960,44 @@ func (s *System) drawTop() {
 	//BlendReset()
 
 	s.brightness = s.brightnessOld
+
 	// Draw Clsn boxes
 	if s.clsnDisplay {
 		alpha := [2]int32{255, 255}
-		s.clsnSpr.Pal[0] = 0xff0000ff
+		// Change the first color of the Clsn sprite
+		setColor := func(color uint32) {
+			s.clsnSpr.Pal[0] = color
+			s.clsnSpr.updatePaletteTexture(s.clsnSpr.Pal)
+		}
+		// Clsn1 HitDef
+		setColor(0xff0000ff)
 		s.debugc1hit.draw(alpha)
-		s.clsnSpr.Pal[0] = 0xff0040c0
+		// Clsn1 ReversalDef
+		setColor(0xff0040c0)
 		s.debugc1rev.draw(alpha)
-		s.clsnSpr.Pal[0] = 0xff000080
+		// Clsn1 Inactive
+		setColor(0xff000080)
 		s.debugc1not.draw(alpha)
-		s.clsnSpr.Pal[0] = 0xffff0000
+		// Clsn2
+		setColor(0xffff0000)
 		s.debugc2.draw(alpha)
-		s.clsnSpr.Pal[0] = 0xff808000
+		// Clsn2 HitBy
+		setColor(0xff808000)
 		s.debugc2hb.draw(alpha)
-		s.clsnSpr.Pal[0] = 0xff004000
+		// Clsn2 Invincible
+		setColor(0xff004000)
 		s.debugc2mtk.draw(alpha)
-		s.clsnSpr.Pal[0] = 0xffc00040
+		// Clsn2 Guarding
+		setColor(0xffc00040)
 		s.debugc2grd.draw(alpha)
-		s.clsnSpr.Pal[0] = 0xff404040
+		// Clsn2 Standby
+		setColor(0xff404040)
 		s.debugc2stb.draw(alpha)
-		s.clsnSpr.Pal[0] = 0xff303030
+		// Size
+		setColor(0xff303030)
 		s.debugcsize.draw(alpha)
-		s.clsnSpr.Pal[0] = 0xffffffff
+		// Crosshair
+		setColor(0xffffffff)
 		s.debugch.draw(alpha)
 	}
 }
@@ -4843,8 +4858,4 @@ func (es *EnvShake) getOffset() [2]float32 {
 			offset * float32(math.Cos(float64(-es.dir)))}
 	}
 	return [2]float32{0, 0}
-}
-
-func pal32ToBytes(pal []uint32) []byte {
-	return unsafe.Slice((*byte)(unsafe.Pointer(&pal[0])), len(pal)*4)
 }


### PR DESCRIPTION
Fixes:
- Fixed some rendering CPU hot spots
- Fixed text flickering at low game speeds
- Enforce minimum width constants when a helper is created by a Mugen character
- Fixed double filtering in ModifyExplod and ModifyProjectile
- Fixed redirections based on player indexes not using same order as before
- Fixes #3164

Refactor:
- OpenGL (all) now preserves a bit more of its state between draw calls
- Some slices are now kept compact instead of with nilled indexes
- Helpers save their parent's ID instead of their index
- Migrated char texts (Text sctrl) to system.go
- Text sprites are now organized per player, similar to explods
- Added a way to recycle dead explods, projectiles, and texts for better memory management
- "Skip screen" AssertSpecial flags now allow skipping a screen even after it started playing
- Game states no longer clone StringPool
- Rollback is automatically enabled for stages if any character can modify them
- numExplod, numStageBG and numTex now use the exact same filter logic as their respective Modify sctrl's
- Sprite window calculations are now independent from draw scale
- Improved integration between character and motif inputs

See individual commits for more details.