### PR TITLE
feat: TickInterpolation option; fixes; refactoring

### DIFF
--- a/external/script/debug.lua
+++ b/external/script/debug.lua
@@ -43,7 +43,6 @@ addHotkey('F10', false, false, false, true, false, 'saveState()')
 addHotkey('SPACE', false, false, false, false, true, 'full(1); full(2); full(3); full(4); full(5); full(6); full(7); full(8); setTime(getRoundTime()); clearConsole()')
 addHotkey('i', true, false, false, true, true, 'stand(1); stand(2); stand(3); stand(4); stand(5); stand(6); stand(7); stand(8)')
 addHotkey('PAUSE', false, false, false, true, false, 'togglePause(); closeMenu()')
-addHotkey('PAUSE', true, false, false, true, false, 'frameStep()')
 addHotkey('SCROLLLOCK', false, false, false, true, false, 'frameStep()')
 
 function changeSpeed(add)

--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -137,8 +137,8 @@ options.t_itemname = {
 			modifyGameOption('Options.Life', 100)
 			modifyGameOption('Options.Time', 99)
 			modifyGameOption('Options.GameSpeed', 0)
-			modifyGameOption('Options.Match.Wins', 2)
 			--modifyGameOption('Options.GameSpeedStep', 5)
+			modifyGameOption('Options.Match.Wins', 2)
 			modifyGameOption('Options.Match.MaxDrawGames', -2) -- -2: match.maxdrawgames
 			modifyGameOption('Options.Credits', 10)
 			modifyGameOption('Options.QuickContinue', false)
@@ -175,7 +175,6 @@ options.t_itemname = {
 			modifyGameOption('Options.Ratio.Level4.Life', 1.40)
 			--modifyGameOption('Config.Motif', "data/system.def")
 			modifyGameOption('Config.Players', 4)
-			--modifyGameOption('Config.Framerate', 60)
 			modifyGameOption('Config.Language', "en")
 			modifyGameOption('Config.AfterImageMax', 128)
 			modifyGameOption('Config.ExplodMax', 512)
@@ -183,6 +182,7 @@ options.t_itemname = {
 			modifyGameOption('Config.ProjectileMax', 256)
 			modifyGameOption('Config.PaletteMax', 100)
 			modifyGameOption('Config.TextMax', 128)
+			--modifyGameOption('Config.TickInterpolation', true)
 			--modifyGameOption('Config.ZoomActive', true)
 			--modifyGameOption('Config.EscOpensMenu', true)
 			--modifyGameOption('Config.BackgroundLoading', false) --TODO: not implemented
@@ -222,6 +222,7 @@ options.t_itemname = {
 			modifyGameOption('Video.Fullscreen', false)
 			--modifyGameOption('Video.Borderless', false)
 			--modifyGameOption('Video.RGBSpriteBilinearFilter', true)
+			--modifyGameOption('Video.Framerate', 60)
 			modifyGameOption('Video.VSync', 1)
 			modifyGameOption('Video.MSAA', 0)
 			--modifyGameOption('Video.WindowCentered', true)

--- a/src/anim.go
+++ b/src/anim.go
@@ -1239,7 +1239,6 @@ func (dl DrawList) draw(cameraX, cameraY, cameraScl float32) {
 		// Restore system brightness
 		sys.brightness = oldBright
 	}
-	//BlendReset()
 }
 
 type ShadowSprite struct {

--- a/src/anim.go
+++ b/src/anim.go
@@ -870,7 +870,7 @@ func (a *Animation) Draw(window *[4]int32, x, y, xcs, ycs, xs, xbs, ys,
 		var pal []uint32
 		pal, paltex = a.pal(pfx)
 		if a.spr.coldepth <= 8 && paltex == nil {
-			paltex = a.spr.CachePalette(pal)
+			paltex = a.spr.CachePalTex(pal)
 		}
 	}
 
@@ -980,7 +980,7 @@ func (a *Animation) ShadowDraw(window *[4]int32, x, y, xscl, yscl, vscl, rxadd f
 		if a.sff.header.Version[0] == 2 && a.sff.header.Version[2] == 1 {
 			pal, _ := a.pal(pfx)
 			if a.spr.PalTex == nil {
-				a.spr.PalTex = a.spr.CachePalette(pal)
+				a.spr.PalTex = a.spr.CachePalTex(pal)
 			}
 			rp.paltex = a.spr.PalTex
 		} else {

--- a/src/anim.go
+++ b/src/anim.go
@@ -977,7 +977,7 @@ func (a *Animation) ShadowDraw(window *[4]int32, x, y, xscl, yscl, vscl, rxadd f
 	//}
 
 	if a.spr.coldepth <= 8 && (color != 0 || intensity > 0) {
-		if a.sff.header.Ver0 == 2 && a.sff.header.Ver2 == 1 {
+		if a.sff.header.Version[0] == 2 && a.sff.header.Version[2] == 1 {
 			pal, _ := a.pal(pfx)
 			if a.spr.PalTex == nil {
 				a.spr.PalTex = a.spr.CachePalette(pal)

--- a/src/char.go
+++ b/src/char.go
@@ -4165,7 +4165,7 @@ func (c *Char) loadPalette() {
 		return nil, false
 	}
 
-	if gi.sff.header.Ver0 == 1 {
+	if gi.sff.header.Version[0] == 1 {
 		gi.palettedata.palList.ResetRemap()
 		tmp := 0
 		for i := 0; i < maxPal; i++ {
@@ -8737,7 +8737,7 @@ func (c *Char) remapPal(pfx *PalFX, src [2]int32, dst [2]int32) {
 		plist.Remap(si, di)
 
 		// Remap palette 1, 1 in SFF v1
-		if src[0] == 1 && src[1] == 1 && c.gi().sff.header.Ver0 == 1 {
+		if src[0] == 1 && src[1] == 1 && c.gi().sff.header.Version[0] == 1 {
 			if spr := c.gi().sff.GetSprite(0, 0); spr != nil {
 				plist.Remap(spr.palidx, di)
 			}

--- a/src/common.go
+++ b/src/common.go
@@ -1099,7 +1099,7 @@ func (l *Layout) DrawFaceSprite(x, y float32, ln int16, s *Sprite, fx *PalFX, fs
 			y += sys.lifebar.fnt_scale * sys.lifebar.scale
 		}
 		if s.coldepth <= 8 && s.PalTex == nil {
-			s.PalTex = s.CachePalette(s.Pal)
+			s.PalTex = s.CachePalTex(s.Pal)
 		}
 		// Xshear offset correction
 		xshear := -l.xshear

--- a/src/config.go
+++ b/src/config.go
@@ -124,7 +124,6 @@ type Config struct {
 	Config struct {
 		Motif            string   `ini:"Motif"`
 		Players          int      `ini:"Players"`
-		Framerate        int      `ini:"Framerate"`
 		Language         string   `ini:"Language"`
 		AfterImageMax    int32    `ini:"AfterImageMax"`
 		ExplodMax        int      `ini:"ExplodMax"`
@@ -132,6 +131,7 @@ type Config struct {
 		ProjectileMax    int      `ini:"ProjectileMax"`
 		PaletteMax       int      `ini:"PaletteMax"`
 		TextMax          int      `ini:"TextMax"`
+		TickInterpolation bool    `ini:"TickInterpolation"`
 		ZoomActive       bool     `ini:"ZoomActive"`
 		EscOpensMenu     bool     `ini:"EscOpensMenu"`
 		FirstRun         bool     `ini:"FirstRun"`
@@ -165,6 +165,7 @@ type Config struct {
 		GameHeight              int32    `ini:"GameHeight"`
 		WindowWidth             int      `ini:"WindowWidth"`
 		WindowHeight            int      `ini:"WindowHeight"`
+		Framerate               int      `ini:"Framerate"`
 		VSync                   int      `ini:"VSync"`
 		Fullscreen              bool     `ini:"Fullscreen"`
 		Borderless              bool     `ini:"Borderless"`
@@ -332,7 +333,6 @@ func (c *Config) initStruct() {
 
 // Normalize values
 func (c *Config) normalize() {
-	c.SetValueUpdate("Config.Framerate", int(Clamp(int32(c.Config.Framerate), 1, 840)))
 	c.SetValueUpdate("Config.Players", int(Clamp(int32(c.Config.Players), 1, int32(MaxSimul)*2)))
 	c.SetValueUpdate("Options.GameSpeed", int(Clamp(int32(c.Options.GameSpeed), -9, 9)))
 	c.SetValueUpdate("Options.GameSpeedStep", int(Clamp(int32(c.Options.GameSpeedStep), 1, 60)))
@@ -340,6 +340,7 @@ func (c *Config) normalize() {
 	c.SetValueUpdate("Options.Simul.Min", int(Clamp(int32(c.Options.Simul.Min), 2, int32(MaxSimul))))
 	c.SetValueUpdate("Options.Tag.Max", int(Clamp(int32(c.Options.Tag.Max), int32(c.Options.Tag.Min), int32(MaxSimul))))
 	c.SetValueUpdate("Options.Tag.Min", int(Clamp(int32(c.Options.Tag.Min), 2, int32(MaxSimul))))
+	c.SetValueUpdate("Video.Framerate", int(Clamp(int32(c.Video.Framerate), 1, 840)))
 
 	// Options that determine allocation sizes should not be negative
 	// Update: AfterImageMax no longer does, but it's good to keep it in mind

--- a/src/font.go
+++ b/src/font.go
@@ -10,6 +10,8 @@ import (
 	"unicode/utf8"
 )
 
+const MaxFontBatchSize = 250
+
 type FontRenderer interface {
 	Init(renderer interface{})
 	LoadFont(file string, scale int32, windowWidth int, windowHeight int) (interface{}, error)

--- a/src/font.go
+++ b/src/font.go
@@ -383,7 +383,7 @@ func LoadFntSff(f *Fnt, fontfile string, filename string) {
 			if f.images[int32(sprite.Group)] == nil {
 				f.images[int32(sprite.Group)] = make(map[rune]*FntCharImage)
 			}
-			if pal_default == nil && sff.header.Ver0 == 1 {
+			if pal_default == nil && sff.header.Version[0] == 1 {
 				pal_default = s.Pal
 			}
 			offsetX := uint16(s.Offset[0])

--- a/src/font_gl32.go
+++ b/src/font_gl32.go
@@ -43,18 +43,19 @@ func (r *FontRenderer_GL32) Init(renderer interface{}) {
 	gl.BindVertexArray(r.vao)
 	gl.BindBuffer(gl.ARRAY_BUFFER, r.vbo)
 
-	gl.BufferData(gl.ARRAY_BUFFER, 6*4*4, nil, gl.STATIC_DRAW)
+	// Pre-allocate for maximum batch size
+	gl.BufferData(gl.ARRAY_BUFFER, MaxFontBatchSize*6*4*4, nil, gl.DYNAMIC_DRAW)
 
+	// Configure attributes
 	vertAttrib := uint32(gl.GetAttribLocation(r.shaderProgram.program, gl.Str("vert\x00")))
 	gl.EnableVertexAttribArray(vertAttrib)
 	gl.VertexAttribPointer(vertAttrib, 2, gl.FLOAT, false, 4*4, gl.PtrOffset(0))
-	defer gl.DisableVertexAttribArray(vertAttrib)
 
 	texCoordAttrib := uint32(gl.GetAttribLocation(r.shaderProgram.program, gl.Str("vertTexCoord\x00")))
 	gl.EnableVertexAttribArray(texCoordAttrib)
 	gl.VertexAttribPointer(texCoordAttrib, 2, gl.FLOAT, false, 4*4, gl.PtrOffset(2*4))
-	defer gl.DisableVertexAttribArray(texCoordAttrib)
 
+	// Clean up binding state, but not attribute state
 	gl.BindBuffer(gl.ARRAY_BUFFER, 0)
 	gl.BindVertexArray(0)
 }
@@ -104,15 +105,14 @@ func (f *Font_GL32) Printf(x, y float32, scale float32, spacingXAdd float32, ali
 	}
 
 	// Buffer to store vertex data for multiple glyphs
-	batchSize := Min(250, int32(len(indices)))
+	batchSize := Min(MaxFontBatchSize, int32(len(indices)))
 	batchVertices := make([]float32, 0, batchSize*6*4)
 
 	//setup blending mode
 	r.SetBlending(blend, BlendAdd, BlendSrcAlpha, BlendOneMinusSrcAlpha)
 
 	//restrict drawing to a certain part of the window
-	gl.Enable(gl.SCISSOR_TEST)
-	gl.Scissor(window[0], window[1], window[2], window[3])
+	r.EnableScissor(window[0], window[1], window[2], window[3])
 
 	// Activate corresponding render state
 	program := gfxFont.(*FontRenderer_GL32).shaderProgram
@@ -123,7 +123,7 @@ func (f *Font_GL32) Printf(x, y float32, scale float32, spacingXAdd float32, ali
 	gl.Uniform2f(program.u["resolution"], float32(f.windowWidth), float32(f.windowHeight))
 
 	gl.ActiveTexture(gl.TEXTURE0)
-	gl.BindVertexArray(gfxFont.(*FontRenderer_GL32).vao)
+	//gl.BindVertexArray(gfxFont.(*FontRenderer_GL32).vao)
 
 	//calculate alignment position
 	if align == 0 {
@@ -157,7 +157,7 @@ func (f *Font_GL32) Printf(x, y float32, scale float32, spacingXAdd float32, ali
 
 		if int32(len(batchVertices)/24) >= batchSize || (textureID != -1 && textureID != int32(ch.textureID)) {
 			// Render the current batch
-			f.renderGlyphBatch(indices, batchVertices, uint32(textureID))
+			f.renderGlyphBatch(batchVertices, uint32(textureID))
 			// Clear the batch buffers
 			batchVertices = make([]float32, 0, batchSize*6*4)
 		}
@@ -190,31 +190,26 @@ func (f *Font_GL32) Printf(x, y float32, scale float32, spacingXAdd float32, ali
 
 	// Render any remaining glyphs in the batch
 	if len(batchVertices) > 0 {
-		f.renderGlyphBatch(indices, batchVertices, uint32(textureID))
+		f.renderGlyphBatch(batchVertices, uint32(textureID))
 	}
 
-	//clear opengl textures and programs
-	gl.BindVertexArray(0)
-	gl.BindTexture(gl.TEXTURE_2D, 0)
-	//gl.UseProgram(0)
-	//gl.Disable(gl.BLEND)
+	// Disable scissor just in case
 	gl.Disable(gl.SCISSOR_TEST)
 
 	return nil
 }
 
 // Helper function to render a batch of glyphs
-func (f *Font_GL32) renderGlyphBatch(indices []rune, vertices []float32, textureID uint32) {
+func (f *Font_GL32) renderGlyphBatch(vertices []float32, textureID uint32) {
+	gl.BindVertexArray(gfxFont.(*FontRenderer_GL32).vao)
 	// Bind the buffer and update its data
 	gl.BindBuffer(gl.ARRAY_BUFFER, gfxFont.(*FontRenderer_GL32).vbo)
-	gl.BufferData(gl.ARRAY_BUFFER, len(vertices)*4, gl.Ptr(vertices), gl.DYNAMIC_DRAW)
 	// Bind the texture
+	//gl.BufferData(gl.ARRAY_BUFFER, len(vertices)*4, gl.Ptr(vertices), gl.DYNAMIC_DRAW)
+	gl.BufferSubData(gl.ARRAY_BUFFER, 0, len(vertices)*4, gl.Ptr(vertices))
+
 	gl.BindTexture(gl.TEXTURE_2D, textureID)
 	gl.DrawArrays(gl.TRIANGLES, 0, int32(len(vertices))/4)
-
-	// Unbind the buffer and texture
-	// gl.BindBuffer(gl.ARRAY_BUFFER, 0)
-	// gl.BindTexture(gl.TEXTURE_2D, 0)
 }
 
 // Width returns the width of a piece of text in pixels

--- a/src/input.go
+++ b/src/input.go
@@ -2405,7 +2405,7 @@ func (nc *NetConnection) Update() bool {
 
 				// Break loop if we have reached the frame that both buffers have sent
 				if nc.time >= foo {
-					if sys.esc || !sys.await(sys.cfg.Config.Framerate) || nc.st != NS_Playing {
+					if sys.esc || !sys.await(sys.cfg.Video.Framerate) || nc.st != NS_Playing {
 						break
 					}
 					continue

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -1785,34 +1785,27 @@ func (fa *LifeBarFace) draw(layerno int16, ref int, far *LifeBarFace) {
 
 	if far.face != nil {
 		// Get player current PalFX if applicable
-		pfx := newPalFX()
+		var pfx *PalFX 
 		if far.palfxshare {
 			pfx = refChar.getPalfx()
 		}
 
-		// Swap palette maps to get the player's current palette
-		if far.palshare {
-			sys.cgi[ref].palettedata.palList.SwapPalMap(&refChar.getPalfx().remap)
-		}
-
-		// Get texture
+		// Update portrait palette
 		if far.face.coldepth <= 8 {
-			// This method created a large hot spot in the profile
-			// It was throwing away good textures because of bad GetPalTex returns
-			//far.face.Pal = nil
-			//if far.face.PalTex != nil {
-			//	far.face.PalTex = far.face.GetPalTex(&sys.cgi[ref].palettedata.palList)
-			//} else {
-			//	far.face.Pal = far.face.GetPal(&sys.cgi[ref].palettedata.palList)
-			//}
-
-			// Now we just update the palette data and let the engine figure it out
-			far.face.Pal = far.face.GetPal(&sys.cgi[ref].palettedata.palList)
-		}
-
-		// Revert palette maps to initial state
-		if far.palshare {
-			sys.cgi[ref].palettedata.palList.SwapPalMap(&refChar.getPalfx().remap)
+			// Check the player's current palette
+			palIdx := far.face.palidx 
+			if far.palshare {
+				remap := refChar.getPalfx().remap
+				if int(palIdx) < len(remap) {
+					palIdx = remap[palIdx]
+				}
+			}
+			// Retrieve that palette
+			palList := &sys.cgi[ref].palettedata.palList
+			charPal := palList.Get(palIdx)
+			// Update portrait palette and cache
+			far.face.Pal = charPal
+			far.face.PalTex = far.face.CachePalTex(charPal)
 		}
 
 		// TODO: PalFX sharing has a bug in Tag in that it uses the parameter from the char's original placement in the team

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -3781,7 +3781,6 @@ func (ro *LifeBarRound) draw(layerno int16, f map[int]*Fnt) {
 			ro.fadeIn.drawRect(rect, ro.shutter_col, 255)
 		}
 	}
-	//BlendReset()
 }
 
 type LifeBarRatio struct {
@@ -5381,7 +5380,6 @@ func (l *Lifebar) draw(layerno int16) {
 		// LifeBarRound
 		l.ro.draw(layerno, l.fnt)
 	}
-	//BlendReset()
 }
 
 func (l *Lifebar) setLifebarScale() {

--- a/src/motif.go
+++ b/src/motif.go
@@ -2707,7 +2707,6 @@ func (m *Motif) drawLoading() {
 		FillRect(sys.scrrect, 0x000000, [2]int32{255, 0})
 
 		ts.Draw(ts.layerno)
-		//BlendReset()
 
 		// Submit and present
 		gfx.EndFrame()
@@ -2991,7 +2990,6 @@ func (m *Motif) draw(layerno int16) {
 			m.fadeIn.draw()
 		}
 	}
-	//BlendReset()
 }
 
 func (m *Motif) isDialogueSet() bool {

--- a/src/render.go
+++ b/src/render.go
@@ -32,9 +32,7 @@ type Renderer interface {
 	IsModelEnabled() bool
 	IsShadowEnabled() bool
 
-	//BlendReset()
 	SetPipeline(eq BlendEquation, src, dst BlendFunc)
-	ReleasePipeline()
 	prepareShadowMapPipeline(bufferIndex uint32)
 	setShadowMapPipeline(doubleSided, invertFrontFace, useUV, useNormal, useTangent, useVertColor, useJoint0, useJoint1 bool, numVertices, vertAttrOffset uint32)
 	ReleaseShadowPipeline()
@@ -489,13 +487,6 @@ func initRenderSpriteQuad(rp *RenderParams) {
 	rp.y += rp.rcy
 }
 
-// We relied too much on this, which hurt performance a little
-/*
-func BlendReset() {
-	gfx.BlendReset()
-}
-*/
-
 func RenderSprite(rp RenderParams) {
 	if !rp.IsValid() {
 		return
@@ -540,8 +531,6 @@ func RenderSprite(rp RenderParams) {
 		gfx.SetUniformF("alpha", a)
 
 		renderSpriteQuad(modelview, rp)
-
-		gfx.ReleasePipeline()
 	}
 
 	renderWithBlending(render, rp.blendMode, rp.blendAlpha, rp.paltex != nil, invblend, &neg, &padd, &pmul, rp.paltex == nil)
@@ -683,7 +672,6 @@ func FillRect(rect [4]int32, color uint32, alpha [2]int32) {
 		gfx.SetUniformI("isFlat", 1)
 		gfx.SetUniformF("tint", r, g, b, a)
 		gfx.RenderQuad()
-		gfx.ReleasePipeline()
 	}
 
 	renderWithBlending(render, TT_add, alpha, true, 0, nil, nil, nil, false)

--- a/src/render.go
+++ b/src/render.go
@@ -48,7 +48,7 @@ type Renderer interface {
 	newCubeMapTexture(widthHeight int32, mipmap bool, lowestMipLevel int32) (t Texture)
 
 	ReadPixels(data []uint8, width, height int)
-	Scissor(x, y, width, height int32)
+	EnableScissor(x, y, width, height int32)
 	DisableScissor()
 
 	SetUniformI(name string, val int)
@@ -505,7 +505,7 @@ func RenderSprite(rp RenderParams) {
 	proj := gfx.OrthographicProjectionMatrix(0, float32(sys.scrrect[2]), 0, float32(sys.scrrect[3]), -65535, 65535)
 	modelview := mgl.Translate3D(0, float32(sys.scrrect[3]), 0)
 
-	gfx.Scissor(rp.window[0], rp.window[1], rp.window[2], rp.window[3])
+	gfx.EnableScissor(rp.window[0], rp.window[1], rp.window[2], rp.window[3])
 
 	render := func(eq BlendEquation, src, dst BlendFunc, a float32) {
 		gfx.SetPipeline(eq, src, dst)

--- a/src/render.go
+++ b/src/render.go
@@ -84,7 +84,7 @@ type Renderer interface {
 	PerspectiveProjectionMatrix(angle, aspect, near, far float32) mgl.Mat4
 	OrthographicProjectionMatrix(left, right, bottom, top, near, far float32) mgl.Mat4
 
-	SetVSync()
+	SetVSync(interval int)
 	NewWorkerThread() bool
 }
 

--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -719,10 +719,6 @@ func (r *Renderer_GL21) BeginFrame(clearColor bool) {
 	}
 }
 
-func (r *Renderer_GL21) BlendReset() {
-	r.SetBlending(true, BlendAdd, BlendSrcAlpha, BlendOneMinusSrcAlpha)
-}
-
 func (r *Renderer_GL21) EndFrame() {
 	if len(r.fbo_pp) == 0 {
 		return
@@ -940,14 +936,6 @@ func (r *Renderer_GL21) SetPipeline(eq BlendEquation, src, dst BlendFunc) {
 	loc = r.spriteShader.a["uv"]
 	gl.EnableVertexAttribArray(uint32(loc))
 	gl.VertexAttribPointerWithOffset(uint32(loc), 2, gl.FLOAT, false, 16, 8)
-}
-
-func (r *Renderer_GL21) ReleasePipeline() {
-	loc := r.spriteShader.a["position"]
-	gl.DisableVertexAttribArray(uint32(loc))
-	loc = r.spriteShader.a["uv"]
-	gl.DisableVertexAttribArray(uint32(loc))
-	//gl.Disable(gl.BLEND)
 }
 
 func (r *Renderer_GL21) prepareShadowMapPipeline(bufferIndex uint32) {

--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -1363,7 +1363,7 @@ func (r *Renderer_GL21) ReadPixels(data []uint8, width, height int) {
 	gl.ReadPixels(0, 0, int32(width), int32(height), gl.RGBA, gl.UNSIGNED_BYTE, unsafe.Pointer(&data[0]))
 }
 
-func (r *Renderer_GL21) Scissor(x, y, width, height int32) {
+func (r *Renderer_GL21) EnableScissor(x, y, width, height int32) {
 	gl.Enable(gl.SCISSOR_TEST)
 	gl.Scissor(x, sys.scrrect[3]-(y+height), width, height)
 }

--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -1687,5 +1687,6 @@ func (r *Renderer_GL21) NewWorkerThread() bool {
 	return false
 }
 
-func (r *Renderer_GL21) SetVSync() {
+func (r *Renderer_GL21) SetVSync(interval int) {
+	sdl.GLSetSwapInterval(interval)
 }

--- a/src/render_gl_gl32.go
+++ b/src/render_gl_gl32.go
@@ -728,10 +728,6 @@ func (r *Renderer_GL32) BeginFrame(clearColor bool) {
 	}
 }
 
-func (r *Renderer_GL32) BlendReset() {
-	r.SetBlending(true, BlendAdd, BlendSrcAlpha, BlendOneMinusSrcAlpha)
-}
-
 func (r *Renderer_GL32) EndFrame() {
 	if len(r.fbo_pp) == 0 {
 		return
@@ -955,14 +951,6 @@ func (r *Renderer_GL32) SetPipeline(eq BlendEquation, src, dst BlendFunc) {
 	loc = r.spriteShader.a["uv"]
 	gl.EnableVertexAttribArray(uint32(loc))
 	gl.VertexAttribPointerWithOffset(uint32(loc), 2, gl.FLOAT, false, 16, 8)
-}
-
-func (r *Renderer_GL32) ReleasePipeline() {
-	loc := r.spriteShader.a["position"]
-	gl.DisableVertexAttribArray(uint32(loc))
-	loc = r.spriteShader.a["uv"]
-	gl.DisableVertexAttribArray(uint32(loc))
-	//gl.Disable(gl.BLEND)
 }
 
 func (r *Renderer_GL32) prepareShadowMapPipeline(bufferIndex uint32) {

--- a/src/render_gl_gl32.go
+++ b/src/render_gl_gl32.go
@@ -1694,5 +1694,6 @@ func (r *Renderer_GL32) NewWorkerThread() bool {
 	return false
 }
 
-func (r *Renderer_GL32) SetVSync() {
+func (r *Renderer_GL32) SetVSync(interval int) {
+	sdl.GLSetSwapInterval(interval)
 }

--- a/src/render_gl_gl32.go
+++ b/src/render_gl_gl32.go
@@ -1373,7 +1373,7 @@ func (r *Renderer_GL32) ReadPixels(data []uint8, width, height int) {
 	gl.ReadPixels(0, 0, int32(width), int32(height), gl.RGBA, gl.UNSIGNED_BYTE, unsafe.Pointer(&data[0]))
 }
 
-func (r *Renderer_GL32) Scissor(x, y, width, height int32) {
+func (r *Renderer_GL32) EnableScissor(x, y, width, height int32) {
 	gl.Enable(gl.SCISSOR_TEST)
 	gl.Scissor(x, sys.scrrect[3]-(y+height), width, height)
 }

--- a/src/render_gl_gles32.go
+++ b/src/render_gl_gles32.go
@@ -1798,5 +1798,6 @@ func (r *Renderer_GLES32) NewWorkerThread() bool {
 	return false
 }
 
-func (r *Renderer_GLES32) SetVSync() {
+func (r *Renderer_GLES32) SetVSync(interval int) {
+	sdl.GLSetSwapInterval(interval)
 }

--- a/src/render_gl_gles32.go
+++ b/src/render_gl_gles32.go
@@ -834,10 +834,6 @@ func (r *Renderer_GLES32) BeginFrame(clearColor bool) {
 	}
 }
 
-func (r *Renderer_GLES32) BlendReset() {
-	r.SetBlending(true, BlendAdd, BlendSrcAlpha, BlendOneMinusSrcAlpha)
-}
-
 func (r *Renderer_GLES32) EndFrame() {
 	if len(r.fbo_pp) == 0 {
 		return
@@ -1059,14 +1055,6 @@ func (r *Renderer_GLES32) SetPipeline(eq BlendEquation, src, dst BlendFunc) {
 	loc = r.spriteShader.a["uv"]
 	gl.EnableVertexAttribArray(uint32(loc))
 	gl.VertexAttribPointerWithOffset(uint32(loc), 2, gl.FLOAT, false, 16, 8)
-}
-
-func (r *Renderer_GLES32) ReleasePipeline() {
-	loc := r.spriteShader.a["position"]
-	gl.DisableVertexAttribArray(uint32(loc))
-	loc = r.spriteShader.a["uv"]
-	gl.DisableVertexAttribArray(uint32(loc))
-	//gl.Disable(gl.BLEND)
 }
 
 func (r *Renderer_GLES32) prepareShadowMapPipeline(bufferIndex uint32) {

--- a/src/render_gl_gles32.go
+++ b/src/render_gl_gles32.go
@@ -1477,7 +1477,7 @@ func (r *Renderer_GLES32) ReadPixels(data []uint8, width, height int) {
 	gl.ReadPixels(0, 0, int32(width), int32(height), gl.RGBA, gl.UNSIGNED_BYTE, unsafe.Pointer(&data[0]))
 }
 
-func (r *Renderer_GLES32) Scissor(x, y, width, height int32) {
+func (r *Renderer_GLES32) EnableScissor(x, y, width, height int32) {
 	gl.Enable(gl.SCISSOR_TEST)
 	gl.Scissor(x, sys.scrrect[3]-(y+height), width, height)
 }

--- a/src/render_vk.go
+++ b/src/render_vk.go
@@ -5009,11 +5009,6 @@ func (r *Renderer_VK) BeginFrame(clearColor bool) {
 	}
 }
 
-func (r *Renderer_VK) BlendReset() {
-	r.VKState.VulkanBlendState.op = BlendAdd
-	r.VKState.VulkanBlendState.src = BlendSrcAlpha
-	r.VKState.VulkanBlendState.dst = BlendOneMinusSrcAlpha
-}
 func (r *Renderer_VK) EndFrame() {
 	if len(r.stagingImageBarriers[0]) > 0 || len(r.tempCommands) > 0 {
 		r.FlushTempCommands()
@@ -5289,10 +5284,6 @@ func (r *Renderer_VK) SetPipeline(eq BlendEquation, src, dst BlendFunc) {
 	r.VKState.VulkanPipelineState.VulkanBlendState.op = eq
 	r.VKState.VulkanPipelineState.VulkanBlendState.src = src
 	r.VKState.VulkanPipelineState.VulkanBlendState.dst = dst
-}
-
-func (r *Renderer_VK) ReleasePipeline() {
-	//Do nothing
 }
 
 func (r *Renderer_VK) prepareShadowMapPipeline(bufferIndex uint32) {

--- a/src/render_vk.go
+++ b/src/render_vk.go
@@ -5605,7 +5605,7 @@ func (r *Renderer_VK) ReadPixels(data []uint8, width, height int) {
 	vk.FreeMemory(r.device, imageMemory, nil)
 }
 
-func (r *Renderer_VK) Scissor(x, y, width, height int32) {
+func (r *Renderer_VK) EnableScissor(x, y, width, height int32) {
 	r.VKState.scissor = vk.Rect2D{
 		Offset: vk.Offset2D{
 			X: int32(MaxI(int(x), 0)),

--- a/src/render_vk.go
+++ b/src/render_vk.go
@@ -7580,6 +7580,7 @@ func (r *Renderer_VK) AllocateImageMemory(img vk.Image, memoryProperty vk.Memory
 	return imageMemory
 }
 
-func (r *Renderer_VK) SetVSync() {
+func (r *Renderer_VK) SetVSync(interval int) {
+	// We just ignore the interval here and force it on
 	r.setVSync = true
 }

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -109,9 +109,6 @@ Ratio.Level4.Life     = 1.4
 Motif               = data/mugen1/system.def
 ; Max amount of player-controlled characters (2-8)
 Players             = 4
-; The rate at which consecutive frames are rendered. The game can refresh
-; internally at a different speed, while maintaining a separate gameplay speed.
-Framerate           = 60
 ; Preferred language (ISO 639-1), e.g. en, es, ja, etc.
 ; See http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
 ; Use 'system' to automatically detect the system language.
@@ -133,6 +130,8 @@ PaletteMax          = 100
 ; Maximum number of texts allowed per player.
 ; Set to a lower number to save memory.
 TextMax = 128
+; Enable sprite position interpolation when Framerate is faster than game logic.
+TickInterpolation   = 1
 ; Zoom toggle (0 disables zoom for stages coded to have it).
 ZoomActive          = 1
 ; Toggles if Esc key should open Pause menu.
@@ -219,6 +218,9 @@ Fullscreen        = 0
 Borderless        = 0
 ; Toggles bilinear filtering for sprites using RGB color formats (non-indexed).
 RGBSpriteBilinearFilter = 1
+; Set the target number of frames to render per second.
+; Adjusts rendering performance without affecting the game logic speed.
+Framerate         = 60
 ; Toggles syncing frame rate with display refresh rate to prevent screen tearing.
 ; May increase input lag.
 VSync             = 1

--- a/src/script.go
+++ b/src/script.go
@@ -2226,7 +2226,7 @@ func systemScriptInit(l *lua.LState) {
 				} else if sys.loader.state == LS_Cancel {
 					return nil
 				}
-				sys.await(sys.cfg.Config.Framerate)
+				sys.await(sys.cfg.Video.Framerate)
 			}
 			runtime.GC()
 			return nil

--- a/src/script.go
+++ b/src/script.go
@@ -3984,11 +3984,9 @@ func systemScriptInit(l *lua.LState) {
 		if !sys.frameSkip {
 			sys.luaFlushDrawQueue()
 			if sys.motif.fadeIn.isActive() {
-				//BlendReset()
 				sys.motif.fadeIn.step()
 				sys.motif.fadeIn.draw()
 			} else if sys.motif.fadeOut.isActive() {
-				//BlendReset()
 				sys.motif.fadeOut.step()
 				sys.motif.fadeOut.draw()
 			}

--- a/src/stage.go
+++ b/src/stage.go
@@ -2022,7 +2022,6 @@ func (s *Stage) draw(layer int32, x, y, scl float32) {
 			b.draw(pos, scl, bgscl, s.localscl, s.scale, ofs[1], true)
 		}
 	}
-	//BlendReset()
 }
 
 func (s *Stage) reset() {

--- a/src/stage.go
+++ b/src/stage.go
@@ -1346,7 +1346,7 @@ func loadStage(def string, maindef bool) (*Stage, error) {
 			}
 			*s.sff = *sff
 			// SFF v2.01 was not available before Mugen 1.1, therefore we assume that's the minimum correct version for the stage
-			if s.sff.header.Ver0 == 2 && s.sff.header.Ver2 == 1 {
+			if s.sff.header.Version[0] == 2 && s.sff.header.Version[2] == 1 {
 				s.mugenver[0] = 1
 				s.mugenver[1] = 1
 			}

--- a/src/system.go
+++ b/src/system.go
@@ -2982,7 +2982,7 @@ func (s *System) drawTop() {
 		// Change the first color of the Clsn sprite
 		setColor := func(color uint32) {
 			s.clsnSpr.Pal[0] = color
-			s.clsnSpr.updatePaletteTexture(s.clsnSpr.Pal)
+			s.clsnSpr.PalTex = s.clsnSpr.CachePalTex(s.clsnSpr.Pal)
 		}
 		// Clsn1 HitDef
 		setColor(0xff0000ff)

--- a/src/system.go
+++ b/src/system.go
@@ -2974,8 +2974,6 @@ func (s *System) drawCharTexts(layerno int16) {
 }
 
 func (s *System) drawTop() {
-	//BlendReset()
-
 	s.brightness = s.brightnessOld
 
 	// Draw Clsn boxes

--- a/src/system.go
+++ b/src/system.go
@@ -1896,7 +1896,7 @@ func (s *System) resetRoundState() {
 		}
 		if s.roundsExisted[i&1] == 0 {
 			s.cgi[i].palettedata.palList.ResetRemap()
-			if s.cgi[i].sff.header.Ver0 == 1 {
+			if s.cgi[i].sff.header.Version[0] == 1 {
 				p[0].remapPal(p[0].getPalfx(),
 					[...]int32{1, 1}, [...]int32{1, s.cgi[i].palno})
 			}
@@ -4117,7 +4117,7 @@ func (s *Select) AddChar(def string) *SelectChar {
 				sc.anims.addSprite(sc.sff, k_spr[0], k_spr[1])
 			}
 			// Synchronize SFFv2 internal palettes with DEF declarations
-			if sc.sff.header.Ver0 != 1 {
+			if sc.sff.header.Version[0] != 1 {
 				defPals := make(map[int32]bool)
 				for _, p := range sc.pal {
 					defPals[p] = true

--- a/src/system.go
+++ b/src/system.go
@@ -839,19 +839,19 @@ func (s *System) update() bool {
 
 	if s.replayFile != nil {
 		if s.anyHardButton() {
-			s.await(s.cfg.Config.Framerate * 4)
+			s.await(s.cfg.Video.Framerate * 4)
 		} else {
-			s.await(s.cfg.Config.Framerate)
+			s.await(s.cfg.Video.Framerate)
 		}
 		return s.replayFile.Update()
 	}
 
 	if s.netConnection != nil {
-		s.await(s.cfg.Config.Framerate)
+		s.await(s.cfg.Video.Framerate)
 		return s.netConnection.Update()
 	}
 
-	return s.await(s.cfg.Config.Framerate)
+	return s.await(s.cfg.Video.Framerate)
 }
 
 func (s *System) tickSound() {
@@ -1973,11 +1973,16 @@ func (s *System) tickNextFrame() bool {
 
 // This divides a frame into fractions for the purpose of drawing position interpolation
 func (s *System) tickInterpolation() float32 {
+	// Always synchronize here
 	if s.tickNextFrame() {
 		return 1
-	} else {
-		return s.tickCountF - s.lastTick + s.nextAddTime
 	}
+	// Apply interpolation if enabled
+	if sys.cfg.Config.TickInterpolation {
+		progress := s.tickCountF - s.lastTick + s.nextAddTime
+		return ClampF(progress, 0, 1)
+	}
+	return 1
 }
 
 func (s *System) addFrameTime(t float32) bool {
@@ -3468,7 +3473,7 @@ func (s *System) gameLogicSpeed() int32 {
 }
 
 func (s *System) gameRenderSpeed() int32 {
-	spd := int32(s.cfg.Config.Framerate)
+	spd := int32(s.cfg.Video.Framerate)
 	return Max(1, spd)
 }
 

--- a/src/system.go
+++ b/src/system.go
@@ -421,6 +421,7 @@ func (s *System) init(w, h int32) *lua.LState {
 	gfx, gfxFont = selectRenderer(s.cfg.Video.RenderMode)
 	Logcat("Check B: Initializing GFX")
 	gfx.Init()
+	s.window.SetSwapInterval(s.cfg.Video.VSync) // VSync must be set after gfx, or our config will be ignored
 	Logcat("Check C: Initializing GFX Font")
 	gfxFont.Init(gfx)
 	Logcat("Check D: We are GOOD")

--- a/src/system_sdl.go
+++ b/src/system_sdl.go
@@ -140,11 +140,6 @@ func (s *System) newWindow(w, h int) (*Window, error) {
 				window.SetPosition(x, y)
 			}
 		}
-
-		// 7. V-SYNC
-		if sys.cfg.Video.RenderMode != "Vulkan" && s.cfg.Video.VSync >= 0 {
-			sdl.GLSetSwapInterval(s.cfg.Video.VSync)
-		}
 	}
 
 	for i := range input.controllers {
@@ -205,11 +200,7 @@ func (w *Window) SetIcon(icon []image.Image) {
 }
 
 func (w *Window) SetSwapInterval(interval int) {
-	if sys.cfg.Video.RenderMode == "OpenGL 3.2" || sys.cfg.Video.RenderMode == "OpenGL 2.1" {
-		sdl.GLSetSwapInterval(interval)
-	} else {
-		gfx.SetVSync()
-	}
+	gfx.SetVSync(interval)
 }
 
 func (w *Window) GetSize() (int, int) {
@@ -283,7 +274,7 @@ func (w *Window) toggleFullscreen() {
 		w.Window.SetFullscreen(uint32(sdl.WINDOW_FULLSCREEN_DESKTOP))
 		sdl.ShowCursor(sdl.DISABLE)
 	}
-	if sys.cfg.Video.VSync != -1 && (sys.cfg.Video.RenderMode == "OpenGL 3.2" || sys.cfg.Video.RenderMode == "OpenGL 2.1") {
+	if sys.cfg.Video.VSync != -1 {
 		sdl.GLSetSwapInterval(sys.cfg.Video.VSync)
 	}
 	w.fullscreen = !w.fullscreen

--- a/src/util_desktop.go
+++ b/src/util_desktop.go
@@ -61,14 +61,20 @@ func LoadFntTtf(f *Fnt, fontfile string, filename string, height int32) {
 func selectRenderer(cfgVal string) (Renderer, FontRenderer) {
 	var gfx Renderer
 	var gfxFont FontRenderer
+
 	// Now we proceed to init the render.
-	if cfgVal == "Vulkan 1.3" {
-		gfx = &Renderer_VK{}
-		gfxFont = &FontRenderer_VK{}
-	} else if cfgVal == "OpenGL 2.1" {
+	switch cfgVal {
+	case "OpenGL 2.1":
 		gfx = &Renderer_GL21{}
 		gfxFont = &FontRenderer_GL21{}
-	} else {
+	case "OpenGL 3.2":
+		gfx = &Renderer_GL32{}
+		gfxFont = &FontRenderer_GL32{}
+	case "Vulkan 1.3":
+		gfx = &Renderer_VK{}
+		gfxFont = &FontRenderer_VK{}
+	default:
+		sys.errLog.Printf("Error: Invalid RenderMode '%s'. Defaulting to OpenGL 3.2.", cfgVal)
 		gfx = &Renderer_GL32{}
 		gfxFont = &FontRenderer_GL32{}
 	}


### PR DESCRIPTION
Features:
- TickInterpolation option. Decouples character position interpolation from Framerate option

Fixes:
- SFF palettes now properly inherit their original color depth
- Fixed portraits not using the same palette as the character by using a different fix for the previous texture leak
- VSync now correctly initializes to whatever the config option is
- Moved pause menu execution to its equivalent location before motif refactor
- Fixes #2408
- Fixes #3080
- "Fixes" #3096
- Fixes https://discord.com/channels/233345562261323776/233363722934943744/1466858491149815820
- Fixes https://discord.com/channels/233345562261323776/282927929548210177/1467641526183133225

Refactor:
- Extracted the palette color reading loops into their own functions
- Removed remnants of ReleasePipeline()
- Removed the previously already disabled BlendReset()
- The OpenGL font renderer no longer aggressively cleans up the rendering state, making it work less between draw calls
- Adjusted GL2.1 font code by replacing inactive VAO logic with explicit assignments
- Moved Framerate option to Video settings
- Centralized VSync toggles
- Added error print if RenderMode is set incorrectly
- Officially drop support for Ctrl+Pause debug key as it conflicts with modern systems