### PR TITLE
feat: pn.cursor.persist

### DIFF
--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -2302,7 +2302,9 @@ function start.f_selectScreen()
 		batchDraw(staticDrawList)
 		--draw done cursors
 		for side = 1, 2 do
-			for _, v in pairs(start.p[side].t_selected) do
+			local persist = motif.select_info['p' .. side].cursor.persist 
+			local totalSelected = #start.p[side].t_selected
+			for k, v in pairs(start.p[side].t_selected) do
 				if v.cursor ~= nil then
 					--get cell coordinates
 					local x = v.cursor[1]
@@ -2317,7 +2319,16 @@ function start.f_selectScreen()
 					--end
 					--render only if cell is not hidden
 					if t.hidden ~= 1 and t.hidden ~= 2 then
-						start.f_drawCursor(v.pn, x, y, 'done', true)
+						local shouldDraw = false
+						if main.coop or persist then
+							shouldDraw = true
+						end
+						if start.p[side].selEnd and k == totalSelected then
+							shouldDraw = true
+						end
+						if shouldDraw then
+							start.f_drawCursor(v.pn, x, y, 'done', true)
+						end
 					end
 				end
 			end
@@ -2363,13 +2374,13 @@ function start.f_selectScreen()
 							start.c[v.player].blink = false
 						end
 					end
+					local cursorState = 'active'
+					if v.selectState > 0 and motif.select_info.paletteselect > 0 then
+						--cursorState when palmenu is active
+						cursorState = 'done'
+					end
 					if v.selectState < 4 and start.f_selGrid(start.c[v.player].cell + 1).hidden ~= 1 and not start.c[v.player].blink then
-						if v.selectState > 0 and motif.select_info.paletteselect > 0 then --draw done cursor when palmenu is active
-							start.f_drawCursor(v.player, start.c[v.player].selX, start.c[v.player].selY, 'done', false)
-						else
-							start.f_drawCursor(v.player, start.c[v.player].selX, start.c[v.player].selY, 'active', false)
-						end
-
+						start.f_drawCursor(v.player, start.c[v.player].selX, start.c[v.player].selY, cursorState, false)
 					end
 				end
 			end

--- a/src/motif.go
+++ b/src/motif.go
@@ -388,6 +388,7 @@ type PlayerCursorProperties struct {
 	SwitchTime int32           `ini:"switchtime"` // only used by P2
 	Tween      TweenProperties `ini:"tween"`
 	Reset      bool            `ini:"reset"`
+	Persist    bool            `ini:"persist"`    // only used by P1 and P2
 }
 
 type ItemProperties struct {

--- a/src/resources/defaultMotif.ini
+++ b/src/resources/defaultMotif.ini
@@ -691,7 +691,12 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	p1.cursor.tween.factor = 0.5, 0.5
 	; Snaps the cursor when wrapping
 	p1.cursor.tween.wrap.snap = 0
+	; Reset cursor animation when changing cells
 	p1.cursor.reset = 0
+	; When in team modes and not in co-op, it makes the cursor stay on each selected team member
+	; When set to 0, the done cursor is only shown on the last member at the end of the selection
+	; Only used by P1 and P2
+	p1.cursor.persist = 1
 
 	p1.cursor.active.anim = -1
 	p1.cursor.active.spr = -1, 0
@@ -1314,6 +1319,7 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	p2.cursor.startcell = 0, 4
 	p2.cursor.tween.factor = 0.5, 0.5
 	p2.cursor.reset = 0
+	p2.cursor.persist = 1
 
 	p2.cursor.active.anim = -1
 	p2.cursor.active.spr = -1, 0


### PR DESCRIPTION
Feat:
- Added ``pX.cursor.persist``, when in team modes and not in co-op, it makes the cursor stay on each selected team member. If it’s set to 0, the done cursors are only shown on the last member at the end of the selection. only used by P1 and P2 (Default is 1).