### PR TITLE
refactor: char lists, framerate, debug; fixes

### DIFF
--- a/external/script/debug.lua
+++ b/external/script/debug.lua
@@ -195,7 +195,7 @@ function boolToInt(bool)
 end
 
 function engineInfo()
-	return string.format('Frames: %d, VSync: %d; Speed: %d/%d%%; FPS: %.3f', roundtime(), gameOption('Video.VSync'), tickspersecond(), gamespeed(), gamefps())
+	return string.format('Frames: %d, VSync: %d; Speed: %d/%d%%; FPS: %.1f', roundtime(), gameOption('Video.VSync'), tickspersecond(), gamespeed(), gamefps())
 end
 
 function playerInfo()

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -2395,7 +2395,7 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 			p3.gi().nameLow == sys.stringPool[sys.workingState.playerNo].List[*(*int32)(unsafe.Pointer(&be[*i]))])
 		*i += 4
 	case OC_const_p4name:
-		p4 := sys.charList.enemyNear(c, 1, true, false)
+		p4 := sys.charList.enemyNear(c, 1, true)
 		sys.bcStack.PushB(p4 != nil &&
 			p4.gi().nameLow == sys.stringPool[sys.workingState.playerNo].List[*(*int32)(unsafe.Pointer(&be[*i]))])
 		*i += 4
@@ -2405,7 +2405,7 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 			p5.gi().nameLow == sys.stringPool[sys.workingState.playerNo].List[*(*int32)(unsafe.Pointer(&be[*i]))])
 		*i += 4
 	case OC_const_p6name:
-		p6 := sys.charList.enemyNear(c, 2, true, false)
+		p6 := sys.charList.enemyNear(c, 2, true)
 		sys.bcStack.PushB(p6 != nil &&
 			p6.gi().nameLow == sys.stringPool[sys.workingState.playerNo].List[*(*int32)(unsafe.Pointer(&be[*i]))])
 		*i += 4
@@ -2415,7 +2415,7 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 			p7.gi().nameLow == sys.stringPool[sys.workingState.playerNo].List[*(*int32)(unsafe.Pointer(&be[*i]))])
 		*i += 4
 	case OC_const_p8name:
-		p8 := sys.charList.enemyNear(c, 3, true, false)
+		p8 := sys.charList.enemyNear(c, 3, true)
 		sys.bcStack.PushB(p8 != nil &&
 			p8.gi().nameLow == sys.stringPool[sys.workingState.playerNo].List[*(*int32)(unsafe.Pointer(&be[*i]))])
 		*i += 4

--- a/src/char.go
+++ b/src/char.go
@@ -12286,6 +12286,12 @@ func (cl *CharList) clear() {
 }
 
 func (cl *CharList) add(c *Char) {
+	// A char ID conflict would be catastrophic for the game logic, so we might as well crash
+	// https://github.com/ikemen-engine/Ikemen-GO/issues/2856
+	if _, exist := cl.idMap[c.id]; exist {
+		panic(Error("Attempted to overwrite an active Char in CharList"))
+	}
+
 	// Append to slices
 	cl.creationOrder = append(cl.creationOrder, c)
 	cl.runOrder = append(cl.runOrder, c)

--- a/src/char.go
+++ b/src/char.go
@@ -9450,6 +9450,19 @@ func (c *Char) offsetY() float32 {
 
 // Gather the character as well as all its proxy children (and their proxy children) in a flat slice
 func (c *Char) flattenClsnProxies() []*Char {
+	// Fast path if char has no children
+	hasProxy := false
+	for _, childID := range c.children {
+		if child := sys.playerID(childID); child != nil && child.isclsnproxy {
+			hasProxy = true
+			break
+		}
+	}
+	if !hasProxy {
+		return []*Char{c}
+	}
+
+	// Slow path if char has proxies
 	list := make([]*Char, 0, 8)
 
 	// Start from our character

--- a/src/char.go
+++ b/src/char.go
@@ -4877,12 +4877,20 @@ func (c *Char) enemy(n int32) *Char {
 
 // This is only used to simplify the redirection call
 func (c *Char) enemyNearTrigger(n int32) *Char {
-	return sys.charList.enemyNear(c, n, false, true)
+	// Search enemy at requested index
+	e := sys.charList.enemyNear(c, n, false)
+
+	// Log invalid return
+	if e == nil {
+		sys.appendToConsole(c.warn() + fmt.Sprintf("has no nearest enemy: %v", n))
+	}
+
+	return e
 }
 
 // Get the "P2" enemy reference
 func (c *Char) p2() *Char {
-	p := sys.charList.enemyNear(c, 0, true, false)
+	p := sys.charList.enemyNear(c, 0, true)
 	// Cache last valid P2 enemy
 	// Mugen seems to do this for the sake of auto turning before win poses
 	if p != nil {
@@ -13258,12 +13266,9 @@ func (cl *CharList) cueDraw() {
 // Update enemy near or "P2" lists and return specified index
 // The current approach makes the distance calculation loops only be done when necessary, using cached enemies the rest of the time
 // In Mugen the P2 enemy reference seems to only refresh at the start of each frame instead
-func (cl *CharList) enemyNear(c *Char, n int32, p2list, log bool) *Char {
-	// Invalid reference
+func (cl *CharList) enemyNear(c *Char, n int32, p2list bool) *Char {
+	// Invalid index
 	if n < 0 {
-		if log {
-			sys.appendToConsole(c.warn() + fmt.Sprintf("has no nearest enemy: %v", n))
-		}
 		return nil
 	}
 
@@ -13343,11 +13348,8 @@ func (cl *CharList) enemyNear(c *Char, n int32, p2list, log bool) *Char {
 		*cache = append(*cache, p.id)
 	}
 
-	// If reference exceeds number of valid enemies
+	// Bounds check
 	if int(n) >= len(*cache) {
-		if log {
-			sys.appendToConsole(c.warn() + fmt.Sprintf("has no nearest enemy: %v", n))
-		}
 		return nil
 	}
 

--- a/src/char.go
+++ b/src/char.go
@@ -13336,9 +13336,9 @@ func (cl *CharList) enemyNear(c *Char, n int32, p2list, log bool) *Char {
 	})
 
 	// Rebuild cache
-	*cache = make([]*Char, len(pairs))
-	for i, pair := range pairs {
-		(*cache)[i] = pair.enemy
+	*cache = PointerSliceReset(*cache) // Nil everything instead of using make
+	for _, pair := range pairs {
+		*cache = append(*cache, pair.enemy)
 	}
 
 	// If reference exceeds number of valid enemies

--- a/src/char.go
+++ b/src/char.go
@@ -3112,9 +3112,9 @@ type Char struct {
 	targets             []int32
 	hitdefTargets       []int32
 	hitdefTargetsBuffer []int32
-	enemyNearList       []*Char // Enemies retrieved by EnemyNear
-	p2EnemyList         []*Char // Enemies retrieved by P2, P4, P6 and P8
-	p2EnemyBackup       *Char   // Backup of last valid P2 enemy
+	enemyNearList       []int32 // Enemies retrieved by EnemyNear
+	p2EnemyList         []int32 // Enemies retrieved by P2, P4, P6 and P8
+	p2EnemyBackup       int32   // Backup of last valid P2 enemy
 	pos                 [3]float32
 	interPos            [3]float32 // Interpolated position. For the visuals when game and logic speed are different
 	oldPos              [3]float32
@@ -4873,7 +4873,7 @@ func (c *Char) p2() *Char {
 	// Cache last valid P2 enemy
 	// Mugen seems to do this for the sake of auto turning before win poses
 	if p != nil {
-		c.p2EnemyBackup = p
+		c.p2EnemyBackup = p.id
 	}
 	return p
 }
@@ -6077,7 +6077,7 @@ func (c *Char) updateFBFlip() {
 		// See shouldFaceP2()
 		e := c.p2()
 		if e == nil {
-			e = c.p2EnemyBackup
+			e = sys.playerID(c.p2EnemyBackup)
 		}
 		if e != nil {
 			distX := c.rdDistX(e, c).ToF() // Already in the char's localcoord
@@ -6101,7 +6101,7 @@ func (c *Char) shouldFaceP2() bool {
 	// If P2 was not found, fall back to the last valid one
 	// Maybe this should only happen during win poses?
 	if e == nil {
-		e = c.p2EnemyBackup
+		e = sys.playerID(c.p2EnemyBackup)
 	}
 
 	if e != nil && !e.asf(ASF_noturntarget) {
@@ -9388,6 +9388,7 @@ func (c *Char) dropTargets() {
 	}
 }
 
+// Remove a target from the char's own list
 func (c *Char) removeTarget(pid int32) {
 	for i, t := range c.targets {
 		if t == pid {
@@ -13260,74 +13261,68 @@ func (cl *CharList) enemyNear(c *Char, n int32, p2list, log bool) *Char {
 
 	// Clear every player's lists if something changed
 	if cl.enemyNearChanged {
-		for _, c := range cl.runOrder {
-			c.enemyNearP2Clear()
+		for _, char := range cl.runOrder {
+			char.enemyNearP2Clear()
 		}
 		cl.enemyNearChanged = false
 	}
 
 	// Select EnemyNear or P2 cache
-	var cache *[]*Char
+	var cache *[]int32
 	if p2list { // List for P2 redirects as well as P4, P6 and P8 triggers
 		cache = &c.p2EnemyList
 	} else {
 		cache = &c.enemyNearList
 	}
 
-	// If we already have the Nth enemy cached, then return it
+	// If we already have the Nth enemy cached, then return it via ID lookup
 	if int(n) < len(*cache) {
-		return (*cache)[n]
+		return sys.playerID((*cache)[n])
 	}
 
 	// Else reset the cache and start over
 	*cache = (*cache)[:0]
 
-	// Gather all valid enemies
-	var enemies []*Char
+	// Local struct for sorting
+	type enemyDist struct {
+		id   int32
+		dist float32
+	}
+	pairs := make([]enemyDist, 0, MaxPlayerNo) 
+
+	// Gather all valid enemies and calculate distances
 	for _, e := range cl.runOrder {
 		if e.isPlayerType() && c.isEnemyOf(e) {
+			valid := false
 			// P2 checks for alive enemies even if they are player type helpers
 			if p2list && !e.scf(SCF_standby) && !e.scf(SCF_over_ko) {
-				enemies = append(enemies, e)
+				valid = true
 			}
 			// EnemyNear checks for dead or alive root players
 			if !p2list && e.helperIndex == 0 {
-				enemies = append(enemies, e)
+				valid = true
+			}
+
+			if valid {
+				// Factor x distance first
+				distX := c.distX(e, c) * c.facing
+				dist := distX
+				// If an enemy is behind the player, an extra distance buffer is added for the "P2" list
+				if p2list && distX < 0 {
+					dist -= 30.0
+				}
+				// Factor z distance if applicable
+				if sys.zEnabled() {
+					distZ := c.distZ(e, c) * 4.0
+					if p2list {
+						distZ *= 4.0
+					}
+					dist = float32(math.Hypot(float64(distX), float64(distZ)))
+				}
+				// Append this enemy and their distance
+				pairs = append(pairs, enemyDist{id: e.id, dist: dist})
 			}
 		}
-	}
-
-	// Calculate distances between all valid enemies and the player
-	type enemyDist struct {
-		enemy *Char
-		dist  float32
-	}
-	pairs := make([]enemyDist, 0, len(enemies))
-
-	for _, e := range enemies {
-		// Factor x distance first
-		distX := c.distX(e, c) * c.facing
-		dist := distX
-		// If an enemy is behind the player, an extra distance buffer is added for the "P2" list
-		// This makes the player turn less frequently when surrounded
-		// Mugen uses a hardcoded value of 30 pixels. Maybe it could be a character constant instead in Ikemen
-		if p2list && distX < 0 {
-			dist -= 30.0
-		}
-		// Factor z distance if applicable
-		if sys.zEnabled() {
-			distZ := c.distZ(e, c) * 4.0
-			if p2list {
-				// We'll arbitrarily give more weight to the z axis, so that the player doesn't turn as easily to enemies on a different plane
-				// 4.0 is a magic number, roughly based on default x and z size ratio
-				// TODO: Calculate z weight like in distzadj in player pushing, or add a global var for x/z ratio
-				distZ *= 4.0
-			}
-			// Calculate the hypotenuse between both
-			dist = float32(math.Hypot(float64(distX), float64(distZ)))
-		}
-		// Append this enemy and their distance
-		pairs = append(pairs, enemyDist{enemy: e, dist: dist})
 	}
 
 	// Sort enemies by shortest absolute distance
@@ -13336,9 +13331,8 @@ func (cl *CharList) enemyNear(c *Char, n int32, p2list, log bool) *Char {
 	})
 
 	// Rebuild cache
-	*cache = PointerSliceReset(*cache) // Nil everything instead of using make
-	for _, pair := range pairs {
-		*cache = append(*cache, pair.enemy)
+	for _, p := range pairs {
+		*cache = append(*cache, p.id)
 	}
 
 	// If reference exceeds number of valid enemies
@@ -13350,7 +13344,7 @@ func (cl *CharList) enemyNear(c *Char, n int32, p2list, log bool) *Char {
 	}
 
 	// Return Nth enemy
-	return (*cache)[n]
+	return sys.playerID((*cache)[n])
 }
 
 type Platform struct {

--- a/src/common.go
+++ b/src/common.go
@@ -1602,9 +1602,13 @@ func SliceDelete[T any](slice []T, i int) []T {
 // Nils out all elements and returns a zero-length slice while preserving the underlying capacity
 // This is better than plain [:0] because we ensure data from previous characters is GC'd
 func PointerSliceReset[T any](slice []*T) []*T {
+	// Recover the whole capacity so we can deep clean it
+	slice = slice[:cap(slice)]
+	// Clear everything
 	for i := range slice {
 		slice[i] = nil
 	}
+	// Shrink back to zero length
 	return slice[:0]
 }
 

--- a/src/input.go
+++ b/src/input.go
@@ -2405,7 +2405,7 @@ func (nc *NetConnection) Update() bool {
 
 				// Break loop if we have reached the frame that both buffers have sent
 				if nc.time >= foo {
-					if sys.esc || !sys.await(sys.cfg.Video.Framerate) || nc.st != NS_Playing {
+					if sys.esc || !sys.await(sys.gameRenderSpeed()) || nc.st != NS_Playing {
 						break
 					}
 					continue

--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -501,9 +501,6 @@ func (r *Renderer_GL21) Init() {
 		sys.msaa = maxSamples
 	}
 
-	// Store current timestamp
-	sys.prevTimestamp = sdl.GetPerformanceCounter()
-
 	r.postShaderSelect = make([]*ShaderProgram_GL21, 1+len(sys.cfg.Video.ExternalShaders))
 
 	// Data buffers for rendering
@@ -709,7 +706,6 @@ func (r *Renderer_GL21) IsShadowEnabled() bool {
 }
 
 func (r *Renderer_GL21) BeginFrame(clearColor bool) {
-	sys.absTickCountF++
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo)
 	gl.Viewport(0, 0, sys.scrrect[2], sys.scrrect[3])
 	if clearColor {

--- a/src/render_gl_gl32.go
+++ b/src/render_gl_gl32.go
@@ -500,9 +500,6 @@ func (r *Renderer_GL32) Init() {
 		sys.msaa = maxSamples
 	}
 
-	// Store current timestamp
-	sys.prevTimestamp = sdl.GetPerformanceCounter()
-
 	r.postShaderSelect = make([]*ShaderProgram_GL32, 1+len(sys.cfg.Video.ExternalShaders))
 
 	// Data buffers for rendering
@@ -717,7 +714,6 @@ func (r *Renderer_GL32) IsShadowEnabled() bool {
 }
 
 func (r *Renderer_GL32) BeginFrame(clearColor bool) {
-	sys.absTickCountF++
 	gl.BindVertexArray(r.vao)
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo)
 	gl.Viewport(0, 0, sys.scrrect[2], sys.scrrect[3])

--- a/src/render_gl_gles32.go
+++ b/src/render_gl_gles32.go
@@ -601,9 +601,6 @@ func (r *Renderer_GLES32) Init() {
 	sys.msaa = 0
 	Logcat("GLES: Past MSAA check")
 
-	// Store current timestamp
-	sys.prevTimestamp = sdl.GetPerformanceCounter()
-
 	r.postShaderSelect = make([]*ShaderProgram_GLES32, 1+len(sys.cfg.Video.ExternalShaders))
 
 	// Data buffers for rendering
@@ -823,7 +820,6 @@ func (r *Renderer_GLES32) IsShadowEnabled() bool {
 }
 
 func (r *Renderer_GLES32) BeginFrame(clearColor bool) {
-	sys.absTickCountF++
 	gl.BindVertexArray(r.vao)
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo)
 	gl.Viewport(0, 0, sys.scrrect[2], sys.scrrect[3])

--- a/src/render_vk.go
+++ b/src/render_vk.go
@@ -4866,15 +4866,7 @@ func (r *Renderer_VK) DestroyResources(queueLength int) {
 }
 
 func (r *Renderer_VK) BeginFrame(clearColor bool) {
-	sys.absTickCountF++
-	now := sdl.GetPerformanceCounter()
-	firstFrame := sys.prevTimestamp == 0
-	diff := float32(now - sys.prevTimestamp)
-	if diff*float32(sdl.GetPerformanceFrequency()) >= 1 {
-		sys.gameFPS = float32(sdl.GetPerformanceFrequency()) / diff
-		sys.absTickCountF = 0
-		sys.prevTimestamp = now
-	}
+	firstFrame := sys.gameFPSprevcount == 0
 	if !firstFrame {
 		vk.WaitForFences(r.device, 1, r.fences[:1], vk.True, 10*1000*1000*1000)
 	}

--- a/src/script.go
+++ b/src/script.go
@@ -2217,7 +2217,10 @@ func systemScriptInit(l *lua.LState) {
 		sys.luaDiscardDrawQueue()
 		sys.gameRunning = true
 		sys.endMatch = false
-		// Anonymous function to load characters and stages, and/or wait for them to finish loading
+
+		// Synchronize timing to prevent speed fluctuations when changing FPS (entering matches)
+		sys.resetFrameTime()
+
 		load := func() error {
 			sys.loader.runTread()
 			for sys.loader.state != LS_Complete {
@@ -2226,7 +2229,7 @@ func systemScriptInit(l *lua.LState) {
 				} else if sys.loader.state == LS_Cancel {
 					return nil
 				}
-				sys.await(sys.cfg.Video.Framerate)
+				sys.await(sys.gameRenderSpeed())
 			}
 			runtime.GC()
 			return nil

--- a/src/script.go
+++ b/src/script.go
@@ -6637,7 +6637,7 @@ func triggerFunctions(l *lua.LState) {
 				l.Push(lua.LString(""))
 			}
 		} else {
-			if p := sys.charList.enemyNear(sys.debugWC, n/2-1, true, false); p != nil {
+			if p := sys.charList.enemyNear(sys.debugWC, n/2-1, true); p != nil {
 				l.Push(lua.LString(p.name))
 			} else {
 				l.Push(lua.LString(""))

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -300,7 +300,7 @@ func (c *Char) Clone(a *arena.Arena, gsp *GameStatePool) (result Char) {
 	// Pointers, slices, maps, functions, channels etc
 	result.ghv = *c.ghv.Clone(a)
 
-	result.children = arena.MakeSlice[*Char](a, len(c.children), len(c.children))
+	result.children = arena.MakeSlice[int32](a, len(c.children), len(c.children))
 	copy(result.children, c.children)
 
 	result.targets = arena.MakeSlice[int32](a, len(c.targets), len(c.targets))

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -312,10 +312,10 @@ func (c *Char) Clone(a *arena.Arena, gsp *GameStatePool) (result Char) {
 	result.hitdefTargetsBuffer = arena.MakeSlice[int32](a, len(c.hitdefTargetsBuffer), len(c.hitdefTargetsBuffer))
 	copy(result.hitdefTargetsBuffer, c.hitdefTargetsBuffer)
 
-	result.enemyNearList = arena.MakeSlice[*Char](a, len(c.enemyNearList), len(c.enemyNearList))
+	result.enemyNearList = arena.MakeSlice[int32](a, len(c.enemyNearList), len(c.enemyNearList))
 	copy(result.enemyNearList, c.enemyNearList)
 
-	result.p2EnemyList = arena.MakeSlice[*Char](a, len(c.p2EnemyList), len(c.p2EnemyList))
+	result.p2EnemyList = arena.MakeSlice[int32](a, len(c.p2EnemyList), len(c.p2EnemyList))
 	copy(result.p2EnemyList, c.p2EnemyList)
 
 	//if c.p2EnemyBackup != nil {
@@ -323,7 +323,8 @@ func (c *Char) Clone(a *arena.Arena, gsp *GameStatePool) (result Char) {
 	//	result.p2EnemyBackup = &tmp
 	//}
 	// This ought to be enough
-	result.p2EnemyBackup = c.p2EnemyBackup
+	//result.p2EnemyBackup = c.p2EnemyBackup
+	// Converted to an ID so the shallow copy now gets it
 
 	result.inputShift = arena.MakeSlice[[2]int](a, len(c.inputShift), len(c.inputShift))
 	copy(result.inputShift, c.inputShift)

--- a/src/system.go
+++ b/src/system.go
@@ -2174,9 +2174,8 @@ func (s *System) action() {
 			s.specialFlag = 0
 		} else {
 			// These flags persist even during pauses
-			// "Intro" seems to have been deliberately added. Does not persist in Mugen 1.1
 			// "NoKOSlow" added to facilitate custom slowdown. In Mugen that flag only needs to be asserted in first frame of KO slowdown
-			s.specialFlag = (s.specialFlag&GSF_intro | s.specialFlag&GSF_nokoslow | s.specialFlag&GSF_timerfreeze)
+			s.specialFlag = (s.specialFlag&GSF_nokoslow | s.specialFlag&GSF_timerfreeze)
 		}
 		s.charList.action()
 		s.nomusic = s.gsf(GSF_nomusic) && !sys.postMatchFlg

--- a/src/system.go
+++ b/src/system.go
@@ -1770,20 +1770,8 @@ func (s *System) clearPlayerAssets(pn int, forceDestroy bool) {
 		// Destroy helpers
 		for _, h := range s.chars[pn][1:] {
 			// F4 now destroys "preserve" helpers when reloading round start backup
-			//if forceDestroy || h.preserve == 0 || (s.roundResetFlg && h.preserve <= s.round) {
 			if !h.preserve || forceDestroy {
 				h.destroy()
-			}
-		}
-
-		// Clear children "family tree"
-		// We only do this because helpers may be preserved
-		for _, c := range s.chars[pn] {
-			// Iterate backwards since we're removing items
-			for i := len(c.children) - 1; i >= 0; i-- {
-				if c.children[i].helperIndex < 0 {
-					c.children = SliceDelete(c.children, i)
-				}
 			}
 		}
 	}

--- a/src/system.go
+++ b/src/system.go
@@ -307,9 +307,8 @@ type System struct {
 	roundBackup  RoundStartBackup
 
 	// for avg. FPS calculations
-	gameFPS       float32
-	prevTimestamp uint64
-	absTickCountF float32
+	gameFPS          float32
+	gameFPSprevcount uint64
 
 	// screenshot deferral
 	isTakingScreenshot bool
@@ -696,6 +695,7 @@ func (s *System) await(fps int) bool {
 		} else {
 			gfx.Await()
 		}
+		s.window.UpdateDebugFPS()
 		if s.isTakingScreenshot {
 			defer captureScreen()
 			s.isTakingScreenshot = false
@@ -2003,7 +2003,7 @@ func (s *System) addFrameTime(t float32) bool {
 }
 
 func (s *System) resetFrameTime() {
-	s.tickCount, s.oldTickCount, s.tickCountF, s.lastTick, s.absTickCountF = 0, -1, 0, 0, 0
+	s.tickCount, s.oldTickCount, s.tickCountF, s.lastTick = 0, -1, 0, 0
 	s.nextAddTime, s.oldNextAddTime = 1, 1
 
 	s.redrawWait.nextTime = time.Now()

--- a/src/system_sdl.go
+++ b/src/system_sdl.go
@@ -151,14 +151,6 @@ func (s *System) newWindow(w, h int) (*Window, error) {
 
 func (w *Window) SwapBuffers() {
 	w.Window.GLSwap()
-	// Retrieve GL timestamp now
-	now := sdl.GetPerformanceCounter()
-	diff := float32(now - sys.prevTimestamp)
-	if diff*float32(sdl.GetPerformanceFrequency()) >= 1 {
-		sys.gameFPS = float32(sdl.GetPerformanceFrequency()) / diff
-		sys.absTickCountF = 0
-		sys.prevTimestamp = now
-	}
 }
 
 func (w *Window) imageToSurface(img image.Image) (*sdl.Surface, error) {
@@ -351,6 +343,20 @@ func attachController(deviceIndex int) {
 	input.controllers[slot] = controller
 	resetControllerState(slot)
 	input.controllerstate[slot].HasRumble = controller.HasRumble()
+}
+
+func (w *Window) UpdateDebugFPS() {
+	now := sdl.GetPerformanceCounter()
+	freq := float32(sdl.GetPerformanceFrequency())
+	diff := float32(now - sys.gameFPSprevcount)
+
+	if diff > 0 {
+		instantFPS := freq / diff
+		// Use an EMA to apply smoothing
+		sys.gameFPS = (sys.gameFPS * 0.95) + (float32(instantFPS) * 0.05)
+	}
+
+	sys.gameFPSprevcount = now
 }
 
 func (w *Window) pollEvents() {


### PR DESCRIPTION
Refactor:
- Adjusted explods so that they're processed by age rather than player number. This makes drawing order fairer and closer to characters
- Refactored some char lists to use ID's instead of pointers. This increases consistency and makes that memory easier to manage
- If two chars somehow end up occupying the same ID, Ikemen will now crash instead of failing silently
- Adjusted Target and (especially) HelperIndex triggers to just get the player we want instead of building temporary player lists
- Added a fast path for hit detection when the char has no Clsn proxies, which is essentially always
- Patched framerate adjustment so that it is locked to 60 during menus and rollback
- AssertSpecial intro flag is no longer buffered during pauses, matching its Mugen behavior
- Centralized debug FPS tracking, added smoothing and switched to one decimal place for easier reading

Fixes:
- Fixes #1099
- Fixes #3230 