### PR TITLE
feat: ai.win/ai.lose lifebar params, pn.cursor.preview; refactors

### DIFF
--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -2424,8 +2424,14 @@ function start.f_selectScreen()
 					end
 					local cursorState = 'active'
 					if v.selectState > 0 and motif.select_info.paletteselect > 0 then
+					local cursorData = motif.select_info['p' .. side].cursor
+						if cursorData.preview and cursorData.preview.default and 
+						(cursorData.preview.default.anim ~= -1 or cursorData.preview.default.spr[1] ~= -1) then
 						--cursorState when palmenu is active
-						cursorState = 'done'
+							cursorState = 'preview'
+						else
+							cursorState = 'done'
+						end
 					end
 					if v.selectState < 4 and start.f_selGrid(start.c[v.player].cell + 1).hidden ~= 1 and not start.c[v.player].blink then
 						start.f_drawCursor(v.player, start.c[v.player].selX, start.c[v.player].selY, cursorState, false)

--- a/src/motif.go
+++ b/src/motif.go
@@ -372,7 +372,7 @@ type TimerProperties struct {
 	Displaytime    int32 `ini:"displaytime"`
 }
 
-type PlayerCursorDoneProperties struct {
+type PlayerCursorStateProperties struct {
 	AnimationProperties
 	Snd [2]int32 `ini:"snd" default:"-1,0"`
 }
@@ -380,7 +380,8 @@ type PlayerCursorDoneProperties struct {
 type PlayerCursorProperties struct {
 	StartCell [2]int32                               `ini:"startcell"`
 	Active    map[string]*AnimationProperties        `ini:"active"`
-	Done      map[string]*PlayerCursorDoneProperties `ini:"done"`
+	Done      map[string]*PlayerCursorStateProperties `ini:"done"`
+	Preview   map[string]*PlayerCursorStateProperties `ini:"preview"`
 	Move      struct {
 		Snd [2]int32 `ini:"snd" default:"-1,0"`
 	} `ini:"move"`

--- a/src/resources/defaultMotif.ini
+++ b/src/resources/defaultMotif.ini
@@ -760,6 +760,37 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	;p1.cursor.done.<col>-<row>.window = 
 	;p1.cursor.done.<col>-<row>.localcoord = 320, 240
 
+    ; Variant used when the palmenu is active, if not defined, it uses the 'done' variant.
+	p1.cursor.preview.anim = -1
+	p1.cursor.preview.spr = -1, 0
+	p1.cursor.preview.offset = 0, 0
+	p1.cursor.preview.facing = 1
+	p1.cursor.preview.scale = 1.0, 1.0
+	p1.cursor.preview.xshear = 0
+	p1.cursor.preview.angle = 0
+	p1.cursor.preview.xangle = 0
+	p1.cursor.preview.yangle = 0
+	p1.cursor.preview.projection = orthographic
+	p1.cursor.preview.focallength = 2048
+	p1.cursor.preview.layerno = 0
+	p1.cursor.preview.window = 
+	p1.cursor.preview.localcoord = 320, 240
+
+	;p1.cursor.preview.<col>-<row>.anim = -1
+	;p1.cursor.preview.<col>-<row>.spr = -1, 0
+	;p1.cursor.preview.<col>-<row>.offset = 0, 0
+	;p1.cursor.preview.<col>-<row>.facing = 1
+	;p1.cursor.preview.<col>-<row>.scale = 1.0, 1.0
+	;p1.cursor.preview.<col>-<row>.xshear = 0
+	;p1.cursor.preview.<col>-<row>.angle = 0
+	;p1.cursor.preview.<col>-<row>.xangle = 0
+	;p1.cursor.preview.<col>-<row>.yangle = 0
+	;p1.cursor.preview.<col>-<row>.projection = orthographic
+	;p1.cursor.preview.<col>-<row>.focallength = 2048
+	;p1.cursor.preview.<col>-<row>.layerno = 0
+	;p1.cursor.preview.<col>-<row>.window = 
+	;p1.cursor.preview.<col>-<row>.localcoord = 320, 240
+
 	p1.cursor.move.snd = 100, 0
 	p1.cursor.done.snd = 100, 1
 	p1.random.move.snd = 100, 0
@@ -1380,6 +1411,36 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	;p2.cursor.done.<col>-<row>.layerno = 0
 	;p2.cursor.done.<col>-<row>.window = 
 	;p2.cursor.done.<col>-<row>.localcoord = 320, 240
+
+	p2.cursor.preview.anim = -1
+	p2.cursor.preview.spr = -1, 0
+	p2.cursor.preview.offset = 0, 0
+	p2.cursor.preview.facing = 1
+	p2.cursor.preview.scale = 1.0, 1.0
+	p2.cursor.preview.xshear = 0
+	p2.cursor.preview.angle = 0
+	p2.cursor.preview.xangle = 0
+	p2.cursor.preview.yangle = 0
+	p2.cursor.preview.projection = orthographic
+	p2.cursor.preview.focallength = 2048
+	p2.cursor.preview.layerno = 0
+	p2.cursor.preview.window = 
+	p2.cursor.preview.localcoord = 320, 240
+
+	;p2.cursor.preview.<col>-<row>.anim = -1
+	;p2.cursor.preview.<col>-<row>.spr = -1, 0
+	;p2.cursor.preview.<col>-<row>.offset = 0, 0
+	;p2.cursor.preview.<col>-<row>.facing = 1
+	;p2.cursor.preview.<col>-<row>.scale = 1.0, 1.0
+	;p2.cursor.preview.<col>-<row>.xshear = 0
+	;p2.cursor.preview.<col>-<row>.angle = 0
+	;p2.cursor.preview.<col>-<row>.xangle = 0
+	;p2.cursor.preview.<col>-<row>.yangle = 0
+	;p2.cursor.preview.<col>-<row>.projection = orthographic
+	;p2.cursor.preview.<col>-<row>.focallength = 2048
+	;p2.cursor.preview.<col>-<row>.layerno = 0
+	;p2.cursor.preview.<col>-<row>.window = 
+	;p2.cursor.preview.<col>-<row>.localcoord = 320, 240
 
 	p2.cursor.move.snd = 100, 0
 	p2.cursor.done.snd = 100, 1


### PR DESCRIPTION
Feat:
- Added ``ai.win`` and ``ai.lose`` params for the lifebar, used only in matches against AI. Example:
```ini
; AI Loses vs Player
ai.lose.time = 60
ai.lose.offset = 160, 70
ai.lose.font = 4,0
ai.lose.scale = 0.8, 0.8
ai.lose.text = "You Win!"

; ai.win2, ai.win3, ai.win4, ai.lose2, ai.lose3, and ai.lose4 and per player variants are also valid.
```
- ``pn.cursor.preview`` variant used when the palmenu is active, if not defined, it uses the 'done' variant.

Refactor:
- Refactored redundant announcement variables into a unified struct array.
- Replaced redundant manual checks for P1/P2/Win/Lose with a dynamic loop over a keys struct.
- Centralized announcement logic in ``handleRoundOutro`` and lifebarRound ``draw``.
- Centralized the lifebarRound ``reset`` logic using helpers to ensure consistent state clearing across all announcement types.