### PR TITLE
fix: option menu F/B keys, %d syntax not working for lifebar win params

### DIFF
--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -102,7 +102,7 @@ options.t_itemname = {
 	end,
 	--Port Change
 	['portchange'] = function(t, item, cursorPosY, moveTxt)
-		if getInput(-1, motif.option_info.menu.add.key, motif.option_info.menu.subtract.key, motif.option_info.menu.done.key) then
+		if getInput(-1, motif.option_info.menu.done.key) then
 			sndPlay(motif.Snd, motif.option_info.cursor.move.snd[1], motif.option_info.cursor.move.snd[2])
 			local port = main.f_drawInput(
 				motif.option_info.textinput.TextSpriteData,
@@ -124,7 +124,7 @@ options.t_itemname = {
 	end,
 	--Default Values
 	['default'] = function(t, item, cursorPosY, moveTxt)
-		if getInput(-1, motif.option_info.menu.add.key, motif.option_info.menu.subtract.key, motif.option_info.menu.done.key) then
+		if getInput(-1, motif.option_info.menu.done.key) then
 			sndPlay(motif.Snd, motif.option_info.cursor.done.snd[1], motif.option_info.cursor.done.snd[2])
 			--modifyGameOption('Common.Air', {"data/common.air"})
 			--modifyGameOption('Common.Cmd', {"data/common.cmd"})
@@ -1390,7 +1390,7 @@ options.t_itemname = {
 	end,
 	--Save and Return
 	['savereturn'] = function(t, item, cursorPosY, moveTxt)
-		if getInput(-1, motif.option_info.menu.add.key, motif.option_info.menu.subtract.key, motif.option_info.menu.done.key) then
+		if getInput(-1, motif.option_info.menu.done.key) then
 			sndPlay(motif.Snd, motif.option_info.cancel.snd[1], motif.option_info.cancel.snd[2])
 			if options.modified then
 				options.f_saveCfg(options.needReload)
@@ -1403,7 +1403,7 @@ options.t_itemname = {
 	end,
 	--Return Without Saving
 	['return'] = function(t, item, cursorPosY, moveTxt)
-		if getInput(-1, motif.option_info.menu.add.key, motif.option_info.menu.subtract.key, motif.option_info.menu.done.key) then
+		if getInput(-1, motif.option_info.menu.done.key) then
 			sndPlay(motif.Snd, motif.option_info.cancel.snd[1], motif.option_info.cancel.snd[2])
 			if options.needReload then
 				main.f_warning(motif.warning_info.text.text.noreload, motif.option_info, motif.optionbgdef)
@@ -1416,7 +1416,7 @@ options.t_itemname = {
 	end,
 	--Save Settings
 	['savesettings'] = function(t, item, cursorPosY, moveTxt)
-		if getInput(-1, motif.option_info.menu.add.key, motif.option_info.menu.subtract.key, motif.option_info.menu.done.key) then
+		if getInput(-1, motif.option_info.menu.done.key) then
 			sndPlay(motif.Snd, motif.option_info.cursor.done.snd[1], motif.option_info.cursor.done.snd[2])
 			if options.modified then
 				options.f_saveCfg(options.needReload)

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -3564,20 +3564,25 @@ func (ro *LifeBarRound) draw(layerno int16, f map[int]*Fnt) {
 					// default win
 					res = &ro.win[idxW]
 				}
-				var displayNames []interface{}
-				for i := activeTeam; i < len(sys.chars); i += 2 {
-					if len(sys.chars[i]) > 0 {
-						displayNames = append(displayNames, sys.cgi[i].displayname)
-					}
-				}
 				// BGs
 				for i := range res.bg[activeTeam] {
 					res.bg[activeTeam][i].Draw(float32(ro.pos[0])+sys.lifebar.offsetX, float32(ro.pos[1]), layerno, sys.lifebar.scale)
 				}
 				// Text
+				var args []interface{}
+				for i := activeTeam; i < len(sys.chars); i += 2 {
+					if len(sys.chars[i]) > 0 {
+						args = append(args, i + 1) // playerNum
+					}
+				}
+				for i := activeTeam; i < len(sys.chars); i += 2 {
+					if len(sys.chars[i]) > 0 {
+						args = append(args, sys.cgi[i].displayname)
+					}
+				}
 				oldTxt := res.text[activeTeam].text.text
-				if len(displayNames) > 0 {
-					res.text[activeTeam].text.text = OldSprintf(oldTxt, displayNames...)
+				if len(args) > 0 {
+					res.text[activeTeam].text.text = OldSprintf(oldTxt, args...)
 				}
 				res.text[activeTeam].Draw(float32(ro.pos[0])+sys.lifebar.offsetX, float32(ro.pos[1]), layerno, f, sys.lifebar.scale)
 				res.text[activeTeam].text.text = oldTxt


### PR DESCRIPTION
Fixes:
- Fixed a bug where, in the option menu, F/B keys were being read as confirmation keys for some items.
- The ``%d`` syntax to display the player number not working with the ``win``, ``ai.win``, and ``ai.lose`` lifebar parameters.