### PR TITLE
fix: palette crash, RemapPal; OpenGL refactoring

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -8755,10 +8755,33 @@ func (c *Char) remapPal(pfx *PalFX, src [2]int32, dst [2]int32) {
 		return
 	}
 
-	// Init palette remap if needed
+	// Get both palettes so we can compare them
+	srcPal := plist.Get(si)
+	dstPal := plist.Get(di)
+
+	// Ensure palettes exist
+	if srcPal == nil || dstPal == nil {
+		return
+	}
+
+	// Check the actual color depths
+	srcDepth := len(srcPal)
+	dstDepth := len(dstPal)
+
+	// Color depths must match
+	// TODO: Now that this actually works, we could make it optional via a new parameter
+	if srcDepth != dstDepth {
+		sys.appendToConsole(c.warn() + fmt.Sprintf(
+			" RemapPal color depth mismatch: %v,%v (%d colors) -> %v,%v (%d colors)", 
+			src[0], src[1], srcDepth, dst[0], dst[1], dstDepth))
+		return
+	}
+
+	// Init remaps if needed
 	if pfx.remap == nil {
 		pfx.remap = plist.GetPalMap()
 	}
+
 	// Perform palette remap
 	if plist.SwapPalMap(&pfx.remap) {
 		plist.Remap(si, di)
@@ -8785,18 +8808,34 @@ func (c *Char) forceRemapPal(pfx *PalFX, dst [2]int32) {
 		return
 	}
 
-	// Get new palette
-	di, ok := c.gi().palettedata.palList.PalTable[[...]uint16{uint16(dst[0]), uint16(dst[1])}]
+	plist := c.gi().palettedata.palList
+
+	// Look up the destination palette
+	di, ok := plist.PalTable[[...]uint16{uint16(dst[0]), uint16(dst[1])}]
 	if !ok || di < 0 {
 		return
 	}
 
-	// Clear previous remaps
-	pfx.remap = make([]int, len(c.gi().palettedata.palList.paletteMap))
+	// Get the depth of the destination palette
+	dstDepth := len(plist.palettes[di])
 
-	// Apply the new remap
+	// Initialize or clear the remap table
+	pfx.remap = make([]int, len(plist.paletteMap))
 	for i := range pfx.remap {
-		pfx.remap[i] = di
+		// TODO: Confirm if this should be reset or not touched at all
+		pfx.remap[i] = i
+	}
+
+	// Selective remap only if color depths match
+	// https://github.com/ikemen-engine/Ikemen-GO/issues/2408
+	for i := 0; i < len(pfx.remap); i++ {
+		// Get the palette at this index
+		if i < len(plist.palettes) && plist.palettes[i] != nil {
+			srcDepth := len(plist.palettes[i])
+			if srcDepth == dstDepth {
+				pfx.remap[i] = di
+			}
+		}
 	}
 }
 

--- a/src/char.go
+++ b/src/char.go
@@ -6753,14 +6753,6 @@ func (c *Char) commitExplod(i int) {
 		}
 	}
 
-	// Emulate legacy ontop behavior
-	// Move from the end of the slice to the beginning to invert drawing order
-	if e.ontop {
-		playerExplods := &sys.explods[c.playerNo]
-		copy((*playerExplods)[1:i+1], (*playerExplods)[0:i])
-		(*playerExplods)[0] = e
-	}
-
 	// Explod ready
 	e.anim.UpdateSprite()
 }

--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -418,13 +418,13 @@ type GL21State struct {
 	scissorRect         [4]int32
 	scissorEnabled      bool
 	lastSpriteTexture   [8]uint32
-	useUV               bool
 	useNormal           bool
 	useTangent          bool
 	useVertColor        bool
 	useJoint0           bool
 	useJoint1           bool
 	useOutlineAttribute bool
+	//useUV               bool // Safer not to cache this one because sprites also use it
 }
 
 func (r *Renderer_GL21) GetName() string {
@@ -442,7 +442,21 @@ func (r *Renderer_GL21) InitModelShader() error {
 	if err != nil {
 		return err
 	}
-	r.modelShader.RegisterAttributes("inVertexId", "position", "uv", "normalIn", "tangentIn", "vertColor", "joints_0", "joints_1", "weights_0", "weights_1", "outlineAttributeIn")
+
+	r.modelShader.RegisterAttributes(
+		"position", // Same position as spriteShader
+		"uv", // Same position as spriteShader
+		"inVertexId",
+		"normalIn",
+		"tangentIn",
+		"vertColor",
+		"joints_0",
+		"joints_1",
+		"weights_0",
+		"weights_1",
+		"outlineAttributeIn", // Not in shadowMapShader
+	)
+
 	r.modelShader.RegisterUniforms("model", "view", "projection", "normalMatrix", "unlit", "baseColorFactor", "add", "mult", "useTexture", "useNormalMap", "useMetallicRoughnessMap", "useEmissionMap", "neg", "gray", "hue",
 		"enableAlpha", "alphaThreshold", "numJoints", "morphTargetWeight", "morphTargetOffset", "morphTargetTextureDimension", "numTargets", "numVertices",
 		"metallicRoughness", "ambientOcclusionStrength", "emission", "environmentIntensity", "mipCount", "meshOutline",
@@ -461,7 +475,20 @@ func (r *Renderer_GL21) InitModelShader() error {
 		if err != nil {
 			return err
 		}
-		r.shadowMapShader.RegisterAttributes("inVertexId", "position", "vertColor", "uv", "joints_0", "joints_1", "weights_0", "weights_1")
+
+		r.shadowMapShader.RegisterAttributes(
+			"position", // Same position as spriteShader
+			"uv", // Same position as spriteShader
+			"inVertexId",
+			"normalIn",
+			"tangentIn",
+			"vertColor",
+			"joints_0",
+			"joints_1",
+			"weights_0",
+			"weights_1",
+		)
+
 		r.shadowMapShader.RegisterUniforms("model", "lightMatrices[0]", "lightMatrices[1]", "lightMatrices[2]", "lightMatrices[3]", "lightMatrices[4]", "lightMatrices[5]",
 			"lightMatrices[6]", "lightMatrices[7]", "lightMatrices[8]", "lightMatrices[9]", "lightMatrices[10]", "lightMatrices[11]",
 			"lightMatrices[12]", "lightMatrices[13]", "lightMatrices[14]", "lightMatrices[15]", "lightMatrices[16]", "lightMatrices[17]",
@@ -934,9 +961,11 @@ func (r *Renderer_GL21) SetPipeline(eq BlendEquation, src, dst BlendFunc) {
 
 	// Must bind buffer before enabling attributes
 	gl.BindBuffer(gl.ARRAY_BUFFER, r.vertexBuffer)
+
 	loc := r.spriteShader.a["position"]
 	gl.EnableVertexAttribArray(uint32(loc))
 	gl.VertexAttribPointerWithOffset(uint32(loc), 2, gl.FLOAT, false, 16, 0)
+
 	loc = r.spriteShader.a["uv"]
 	gl.EnableVertexAttribArray(uint32(loc))
 	gl.VertexAttribPointerWithOffset(uint32(loc), 2, gl.FLOAT, false, 16, 8)
@@ -987,18 +1016,17 @@ func (r *Renderer_GL21) setShadowMapPipeline(doubleSided, invertFrontFace, useUV
 	gl.EnableVertexAttribArray(uint32(loc))
 	gl.VertexAttribPointerWithOffset(uint32(loc), 3, gl.FLOAT, false, 0, uintptr(offset))
 	offset += 12 * numVertices
+
+	loc = r.shadowMapShader.a["uv"]
 	if useUV {
-		r.useUV = true
-		loc = r.shadowMapShader.a["uv"]
 		gl.EnableVertexAttribArray(uint32(loc))
 		gl.VertexAttribPointerWithOffset(uint32(loc), 2, gl.FLOAT, false, 0, uintptr(offset))
 		offset += 8 * numVertices
-	} else if r.useUV {
-		r.useUV = false
-		loc = r.shadowMapShader.a["uv"]
+	} else {
 		gl.DisableVertexAttribArray(uint32(loc))
 		gl.VertexAttrib2f(uint32(loc), 0, 0)
 	}
+
 	if useNormal {
 		offset += 12 * numVertices
 	}
@@ -1090,7 +1118,6 @@ func (r *Renderer_GL21) ReleaseShadowPipeline() {
 	gl.Disable(gl.DEPTH_TEST)
 	gl.Disable(gl.CULL_FACE)
 	gl.Disable(gl.BLEND)
-	r.useUV = false
 	r.useJoint0 = false
 	r.useJoint1 = false
 }
@@ -1193,18 +1220,17 @@ func (r *Renderer_GL21) SetModelPipeline(eq BlendEquation, src, dst BlendFunc, d
 	gl.EnableVertexAttribArray(uint32(loc))
 	gl.VertexAttribPointerWithOffset(uint32(loc), 3, gl.FLOAT, false, 0, uintptr(offset))
 	offset += 12 * numVertices
+
+	loc = r.modelShader.a["uv"]
 	if useUV {
-		r.useUV = true
-		loc = r.modelShader.a["uv"]
 		gl.EnableVertexAttribArray(uint32(loc))
 		gl.VertexAttribPointerWithOffset(uint32(loc), 2, gl.FLOAT, false, 0, uintptr(offset))
 		offset += 8 * numVertices
-	} else if r.useUV {
-		r.useUV = false
-		loc = r.modelShader.a["uv"]
+	} else {
 		gl.DisableVertexAttribArray(uint32(loc))
 		gl.VertexAttrib2f(uint32(loc), 0, 0)
 	}
+
 	if useNormal {
 		r.useNormal = true
 		loc = r.modelShader.a["normalIn"]
@@ -1342,7 +1368,6 @@ func (r *Renderer_GL21) ReleaseModelPipeline() {
 	gl.DepthMask(true)
 	gl.Disable(gl.DEPTH_TEST)
 	gl.Disable(gl.CULL_FACE)
-	r.useUV = false
 	r.useNormal = false
 	r.useTangent = false
 	r.useVertColor = false

--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -417,6 +417,7 @@ type GL21State struct {
 	blendDst            BlendFunc
 	scissorRect         [4]int32
 	scissorEnabled      bool
+	lastSpriteTexture   [8]uint32
 	useUV               bool
 	useNormal           bool
 	useTangent          bool
@@ -895,6 +896,11 @@ func (r *Renderer_GL21) UseProgram(program uint32) {
 	if r.program != program {
 		gl.UseProgram(program)
 		r.program = program
+
+		// Clear cache between shaders
+		for i := range r.lastSpriteTexture {
+			r.lastSpriteTexture[i] = 0
+		}
 	}
 }
 
@@ -1427,7 +1433,13 @@ func (r *Renderer_GL21) SetUniformMatrix(name string, value []float32) {
 func (r *Renderer_GL21) SetTexture(name string, tex Texture) {
 	t := tex.(*Texture_GL21)
 	loc, unit := r.spriteShader.u[name], r.spriteShader.t[name]
-	gl.ActiveTexture((uint32(gl.TEXTURE0 + unit)))
+
+	if r.lastSpriteTexture[unit] == t.handle {
+		return
+	}
+
+	r.lastSpriteTexture[unit] = t.handle
+	gl.ActiveTexture(uint32(gl.TEXTURE0 + unit))
 	gl.BindTexture(gl.TEXTURE_2D, t.handle)
 	gl.Uniform1i(loc, int32(unit))
 }

--- a/src/render_gl.go
+++ b/src/render_gl.go
@@ -415,6 +415,8 @@ type GL21State struct {
 	blendEquation       BlendEquation
 	blendSrc            BlendFunc
 	blendDst            BlendFunc
+	scissorRect         [4]int32
+	scissorEnabled      bool
 	useUV               bool
 	useNormal           bool
 	useTangent          bool
@@ -1360,12 +1362,30 @@ func (r *Renderer_GL21) ReadPixels(data []uint8, width, height int) {
 }
 
 func (r *Renderer_GL21) EnableScissor(x, y, width, height int32) {
-	gl.Enable(gl.SCISSOR_TEST)
-	gl.Scissor(x, sys.scrrect[3]-(y+height), width, height)
+	// Flip Y to OpenGL convention
+	realY := sys.scrrect[3] - (y + height)
+
+	if r.scissorEnabled &&
+		r.scissorRect[0] == x && r.scissorRect[1] == realY &&
+		r.scissorRect[2] == width && r.scissorRect[3] == height {
+		return
+	}
+
+	if !r.scissorEnabled {
+		gl.Enable(gl.SCISSOR_TEST)
+		r.scissorEnabled = true
+	}
+
+	gl.Scissor(x, realY, width, height)
+	r.scissorRect = [4]int32{x, realY, width, height}
 }
 
 func (r *Renderer_GL21) DisableScissor() {
-	gl.Disable(gl.SCISSOR_TEST)
+	if r.scissorEnabled {
+		gl.Disable(gl.SCISSOR_TEST)
+		r.scissorEnabled = false
+		r.scissorRect = [4]int32{0, 0, 0, 0}
+	}
 }
 
 func (r *Renderer_GL21) SetUniformI(name string, val int) {

--- a/src/render_gl_gl32.go
+++ b/src/render_gl_gl32.go
@@ -419,13 +419,13 @@ type GL32State struct {
 	scissorRect         [4]int32
 	scissorEnabled      bool
 	lastSpriteTexture   [8]uint32
-	useUV               bool
 	useNormal           bool
 	useTangent          bool
 	useVertColor        bool
 	useJoint0           bool
 	useJoint1           bool
 	useOutlineAttribute bool
+	//useUV               bool // Safer not to cache this one because sprites also use it
 }
 
 func (r *Renderer_GL32) GetName() string {
@@ -443,7 +443,21 @@ func (r *Renderer_GL32) InitModelShader() error {
 	if err != nil {
 		return err
 	}
-	r.modelShader.RegisterAttributes("inVertexId", "position", "uv", "normalIn", "tangentIn", "vertColor", "joints_0", "joints_1", "weights_0", "weights_1", "outlineAttributeIn")
+
+	r.modelShader.RegisterAttributes(
+		"position", // Same position as spriteShader
+		"uv", // Same position as spriteShader
+		"inVertexId",
+		"normalIn",
+		"tangentIn",
+		"vertColor",
+		"joints_0",
+		"joints_1",
+		"weights_0",
+		"weights_1",
+		"outlineAttributeIn", // Not in shadowMapShader
+	)
+
 	r.modelShader.RegisterUniforms("model", "view", "projection", "normalMatrix", "unlit", "baseColorFactor", "add", "mult", "useTexture", "useNormalMap", "useMetallicRoughnessMap", "useEmissionMap", "neg", "gray", "hue",
 		"enableAlpha", "alphaThreshold", "numJoints", "morphTargetWeight", "morphTargetOffset", "morphTargetTextureDimension", "numTargets", "numVertices",
 		"metallicRoughness", "ambientOcclusionStrength", "emission", "environmentIntensity", "mipCount", "meshOutline",
@@ -462,7 +476,20 @@ func (r *Renderer_GL32) InitModelShader() error {
 		if err != nil {
 			return err
 		}
-		r.shadowMapShader.RegisterAttributes("inVertexId", "position", "vertColor", "uv", "joints_0", "joints_1", "weights_0", "weights_1")
+
+		r.shadowMapShader.RegisterAttributes(
+			"position", // Same position as spriteShader
+			"uv", // Same position as spriteShader
+			"inVertexId",
+			"normalIn",
+			"tangentIn",
+			"vertColor",
+			"joints_0",
+			"joints_1",
+			"weights_0",
+			"weights_1",
+		)
+
 		r.shadowMapShader.RegisterUniforms("model", "lightMatrices[0]", "lightMatrices[1]", "lightMatrices[2]", "lightMatrices[3]", "lightMatrices[4]", "lightMatrices[5]",
 			"lightMatrices[6]", "lightMatrices[7]", "lightMatrices[8]", "lightMatrices[9]", "lightMatrices[10]", "lightMatrices[11]",
 			"lightMatrices[12]", "lightMatrices[13]", "lightMatrices[14]", "lightMatrices[15]", "lightMatrices[16]", "lightMatrices[17]",
@@ -949,9 +976,11 @@ func (r *Renderer_GL32) SetPipeline(eq BlendEquation, src, dst BlendFunc) {
 
 	// Must bind buffer before enabling attributes
 	gl.BindBuffer(gl.ARRAY_BUFFER, r.vertexBuffer)
+
 	loc := r.spriteShader.a["position"]
 	gl.EnableVertexAttribArray(uint32(loc))
 	gl.VertexAttribPointerWithOffset(uint32(loc), 2, gl.FLOAT, false, 16, 0)
+
 	loc = r.spriteShader.a["uv"]
 	gl.EnableVertexAttribArray(uint32(loc))
 	gl.VertexAttribPointerWithOffset(uint32(loc), 2, gl.FLOAT, false, 16, 8)
@@ -1005,18 +1034,17 @@ func (r *Renderer_GL32) setShadowMapPipeline(doubleSided, invertFrontFace, useUV
 	gl.EnableVertexAttribArray(uint32(loc))
 	gl.VertexAttribPointerWithOffset(uint32(loc), 3, gl.FLOAT, false, 0, uintptr(offset))
 	offset += 12 * numVertices
+
+	loc = r.shadowMapShader.a["uv"]
 	if useUV {
-		r.useUV = true
-		loc = r.shadowMapShader.a["uv"]
 		gl.EnableVertexAttribArray(uint32(loc))
 		gl.VertexAttribPointerWithOffset(uint32(loc), 2, gl.FLOAT, false, 0, uintptr(offset))
 		offset += 8 * numVertices
-	} else if r.useUV {
-		r.useUV = false
-		loc = r.shadowMapShader.a["uv"]
+	} else {
 		gl.DisableVertexAttribArray(uint32(loc))
 		gl.VertexAttrib2f(uint32(loc), 0, 0)
 	}
+
 	if useNormal {
 		offset += 12 * numVertices
 	}
@@ -1108,7 +1136,6 @@ func (r *Renderer_GL32) ReleaseShadowPipeline() {
 	gl.Disable(gl.DEPTH_TEST)
 	gl.Disable(gl.CULL_FACE)
 	gl.Disable(gl.BLEND)
-	r.useUV = false
 	r.useJoint0 = false
 	r.useJoint1 = false
 }
@@ -1209,18 +1236,17 @@ func (r *Renderer_GL32) SetModelPipeline(eq BlendEquation, src, dst BlendFunc, d
 	gl.EnableVertexAttribArray(uint32(loc))
 	gl.VertexAttribPointerWithOffset(uint32(loc), 3, gl.FLOAT, false, 0, uintptr(offset))
 	offset += 12 * numVertices
+
+	loc = r.modelShader.a["uv"]
 	if useUV {
-		r.useUV = true
-		loc = r.modelShader.a["uv"]
 		gl.EnableVertexAttribArray(uint32(loc))
 		gl.VertexAttribPointerWithOffset(uint32(loc), 2, gl.FLOAT, false, 0, uintptr(offset))
 		offset += 8 * numVertices
-	} else if r.useUV {
-		r.useUV = false
-		loc = r.modelShader.a["uv"]
+	} else {
 		gl.DisableVertexAttribArray(uint32(loc))
 		gl.VertexAttrib2f(uint32(loc), 0, 0)
 	}
+
 	if useNormal {
 		r.useNormal = true
 		loc = r.modelShader.a["normalIn"]
@@ -1361,7 +1387,6 @@ func (r *Renderer_GL32) ReleaseModelPipeline() {
 	gl.DepthMask(true)
 	gl.Disable(gl.DEPTH_TEST)
 	gl.Disable(gl.CULL_FACE)
-	r.useUV = false
 	r.useNormal = false
 	r.useTangent = false
 	r.useVertColor = false

--- a/src/render_gl_gl32.go
+++ b/src/render_gl_gl32.go
@@ -416,6 +416,9 @@ type GL32State struct {
 	blendEquation       BlendEquation
 	blendSrc            BlendFunc
 	blendDst            BlendFunc
+	scissorRect         [4]int32
+	scissorEnabled      bool
+	lastTexUnits        [8]uint32
 	useUV               bool
 	useNormal           bool
 	useTangent          bool
@@ -1370,12 +1373,30 @@ func (r *Renderer_GL32) ReadPixels(data []uint8, width, height int) {
 }
 
 func (r *Renderer_GL32) EnableScissor(x, y, width, height int32) {
-	gl.Enable(gl.SCISSOR_TEST)
-	gl.Scissor(x, sys.scrrect[3]-(y+height), width, height)
+	// Flip Y to OpenGL convention
+	realY := sys.scrrect[3] - (y + height)
+
+	if r.scissorEnabled &&
+		r.scissorRect[0] == x && r.scissorRect[1] == realY &&
+		r.scissorRect[2] == width && r.scissorRect[3] == height {
+		return
+	}
+
+	if !r.scissorEnabled {
+		gl.Enable(gl.SCISSOR_TEST)
+		r.scissorEnabled = true
+	}
+
+	gl.Scissor(x, realY, width, height)
+	r.scissorRect = [4]int32{x, realY, width, height}
 }
 
 func (r *Renderer_GL32) DisableScissor() {
-	gl.Disable(gl.SCISSOR_TEST)
+	if r.scissorEnabled {
+		gl.Disable(gl.SCISSOR_TEST)
+		r.scissorEnabled = false
+		r.scissorRect = [4]int32{0, 0, 0, 0}
+	}
 }
 
 func (r *Renderer_GL32) SetUniformI(name string, val int) {

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -381,6 +381,9 @@ func (c *Char) Clone(a *arena.Arena, gsp *GameStatePool) (result Char) {
 func (cl *CharList) Clone(a *arena.Arena, gsp *GameStatePool) (result CharList) {
 	result = *cl
 
+	result.creationOrder = arena.MakeSlice[*Char](a, len(cl.creationOrder), len(cl.creationOrder))
+	copy(result.creationOrder, cl.creationOrder)
+
 	result.runOrder = arena.MakeSlice[*Char](a, len(cl.runOrder), len(cl.runOrder))
 	copy(result.runOrder, cl.runOrder)
 

--- a/src/system.go
+++ b/src/system.go
@@ -2363,10 +2363,27 @@ func (s *System) explodUpdate() {
 		s.explodRunOrder = append(s.explodRunOrder, s.explods[i]...)
 	}
 
-	// Sort by age
-	// Older explods run first
-	sort.Slice(s.explodRunOrder, func(i, j int) bool {
-		return s.explodRunOrder[i].timestamp < s.explodRunOrder[j].timestamp
+	// Sort explods by age
+	// For the sake of backward compatibility we must also open exceptions for the ontop parameter
+	sort.SliceStable(s.explodRunOrder, func(i, j int) bool {
+		a, b := s.explodRunOrder[i], s.explodRunOrder[j]
+		// All ontop explods come before the rest
+		if a.ontop != b.ontop {
+			return a.ontop 
+		}
+		// If both are ontop the normal logic is inverted (old index shift trick)
+		if a.ontop && b.ontop {
+			if a.timestamp != b.timestamp {
+				return a.timestamp > b.timestamp
+			}
+			return true 
+		}
+		// Normal case: older timestamps come first
+		if a.timestamp != b.timestamp {
+			return a.timestamp < b.timestamp
+		}
+		// Same timestamp: do nothing
+		return false
 	})
 
 	// Update logic


### PR DESCRIPTION
Fixes:
- Fixed regression in OpenGL 2.1 TTF performance
- Fixed GPU receiving palettes with less than 256 colors
- RemapPal no longer works if source and destination palettes have different color depths
- Added a missing char slice to save states
- Integrated Explod "ontop" logic into the new draw order sorting code
- Fixes #2408 (correctly this time)
- Fixes #3253 

Refactor:
- OpenGL now tracks scissor state. So we do something with the existing helper functions
- Adjusted generic render calls to need a lot less texture binds, reducing driver overhead
- When drawing the same sprites or palettes repeatedly, OpenGL will now just skip binding the textures. This makes drawing particle effects and such duplicate objects more efficient
- Aligned sprite and model attributes a little closer. Models no longer cache the "uv" state as that parameter is shared with sprites and caching it has no measurable benefits