### PR TITLE
feat: ForceStageAutoZoom option

### DIFF
--- a/src/config.go
+++ b/src/config.go
@@ -155,6 +155,7 @@ type Config struct {
 		StartStage          string  `ini:"StartStage"`
 		ForceStageZoomout   float32 `ini:"ForceStageZoomout"`
 		ForceStageZoomin    float32 `ini:"ForceStageZoomin"`
+		ForceStageAutoZoom  bool    `ini:"ForceStageAutoZoom"`
 		KeepSpritesOnReload bool    `ini:"KeepSpritesOnReload"`
 		MacOSUseCommandKey  bool    `ini:"MacOSUseCommandKey"`
 		SpeedTest           int     `ini:"SpeedTest"`

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -184,6 +184,9 @@ StartStage          = stages/stage0-720.def
 ; This is a debug parameter and may be removed in future versions.
 ForceStageZoomout   = 0
 ForceStageZoomin    = 0
+; Set to 1 to force AutoZoom on all stages that don't have it explicitly defined
+; or have a custom zoomout value set.
+ForceStageAutoZoom  = 0
 ; Set to 1 to prevent character SFF files from being reloaded when Shift+F4 is used.
 KeepSpritesOnReload = 0
 ; macOS Command Key in place of Ctrl for hotkeys (enabled by default)

--- a/src/stage.go
+++ b/src/stage.go
@@ -1271,7 +1271,12 @@ func loadStage(def string, maindef bool) (*Stage, error) {
 		if strings.ToLower(anchor) == "bottom" {
 			s.stageCamera.zoomanchor = true
 		}
-		sec[0].ReadBool("autozoom", &s.stageCamera.autoZoom)
+
+		autoZoomExisted := sec[0].ReadBool("autozoom", &s.stageCamera.autoZoom)
+		if sys.cfg.Debug.ForceStageAutoZoom && !autoZoomExisted &&
+			(s.stageCamera.zoomin == 1 || sys.cfg.Debug.ForceStageZoomin > 0) && (s.stageCamera.zoomout == 1 || sys.cfg.Debug.ForceStageZoomout > 0) {
+			s.stageCamera.autoZoom = true
+		}
 
 		if s.stageCamera.autoZoom {
 			if s.stageCamera.zoomin == 1 {


### PR DESCRIPTION
・implement ForceStageAutoZoom option

・Fixes https://discord.com/channels/233345562261323776/282927929548210177/1457242821688823909
Fixed a bug where targets could not be acquired when multiple p2stateno were hit at the same time.

・Changed the default value of air.gethit.groundlevel to 25, the same as kfm.
This value is also set to 25 in winmugen, so this makes more sense for compatibility.