### PR TITLE
feat: powerbar max params, clutch win type; fixes

### DIFF
--- a/data/action.zss
+++ b/data/action.zss
@@ -81,6 +81,11 @@ ignoreHitPause if !const(Default.Enable.Action) || isHelper || teamSide = 0 {
 				lifebarAction{spr: const(MsgCombo3), 0; top: 1}
 			}
 		}
+		# Win Clutch
+		let ret = call IkSys_WinClutch();
+		if $ret {
+			lifebarAction{spr: const(MsgWinClutch), 0; timeMul: 3; top: 1}
+		}
 		# Win Perfect
 		let ret = call IkSys_WinPerfect();
 		if $ret {

--- a/data/common.const
+++ b/data/common.const
@@ -272,6 +272,7 @@ MsgCounterSwitch = 421   ; Not used by default tag system
 MsgGuardBreak = 422
 MsgParry = 423
 MsgJustDefend = 424
+MsgWinClutch = 425
 
 ; Bitwise shifting
 Bit1 = 1

--- a/data/functions.zss
+++ b/data/functions.zss
@@ -145,6 +145,16 @@ ignoreHitPause{
 	}
 }
 
+# Win Clutch
+[Function IkSys_WinClutch() ret]
+ignoreHitPause{
+	let ret = 0;
+	if winClutch && (map(_iksys_winFlag) = 0 || map(_iksys_winFlag) = gameTime) {
+		let ret = 1;
+		map(_iksys_winFlag) := gameTime;
+	}
+}
+
 # Win Perfect
 [Function IkSys_WinPerfect() ret]
 ignoreHitPause{

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -496,6 +496,7 @@ const (
 	OC_ex_win
 	OC_ex_winko
 	OC_ex_wintime
+	OC_ex_winclutch
 	OC_ex_winperfect
 	OC_ex_winspecial
 	OC_ex_winhyper
@@ -2674,6 +2675,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushB(c.winKO())
 	case OC_ex_wintime:
 		sys.bcStack.PushB(c.winTime())
+	case OC_ex_winclutch:
+		sys.bcStack.PushB(c.winClutch())
 	case OC_ex_winperfect:
 		sys.bcStack.PushB(c.winPerfect())
 	case OC_ex_winspecial:

--- a/src/char.go
+++ b/src/char.go
@@ -8726,11 +8726,7 @@ func (c *Char) remapPal(pfx *PalFX, src [2]int32, dst [2]int32) {
 
 	// Init palette remap if needed
 	if pfx.remap == nil {
-		pfx.remap = make([]int, len(plist.paletteMap))
-		// This ensures that SFFv2 unique palettes are preserved
-		for i := range pfx.remap {
-			pfx.remap[i] = i
-		}
+		pfx.remap = plist.GetPalMap()
 	}
 	// Perform palette remap
 	if plist.SwapPalMap(&pfx.remap) {
@@ -8759,34 +8755,17 @@ func (c *Char) forceRemapPal(pfx *PalFX, dst [2]int32) {
 	}
 
 	// Get new palette
-	plist := c.gi().palettedata.palList
-	di, ok := plist.PalTable[[...]uint16{uint16(dst[0]), uint16(dst[1])}]
+	di, ok := c.gi().palettedata.palList.PalTable[[...]uint16{uint16(dst[0]), uint16(dst[1])}]
 	if !ok || di < 0 {
 		return
 	}
 
 	// Clear previous remaps
-	pfx.remap = make([]int, len(plist.paletteMap))
+	pfx.remap = make([]int, len(c.gi().palettedata.palList.paletteMap))
+
 	// Apply the new remap
-	if c.gi().sff.header.Ver0 == 1 {
-		for i := range pfx.remap {
-			pfx.remap[i] = di
-		}
-		return
-	}
-
-	// SFFv2: Use selective remapping to preserve unique palettes
 	for i := range pfx.remap {
-		pfx.remap[i] = i
-	}
-
-	maxPal := sys.cfg.Config.PaletteMax
-	for i := 1; i <= maxPal; i++ {
-		if idx, exists := plist.PalTable[[...]uint16{1, uint16(i)}]; exists {
-			if idx >= 0 && int(idx) < len(pfx.remap) {
-				pfx.remap[idx] = di
-			}
-		}
+		pfx.remap[i] = di
 	}
 }
 

--- a/src/char.go
+++ b/src/char.go
@@ -5959,7 +5959,11 @@ func (c *Char) winTime() bool {
 }
 
 func (c *Char) winPerfect() bool {
-	return c.win() && sys.winType[c.playerNo&1] >= WT_PNormal
+	return c.win() && sys.winType[c.playerNo&1] >= WT_PNormal && sys.winType[c.playerNo&1] < WT_CNormal
+}
+
+func (c *Char) winClutch() bool {
+	return c.win() && sys.winType[c.playerNo&1] >= WT_CNormal
 }
 
 func (c *Char) winType(wt WinType) bool {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -472,6 +472,7 @@ var triggerMap = map[string]int{
 	"timeelapsed":        1,
 	"timeremaining":      1,
 	"timetotal":          1,
+	"winclutch":          1,
 	"winhyper":           1,
 	"winspecial":         1,
 	"xshear":             1,
@@ -3857,6 +3858,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(OC_ex_, OC_ex_wintime)
 	case "winperfect":
 		out.append(OC_ex_, OC_ex_winperfect)
+	case "winclutch":
+		out.append(OC_ex_, OC_ex_winclutch)
 	case "winspecial":
 		out.append(OC_ex_, OC_ex_winspecial)
 	case "winhyper":

--- a/src/image.go
+++ b/src/image.go
@@ -1672,7 +1672,7 @@ func preloadSff(filename string, char bool, preloadSpr map[[2]uint16]bool) (*Sff
 	preloadRef := make(map[int]bool)
 	headerXofs := make([]uint32, len(spriteList))
 	headerSize := make([]uint32, len(spriteList))
-	headerShofs32 := make([]int64, len(spriteList)) // só usado em Ver0 == 1
+	headerShofs32 := make([]int64, len(spriteList)) // only used with Ver0 == 1
 
 	//set various variables that let us know if a sprite should use it's own palette
 	paletteState := 0

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -2683,6 +2683,7 @@ type LifeBarRound struct {
 	shutter_time        int32
 	shutter_col         uint32
 	callfight_time      int32
+	clutch_threshold    int32
 	triggerRoundDisplay bool // FightScreenState trigger
 	triggerFightDisplay bool
 	triggerKODisplay    bool
@@ -2706,6 +2707,7 @@ func newLifeBarRound(snd *Snd) *LifeBarRound {
 		over_time:          210,
 		shutter_time:       15,
 		callfight_time:     60,
+		clutch_threshold:   10,
 	}
 }
 
@@ -3031,6 +3033,7 @@ func readLifeBarRound(is IniSection,
 	ro.fadeOut = readLbFade("fadeout.", is, sff, at)
 	ro.over_time = Max(ro.fadeOut.time, ro.over_time)
 	is.ReadI32("shutter.time", &ro.shutter_time)
+	is.ReadI32("clutch.threshold", &ro.clutch_threshold)
 	var col [3]int32
 	if is.ReadI32("shutter.col", &col[0], &col[1], &col[2]) {
 		ro.shutter_col = uint32(col[0]&0xff<<16 | col[1]&0xff<<8 | col[2]&0xff)

--- a/src/resources/defaultMotif.ini
+++ b/src/resources/defaultMotif.ini
@@ -672,6 +672,7 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	; Asterisk <col-*> or <*-row> can be used as a wildcard to apply changes to entire columns or rows.
 	; <*-*> can be used to aplly changes to all cells.
 	; Portraits, cell backgrounds, and cursors inherit all cell transformations.
+	;cell.<col>-<row>.spacing = 0, 0
 	;cell.<col>-<row>.offset = 0, 0
 	;cell.<col>-<row>.facing = 0
 	;cell.<col>-<row>.scale = 1.0, 1.0

--- a/src/script.go
+++ b/src/script.go
@@ -7588,6 +7588,10 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LBool(sys.debugWC.winTime()))
 		return 1
 	})
+	luaRegister(l, "winclutch", func(*lua.LState) int {
+		l.Push(lua.LBool(sys.debugWC.winClutch()))
+		return 1
+	})
 	luaRegister(l, "winperfect", func(*lua.LState) int {
 		l.Push(lua.LBool(sys.debugWC.winPerfect()))
 		return 1

--- a/src/system.go
+++ b/src/system.go
@@ -2674,6 +2674,19 @@ func (s *System) roundEndDecision() bool {
 		return false
 	}
 
+	checkClutch := func(team int) bool {
+		clutchRatio := float32(0.10)
+		for i := team; i < MaxSimul*2; i += 2 {
+			if len(s.chars[i]) > 0 {
+				char := s.chars[i][0]
+				if float32(char.life) > float32(char.lifeMax)*clutchRatio {
+					return false
+				}
+			}
+		}
+		return true
+	}
+
 	// KO check
 	ko := [2]bool{true, true}
 	for loser := range ko {
@@ -2692,6 +2705,8 @@ func (s *System) roundEndDecision() bool {
 		if ko[loser] {
 			if checkPerfect(loser ^ 1) {
 				s.winType[loser^1].SetPerfect()
+			} else if checkClutch(loser ^ 1) {
+					s.winType[loser^1].SetClutch()
 			}
 		}
 	}
@@ -2722,6 +2737,8 @@ func (s *System) roundEndDecision() bool {
 			}
 			if checkPerfect(winner) {
 				s.winType[winner].SetPerfect()
+			} else if checkClutch(winner) {
+				s.winType[winner].SetClutch()
 			}
 			s.finishType = FT_TO
 			s.winTeam = winner

--- a/src/system.go
+++ b/src/system.go
@@ -2675,7 +2675,7 @@ func (s *System) roundEndDecision() bool {
 	}
 
 	checkClutch := func(team int) bool {
-		clutchRatio := float32(0.10)
+		clutchRatio := float32(s.lifebar.ro.clutch_threshold) / 100.0
 		for i := team; i < MaxSimul*2; i += 2 {
 			if len(s.chars[i]) > 0 {
 				char := s.chars[i][0]


### PR DESCRIPTION
Feat:
- Powerbar elements can use the “max” suffix to define the element that should be used when the power reaches maximum, 

Example:
```ini
p1.counterMax.font = 6, 0, 0
p1.counterMax.offset = 7,-64
p1.counterMax.text = "MAX"
levelmax.snd = 21, 1
```

- Added clutch win type. It’s shown when a char (or team) wins a match with less than the defined remaining life percentage, set via ``clutch.threshold`` (default is 10% if not defined). Win icon overlays can also be defined for this win type, they work the same way as the overlays for the Perfect win type

Example:
```ini
[Round]
p1.clutch.pos = 0, 0
p1.clutch.text.offset = 160, 55
p1.clutch.text.font = 4, 0, 0
p1.clutch.life = 10
p1.clutch.text.text = "GREAT!"
p1.clutch.time = 120
p1.clutch.displaytime = 900
p1.clutch.snd = 3, 4
p1.clutch.sndtime = 120

clutch.threshold = 20
```
```ini
[WinIcon]
p1.clutch.spr = 108,0
p1.clutch.scale = 0.5,0.5
```
- Added ``winClutch`` trigger

Fix;
- Fixes #3205 
- Broken remapPal for explods

Added clutch graphics to fight.sff
https://github.com/ikemen-engine/Ikemen_GO-Elecbyte-Screenpack/pull/54