### PR TITLE
feat: AssertSpecial nodestroyself; PlayerPush affectteam

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -9754,6 +9754,7 @@ type playerPush StateControllerBase
 const (
 	playerPush_value byte = iota
 	playerPush_priority
+	playerPush_affectteam
 	playerPush_redirectid
 )
 
@@ -9773,6 +9774,8 @@ func (sc playerPush) Run(c *Char, _ []int32) bool {
 			}
 		case playerPush_priority:
 			crun.pushPriority = exp[0].evalI(c)
+		case playerPush_affectteam:
+			crun.pushAffectTeam = exp[0].evalI(c)
 		}
 		return true
 	})

--- a/src/char.go
+++ b/src/char.go
@@ -111,7 +111,6 @@ const (
 	ASF_runfirst
 	ASF_runlast
 	ASF_sizepushonly
-	ASF_teampush
 	ASF_nodestroyself
 )
 
@@ -3193,6 +3192,7 @@ type Char struct {
 	reflectfLength       float32
 	ownclsnscale         bool
 	pushPriority         int32
+	pushAffectTeam       int32
 	prevfallflag         bool
 	makeDustSpacing      int
 	hitStateChangeIdx    int32
@@ -3266,7 +3266,7 @@ func (c *Char) init(n int, idx int) {
 	if n >= 0 && n < len(sys.aiLevel) && sys.aiLevel[n] != 0 {
 		c.controller ^= -1
 	}
-
+	c.pushAffectTeam = 1
 	c.clearState()
 }
 
@@ -11095,6 +11095,7 @@ func (c *Char) actionPrepare() {
 			}
 			// Reset player pushing priority
 			c.pushPriority = 0
+			c.pushAffectTeam = 1
 			// HitBy timers
 			// In Mugen this seems to happen at the end of each frame instead
 			for i := range c.hitby {
@@ -13037,8 +13038,17 @@ func (cl *CharList) pushDetection(getter *Char) {
 
 	for _, c := range cl.runOrder {
 		// Stop current iteration if char won't push
-		if !c.csf(CSF_playerpush) || (c.teamside == getter.teamside && !getter.asf(ASF_teampush) && !c.asf(ASF_teampush)) ||
-			c.scf(SCF_standby) || c.scf(SCF_disabled) {
+		interact := false
+		if c.teamside == getter.teamside {
+			if c.pushAffectTeam <= 0 {
+				interact = true
+			}
+		} else {
+			if c.pushAffectTeam >= 0 && getter.pushAffectTeam >= 0 {
+				interact = true
+			}
+		}
+		if !c.csf(CSF_playerpush) || !interact || c.scf(SCF_standby) || c.scf(SCF_disabled) {
 			continue
 		}
 

--- a/src/char.go
+++ b/src/char.go
@@ -111,6 +111,8 @@ const (
 	ASF_runfirst
 	ASF_runlast
 	ASF_sizepushonly
+	ASF_teampush
+	ASF_nodestroyself
 )
 
 type GlobalSpecialFlag uint32
@@ -6398,7 +6400,7 @@ func (c *Char) destroy() {
 // Mugen clears the helper ID here, before fully removing the helper (c.helperID = 0)
 // We don't so that all helper triggers behave the same
 func (c *Char) destroySelf(recursive, removeexplods, removetexts bool) bool {
-	if c.helperIndex <= 0 {
+	if c.helperIndex <= 0 || c.asf(ASF_nodestroyself) {
 		return false
 	}
 
@@ -13035,7 +13037,8 @@ func (cl *CharList) pushDetection(getter *Char) {
 
 	for _, c := range cl.runOrder {
 		// Stop current iteration if char won't push
-		if !c.csf(CSF_playerpush) || c.teamside == getter.teamside || c.scf(SCF_standby) || c.scf(SCF_disabled) {
+		if !c.csf(CSF_playerpush) || (c.teamside == getter.teamside && !getter.asf(ASF_teampush) && !c.asf(ASF_teampush)) ||
+			c.scf(SCF_standby) || c.scf(SCF_disabled) {
 			continue
 		}
 

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -4721,8 +4721,6 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_runlast))
 		case "sizepushonly":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_sizepushonly))
-		case "teampush":
-			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_teampush))
 		case "nodestroyself":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nodestroyself))
 		// Ikemen global flags

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -4721,6 +4721,10 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_runlast))
 		case "sizepushonly":
 			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_sizepushonly))
+		case "teampush":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_teampush))
+		case "nodestroyself":
+			out.appendI64Op(OC_ex_isassertedchar, int64(ASF_nodestroyself))
 		// Ikemen global flags
 		case "camerafreeze":
 			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_camerafreeze))

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -277,8 +277,6 @@ func (c *Compiler) assertSpecial(is IniSection, sc *StateControllerBase, _ int8)
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_runlast)))
 			case "sizepushonly":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_sizepushonly)))
-			case "teampush":
-				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_teampush)))
 			case "nodestroyself":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nodestroyself)))
 			// Ikemen global flags
@@ -3508,6 +3506,27 @@ func (c *Compiler) playerPush(is IniSection, sc *StateControllerBase, _ int8) (S
 		if err := c.stateParam(is, "priority", false, func(data string) error {
 			any = true
 			return c.scAdd(sc, playerPush_priority, data, VT_Int, 1)
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "affectteam", false, func(data string) error {
+			any = true
+			if len(data) == 0 {
+				return Error("affectteam not specified")
+			}
+			var at int32
+			switch strings.ToUpper(data)[0] {
+			case 'E':
+				at = 1
+			case 'F':
+				at = -1
+			case 'B':
+				at = 0
+			default:
+				return Error("Invalid affectteam: " + data)
+			}
+			sc.add(playerPush_affectteam, sc.iToExp(at))
+			return nil
 		}); err != nil {
 			return err
 		}

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -277,6 +277,10 @@ func (c *Compiler) assertSpecial(is IniSection, sc *StateControllerBase, _ int8)
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_runlast)))
 			case "sizepushonly":
 				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_sizepushonly)))
+			case "teampush":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_teampush)))
+			case "nodestroyself":
+				sc.add(assertSpecial_flag, sc.i64ToExp(int64(ASF_nodestroyself)))
 			// Ikemen global flags
 			case "camerafreeze":
 				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_camerafreeze)))

--- a/src/script.go
+++ b/src/script.go
@@ -8095,8 +8095,6 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_runlast)))
 		case "sizepushonly":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_sizepushonly)))
-		case "teampush":
-			l.Push(lua.LBool(sys.debugWC.asf(ASF_teampush)))
 		case "nodestroyself":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_nodestroyself)))
 		// GlobalSpecialFlag (Mugen)

--- a/src/script.go
+++ b/src/script.go
@@ -8095,6 +8095,10 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_runlast)))
 		case "sizepushonly":
 			l.Push(lua.LBool(sys.debugWC.asf(ASF_sizepushonly)))
+		case "teampush":
+			l.Push(lua.LBool(sys.debugWC.asf(ASF_teampush)))
+		case "nodestroyself":
+			l.Push(lua.LBool(sys.debugWC.asf(ASF_nodestroyself)))
 		// GlobalSpecialFlag (Mugen)
 		case "globalnoko":
 			l.Push(lua.LBool(sys.gsf(GSF_globalnoko)))

--- a/src/system.go
+++ b/src/system.go
@@ -5103,7 +5103,6 @@ func (s *System) restoreCharVars(c *Char) {
 
 	for k, v := range bk.cnsvar {
 		c.cnsvar[k] = v
-		println(k, v)
 	}
 	for k, v := range bk.cnsfvar {
 		c.cnsfvar[k] = v


### PR DESCRIPTION
Added a new flag to AssertSpecial and PlayerPush

AssertSpecial 
- nodestroyself
Disables destroyself while this flag is active.

PlayerPush
- AffectTeam
F ; Allows only allies to be pushed out (enemies will pass through)
B ; Pushes both allies and enemies
E ; Pushes only enemies (default)