### PR TITLE
refactor: use SearchFile for palette loading in select screen

### DIFF
--- a/src/image.go
+++ b/src/image.go
@@ -1637,9 +1637,7 @@ func loadCharPalettes(sff *Sff, filename string, ref int) error {
 	// TODO: External .ACTs on SFFv2 without palette slots may cause color bleeding,
 	// on sprites with unique palettes if a SFFv2 with Acts is loaded by sffNew, since is a simplified utility
 	// and lacks the engine's palInfo/cgi logic to properly isolate palette remapping during rendering.
-	normalizedDef := strings.ReplaceAll(c.def, "\\", "/")
-	parts := strings.SplitAfterN(normalizedDef, "/", -1)
-	pathname := strings.Join(parts[:len(parts)-1], "")
+	searchDirs := []string{c.def}
 
 	// Read ACT palettes
 	for x := 0; x < len(c.pal_files) && x < len(c.pal); x++ {
@@ -1654,11 +1652,10 @@ func loadCharPalettes(sff *Sff, filename string, ref int) error {
 			continue
 		}
 
-		normalizedPalPath := strings.ReplaceAll(c.pal_files[x], "\\", "/")
-
-		pal, err := readActPalette(pathname + normalizedPalPath)
+		palPath := SearchFile(c.pal_files[x], searchDirs)
+		pal, err := readActPalette(palPath)
 		if err != nil {
-			fmt.Println("Error reading " + c.pal_files[x])
+			fmt.Println("Error reading " + palPath)
 			continue
 		}
 


### PR DESCRIPTION
- Use ``SearchFiles`` in the ``loadCharPalettes`` function instead of manually converting to unix-style paths, for better consistency.