### PR TITLE
fix: regressions, sounds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ srcFiles=src/resources/defaultConfig.ini \
 	src/config.go \
 	src/dllsearch_windows.go \
 	src/font.go \
-	src/font_gl32.go \
+	src/font_gl33.go \
 	src/font_gles32.go \
 	src/font_vk.go \
 	src/hiscore_rank.go \
@@ -31,8 +31,8 @@ srcFiles=src/resources/defaultConfig.ini \
 	src/net.go \
 	src/rect.go \
 	src/render.go \
-	src/render_gl_gl32.go \
-	src/render_gl_gles32.go \
+	src/render_gl33.go \
+	src/render_gles32.go \
 	src/render_vk.go \
 	src/rollback.go \
 	src/script.go \

--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -213,7 +213,7 @@ options.t_itemname = {
 			if runtimeOS == 'android' then
 				modifyGameOption('Video.RenderMode', 'OpenGL ES 3.2')
 			else
-				modifyGameOption('Video.RenderMode', "OpenGL 3.2")
+				modifyGameOption('Video.RenderMode', "OpenGL 3.3")
 			end
 			modifyGameOption('Video.GameWidth', 1280)
 			modifyGameOption('Video.GameHeight', 720)
@@ -805,7 +805,7 @@ options.t_itemname = {
 	['gl32'] = function(t, item, cursorPosY, moveTxt)
 		if getInput(-1, motif.option_info.menu.done.key) then
 			sndPlay(motif.Snd, motif.option_info.cursor.move.snd[1], motif.option_info.cursor.move.snd[2])
-			modifyGameOption('Video.RenderMode', "OpenGL 3.2")
+			modifyGameOption('Video.RenderMode', "OpenGL 3.3")
 			options.modified = true
 			options.needReload = true
 			return false

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -12244,7 +12244,7 @@ func (sc modifySnd) Run(c *Char, _ []int32) bool {
 				snd.stopOnGetHit = stopgh != 0
 			}
 			if stopcs >= 0 {
-				snd.stopOnChangeState = stopgh != 0
+				snd.stopOnChangeState = stopcs != 0
 			}
 		}
 	}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -10486,14 +10486,22 @@ func (sc stopSnd) Run(c *Char, _ []int32) bool {
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
 		case stopSnd_channel:
-			if ch := Min(255, exp[0].evalI(c)); ch < 0 {
-				sys.stopAllCharSound()
-			} else if c := crun.soundChannels.Get(ch); c != nil {
-				c.Stop()
+			val := exp[0].evalI(c)
+			switch {
+			case val <= -2:
+				crun.soundChannels.StopAll()
+			case val == -1:
+				// Backward compatibility: stop sounds for all players
+				sys.stopAllCharSounds()
+			default:
+				if s := crun.soundChannels.Get(val); s != nil {
+					s.Stop()
+				}
 			}
 		}
 		return true
 	})
+
 	return false
 }
 

--- a/src/char.go
+++ b/src/char.go
@@ -2113,6 +2113,7 @@ func (e *Explod) update() {
 	sd.alpha = alp
 	sd.layerno = e.layerno
 	sd.priority = e.sprpriority + int32(e.interPos[2]*e.localscl)
+	sd.under = e.under
 	sd.rot = rot
 	sd.screen = e.space == Space_screen
 	sd.undarken = parent != nil && parent.ignoreDarkenTime > 0
@@ -4149,7 +4150,7 @@ func (c *Char) load(def string) error {
 	return nil
 }
 
-func (c *Char) initPalettes() {
+func (c *Char) loadPalettes() {
 	gi := c.gi()
 	maxPal := sys.cfg.Config.PaletteMax
 
@@ -4209,7 +4210,7 @@ func (c *Char) initPalettes() {
 		// SFFv2 logic
 		numPals := int(gi.sff.header.NumberOfPalettes)
 
-		// Ensure GPU textures are ready for all internal SFFv2 palettes
+		// Ensure textures are ready for all internal SFFv2 palettes
 		for i := 0; i < numPals; i++ {
 			if pData := gi.sff.palList.Get(i); pData != nil {
 				// SetSource ensures allocation exists
@@ -12340,6 +12341,7 @@ func (c *Char) cueDraw() {
 		charSD.alpha = c.alpha
 		charSD.layerno = c.layerNo
 		charSD.priority = c.sprPriority + int32(c.pos[2]*c.localscl)
+		charSD.under = c.asf(ASF_drawunder)
 		charSD.rot = rot
 		charSD.undarken = c.ignoreDarkenTime > 0
 		charSD.facing = c.facing

--- a/src/char.go
+++ b/src/char.go
@@ -4150,6 +4150,7 @@ func (c *Char) load(def string) error {
 	return nil
 }
 
+// Loads all of the character's palettes. Selectable or not
 func (c *Char) loadPalettes() {
 	gi := c.gi()
 	maxPal := sys.cfg.Config.PaletteMax
@@ -4173,10 +4174,10 @@ func (c *Char) loadPalettes() {
 		gi.palettedata.palList.ResetRemap()
 		tmp := 0
 
+		// Append ACT palettes instead of overwriting
 		for i := 0; i < maxPal; i++ {
 			pal := gi.palInfo[i]
 			if pl, ok := readAct(&pal); ok {
-				// Append instead of overwriting
 				targetIdx := len(gi.palettedata.palList.palettes)
 
 				// Allocate space if necessary
@@ -4219,7 +4220,7 @@ func (c *Char) loadPalettes() {
 			}
 		}
 
-		// Process external ACT overrides up to the PaletteMax limit
+		// Overwrite SFF palettes with ACT palettes
 		for i := 0; i < maxPal; i++ {
 			pal := gi.palInfo[i]
 			pIdx, existsInSff := gi.palettedata.palList.PalTable[[...]uint16{1, uint16(i + 1)}]
@@ -4238,7 +4239,8 @@ func (c *Char) loadPalettes() {
 				// Assign the new palette
 				gi.palettedata.palList.SetSource(targetIdx, pl)
 				gi.palettedata.palList.PalTex[targetIdx] = NewTextureFromPalette(pl)
-				gi.palettedata.palList.PalTable[[...]uint16{1, uint16(i + 1)}] = targetIdx
+				gi.palettedata.palList.PalTable[[2]uint16{1, uint16(i + 1)}] = targetIdx
+				gi.palettedata.palList.numcols[[2]uint16{1, uint16(i + 1)}] = 256 // ACT files are always 256 colors
 
 				pal.exists = true
 			} else {

--- a/src/char.go
+++ b/src/char.go
@@ -6171,6 +6171,7 @@ func (c *Char) playSound(ffx string, lowpriority bool, loopCount int32, g, n, ch
 	if _, ok := sys.cmdFlags["-nosound"]; ok {
 		return
 	}
+
 	var s *Sound
 	if current_ffx == "" || current_ffx == "s" {
 		if c.gi().snd != nil {
@@ -6200,27 +6201,34 @@ func (c *Char) playSound(ffx string, lowpriority bool, loopCount int32, g, n, ch
 		}
 		return
 	}
+
+	// Handle channel inheritance
 	crun := c
 	if c.inheritChannels == 1 && c.parent(false) != nil {
 		crun = c.parent(false)
 	} else if c.inheritChannels == 2 && c.root(false) != nil {
 		crun = c.root(false)
 	}
-	if ch := crun.soundChannels.New(chNo, lowpriority, priority); ch != nil {
+
+	if ch := crun.soundChannels.Request(chNo, lowpriority, priority); ch != nil {
 		ch.Play(s, g, n, loopCount, freqmul, loopstart, loopend, startposition)
 		vol = Clamp(vol, -25600, 25600)
+
+		//ch.channelNo = chNo // Handled by Request()
+
 		//if c.gi().mugenver[0] == 1 {
 		if current_ffx != "" {
 			ch.SetVolume(float32(vol * 64 / 25))
 		} else {
 			ch.SetVolume(float32(c.gi().data.volume * vol / 100))
 		}
+
 		if chNo >= 0 {
-			ch.SetChannel(chNo)
 			if priority != 0 {
-				ch.SetPriority(priority)
+				ch.SetPriority(priority) // TODO: We can probably allow priority in channel -1 now
 			}
 		}
+
 		//} else {
 		//	if f {
 		//		ch.SetVolume(float32(vol + 256))
@@ -6228,6 +6236,7 @@ func (c *Char) playSound(ffx string, lowpriority bool, loopCount int32, g, n, ch
 		//		ch.SetVolume(float32(c.gi().data.volume + vol))
 		//	}
 		//}
+
 		ch.stopOnGetHit = stopgh
 		ch.stopOnChangeState = stopcs
 		ch.SetPan(p*c.facing, ls, x)

--- a/src/char.go
+++ b/src/char.go
@@ -5562,11 +5562,7 @@ func (c *Char) soundVar(chid BytecodeValue, vtype OpCode) BytecodeValue {
 		return BytecodeSF()
 	}
 
-	// See compiler.go:SoundVar
 	var id = chid.ToI()
-	if id > 0 {
-		id--
-	}
 	var ch *SoundChannel
 
 	// First, grab a channel.
@@ -5603,7 +5599,7 @@ func (c *Char) soundVar(chid BytecodeValue, vtype OpCode) BytecodeValue {
 		}
 		return BytecodeFloat(1)
 	case OC_ex2_soundvar_isplaying:
-		if ch != nil && ch.sfx != nil {
+		if ch != nil {
 			return BytecodeBool(ch.IsPlaying())
 		}
 		return BytecodeBool(false)

--- a/src/common.go
+++ b/src/common.go
@@ -1528,6 +1528,17 @@ func (zmfr *zipMemFileReader) Close() error {
 	return zmfr.zipArchive.Close()
 }
 
+// Standardizes slashes then returns the directory and filename. Necessary for Unix systems
+// https://github.com/ikemen-engine/Ikemen-GO/issues/3126
+func SplitPath(p string) (dir, file string) {
+	p = strings.ReplaceAll(p, "\\", "/")
+	idx := strings.LastIndex(p, "/")
+	if idx < 0 {
+		return "", p // Local file, no directory
+	}
+	return p[:idx+1], p[idx+1:]
+}
+
 // OpenFile opens a regular file or a file within a zip archive.
 // For zip files, it reads the entire entry into memory to ensure full io.Seeker compatibility.
 // It returns an io.ReadSeekCloser that must be closed by the caller.

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1911,17 +1911,15 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		if err := c.checkClosingParenthesis(); err != nil {
 			return bvNone(), err
 		}
-		be2.appendValue(bv2)
-		be1.appendValue(bv1)
-		if len(be2) > int(math.MaxUint8-1) {
-			be1.appendI32Op(OC_jz, int32(len(be2)+1))
-		} else {
-			be1.append(OC_jz8, OpCode(len(be2)+1))
-		}
-		be1.append(be2...)
+
+		be1.appendValue(bv1) 
+		be1.append(be2...) 
+		be1.appendValue(bv2) 
+
 		if rd {
 			out.appendI32Op(OC_nordrun, int32(len(be1)))
 		}
+		
 		// Just in case anybody else bangs their head against a wall with redirects:
 		// it is imperative that the be1.append(opcodetype, opcode) comes after the
 		// rd out.appendI32Op(OC_nordrun, int32(len(be1)))
@@ -2422,14 +2420,10 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			}
 		}
 
-		be2.appendValue(bv2)
 		be1.appendValue(bv1)
-		if len(be2) > int(math.MaxUint8-1) {
-			be1.appendI32Op(OC_jz, int32(len(be2)+1))
-		} else {
-			be1.append(OC_jz8, OpCode(len(be2)+1))
-		}
 		be1.append(be2...)
+		be1.appendValue(bv2)
+
 		if rd {
 			out.appendI32Op(OC_nordrun, int32(len(be1)))
 		}
@@ -3493,23 +3487,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 
-		// If bv1 is ever 0 Ikemen crashes.
-		// I do not know why this happens.
-		// It happened with clsnVar.
-		idx := bv1.ToI()
-		if idx >= 0 {
-			bv1.SetI(idx + 1)
-		}
-
-		be2.appendValue(bv2)
 		be1.appendValue(bv1)
-
-		if len(be2) > int(math.MaxUint8-1) {
-			be1.appendI32Op(OC_jz, int32(len(be2)+1))
-		} else {
-			be1.append(OC_jz8, OpCode(len(be2)+1))
-		}
-		be1.append(be2...)
 
 		if rd {
 			out.appendI32Op(OC_nordrun, int32(len(be1)))

--- a/src/font_gl32.go
+++ b/src/font_gl32.go
@@ -58,9 +58,9 @@ func (r *FontRenderer_GL32) Init(renderer interface{}) {
 	gl.EnableVertexAttribArray(tLoc)
 	gl.VertexAttribPointer(tLoc, 2, gl.FLOAT, false, 4*4, gl.PtrOffset(2*4))
 
-	// Clean up binding state, but not attribute state
-	gl.BindBuffer(gl.ARRAY_BUFFER, 0)
+	// Unbind for safety
 	gl.BindVertexArray(0)
+	gl.BindBuffer(gl.ARRAY_BUFFER, 0)
 }
 
 // LoadFont loads the specified font at the given scale.
@@ -107,16 +107,11 @@ func (r *FontRenderer_GL32) SetFontPipeline() {
 
 	mr.ChangeProgram(r.shaderProgram.program)
 
+	// Bind VAO
 	gl.BindVertexArray(r.vao)
+
+	// We need to bind VBO here as well
 	gl.BindBuffer(gl.ARRAY_BUFFER, r.vbo)
-
-	vLoc := uint32(r.shaderProgram.attributes["vert"])
-	gl.EnableVertexAttribArray(vLoc)
-	gl.VertexAttribPointer(vLoc, 2, gl.FLOAT, false, 4*4, gl.PtrOffset(0))
-
-	tLoc := uint32(r.shaderProgram.attributes["vertTexCoord"])
-	gl.EnableVertexAttribArray(tLoc)
-	gl.VertexAttribPointer(tLoc, 2, gl.FLOAT, false, 4*4, gl.PtrOffset(2*4))
 }
 
 // Printf draws a string to the screen, takes a list of arguments like printf
@@ -247,13 +242,8 @@ func (f *Font_GL32) renderGlyphBatch(vertices []float32, textureID uint32) {
 }
 
 func (r *FontRenderer_GL32) ReleaseFontPipeline() {
-	locVert := r.shaderProgram.attributes["vert"]
-	gl.DisableVertexAttribArray(uint32(locVert))
-	locTex := r.shaderProgram.attributes["vertTexCoord"]
-	gl.DisableVertexAttribArray(uint32(locTex))
-
-	//gl.BindVertexArray(0)
-	//gl.BindBuffer(gl.ARRAY_BUFFER, 0)
+	gl.BindVertexArray(0)
+	gl.BindBuffer(gl.ARRAY_BUFFER, 0)
 }
 
 // Width returns the width of a piece of text in pixels

--- a/src/font_gl33.go
+++ b/src/font_gl33.go
@@ -10,14 +10,14 @@ import (
 	"io/ioutil"
 	"os"
 
-	gl "github.com/go-gl/gl/v3.2-core/gl"
+	gl "github.com/go-gl/gl/v3.3-core/gl"
 	"github.com/golang/freetype"
 	"github.com/golang/freetype/truetype"
 	"golang.org/x/image/font"
 	"golang.org/x/image/math/fixed"
 )
 
-type Font_GL32 struct {
+type Font_GL33 struct {
 	fontChar     map[rune]*character
 	ttf          *truetype.Font
 	scale        int32
@@ -27,13 +27,13 @@ type Font_GL32 struct {
 	color        color
 }
 
-type FontRenderer_GL32 struct {
-	shaderProgram *ShaderProgram_GL32
+type FontRenderer_GL33 struct {
+	shaderProgram *ShaderProgram_GL33
 	vao           uint32
 	vbo           uint32
 }
 
-func (r *FontRenderer_GL32) Init(renderer interface{}) {
+func (r *FontRenderer_GL33) Init(renderer interface{}) {
 	// Configure the default font vertex and fragment shaders
 	r.newProgram(150, vertexFontShader, fragmentFontShader)
 
@@ -64,7 +64,7 @@ func (r *FontRenderer_GL32) Init(renderer interface{}) {
 }
 
 // LoadFont loads the specified font at the given scale.
-func (r *FontRenderer_GL32) LoadFont(file string, scale int32, windowWidth int, windowHeight int) (interface{}, error) {
+func (r *FontRenderer_GL33) LoadFont(file string, scale int32, windowWidth int, windowHeight int) (interface{}, error) {
 	fd, err := os.Open(file)
 	if err != nil {
 		return nil, err
@@ -85,20 +85,20 @@ func (r *FontRenderer_GL32) LoadFont(file string, scale int32, windowWidth int, 
 }
 
 // SetColor allows you to set the text color to be used when you draw the text
-func (f *Font_GL32) SetColor(red float32, green float32, blue float32, alpha float32) {
+func (f *Font_GL33) SetColor(red float32, green float32, blue float32, alpha float32) {
 	f.color.r = red
 	f.color.g = green
 	f.color.b = blue
 	f.color.a = alpha
 }
 
-func (f *Font_GL32) UpdateResolution(windowWidth int, windowHeight int) {
+func (f *Font_GL33) UpdateResolution(windowWidth int, windowHeight int) {
 	f.windowWidth = windowWidth
 	f.windowHeight = windowHeight
 }
 
-func (r *FontRenderer_GL32) SetFontPipeline() {
-	mr := gfx.(*Renderer_GL32)
+func (r *FontRenderer_GL33) SetFontPipeline() {
+	mr := gfx.(*Renderer_GL33)
 
 	// Do nothing if we were already using the font shader
 	if mr.program == r.shaderProgram.program {
@@ -115,12 +115,12 @@ func (r *FontRenderer_GL32) SetFontPipeline() {
 }
 
 // Printf draws a string to the screen, takes a list of arguments like printf
-func (f *Font_GL32) Printf(x, y float32, scale float32, spacingXAdd float32,
+func (f *Font_GL33) Printf(x, y float32, scale float32, spacingXAdd float32,
 	align int32, blend bool, window [4]int32, fs string, argv ...interface{}) error {
 
 	indices := []rune(fmt.Sprintf(fs, argv...))
-	r := gfx.(*Renderer_GL32)
-	fr := gfxFont.(*FontRenderer_GL32)
+	r := gfx.(*Renderer_GL33)
+	fr := gfxFont.(*FontRenderer_GL33)
 
 	if len(indices) == 0 {
 		return nil
@@ -154,7 +154,7 @@ func (f *Font_GL32) Printf(x, y float32, scale float32, spacingXAdd float32,
 	r.SetUniformFSub(program.uniforms["resolution"], float32(f.windowWidth), float32(f.windowHeight))
 
 	gl.ActiveTexture(gl.TEXTURE0)
-	//gl.BindVertexArray(gfxFont.(*FontRenderer_GL32).vao)
+	//gl.BindVertexArray(gfxFont.(*FontRenderer_GL33).vao)
 
 	//calculate alignment position
 	if align == 0 {
@@ -231,8 +231,8 @@ func (f *Font_GL32) Printf(x, y float32, scale float32, spacingXAdd float32,
 }
 
 // Helper function to render a batch of glyphs
-func (f *Font_GL32) renderGlyphBatch(vertices []float32, textureID uint32) {
-	fr := gfxFont.(*FontRenderer_GL32)
+func (f *Font_GL33) renderGlyphBatch(vertices []float32, textureID uint32) {
+	fr := gfxFont.(*FontRenderer_GL33)
 
 	gl.BindBuffer(gl.ARRAY_BUFFER, fr.vbo)
 	gl.BufferSubData(gl.ARRAY_BUFFER, 0, len(vertices)*4, gl.Ptr(vertices))
@@ -241,13 +241,13 @@ func (f *Font_GL32) renderGlyphBatch(vertices []float32, textureID uint32) {
 	gl.DrawArrays(gl.TRIANGLES, 0, int32(len(vertices))/4)
 }
 
-func (r *FontRenderer_GL32) ReleaseFontPipeline() {
+func (r *FontRenderer_GL33) ReleaseFontPipeline() {
 	gl.BindVertexArray(0)
 	gl.BindBuffer(gl.ARRAY_BUFFER, 0)
 }
 
 // Width returns the width of a piece of text in pixels
-func (f *Font_GL32) Width(scale float32, spacingXAdd float32, fs string, argv ...interface{}) float32 {
+func (f *Font_GL33) Width(scale float32, spacingXAdd float32, fs string, argv ...interface{}) float32 {
 
 	var width float32
 
@@ -295,7 +295,7 @@ func (f *Font_GL32) Width(scale float32, spacingXAdd float32, fs string, argv ..
 }
 
 // GenerateGlyphs builds a set of textures based on a ttf files glyphs
-func (f *Font_GL32) GenerateGlyphs(low, high rune) error {
+func (f *Font_GL33) GenerateGlyphs(low, high rune) error {
 	//create a freetype context for drawing
 	c := freetype.NewContext()
 	c.SetDPI(72)
@@ -411,7 +411,7 @@ func (f *Font_GL32) GenerateGlyphs(low, high rune) error {
 		// uv[3] -= off_v
 
 		char.uv = uv
-		char.textureID = texAtlas.texture.(*Texture_GL32).handle
+		char.textureID = texAtlas.texture.(*Texture_GL33).handle
 
 		//add char to fontChar list
 		f.fontChar[ch] = char
@@ -422,7 +422,7 @@ func (f *Font_GL32) GenerateGlyphs(low, high rune) error {
 }
 
 // LoadTrueTypeFont builds OpenGL buffers and glyph textures based on a ttf file
-func (r *FontRenderer_GL32) LoadTrueTypeFont(reader io.Reader, scale int32, low, high rune, dir Direction) (*Font_GL32, error) {
+func (r *FontRenderer_GL33) LoadTrueTypeFont(reader io.Reader, scale int32, low, high rune, dir Direction) (*Font_GL33, error) {
 	data, err := ioutil.ReadAll(reader)
 	if err != nil {
 		return nil, err
@@ -435,7 +435,7 @@ func (r *FontRenderer_GL32) LoadTrueTypeFont(reader io.Reader, scale int32, low,
 	}
 
 	//make Font stuct type
-	f := new(Font_GL32)
+	f := new(Font_GL33)
 	f.fontChar = make(map[rune]*character)
 	f.ttf = ttf
 	f.scale = scale
@@ -451,8 +451,8 @@ func (r *FontRenderer_GL32) LoadTrueTypeFont(reader io.Reader, scale int32, low,
 }
 
 // newProgram links the frag and vertex shader programs
-func (r *FontRenderer_GL32) newProgram(GLSLVersion uint, vertexShaderSource, fragmentShaderSource string) {
-	shaderProgram, _ := gfx.(*Renderer_GL32).newShaderProgram(vertexShaderSource, fragmentShaderSource, "", "font shader", true)
+func (r *FontRenderer_GL33) newProgram(GLSLVersion uint, vertexShaderSource, fragmentShaderSource string) {
+	shaderProgram, _ := gfx.(*Renderer_GL33).newShaderProgram(vertexShaderSource, fragmentShaderSource, "", "font shader", true)
 	r.shaderProgram = shaderProgram
 	r.shaderProgram.RegisterUniforms("textColor", "resolution", "tex")
 }

--- a/src/font_gles32.go
+++ b/src/font_gles32.go
@@ -60,9 +60,9 @@ func (r *FontRenderer_GLES32) Init(renderer interface{}) {
 	gl.EnableVertexAttribArray(tLoc)
 	gl.VertexAttribPointer(tLoc, 2, gl.FLOAT, false, 4*4, gl.PtrOffset(2*4))
 
-	// Clean up binding state, but not attribute state
-	gl.BindBuffer(gl.ARRAY_BUFFER, 0)
+	// Unbind for safety
 	gl.BindVertexArray(0)
+	gl.BindBuffer(gl.ARRAY_BUFFER, 0)
 }
 
 // LoadFont builds the font structure
@@ -105,16 +105,11 @@ func (r *FontRenderer_GLES32) SetFontPipeline() {
 
 	mr.ChangeProgram(r.shaderProgram.program)
 
+	// Bind VAO
 	gl.BindVertexArray(r.vao)
+
+	// We need to bind VBO here as well
 	gl.BindBuffer(gl.ARRAY_BUFFER, r.vbo)
-
-	vLoc := uint32(r.shaderProgram.attributes["vert"])
-	gl.EnableVertexAttribArray(vLoc)
-	gl.VertexAttribPointer(vLoc, 2, gl.FLOAT, false, 4*4, gl.PtrOffset(0))
-
-	tLoc := uint32(r.shaderProgram.attributes["vertTexCoord"])
-	gl.EnableVertexAttribArray(tLoc)
-	gl.VertexAttribPointer(tLoc, 2, gl.FLOAT, false, 4*4, gl.PtrOffset(2*4))
 }
 
 // Printf draws a string to the screen, takes a list of arguments like printf
@@ -247,13 +242,8 @@ func (f *Font_GLES32) renderGlyphBatch(vertices []float32, textureID uint32) {
 }
 
 func (r *FontRenderer_GLES32) ReleaseFontPipeline() {
-	locVert := r.shaderProgram.attributes["vert"]
-	gl.DisableVertexAttribArray(uint32(locVert))
-	locTex := r.shaderProgram.attributes["vertTexCoord"]
-	gl.DisableVertexAttribArray(uint32(locTex))
-
-	//gl.BindVertexArray(0)
-	//gl.BindBuffer(gl.ARRAY_BUFFER, 0)
+	gl.BindVertexArray(0)
+	gl.BindBuffer(gl.ARRAY_BUFFER, 0)
 }
 
 // Width returns the width of a piece of text in pixels

--- a/src/image.go
+++ b/src/image.go
@@ -382,9 +382,9 @@ func (pf *PalFX) setColor(r, g, b int32) {
 }
 
 type PaletteList struct {
-	palettes   [][]uint32
-	paletteMap []int
-	PalTable   map[[2]uint16]int
+	palettes   [][]uint32        // The actual (unordered) palettes
+	paletteMap []int             // Logical index to actual index mapping. For remapping
+	PalTable   map[[2]uint16]int // Group/index key to original index value
 	numcols    map[[2]uint16]int
 	PalTex     []Texture
 }

--- a/src/image.go
+++ b/src/image.go
@@ -1663,14 +1663,13 @@ func loadCharPalettes(sff *Sff, filename string, ref int) error {
 		}
 	}
 
+	// Get char directory
+	chardir, _ := SplitPath(c.def)
+
 	// SFFv1 and Act Overrides
 	// TODO: External .ACTs on SFFv2 without palette slots may cause color bleeding,
 	// on sprites with unique palettes if a SFFv2 with Acts is loaded by sffNew, since is a simplified utility
 	// and lacks the engine's palInfo/cgi logic to properly isolate palette remapping during rendering.
-	parts := strings.SplitAfterN(c.def, "/", -1)
-	pathname := strings.Join(parts[:len(parts)-1], "")
-
-	// Read ACT palettes
 	for x := 0; x < len(c.pal_files) && x < len(c.pal); x++ {
 		if c.pal_files[x] == "" {
 			continue
@@ -1683,7 +1682,7 @@ func loadCharPalettes(sff *Sff, filename string, ref int) error {
 			continue
 		}
 
-		pal, err := readActPalette(pathname + c.pal_files[x])
+		pal, err := readActPalette(chardir + c.pal_files[x])
 		if err != nil {
 			fmt.Println("Error reading " + c.pal_files[x])
 			continue
@@ -1691,7 +1690,12 @@ func loadCharPalettes(sff *Sff, filename string, ref int) error {
 
 		// For SFFv1, append the ACT palettes so they don't overwrite the unique unshared ones
 		if h.Version[0] == 1 {
-			targetIdx = len(sff.palList.palettes)
+			// But only append if this specific slot isn't already mapped
+			if existingIdx, exists := sff.palList.PalTable[[2]uint16{1, palSlot}]; exists {
+				targetIdx = existingIdx
+			} else {
+				targetIdx = len(sff.palList.palettes)
+			}
 		}
 
 		// Update the PalTable mapping

--- a/src/image.go
+++ b/src/image.go
@@ -381,6 +381,20 @@ func (pf *PalFX) setColor(r, g, b int32) {
 	}
 }
 
+type Palette struct {
+	palList PaletteList
+}
+
+func newPaldata() (p *Palette) {
+	p = &Palette{}
+	p.palList.init()
+	// Pre-allocation creates false positives when checking if a palette exists
+	//for i := uint16(1); i <= uint16(sys.cfg.Config.PaletteMax); i++ {
+	//	p.palList.PalTable[[...]uint16{1, i}], _ = p.palList.NewPal()
+	//}
+	return
+}
+
 type PaletteList struct {
 	palettes   [][]uint32        // The actual (unordered) palettes
 	paletteMap []int             // Logical index to actual index mapping. For remapping
@@ -491,92 +505,168 @@ func NewTextureFromPalette(pal []uint32) Texture {
 	return tx
 }
 
-type SffHeader struct {
-	Version                  [4]byte // verhi, verlo1, verlo2, verlo3
-	FirstSpriteHeaderOffset  uint32
-	FirstPaletteHeaderOffset uint32
-	NumberOfSprites          uint32
-	NumberOfPalettes         uint32
+func readActPalette(filename string) ([]uint32, error) {
+	f, err := OpenFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		chk(f.Close())
+	}()
+
+	// Standard size is 256 colors * 3 bytes = 768 bytes
+	const actSize = 768
+	data := make([]byte, actSize)
+
+	// Read as much as possible
+	// If file is smaller, we just process what we got
+	n, err := io.ReadFull(f, data)
+	if err != nil && err != io.ErrUnexpectedEOF && err != io.EOF {
+		return nil, err
+	}
+
+	// Always return a 256-color palette
+	pal := make([]uint32, 256)
+
+	// Process bytes sequentially, but assign them in reverse order
+	count := n / 3
+	for i := 0; i < count; i++ {
+		offset := i * 3
+		r := data[offset]
+		g := data[offset+1]
+		b := data[offset+2]
+
+		// Calculate reverse index
+		destIdx := 255 - i
+		if destIdx < 0 {
+			break
+		}
+
+		var alpha byte = 255
+		if destIdx == 0 {
+			alpha = 0 // Index 0 is transparent
+		}
+
+		pal[destIdx] = uint32(alpha)<<24 | uint32(b)<<16 | uint32(g)<<8 | uint32(r)
+	}
+
+	return pal, nil
 }
 
-func (sh *SffHeader) Read(r io.Reader, lofs *uint32, tofs *uint32) error {
-	buf := make([]byte, 12)
-	n, err := r.Read(buf)
+// Loads a char's selectable palettes for the motif/scripts
+// Used by things like palette selection and Turns faces colors
+func loadCharPalettes(sff *Sff, filename string, ref int) error {
+	f, err := OpenFile(filename)
 	if err != nil {
 		return err
 	}
-	// Read signature
-	if string(buf[:n]) != "ElecbyteSpr\x00" {
-		return Error("Unrecognized SFF file, invalid header")
-	}
-
+	defer f.Close()
+	h := sff.header
 	read := func(x interface{}) error {
-		return binary.Read(r, binary.LittleEndian, x)
+		return binary.Read(f, binary.LittleEndian, x)
 	}
+	var lofs, tofs uint32
+	if err := h.Read(f, &lofs, &tofs); err != nil {
+		return err
+	}
+	maxPal := int(sys.cfg.Config.PaletteMax)
+	c := sys.sel.charlist[ref]
 
-	// Read verlo3
-	if err := read(&sh.Version[3]); err != nil {
-		return err
-	}
-	// Read verlo2
-	if err := read(&sh.Version[2]); err != nil {
-		return err
-	}
-	// Read verlo1
-	if err := read(&sh.Version[1]); err != nil {
-		return err
-	}
-	// Read verhi
-	if err := read(&sh.Version[0]); err != nil {
-		return err
-	}
+	// SFF v2
+	uniquePals := make(map[[2]uint16]int)
+	loaded := make(map[int]bool)
 
-	var dummy uint32
-	if err := read(&dummy); err != nil {
-		return err
-	}
+	for headerIdx := 0; headerIdx < int(h.NumberOfPalettes); headerIdx++ {
+		f.Seek(int64(h.FirstPaletteHeaderOffset)+int64(headerIdx*16), 0)
 
-	switch sh.Version[0] {
-	case 1:
-		sh.FirstPaletteHeaderOffset, sh.NumberOfPalettes = 0, 0
-		if err := read(&sh.NumberOfSprites); err != nil {
+		var gn_ [3]uint16
+		if err := read(gn_[:]); err != nil {
 			return err
 		}
-		if err := read(&sh.FirstSpriteHeaderOffset); err != nil {
+
+		// We only care about group 1
+		if gn_[0] != 1 || gn_[1] <= 0 {
+			continue
+		}
+
+		destIdx := int(gn_[1]) - 1
+		if destIdx < 0 || destIdx >= maxPal {
+			continue
+		}
+
+		var link uint16
+		if err := read(&link); err != nil {
 			return err
 		}
-		if err := read(&dummy); err != nil {
+		var ofs, plSize uint32
+		if err := read(&ofs); err != nil {
 			return err
 		}
-	case 2:
-		for i := 0; i < 4; i++ {
-			if err := read(&dummy); err != nil {
+		if err := read(&plSize); err != nil {
+			return err
+		}
+
+		var pal []uint32
+		// Reuse duplicate if already loaded
+		if old, ok := uniquePals[[2]uint16{gn_[0], gn_[1]}]; ok {
+			if old >= 0 && old < maxPal && loaded[old] {
+				pal = sff.palList.Get(old)
+				destIdx = old
+			}
+		} else if plSize == 0 {
+			// Link must point to a previously loaded slot
+			linkIdx := int(link) - 1
+			if linkIdx >= 0 && linkIdx < maxPal && loaded[linkIdx] {
+				pal = sff.palList.Get(linkIdx)
+				destIdx = linkIdx
+			}
+		} else {
+			// Read SFF palette data
+			var err error
+			pal, err = sff.ReadPalette(f, int64(lofs+ofs), plSize)
+			if err != nil {
 				return err
 			}
 		}
-		if err := read(&sh.FirstSpriteHeaderOffset); err != nil {
-			return err
+		// Register only if we have data
+		if pal != nil {
+			sff.palList.SetSource(destIdx, pal)
+			loaded[destIdx] = true
+			uniquePals[[2]uint16{gn_[0], gn_[1]}] = destIdx
+			sff.palList.PalTable[[2]uint16{gn_[0], gn_[1]}] = destIdx
+			sff.palList.numcols[[2]uint16{gn_[0], gn_[1]}] = int(gn_[2])
 		}
-		if err := read(&sh.NumberOfSprites); err != nil {
-			return err
+	}
+
+	// Get char directory
+	chardir, _ := SplitPath(c.def)
+
+	// SFFv1 and Act Overrides
+	// TODO: External .ACTs on SFFv2 without palette slots may cause color bleeding,
+	// on sprites with unique palettes if a SFFv2 with Acts is loaded by sffNew, since is a simplified utility
+	// and lacks the engine's palInfo/cgi logic to properly isolate palette remapping during rendering.
+	for x := 0; x < len(c.pal_files) && x < len(c.pal); x++ {
+		if c.pal_files[x] == "" {
+			continue
 		}
-		if err := read(&sh.FirstPaletteHeaderOffset); err != nil {
-			return err
+
+		palSlot := uint16(c.pal[x])
+		targetIdx := int(palSlot) - 1
+
+		if targetIdx < 0 || targetIdx >= maxPal {
+			continue
 		}
-		if err := read(&sh.NumberOfPalettes); err != nil {
-			return err
+
+		pal, err := readActPalette(chardir + c.pal_files[x])
+		if err != nil {
+			fmt.Println("Error reading " + c.pal_files[x])
+			continue
 		}
-		if err := read(lofs); err != nil {
-			return err
-		}
-		if err := read(&dummy); err != nil {
-			return err
-		}
-		if err := read(tofs); err != nil {
-			return err
-		}
-	default:
-		return Error("Unrecognized SFF version")
+
+		// Update the PalTable mapping
+		sff.palList.SetSource(targetIdx, pal)
+		sff.palList.PalTable[[2]uint16{1, palSlot}] = targetIdx
+		sff.palList.numcols[[2]uint16{1, palSlot}] = 256 // ACT files are always 256 colors
 	}
 
 	return nil
@@ -730,6 +820,7 @@ func newSprite() *Sprite {
 		return s, nil
 	}
 */
+
 func (s *Sprite) shareCopy(src *Sprite) {
 	s.Pal = src.Pal
 	s.Tex = src.Tex
@@ -1343,15 +1434,102 @@ func (s *Sprite) Draw(x, y, xscale, yscale float32, rxadd float32, rot Rotation,
 	RenderSprite(rp)
 }
 
+type SffHeader struct {
+	Version                  [4]byte // verhi, verlo1, verlo2, verlo3
+	FirstSpriteHeaderOffset  uint32
+	FirstPaletteHeaderOffset uint32
+	NumberOfSprites          uint32
+	NumberOfPalettes         uint32
+}
+
+func (sh *SffHeader) Read(r io.Reader, lofs *uint32, tofs *uint32) error {
+	buf := make([]byte, 12)
+	n, err := r.Read(buf)
+	if err != nil {
+		return err
+	}
+	// Read signature
+	if string(buf[:n]) != "ElecbyteSpr\x00" {
+		return Error("Unrecognized SFF file, invalid header")
+	}
+
+	read := func(x interface{}) error {
+		return binary.Read(r, binary.LittleEndian, x)
+	}
+
+	// Read verlo3
+	if err := read(&sh.Version[3]); err != nil {
+		return err
+	}
+	// Read verlo2
+	if err := read(&sh.Version[2]); err != nil {
+		return err
+	}
+	// Read verlo1
+	if err := read(&sh.Version[1]); err != nil {
+		return err
+	}
+	// Read verhi
+	if err := read(&sh.Version[0]); err != nil {
+		return err
+	}
+
+	var dummy uint32
+	if err := read(&dummy); err != nil {
+		return err
+	}
+
+	switch sh.Version[0] {
+	case 1:
+		sh.FirstPaletteHeaderOffset, sh.NumberOfPalettes = 0, 0
+		if err := read(&sh.NumberOfSprites); err != nil {
+			return err
+		}
+		if err := read(&sh.FirstSpriteHeaderOffset); err != nil {
+			return err
+		}
+		if err := read(&dummy); err != nil {
+			return err
+		}
+	case 2:
+		for i := 0; i < 4; i++ {
+			if err := read(&dummy); err != nil {
+				return err
+			}
+		}
+		if err := read(&sh.FirstSpriteHeaderOffset); err != nil {
+			return err
+		}
+		if err := read(&sh.NumberOfSprites); err != nil {
+			return err
+		}
+		if err := read(&sh.FirstPaletteHeaderOffset); err != nil {
+			return err
+		}
+		if err := read(&sh.NumberOfPalettes); err != nil {
+			return err
+		}
+		if err := read(lofs); err != nil {
+			return err
+		}
+		if err := read(&dummy); err != nil {
+			return err
+		}
+		if err := read(tofs); err != nil {
+			return err
+		}
+	default:
+		return Error("Unrecognized SFF version")
+	}
+
+	return nil
+}
+
 type Sff struct {
 	header   SffHeader
 	sprites  map[[2]uint16]*Sprite
 	palList  PaletteList
 	filename string // This is the sffCache key
-}
-
-type Palette struct {
-	palList PaletteList
 }
 
 func newSff() (s *Sff) {
@@ -1360,16 +1538,6 @@ func newSff() (s *Sff) {
 	// Pre-allocation creates false positives when checking if a palette exists
 	//for i := uint16(1); i <= uint16(sys.cfg.Config.PaletteMax); i++ {
 	//	s.palList.PalTable[[...]uint16{1, i}], _ = s.palList.NewPal()
-	//}
-	return
-}
-
-func newPaldata() (p *Palette) {
-	p = &Palette{}
-	p.palList.init()
-	// Pre-allocation creates false positives when checking if a palette exists
-	//for i := uint16(1); i <= uint16(sys.cfg.Config.PaletteMax); i++ {
-	//	p.palList.PalTable[[...]uint16{1, i}], _ = p.palList.NewPal()
 	//}
 	return
 }
@@ -1388,54 +1556,7 @@ func removeSFFCache(filename string) {
 	}
 }
 
-func readActPalette(filename string) ([]uint32, error) {
-	f, err := OpenFile(filename)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		chk(f.Close())
-	}()
-
-	// Standard size is 256 colors * 3 bytes = 768 bytes
-	const actSize = 768
-	data := make([]byte, actSize)
-
-	// Read as much as possible
-	// If file is smaller, we just process what we got
-	n, err := io.ReadFull(f, data)
-	if err != nil && err != io.ErrUnexpectedEOF && err != io.EOF {
-		return nil, err
-	}
-
-	// Always return a 256-color palette
-	pal := make([]uint32, 256)
-
-	// Process bytes sequentially, but assign them in reverse order
-	count := n / 3
-	for i := 0; i < count; i++ {
-		offset := i * 3
-		r := data[offset]
-		g := data[offset+1]
-		b := data[offset+2]
-
-		// Calculate reverse index
-		destIdx := 255 - i
-		if destIdx < 0 {
-			break
-		}
-
-		var alpha byte = 255
-		if destIdx == 0 {
-			alpha = 0 // Index 0 is transparent
-		}
-
-		pal[destIdx] = uint32(alpha)<<24 | uint32(b)<<16 | uint32(g)<<8 | uint32(r)
-	}
-
-	return pal, nil
-}
-
+// Loads the full SFF file
 func loadSff(filename string, char bool, isMainThread bool, isActPal bool) (*Sff, error) {
 	// If this SFF is already in the cache, just return a copy
 	if cached, ok := SffCache[filename]; ok {
@@ -1443,20 +1564,26 @@ func loadSff(filename string, char bool, isMainThread bool, isActPal bool) (*Sff
 		s := cached.sffData
 		return &s, nil
 	}
+
 	s := newSff()
 	s.filename = filename
+
 	f, err := OpenFile(filename)
 	if err != nil {
 		return nil, err
 	}
+
 	defer func() { chk(f.Close()) }()
+
 	var lofs, tofs uint32
 	if err := s.header.Read(f, &lofs, &tofs); err != nil {
 		return nil, err
 	}
+
 	read := func(x interface{}) error {
 		return binary.Read(f, binary.LittleEndian, x)
 	}
+
 	if s.header.Version[0] != 1 {
 		uniquePals := make(map[[2]uint16]int)
 		for i := 0; i < int(s.header.NumberOfPalettes); i++ {
@@ -1497,6 +1624,8 @@ func loadSff(filename string, char bool, isMainThread bool, isActPal bool) (*Sff
 			uniquePals[[...]uint16{gn_[0], gn_[1]}] = idx
 			s.palList.SetSource(i, pal)
 			s.palList.PalTable[[...]uint16{gn_[0], gn_[1]}] = idx
+			// Number of colors as specified in the SFF
+			// We'll use a length check later instead because that's more reliable
 			s.palList.numcols[[...]uint16{gn_[0], gn_[1]}] = int(gn_[2])
 			if i <= sys.cfg.Config.PaletteMax &&
 				s.palList.PalTable[[...]uint16{1, uint16(i + 1)}] == s.palList.PalTable[[...]uint16{gn_[0], gn_[1]}] &&
@@ -1580,145 +1709,23 @@ func loadSff(filename string, char bool, isMainThread bool, isActPal bool) (*Sff
 	return s, nil
 }
 
-func loadCharPalettes(sff *Sff, filename string, ref int) error {
-	f, err := OpenFile(filename)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	h := sff.header
-	read := func(x interface{}) error {
-		return binary.Read(f, binary.LittleEndian, x)
-	}
-	var lofs, tofs uint32
-	if err := h.Read(f, &lofs, &tofs); err != nil {
-		return err
-	}
-	maxPal := int(sys.cfg.Config.PaletteMax)
-	c := sys.sel.charlist[ref]
-
-	// SFF v2
-	uniquePals := make(map[[2]uint16]int)
-	loaded := make(map[int]bool)
-
-	for headerIdx := 0; headerIdx < int(h.NumberOfPalettes); headerIdx++ {
-		f.Seek(int64(h.FirstPaletteHeaderOffset)+int64(headerIdx*16), 0)
-
-		var gn_ [3]uint16
-		if err := read(gn_[:]); err != nil {
-			return err
-		}
-		if gn_[0] != 1 || gn_[1] <= 0 {
-			continue
-		}
-
-		destIdx := int(gn_[1]) - 1
-		if destIdx < 0 || destIdx >= maxPal {
-			continue
-		}
-
-		var link uint16
-		if err := read(&link); err != nil {
-			return err
-		}
-		var ofs, plSize uint32
-		if err := read(&ofs); err != nil {
-			return err
-		}
-		if err := read(&plSize); err != nil {
-			return err
-		}
-
-		var pal []uint32
-		// Reuse duplicate if already loaded
-		if old, ok := uniquePals[[2]uint16{gn_[0], gn_[1]}]; ok {
-			if old >= 0 && old < maxPal && loaded[old] {
-				pal = sff.palList.Get(old)
-				destIdx = old
-			}
-		} else if plSize == 0 {
-			// Link must point to a previously loaded slot
-			linkIdx := int(link) - 1
-			if linkIdx >= 0 && linkIdx < maxPal && loaded[linkIdx] {
-				pal = sff.palList.Get(linkIdx)
-				destIdx = linkIdx
-			}
-		} else {
-			// Read SFF palette data
-			var err error
-			pal, err = sff.ReadPalette(f, int64(lofs+ofs), plSize)
-			if err != nil {
-				return err
-			}
-		}
-		// Register only if we have data
-		if pal != nil {
-			sff.palList.SetSource(destIdx, pal)
-			loaded[destIdx] = true
-			uniquePals[[2]uint16{gn_[0], gn_[1]}] = destIdx
-			sff.palList.PalTable[[2]uint16{gn_[0], gn_[1]}] = destIdx
-			// Number of colors as specified in the SFF
-			// We use a length check later instead because that's more reliable
-			sff.palList.numcols[[2]uint16{gn_[0], gn_[1]}] = int(gn_[2])
-		}
-	}
-
-	// Get char directory
-	chardir, _ := SplitPath(c.def)
-
-	// SFFv1 and Act Overrides
-	// TODO: External .ACTs on SFFv2 without palette slots may cause color bleeding,
-	// on sprites with unique palettes if a SFFv2 with Acts is loaded by sffNew, since is a simplified utility
-	// and lacks the engine's palInfo/cgi logic to properly isolate palette remapping during rendering.
-	for x := 0; x < len(c.pal_files) && x < len(c.pal); x++ {
-		if c.pal_files[x] == "" {
-			continue
-		}
-
-		palSlot := uint16(c.pal[x])
-		targetIdx := int(palSlot) - 1
-
-		if targetIdx < 0 || targetIdx >= maxPal {
-			continue
-		}
-
-		pal, err := readActPalette(chardir + c.pal_files[x])
-		if err != nil {
-			fmt.Println("Error reading " + c.pal_files[x])
-			continue
-		}
-
-		// For SFFv1, append the ACT palettes so they don't overwrite the unique unshared ones
-		if h.Version[0] == 1 {
-			// But only append if this specific slot isn't already mapped
-			if existingIdx, exists := sff.palList.PalTable[[2]uint16{1, palSlot}]; exists {
-				targetIdx = existingIdx
-			} else {
-				targetIdx = len(sff.palList.palettes)
-			}
-		}
-
-		// Update the PalTable mapping
-		sff.palList.SetSource(targetIdx, pal)
-		sff.palList.PalTable[[2]uint16{1, palSlot}] = targetIdx
-		sff.palList.numcols[[2]uint16{1, palSlot}] = 256 // ACT files are always 256 colors
-	}
-
-	return nil
-}
-
+// Loads a SFF with only specific sprites
 func preloadSff(filename string, char bool, preloadSpr map[[2]uint16]bool) (*Sff, []int32, error) {
 	sff := newSff()
+
 	f, err := OpenFile(filename)
 	if err != nil {
 		return nil, nil, err
 	}
+
 	defer func() { chk(f.Close()) }()
+
 	h := &SffHeader{}
 	var lofs, tofs uint32
 	if err := h.Read(f, &lofs, &tofs); err != nil {
 		return nil, nil, err
 	}
+
 	sff.filename = filename
 	sff.header.Version[0] = h.Version[0]
 	sff.header.Version[1] = h.Version[1]
@@ -1726,9 +1733,11 @@ func preloadSff(filename string, char bool, preloadSpr map[[2]uint16]bool) (*Sff
 	sff.header.Version[3] = h.Version[3]
 	sff.header.FirstPaletteHeaderOffset = h.FirstPaletteHeaderOffset
 	sff.header.NumberOfPalettes = h.NumberOfPalettes
+
 	read := func(x interface{}) error {
 		return binary.Read(f, binary.LittleEndian, x)
 	}
+
 	var shofs, xofs, size uint32 = h.FirstSpriteHeaderOffset, 0, 0
 	var indexOfPrevious uint16
 	var plShofs, plXofs, plSize uint32 = h.FirstPaletteHeaderOffset, 0, 0

--- a/src/render.go
+++ b/src/render.go
@@ -39,7 +39,7 @@ type Renderer interface {
 	ReleaseShadowPipeline()
 	prepareModelPipeline(bufferIndex uint32, env *Environment)
 	SetModelPipeline(eq BlendEquation, src, dst BlendFunc, depthTest, depthMask, doubleSided, invertFrontFace, useUV, useNormal, useTangent, useVertColor, useJoint0, useJoint1, useOutlineAttribute bool, numVertices, vertAttrOffset uint32)
-	SetMeshOulinePipeline(invertFrontFace bool, meshOutline float32)
+	SetMeshOutlinePipeline(invertFrontFace bool, meshOutline float32)
 	ReleaseModelPipeline()
 	newTexture(width, height, depth int32, filter bool) (t Texture)
 	newPaletteTexture() (t Texture)

--- a/src/render_gl33.go
+++ b/src/render_gl33.go
@@ -1,31 +1,23 @@
-// This is almost identical to render_gles.go except it uses a VAO
-// for GLES 3.2 which is the main version that runs on modern
-// Android (ARM). Work adapted from Leon Kasovan
-
-//go:build android
+//go:build !android
 
 package main
 
 import (
 	"bytes"
+	_ "embed" // Support for go:embed resources
 	"encoding/binary"
 	"fmt"
 	"math"
 	"runtime"
-	"strings"
-	"sync"
 	"unsafe"
 
+	gl "github.com/go-gl/gl/v3.3-core/gl"
 	mgl "github.com/go-gl/mathgl/mgl32"
-	gl "github.com/leonkasovan/gl/v3.2/gles2"
 	"github.com/veandco/go-sdl2/sdl"
 	"golang.org/x/mobile/exp/f32"
 )
 
-// ------------------------------------------------------------------
-// ShaderProgram_GLES32
-
-type ShaderProgram_GLES32 struct {
+type ShaderProgram_GL33 struct {
 	program    uint32           // OpenGL handle
 	attributes map[string]int32 // Attribute name to location
 	uniforms   map[string]int32 // Uniform name to location
@@ -33,188 +25,153 @@ type ShaderProgram_GLES32 struct {
 	name       string           // For debugging
 }
 
-var shaderCompileMutex sync.Mutex
-
-func (r *Renderer_GLES32) newShaderProgram(vert, frag, geo, name string, crashWhenFail bool) (s *ShaderProgram_GLES32, err error) {
-	// LOCK THE THREAD HERE
-	shaderCompileMutex.Lock()
-	defer shaderCompileMutex.Unlock()
-
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
-	Logcat("GLES: [LOCKED] Starting: " + name)
-	var vertObj, fragObj, prog uint32
-
-	vertObj, err = r.compileShader(gl.VERTEX_SHADER, vert)
-	if err != nil {
+func (r *Renderer_GL33) newShaderProgram(vert, frag, geo, name string, crashWhenFail bool) (s *ShaderProgram_GL33, err error) {
+	var vertObj, fragObj, geoObj, prog uint32
+	if vertObj, err = r.compileShader(gl.VERTEX_SHADER, vert); chkEX(err, "Shader compilation error on "+name+"\n", crashWhenFail) {
 		return nil, err
 	}
-	Logcat("GLES: Vertex Obj created: " + name)
-
-	fragObj, err = r.compileShader(gl.FRAGMENT_SHADER, frag)
-	if err != nil {
+	if fragObj, err = r.compileShader(gl.FRAGMENT_SHADER, frag); chkEX(err, "Shader compilation error on "+name+"\n", crashWhenFail) {
 		return nil, err
 	}
-	Logcat("GLES: Frag Obj created: " + name)
-
-	// IMPORTANT: Geometry shaders are very unstable on GLES 3.2 mobile.
-	// For now, let's force skip them to see if we can reach the main menu.
-	if false && len(geo) > 0 {
-		if geoObj, err := r.compileShader(gl.GEOMETRY_SHADER, geo); chkEX(err, "Shader compliation error on "+name+"\n", crashWhenFail) {
+	if len(geo) > 0 {
+		if geoObj, err = r.compileShader(gl.GEOMETRY_SHADER, geo); chkEX(err, "Shader compilation error on "+name+"\n", crashWhenFail) {
 			return nil, err
-		} else {
-			if prog, err = r.linkProgram(vertObj, fragObj, geoObj); chkEX(err, "Link program error on "+name+"\n", crashWhenFail) {
-				return nil, err
-			}
+		}
+		if prog, err = r.linkProgram(vertObj, fragObj, geoObj); chkEX(err, "Link program error on "+name+"\n", crashWhenFail) {
+			return nil, err
 		}
 	} else {
-		Logcat("GLES: Entering linkProgram...")
-		prog, err = r.linkProgram(vertObj, fragObj)
-		if err != nil {
+		if prog, err = r.linkProgram(vertObj, fragObj); chkEX(err, "Link program error on "+name+"\n", crashWhenFail) {
 			return nil, err
 		}
 	}
-
-	Logcat("GLES: Program linked, creating struct...")
-	s = &ShaderProgram_GLES32{program: prog, name: name}
+	s = &ShaderProgram_GL33{program: prog, name: name}
 	s.attributes = make(map[string]int32)
 	s.uniforms = make(map[string]int32)
 	s.textures = make(map[string]int)
 
-	Logcat("GLES: Shader initialization complete for: " + name)
+	// Debug
+	if r.debugMode {
+		fmt.Printf("[GL Debug] Linked shader '%s' as Program ID: %d\n", name, prog)
+	}
+
 	return s, nil
 }
 
-func (r *ShaderProgram_GLES32) glStr(s string) *uint8 {
+func (r *ShaderProgram_GL33) glStr(s string) *uint8 {
 	return gl.Str(s + "\x00")
 }
 
-func (s *ShaderProgram_GLES32) RegisterAttributes(names ...string) {
+func (s *ShaderProgram_GL33) RegisterAttributes(names ...string) {
+	r := gfx.(*Renderer_GL33)
 	for _, name := range names {
-		cstr := gl.Str(name + "\x00")
-		loc := gl.GetAttribLocation(s.program, cstr)
+		loc := gl.GetAttribLocation(s.program, s.glStr(name))
 		s.attributes[name] = loc
-		Logcat(fmt.Sprintf("GLES: Attribute [%s] mapped to %d", name, loc))
+
+		if r.debugMode && loc == -1 {
+			fmt.Printf("[GL Debug] Shader %v: Attribute '%s' not found!\n", s.name, name)
+		}
 	}
 }
 
-func (s *ShaderProgram_GLES32) RegisterUniforms(names ...string) {
+func (s *ShaderProgram_GL33) RegisterUniforms(names ...string) {
+	r := gfx.(*Renderer_GL33)
 	for _, name := range names {
-		cstr := gl.Str(name + "\x00")
-		loc := gl.GetUniformLocation(s.program, cstr)
+		loc := gl.GetUniformLocation(s.program, s.glStr(name))
 		s.uniforms[name] = loc
-		Logcat(fmt.Sprintf("GLES: Uniform [%s] mapped to %d", name, loc))
+
+		if r.debugMode && loc == -1 {
+			fmt.Printf("[GL Debug] Shader %v: Uniform '%s' not found!\n", s.name, name)
+		}
 	}
 }
 
-func (s *ShaderProgram_GLES32) RegisterTextures(names ...string) {
+func (s *ShaderProgram_GL33) RegisterTextures(names ...string) {
+	r := gfx.(*Renderer_GL33)
 	for _, name := range names {
-		cstr := gl.Str(name + "\x00")
-		loc := gl.GetUniformLocation(s.program, cstr)
+		loc := gl.GetUniformLocation(s.program, s.glStr(name))
 		s.uniforms[name] = loc
 		s.textures[name] = len(s.textures)
-		Logcat(fmt.Sprintf("GLES: Texture [%s] mapped to %d", name, loc))
+
+		if r.debugMode && loc == -1 {
+			fmt.Printf("[GL Debug] Shader %v: Texture uniform '%s' not found or optimized out!\n", s.name, name)
+		}
 	}
 }
 
-func (r *Renderer_GLES32) compileShader(shaderType uint32, src string) (uint32, error) {
-	shader := gl.CreateShader(shaderType)
+func (r *Renderer_GL33) compileShader(shaderType uint32, src string) (shader uint32, err error) {
+	shader = gl.CreateShader(shaderType)
 
-	// 1. SMART HEADER INJECTION
-	// GLES 3.0+ drivers REQUIRE the version to be the very first line.
-	// If your file doesn't have it, we add it here.
-	fullSrc := src
-	if !strings.HasPrefix(strings.TrimSpace(src), "#version") {
-		// Anchor to 300 es for best mobile compatibility
-		header := "#version 310 es\n"
-		fullSrc = header + src
-	}
-
-	// Ensure null-termination for CGO
-	fullSrc = fullSrc + "\x00"
-
-	typeName := "VERTEX"
-	if shaderType == gl.FRAGMENT_SHADER {
-		typeName = "FRAGMENT"
-	}
-
-	Logcat(fmt.Sprintf("GLES: Compiling %s Shader...", typeName))
-	// Logcat("DEBUG SHADER SRC:\n" + fullSrc) // Keep for emergencies
-
-	// 2. MEMORY PINNING
-	csource, free := gl.Strs(fullSrc)
+	src = "#version 330 core\n" + src + "\x00" 
+	s, free := gl.Strs(src)
 	defer free()
 
-	gl.ShaderSource(shader, 1, csource, nil)
+	gl.ShaderSource(shader, 1, s, nil)
 	gl.CompileShader(shader)
 
-	// 3. STATUS CHECK
-	var status int32
-	gl.GetShaderiv(shader, gl.COMPILE_STATUS, (*int32)(unsafe.Pointer(&status)))
-
-	if status == 0 {
-		var logLength int32
-		gl.GetShaderiv(shader, gl.INFO_LOG_LENGTH, (*int32)(unsafe.Pointer(&logLength)))
-
-		if logLength > 0 {
-			logBytes := make([]byte, logLength)
-			gl.GetShaderInfoLog(shader, logLength, nil, (*uint8)(unsafe.Pointer(&logBytes[0])))
-			err := fmt.Errorf("GLES %s Shader Err: %s", typeName, string(logBytes))
-			Logcat("GLES Error: " + err.Error())
-			return 0, err
+	var ok int32
+	gl.GetShaderiv(shader, gl.COMPILE_STATUS, &ok)
+	if ok == 0 {
+		//var err error
+		var size, l int32
+		gl.GetShaderiv(shader, gl.INFO_LOG_LENGTH, &size)
+		if size > 0 {
+			str := make([]byte, size+1)
+			gl.GetShaderInfoLog(shader, size, &l, &str[0])
+			err = Error(str[:l])
+		} else {
+			err = Error("Unknown shader compile error")
 		}
-		return 0, fmt.Errorf("GLES %s Shader Err: Unknown error", typeName)
+		//chk(err)
+		gl.DeleteShader(shader)
+		//panic(Error("Shader compile error"))
+		return 0, err
 	}
-
-	Logcat(fmt.Sprintf("GLES: %s ready.", typeName))
 	return shader, nil
 }
 
-func (r *Renderer_GLES32) linkProgram(params ...uint32) (program uint32, err error) {
+func (r *Renderer_GL33) linkProgram(params ...uint32) (program uint32, err error) {
 	program = gl.CreateProgram()
 	for _, param := range params {
 		gl.AttachShader(program, param)
 	}
-	// if len(params) > 2 {
-	// 	// Geometry Shader Params
-	// 	gl.ProgramParameteri(program, gl.GEOMETRY_INPUT_TYPE, gl.TRIANGLES)
-	// 	gl.ProgramParameteri(program, gl.GEOMETRY_OUTPUT_TYPE, gl.TRIANGLE_STRIP)
-	// 	gl.ProgramParameteri(program, gl.GEOMETRY_VERTICES_OUT, 3*6)
-	// }
-	Logcat("GLES: Linking program...")
+
+	// In GL3.3 this must be in the shader file
+	//if len(params) > 2 {
+	//	// Geometry Shader Params
+	//	gl.ProgramParameteri(program, gl.GEOMETRY_INPUT_TYPE, gl.TRIANGLES)
+	//	gl.ProgramParameteri(program, gl.GEOMETRY_OUTPUT_TYPE, gl.TRIANGLE_STRIP)
+	//	gl.ProgramParameteri(program, gl.GEOMETRY_VERTICES_OUT, 3*6)
+	//}
+
 	gl.LinkProgram(program)
+
 	// Mark shaders for deletion when the program is deleted
 	for _, param := range params {
-		gl.DetachShader(program, param)
 		gl.DeleteShader(param)
 	}
-
 	var ok int32
 	gl.GetProgramiv(program, gl.LINK_STATUS, &ok)
 	if ok == 0 {
+		//var err error
 		var size, l int32
 		gl.GetProgramiv(program, gl.INFO_LOG_LENGTH, &size)
 		if size > 0 {
 			str := make([]byte, size+1)
 			gl.GetProgramInfoLog(program, size, &l, &str[0])
-			err = fmt.Errorf("Link error: %s", string(str[:l]))
+			err = Error(str[:l])
 		} else {
-			err = fmt.Errorf("Unknown link error")
+			err = Error("Unknown link error")
 		}
-		Logcat("GLES: " + err.Error())
+		//chk(err)
 		gl.DeleteProgram(program)
+		//panic(Error("Link error"))
 		return 0, err
 	}
-
-	Logcat("GLES: Link Successful!")
 	return program, nil
 }
 
-// ------------------------------------------------------------------
-// Texture_GLES32
-
-type Texture_GLES32 struct {
+type Texture_GL33 struct {
 	width  int32
 	height int32
 	depth  int32
@@ -224,14 +181,14 @@ type Texture_GLES32 struct {
 }
 
 // Helper that wraps the actual GL call to generate a texture
-func (r *Renderer_GLES32) generateTexture(width, height, depth int32, filter bool) *Texture_GLES32 {
+func (r *Renderer_GL33) generateTexture(width, height, depth int32, filter bool) *Texture_GL33 {
 	var h uint32
 	gl.GenTextures(1, &h)
 
 	// Ensure a unique ID even if GL reuses the handle
 	textureSerialNumber++
 
-	tex := &Texture_GLES32{
+	tex := &Texture_GL33{
 		width:  width,
 		height: height,
 		depth:  depth,
@@ -240,7 +197,7 @@ func (r *Renderer_GLES32) generateTexture(width, height, depth int32, filter boo
 		serial: textureSerialNumber,
 	}
 
-	runtime.SetFinalizer(tex, func(t *Texture_GLES32) {
+	runtime.SetFinalizer(tex, func(t *Texture_GL33) {
 		sys.mainThreadTask <- func() {
 			gl.DeleteTextures(1, &t.handle)
 		}
@@ -250,26 +207,31 @@ func (r *Renderer_GLES32) generateTexture(width, height, depth int32, filter boo
 }
 
 // Creates a generic texture
-func (r *Renderer_GLES32) newTexture(width, height, depth int32, filter bool) Texture {
+func (r *Renderer_GL33) newTexture(width, height, depth int32, filter bool) Texture {
 	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	t := r.generateTexture(width, height, depth, filter)
 
+	format := t.MapInternalFormat(Max(depth, 8))
+	gl.BindTexture(gl.TEXTURE_2D, t.handle)
+	gl.TexImage2D(gl.TEXTURE_2D, 0, int32(format), width, height, 0, format, gl.UNSIGNED_BYTE, nil)
+	gl.BindTexture(gl.TEXTURE_2D, 0)
+
 	return t
 }
 
-func (r *Renderer_GLES32) newPaletteTexture() Texture {
+func (r *Renderer_GL33) newPaletteTexture() Texture {
 	return r.newTexture(256, 1, 32, false)
 }
 
-func (r *Renderer_GLES32) newModelTexture(width, height, depth int32, filter bool) Texture {
+func (r *Renderer_GL33) newModelTexture(width, height, depth int32, filter bool) Texture {
 	return r.newTexture(width, height, depth, filter)
 }
 
-func (r *Renderer_GLES32) newDataTexture(width, height int32) Texture {
+func (r *Renderer_GL33) newDataTexture(width, height int32) Texture {
 	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
-	t := r.generateTexture(width, height, 32, false)
+	t := r.generateTexture(width, height, 128, false)
 
 	gl.BindTexture(gl.TEXTURE_2D, t.handle)
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
@@ -279,10 +241,10 @@ func (r *Renderer_GLES32) newDataTexture(width, height int32) Texture {
 	return t
 }
 
-func (r *Renderer_GLES32) newHDRTexture(width, height int32) Texture {
+func (r *Renderer_GL33) newHDRTexture(width, height int32) Texture {
 	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
-	t := r.generateTexture(width, height, 24, false)
+	t := r.generateTexture(width, height, 96, false)
 
 	gl.BindTexture(gl.TEXTURE_2D, t.handle)
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
@@ -292,7 +254,7 @@ func (r *Renderer_GLES32) newHDRTexture(width, height int32) Texture {
 	return t
 }
 
-func (r *Renderer_GLES32) newCubeMapTexture(widthHeight int32, mipmap bool, lowestMipLevel int32) Texture {
+func (r *Renderer_GL33) newCubeMapTexture(widthHeight int32, mipmap bool, lowestMipLevel int32) Texture {
 	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	t := r.generateTexture(widthHeight, widthHeight, 24, false)
@@ -316,18 +278,15 @@ func (r *Renderer_GLES32) newCubeMapTexture(widthHeight int32, mipmap bool, lowe
 }
 
 // Bind a texture and upload texel data to it
-func (t *Texture_GLES32) SetData(data []byte) {
+func (t *Texture_GL33) SetData(data []byte) {
 	var interp int32 = gl.NEAREST
 	if t.filter {
 		interp = gl.LINEAR
 	}
 
-	bits := Max(t.depth, 8)
-	internalFormat := t.MapSizedInternalFormat(bits)
-	uploadFormat := t.MapUploadFormat(bits)
-	uploadType := t.MapUploadType(bits)
+	format := t.MapInternalFormat(Max(t.depth, 8))
 
-	r := gfx.(*Renderer_GLES32)
+	r := gfx.(*Renderer_GL33)
 	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	gl.BindTexture(gl.TEXTURE_2D, t.handle)
@@ -335,9 +294,9 @@ func (t *Texture_GLES32) SetData(data []byte) {
 	gl.PixelStorei(gl.UNPACK_ROW_LENGTH, 0)
 
 	if data != nil {
-		gl.TexImage2D(gl.TEXTURE_2D, 0, int32(internalFormat), t.width, t.height, 0, uploadFormat, uploadType, unsafe.Pointer(&data[0]))
+		gl.TexImage2D(gl.TEXTURE_2D, 0, int32(format), t.width, t.height, 0, format, gl.UNSIGNED_BYTE, unsafe.Pointer(&data[0]))
 	} else {
-		gl.TexImage2D(gl.TEXTURE_2D, 0, int32(internalFormat), t.width, t.height, 0, uploadFormat, uploadType, nil)
+		gl.TexImage2D(gl.TEXTURE_2D, 0, int32(format), t.width, t.height, 0, format, gl.UNSIGNED_BYTE, nil)
 	}
 
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, interp)
@@ -346,51 +305,38 @@ func (t *Texture_GLES32) SetData(data []byte) {
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
 }
 
-func (t *Texture_GLES32) SetSubData(data []byte, x, y, width, height, stride int32) {
+func (t *Texture_GL33) SetSubData(data []byte, x, y, width, height, stride int32) {
 	var interp int32 = gl.NEAREST
 	if t.filter {
 		interp = gl.LINEAR
 	}
 
-	r := gfx.(*Renderer_GLES32)
+	r := gfx.(*Renderer_GL33)
 	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	gl.BindTexture(gl.TEXTURE_2D, t.handle)
 	gl.PixelStorei(gl.UNPACK_ALIGNMENT, 1)
 
-	bits := Max(t.depth, 8)
-	uploadFormat := t.MapUploadFormat(bits)
-	uploadType := t.MapUploadType(bits)
+	format := t.MapInternalFormat(Max(t.depth, 8))
 	bytesPerPixel := t.depth / 8
 	if bytesPerPixel < 1 {
 		bytesPerPixel = 1
 	}
 
-	var rowLength int32 = 0
-	if stride != width*bytesPerPixel {
-		rowLength = stride / bytesPerPixel
-	}
-
-	gl.PixelStorei(gl.UNPACK_ROW_LENGTH, rowLength)
-
-	ptr := unsafe.Pointer(nil)
-	if data != nil {
-		ptr = unsafe.Pointer(&data[0])
-	}
-
-	if data != nil {
-		gl.TexSubImage2D(gl.TEXTURE_2D, 0, x, y, width, height, uint32(uploadFormat), uploadType, ptr)
+	// Doing this should respect both Linux and Android requirements
+	if stride > 0 && stride != width*bytesPerPixel {
+		gl.PixelStorei(gl.UNPACK_ROW_LENGTH, stride/bytesPerPixel)
 	} else {
-		gl.TexSubImage2D(gl.TEXTURE_2D, 0, x, y, width, height, uint32(uploadFormat), uploadType, nil)
-	}
-
-	if err := gl.GetError(); err != 0 {
-		Logcat(fmt.Sprintf("GL ERROR in SetSubData: %v | w:%d h:%d s:%d", err, width, height, stride))
-	}
-
-	if rowLength != 0 {
 		gl.PixelStorei(gl.UNPACK_ROW_LENGTH, 0)
 	}
+
+	if data != nil {
+		gl.TexSubImage2D(gl.TEXTURE_2D, 0, x, y, width, height, uint32(format), gl.UNSIGNED_BYTE, unsafe.Pointer(&data[0]))
+	} else {
+		gl.TexSubImage2D(gl.TEXTURE_2D, 0, x, y, width, height, uint32(format), gl.UNSIGNED_BYTE, nil)
+	}
+
+	gl.PixelStorei(gl.UNPACK_ROW_LENGTH, 0)
 
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, interp)
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, interp)
@@ -398,153 +344,105 @@ func (t *Texture_GLES32) SetSubData(data []byte, x, y, width, height, stride int
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
 }
 
-func (t *Texture_GLES32) SetDataG(data []byte, mag, min, ws, wt TextureSamplingParam) {
-	bits := Max(t.depth, 8)
-	internalFormat := t.MapSizedInternalFormat(bits)
-	uploadFormat := t.MapUploadFormat(bits)
-	uploadType := t.MapUploadType(bits)
+func (t *Texture_GL33) SetDataG(data []byte, mag, min, ws, wt TextureSamplingParam) {
+	format := t.MapInternalFormat(Max(t.depth, 8))
 
-	r := gfx.(*Renderer_GLES32)
+	r := gfx.(*Renderer_GL33)
 	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	gl.BindTexture(gl.TEXTURE_2D, t.handle)
 	gl.PixelStorei(gl.UNPACK_ALIGNMENT, 1)
 	gl.PixelStorei(gl.UNPACK_ROW_LENGTH, 0)
-	gl.TexImage2D(gl.TEXTURE_2D, 0, int32(internalFormat), t.width, t.height, 0, uploadFormat, uploadType, unsafe.Pointer(&data[0]))
+	gl.TexImage2D(gl.TEXTURE_2D, 0, int32(format), t.width, t.height, 0, format, gl.UNSIGNED_BYTE, unsafe.Pointer(&data[0]))
 	gl.GenerateMipmap(gl.TEXTURE_2D)
-	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, int32(mag))
-	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, int32(min))
-	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, int32(ws))
-	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, int32(wt))
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, t.MapTextureSamplingParam(mag))
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, t.MapTextureSamplingParam(min))
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, t.MapTextureSamplingParam(ws))
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, t.MapTextureSamplingParam(wt))
 }
 
-func (t *Texture_GLES32) SetPixelData(data []float32) {
-	r := gfx.(*Renderer_GLES32)
+func (t *Texture_GL33) SetPixelData(data []float32) {
+	format := t.MapInternalFormat(Max(t.depth/4, 8))
+	internalFormat := t.MapInternalFormat(Max(t.depth, 8))
+
+	r := gfx.(*Renderer_GL33)
 	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	gl.BindTexture(gl.TEXTURE_2D, t.handle)
 	gl.PixelStorei(gl.UNPACK_ALIGNMENT, 1)
 	gl.PixelStorei(gl.UNPACK_ROW_LENGTH, 0)
-	gl.TexImage2D(gl.TEXTURE_2D, 0, gl.RGBA32F, t.width, t.height, 0, gl.RGBA, gl.FLOAT, unsafe.Pointer(&data[0]))
+	gl.TexImage2D(gl.TEXTURE_2D, 0, int32(internalFormat), t.width, t.height, 0, uint32(format), gl.FLOAT, unsafe.Pointer(&data[0]))
 }
 
-func (t Texture_GLES32) CopyData(src *Texture) {
-	r := gfx.(*Renderer_GLES32)
-	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
+func (t Texture_GL33) CopyData(src *Texture) {
 
-	gl.BindTexture(gl.TEXTURE_2D, 0) // Unbind whatever is currently bound
-	srcES := (*src).(*Texture_GLES32)
-	var fbo uint32
-	gl.GenFramebuffers(1, &fbo)
-	gl.BindFramebuffer(gl.READ_FRAMEBUFFER, fbo)
-	gl.FramebufferTexture2D(gl.READ_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, srcES.handle, 0)
-
-	gl.BindTexture(gl.TEXTURE_2D, t.handle)
-	// Copy the old texture data into the top-left of the new, larger texture
-	gl.CopyTexSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 0, 0, srcES.width, srcES.height)
-
-	gl.BindFramebuffer(gl.READ_FRAMEBUFFER, 0)
-	gl.DeleteFramebuffers(1, &fbo)
 }
-
-/*
-// Not called anywhere
-func (t *Texture_GLES32) SetRGBPixelData(data []float32) {
-	r := gfx.(*Renderer_GLES32)
-	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
-
-	gl.BindTexture(gl.TEXTURE_2D, t.handle)
-	gl.PixelStorei(gl.UNPACK_ALIGNMENT, 1)
-	gl.PixelStorei(gl.UNPACK_ROW_LENGTH, 0)
-	gl.TexImage2D(gl.TEXTURE_2D, 0, gl.RGB32F, t.width, t.height, 0, gl.RGB, gl.FLOAT, unsafe.Pointer(&data[0]))
-}
-*/
 
 // Return whether texture has a valid handle
-func (t *Texture_GLES32) IsValid() bool {
+func (t *Texture_GL33) IsValid() bool {
 	return t.width != 0 && t.height != 0 && t.handle != 0
 }
 
-func (t *Texture_GLES32) GetWidth() int32 {
+func (t *Texture_GL33) GetWidth() int32 {
 	return t.width
 }
 
-func (t *Texture_GLES32) GetHeight() int32 {
+func (t *Texture_GL33) GetHeight() int32 {
 	return t.height
 }
 
-func (t *Texture_GLES32) MapUploadType(i int32) uint32 {
-	switch i {
-	case 96, 128:
-		return gl.FLOAT
-	default:
-		return gl.UNSIGNED_BYTE
+func (t *Texture_GL33) MapInternalFormat(i int32) uint32 {
+	var InternalFormatLUT = map[int32]uint32{
+		8:   gl.RED,
+		24:  gl.RGB,
+		32:  gl.RGBA,
+		96:  gl.RGB32F,
+		128: gl.RGBA32F,
 	}
+	return InternalFormatLUT[i]
 }
 
-func (t *Texture_GLES32) MapUploadFormat(i int32) uint32 {
-	switch i {
-	case 8:
-		return gl.RED
-	case 24:
-		return gl.RGB
-	case 32:
-		return gl.RGBA
-	case 96:
-		return gl.RGB
-	case 128:
-		return gl.RGBA
-	default:
-		return gl.RGBA
+func (t *Texture_GL33) MapTextureSamplingParam(i TextureSamplingParam) int32 {
+	var SamplingParam = map[TextureSamplingParam]int32{
+		TextureSamplingFilterNearest:              gl.NEAREST,
+		TextureSamplingFilterLinear:               gl.LINEAR,
+		TextureSamplingFilterNearestMipMapNearest: gl.NEAREST_MIPMAP_NEAREST,
+		TextureSamplingFilterLinearMipMapNearest:  gl.LINEAR_MIPMAP_NEAREST,
+		TextureSamplingFilterNearestMipMapLinear:  gl.NEAREST_MIPMAP_LINEAR,
+		TextureSamplingFilterLinearMipMapLinear:   gl.LINEAR_MIPMAP_LINEAR,
+		TextureSamplingWrapClampToEdge:            gl.CLAMP_TO_EDGE,
+		TextureSamplingWrapMirroredRepeat:         gl.MIRRORED_REPEAT,
+		TextureSamplingWrapRepeat:                 gl.REPEAT,
 	}
+	return SamplingParam[i]
 }
 
-func (t *Texture_GLES32) MapSizedInternalFormat(i int32) uint32 {
-	switch i {
-	case 8:
-		return gl.R8
-	case 24:
-		return gl.RGB8
-	case 32:
-		return gl.RGBA8
-	case 96:
-		return gl.RGB32F
-	case 128:
-		return gl.RGBA32F
-	default:
-		return gl.RGBA8
-	}
-}
-
-// ------------------------------------------------------------------
-// Renderer_GLES32
-
-type Renderer_GLES32 struct {
+type Renderer_GL33 struct {
 	fbo         uint32
 	fbo_texture uint32
 	// Normal rendering
 	rbo_depth uint32
 	// MSAA rendering
 	fbo_f         uint32
-	fbo_f_texture *Texture_GLES32
+	fbo_f_texture *Texture_GL33
 	// Shadow Map
-	fbo_shadow               uint32
-	fbo_shadow_cube_textures [4]uint32
-	fbo_env                  uint32
-	// Postprocessing FBOs
+	fbo_shadow              uint32
+	fbo_shadow_cube_texture uint32
+	fbo_env                 uint32
+	// Post-processing FBOs
 	fbo_pp         []uint32
 	fbo_pp_texture []uint32
 	// Post-processing shaders
 	postVertBuffer   uint32
-	postShaderSelect []*ShaderProgram_GLES32
+	postShaderSelect []*ShaderProgram_GL33
 	// Shader and vertex data for primitive rendering
-	spriteShader *ShaderProgram_GLES32
+	spriteShader *ShaderProgram_GL33
 	vertexBuffer uint32
 	// Shader and index data for 3D model rendering
-	shadowMapShader         *ShaderProgram_GLES32
-	modelShader             *ShaderProgram_GLES32
-	panoramaToCubeMapShader *ShaderProgram_GLES32
-	cubemapFilteringShader  *ShaderProgram_GLES32
+	shadowMapShader         *ShaderProgram_GL33
+	modelShader             *ShaderProgram_GL33
+	panoramaToCubeMapShader *ShaderProgram_GL33
+	cubemapFilteringShader  *ShaderProgram_GL33
 	modelVertexBuffer       [2]uint32
 	modelIndexBuffer        [2]uint32
 	spriteVAO               uint32
@@ -553,9 +451,11 @@ type Renderer_GLES32 struct {
 
 	enableModel  bool
 	enableShadow bool
-	GLES32State
+	debugMode    bool
+	GL33State
 }
-type GLES32State struct {
+
+type GL33State struct {
 	program             uint32
 	depthTest           bool
 	depthMask           bool
@@ -584,12 +484,12 @@ type GLES32State struct {
 	useOutlineAttribute bool
 }
 
-func (r *Renderer_GLES32) GetName() string {
-	return "OpenGL ES 3.2"
+func (r *Renderer_GL33) GetName() string {
+	return "OpenGL 3.3"
 }
 
 // init 3D model shader
-func (r *Renderer_GLES32) InitModelShader() error {
+func (r *Renderer_GL33) InitModelShader() error {
 	var err error
 	if r.enableShadow {
 		r.modelShader, err = r.newShaderProgram(modelVertShader, "#define ENABLE_SHADOW\n"+modelFragShader, "", "Model Shader", false)
@@ -612,11 +512,12 @@ func (r *Renderer_GLES32) InitModelShader() error {
 		"lights[2].direction", "lights[2].range", "lights[2].color", "lights[2].intensity", "lights[2].position", "lights[2].innerConeCos", "lights[2].outerConeCos", "lights[2].type", "lights[2].shadowBias", "lights[2].shadowMapFar",
 		"lights[3].direction", "lights[3].range", "lights[3].color", "lights[3].intensity", "lights[3].position", "lights[3].innerConeCos", "lights[3].outerConeCos", "lights[3].type", "lights[3].shadowBias", "lights[3].shadowMapFar",
 	)
+
 	r.modelShader.RegisterTextures(
 		"tex", "morphTargetValues", "jointMatrices",
 		"normalMap", "metallicRoughnessMap", "ambientOcclusionMap", "emissionMap",
 		"lambertianEnvSampler", "GGXEnvSampler", "GGXLUT",
-		"shadowCubeMap0", "shadowCubeMap1", "shadowCubeMap2", "shadowCubeMap3",
+		"shadowCubeMap",
 	)
 
 	if r.enableShadow {
@@ -627,10 +528,14 @@ func (r *Renderer_GLES32) InitModelShader() error {
 
 		r.shadowMapShader.RegisterAttributes("vertexId", "position", "vertColor", "uv", "joints_0", "joints_1", "weights_0", "weights_1")
 
-		r.shadowMapShader.RegisterUniforms("model", "lightMatrix",
+		r.shadowMapShader.RegisterUniforms("model", "lightMatrices[0]", "lightMatrices[1]", "lightMatrices[2]", "lightMatrices[3]", "lightMatrices[4]", "lightMatrices[5]",
+			"lightMatrices[6]", "lightMatrices[7]", "lightMatrices[8]", "lightMatrices[9]", "lightMatrices[10]", "lightMatrices[11]",
+			"lightMatrices[12]", "lightMatrices[13]", "lightMatrices[14]", "lightMatrices[15]", "lightMatrices[16]", "lightMatrices[17]",
+			"lightMatrices[18]", "lightMatrices[19]", "lightMatrices[20]", "lightMatrices[21]", "lightMatrices[22]", "lightMatrices[23]",
 			"lights[0].type", "lights[1].type", "lights[2].type", "lights[3].type", "lights[0].position", "lights[1].position", "lights[2].position", "lights[3].position",
 			"lights[0].shadowMapFar", "lights[1].shadowMapFar", "lights[2].shadowMapFar", "lights[3].shadowMapFar", "numJoints", "morphTargetWeight", "morphTargetOffset", "morphTargetTextureDimension",
 			"numTargets", "numVertices", "enableAlpha", "alphaThreshold", "baseColorFactor", "useTexture", "texTransform", "layerOffset", "lightIndex")
+
 		r.shadowMapShader.RegisterTextures("morphTargetValues", "jointMatrices", "tex")
 	}
 	r.panoramaToCubeMapShader, err = r.newShaderProgram(identVertShader, panoramaToCubeMapFragShader, "", "Panorama To Cubemap Shader", false)
@@ -653,25 +558,16 @@ func (r *Renderer_GLES32) InitModelShader() error {
 
 // Render initialization.
 // Creates the default shaders, the framebuffer and enables MSAA.
-func (r *Renderer_GLES32) Init() {
-	chk(gl.Init(func(name string) unsafe.Pointer {
-		return eglGetProcAddress(name)
-	}))
-	if runtime.GOOS != "android" {
-		sys.errLog.Printf("Using OpenGL %v (%v)", gl.GoStr(gl.GetString(gl.VERSION)), gl.GoStr(gl.GetString(gl.RENDERER)))
-	} else {
-		Logcat(fmt.Sprintf("Using OpenGL %v (%v)", gl.GoStr(gl.GetString(gl.VERSION)), gl.GoStr(gl.GetString(gl.RENDERER))))
-	}
+func (r *Renderer_GL33) Init() {
+	chk(gl.Init())
+	sys.errLog.Printf("Using OpenGL %v (%v)", gl.GoStr(gl.GetString(gl.VERSION)), gl.GoStr(gl.GetString(gl.RENDERER)))
 
-	// Logcat("GLES: Querying Max Samples")
-	// var maxSamples int32
-	// gl.GetIntegerv(gl.MAX_SAMPLES, &maxSamples)
-	// if sys.msaa > maxSamples {
-	// 	sys.cfg.SetValueUpdate("Video.MSAA", maxSamples)
-	// 	sys.msaa = maxSamples
-	// }
-	sys.msaa = 0
-	Logcat("GLES: Past MSAA check")
+	var maxSamples int32
+	gl.GetIntegerv(gl.MAX_SAMPLES, &maxSamples)
+	if sys.msaa > maxSamples {
+		sys.cfg.SetValueUpdate("Video.MSAA", maxSamples)
+		sys.msaa = maxSamples
+	}
 
 	// Data buffers for rendering
 	postVertData := f32.Bytes(binary.LittleEndian, -1, -1, 1, -1, -1, 1, 1, 1)
@@ -679,39 +575,24 @@ func (r *Renderer_GLES32) Init() {
 	r.enableModel = sys.cfg.Video.EnableModel
 	r.enableShadow = sys.cfg.Video.EnableModelShadow
 
+	if sys.cfg.Video.RendererDebugMode {
+		r.EnableDebug()
+	}
+
 	// Generate VAO's
 	gl.GenVertexArrays(1, &r.spriteVAO)
 	gl.GenVertexArrays(1, &r.modelVAO)
 	gl.GenVertexArrays(1, &r.postVAO)
-	Logcat("GLES: Sprite, model and post VAO's generated")
-
-	//Logcat("GLES: VAO Bound")
 
 	// Generate buffers
 	gl.GenBuffers(1, &r.vertexBuffer)
-	Logcat("GLES: VertexBuffer Generated")
-
-	gl.GenBuffers(1, &r.modelVertexBuffer[0])
-	gl.GenBuffers(1, &r.modelVertexBuffer[1])
-	Logcat("GLES: ModelVertexBuffers Generated")
-
-	gl.GenBuffers(1, &r.modelIndexBuffer[0])
-	gl.GenBuffers(1, &r.modelIndexBuffer[1])
-	Logcat("GLES: ModelIndexBuffers Generated")
-
+	gl.GenBuffers(2, &r.modelVertexBuffer[0])
+	gl.GenBuffers(2, &r.modelIndexBuffer[0])
 	gl.GenBuffers(1, &r.postVertBuffer)
-	Logcat("GLES: PostVertBuffer Generated")
 
 	// Initialize post-processing vertex buffer
 	gl.BindBuffer(gl.ARRAY_BUFFER, r.postVertBuffer)
-	Logcat(fmt.Sprintf("GLES: Data Size: %d", len(postVertData)))
-
-	if len(postVertData) > 0 {
-		gl.BufferData(gl.ARRAY_BUFFER, len(postVertData), unsafe.Pointer(&postVertData[0]), gl.STATIC_DRAW)
-		Logcat("GLES: PostVertBuffer Data Uploaded")
-	} else {
-		Logcat("GLES: ERROR - postVertData is empty!")
-	}
+	gl.BufferData(gl.ARRAY_BUFFER, len(postVertData), unsafe.Pointer(&postVertData[0]), gl.STATIC_DRAW)
 
 	// Unbind for safety
 	gl.BindBuffer(gl.ARRAY_BUFFER, 0)
@@ -744,11 +625,11 @@ func (r *Renderer_GLES32) Init() {
 		}
 	}
 
-	// Compile postprocessing shaders
+	// Compile post-processing shaders
 	// Because we only have one VAO, the attributes will only be set in EndFrame()
 
 	// Pre-allocate the shader slice to accommodate all external shaders plus the identity shader
-	r.postShaderSelect = make([]*ShaderProgram_GLES32, len(sys.cfg.Video.ExternalShaders)+1)
+	r.postShaderSelect = make([]*ShaderProgram_GL33, len(sys.cfg.Video.ExternalShaders)+1)
 
 	// Configure postVAO
 	gl.BindVertexArray(r.postVAO)
@@ -759,7 +640,7 @@ func (r *Renderer_GLES32) Init() {
 		r.postShaderSelect[i], _ = r.newShaderProgram(string(sys.externalShaders[0][i])+"\x00", string(sys.externalShaders[1][i])+"\x00",
 			"", fmt.Sprintf("Postprocess Shader #%v", i), true)
 		r.postShaderSelect[i].RegisterAttributes("VertCoord") // "TexCoord" was registered but never used
-		r.postShaderSelect[i].RegisterUniforms("Texture_GLES32", "TextureSize", "CurrentTime")
+		r.postShaderSelect[i].RegisterUniforms("Texture_GL33", "TextureSize", "CurrentTime")
 
 		// Configure postVAO for this specific shader's attribute location
 		if loc, ok := r.postShaderSelect[i].attributes["VertCoord"]; ok && loc >= 0 {
@@ -768,10 +649,10 @@ func (r *Renderer_GLES32) Init() {
 		}
 	}
 
-	// Identity shader (no postprocessing). This should be the last one in modern OpenGL
+	// Identity shader (no post-processing)
 	identShader, _ := r.newShaderProgram(identVertShader, identFragShader, "", "Identity Postprocess", true)
 	identShader.RegisterAttributes("VertCoord")
-	//identShader.RegisterUniforms("Texture_GLES32", "TextureSize", "CurrentTime") // None of these are used
+	//identShader.RegisterUniforms("Texture_GL33", "TextureSize", "CurrentTime") // None of these are used
 
 	// Configure postVAO for the identity shader's attribute location
 	if loc, ok := identShader.attributes["VertCoord"]; ok && loc >= 0 {
@@ -786,33 +667,55 @@ func (r *Renderer_GLES32) Init() {
 	gl.BindVertexArray(0)
 	gl.BindBuffer(gl.ARRAY_BUFFER, 0)
 
+	// Toggle MSAA first
+	if sys.msaa > 0 {
+		gl.Enable(gl.MULTISAMPLE)
+	} else {
+		gl.Disable(gl.MULTISAMPLE)
+	}
+
 	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	// create a texture for r.fbo
 	gl.GenTextures(1, &r.fbo_texture)
 	textureSerialNumber++
 
-	gl.BindTexture(gl.TEXTURE_2D, r.fbo_texture)
-
-	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
-	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
-	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
-	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+	// Match texture storage type to the MSAA setting
+	if sys.msaa > 0 {
+		gl.BindTexture(gl.TEXTURE_2D_MULTISAMPLE, r.fbo_texture)
+		// Multisample textures do not support TexParameteri
+	} else {
+		gl.BindTexture(gl.TEXTURE_2D, r.fbo_texture)
+		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
+		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
+		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+	}
 
 	// Don't change this from gl.RGBA.
 	// It breaks mixing between subtractive and additive.
-	Logcat("GLES: Creating RGBA Textures")
-	gl.TexImage2D(
-		gl.TEXTURE_2D,
-		0,
-		gl.RGBA,
-		sys.scrrect[2],
-		sys.scrrect[3],
-		0,
-		gl.RGBA,
-		gl.UNSIGNED_BYTE,
-		nil,
-	)
+	if sys.msaa > 0 {
+		gl.TexImage2DMultisample(
+			gl.TEXTURE_2D_MULTISAMPLE,
+			sys.msaa,
+			gl.RGBA,
+			sys.scrrect[2],
+			sys.scrrect[3],
+			true,
+		)
+	} else {
+		gl.TexImage2D(
+			gl.TEXTURE_2D,
+			0,
+			gl.RGBA,
+			sys.scrrect[2],
+			sys.scrrect[3],
+			0,
+			gl.RGBA,
+			gl.UNSIGNED_BYTE,
+			nil,
+		)
+	}
 
 	r.fbo_pp = make([]uint32, 2)
 	r.fbo_pp_texture = make([]uint32, 2)
@@ -843,7 +746,11 @@ func (r *Renderer_GLES32) Init() {
 	}
 
 	// done with r.fbo_texture, unbind it
-	gl.BindTexture(gl.TEXTURE_2D, 0)
+	if sys.msaa > 0 {
+		gl.BindTexture(gl.TEXTURE_2D_MULTISAMPLE, 0)
+	} else {
+		gl.BindTexture(gl.TEXTURE_2D, 0)
+	}
 
 	//r.rbo_depth = gl.CreateRenderbuffer()
 	gl.GenRenderbuffers(1, &r.rbo_depth)
@@ -857,7 +764,7 @@ func (r *Renderer_GLES32) Init() {
 	}
 	gl.BindRenderbuffer(gl.RENDERBUFFER, 0)
 	if sys.msaa > 0 {
-		r.fbo_f_texture = r.newTexture(sys.scrrect[2], sys.scrrect[3], 32, false).(*Texture_GLES32)
+		r.fbo_f_texture = r.newTexture(sys.scrrect[2], sys.scrrect[3], 32, false).(*Texture_GL33)
 		r.fbo_f_texture.SetData(nil)
 	} else {
 		//r.rbo_depth = gl.CreateRenderbuffer()
@@ -885,7 +792,7 @@ func (r *Renderer_GLES32) Init() {
 		gl.FramebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, r.rbo_depth)
 	}
 
-	// create our two FBOs for our postprocessing needs
+	// create our two FBOs for our post-processing needs
 	for i := 0; i < 2; i++ {
 		gl.GenFramebuffers(1, &(r.fbo_pp[i]))
 		gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_pp[i])
@@ -895,46 +802,24 @@ func (r *Renderer_GLES32) Init() {
 	// create an FBO for our model stuff
 	if r.enableModel {
 		if r.enableShadow {
-			// create FBO for shadow rendering
 			gl.GenFramebuffers(1, &r.fbo_shadow)
 			r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
+			gl.GenTextures(1, &r.fbo_shadow_cube_texture)
+			textureSerialNumber++
 
-			// create 4 separate GL_TEXTURE_CUBE_MAP textures (one per shadow caster/light)
-			gl.GenTextures(4, &r.fbo_shadow_cube_textures[0])
-			textureSerialNumber += 4
+			gl.BindTexture(gl.TEXTURE_CUBE_MAP_ARRAY_ARB, r.fbo_shadow_cube_texture)
+			gl.TexStorage3D(gl.TEXTURE_CUBE_MAP_ARRAY_ARB, 1, gl.DEPTH_COMPONENT24, 1024, 1024, 4*6)
+			gl.TexParameteri(gl.TEXTURE_CUBE_MAP_ARRAY_ARB, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
+			gl.TexParameteri(gl.TEXTURE_CUBE_MAP_ARRAY_ARB, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
+			gl.TexParameteri(gl.TEXTURE_CUBE_MAP_ARRAY_ARB, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+			gl.TexParameteri(gl.TEXTURE_CUBE_MAP_ARRAY_ARB, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
 
-			for i := 0; i < 4; i++ {
-				// bind and allocate each cube-map's 6 faces as depth textures
-				gl.ActiveTexture(uint32(gl.TEXTURE0 + uint32(i)))
-				gl.BindTexture(gl.TEXTURE_CUBE_MAP, r.fbo_shadow_cube_textures[i])
-
-				// Allocate depth storage for each face
-				for face := 0; face < 6; face++ {
-					gl.TexImage2D(
-						uint32(gl.TEXTURE_CUBE_MAP_POSITIVE_X)+uint32(face),
-						0,
-						gl.DEPTH_COMPONENT24,
-						1024, 1024,
-						0,
-						gl.DEPTH_COMPONENT,
-						gl.UNSIGNED_INT,
-						nil,
-					)
-				}
-
-				gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
-				gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
-				gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
-				gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
-				// Note: GL_TEXTURE_WRAP_R can also be set if desired:
-				// gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_WRAP_R, gl.CLAMP_TO_EDGE)
-			}
-
-			// Create (empty) FBO. We'll attach the proper cube-face when rendering each face.
 			gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_shadow)
-			// Leave the depth attachment empty here — attach per-face with FramebufferTexture2D()
-			// Restore default framebuffer binding
-			gl.BindFramebuffer(gl.FRAMEBUFFER, 0)
+			gl.DrawBuffer(gl.NONE)
+			gl.ReadBuffer(gl.NONE)
+			if status := gl.CheckFramebufferStatus(gl.FRAMEBUFFER); status != gl.FRAMEBUFFER_COMPLETE {
+				sys.errLog.Printf("framebuffer create failed: 0x%x", status)
+			}
 		}
 		gl.GenFramebuffers(1, &r.fbo_env)
 	}
@@ -944,10 +829,10 @@ func (r *Renderer_GLES32) Init() {
 	r.InitStateCache()
 }
 
-func (r *Renderer_GLES32) Close() {
+func (r *Renderer_GL33) Close() {
 }
 
-func (r *Renderer_GLES32) InitStateCache() {
+func (r *Renderer_GL33) InitStateCache() {
 	// Match standard OpenGL hardware defaults
 	r.program = 0
 	r.depthTest = false
@@ -971,9 +856,9 @@ func (r *Renderer_GLES32) InitStateCache() {
 	var maxTex int32
 	gl.GetIntegerv(gl.MAX_TEXTURE_IMAGE_UNITS, &maxTex)
 
-	//if r.debugMode {
-	//	fmt.Printf("[GL Debug] GPU supports up to %d textures\n", maxTex)
-	//}
+	if r.debugMode {
+		fmt.Printf("[GL Debug] GPU supports up to %d textures\n", maxTex)
+	}
 
 	// Initialize sprite texture cache
 	r.texCacheTexSerial = make([]uint64, maxTex)
@@ -987,19 +872,159 @@ func (r *Renderer_GLES32) InitStateCache() {
 	r.uniformF4Cache = make(map[uint32][4]float32, 32)
 }
 
-func (r *Renderer_GLES32) EnableDebug() {
-	// Do nothing yet
+func (r *Renderer_GL33) EnableDebug() {
+	r.debugMode = true
+	gl.Enable(gl.DEBUG_OUTPUT)
+	gl.Enable(gl.DEBUG_OUTPUT_SYNCHRONOUS)
+
+	gl.DebugMessageCallback(func(
+		source uint32,
+		gltype uint32,
+		id uint32,
+		severity uint32,
+		length int32,
+		message string,
+		userParam unsafe.Pointer) {
+
+		if severity == gl.DEBUG_SEVERITY_NOTIFICATION {
+			return
+		}
+
+		fmt.Printf("[GL Debug] %s\n", message)
+
+		// Crash here so the log catches it
+		if severity == gl.DEBUG_SEVERITY_HIGH {
+			panic("Critical OpenGL Error Detected!")
+		}
+	}, nil)
+
+	fmt.Printf("[GL Debug] Debug mode enabled\n")
 }
 
-func (r *Renderer_GLES32) IsModelEnabled() bool {
+/*
+func (r *Renderer_GL33) DebugCheckLeaks(nextprog uint32) {
+	// Only query attributes if a VAO is bound
+	var currentVAO int32
+	gl.GetIntegerv(gl.VERTEX_ARRAY_BINDING, &currentVAO)
+	if currentVAO == 0 {
+		return 
+	}
+
+	var enabled int32
+	leaked := []int{}
+	// Only check up to the hardware limit
+	for slot := uint32(0); slot < 16; slot++ {
+		gl.GetVertexAttribiv(slot, gl.VERTEX_ATTRIB_ARRAY_ENABLED, &enabled)
+		if enabled != 0 {
+			leaked = append(leaked, int(slot))
+		}
+	}
+	if len(leaked) > 0 {
+		fmt.Printf("[GL Debug] Changing to program %d with attributes %v enabled in VAO %d.\n", nextprog, leaked, currentVAO)
+	}
+}
+*/
+
+func (r *Renderer_GL33) DebugVerifyCache() {
+	if !r.debugMode {
+		return
+	}
+
+	// Program and global toggle states
+	var hwProg int32
+	gl.GetIntegerv(gl.CURRENT_PROGRAM, &hwProg)
+	if uint32(hwProg) != r.program {
+		fmt.Printf("[GL Cache Error] Program mismatch! Cache: %d, HW: %d\n", r.program, hwProg)
+	}
+
+	if gl.IsEnabled(gl.DEPTH_TEST) != r.depthTest {
+		fmt.Printf("[GL Cache Error] DepthTest mismatch! Cache: %v, HW: %v\n", r.depthTest, !r.depthTest)
+	}
+
+	var depthMask bool
+	gl.GetBooleanv(gl.DEPTH_WRITEMASK, &depthMask)
+	if depthMask != r.depthMask {
+		fmt.Printf("[GL Cache Error] DepthMask mismatch! Cache: %v, HW: %v\n", r.depthMask, depthMask)
+	}
+
+	// doubleSided = true means CULL_FACE is DISABLED
+	if (gl.IsEnabled(gl.CULL_FACE) == false) != r.doubleSided {
+		fmt.Printf("[GL Cache Error] DoubleSided mismatch! Cache: %v, HW: %v\n", r.doubleSided, !r.doubleSided)
+	}
+
+	var frontFace int32
+	gl.GetIntegerv(gl.FRONT_FACE, &frontFace)
+	if (frontFace == gl.CW) != r.invertFrontFace {
+		fmt.Printf("[GL Cache Error] FrontFace mismatch! Cache: %v, HW: %v\n", r.invertFrontFace, frontFace == gl.CW)
+	}
+
+	if gl.IsEnabled(gl.BLEND) != r.blendEnabled {
+		fmt.Printf("[GL Cache Error] BlendEnabled mismatch! Cache: %v, HW: %v\n", r.blendEnabled, !r.blendEnabled)
+	}
+
+	if gl.IsEnabled(gl.SCISSOR_TEST) != r.scissorEnabled {
+		fmt.Printf("[GL Cache Error] ScissorEnabled mismatch! Cache: %v, HW: %v\n", r.scissorEnabled, !r.scissorEnabled)
+	}
+
+	// We only care about these if the corresponding test is enabled.
+	if r.blendEnabled {
+		var eq, src, dst int32
+		gl.GetIntegerv(gl.BLEND_EQUATION_RGB, &eq)
+		gl.GetIntegerv(gl.BLEND_SRC_RGB, &src)
+		gl.GetIntegerv(gl.BLEND_DST_RGB, &dst)
+		if uint32(eq) != r.MapBlendEquation(r.blendEquation) {
+			fmt.Printf("[GL Cache Error] BlendEquation mismatch!\n")
+		}
+		if uint32(src) != r.MapBlendFunction(r.blendSrc) || uint32(dst) != r.MapBlendFunction(r.blendDst) {
+			fmt.Printf("[GL Cache Error] BlendFunc mismatch!\n")
+		}
+	}
+
+	if r.scissorEnabled {
+		var hwScissor [4]int32
+		gl.GetIntegerv(gl.SCISSOR_BOX, &hwScissor[0])
+		if hwScissor != r.scissorRect {
+			fmt.Printf("[GL Cache Error] ScissorRect mismatch! Cache: %v, HW: %v\n", r.scissorRect, hwScissor)
+		}
+	}
+
+	// Attributes
+	checkAttr := func(flag bool, attrKey string) {
+		var shader *ShaderProgram_GL33
+		if r.program == r.modelShader.program {
+			shader = r.modelShader
+		} else if r.program == r.shadowMapShader.program {
+			shader = r.shadowMapShader
+		} else {
+			return
+		}
+		if loc, ok := shader.attributes[attrKey]; ok && loc >= 0 {
+			var enabled int32
+			gl.GetVertexAttribiv(uint32(loc), gl.VERTEX_ATTRIB_ARRAY_ENABLED, &enabled)
+			if (enabled != 0) != flag {
+				fmt.Printf("[GL Cache Error] %s mismatch! Cache: %v, HW: %v\n", attrKey, flag, enabled != 0)
+			}
+		}
+	}
+
+	checkAttr(r.useUV, "uv")
+	checkAttr(r.useNormal, "normalIn")
+	checkAttr(r.useTangent, "tangentIn")
+	checkAttr(r.useVertColor, "vertColor")
+	checkAttr(r.useJoint0, "joints_0")
+	checkAttr(r.useJoint1, "joints_1")
+	checkAttr(r.useOutlineAttribute, "outlineAttributeIn")
+}
+
+func (r *Renderer_GL33) IsModelEnabled() bool {
 	return r.enableModel
 }
 
-func (r *Renderer_GLES32) IsShadowEnabled() bool {
+func (r *Renderer_GL33) IsShadowEnabled() bool {
 	return r.enableShadow
 }
 
-func (r *Renderer_GLES32) BeginFrame(clearColor bool) {
+func (r *Renderer_GL33) BeginFrame(clearColor bool) {
 	//gl.BindVertexArray(r.vao)
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo)
 	gl.Viewport(0, 0, sys.scrrect[2], sys.scrrect[3])
@@ -1010,7 +1035,7 @@ func (r *Renderer_GLES32) BeginFrame(clearColor bool) {
 	}
 }
 
-func (r *Renderer_GLES32) EndFrame() {
+func (r *Renderer_GL33) EndFrame() {
 	if len(r.fbo_pp) == 0 {
 		return
 	}
@@ -1093,7 +1118,7 @@ func (r *Renderer_GLES32) EndFrame() {
 		}
 
 		// set post-processing parameters
-		if loc, ok := postShader.uniforms["Texture_GLES32"]; ok && loc >= 0 {
+		if loc, ok := postShader.uniforms["Texture_GL33"]; ok && loc >= 0 {
 			r.SetUniformISub(loc, 0)
 		}
 		if loc, ok := postShader.uniforms["TextureSize"]; ok && loc >= 0 {
@@ -1111,11 +1136,11 @@ func (r *Renderer_GLES32) EndFrame() {
 	}
 }
 
-func (r *Renderer_GLES32) Await() {
+func (r *Renderer_GL33) Await() {
 	gl.Finish()
 }
 
-func (r *Renderer_GLES32) MapBlendEquation(i BlendEquation) uint32 {
+func (r *Renderer_GL33) MapBlendEquation(i BlendEquation) uint32 {
 	var BlendEquationLUT = map[BlendEquation]uint32{
 		BlendAdd:             gl.FUNC_ADD,
 		BlendReverseSubtract: gl.FUNC_REVERSE_SUBTRACT,
@@ -1123,17 +1148,19 @@ func (r *Renderer_GLES32) MapBlendEquation(i BlendEquation) uint32 {
 	return BlendEquationLUT[i]
 }
 
-func (r *Renderer_GLES32) MapBlendFunction(i BlendFunc) uint32 {
+func (r *Renderer_GL33) MapBlendFunction(i BlendFunc) uint32 {
 	var BlendFunctionLUT = map[BlendFunc]uint32{
 		BlendOne:              gl.ONE,
 		BlendZero:             gl.ZERO,
 		BlendSrcAlpha:         gl.SRC_ALPHA,
 		BlendOneMinusSrcAlpha: gl.ONE_MINUS_SRC_ALPHA,
+		BlendOneMinusDstColor: gl.ONE_MINUS_DST_COLOR,
+		BlendDstColor:         gl.DST_COLOR,
 	}
 	return BlendFunctionLUT[i]
 }
 
-func (r *Renderer_GLES32) MapPrimitiveMode(i PrimitiveMode) uint32 {
+func (r *Renderer_GL33) MapPrimitiveMode(i PrimitiveMode) uint32 {
 	var PrimitiveModeLUT = map[PrimitiveMode]uint32{
 		LINES:          gl.LINES,
 		LINE_LOOP:      gl.LINE_LOOP,
@@ -1145,7 +1172,7 @@ func (r *Renderer_GLES32) MapPrimitiveMode(i PrimitiveMode) uint32 {
 	return PrimitiveModeLUT[i]
 }
 
-func (r *Renderer_GLES32) SetDepthTest(depthTest bool) {
+func (r *Renderer_GL33) SetDepthTest(depthTest bool) {
 	if depthTest != r.depthTest {
 		r.depthTest = depthTest
 		if depthTest {
@@ -1158,14 +1185,14 @@ func (r *Renderer_GLES32) SetDepthTest(depthTest bool) {
 }
 
 // Note: This one defaults to enable so we must sync the cache early
-func (r *Renderer_GLES32) SetDepthMask(depthMask bool) {
+func (r *Renderer_GL33) SetDepthMask(depthMask bool) {
 	if depthMask != r.depthMask {
 		r.depthMask = depthMask
 		gl.DepthMask(depthMask)
 	}
 }
 
-func (r *Renderer_GLES32) SetFrontFace(invertFrontFace bool) {
+func (r *Renderer_GL33) SetFrontFace(invertFrontFace bool) {
 	if invertFrontFace != r.invertFrontFace {
 		r.invertFrontFace = invertFrontFace
 		if invertFrontFace {
@@ -1176,7 +1203,7 @@ func (r *Renderer_GLES32) SetFrontFace(invertFrontFace bool) {
 	}
 }
 
-func (r *Renderer_GLES32) SetCullFace(doubleSided bool) {
+func (r *Renderer_GL33) SetCullFace(doubleSided bool) {
 	if doubleSided != r.doubleSided {
 		r.doubleSided = doubleSided
 		if !doubleSided {
@@ -1189,7 +1216,7 @@ func (r *Renderer_GLES32) SetCullFace(doubleSided bool) {
 }
 
 // This should be called instead of gl.UseProgram()
-func (r *Renderer_GLES32) ChangeProgram(prog uint32) {
+func (r *Renderer_GL33) ChangeProgram(prog uint32) {
 	// Program already in use
 	if r.program == prog {
 		return
@@ -1202,8 +1229,15 @@ func (r *Renderer_GLES32) ChangeProgram(prog uint32) {
 	}
 
 	// Same for TTF fonts
-	if r.program == gfxFont.(*FontRenderer_GLES32).shaderProgram.program {
-		gfxFont.(*FontRenderer_GLES32).ReleaseFontPipeline()
+	if r.program == gfxFont.(*FontRenderer_GL33).shaderProgram.program {
+		gfxFont.(*FontRenderer_GL33).ReleaseFontPipeline()
+	}
+
+	// State leak detector
+	// TODO: Just move to separate VAO's if we drop GL2.1
+	if r.debugMode {
+		//r.DebugCheckLeaks(prog)
+		r.DebugVerifyCache()
 	}
 
 	// Switch program
@@ -1216,9 +1250,22 @@ func (r *Renderer_GLES32) ChangeProgram(prog uint32) {
 		r.texCacheLastUsed[i] = 0
 	}
 	r.texCacheTimer = 1
+
+	/*
+		// No need to reset these anymore since the cache is now keyed to the spriteShader
+		for i := range r.uniformICache {
+			r.uniformICache[i] = -1e9
+		}
+		for i := range r.uniformF1Cache {
+			r.uniformF1Cache[i] = -1e9
+		}
+		for i := range r.uniformF3Cache {
+			r.uniformF3Cache[i] = -1e9
+		}
+	*/
 }
 
-func (r *Renderer_GLES32) EnableBlending(eq BlendEquation, src, dst BlendFunc) {
+func (r *Renderer_GL33) EnableBlending(eq BlendEquation, src, dst BlendFunc) {
 	if !r.blendEnabled {
 		gl.Enable(gl.BLEND)
 		r.blendEnabled = true
@@ -1236,7 +1283,7 @@ func (r *Renderer_GLES32) EnableBlending(eq BlendEquation, src, dst BlendFunc) {
 	}
 }
 
-func (r *Renderer_GLES32) DisableBlending() {
+func (r *Renderer_GL33) DisableBlending() {
 	if r.blendEnabled {
 		gl.Disable(gl.BLEND)
 		r.blendEnabled = false
@@ -1244,7 +1291,7 @@ func (r *Renderer_GLES32) DisableBlending() {
 	}
 }
 
-func (r *Renderer_GLES32) SetPipeline() {
+func (r *Renderer_GL33) SetPipeline() {
 	// Do nothing if we were already using the sprite shader
 	if r.program == r.spriteShader.program {
 		return
@@ -1255,18 +1302,19 @@ func (r *Renderer_GLES32) SetPipeline() {
 	gl.BindVertexArray(r.spriteVAO)
 }
 
-func (r *Renderer_GLES32) ReleasePipeline() {
+func (r *Renderer_GL33) ReleasePipeline() {
 	gl.BindVertexArray(0)
 	//r.DisableBlending()
 }
 
-func (r *Renderer_GLES32) prepareShadowMapPipeline(bufferIndex uint32) {
+func (r *Renderer_GL33) prepareShadowMapPipeline(bufferIndex uint32) {
 	r.ChangeProgram(r.shadowMapShader.program)
 
 	gl.BindVertexArray(r.modelVAO)
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_shadow)
+
 	gl.Viewport(0, 0, 1024, 1024)
-	// Removed gl.Enable(gl.TEXTURE_2D) — not needed / invalid in GLES3 core
+	//gl.Enable(gl.TEXTURE_2D) // Causes OpenGL error
 
 	// Set global state
 	r.SetDepthTest(true)
@@ -1278,14 +1326,13 @@ func (r *Renderer_GLES32) prepareShadowMapPipeline(bufferIndex uint32) {
 	gl.BindBuffer(gl.ARRAY_BUFFER, r.modelVertexBuffer[bufferIndex])
 	gl.BindBuffer(gl.ELEMENT_ARRAY_BUFFER, r.modelIndexBuffer[bufferIndex])
 
-	// Don't attach a depth texture here: attach the specific cube-face with
-	// SetShadowFrameCubeTexture(...) before rendering each face.
-	// Clearing must be done after the correct face is attached.
+	gl.FramebufferTexture(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, r.fbo_shadow_cube_texture, 0)
+	gl.Clear(gl.DEPTH_BUFFER_BIT)
 
 	r.SetActiveTexture0() // gl.ActiveTexture(gl.TEXTURE0)
 }
 
-func (r *Renderer_GLES32) setShadowMapPipeline(doubleSided, invertFrontFace, useUV, useNormal, useTangent, useVertColor, useJoint0, useJoint1 bool, numVertices, vertAttrOffset uint32) {
+func (r *Renderer_GL33) setShadowMapPipeline(doubleSided, invertFrontFace, useUV, useNormal, useTangent, useVertColor, useJoint0, useJoint1 bool, numVertices, vertAttrOffset uint32) {
 	r.SetFrontFace(invertFrontFace)
 	r.SetCullFace(doubleSided)
 
@@ -1375,7 +1422,7 @@ func (r *Renderer_GLES32) setShadowMapPipeline(doubleSided, invertFrontFace, use
 	}
 }
 
-func (r *Renderer_GLES32) ReleaseShadowPipeline() {
+func (r *Renderer_GL33) ReleaseShadowPipeline() {
 	loc := r.shadowMapShader.attributes["vertexId"]
 	gl.DisableVertexAttribArray(uint32(loc))
 	loc = r.shadowMapShader.attributes["position"]
@@ -1409,7 +1456,7 @@ func (r *Renderer_GLES32) ReleaseShadowPipeline() {
 	r.useJoint1 = false
 }
 
-func (r *Renderer_GLES32) prepareModelPipeline(bufferIndex uint32, env *Environment) {
+func (r *Renderer_GL33) prepareModelPipeline(bufferIndex uint32, env *Environment) {
 	r.ChangeProgram(r.modelShader.program)
 
 	gl.BindVertexArray(r.modelVAO)
@@ -1417,8 +1464,9 @@ func (r *Renderer_GLES32) prepareModelPipeline(bufferIndex uint32, env *Environm
 
 	gl.Viewport(0, 0, sys.scrrect[2], sys.scrrect[3])
 	gl.Clear(gl.DEPTH_BUFFER_BIT)
-	//gl.Enable(gl.TEXTURE_2D)
-	gl.Enable(gl.TEXTURE_CUBE_MAP)
+	//gl.Enable(gl.TEXTURE_2D) // Causes OpenGL error
+	//gl.Enable(gl.TEXTURE_CUBE_MAP) // Causes OpenGL error
+
 	// Set global state
 	r.EnableBlending(r.blendEquation, r.blendSrc, r.blendDst)
 	r.SetDepthTest(true)
@@ -1428,30 +1476,24 @@ func (r *Renderer_GLES32) prepareModelPipeline(bufferIndex uint32, env *Environm
 
 	gl.BindBuffer(gl.ARRAY_BUFFER, r.modelVertexBuffer[bufferIndex])
 	gl.BindBuffer(gl.ELEMENT_ARRAY_BUFFER, r.modelIndexBuffer[bufferIndex])
-	// Bind the 4 cube-map textures to the corresponding sampler uniforms/units
 	if r.enableShadow {
-		for i := 0; i < 4; i++ {
-			name := fmt.Sprintf("shadowCubeMap%d", i)
-			loc := r.modelShader.uniforms[name]
-			unit := r.modelShader.textures[name] // texture unit assigned by RegisterTextures
-
-			gl.ActiveTexture(uint32(gl.TEXTURE0 + unit))
-			gl.BindTexture(gl.TEXTURE_CUBE_MAP, r.fbo_shadow_cube_textures[i])
-			gl.Uniform1i(loc, int32(unit))
-		}
+		loc, unit := r.modelShader.uniforms["shadowCubeMap"], r.modelShader.textures["shadowCubeMap"]
+		gl.ActiveTexture((uint32(gl.TEXTURE0 + unit)))
+		gl.BindTexture(gl.TEXTURE_CUBE_MAP_ARRAY_ARB, r.fbo_shadow_cube_texture)
+		gl.Uniform1i(loc, int32(unit))
 	}
 	if env != nil {
 		loc, unit := r.modelShader.uniforms["lambertianEnvSampler"], r.modelShader.textures["lambertianEnvSampler"]
 		gl.ActiveTexture((uint32(gl.TEXTURE0 + unit)))
-		gl.BindTexture(gl.TEXTURE_CUBE_MAP, env.lambertianTexture.tex.(*Texture_GLES32).handle)
+		gl.BindTexture(gl.TEXTURE_CUBE_MAP, env.lambertianTexture.tex.(*Texture_GL33).handle)
 		gl.Uniform1i(loc, int32(unit))
 		loc, unit = r.modelShader.uniforms["GGXEnvSampler"], r.modelShader.textures["GGXEnvSampler"]
 		gl.ActiveTexture((uint32(gl.TEXTURE0 + unit)))
-		gl.BindTexture(gl.TEXTURE_CUBE_MAP, env.GGXTexture.tex.(*Texture_GLES32).handle)
+		gl.BindTexture(gl.TEXTURE_CUBE_MAP, env.GGXTexture.tex.(*Texture_GL33).handle)
 		gl.Uniform1i(loc, int32(unit))
 		loc, unit = r.modelShader.uniforms["GGXLUT"], r.modelShader.textures["GGXLUT"]
 		gl.ActiveTexture((uint32(gl.TEXTURE0 + unit)))
-		gl.BindTexture(gl.TEXTURE_2D, env.GGXLUT.tex.(*Texture_GLES32).handle)
+		gl.BindTexture(gl.TEXTURE_2D, env.GGXLUT.tex.(*Texture_GL33).handle)
 		gl.Uniform1i(loc, int32(unit))
 
 		loc = r.modelShader.uniforms["environmentIntensity"]
@@ -1483,7 +1525,7 @@ func (r *Renderer_GLES32) prepareModelPipeline(bufferIndex uint32, env *Environm
 	r.SetActiveTexture0() // gl.ActiveTexture(gl.TEXTURE0)
 }
 
-func (r *Renderer_GLES32) SetModelPipeline(eq BlendEquation, src, dst BlendFunc, depthTest, depthMask, doubleSided, invertFrontFace,
+func (r *Renderer_GL33) SetModelPipeline(eq BlendEquation, src, dst BlendFunc, depthTest, depthMask, doubleSided, invertFrontFace,
 	useUV, useNormal, useTangent, useVertColor, useJoint0, useJoint1, useOutlineAttribute bool, numVertices, vertAttrOffset uint32) {
 	r.SetDepthTest(depthTest)
 	r.SetDepthMask(depthMask)
@@ -1609,7 +1651,7 @@ func (r *Renderer_GLES32) SetModelPipeline(eq BlendEquation, src, dst BlendFunc,
 	}
 }
 
-func (r *Renderer_GLES32) SetMeshOutlinePipeline(invertFrontFace bool, meshOutline float32) {
+func (r *Renderer_GL33) SetMeshOutlinePipeline(invertFrontFace bool, meshOutline float32) {
 	r.SetFrontFace(invertFrontFace)
 	r.SetDepthTest(true)
 	r.SetDepthMask(true)
@@ -1618,7 +1660,7 @@ func (r *Renderer_GLES32) SetMeshOutlinePipeline(invertFrontFace bool, meshOutli
 	gl.Uniform1f(loc, meshOutline)
 }
 
-func (r *Renderer_GLES32) ReleaseModelPipeline() {
+func (r *Renderer_GL33) ReleaseModelPipeline() {
 	loc := r.modelShader.attributes["inVertexId"]
 	gl.DisableVertexAttribArray(uint32(loc))
 	loc = r.modelShader.attributes["position"]
@@ -1664,14 +1706,14 @@ func (r *Renderer_GLES32) ReleaseModelPipeline() {
 	r.useOutlineAttribute = false
 }
 
-func (r *Renderer_GLES32) ReadPixels(data []uint8, width, height int) {
+func (r *Renderer_GL33) ReadPixels(data []uint8, width, height int) {
 	// we defer the EndFrame(), SwapBuffers(), and BeginFrame() calls that were previously below now to
 	// a single spot in order to prevent the blank screenshot bug on single digit FPS
 	gl.BindFramebuffer(gl.READ_FRAMEBUFFER, 0)
 	gl.ReadPixels(0, 0, int32(width), int32(height), gl.RGBA, gl.UNSIGNED_BYTE, unsafe.Pointer(&data[0]))
 }
 
-func (r *Renderer_GLES32) EnableScissor(x, y, width, height int32) {
+func (r *Renderer_GL33) EnableScissor(x, y, width, height int32) {
 	// Flip Y to OpenGL convention
 	realY := sys.scrrect[3] - (y + height)
 
@@ -1690,7 +1732,7 @@ func (r *Renderer_GLES32) EnableScissor(x, y, width, height int32) {
 	r.scissorRect = [4]int32{x, realY, width, height}
 }
 
-func (r *Renderer_GLES32) DisableScissor() {
+func (r *Renderer_GL33) DisableScissor() {
 	if r.scissorEnabled {
 		gl.Disable(gl.SCISSOR_TEST)
 		r.scissorEnabled = false
@@ -1698,7 +1740,7 @@ func (r *Renderer_GLES32) DisableScissor() {
 	}
 }
 
-func (r *Renderer_GLES32) SetUniformISub(loc int32, val int32) {
+func (r *Renderer_GL33) SetUniformISub(loc int32, val int32) {
 	if loc < 0 {
 		return
 	}
@@ -1715,12 +1757,12 @@ func (r *Renderer_GLES32) SetUniformISub(loc int32, val int32) {
 	gl.Uniform1i(loc, val)
 }
 
-func (r *Renderer_GLES32) SetUniformFSub(loc int32, values ...float32) {
+func (r *Renderer_GL33) SetUniformFSub(loc int32, values ...float32) {
 	if loc < 0 || len(values) == 0 {
 		return
 	}
 
-	// Cached path for the sprite shader
+	// Cached path for sprite shader
 	if r.program == r.spriteShader.program {
 		key := (r.program << 16) | uint32(loc)
 
@@ -1764,7 +1806,7 @@ func (r *Renderer_GLES32) SetUniformFSub(loc int32, values ...float32) {
 	}
 }
 
-func (r *Renderer_GLES32) SetUniformFvSub(loc int32, values []float32) {
+func (r *Renderer_GL33) SetUniformFvSub(loc int32, values []float32) {
 	if loc < 0 || len(values) == 0 {
 		return
 	}
@@ -1779,134 +1821,134 @@ func (r *Renderer_GLES32) SetUniformFvSub(loc int32, values []float32) {
 	}
 }
 
-func (r *Renderer_GLES32) SetUniformI(name string, val int) {
+func (r *Renderer_GL33) SetUniformI(name string, val int) {
 	loc := r.spriteShader.uniforms[name]
 	r.SetUniformISub(loc, int32(val))
 }
 
-func (r *Renderer_GLES32) SetUniformF(name string, values ...float32) {
+func (r *Renderer_GL33) SetUniformF(name string, values ...float32) {
 	loc := r.spriteShader.uniforms[name]
 	r.SetUniformFSub(loc, values...)
 }
 
-func (r *Renderer_GLES32) SetUniformFv(name string, values []float32) {
+func (r *Renderer_GL33) SetUniformFv(name string, values []float32) {
 	loc := r.spriteShader.uniforms[name]
 	r.SetUniformFvSub(loc, values)
 }
 
 // Caching matrices is as expensive as direct function calls
-func (r *Renderer_GLES32) SetUniformMatrix(name string, value []float32) {
+func (r *Renderer_GL33) SetUniformMatrix(name string, value []float32) {
 	loc, ok := r.spriteShader.uniforms[name]
 	if ok && loc >= 0 {
 		gl.UniformMatrix4fv(loc, 1, false, &value[0])
 	}
 }
 
-func (r *Renderer_GLES32) SetModelUniformI(name string, val int) {
+func (r *Renderer_GL33) SetModelUniformI(name string, val int) {
 	loc, ok := r.modelShader.uniforms[name]
 	if !ok || loc < 0 {
-		//if r.debugMode {
-		//	fmt.Printf("[GL Debug] Model uniform '%s' not registered\n", name)
-		//}
+		if r.debugMode {
+			fmt.Printf("[GL Debug] Model uniform '%s' not registered\n", name)
+		}
 		return
 	}
 	r.SetUniformISub(loc, int32(val))
 }
 
-func (r *Renderer_GLES32) SetModelUniformF(name string, values ...float32) {
+func (r *Renderer_GL33) SetModelUniformF(name string, values ...float32) {
 	loc, ok := r.modelShader.uniforms[name]
 	if !ok || loc < 0 {
-		//if r.debugMode {
-		//	fmt.Printf("[GL Debug] Model uniform '%s' not registered\n", name)
-		//}
+		if r.debugMode {
+			fmt.Printf("[GL Debug] Model uniform '%s' not registered\n", name)
+		}
 		return
 	}
 	r.SetUniformFSub(loc, values...)
 }
 
-func (r *Renderer_GLES32) SetModelUniformFv(name string, values []float32) {
+func (r *Renderer_GL33) SetModelUniformFv(name string, values []float32) {
 	loc, ok := r.modelShader.uniforms[name]
 	if !ok || loc < 0 {
-		//if r.debugMode {
-		//	fmt.Printf("[GL Debug] Model uniform '%s' not registered\n", name)
-		//}
+		if r.debugMode {
+			fmt.Printf("[GL Debug] Model uniform '%s' not registered\n", name)
+		}
 		return
 	}
 	r.SetUniformFvSub(loc, values)
 }
 
-func (r *Renderer_GLES32) SetModelUniformMatrix(name string, value []float32) {
+func (r *Renderer_GL33) SetModelUniformMatrix(name string, value []float32) {
 	loc, ok := r.modelShader.uniforms[name]
 	if !ok || loc < 0 {
-		//if r.debugMode {
-		//	fmt.Printf("[GL Debug] Model uniform '%s' not registered\n", name)
-		//}
+		if r.debugMode {
+			fmt.Printf("[GL Debug] Model uniform '%s' not registered\n", name)
+		}
 		return
 	}
 	gl.UniformMatrix4fv(loc, 1, false, &value[0])
 }
 
-func (r *Renderer_GLES32) SetModelUniformMatrix3(name string, value []float32) {
+func (r *Renderer_GL33) SetModelUniformMatrix3(name string, value []float32) {
 	loc, ok := r.modelShader.uniforms[name]
 	if !ok || loc < 0 {
-		//if r.debugMode {
-		//	fmt.Printf("[GL Debug] Model uniform '%s' not registered\n", name)
-		//}
+		if r.debugMode {
+			fmt.Printf("[GL Debug] Model uniform '%s' not registered\n", name)
+		}
 		return
 	}
 	gl.UniformMatrix3fv(loc, 1, false, &value[0])
 }
 
-func (r *Renderer_GLES32) SetShadowMapUniformI(name string, val int) {
+func (r *Renderer_GL33) SetShadowMapUniformI(name string, val int) {
 	loc, ok := r.shadowMapShader.uniforms[name]
 	if !ok || loc < 0 {
-		//if r.debugMode {
-		//	fmt.Printf("[GL Debug] Shadow uniform '%s' not registered\n", name)
-		//}
+		if r.debugMode {
+			fmt.Printf("[GL Debug] Shadow uniform '%s' not registered\n", name)
+		}
 		return
 	}
 	r.SetUniformISub(loc, int32(val))
 }
 
-func (r *Renderer_GLES32) SetShadowMapUniformF(name string, values ...float32) {
+func (r *Renderer_GL33) SetShadowMapUniformF(name string, values ...float32) {
 	loc, ok := r.shadowMapShader.uniforms[name]
 	if !ok || loc < 0 {
-		//if r.debugMode {
-		//	fmt.Printf("[GL Debug] Shadow uniform '%s' not registered\n", name)
-		//}
+		if r.debugMode {
+			fmt.Printf("[GL Debug] Shadow uniform '%s' not registered\n", name)
+		}
 		return
 	}
 	r.SetUniformFSub(loc, values...)
 }
 
-func (r *Renderer_GLES32) SetShadowMapUniformFv(name string, values []float32) {
+func (r *Renderer_GL33) SetShadowMapUniformFv(name string, values []float32) {
 	loc, ok := r.shadowMapShader.uniforms[name]
 	if !ok || loc < 0 {
-		//if r.debugMode {
-		//	fmt.Printf("[GL Debug] Shadow uniform '%s' not registered\n", name)
-		//}
+		if r.debugMode {
+			fmt.Printf("[GL Debug] Shadow uniform '%s' not registered\n", name)
+		}
 		return
 	}
 	r.SetUniformFvSub(loc, values)
 }
 
-func (r *Renderer_GLES32) SetShadowMapUniformMatrix(name string, value []float32) {
+func (r *Renderer_GL33) SetShadowMapUniformMatrix(name string, value []float32) {
 	loc, ok := r.shadowMapShader.uniforms[name]
 	if !ok || loc < 0 {
-		//if r.debugMode {
-		//	fmt.Printf("[GL Debug] Shadow uniform '%s' not registered\n", name)
-		//}
+		if r.debugMode {
+			fmt.Printf("[GL Debug] Shadow uniform '%s' not registered\n", name)
+		}
 		return
 	}
 	gl.UniformMatrix4fv(loc, 1, false, &value[0])
 }
 
-func (r *Renderer_GLES32) SetShadowMapUniformMatrix3(name string, value []float32) {
+func (r *Renderer_GL33) SetShadowMapUniformMatrix3(name string, value []float32) {
 	loc, ok := r.shadowMapShader.uniforms[name]
 	if !ok || loc < 0 {
-		//if r.debugMode {
-		//	fmt.Printf("[GL Debug] Shadow uniform '%s' not registered\n", name)
-		//}
+		if r.debugMode {
+			fmt.Printf("[GL Debug] Shadow uniform '%s' not registered\n", name)
+		}
 		return
 	}
 	gl.UniformMatrix3fv(loc, 1, false, &value[0])
@@ -1914,7 +1956,7 @@ func (r *Renderer_GLES32) SetShadowMapUniformMatrix3(name string, value []float3
 
 // Selects texture unit 0 as active and tells the cache it's dirty
 // Prevents the sprite renderer from desyncing during texture maintenance
-func (r *Renderer_GLES32) SetActiveTexture0() {
+func (r *Renderer_GL33) SetActiveTexture0() {
 	gl.ActiveTexture(gl.TEXTURE0)
 
 	if len(r.texCacheTexSerial) > 0 {
@@ -1923,8 +1965,8 @@ func (r *Renderer_GLES32) SetActiveTexture0() {
 	}
 }
 
-func (r *Renderer_GLES32) SetTextureSub(uMap map[string]int32, tMap map[string]int, name string, tex Texture) {
-	t := tex.(*Texture_GLES32)
+func (r *Renderer_GL33) SetTextureSub(uMap map[string]int32, tMap map[string]int, name string, tex Texture) {
+	t := tex.(*Texture_GL33)
 	loc := uMap[name]
 
 	// Cached path for the sprite shader
@@ -1972,71 +2014,40 @@ func (r *Renderer_GLES32) SetTextureSub(uMap map[string]int32, tMap map[string]i
 	r.SetUniformISub(loc, int32(fixedUnit))
 }
 
-func (r *Renderer_GLES32) SetTexture(name string, tex Texture) {
+func (r *Renderer_GL33) SetTexture(name string, tex Texture) {
 	r.SetTextureSub(r.spriteShader.uniforms, r.spriteShader.textures, name, tex)
 }
 
-func (r *Renderer_GLES32) SetModelTexture(name string, tex Texture) {
+func (r *Renderer_GL33) SetModelTexture(name string, tex Texture) {
 	r.SetTextureSub(r.modelShader.uniforms, r.modelShader.textures, name, tex)
 }
 
-func (r *Renderer_GLES32) SetShadowMapTexture(name string, tex Texture) {
+func (r *Renderer_GL33) SetShadowMapTexture(name string, tex Texture) {
 	r.SetTextureSub(r.shadowMapShader.uniforms, r.shadowMapShader.textures, name, tex)
 }
 
-func (r *Renderer_GLES32) SetShadowFrameTexture(i uint32) {
-	// Backwards-compatible alias: treat i as combined index (light*6 + face)
-	r.SetShadowFrameCubeTexture(i)
+func (r *Renderer_GL33) SetShadowFrameTexture(i uint32) {
+	gl.FramebufferTexture(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, r.fbo_shadow_cube_texture, 0)
 }
 
-func (r *Renderer_GLES32) SetShadowFrameCubeTexture(i uint32) {
-	// Interpret i as a combined index: lightIndex = i / 6, faceIndex = i % 6
-	lightIndex := int(i / 6)
-	faceIndex := int(i % 6)
-
-	// clamp lightIndex to available range
-	if lightIndex < 0 {
-		lightIndex = 0
-	}
-	if lightIndex >= len(r.fbo_shadow_cube_textures) {
-		lightIndex = len(r.fbo_shadow_cube_textures) - 1
-	}
-	if faceIndex < 0 {
-		faceIndex = 0
-	}
-	if faceIndex > 5 {
-		faceIndex = 5
-	}
-
-	tex := r.fbo_shadow_cube_textures[lightIndex]
-
-	// Attach the requested face of the cube map as the framebuffer depth attachment.
-	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_shadow)
-
-	target := uint32(gl.TEXTURE_CUBE_MAP_POSITIVE_X) + uint32(faceIndex)
-	gl.FramebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, target, tex, 0)
-
-	// Make sure draw/read buffers are set appropriately (depth-only FBO)
-	bufs := []uint32{gl.NONE}
-	gl.DrawBuffers(1, &bufs[0])
-	gl.ReadBuffer(gl.NONE)
-
-	// Clear the depth buffer for this face before rendering
-	gl.Clear(gl.DEPTH_BUFFER_BIT)
+func (r *Renderer_GL33) SetShadowFrameCubeTexture(i uint32) {
+	gl.FramebufferTexture(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, r.fbo_shadow_cube_texture, 0)
 }
 
-func (r *Renderer_GLES32) SetVertexData(values ...float32) {
+func (r *Renderer_GL33) SetVertexData(values ...float32) {
 	data := f32.Bytes(binary.LittleEndian, values...)
 	gl.BindBuffer(gl.ARRAY_BUFFER, r.vertexBuffer)
 	gl.BufferData(gl.ARRAY_BUFFER, len(data), unsafe.Pointer(&data[0]), gl.STATIC_DRAW)
+	// STREAM_DRAW was attempted here, but some users might be havign trouble with it
+	// https://github.com/ikemen-engine/Ikemen-GO/issues/3292
 }
 
-func (r *Renderer_GLES32) SetModelVertexData(bufferIndex uint32, values []byte) {
+func (r *Renderer_GL33) SetModelVertexData(bufferIndex uint32, values []byte) {
 	gl.BindBuffer(gl.ARRAY_BUFFER, r.modelVertexBuffer[bufferIndex])
 	gl.BufferData(gl.ARRAY_BUFFER, len(values), unsafe.Pointer(&values[0]), gl.STATIC_DRAW)
 }
 
-func (r *Renderer_GLES32) SetModelIndexData(bufferIndex uint32, values ...uint32) {
+func (r *Renderer_GL33) SetModelIndexData(bufferIndex uint32, values ...uint32) {
 	data := new(bytes.Buffer)
 	binary.Write(data, binary.LittleEndian, values)
 
@@ -2044,21 +2055,21 @@ func (r *Renderer_GLES32) SetModelIndexData(bufferIndex uint32, values ...uint32
 	gl.BufferData(gl.ELEMENT_ARRAY_BUFFER, len(values)*4, unsafe.Pointer(&data.Bytes()[0]), gl.STATIC_DRAW)
 }
 
-func (r *Renderer_GLES32) RenderQuad() {
+func (r *Renderer_GL33) RenderQuad() {
 	gl.DrawArrays(gl.TRIANGLE_STRIP, 0, 4)
 }
 
-func (r *Renderer_GLES32) RenderElements(mode PrimitiveMode, count, offset int) {
+func (r *Renderer_GL33) RenderElements(mode PrimitiveMode, count, offset int) {
 	gl.DrawElementsWithOffset(r.MapPrimitiveMode(mode), int32(count), gl.UNSIGNED_INT, uintptr(offset))
 }
 
-func (r *Renderer_GLES32) RenderShadowMapElements(mode PrimitiveMode, count, offset int) {
+func (r *Renderer_GL33) RenderShadowMapElements(mode PrimitiveMode, count, offset int) {
 	r.RenderElements(mode, count, offset)
 }
 
-func (r *Renderer_GLES32) RenderCubeMap(envTex Texture, cubeTex Texture) {
-	envTexture := envTex.(*Texture_GLES32)
-	cubeTexture := cubeTex.(*Texture_GLES32)
+func (r *Renderer_GL33) RenderCubeMap(envTex Texture, cubeTex Texture) {
+	envTexture := envTex.(*Texture_GL33)
+	cubeTexture := cubeTex.(*Texture_GL33)
 	textureSize := cubeTexture.width
 
 	r.ChangeProgram(r.panoramaToCubeMapShader.program)
@@ -2091,9 +2102,9 @@ func (r *Renderer_GLES32) RenderCubeMap(envTex Texture, cubeTex Texture) {
 	gl.GenerateMipmap(gl.TEXTURE_CUBE_MAP)
 }
 
-func (r *Renderer_GLES32) RenderFilteredCubeMap(distribution int32, cubeTex Texture, filteredTex Texture, mipmapLevel, sampleCount int32, roughness float32) {
-	cubeTexture := cubeTex.(*Texture_GLES32)
-	filteredTexture := filteredTex.(*Texture_GLES32)
+func (r *Renderer_GL33) RenderFilteredCubeMap(distribution int32, cubeTex Texture, filteredTex Texture, mipmapLevel, sampleCount int32, roughness float32) {
+	cubeTexture := cubeTex.(*Texture_GL33)
+	filteredTexture := filteredTex.(*Texture_GL33)
 	textureSize := filteredTexture.width
 	currentTextureSize := textureSize >> mipmapLevel
 
@@ -2139,9 +2150,9 @@ func (r *Renderer_GLES32) RenderFilteredCubeMap(distribution int32, cubeTex Text
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo)
 }
 
-func (r *Renderer_GLES32) RenderLUT(distribution int32, cubeTex Texture, lutTex Texture, sampleCount int32) {
-	cubeTexture := cubeTex.(*Texture_GLES32)
-	lutTexture := lutTex.(*Texture_GLES32)
+func (r *Renderer_GL33) RenderLUT(distribution int32, cubeTex Texture, lutTex Texture, sampleCount int32) {
+	cubeTexture := cubeTex.(*Texture_GL33)
+	lutTexture := lutTex.(*Texture_GL33)
 	textureSize := lutTexture.width
 
 	r.ChangeProgram(r.cubemapFilteringShader.program)
@@ -2186,19 +2197,19 @@ func (r *Renderer_GLES32) RenderLUT(distribution int32, cubeTex Texture, lutTex 
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo)
 }
 
-func (r *Renderer_GLES32) PerspectiveProjectionMatrix(angle, aspect, near, far float32) mgl.Mat4 {
+func (r *Renderer_GL33) PerspectiveProjectionMatrix(angle, aspect, near, far float32) mgl.Mat4 {
 	return mgl.Perspective(angle, aspect, near, far)
 }
 
-func (r *Renderer_GLES32) OrthographicProjectionMatrix(left, right, bottom, top, near, far float32) mgl.Mat4 {
+func (r *Renderer_GL33) OrthographicProjectionMatrix(left, right, bottom, top, near, far float32) mgl.Mat4 {
 	ret := mgl.Ortho(left, right, bottom, top, near, far)
 	return ret
 }
 
-func (r *Renderer_GLES32) NewWorkerThread() bool {
+func (r *Renderer_GL33) NewWorkerThread() bool {
 	return false
 }
 
-func (r *Renderer_GLES32) SetVSync(interval int) {
+func (r *Renderer_GL33) SetVSync(interval int) {
 	sdl.GLSetSwapInterval(interval)
 }

--- a/src/render_gl_gl32.go
+++ b/src/render_gl_gl32.go
@@ -217,7 +217,7 @@ func (r *Renderer_GL32) generateTexture(width, height, depth int32, filter bool)
 
 // Creates a generic texture
 func (r *Renderer_GL32) newTexture(width, height, depth int32, filter bool) Texture {
-	r.UseScratchUnit() //gl.ActiveTexture(gl.TEXTURE0)
+	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	t := r.generateTexture(width, height, depth, filter)
 
@@ -238,7 +238,7 @@ func (r *Renderer_GL32) newModelTexture(width, height, depth int32, filter bool)
 }
 
 func (r *Renderer_GL32) newDataTexture(width, height int32) Texture {
-	r.UseScratchUnit() //gl.ActiveTexture(gl.TEXTURE0)
+	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	t := r.generateTexture(width, height, 128, false)
 
@@ -251,7 +251,7 @@ func (r *Renderer_GL32) newDataTexture(width, height int32) Texture {
 }
 
 func (r *Renderer_GL32) newHDRTexture(width, height int32) Texture {
-	r.UseScratchUnit() //gl.ActiveTexture(gl.TEXTURE0)
+	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	t := r.generateTexture(width, height, 96, false)
 
@@ -264,7 +264,7 @@ func (r *Renderer_GL32) newHDRTexture(width, height int32) Texture {
 }
 
 func (r *Renderer_GL32) newCubeMapTexture(widthHeight int32, mipmap bool, lowestMipLevel int32) Texture {
-	r.UseScratchUnit() //gl.ActiveTexture(gl.TEXTURE0)
+	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	t := r.generateTexture(widthHeight, widthHeight, 24, false)
 
@@ -296,7 +296,7 @@ func (t *Texture_GL32) SetData(data []byte) {
 	format := t.MapInternalFormat(Max(t.depth, 8))
 
 	r := gfx.(*Renderer_GL32)
-	r.UseScratchUnit() //gl.ActiveTexture(gl.TEXTURE0)
+	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	gl.BindTexture(gl.TEXTURE_2D, t.handle)
 	gl.PixelStorei(gl.UNPACK_ALIGNMENT, 1)
@@ -321,7 +321,7 @@ func (t *Texture_GL32) SetSubData(data []byte, x, y, width, height, stride int32
 	}
 
 	r := gfx.(*Renderer_GL32)
-	r.UseScratchUnit() //gl.ActiveTexture(gl.TEXTURE0)
+	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	gl.BindTexture(gl.TEXTURE_2D, t.handle)
 	gl.PixelStorei(gl.UNPACK_ALIGNMENT, 1)
@@ -357,7 +357,7 @@ func (t *Texture_GL32) SetDataG(data []byte, mag, min, ws, wt TextureSamplingPar
 	format := t.MapInternalFormat(Max(t.depth, 8))
 
 	r := gfx.(*Renderer_GL32)
-	r.UseScratchUnit() //gl.ActiveTexture(gl.TEXTURE0)
+	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	gl.BindTexture(gl.TEXTURE_2D, t.handle)
 	gl.PixelStorei(gl.UNPACK_ALIGNMENT, 1)
@@ -375,7 +375,7 @@ func (t *Texture_GL32) SetPixelData(data []float32) {
 	internalFormat := t.MapInternalFormat(Max(t.depth, 8))
 
 	r := gfx.(*Renderer_GL32)
-	r.UseScratchUnit() //gl.ActiveTexture(gl.TEXTURE0)
+	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	gl.BindTexture(gl.TEXTURE_2D, t.handle)
 	gl.PixelStorei(gl.UNPACK_ALIGNMENT, 1)
@@ -643,7 +643,7 @@ func (r *Renderer_GL32) Init() {
 		gl.Disable(gl.MULTISAMPLE)
 	}
 
-	r.UseScratchUnit() //gl.ActiveTexture(gl.TEXTURE0)
+	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	// create a texture for r.fbo
 	gl.GenTextures(1, &r.fbo_texture)
@@ -772,7 +772,7 @@ func (r *Renderer_GL32) Init() {
 	if r.enableModel {
 		if r.enableShadow {
 			gl.GenFramebuffers(1, &r.fbo_shadow)
-			r.UseScratchUnit() //gl.ActiveTexture(gl.TEXTURE0)
+			r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 			gl.GenTextures(1, &r.fbo_shadow_cube_texture)
 			textureSerialNumber++
 
@@ -1023,7 +1023,7 @@ func (r *Renderer_GL32) EndFrame() {
 		gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_pp[i])
 		gl.Clear(gl.COLOR_BUFFER_BIT)
 	}
-	r.UseScratchUnit() //gl.ActiveTexture(gl.TEXTURE0) // later referred to by Texture_GL
+	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0) // later referred to by Texture_GL
 
 	fbo_texture := r.fbo_texture
 	if sys.msaa > 0 {
@@ -1333,7 +1333,7 @@ func (r *Renderer_GL32) prepareShadowMapPipeline(bufferIndex uint32) {
 	gl.FramebufferTexture(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, r.fbo_shadow_cube_texture, 0)
 	gl.Clear(gl.DEPTH_BUFFER_BIT)
 
-	r.UseScratchUnit() // gl.ActiveTexture(gl.TEXTURE0)
+	r.SetActiveTexture0() // gl.ActiveTexture(gl.TEXTURE0)
 }
 
 func (r *Renderer_GL32) setShadowMapPipeline(doubleSided, invertFrontFace, useUV, useNormal, useTangent, useVertColor, useJoint0, useJoint1 bool, numVertices, vertAttrOffset uint32) {
@@ -1526,7 +1526,7 @@ func (r *Renderer_GL32) prepareModelPipeline(bufferIndex uint32, env *Environmen
 		gl.Uniform1f(loc, 0)
 	}
 
-	r.UseScratchUnit() // gl.ActiveTexture(gl.TEXTURE0)
+	r.SetActiveTexture0() // gl.ActiveTexture(gl.TEXTURE0)
 }
 
 func (r *Renderer_GL32) SetModelPipeline(eq BlendEquation, src, dst BlendFunc, depthTest, depthMask, doubleSided, invertFrontFace,
@@ -1655,7 +1655,7 @@ func (r *Renderer_GL32) SetModelPipeline(eq BlendEquation, src, dst BlendFunc, d
 	}
 }
 
-func (r *Renderer_GL32) SetMeshOulinePipeline(invertFrontFace bool, meshOutline float32) {
+func (r *Renderer_GL32) SetMeshOutlinePipeline(invertFrontFace bool, meshOutline float32) {
 	r.SetFrontFace(invertFrontFace)
 	r.SetDepthTest(true)
 	r.SetDepthMask(true)
@@ -1960,7 +1960,7 @@ func (r *Renderer_GL32) SetShadowMapUniformMatrix3(name string, value []float32)
 
 // Selects texture unit 0 as active and tells the cache it's dirty
 // Prevents the sprite renderer from desyncing during texture maintenance
-func (r *Renderer_GL32) UseScratchUnit() {
+func (r *Renderer_GL32) SetActiveTexture0() {
 	gl.ActiveTexture(gl.TEXTURE0)
 
 	if len(r.texCacheTexSerial) > 0 {

--- a/src/render_gl_gl32.go
+++ b/src/render_gl_gl32.go
@@ -457,7 +457,9 @@ type Renderer_GL32 struct {
 	cubemapFilteringShader  *ShaderProgram_GL32
 	modelVertexBuffer       [2]uint32
 	modelIndexBuffer        [2]uint32
-	vao                     uint32
+	spriteVAO               uint32
+	modelVAO                uint32
+	postVAO                 uint32
 
 	enableModel  bool
 	enableShadow bool
@@ -589,17 +591,23 @@ func (r *Renderer_GL32) Init() {
 		r.EnableDebug()
 	}
 
-	gl.GenVertexArrays(1, &r.vao)
-	gl.BindVertexArray(r.vao)
+	// Generate VAO's
+	gl.GenVertexArrays(1, &r.spriteVAO)
+	gl.GenVertexArrays(1, &r.modelVAO)
+	gl.GenVertexArrays(1, &r.postVAO)
 
-	gl.GenBuffers(1, &r.postVertBuffer)
-
-	gl.BindBuffer(gl.ARRAY_BUFFER, r.postVertBuffer)
-	gl.BufferData(gl.ARRAY_BUFFER, len(postVertData), unsafe.Pointer(&postVertData[0]), gl.STATIC_DRAW)
-
+	// Generate buffers
 	gl.GenBuffers(1, &r.vertexBuffer)
 	gl.GenBuffers(2, &r.modelVertexBuffer[0])
 	gl.GenBuffers(2, &r.modelIndexBuffer[0])
+	gl.GenBuffers(1, &r.postVertBuffer)
+
+	// Initialize post-processing vertex buffer
+	gl.BindBuffer(gl.ARRAY_BUFFER, r.postVertBuffer)
+	gl.BufferData(gl.ARRAY_BUFFER, len(postVertData), unsafe.Pointer(&postVertData[0]), gl.STATIC_DRAW)
+
+	// Unbind for safety
+	gl.BindBuffer(gl.ARRAY_BUFFER, 0)
 
 	// Sprite shader
 	r.spriteShader, _ = r.newShaderProgram(vertShader, fragShader, "", "Main Shader", true)
@@ -607,6 +615,21 @@ func (r *Renderer_GL32) Init() {
 	r.spriteShader.RegisterUniforms("modelview", "projection", "x1x2x4x3",
 		"alpha", "tint", "mask", "neg", "gray", "add", "mult", "isFlat", "isRgba", "isTrapez", "hue")
 	r.spriteShader.RegisterTextures("pal", "tex")
+
+	// Configure spriteVAO
+	gl.BindVertexArray(r.spriteVAO)
+	gl.BindBuffer(gl.ARRAY_BUFFER, r.vertexBuffer)
+
+	locPos := r.spriteShader.attributes["position"]
+	gl.EnableVertexAttribArray(uint32(locPos))
+	gl.VertexAttribPointerWithOffset(uint32(locPos), 2, gl.FLOAT, false, 16, 0)
+
+	locUV := r.spriteShader.attributes["uv"]
+	gl.EnableVertexAttribArray(uint32(locUV))
+	gl.VertexAttribPointerWithOffset(uint32(locUV), 2, gl.FLOAT, false, 16, 8)
+
+	// Unbind for safety
+	gl.BindVertexArray(0)
 
 	if r.enableModel {
 		if err := r.InitModelShader(); err != nil {
@@ -620,12 +643,22 @@ func (r *Renderer_GL32) Init() {
 	// Pre-allocate the shader slice to accommodate all external shaders plus the identity shader
 	r.postShaderSelect = make([]*ShaderProgram_GL32, len(sys.cfg.Video.ExternalShaders)+1)
 
+	// Configure postVAO
+	gl.BindVertexArray(r.postVAO)
+	gl.BindBuffer(gl.ARRAY_BUFFER, r.postVertBuffer)
+
 	// External Shaders
 	for i := 0; i < len(sys.cfg.Video.ExternalShaders); i++ {
 		r.postShaderSelect[i], _ = r.newShaderProgram(string(sys.externalShaders[0][i])+"\x00", string(sys.externalShaders[1][i])+"\x00",
 			"", fmt.Sprintf("Postprocess Shader #%v", i), true)
 		r.postShaderSelect[i].RegisterAttributes("VertCoord") // "TexCoord" was registered but never used
 		r.postShaderSelect[i].RegisterUniforms("Texture_GL32", "TextureSize", "CurrentTime")
+
+		// Configure postVAO for this specific shader's attribute location
+		if loc, ok := r.postShaderSelect[i].attributes["VertCoord"]; ok && loc >= 0 {
+			gl.EnableVertexAttribArray(uint32(loc))
+			gl.VertexAttribPointer(uint32(loc), 2, gl.FLOAT, false, 0, nil)
+		}
 	}
 
 	// Identity shader (no postprocessing)
@@ -633,8 +666,18 @@ func (r *Renderer_GL32) Init() {
 	identShader.RegisterAttributes("VertCoord")
 	//identShader.RegisterUniforms("Texture_GL32", "TextureSize", "CurrentTime") // None of these are used
 
+	// Configure postVAO for the identity shader's attribute location
+	if loc, ok := identShader.attributes["VertCoord"]; ok && loc >= 0 {
+		gl.EnableVertexAttribArray(uint32(loc))
+		gl.VertexAttribPointer(uint32(loc), 2, gl.FLOAT, false, 0, nil)
+	}
+
 	// It should be the last one in modern OpenGL
 	r.postShaderSelect[len(r.postShaderSelect)-1] = identShader
+
+	// Unbind for safety
+	gl.BindVertexArray(0)
+	gl.BindBuffer(gl.ARRAY_BUFFER, 0)
 
 	// Toggle MSAA first
 	if sys.msaa > 0 {
@@ -870,9 +913,18 @@ func (r *Renderer_GL32) EnableDebug() {
 	fmt.Printf("[GL Debug] Debug mode enabled\n")
 }
 
+/*
 func (r *Renderer_GL32) DebugCheckLeaks(nextprog uint32) {
+	// Only query attributes if a VAO is bound
+	var currentVAO int32
+	gl.GetIntegerv(gl.VERTEX_ARRAY_BINDING, &currentVAO)
+	if currentVAO == 0 {
+		return 
+	}
+
 	var enabled int32
 	leaked := []int{}
+	// Only check up to the hardware limit
 	for slot := uint32(0); slot < 16; slot++ {
 		gl.GetVertexAttribiv(slot, gl.VERTEX_ATTRIB_ARRAY_ENABLED, &enabled)
 		if enabled != 0 {
@@ -880,9 +932,10 @@ func (r *Renderer_GL32) DebugCheckLeaks(nextprog uint32) {
 		}
 	}
 	if len(leaked) > 0 {
-		fmt.Printf("[GL Debug] Changing to program %d with program %d's attributes %v enabled.\n", nextprog, r.program, leaked)
+		fmt.Printf("[GL Debug] Changing to program %d with attributes %v enabled in VAO %d.\n", nextprog, leaked, currentVAO)
 	}
 }
+*/
 
 func (r *Renderer_GL32) DebugVerifyCache() {
 	if !r.debugMode {
@@ -984,7 +1037,7 @@ func (r *Renderer_GL32) IsShadowEnabled() bool {
 }
 
 func (r *Renderer_GL32) BeginFrame(clearColor bool) {
-	gl.BindVertexArray(r.vao)
+	//gl.BindVertexArray(r.vao)
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo)
 	gl.Viewport(0, 0, sys.scrrect[2], sys.scrrect[3])
 	if clearColor {
@@ -1044,7 +1097,7 @@ func (r *Renderer_GL32) EndFrame() {
 
 		// tell GL to use our vertex array object
 		// this'll be where our quad is stored
-		gl.BindVertexArray(r.vao)
+		gl.BindVertexArray(r.postVAO)
 
 		// this is here because it is undefined
 		// behavior to write to the same FBO
@@ -1090,34 +1143,8 @@ func (r *Renderer_GL32) EndFrame() {
 		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, scaleMode)
 		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, scaleMode)
 
-		// this actually draws the image to the FBO
-		// by constructing a quad (2 tris)
-		gl.BindBuffer(gl.ARRAY_BUFFER, r.postVertBuffer)
-
-		// construct the UVs of the quad
-		// VertCoord is the primary position attribute
-		if loc, ok := postShader.attributes["VertCoord"]; ok && loc >= 0 {
-			vLoc := uint32(loc)
-			gl.EnableVertexAttribArray(vLoc)
-			gl.VertexAttribPointer(vLoc, 2, gl.FLOAT, false, 0, nil)
-		}
-
-		// Some external shaders may use a separate TexCoord attribute instead of calculating it from VertCoord
-		//if loc, ok := postShader.attributes["TexCoord"]; ok && loc >= 0 {
-		//	tLoc := uint32(loc)
-		//	gl.EnableVertexAttribArray(tLoc)
-		//	gl.VertexAttribPointer(tLoc, 2, gl.FLOAT, false, 0, nil)
-		//}
-
 		// construct the quad and draw it
 		gl.DrawArrays(gl.TRIANGLE_STRIP, 0, 4)
-
-		// Disable attributes after use
-		for _, loc := range postShader.attributes {
-			if loc >= 0 {
-				gl.DisableVertexAttribArray(uint32(loc))
-			}
-		}
 	}
 }
 
@@ -1221,7 +1248,7 @@ func (r *Renderer_GL32) ChangeProgram(prog uint32) {
 	// State leak detector
 	// TODO: Just move to separate VAO's if we drop GL2.1
 	if r.debugMode {
-		r.DebugCheckLeaks(prog)
+		//r.DebugCheckLeaks(prog)
 		r.DebugVerifyCache()
 	}
 
@@ -1284,37 +1311,18 @@ func (r *Renderer_GL32) SetPipeline() {
 
 	r.ChangeProgram(r.spriteShader.program)
 
-	gl.BindVertexArray(r.vao)
-	gl.BindBuffer(gl.ARRAY_BUFFER, r.vertexBuffer)
-
-	// Disable all active attributes
-	// Prevents "vertex shader is being recompiled" errors
-	// Note: We use 11 attributes tops. This may need to be updated in the future
-	//for i := uint32(0); i < 11; i++ {
-	//	gl.DisableVertexAttribArray(i)
-	//}
-
-	locPos := r.spriteShader.attributes["position"]
-	gl.EnableVertexAttribArray(uint32(locPos))
-	gl.VertexAttribPointerWithOffset(uint32(locPos), 2, gl.FLOAT, false, 16, 0)
-
-	locUV := r.spriteShader.attributes["uv"]
-	gl.EnableVertexAttribArray(uint32(locUV))
-	gl.VertexAttribPointerWithOffset(uint32(locUV), 2, gl.FLOAT, false, 16, 8)
+	gl.BindVertexArray(r.spriteVAO)
 }
 
 func (r *Renderer_GL32) ReleasePipeline() {
-	loc := r.spriteShader.attributes["position"]
-	gl.DisableVertexAttribArray(uint32(loc))
-	loc = r.spriteShader.attributes["uv"]
-	gl.DisableVertexAttribArray(uint32(loc))
+	gl.BindVertexArray(0)
 	//r.DisableBlending()
 }
 
 func (r *Renderer_GL32) prepareShadowMapPipeline(bufferIndex uint32) {
 	r.ChangeProgram(r.shadowMapShader.program)
 
-	gl.BindVertexArray(r.vao)
+	gl.BindVertexArray(r.modelVAO)
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_shadow)
 
 	gl.Viewport(0, 0, 1024, 1024)
@@ -1463,7 +1471,7 @@ func (r *Renderer_GL32) ReleaseShadowPipeline() {
 func (r *Renderer_GL32) prepareModelPipeline(bufferIndex uint32, env *Environment) {
 	r.ChangeProgram(r.modelShader.program)
 
-	gl.BindVertexArray(r.vao)
+	gl.BindVertexArray(r.modelVAO)
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo)
 
 	gl.Viewport(0, 0, sys.scrrect[2], sys.scrrect[3])
@@ -2078,7 +2086,7 @@ func (r *Renderer_GL32) RenderCubeMap(envTex Texture, cubeTex Texture) {
 
 	r.ChangeProgram(r.panoramaToCubeMapShader.program)
 
-	gl.BindVertexArray(r.vao)
+	gl.BindVertexArray(r.modelVAO)
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_env)
 	gl.Viewport(0, 0, textureSize, textureSize)
 
@@ -2114,7 +2122,7 @@ func (r *Renderer_GL32) RenderFilteredCubeMap(distribution int32, cubeTex Textur
 
 	r.ChangeProgram(r.cubemapFilteringShader.program)
 
-	gl.BindVertexArray(r.vao)
+	gl.BindVertexArray(r.modelVAO)
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_env)
 	gl.Viewport(0, 0, currentTextureSize, currentTextureSize)
 
@@ -2161,7 +2169,7 @@ func (r *Renderer_GL32) RenderLUT(distribution int32, cubeTex Texture, lutTex Te
 
 	r.ChangeProgram(r.cubemapFilteringShader.program)
 
-	gl.BindVertexArray(r.vao)
+	gl.BindVertexArray(r.modelVAO)
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_env)
 	gl.Viewport(0, 0, textureSize, textureSize)
 

--- a/src/render_gl_gles32.go
+++ b/src/render_gl_gles32.go
@@ -251,7 +251,7 @@ func (r *Renderer_GLES32) generateTexture(width, height, depth int32, filter boo
 
 // Creates a generic texture
 func (r *Renderer_GLES32) newTexture(width, height, depth int32, filter bool) Texture {
-	r.UseScratchUnit() //gl.ActiveTexture(gl.TEXTURE0)
+	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	t := r.generateTexture(width, height, depth, filter)
 
@@ -267,7 +267,7 @@ func (r *Renderer_GLES32) newModelTexture(width, height, depth int32, filter boo
 }
 
 func (r *Renderer_GLES32) newDataTexture(width, height int32) Texture {
-	r.UseScratchUnit() //gl.ActiveTexture(gl.TEXTURE0)
+	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	t := r.generateTexture(width, height, 32, false)
 
@@ -280,7 +280,7 @@ func (r *Renderer_GLES32) newDataTexture(width, height int32) Texture {
 }
 
 func (r *Renderer_GLES32) newHDRTexture(width, height int32) Texture {
-	r.UseScratchUnit() //gl.ActiveTexture(gl.TEXTURE0)
+	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	t := r.generateTexture(width, height, 24, false)
 
@@ -293,7 +293,7 @@ func (r *Renderer_GLES32) newHDRTexture(width, height int32) Texture {
 }
 
 func (r *Renderer_GLES32) newCubeMapTexture(widthHeight int32, mipmap bool, lowestMipLevel int32) Texture {
-	r.UseScratchUnit() //gl.ActiveTexture(gl.TEXTURE0)
+	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	t := r.generateTexture(widthHeight, widthHeight, 24, false)
 
@@ -328,7 +328,7 @@ func (t *Texture_GLES32) SetData(data []byte) {
 	uploadType := t.MapUploadType(bits)
 
 	r := gfx.(*Renderer_GLES32)
-	r.UseScratchUnit() //gl.ActiveTexture(gl.TEXTURE0)
+	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	gl.BindTexture(gl.TEXTURE_2D, t.handle)
 	gl.PixelStorei(gl.UNPACK_ALIGNMENT, 1)
@@ -353,7 +353,7 @@ func (t *Texture_GLES32) SetSubData(data []byte, x, y, width, height, stride int
 	}
 
 	r := gfx.(*Renderer_GLES32)
-	r.UseScratchUnit() //gl.ActiveTexture(gl.TEXTURE0)
+	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	gl.BindTexture(gl.TEXTURE_2D, t.handle)
 	gl.PixelStorei(gl.UNPACK_ALIGNMENT, 1)
@@ -405,7 +405,7 @@ func (t *Texture_GLES32) SetDataG(data []byte, mag, min, ws, wt TextureSamplingP
 	uploadType := t.MapUploadType(bits)
 
 	r := gfx.(*Renderer_GLES32)
-	r.UseScratchUnit() //gl.ActiveTexture(gl.TEXTURE0)
+	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	gl.BindTexture(gl.TEXTURE_2D, t.handle)
 	gl.PixelStorei(gl.UNPACK_ALIGNMENT, 1)
@@ -420,7 +420,7 @@ func (t *Texture_GLES32) SetDataG(data []byte, mag, min, ws, wt TextureSamplingP
 
 func (t *Texture_GLES32) SetPixelData(data []float32) {
 	r := gfx.(*Renderer_GLES32)
-	r.UseScratchUnit() //gl.ActiveTexture(gl.TEXTURE0)
+	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	gl.BindTexture(gl.TEXTURE_2D, t.handle)
 	gl.PixelStorei(gl.UNPACK_ALIGNMENT, 1)
@@ -430,7 +430,7 @@ func (t *Texture_GLES32) SetPixelData(data []float32) {
 
 func (t Texture_GLES32) CopyData(src *Texture) {
 	r := gfx.(*Renderer_GLES32)
-	r.UseScratchUnit() //gl.ActiveTexture(gl.TEXTURE0)
+	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	gl.BindTexture(gl.TEXTURE_2D, 0) // Unbind whatever is currently bound
 	srcES := (*src).(*Texture_GLES32)
@@ -451,7 +451,7 @@ func (t Texture_GLES32) CopyData(src *Texture) {
 // Not called anywhere
 func (t *Texture_GLES32) SetRGBPixelData(data []float32) {
 	r := gfx.(*Renderer_GLES32)
-	r.UseScratchUnit() //gl.ActiveTexture(gl.TEXTURE0)
+	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	gl.BindTexture(gl.TEXTURE_2D, t.handle)
 	gl.PixelStorei(gl.UNPACK_ALIGNMENT, 1)
@@ -740,7 +740,7 @@ func (r *Renderer_GLES32) Init() {
 	// It should be the last one in modern OpenGL
 	r.postShaderSelect[len(r.postShaderSelect)-1] = identShader
 
-	r.UseScratchUnit() //gl.ActiveTexture(gl.TEXTURE0)
+	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	// create a texture for r.fbo
 	gl.GenTextures(1, &r.fbo_texture)
@@ -851,7 +851,7 @@ func (r *Renderer_GLES32) Init() {
 		if r.enableShadow {
 			// create FBO for shadow rendering
 			gl.GenFramebuffers(1, &r.fbo_shadow)
-			r.UseScratchUnit() //gl.ActiveTexture(gl.TEXTURE0)
+			r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 			// create 4 separate GL_TEXTURE_CUBE_MAP textures (one per shadow caster/light)
 			gl.GenTextures(4, &r.fbo_shadow_cube_textures[0])
@@ -993,7 +993,7 @@ func (r *Renderer_GLES32) EndFrame() {
 		gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_pp[i])
 		gl.Clear(gl.COLOR_BUFFER_BIT)
 	}
-	r.UseScratchUnit() //gl.ActiveTexture(gl.TEXTURE0) // later referred to by Texture_GL
+	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0) // later referred to by Texture_GL
 
 	fbo_texture := r.fbo_texture
 	if sys.msaa > 0 {
@@ -1274,7 +1274,7 @@ func (r *Renderer_GLES32) prepareShadowMapPipeline(bufferIndex uint32) {
 	// SetShadowFrameCubeTexture(...) before rendering each face.
 	// Clearing must be done after the correct face is attached.
 
-	r.UseScratchUnit() // gl.ActiveTexture(gl.TEXTURE0)
+	r.SetActiveTexture0() // gl.ActiveTexture(gl.TEXTURE0)
 }
 
 func (r *Renderer_GLES32) setShadowMapPipeline(doubleSided, invertFrontFace, useUV, useNormal, useTangent, useVertColor, useJoint0, useJoint1 bool, numVertices, vertAttrOffset uint32) {
@@ -1472,7 +1472,7 @@ func (r *Renderer_GLES32) prepareModelPipeline(bufferIndex uint32, env *Environm
 		gl.Uniform1f(loc, 0)
 	}
 
-	r.UseScratchUnit() // gl.ActiveTexture(gl.TEXTURE0)
+	r.SetActiveTexture0() // gl.ActiveTexture(gl.TEXTURE0)
 }
 
 func (r *Renderer_GLES32) SetModelPipeline(eq BlendEquation, src, dst BlendFunc, depthTest, depthMask, doubleSided, invertFrontFace,
@@ -1601,7 +1601,7 @@ func (r *Renderer_GLES32) SetModelPipeline(eq BlendEquation, src, dst BlendFunc,
 	}
 }
 
-func (r *Renderer_GLES32) SetMeshOulinePipeline(invertFrontFace bool, meshOutline float32) {
+func (r *Renderer_GLES32) SetMeshOutlinePipeline(invertFrontFace bool, meshOutline float32) {
 	r.SetFrontFace(invertFrontFace)
 	r.SetDepthTest(true)
 	r.SetDepthMask(true)
@@ -1906,7 +1906,7 @@ func (r *Renderer_GLES32) SetShadowMapUniformMatrix3(name string, value []float3
 
 // Selects texture unit 0 as active and tells the cache it's dirty
 // Prevents the sprite renderer from desyncing during texture maintenance
-func (r *Renderer_GLES32) UseScratchUnit() {
+func (r *Renderer_GLES32) SetActiveTexture0() {
 	gl.ActiveTexture(gl.TEXTURE0)
 
 	if len(r.texCacheTexSerial) > 0 {

--- a/src/render_gl_gles32.go
+++ b/src/render_gl_gles32.go
@@ -547,7 +547,9 @@ type Renderer_GLES32 struct {
 	cubemapFilteringShader  *ShaderProgram_GLES32
 	modelVertexBuffer       [2]uint32
 	modelIndexBuffer        [2]uint32
-	vao                     uint32
+	spriteVAO               uint32
+	modelVAO                uint32
+	postVAO                 uint32
 
 	enableModel  bool
 	enableShadow bool
@@ -677,14 +679,30 @@ func (r *Renderer_GLES32) Init() {
 	r.enableModel = sys.cfg.Video.EnableModel
 	r.enableShadow = sys.cfg.Video.EnableModelShadow
 
-	Logcat("GLES: About to Gen VAO")
-	gl.GenVertexArrays(1, &r.vao)
-	gl.BindVertexArray(r.vao)
-	Logcat("GLES: VAO Bound")
+	// Generate VAO's
+	gl.GenVertexArrays(1, &r.spriteVAO)
+	gl.GenVertexArrays(1, &r.modelVAO)
+	gl.GenVertexArrays(1, &r.postVAO)
+	Logcat("GLES: Sprite, model and post VAO's generated")
+
+	//Logcat("GLES: VAO Bound")
+
+	// Generate buffers
+	gl.GenBuffers(1, &r.vertexBuffer)
+	Logcat("GLES: VertexBuffer Generated")
+
+	gl.GenBuffers(1, &r.modelVertexBuffer[0])
+	gl.GenBuffers(1, &r.modelVertexBuffer[1])
+	Logcat("GLES: ModelVertexBuffers Generated")
+
+	gl.GenBuffers(1, &r.modelIndexBuffer[0])
+	gl.GenBuffers(1, &r.modelIndexBuffer[1])
+	Logcat("GLES: ModelIndexBuffers Generated")
 
 	gl.GenBuffers(1, &r.postVertBuffer)
 	Logcat("GLES: PostVertBuffer Generated")
 
+	// Initialize post-processing vertex buffer
 	gl.BindBuffer(gl.ARRAY_BUFFER, r.postVertBuffer)
 	Logcat(fmt.Sprintf("GLES: Data Size: %d", len(postVertData)))
 
@@ -695,15 +713,8 @@ func (r *Renderer_GLES32) Init() {
 		Logcat("GLES: ERROR - postVertData is empty!")
 	}
 
-	gl.GenBuffers(1, &r.vertexBuffer)
-	Logcat("GLES: VertexBuffer Generated")
-	gl.GenBuffers(1, &r.modelVertexBuffer[0])
-	gl.GenBuffers(1, &r.modelVertexBuffer[1])
-	Logcat("GLES: ModelVertexBuffers Generated")
-
-	gl.GenBuffers(1, &r.modelIndexBuffer[0])
-	gl.GenBuffers(1, &r.modelIndexBuffer[1])
-	Logcat("GLES: ModelIndexBuffers Generated")
+	// Unbind for safety
+	gl.BindBuffer(gl.ARRAY_BUFFER, 0)
 
 	// Sprite shader
 	r.spriteShader, _ = r.newShaderProgram(vertShader, fragShader, "", "Main Shader", true)
@@ -711,6 +722,21 @@ func (r *Renderer_GLES32) Init() {
 	r.spriteShader.RegisterUniforms("modelview", "projection", "x1x2x4x3",
 		"alpha", "tint", "mask", "neg", "gray", "add", "mult", "isFlat", "isRgba", "isTrapez", "hue")
 	r.spriteShader.RegisterTextures("pal", "tex")
+
+	// Configure spriteVAO
+	gl.BindVertexArray(r.spriteVAO)
+	gl.BindBuffer(gl.ARRAY_BUFFER, r.vertexBuffer)
+
+	locPos := r.spriteShader.attributes["position"]
+	gl.EnableVertexAttribArray(uint32(locPos))
+	gl.VertexAttribPointerWithOffset(uint32(locPos), 2, gl.FLOAT, false, 16, 0)
+
+	locUV := r.spriteShader.attributes["uv"]
+	gl.EnableVertexAttribArray(uint32(locUV))
+	gl.VertexAttribPointerWithOffset(uint32(locUV), 2, gl.FLOAT, false, 16, 8)
+
+	// Unbind for safety
+	gl.BindVertexArray(0)
 
 	if r.enableModel {
 		if err := r.InitModelShader(); err != nil {
@@ -724,12 +750,22 @@ func (r *Renderer_GLES32) Init() {
 	// Pre-allocate the shader slice to accommodate all external shaders plus the identity shader
 	r.postShaderSelect = make([]*ShaderProgram_GLES32, len(sys.cfg.Video.ExternalShaders)+1)
 
+	// Configure postVAO
+	gl.BindVertexArray(r.postVAO)
+	gl.BindBuffer(gl.ARRAY_BUFFER, r.postVertBuffer)
+
 	// External Shaders
 	for i := 0; i < len(sys.cfg.Video.ExternalShaders); i++ {
 		r.postShaderSelect[i], _ = r.newShaderProgram(string(sys.externalShaders[0][i])+"\x00", string(sys.externalShaders[1][i])+"\x00",
 			"", fmt.Sprintf("Postprocess Shader #%v", i), true)
 		r.postShaderSelect[i].RegisterAttributes("VertCoord") // "TexCoord" was registered but never used
 		r.postShaderSelect[i].RegisterUniforms("Texture_GLES32", "TextureSize", "CurrentTime")
+
+		// Configure postVAO for this specific shader's attribute location
+		if loc, ok := r.postShaderSelect[i].attributes["VertCoord"]; ok && loc >= 0 {
+			gl.EnableVertexAttribArray(uint32(loc))
+			gl.VertexAttribPointer(uint32(loc), 2, gl.FLOAT, false, 0, nil)
+		}
 	}
 
 	// Identity shader (no postprocessing). This should be the last one in modern OpenGL
@@ -737,8 +773,18 @@ func (r *Renderer_GLES32) Init() {
 	identShader.RegisterAttributes("VertCoord")
 	//identShader.RegisterUniforms("Texture_GLES32", "TextureSize", "CurrentTime") // None of these are used
 
+	// Configure postVAO for the identity shader's attribute location
+	if loc, ok := identShader.attributes["VertCoord"]; ok && loc >= 0 {
+		gl.EnableVertexAttribArray(uint32(loc))
+		gl.VertexAttribPointer(uint32(loc), 2, gl.FLOAT, false, 0, nil)
+	}
+
 	// It should be the last one in modern OpenGL
 	r.postShaderSelect[len(r.postShaderSelect)-1] = identShader
+
+	// Unbind for safety
+	gl.BindVertexArray(0)
+	gl.BindBuffer(gl.ARRAY_BUFFER, 0)
 
 	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
@@ -954,7 +1000,7 @@ func (r *Renderer_GLES32) IsShadowEnabled() bool {
 }
 
 func (r *Renderer_GLES32) BeginFrame(clearColor bool) {
-	gl.BindVertexArray(r.vao)
+	//gl.BindVertexArray(r.vao)
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo)
 	gl.Viewport(0, 0, sys.scrrect[2], sys.scrrect[3])
 	if clearColor {
@@ -1014,7 +1060,7 @@ func (r *Renderer_GLES32) EndFrame() {
 
 		// tell GL to use our vertex array object
 		// this'll be where our quad is stored
-		gl.BindVertexArray(r.vao)
+		gl.BindVertexArray(r.postVAO)
 
 		// this is here because it is undefined
 		// behavior to write to the same FBO
@@ -1060,34 +1106,8 @@ func (r *Renderer_GLES32) EndFrame() {
 		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, scaleMode)
 		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, scaleMode)
 
-		// this actually draws the image to the FBO
-		// by constructing a quad (2 tris)
-		gl.BindBuffer(gl.ARRAY_BUFFER, r.postVertBuffer)
-
-		// construct the UVs of the quad
-		// VertCoord is the primary position attribute
-		if loc, ok := postShader.attributes["VertCoord"]; ok && loc >= 0 {
-			vLoc := uint32(loc)
-			gl.EnableVertexAttribArray(vLoc)
-			gl.VertexAttribPointer(vLoc, 2, gl.FLOAT, false, 0, nil)
-		}
-
-		// Some external shaders may use a separate TexCoord attribute instead of calculating it from VertCoord
-		//if loc, ok := postShader.attributes["TexCoord"]; ok && loc >= 0 {
-		//	tLoc := uint32(loc)
-		//	gl.EnableVertexAttribArray(tLoc)
-		//	gl.VertexAttribPointer(tLoc, 2, gl.FLOAT, false, 0, nil)
-		//}
-
 		// construct the quad and draw it
 		gl.DrawArrays(gl.TRIANGLE_STRIP, 0, 4)
-
-		// Disable attributes after use
-		for _, loc := range postShader.attributes {
-			if loc >= 0 {
-				gl.DisableVertexAttribArray(uint32(loc))
-			}
-		}
 	}
 }
 
@@ -1232,30 +1252,18 @@ func (r *Renderer_GLES32) SetPipeline() {
 
 	r.ChangeProgram(r.spriteShader.program)
 
-	gl.BindVertexArray(r.vao)
-	gl.BindBuffer(gl.ARRAY_BUFFER, r.vertexBuffer)
-
-	locPos := r.spriteShader.attributes["position"]
-	gl.EnableVertexAttribArray(uint32(locPos))
-	gl.VertexAttribPointerWithOffset(uint32(locPos), 2, gl.FLOAT, false, 16, 0)
-
-	locUV := r.spriteShader.attributes["uv"]
-	gl.EnableVertexAttribArray(uint32(locUV))
-	gl.VertexAttribPointerWithOffset(uint32(locUV), 2, gl.FLOAT, false, 16, 8)
+	gl.BindVertexArray(r.spriteVAO)
 }
 
 func (r *Renderer_GLES32) ReleasePipeline() {
-	loc := r.spriteShader.attributes["position"]
-	gl.DisableVertexAttribArray(uint32(loc))
-	loc = r.spriteShader.attributes["uv"]
-	gl.DisableVertexAttribArray(uint32(loc))
+	gl.BindVertexArray(0)
 	//r.DisableBlending()
 }
 
 func (r *Renderer_GLES32) prepareShadowMapPipeline(bufferIndex uint32) {
 	r.ChangeProgram(r.shadowMapShader.program)
 
-	gl.BindVertexArray(r.vao)
+	gl.BindVertexArray(r.modelVAO)
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_shadow)
 	gl.Viewport(0, 0, 1024, 1024)
 	// Removed gl.Enable(gl.TEXTURE_2D) — not needed / invalid in GLES3 core
@@ -1404,7 +1412,7 @@ func (r *Renderer_GLES32) ReleaseShadowPipeline() {
 func (r *Renderer_GLES32) prepareModelPipeline(bufferIndex uint32, env *Environment) {
 	r.ChangeProgram(r.modelShader.program)
 
-	gl.BindVertexArray(r.vao)
+	gl.BindVertexArray(r.modelVAO)
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo)
 
 	gl.Viewport(0, 0, sys.scrrect[2], sys.scrrect[3])
@@ -2055,7 +2063,7 @@ func (r *Renderer_GLES32) RenderCubeMap(envTex Texture, cubeTex Texture) {
 
 	r.ChangeProgram(r.panoramaToCubeMapShader.program)
 
-	gl.BindVertexArray(r.vao)
+	gl.BindVertexArray(r.modelVAO)
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_env)
 	gl.Viewport(0, 0, textureSize, textureSize)
 
@@ -2091,7 +2099,7 @@ func (r *Renderer_GLES32) RenderFilteredCubeMap(distribution int32, cubeTex Text
 
 	r.ChangeProgram(r.cubemapFilteringShader.program)
 
-	gl.BindVertexArray(r.vao)
+	gl.BindVertexArray(r.modelVAO)
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_env)
 	gl.Viewport(0, 0, currentTextureSize, currentTextureSize)
 
@@ -2138,7 +2146,7 @@ func (r *Renderer_GLES32) RenderLUT(distribution int32, cubeTex Texture, lutTex 
 
 	r.ChangeProgram(r.cubemapFilteringShader.program)
 
-	gl.BindVertexArray(r.vao)
+	gl.BindVertexArray(r.modelVAO)
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_env)
 	gl.Viewport(0, 0, textureSize, textureSize)
 

--- a/src/render_gles32.go
+++ b/src/render_gles32.go
@@ -1,32 +1,31 @@
-// This is almost identical to render_gl.go except it uses a VAO
-// for GL 3.2 which is the minimum version that runs on modern
-// macOS (Intel and ARM). Work adapted from assemblaj/fantasma
+// This is almost identical to render_gles.go except it uses a VAO
+// for GLES 3.2 which is the main version that runs on modern
+// Android (ARM). Work adapted from Leon Kasovan
 
-//go:build !android
+//go:build android
 
 package main
 
 import (
 	"bytes"
-	_ "embed" // Support for go:embed resources
 	"encoding/binary"
 	"fmt"
 	"math"
 	"runtime"
+	"strings"
+	"sync"
 	"unsafe"
 
-	gl "github.com/go-gl/gl/v3.2-core/gl"
 	mgl "github.com/go-gl/mathgl/mgl32"
+	gl "github.com/leonkasovan/gl/v3.2/gles2"
 	"github.com/veandco/go-sdl2/sdl"
 	"golang.org/x/mobile/exp/f32"
 )
 
-//const GL_SHADER_VER = 150 // OpenGL 3.2
-
 // ------------------------------------------------------------------
-// ShaderProgram_GL32
+// ShaderProgram_GLES32
 
-type ShaderProgram_GL32 struct {
+type ShaderProgram_GLES32 struct {
 	program    uint32           // OpenGL handle
 	attributes map[string]int32 // Attribute name to location
 	uniforms   map[string]int32 // Uniform name to location
@@ -34,153 +33,188 @@ type ShaderProgram_GL32 struct {
 	name       string           // For debugging
 }
 
-func (r *Renderer_GL32) newShaderProgram(vert, frag, geo, name string, crashWhenFail bool) (s *ShaderProgram_GL32, err error) {
-	var vertObj, fragObj, geoObj, prog uint32
-	if vertObj, err = r.compileShader(gl.VERTEX_SHADER, vert); chkEX(err, "Shader compilation error on "+name+"\n", crashWhenFail) {
+var shaderCompileMutex sync.Mutex
+
+func (r *Renderer_GLES32) newShaderProgram(vert, frag, geo, name string, crashWhenFail bool) (s *ShaderProgram_GLES32, err error) {
+	// LOCK THE THREAD HERE
+	shaderCompileMutex.Lock()
+	defer shaderCompileMutex.Unlock()
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	Logcat("GLES: [LOCKED] Starting: " + name)
+	var vertObj, fragObj, prog uint32
+
+	vertObj, err = r.compileShader(gl.VERTEX_SHADER, vert)
+	if err != nil {
 		return nil, err
 	}
-	if fragObj, err = r.compileShader(gl.FRAGMENT_SHADER, frag); chkEX(err, "Shader compilation error on "+name+"\n", crashWhenFail) {
+	Logcat("GLES: Vertex Obj created: " + name)
+
+	fragObj, err = r.compileShader(gl.FRAGMENT_SHADER, frag)
+	if err != nil {
 		return nil, err
 	}
-	if len(geo) > 0 {
-		if geoObj, err = r.compileShader(gl.GEOMETRY_SHADER, geo); chkEX(err, "Shader compilation error on "+name+"\n", crashWhenFail) {
+	Logcat("GLES: Frag Obj created: " + name)
+
+	// IMPORTANT: Geometry shaders are very unstable on GLES 3.2 mobile.
+	// For now, let's force skip them to see if we can reach the main menu.
+	if false && len(geo) > 0 {
+		if geoObj, err := r.compileShader(gl.GEOMETRY_SHADER, geo); chkEX(err, "Shader compilation error on "+name+"\n", crashWhenFail) {
 			return nil, err
-		}
-		if prog, err = r.linkProgram(vertObj, fragObj, geoObj); chkEX(err, "Link program error on "+name+"\n", crashWhenFail) {
-			return nil, err
+		} else {
+			if prog, err = r.linkProgram(vertObj, fragObj, geoObj); chkEX(err, "Link program error on "+name+"\n", crashWhenFail) {
+				return nil, err
+			}
 		}
 	} else {
-		if prog, err = r.linkProgram(vertObj, fragObj); chkEX(err, "Link program error on "+name+"\n", crashWhenFail) {
+		Logcat("GLES: Entering linkProgram...")
+		prog, err = r.linkProgram(vertObj, fragObj)
+		if err != nil {
 			return nil, err
 		}
 	}
-	s = &ShaderProgram_GL32{program: prog, name: name}
+
+	Logcat("GLES: Program linked, creating struct...")
+	s = &ShaderProgram_GLES32{program: prog, name: name}
 	s.attributes = make(map[string]int32)
 	s.uniforms = make(map[string]int32)
 	s.textures = make(map[string]int)
 
-	// Debug
-	if r.debugMode {
-		fmt.Printf("[GL Debug] Linked shader '%s' as Program ID: %d\n", name, prog)
-	}
-
+	Logcat("GLES: Shader initialization complete for: " + name)
 	return s, nil
 }
 
-func (r *ShaderProgram_GL32) glStr(s string) *uint8 {
+func (r *ShaderProgram_GLES32) glStr(s string) *uint8 {
 	return gl.Str(s + "\x00")
 }
 
-func (s *ShaderProgram_GL32) RegisterAttributes(names ...string) {
-	r := gfx.(*Renderer_GL32)
+func (s *ShaderProgram_GLES32) RegisterAttributes(names ...string) {
 	for _, name := range names {
-		loc := gl.GetAttribLocation(s.program, s.glStr(name))
+		cstr := gl.Str(name + "\x00")
+		loc := gl.GetAttribLocation(s.program, cstr)
 		s.attributes[name] = loc
-
-		if r.debugMode && loc == -1 {
-			fmt.Printf("[GL Debug] Shader %v: Attribute '%s' not found!\n", s.name, name)
-		}
+		Logcat(fmt.Sprintf("GLES: Attribute [%s] mapped to %d", name, loc))
 	}
 }
 
-func (s *ShaderProgram_GL32) RegisterUniforms(names ...string) {
-	r := gfx.(*Renderer_GL32)
+func (s *ShaderProgram_GLES32) RegisterUniforms(names ...string) {
 	for _, name := range names {
-		loc := gl.GetUniformLocation(s.program, s.glStr(name))
+		cstr := gl.Str(name + "\x00")
+		loc := gl.GetUniformLocation(s.program, cstr)
 		s.uniforms[name] = loc
-
-		if r.debugMode && loc == -1 {
-			fmt.Printf("[GL Debug] Shader %v: Uniform '%s' not found!\n", s.name, name)
-		}
+		Logcat(fmt.Sprintf("GLES: Uniform [%s] mapped to %d", name, loc))
 	}
 }
 
-func (s *ShaderProgram_GL32) RegisterTextures(names ...string) {
-	r := gfx.(*Renderer_GL32)
+func (s *ShaderProgram_GLES32) RegisterTextures(names ...string) {
 	for _, name := range names {
-		loc := gl.GetUniformLocation(s.program, s.glStr(name))
+		cstr := gl.Str(name + "\x00")
+		loc := gl.GetUniformLocation(s.program, cstr)
 		s.uniforms[name] = loc
 		s.textures[name] = len(s.textures)
-
-		if r.debugMode && loc == -1 {
-			fmt.Printf("[GL Debug] Shader %v: Texture uniform '%s' not found or optimized out!\n", s.name, name)
-		}
+		Logcat(fmt.Sprintf("GLES: Texture [%s] mapped to %d", name, loc))
 	}
 }
 
-func (r *Renderer_GL32) compileShader(shaderType uint32, src string) (shader uint32, err error) {
-	shader = gl.CreateShader(shaderType)
-	src = "#version 150\n" + src + "\x00"
-	s, _ := gl.Strs(src)
-	var l int32 = int32(len(src) - 1)
-	gl.ShaderSource(shader, 1, s, &l)
-	gl.CompileShader(shader)
-	var ok int32
-	gl.GetShaderiv(shader, gl.COMPILE_STATUS, &ok)
-	if ok == 0 {
-		//var err error
-		var size, l int32
-		gl.GetShaderiv(shader, gl.INFO_LOG_LENGTH, &size)
-		if size > 0 {
-			str := make([]byte, size+1)
-			gl.GetShaderInfoLog(shader, size, &l, &str[0])
-			err = Error(str[:l])
-		} else {
-			err = Error("Unknown shader compile error")
-		}
-		//chk(err)
-		gl.DeleteShader(shader)
-		//panic(Error("Shader compile error"))
-		return 0, err
+func (r *Renderer_GLES32) compileShader(shaderType uint32, src string) (uint32, error) {
+	shader := gl.CreateShader(shaderType)
+
+	// 1. SMART HEADER INJECTION
+	// GLES 3.0+ drivers REQUIRE the version to be the very first line.
+	// If your file doesn't have it, we add it here.
+	fullSrc := src
+	if !strings.HasPrefix(strings.TrimSpace(src), "#version") {
+		// Anchor to 300 es for best mobile compatibility
+		header := "#version 310 es\n"
+		fullSrc = header + src
 	}
+
+	// Ensure null-termination for CGO
+	fullSrc = fullSrc + "\x00"
+
+	typeName := "VERTEX"
+	if shaderType == gl.FRAGMENT_SHADER {
+		typeName = "FRAGMENT"
+	}
+
+	Logcat(fmt.Sprintf("GLES: Compiling %s Shader...", typeName))
+	// Logcat("DEBUG SHADER SRC:\n" + fullSrc) // Keep for emergencies
+
+	// 2. MEMORY PINNING
+	csource, free := gl.Strs(fullSrc)
+	defer free()
+
+	gl.ShaderSource(shader, 1, csource, nil)
+	gl.CompileShader(shader)
+
+	// 3. STATUS CHECK
+	var status int32
+	gl.GetShaderiv(shader, gl.COMPILE_STATUS, (*int32)(unsafe.Pointer(&status)))
+
+	if status == 0 {
+		var logLength int32
+		gl.GetShaderiv(shader, gl.INFO_LOG_LENGTH, (*int32)(unsafe.Pointer(&logLength)))
+
+		if logLength > 0 {
+			logBytes := make([]byte, logLength)
+			gl.GetShaderInfoLog(shader, logLength, nil, (*uint8)(unsafe.Pointer(&logBytes[0])))
+			err := fmt.Errorf("GLES %s Shader Err: %s", typeName, string(logBytes))
+			Logcat("GLES Error: " + err.Error())
+			return 0, err
+		}
+		return 0, fmt.Errorf("GLES %s Shader Err: Unknown error", typeName)
+	}
+
+	Logcat(fmt.Sprintf("GLES: %s ready.", typeName))
 	return shader, nil
 }
 
-func (r *Renderer_GL32) linkProgram(params ...uint32) (program uint32, err error) {
+func (r *Renderer_GLES32) linkProgram(params ...uint32) (program uint32, err error) {
 	program = gl.CreateProgram()
 	for _, param := range params {
 		gl.AttachShader(program, param)
 	}
-
-	// In GL3.2 this must be in the shader file
-	//if len(params) > 2 {
-	//	// Geometry Shader Params
-	//	gl.ProgramParameteri(program, gl.GEOMETRY_INPUT_TYPE, gl.TRIANGLES)
-	//	gl.ProgramParameteri(program, gl.GEOMETRY_OUTPUT_TYPE, gl.TRIANGLE_STRIP)
-	//	gl.ProgramParameteri(program, gl.GEOMETRY_VERTICES_OUT, 3*6)
-	//}
-
+	// if len(params) > 2 {
+	// 	// Geometry Shader Params
+	// 	gl.ProgramParameteri(program, gl.GEOMETRY_INPUT_TYPE, gl.TRIANGLES)
+	// 	gl.ProgramParameteri(program, gl.GEOMETRY_OUTPUT_TYPE, gl.TRIANGLE_STRIP)
+	// 	gl.ProgramParameteri(program, gl.GEOMETRY_VERTICES_OUT, 3*6)
+	// }
+	Logcat("GLES: Linking program...")
 	gl.LinkProgram(program)
-
 	// Mark shaders for deletion when the program is deleted
 	for _, param := range params {
+		gl.DetachShader(program, param)
 		gl.DeleteShader(param)
 	}
+
 	var ok int32
 	gl.GetProgramiv(program, gl.LINK_STATUS, &ok)
 	if ok == 0 {
-		//var err error
 		var size, l int32
 		gl.GetProgramiv(program, gl.INFO_LOG_LENGTH, &size)
 		if size > 0 {
 			str := make([]byte, size+1)
 			gl.GetProgramInfoLog(program, size, &l, &str[0])
-			err = Error(str[:l])
+			err = fmt.Errorf("Link error: %s", string(str[:l]))
 		} else {
-			err = Error("Unknown link error")
+			err = fmt.Errorf("Unknown link error")
 		}
-		//chk(err)
+		Logcat("GLES: " + err.Error())
 		gl.DeleteProgram(program)
-		//panic(Error("Link error"))
 		return 0, err
 	}
+
+	Logcat("GLES: Link Successful!")
 	return program, nil
 }
 
 // ------------------------------------------------------------------
-// Texture_GL32
+// Texture_GLES32
 
-type Texture_GL32 struct {
+type Texture_GLES32 struct {
 	width  int32
 	height int32
 	depth  int32
@@ -190,14 +224,14 @@ type Texture_GL32 struct {
 }
 
 // Helper that wraps the actual GL call to generate a texture
-func (r *Renderer_GL32) generateTexture(width, height, depth int32, filter bool) *Texture_GL32 {
+func (r *Renderer_GLES32) generateTexture(width, height, depth int32, filter bool) *Texture_GLES32 {
 	var h uint32
 	gl.GenTextures(1, &h)
 
 	// Ensure a unique ID even if GL reuses the handle
 	textureSerialNumber++
 
-	tex := &Texture_GL32{
+	tex := &Texture_GLES32{
 		width:  width,
 		height: height,
 		depth:  depth,
@@ -206,7 +240,7 @@ func (r *Renderer_GL32) generateTexture(width, height, depth int32, filter bool)
 		serial: textureSerialNumber,
 	}
 
-	runtime.SetFinalizer(tex, func(t *Texture_GL32) {
+	runtime.SetFinalizer(tex, func(t *Texture_GLES32) {
 		sys.mainThreadTask <- func() {
 			gl.DeleteTextures(1, &t.handle)
 		}
@@ -216,31 +250,26 @@ func (r *Renderer_GL32) generateTexture(width, height, depth int32, filter bool)
 }
 
 // Creates a generic texture
-func (r *Renderer_GL32) newTexture(width, height, depth int32, filter bool) Texture {
+func (r *Renderer_GLES32) newTexture(width, height, depth int32, filter bool) Texture {
 	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	t := r.generateTexture(width, height, depth, filter)
 
-	format := t.MapInternalFormat(Max(depth, 8))
-	gl.BindTexture(gl.TEXTURE_2D, t.handle)
-	gl.TexImage2D(gl.TEXTURE_2D, 0, int32(format), width, height, 0, format, gl.UNSIGNED_BYTE, nil)
-	gl.BindTexture(gl.TEXTURE_2D, 0)
-
 	return t
 }
 
-func (r *Renderer_GL32) newPaletteTexture() Texture {
+func (r *Renderer_GLES32) newPaletteTexture() Texture {
 	return r.newTexture(256, 1, 32, false)
 }
 
-func (r *Renderer_GL32) newModelTexture(width, height, depth int32, filter bool) Texture {
+func (r *Renderer_GLES32) newModelTexture(width, height, depth int32, filter bool) Texture {
 	return r.newTexture(width, height, depth, filter)
 }
 
-func (r *Renderer_GL32) newDataTexture(width, height int32) Texture {
+func (r *Renderer_GLES32) newDataTexture(width, height int32) Texture {
 	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
-	t := r.generateTexture(width, height, 128, false)
+	t := r.generateTexture(width, height, 32, false)
 
 	gl.BindTexture(gl.TEXTURE_2D, t.handle)
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
@@ -250,10 +279,10 @@ func (r *Renderer_GL32) newDataTexture(width, height int32) Texture {
 	return t
 }
 
-func (r *Renderer_GL32) newHDRTexture(width, height int32) Texture {
+func (r *Renderer_GLES32) newHDRTexture(width, height int32) Texture {
 	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
-	t := r.generateTexture(width, height, 96, false)
+	t := r.generateTexture(width, height, 24, false)
 
 	gl.BindTexture(gl.TEXTURE_2D, t.handle)
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
@@ -263,7 +292,7 @@ func (r *Renderer_GL32) newHDRTexture(width, height int32) Texture {
 	return t
 }
 
-func (r *Renderer_GL32) newCubeMapTexture(widthHeight int32, mipmap bool, lowestMipLevel int32) Texture {
+func (r *Renderer_GLES32) newCubeMapTexture(widthHeight int32, mipmap bool, lowestMipLevel int32) Texture {
 	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	t := r.generateTexture(widthHeight, widthHeight, 24, false)
@@ -287,15 +316,18 @@ func (r *Renderer_GL32) newCubeMapTexture(widthHeight int32, mipmap bool, lowest
 }
 
 // Bind a texture and upload texel data to it
-func (t *Texture_GL32) SetData(data []byte) {
+func (t *Texture_GLES32) SetData(data []byte) {
 	var interp int32 = gl.NEAREST
 	if t.filter {
 		interp = gl.LINEAR
 	}
 
-	format := t.MapInternalFormat(Max(t.depth, 8))
+	bits := Max(t.depth, 8)
+	internalFormat := t.MapSizedInternalFormat(bits)
+	uploadFormat := t.MapUploadFormat(bits)
+	uploadType := t.MapUploadType(bits)
 
-	r := gfx.(*Renderer_GL32)
+	r := gfx.(*Renderer_GLES32)
 	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	gl.BindTexture(gl.TEXTURE_2D, t.handle)
@@ -303,9 +335,9 @@ func (t *Texture_GL32) SetData(data []byte) {
 	gl.PixelStorei(gl.UNPACK_ROW_LENGTH, 0)
 
 	if data != nil {
-		gl.TexImage2D(gl.TEXTURE_2D, 0, int32(format), t.width, t.height, 0, format, gl.UNSIGNED_BYTE, unsafe.Pointer(&data[0]))
+		gl.TexImage2D(gl.TEXTURE_2D, 0, int32(internalFormat), t.width, t.height, 0, uploadFormat, uploadType, unsafe.Pointer(&data[0]))
 	} else {
-		gl.TexImage2D(gl.TEXTURE_2D, 0, int32(format), t.width, t.height, 0, format, gl.UNSIGNED_BYTE, nil)
+		gl.TexImage2D(gl.TEXTURE_2D, 0, int32(internalFormat), t.width, t.height, 0, uploadFormat, uploadType, nil)
 	}
 
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, interp)
@@ -314,38 +346,51 @@ func (t *Texture_GL32) SetData(data []byte) {
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
 }
 
-func (t *Texture_GL32) SetSubData(data []byte, x, y, width, height, stride int32) {
+func (t *Texture_GLES32) SetSubData(data []byte, x, y, width, height, stride int32) {
 	var interp int32 = gl.NEAREST
 	if t.filter {
 		interp = gl.LINEAR
 	}
 
-	r := gfx.(*Renderer_GL32)
+	r := gfx.(*Renderer_GLES32)
 	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	gl.BindTexture(gl.TEXTURE_2D, t.handle)
 	gl.PixelStorei(gl.UNPACK_ALIGNMENT, 1)
 
-	format := t.MapInternalFormat(Max(t.depth, 8))
+	bits := Max(t.depth, 8)
+	uploadFormat := t.MapUploadFormat(bits)
+	uploadType := t.MapUploadType(bits)
 	bytesPerPixel := t.depth / 8
 	if bytesPerPixel < 1 {
 		bytesPerPixel = 1
 	}
 
-	// Doing this should respect both Linux and Android requirements
-	if stride > 0 && stride != width*bytesPerPixel {
-		gl.PixelStorei(gl.UNPACK_ROW_LENGTH, stride/bytesPerPixel)
-	} else {
-		gl.PixelStorei(gl.UNPACK_ROW_LENGTH, 0)
+	var rowLength int32 = 0
+	if stride != width*bytesPerPixel {
+		rowLength = stride / bytesPerPixel
+	}
+
+	gl.PixelStorei(gl.UNPACK_ROW_LENGTH, rowLength)
+
+	ptr := unsafe.Pointer(nil)
+	if data != nil {
+		ptr = unsafe.Pointer(&data[0])
 	}
 
 	if data != nil {
-		gl.TexSubImage2D(gl.TEXTURE_2D, 0, x, y, width, height, uint32(format), gl.UNSIGNED_BYTE, unsafe.Pointer(&data[0]))
+		gl.TexSubImage2D(gl.TEXTURE_2D, 0, x, y, width, height, uint32(uploadFormat), uploadType, ptr)
 	} else {
-		gl.TexSubImage2D(gl.TEXTURE_2D, 0, x, y, width, height, uint32(format), gl.UNSIGNED_BYTE, nil)
+		gl.TexSubImage2D(gl.TEXTURE_2D, 0, x, y, width, height, uint32(uploadFormat), uploadType, nil)
 	}
 
-	gl.PixelStorei(gl.UNPACK_ROW_LENGTH, 0)
+	if err := gl.GetError(); err != 0 {
+		Logcat(fmt.Sprintf("GL ERROR in SetSubData: %v | w:%d h:%d s:%d", err, width, height, stride))
+	}
+
+	if rowLength != 0 {
+		gl.PixelStorei(gl.UNPACK_ROW_LENGTH, 0)
+	}
 
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, interp)
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, interp)
@@ -353,108 +398,153 @@ func (t *Texture_GL32) SetSubData(data []byte, x, y, width, height, stride int32
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
 }
 
-func (t *Texture_GL32) SetDataG(data []byte, mag, min, ws, wt TextureSamplingParam) {
-	format := t.MapInternalFormat(Max(t.depth, 8))
+func (t *Texture_GLES32) SetDataG(data []byte, mag, min, ws, wt TextureSamplingParam) {
+	bits := Max(t.depth, 8)
+	internalFormat := t.MapSizedInternalFormat(bits)
+	uploadFormat := t.MapUploadFormat(bits)
+	uploadType := t.MapUploadType(bits)
 
-	r := gfx.(*Renderer_GL32)
+	r := gfx.(*Renderer_GLES32)
 	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	gl.BindTexture(gl.TEXTURE_2D, t.handle)
 	gl.PixelStorei(gl.UNPACK_ALIGNMENT, 1)
 	gl.PixelStorei(gl.UNPACK_ROW_LENGTH, 0)
-	gl.TexImage2D(gl.TEXTURE_2D, 0, int32(format), t.width, t.height, 0, format, gl.UNSIGNED_BYTE, unsafe.Pointer(&data[0]))
+	gl.TexImage2D(gl.TEXTURE_2D, 0, int32(internalFormat), t.width, t.height, 0, uploadFormat, uploadType, unsafe.Pointer(&data[0]))
 	gl.GenerateMipmap(gl.TEXTURE_2D)
-	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, t.MapTextureSamplingParam(mag))
-	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, t.MapTextureSamplingParam(min))
-	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, t.MapTextureSamplingParam(ws))
-	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, t.MapTextureSamplingParam(wt))
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, int32(mag))
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, int32(min))
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, int32(ws))
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, int32(wt))
 }
 
-func (t *Texture_GL32) SetPixelData(data []float32) {
-	format := t.MapInternalFormat(Max(t.depth/4, 8))
-	internalFormat := t.MapInternalFormat(Max(t.depth, 8))
-
-	r := gfx.(*Renderer_GL32)
+func (t *Texture_GLES32) SetPixelData(data []float32) {
+	r := gfx.(*Renderer_GLES32)
 	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	gl.BindTexture(gl.TEXTURE_2D, t.handle)
 	gl.PixelStorei(gl.UNPACK_ALIGNMENT, 1)
 	gl.PixelStorei(gl.UNPACK_ROW_LENGTH, 0)
-	gl.TexImage2D(gl.TEXTURE_2D, 0, int32(internalFormat), t.width, t.height, 0, uint32(format), gl.FLOAT, unsafe.Pointer(&data[0]))
+	gl.TexImage2D(gl.TEXTURE_2D, 0, gl.RGBA32F, t.width, t.height, 0, gl.RGBA, gl.FLOAT, unsafe.Pointer(&data[0]))
 }
 
-func (t Texture_GL32) CopyData(src *Texture) {
+func (t Texture_GLES32) CopyData(src *Texture) {
+	r := gfx.(*Renderer_GLES32)
+	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
+	gl.BindTexture(gl.TEXTURE_2D, 0) // Unbind whatever is currently bound
+	srcES := (*src).(*Texture_GLES32)
+	var fbo uint32
+	gl.GenFramebuffers(1, &fbo)
+	gl.BindFramebuffer(gl.READ_FRAMEBUFFER, fbo)
+	gl.FramebufferTexture2D(gl.READ_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, srcES.handle, 0)
+
+	gl.BindTexture(gl.TEXTURE_2D, t.handle)
+	// Copy the old texture data into the top-left of the new, larger texture
+	gl.CopyTexSubImage2D(gl.TEXTURE_2D, 0, 0, 0, 0, 0, srcES.width, srcES.height)
+
+	gl.BindFramebuffer(gl.READ_FRAMEBUFFER, 0)
+	gl.DeleteFramebuffers(1, &fbo)
 }
+
+/*
+// Not called anywhere
+func (t *Texture_GLES32) SetRGBPixelData(data []float32) {
+	r := gfx.(*Renderer_GLES32)
+	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
+
+	gl.BindTexture(gl.TEXTURE_2D, t.handle)
+	gl.PixelStorei(gl.UNPACK_ALIGNMENT, 1)
+	gl.PixelStorei(gl.UNPACK_ROW_LENGTH, 0)
+	gl.TexImage2D(gl.TEXTURE_2D, 0, gl.RGB32F, t.width, t.height, 0, gl.RGB, gl.FLOAT, unsafe.Pointer(&data[0]))
+}
+*/
 
 // Return whether texture has a valid handle
-func (t *Texture_GL32) IsValid() bool {
+func (t *Texture_GLES32) IsValid() bool {
 	return t.width != 0 && t.height != 0 && t.handle != 0
 }
 
-func (t *Texture_GL32) GetWidth() int32 {
+func (t *Texture_GLES32) GetWidth() int32 {
 	return t.width
 }
 
-func (t *Texture_GL32) GetHeight() int32 {
+func (t *Texture_GLES32) GetHeight() int32 {
 	return t.height
 }
 
-func (t *Texture_GL32) MapInternalFormat(i int32) uint32 {
-	var InternalFormatLUT = map[int32]uint32{
-		8:   gl.RED,
-		24:  gl.RGB,
-		32:  gl.RGBA,
-		96:  gl.RGB32F,
-		128: gl.RGBA32F,
+func (t *Texture_GLES32) MapUploadType(i int32) uint32 {
+	switch i {
+	case 96, 128:
+		return gl.FLOAT
+	default:
+		return gl.UNSIGNED_BYTE
 	}
-	return InternalFormatLUT[i]
 }
 
-func (t *Texture_GL32) MapTextureSamplingParam(i TextureSamplingParam) int32 {
-	var SamplingParam = map[TextureSamplingParam]int32{
-		TextureSamplingFilterNearest:              gl.NEAREST,
-		TextureSamplingFilterLinear:               gl.LINEAR,
-		TextureSamplingFilterNearestMipMapNearest: gl.NEAREST_MIPMAP_NEAREST,
-		TextureSamplingFilterLinearMipMapNearest:  gl.LINEAR_MIPMAP_NEAREST,
-		TextureSamplingFilterNearestMipMapLinear:  gl.NEAREST_MIPMAP_LINEAR,
-		TextureSamplingFilterLinearMipMapLinear:   gl.LINEAR_MIPMAP_LINEAR,
-		TextureSamplingWrapClampToEdge:            gl.CLAMP_TO_EDGE,
-		TextureSamplingWrapMirroredRepeat:         gl.MIRRORED_REPEAT,
-		TextureSamplingWrapRepeat:                 gl.REPEAT,
+func (t *Texture_GLES32) MapUploadFormat(i int32) uint32 {
+	switch i {
+	case 8:
+		return gl.RED
+	case 24:
+		return gl.RGB
+	case 32:
+		return gl.RGBA
+	case 96:
+		return gl.RGB
+	case 128:
+		return gl.RGBA
+	default:
+		return gl.RGBA
 	}
-	return SamplingParam[i]
+}
+
+func (t *Texture_GLES32) MapSizedInternalFormat(i int32) uint32 {
+	switch i {
+	case 8:
+		return gl.R8
+	case 24:
+		return gl.RGB8
+	case 32:
+		return gl.RGBA8
+	case 96:
+		return gl.RGB32F
+	case 128:
+		return gl.RGBA32F
+	default:
+		return gl.RGBA8
+	}
 }
 
 // ------------------------------------------------------------------
-// Renderer_GL32
+// Renderer_GLES32
 
-type Renderer_GL32 struct {
+type Renderer_GLES32 struct {
 	fbo         uint32
 	fbo_texture uint32
 	// Normal rendering
 	rbo_depth uint32
 	// MSAA rendering
 	fbo_f         uint32
-	fbo_f_texture *Texture_GL32
+	fbo_f_texture *Texture_GLES32
 	// Shadow Map
-	fbo_shadow              uint32
-	fbo_shadow_cube_texture uint32
-	fbo_env                 uint32
-	// Postprocessing FBOs
+	fbo_shadow               uint32
+	fbo_shadow_cube_textures [4]uint32
+	fbo_env                  uint32
+	// Post-processing FBOs
 	fbo_pp         []uint32
 	fbo_pp_texture []uint32
 	// Post-processing shaders
 	postVertBuffer   uint32
-	postShaderSelect []*ShaderProgram_GL32
+	postShaderSelect []*ShaderProgram_GLES32
 	// Shader and vertex data for primitive rendering
-	spriteShader *ShaderProgram_GL32
+	spriteShader *ShaderProgram_GLES32
 	vertexBuffer uint32
 	// Shader and index data for 3D model rendering
-	shadowMapShader         *ShaderProgram_GL32
-	modelShader             *ShaderProgram_GL32
-	panoramaToCubeMapShader *ShaderProgram_GL32
-	cubemapFilteringShader  *ShaderProgram_GL32
+	shadowMapShader         *ShaderProgram_GLES32
+	modelShader             *ShaderProgram_GLES32
+	panoramaToCubeMapShader *ShaderProgram_GLES32
+	cubemapFilteringShader  *ShaderProgram_GLES32
 	modelVertexBuffer       [2]uint32
 	modelIndexBuffer        [2]uint32
 	spriteVAO               uint32
@@ -463,11 +553,9 @@ type Renderer_GL32 struct {
 
 	enableModel  bool
 	enableShadow bool
-	debugMode    bool
-	GL32State
+	GLES32State
 }
-
-type GL32State struct {
+type GLES32State struct {
 	program             uint32
 	depthTest           bool
 	depthMask           bool
@@ -496,12 +584,12 @@ type GL32State struct {
 	useOutlineAttribute bool
 }
 
-func (r *Renderer_GL32) GetName() string {
-	return "OpenGL 3.2"
+func (r *Renderer_GLES32) GetName() string {
+	return "OpenGL ES 3.2"
 }
 
 // init 3D model shader
-func (r *Renderer_GL32) InitModelShader() error {
+func (r *Renderer_GLES32) InitModelShader() error {
 	var err error
 	if r.enableShadow {
 		r.modelShader, err = r.newShaderProgram(modelVertShader, "#define ENABLE_SHADOW\n"+modelFragShader, "", "Model Shader", false)
@@ -524,12 +612,11 @@ func (r *Renderer_GL32) InitModelShader() error {
 		"lights[2].direction", "lights[2].range", "lights[2].color", "lights[2].intensity", "lights[2].position", "lights[2].innerConeCos", "lights[2].outerConeCos", "lights[2].type", "lights[2].shadowBias", "lights[2].shadowMapFar",
 		"lights[3].direction", "lights[3].range", "lights[3].color", "lights[3].intensity", "lights[3].position", "lights[3].innerConeCos", "lights[3].outerConeCos", "lights[3].type", "lights[3].shadowBias", "lights[3].shadowMapFar",
 	)
-
 	r.modelShader.RegisterTextures(
 		"tex", "morphTargetValues", "jointMatrices",
 		"normalMap", "metallicRoughnessMap", "ambientOcclusionMap", "emissionMap",
 		"lambertianEnvSampler", "GGXEnvSampler", "GGXLUT",
-		"shadowCubeMap",
+		"shadowCubeMap0", "shadowCubeMap1", "shadowCubeMap2", "shadowCubeMap3",
 	)
 
 	if r.enableShadow {
@@ -540,14 +627,10 @@ func (r *Renderer_GL32) InitModelShader() error {
 
 		r.shadowMapShader.RegisterAttributes("vertexId", "position", "vertColor", "uv", "joints_0", "joints_1", "weights_0", "weights_1")
 
-		r.shadowMapShader.RegisterUniforms("model", "lightMatrices[0]", "lightMatrices[1]", "lightMatrices[2]", "lightMatrices[3]", "lightMatrices[4]", "lightMatrices[5]",
-			"lightMatrices[6]", "lightMatrices[7]", "lightMatrices[8]", "lightMatrices[9]", "lightMatrices[10]", "lightMatrices[11]",
-			"lightMatrices[12]", "lightMatrices[13]", "lightMatrices[14]", "lightMatrices[15]", "lightMatrices[16]", "lightMatrices[17]",
-			"lightMatrices[18]", "lightMatrices[19]", "lightMatrices[20]", "lightMatrices[21]", "lightMatrices[22]", "lightMatrices[23]",
+		r.shadowMapShader.RegisterUniforms("model", "lightMatrix",
 			"lights[0].type", "lights[1].type", "lights[2].type", "lights[3].type", "lights[0].position", "lights[1].position", "lights[2].position", "lights[3].position",
 			"lights[0].shadowMapFar", "lights[1].shadowMapFar", "lights[2].shadowMapFar", "lights[3].shadowMapFar", "numJoints", "morphTargetWeight", "morphTargetOffset", "morphTargetTextureDimension",
 			"numTargets", "numVertices", "enableAlpha", "alphaThreshold", "baseColorFactor", "useTexture", "texTransform", "layerOffset", "lightIndex")
-
 		r.shadowMapShader.RegisterTextures("morphTargetValues", "jointMatrices", "tex")
 	}
 	r.panoramaToCubeMapShader, err = r.newShaderProgram(identVertShader, panoramaToCubeMapFragShader, "", "Panorama To Cubemap Shader", false)
@@ -570,16 +653,25 @@ func (r *Renderer_GL32) InitModelShader() error {
 
 // Render initialization.
 // Creates the default shaders, the framebuffer and enables MSAA.
-func (r *Renderer_GL32) Init() {
-	chk(gl.Init())
-	sys.errLog.Printf("Using OpenGL %v (%v)", gl.GoStr(gl.GetString(gl.VERSION)), gl.GoStr(gl.GetString(gl.RENDERER)))
-
-	var maxSamples int32
-	gl.GetIntegerv(gl.MAX_SAMPLES, &maxSamples)
-	if sys.msaa > maxSamples {
-		sys.cfg.SetValueUpdate("Video.MSAA", maxSamples)
-		sys.msaa = maxSamples
+func (r *Renderer_GLES32) Init() {
+	chk(gl.Init(func(name string) unsafe.Pointer {
+		return eglGetProcAddress(name)
+	}))
+	if runtime.GOOS != "android" {
+		sys.errLog.Printf("Using OpenGL %v (%v)", gl.GoStr(gl.GetString(gl.VERSION)), gl.GoStr(gl.GetString(gl.RENDERER)))
+	} else {
+		Logcat(fmt.Sprintf("Using OpenGL %v (%v)", gl.GoStr(gl.GetString(gl.VERSION)), gl.GoStr(gl.GetString(gl.RENDERER))))
 	}
+
+	// Logcat("GLES: Querying Max Samples")
+	// var maxSamples int32
+	// gl.GetIntegerv(gl.MAX_SAMPLES, &maxSamples)
+	// if sys.msaa > maxSamples {
+	// 	sys.cfg.SetValueUpdate("Video.MSAA", maxSamples)
+	// 	sys.msaa = maxSamples
+	// }
+	sys.msaa = 0
+	Logcat("GLES: Past MSAA check")
 
 	// Data buffers for rendering
 	postVertData := f32.Bytes(binary.LittleEndian, -1, -1, 1, -1, -1, 1, 1, 1)
@@ -587,24 +679,39 @@ func (r *Renderer_GL32) Init() {
 	r.enableModel = sys.cfg.Video.EnableModel
 	r.enableShadow = sys.cfg.Video.EnableModelShadow
 
-	if sys.cfg.Video.RendererDebugMode {
-		r.EnableDebug()
-	}
-
 	// Generate VAO's
 	gl.GenVertexArrays(1, &r.spriteVAO)
 	gl.GenVertexArrays(1, &r.modelVAO)
 	gl.GenVertexArrays(1, &r.postVAO)
+	Logcat("GLES: Sprite, model and post VAO's generated")
+
+	//Logcat("GLES: VAO Bound")
 
 	// Generate buffers
 	gl.GenBuffers(1, &r.vertexBuffer)
-	gl.GenBuffers(2, &r.modelVertexBuffer[0])
-	gl.GenBuffers(2, &r.modelIndexBuffer[0])
+	Logcat("GLES: VertexBuffer Generated")
+
+	gl.GenBuffers(1, &r.modelVertexBuffer[0])
+	gl.GenBuffers(1, &r.modelVertexBuffer[1])
+	Logcat("GLES: ModelVertexBuffers Generated")
+
+	gl.GenBuffers(1, &r.modelIndexBuffer[0])
+	gl.GenBuffers(1, &r.modelIndexBuffer[1])
+	Logcat("GLES: ModelIndexBuffers Generated")
+
 	gl.GenBuffers(1, &r.postVertBuffer)
+	Logcat("GLES: PostVertBuffer Generated")
 
 	// Initialize post-processing vertex buffer
 	gl.BindBuffer(gl.ARRAY_BUFFER, r.postVertBuffer)
-	gl.BufferData(gl.ARRAY_BUFFER, len(postVertData), unsafe.Pointer(&postVertData[0]), gl.STATIC_DRAW)
+	Logcat(fmt.Sprintf("GLES: Data Size: %d", len(postVertData)))
+
+	if len(postVertData) > 0 {
+		gl.BufferData(gl.ARRAY_BUFFER, len(postVertData), unsafe.Pointer(&postVertData[0]), gl.STATIC_DRAW)
+		Logcat("GLES: PostVertBuffer Data Uploaded")
+	} else {
+		Logcat("GLES: ERROR - postVertData is empty!")
+	}
 
 	// Unbind for safety
 	gl.BindBuffer(gl.ARRAY_BUFFER, 0)
@@ -637,11 +744,11 @@ func (r *Renderer_GL32) Init() {
 		}
 	}
 
-	// Compile postprocessing shaders
+	// Compile post-processing shaders
 	// Because we only have one VAO, the attributes will only be set in EndFrame()
 
 	// Pre-allocate the shader slice to accommodate all external shaders plus the identity shader
-	r.postShaderSelect = make([]*ShaderProgram_GL32, len(sys.cfg.Video.ExternalShaders)+1)
+	r.postShaderSelect = make([]*ShaderProgram_GLES32, len(sys.cfg.Video.ExternalShaders)+1)
 
 	// Configure postVAO
 	gl.BindVertexArray(r.postVAO)
@@ -652,7 +759,7 @@ func (r *Renderer_GL32) Init() {
 		r.postShaderSelect[i], _ = r.newShaderProgram(string(sys.externalShaders[0][i])+"\x00", string(sys.externalShaders[1][i])+"\x00",
 			"", fmt.Sprintf("Postprocess Shader #%v", i), true)
 		r.postShaderSelect[i].RegisterAttributes("VertCoord") // "TexCoord" was registered but never used
-		r.postShaderSelect[i].RegisterUniforms("Texture_GL32", "TextureSize", "CurrentTime")
+		r.postShaderSelect[i].RegisterUniforms("Texture_GLES32", "TextureSize", "CurrentTime")
 
 		// Configure postVAO for this specific shader's attribute location
 		if loc, ok := r.postShaderSelect[i].attributes["VertCoord"]; ok && loc >= 0 {
@@ -661,10 +768,10 @@ func (r *Renderer_GL32) Init() {
 		}
 	}
 
-	// Identity shader (no postprocessing)
+	// Identity shader (no post-processing). This should be the last one in modern OpenGL
 	identShader, _ := r.newShaderProgram(identVertShader, identFragShader, "", "Identity Postprocess", true)
 	identShader.RegisterAttributes("VertCoord")
-	//identShader.RegisterUniforms("Texture_GL32", "TextureSize", "CurrentTime") // None of these are used
+	//identShader.RegisterUniforms("Texture_GLES32", "TextureSize", "CurrentTime") // None of these are used
 
 	// Configure postVAO for the identity shader's attribute location
 	if loc, ok := identShader.attributes["VertCoord"]; ok && loc >= 0 {
@@ -679,55 +786,33 @@ func (r *Renderer_GL32) Init() {
 	gl.BindVertexArray(0)
 	gl.BindBuffer(gl.ARRAY_BUFFER, 0)
 
-	// Toggle MSAA first
-	if sys.msaa > 0 {
-		gl.Enable(gl.MULTISAMPLE)
-	} else {
-		gl.Disable(gl.MULTISAMPLE)
-	}
-
 	r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
 
 	// create a texture for r.fbo
 	gl.GenTextures(1, &r.fbo_texture)
 	textureSerialNumber++
 
-	// Match texture storage type to the MSAA setting
-	if sys.msaa > 0 {
-		gl.BindTexture(gl.TEXTURE_2D_MULTISAMPLE, r.fbo_texture)
-		// Multisample textures do not support TexParameteri
-	} else {
-		gl.BindTexture(gl.TEXTURE_2D, r.fbo_texture)
-		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
-		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
-		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
-		gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
-	}
+	gl.BindTexture(gl.TEXTURE_2D, r.fbo_texture)
+
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
 
 	// Don't change this from gl.RGBA.
 	// It breaks mixing between subtractive and additive.
-	if sys.msaa > 0 {
-		gl.TexImage2DMultisample(
-			gl.TEXTURE_2D_MULTISAMPLE,
-			sys.msaa,
-			gl.RGBA,
-			sys.scrrect[2],
-			sys.scrrect[3],
-			true,
-		)
-	} else {
-		gl.TexImage2D(
-			gl.TEXTURE_2D,
-			0,
-			gl.RGBA,
-			sys.scrrect[2],
-			sys.scrrect[3],
-			0,
-			gl.RGBA,
-			gl.UNSIGNED_BYTE,
-			nil,
-		)
-	}
+	Logcat("GLES: Creating RGBA Textures")
+	gl.TexImage2D(
+		gl.TEXTURE_2D,
+		0,
+		gl.RGBA,
+		sys.scrrect[2],
+		sys.scrrect[3],
+		0,
+		gl.RGBA,
+		gl.UNSIGNED_BYTE,
+		nil,
+	)
 
 	r.fbo_pp = make([]uint32, 2)
 	r.fbo_pp_texture = make([]uint32, 2)
@@ -758,11 +843,7 @@ func (r *Renderer_GL32) Init() {
 	}
 
 	// done with r.fbo_texture, unbind it
-	if sys.msaa > 0 {
-		gl.BindTexture(gl.TEXTURE_2D_MULTISAMPLE, 0)
-	} else {
-		gl.BindTexture(gl.TEXTURE_2D, 0)
-	}
+	gl.BindTexture(gl.TEXTURE_2D, 0)
 
 	//r.rbo_depth = gl.CreateRenderbuffer()
 	gl.GenRenderbuffers(1, &r.rbo_depth)
@@ -776,7 +857,7 @@ func (r *Renderer_GL32) Init() {
 	}
 	gl.BindRenderbuffer(gl.RENDERBUFFER, 0)
 	if sys.msaa > 0 {
-		r.fbo_f_texture = r.newTexture(sys.scrrect[2], sys.scrrect[3], 32, false).(*Texture_GL32)
+		r.fbo_f_texture = r.newTexture(sys.scrrect[2], sys.scrrect[3], 32, false).(*Texture_GLES32)
 		r.fbo_f_texture.SetData(nil)
 	} else {
 		//r.rbo_depth = gl.CreateRenderbuffer()
@@ -804,7 +885,7 @@ func (r *Renderer_GL32) Init() {
 		gl.FramebufferRenderbuffer(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, gl.RENDERBUFFER, r.rbo_depth)
 	}
 
-	// create our two FBOs for our postprocessing needs
+	// create our two FBOs for our post-processing needs
 	for i := 0; i < 2; i++ {
 		gl.GenFramebuffers(1, &(r.fbo_pp[i]))
 		gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_pp[i])
@@ -814,24 +895,46 @@ func (r *Renderer_GL32) Init() {
 	// create an FBO for our model stuff
 	if r.enableModel {
 		if r.enableShadow {
+			// create FBO for shadow rendering
 			gl.GenFramebuffers(1, &r.fbo_shadow)
 			r.SetActiveTexture0() //gl.ActiveTexture(gl.TEXTURE0)
-			gl.GenTextures(1, &r.fbo_shadow_cube_texture)
-			textureSerialNumber++
 
-			gl.BindTexture(gl.TEXTURE_CUBE_MAP_ARRAY_ARB, r.fbo_shadow_cube_texture)
-			gl.TexStorage3D(gl.TEXTURE_CUBE_MAP_ARRAY_ARB, 1, gl.DEPTH_COMPONENT24, 1024, 1024, 4*6)
-			gl.TexParameteri(gl.TEXTURE_CUBE_MAP_ARRAY_ARB, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
-			gl.TexParameteri(gl.TEXTURE_CUBE_MAP_ARRAY_ARB, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
-			gl.TexParameteri(gl.TEXTURE_CUBE_MAP_ARRAY_ARB, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
-			gl.TexParameteri(gl.TEXTURE_CUBE_MAP_ARRAY_ARB, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+			// create 4 separate GL_TEXTURE_CUBE_MAP textures (one per shadow caster/light)
+			gl.GenTextures(4, &r.fbo_shadow_cube_textures[0])
+			textureSerialNumber += 4
 
-			gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_shadow)
-			gl.DrawBuffer(gl.NONE)
-			gl.ReadBuffer(gl.NONE)
-			if status := gl.CheckFramebufferStatus(gl.FRAMEBUFFER); status != gl.FRAMEBUFFER_COMPLETE {
-				sys.errLog.Printf("framebuffer create failed: 0x%x", status)
+			for i := 0; i < 4; i++ {
+				// bind and allocate each cube-map's 6 faces as depth textures
+				gl.ActiveTexture(uint32(gl.TEXTURE0 + uint32(i)))
+				gl.BindTexture(gl.TEXTURE_CUBE_MAP, r.fbo_shadow_cube_textures[i])
+
+				// Allocate depth storage for each face
+				for face := 0; face < 6; face++ {
+					gl.TexImage2D(
+						uint32(gl.TEXTURE_CUBE_MAP_POSITIVE_X)+uint32(face),
+						0,
+						gl.DEPTH_COMPONENT24,
+						1024, 1024,
+						0,
+						gl.DEPTH_COMPONENT,
+						gl.UNSIGNED_INT,
+						nil,
+					)
+				}
+
+				gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
+				gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
+				gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+				gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+				// Note: GL_TEXTURE_WRAP_R can also be set if desired:
+				// gl.TexParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_WRAP_R, gl.CLAMP_TO_EDGE)
 			}
+
+			// Create (empty) FBO. We'll attach the proper cube-face when rendering each face.
+			gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_shadow)
+			// Leave the depth attachment empty here — attach per-face with FramebufferTexture2D()
+			// Restore default framebuffer binding
+			gl.BindFramebuffer(gl.FRAMEBUFFER, 0)
 		}
 		gl.GenFramebuffers(1, &r.fbo_env)
 	}
@@ -841,10 +944,10 @@ func (r *Renderer_GL32) Init() {
 	r.InitStateCache()
 }
 
-func (r *Renderer_GL32) Close() {
+func (r *Renderer_GLES32) Close() {
 }
 
-func (r *Renderer_GL32) InitStateCache() {
+func (r *Renderer_GLES32) InitStateCache() {
 	// Match standard OpenGL hardware defaults
 	r.program = 0
 	r.depthTest = false
@@ -868,9 +971,9 @@ func (r *Renderer_GL32) InitStateCache() {
 	var maxTex int32
 	gl.GetIntegerv(gl.MAX_TEXTURE_IMAGE_UNITS, &maxTex)
 
-	if r.debugMode {
-		fmt.Printf("[GL Debug] GPU supports up to %d textures\n", maxTex)
-	}
+	//if r.debugMode {
+	//	fmt.Printf("[GL Debug] GPU supports up to %d textures\n", maxTex)
+	//}
 
 	// Initialize sprite texture cache
 	r.texCacheTexSerial = make([]uint64, maxTex)
@@ -884,159 +987,19 @@ func (r *Renderer_GL32) InitStateCache() {
 	r.uniformF4Cache = make(map[uint32][4]float32, 32)
 }
 
-func (r *Renderer_GL32) EnableDebug() {
-	r.debugMode = true
-	gl.Enable(gl.DEBUG_OUTPUT)
-	gl.Enable(gl.DEBUG_OUTPUT_SYNCHRONOUS)
-
-	gl.DebugMessageCallback(func(
-		source uint32,
-		gltype uint32,
-		id uint32,
-		severity uint32,
-		length int32,
-		message string,
-		userParam unsafe.Pointer) {
-
-		if severity == gl.DEBUG_SEVERITY_NOTIFICATION {
-			return
-		}
-
-		fmt.Printf("[GL Debug] %s\n", message)
-
-		// Crash here so the log catches it
-		if severity == gl.DEBUG_SEVERITY_HIGH {
-			panic("Critical OpenGL Error Detected!")
-		}
-	}, nil)
-
-	fmt.Printf("[GL Debug] Debug mode enabled\n")
+func (r *Renderer_GLES32) EnableDebug() {
+	// Do nothing yet
 }
 
-/*
-func (r *Renderer_GL32) DebugCheckLeaks(nextprog uint32) {
-	// Only query attributes if a VAO is bound
-	var currentVAO int32
-	gl.GetIntegerv(gl.VERTEX_ARRAY_BINDING, &currentVAO)
-	if currentVAO == 0 {
-		return 
-	}
-
-	var enabled int32
-	leaked := []int{}
-	// Only check up to the hardware limit
-	for slot := uint32(0); slot < 16; slot++ {
-		gl.GetVertexAttribiv(slot, gl.VERTEX_ATTRIB_ARRAY_ENABLED, &enabled)
-		if enabled != 0 {
-			leaked = append(leaked, int(slot))
-		}
-	}
-	if len(leaked) > 0 {
-		fmt.Printf("[GL Debug] Changing to program %d with attributes %v enabled in VAO %d.\n", nextprog, leaked, currentVAO)
-	}
-}
-*/
-
-func (r *Renderer_GL32) DebugVerifyCache() {
-	if !r.debugMode {
-		return
-	}
-
-	// Program and global toggle states
-	var hwProg int32
-	gl.GetIntegerv(gl.CURRENT_PROGRAM, &hwProg)
-	if uint32(hwProg) != r.program {
-		fmt.Printf("[GL Cache Error] Program mismatch! Cache: %d, HW: %d\n", r.program, hwProg)
-	}
-
-	if gl.IsEnabled(gl.DEPTH_TEST) != r.depthTest {
-		fmt.Printf("[GL Cache Error] DepthTest mismatch! Cache: %v, HW: %v\n", r.depthTest, !r.depthTest)
-	}
-
-	var depthMask bool
-	gl.GetBooleanv(gl.DEPTH_WRITEMASK, &depthMask)
-	if depthMask != r.depthMask {
-		fmt.Printf("[GL Cache Error] DepthMask mismatch! Cache: %v, HW: %v\n", r.depthMask, depthMask)
-	}
-
-	// doubleSided = true means CULL_FACE is DISABLED
-	if (gl.IsEnabled(gl.CULL_FACE) == false) != r.doubleSided {
-		fmt.Printf("[GL Cache Error] DoubleSided mismatch! Cache: %v, HW: %v\n", r.doubleSided, !r.doubleSided)
-	}
-
-	var frontFace int32
-	gl.GetIntegerv(gl.FRONT_FACE, &frontFace)
-	if (frontFace == gl.CW) != r.invertFrontFace {
-		fmt.Printf("[GL Cache Error] FrontFace mismatch! Cache: %v, HW: %v\n", r.invertFrontFace, frontFace == gl.CW)
-	}
-
-	if gl.IsEnabled(gl.BLEND) != r.blendEnabled {
-		fmt.Printf("[GL Cache Error] BlendEnabled mismatch! Cache: %v, HW: %v\n", r.blendEnabled, !r.blendEnabled)
-	}
-
-	if gl.IsEnabled(gl.SCISSOR_TEST) != r.scissorEnabled {
-		fmt.Printf("[GL Cache Error] ScissorEnabled mismatch! Cache: %v, HW: %v\n", r.scissorEnabled, !r.scissorEnabled)
-	}
-
-	// We only care about these if the corresponding test is enabled.
-	if r.blendEnabled {
-		var eq, src, dst int32
-		gl.GetIntegerv(gl.BLEND_EQUATION_RGB, &eq)
-		gl.GetIntegerv(gl.BLEND_SRC_RGB, &src)
-		gl.GetIntegerv(gl.BLEND_DST_RGB, &dst)
-		if uint32(eq) != r.MapBlendEquation(r.blendEquation) {
-			fmt.Printf("[GL Cache Error] BlendEquation mismatch!\n")
-		}
-		if uint32(src) != r.MapBlendFunction(r.blendSrc) || uint32(dst) != r.MapBlendFunction(r.blendDst) {
-			fmt.Printf("[GL Cache Error] BlendFunc mismatch!\n")
-		}
-	}
-
-	if r.scissorEnabled {
-		var hwScissor [4]int32
-		gl.GetIntegerv(gl.SCISSOR_BOX, &hwScissor[0])
-		if hwScissor != r.scissorRect {
-			fmt.Printf("[GL Cache Error] ScissorRect mismatch! Cache: %v, HW: %v\n", r.scissorRect, hwScissor)
-		}
-	}
-
-	// Attributes
-	checkAttr := func(flag bool, attrKey string) {
-		var shader *ShaderProgram_GL32
-		if r.program == r.modelShader.program {
-			shader = r.modelShader
-		} else if r.program == r.shadowMapShader.program {
-			shader = r.shadowMapShader
-		} else {
-			return
-		}
-		if loc, ok := shader.attributes[attrKey]; ok && loc >= 0 {
-			var enabled int32
-			gl.GetVertexAttribiv(uint32(loc), gl.VERTEX_ATTRIB_ARRAY_ENABLED, &enabled)
-			if (enabled != 0) != flag {
-				fmt.Printf("[GL Cache Error] %s mismatch! Cache: %v, HW: %v\n", attrKey, flag, enabled != 0)
-			}
-		}
-	}
-
-	checkAttr(r.useUV, "uv")
-	checkAttr(r.useNormal, "normalIn")
-	checkAttr(r.useTangent, "tangentIn")
-	checkAttr(r.useVertColor, "vertColor")
-	checkAttr(r.useJoint0, "joints_0")
-	checkAttr(r.useJoint1, "joints_1")
-	checkAttr(r.useOutlineAttribute, "outlineAttributeIn")
-}
-
-func (r *Renderer_GL32) IsModelEnabled() bool {
+func (r *Renderer_GLES32) IsModelEnabled() bool {
 	return r.enableModel
 }
 
-func (r *Renderer_GL32) IsShadowEnabled() bool {
+func (r *Renderer_GLES32) IsShadowEnabled() bool {
 	return r.enableShadow
 }
 
-func (r *Renderer_GL32) BeginFrame(clearColor bool) {
+func (r *Renderer_GLES32) BeginFrame(clearColor bool) {
 	//gl.BindVertexArray(r.vao)
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo)
 	gl.Viewport(0, 0, sys.scrrect[2], sys.scrrect[3])
@@ -1047,7 +1010,7 @@ func (r *Renderer_GL32) BeginFrame(clearColor bool) {
 	}
 }
 
-func (r *Renderer_GL32) EndFrame() {
+func (r *Renderer_GLES32) EndFrame() {
 	if len(r.fbo_pp) == 0 {
 		return
 	}
@@ -1130,7 +1093,7 @@ func (r *Renderer_GL32) EndFrame() {
 		}
 
 		// set post-processing parameters
-		if loc, ok := postShader.uniforms["Texture_GL32"]; ok && loc >= 0 {
+		if loc, ok := postShader.uniforms["Texture_GLES32"]; ok && loc >= 0 {
 			r.SetUniformISub(loc, 0)
 		}
 		if loc, ok := postShader.uniforms["TextureSize"]; ok && loc >= 0 {
@@ -1148,11 +1111,11 @@ func (r *Renderer_GL32) EndFrame() {
 	}
 }
 
-func (r *Renderer_GL32) Await() {
+func (r *Renderer_GLES32) Await() {
 	gl.Finish()
 }
 
-func (r *Renderer_GL32) MapBlendEquation(i BlendEquation) uint32 {
+func (r *Renderer_GLES32) MapBlendEquation(i BlendEquation) uint32 {
 	var BlendEquationLUT = map[BlendEquation]uint32{
 		BlendAdd:             gl.FUNC_ADD,
 		BlendReverseSubtract: gl.FUNC_REVERSE_SUBTRACT,
@@ -1160,19 +1123,17 @@ func (r *Renderer_GL32) MapBlendEquation(i BlendEquation) uint32 {
 	return BlendEquationLUT[i]
 }
 
-func (r *Renderer_GL32) MapBlendFunction(i BlendFunc) uint32 {
+func (r *Renderer_GLES32) MapBlendFunction(i BlendFunc) uint32 {
 	var BlendFunctionLUT = map[BlendFunc]uint32{
 		BlendOne:              gl.ONE,
 		BlendZero:             gl.ZERO,
 		BlendSrcAlpha:         gl.SRC_ALPHA,
 		BlendOneMinusSrcAlpha: gl.ONE_MINUS_SRC_ALPHA,
-		BlendOneMinusDstColor: gl.ONE_MINUS_DST_COLOR,
-		BlendDstColor:         gl.DST_COLOR,
 	}
 	return BlendFunctionLUT[i]
 }
 
-func (r *Renderer_GL32) MapPrimitiveMode(i PrimitiveMode) uint32 {
+func (r *Renderer_GLES32) MapPrimitiveMode(i PrimitiveMode) uint32 {
 	var PrimitiveModeLUT = map[PrimitiveMode]uint32{
 		LINES:          gl.LINES,
 		LINE_LOOP:      gl.LINE_LOOP,
@@ -1184,7 +1145,7 @@ func (r *Renderer_GL32) MapPrimitiveMode(i PrimitiveMode) uint32 {
 	return PrimitiveModeLUT[i]
 }
 
-func (r *Renderer_GL32) SetDepthTest(depthTest bool) {
+func (r *Renderer_GLES32) SetDepthTest(depthTest bool) {
 	if depthTest != r.depthTest {
 		r.depthTest = depthTest
 		if depthTest {
@@ -1197,14 +1158,14 @@ func (r *Renderer_GL32) SetDepthTest(depthTest bool) {
 }
 
 // Note: This one defaults to enable so we must sync the cache early
-func (r *Renderer_GL32) SetDepthMask(depthMask bool) {
+func (r *Renderer_GLES32) SetDepthMask(depthMask bool) {
 	if depthMask != r.depthMask {
 		r.depthMask = depthMask
 		gl.DepthMask(depthMask)
 	}
 }
 
-func (r *Renderer_GL32) SetFrontFace(invertFrontFace bool) {
+func (r *Renderer_GLES32) SetFrontFace(invertFrontFace bool) {
 	if invertFrontFace != r.invertFrontFace {
 		r.invertFrontFace = invertFrontFace
 		if invertFrontFace {
@@ -1215,7 +1176,7 @@ func (r *Renderer_GL32) SetFrontFace(invertFrontFace bool) {
 	}
 }
 
-func (r *Renderer_GL32) SetCullFace(doubleSided bool) {
+func (r *Renderer_GLES32) SetCullFace(doubleSided bool) {
 	if doubleSided != r.doubleSided {
 		r.doubleSided = doubleSided
 		if !doubleSided {
@@ -1228,7 +1189,7 @@ func (r *Renderer_GL32) SetCullFace(doubleSided bool) {
 }
 
 // This should be called instead of gl.UseProgram()
-func (r *Renderer_GL32) ChangeProgram(prog uint32) {
+func (r *Renderer_GLES32) ChangeProgram(prog uint32) {
 	// Program already in use
 	if r.program == prog {
 		return
@@ -1241,15 +1202,8 @@ func (r *Renderer_GL32) ChangeProgram(prog uint32) {
 	}
 
 	// Same for TTF fonts
-	if r.program == gfxFont.(*FontRenderer_GL32).shaderProgram.program {
-		gfxFont.(*FontRenderer_GL32).ReleaseFontPipeline()
-	}
-
-	// State leak detector
-	// TODO: Just move to separate VAO's if we drop GL2.1
-	if r.debugMode {
-		//r.DebugCheckLeaks(prog)
-		r.DebugVerifyCache()
+	if r.program == gfxFont.(*FontRenderer_GLES32).shaderProgram.program {
+		gfxFont.(*FontRenderer_GLES32).ReleaseFontPipeline()
 	}
 
 	// Switch program
@@ -1262,22 +1216,9 @@ func (r *Renderer_GL32) ChangeProgram(prog uint32) {
 		r.texCacheLastUsed[i] = 0
 	}
 	r.texCacheTimer = 1
-
-	/*
-		// No need to reset these anymore since the cache is now keyed to the spriteShader
-		for i := range r.uniformICache {
-			r.uniformICache[i] = -1e9
-		}
-		for i := range r.uniformF1Cache {
-			r.uniformF1Cache[i] = -1e9
-		}
-		for i := range r.uniformF3Cache {
-			r.uniformF3Cache[i] = -1e9
-		}
-	*/
 }
 
-func (r *Renderer_GL32) EnableBlending(eq BlendEquation, src, dst BlendFunc) {
+func (r *Renderer_GLES32) EnableBlending(eq BlendEquation, src, dst BlendFunc) {
 	if !r.blendEnabled {
 		gl.Enable(gl.BLEND)
 		r.blendEnabled = true
@@ -1295,7 +1236,7 @@ func (r *Renderer_GL32) EnableBlending(eq BlendEquation, src, dst BlendFunc) {
 	}
 }
 
-func (r *Renderer_GL32) DisableBlending() {
+func (r *Renderer_GLES32) DisableBlending() {
 	if r.blendEnabled {
 		gl.Disable(gl.BLEND)
 		r.blendEnabled = false
@@ -1303,7 +1244,7 @@ func (r *Renderer_GL32) DisableBlending() {
 	}
 }
 
-func (r *Renderer_GL32) SetPipeline() {
+func (r *Renderer_GLES32) SetPipeline() {
 	// Do nothing if we were already using the sprite shader
 	if r.program == r.spriteShader.program {
 		return
@@ -1314,19 +1255,18 @@ func (r *Renderer_GL32) SetPipeline() {
 	gl.BindVertexArray(r.spriteVAO)
 }
 
-func (r *Renderer_GL32) ReleasePipeline() {
+func (r *Renderer_GLES32) ReleasePipeline() {
 	gl.BindVertexArray(0)
 	//r.DisableBlending()
 }
 
-func (r *Renderer_GL32) prepareShadowMapPipeline(bufferIndex uint32) {
+func (r *Renderer_GLES32) prepareShadowMapPipeline(bufferIndex uint32) {
 	r.ChangeProgram(r.shadowMapShader.program)
 
 	gl.BindVertexArray(r.modelVAO)
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_shadow)
-
 	gl.Viewport(0, 0, 1024, 1024)
-	//gl.Enable(gl.TEXTURE_2D) // Causes OpenGL error
+	// Removed gl.Enable(gl.TEXTURE_2D) — not needed / invalid in GLES3 core
 
 	// Set global state
 	r.SetDepthTest(true)
@@ -1338,13 +1278,14 @@ func (r *Renderer_GL32) prepareShadowMapPipeline(bufferIndex uint32) {
 	gl.BindBuffer(gl.ARRAY_BUFFER, r.modelVertexBuffer[bufferIndex])
 	gl.BindBuffer(gl.ELEMENT_ARRAY_BUFFER, r.modelIndexBuffer[bufferIndex])
 
-	gl.FramebufferTexture(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, r.fbo_shadow_cube_texture, 0)
-	gl.Clear(gl.DEPTH_BUFFER_BIT)
+	// Don't attach a depth texture here: attach the specific cube-face with
+	// SetShadowFrameCubeTexture(...) before rendering each face.
+	// Clearing must be done after the correct face is attached.
 
 	r.SetActiveTexture0() // gl.ActiveTexture(gl.TEXTURE0)
 }
 
-func (r *Renderer_GL32) setShadowMapPipeline(doubleSided, invertFrontFace, useUV, useNormal, useTangent, useVertColor, useJoint0, useJoint1 bool, numVertices, vertAttrOffset uint32) {
+func (r *Renderer_GLES32) setShadowMapPipeline(doubleSided, invertFrontFace, useUV, useNormal, useTangent, useVertColor, useJoint0, useJoint1 bool, numVertices, vertAttrOffset uint32) {
 	r.SetFrontFace(invertFrontFace)
 	r.SetCullFace(doubleSided)
 
@@ -1434,7 +1375,7 @@ func (r *Renderer_GL32) setShadowMapPipeline(doubleSided, invertFrontFace, useUV
 	}
 }
 
-func (r *Renderer_GL32) ReleaseShadowPipeline() {
+func (r *Renderer_GLES32) ReleaseShadowPipeline() {
 	loc := r.shadowMapShader.attributes["vertexId"]
 	gl.DisableVertexAttribArray(uint32(loc))
 	loc = r.shadowMapShader.attributes["position"]
@@ -1468,7 +1409,7 @@ func (r *Renderer_GL32) ReleaseShadowPipeline() {
 	r.useJoint1 = false
 }
 
-func (r *Renderer_GL32) prepareModelPipeline(bufferIndex uint32, env *Environment) {
+func (r *Renderer_GLES32) prepareModelPipeline(bufferIndex uint32, env *Environment) {
 	r.ChangeProgram(r.modelShader.program)
 
 	gl.BindVertexArray(r.modelVAO)
@@ -1476,9 +1417,8 @@ func (r *Renderer_GL32) prepareModelPipeline(bufferIndex uint32, env *Environmen
 
 	gl.Viewport(0, 0, sys.scrrect[2], sys.scrrect[3])
 	gl.Clear(gl.DEPTH_BUFFER_BIT)
-	//gl.Enable(gl.TEXTURE_2D) // Causes OpenGL error
-	//gl.Enable(gl.TEXTURE_CUBE_MAP) // Causes OpenGL error
-
+	//gl.Enable(gl.TEXTURE_2D)
+	gl.Enable(gl.TEXTURE_CUBE_MAP)
 	// Set global state
 	r.EnableBlending(r.blendEquation, r.blendSrc, r.blendDst)
 	r.SetDepthTest(true)
@@ -1488,24 +1428,30 @@ func (r *Renderer_GL32) prepareModelPipeline(bufferIndex uint32, env *Environmen
 
 	gl.BindBuffer(gl.ARRAY_BUFFER, r.modelVertexBuffer[bufferIndex])
 	gl.BindBuffer(gl.ELEMENT_ARRAY_BUFFER, r.modelIndexBuffer[bufferIndex])
+	// Bind the 4 cube-map textures to the corresponding sampler uniforms/units
 	if r.enableShadow {
-		loc, unit := r.modelShader.uniforms["shadowCubeMap"], r.modelShader.textures["shadowCubeMap"]
-		gl.ActiveTexture((uint32(gl.TEXTURE0 + unit)))
-		gl.BindTexture(gl.TEXTURE_CUBE_MAP_ARRAY_ARB, r.fbo_shadow_cube_texture)
-		gl.Uniform1i(loc, int32(unit))
+		for i := 0; i < 4; i++ {
+			name := fmt.Sprintf("shadowCubeMap%d", i)
+			loc := r.modelShader.uniforms[name]
+			unit := r.modelShader.textures[name] // texture unit assigned by RegisterTextures
+
+			gl.ActiveTexture(uint32(gl.TEXTURE0 + unit))
+			gl.BindTexture(gl.TEXTURE_CUBE_MAP, r.fbo_shadow_cube_textures[i])
+			gl.Uniform1i(loc, int32(unit))
+		}
 	}
 	if env != nil {
 		loc, unit := r.modelShader.uniforms["lambertianEnvSampler"], r.modelShader.textures["lambertianEnvSampler"]
 		gl.ActiveTexture((uint32(gl.TEXTURE0 + unit)))
-		gl.BindTexture(gl.TEXTURE_CUBE_MAP, env.lambertianTexture.tex.(*Texture_GL32).handle)
+		gl.BindTexture(gl.TEXTURE_CUBE_MAP, env.lambertianTexture.tex.(*Texture_GLES32).handle)
 		gl.Uniform1i(loc, int32(unit))
 		loc, unit = r.modelShader.uniforms["GGXEnvSampler"], r.modelShader.textures["GGXEnvSampler"]
 		gl.ActiveTexture((uint32(gl.TEXTURE0 + unit)))
-		gl.BindTexture(gl.TEXTURE_CUBE_MAP, env.GGXTexture.tex.(*Texture_GL32).handle)
+		gl.BindTexture(gl.TEXTURE_CUBE_MAP, env.GGXTexture.tex.(*Texture_GLES32).handle)
 		gl.Uniform1i(loc, int32(unit))
 		loc, unit = r.modelShader.uniforms["GGXLUT"], r.modelShader.textures["GGXLUT"]
 		gl.ActiveTexture((uint32(gl.TEXTURE0 + unit)))
-		gl.BindTexture(gl.TEXTURE_2D, env.GGXLUT.tex.(*Texture_GL32).handle)
+		gl.BindTexture(gl.TEXTURE_2D, env.GGXLUT.tex.(*Texture_GLES32).handle)
 		gl.Uniform1i(loc, int32(unit))
 
 		loc = r.modelShader.uniforms["environmentIntensity"]
@@ -1537,7 +1483,7 @@ func (r *Renderer_GL32) prepareModelPipeline(bufferIndex uint32, env *Environmen
 	r.SetActiveTexture0() // gl.ActiveTexture(gl.TEXTURE0)
 }
 
-func (r *Renderer_GL32) SetModelPipeline(eq BlendEquation, src, dst BlendFunc, depthTest, depthMask, doubleSided, invertFrontFace,
+func (r *Renderer_GLES32) SetModelPipeline(eq BlendEquation, src, dst BlendFunc, depthTest, depthMask, doubleSided, invertFrontFace,
 	useUV, useNormal, useTangent, useVertColor, useJoint0, useJoint1, useOutlineAttribute bool, numVertices, vertAttrOffset uint32) {
 	r.SetDepthTest(depthTest)
 	r.SetDepthMask(depthMask)
@@ -1663,7 +1609,7 @@ func (r *Renderer_GL32) SetModelPipeline(eq BlendEquation, src, dst BlendFunc, d
 	}
 }
 
-func (r *Renderer_GL32) SetMeshOutlinePipeline(invertFrontFace bool, meshOutline float32) {
+func (r *Renderer_GLES32) SetMeshOutlinePipeline(invertFrontFace bool, meshOutline float32) {
 	r.SetFrontFace(invertFrontFace)
 	r.SetDepthTest(true)
 	r.SetDepthMask(true)
@@ -1672,7 +1618,7 @@ func (r *Renderer_GL32) SetMeshOutlinePipeline(invertFrontFace bool, meshOutline
 	gl.Uniform1f(loc, meshOutline)
 }
 
-func (r *Renderer_GL32) ReleaseModelPipeline() {
+func (r *Renderer_GLES32) ReleaseModelPipeline() {
 	loc := r.modelShader.attributes["inVertexId"]
 	gl.DisableVertexAttribArray(uint32(loc))
 	loc = r.modelShader.attributes["position"]
@@ -1718,14 +1664,14 @@ func (r *Renderer_GL32) ReleaseModelPipeline() {
 	r.useOutlineAttribute = false
 }
 
-func (r *Renderer_GL32) ReadPixels(data []uint8, width, height int) {
+func (r *Renderer_GLES32) ReadPixels(data []uint8, width, height int) {
 	// we defer the EndFrame(), SwapBuffers(), and BeginFrame() calls that were previously below now to
 	// a single spot in order to prevent the blank screenshot bug on single digit FPS
 	gl.BindFramebuffer(gl.READ_FRAMEBUFFER, 0)
 	gl.ReadPixels(0, 0, int32(width), int32(height), gl.RGBA, gl.UNSIGNED_BYTE, unsafe.Pointer(&data[0]))
 }
 
-func (r *Renderer_GL32) EnableScissor(x, y, width, height int32) {
+func (r *Renderer_GLES32) EnableScissor(x, y, width, height int32) {
 	// Flip Y to OpenGL convention
 	realY := sys.scrrect[3] - (y + height)
 
@@ -1744,7 +1690,7 @@ func (r *Renderer_GL32) EnableScissor(x, y, width, height int32) {
 	r.scissorRect = [4]int32{x, realY, width, height}
 }
 
-func (r *Renderer_GL32) DisableScissor() {
+func (r *Renderer_GLES32) DisableScissor() {
 	if r.scissorEnabled {
 		gl.Disable(gl.SCISSOR_TEST)
 		r.scissorEnabled = false
@@ -1752,7 +1698,7 @@ func (r *Renderer_GL32) DisableScissor() {
 	}
 }
 
-func (r *Renderer_GL32) SetUniformISub(loc int32, val int32) {
+func (r *Renderer_GLES32) SetUniformISub(loc int32, val int32) {
 	if loc < 0 {
 		return
 	}
@@ -1769,12 +1715,12 @@ func (r *Renderer_GL32) SetUniformISub(loc int32, val int32) {
 	gl.Uniform1i(loc, val)
 }
 
-func (r *Renderer_GL32) SetUniformFSub(loc int32, values ...float32) {
+func (r *Renderer_GLES32) SetUniformFSub(loc int32, values ...float32) {
 	if loc < 0 || len(values) == 0 {
 		return
 	}
 
-	// Cached path for sprite shader
+	// Cached path for the sprite shader
 	if r.program == r.spriteShader.program {
 		key := (r.program << 16) | uint32(loc)
 
@@ -1818,7 +1764,7 @@ func (r *Renderer_GL32) SetUniformFSub(loc int32, values ...float32) {
 	}
 }
 
-func (r *Renderer_GL32) SetUniformFvSub(loc int32, values []float32) {
+func (r *Renderer_GLES32) SetUniformFvSub(loc int32, values []float32) {
 	if loc < 0 || len(values) == 0 {
 		return
 	}
@@ -1833,134 +1779,134 @@ func (r *Renderer_GL32) SetUniformFvSub(loc int32, values []float32) {
 	}
 }
 
-func (r *Renderer_GL32) SetUniformI(name string, val int) {
+func (r *Renderer_GLES32) SetUniformI(name string, val int) {
 	loc := r.spriteShader.uniforms[name]
 	r.SetUniformISub(loc, int32(val))
 }
 
-func (r *Renderer_GL32) SetUniformF(name string, values ...float32) {
+func (r *Renderer_GLES32) SetUniformF(name string, values ...float32) {
 	loc := r.spriteShader.uniforms[name]
 	r.SetUniformFSub(loc, values...)
 }
 
-func (r *Renderer_GL32) SetUniformFv(name string, values []float32) {
+func (r *Renderer_GLES32) SetUniformFv(name string, values []float32) {
 	loc := r.spriteShader.uniforms[name]
 	r.SetUniformFvSub(loc, values)
 }
 
 // Caching matrices is as expensive as direct function calls
-func (r *Renderer_GL32) SetUniformMatrix(name string, value []float32) {
+func (r *Renderer_GLES32) SetUniformMatrix(name string, value []float32) {
 	loc, ok := r.spriteShader.uniforms[name]
 	if ok && loc >= 0 {
 		gl.UniformMatrix4fv(loc, 1, false, &value[0])
 	}
 }
 
-func (r *Renderer_GL32) SetModelUniformI(name string, val int) {
+func (r *Renderer_GLES32) SetModelUniformI(name string, val int) {
 	loc, ok := r.modelShader.uniforms[name]
 	if !ok || loc < 0 {
-		if r.debugMode {
-			fmt.Printf("[GL Debug] Model uniform '%s' not registered\n", name)
-		}
+		//if r.debugMode {
+		//	fmt.Printf("[GL Debug] Model uniform '%s' not registered\n", name)
+		//}
 		return
 	}
 	r.SetUniformISub(loc, int32(val))
 }
 
-func (r *Renderer_GL32) SetModelUniformF(name string, values ...float32) {
+func (r *Renderer_GLES32) SetModelUniformF(name string, values ...float32) {
 	loc, ok := r.modelShader.uniforms[name]
 	if !ok || loc < 0 {
-		if r.debugMode {
-			fmt.Printf("[GL Debug] Model uniform '%s' not registered\n", name)
-		}
+		//if r.debugMode {
+		//	fmt.Printf("[GL Debug] Model uniform '%s' not registered\n", name)
+		//}
 		return
 	}
 	r.SetUniformFSub(loc, values...)
 }
 
-func (r *Renderer_GL32) SetModelUniformFv(name string, values []float32) {
+func (r *Renderer_GLES32) SetModelUniformFv(name string, values []float32) {
 	loc, ok := r.modelShader.uniforms[name]
 	if !ok || loc < 0 {
-		if r.debugMode {
-			fmt.Printf("[GL Debug] Model uniform '%s' not registered\n", name)
-		}
+		//if r.debugMode {
+		//	fmt.Printf("[GL Debug] Model uniform '%s' not registered\n", name)
+		//}
 		return
 	}
 	r.SetUniformFvSub(loc, values)
 }
 
-func (r *Renderer_GL32) SetModelUniformMatrix(name string, value []float32) {
+func (r *Renderer_GLES32) SetModelUniformMatrix(name string, value []float32) {
 	loc, ok := r.modelShader.uniforms[name]
 	if !ok || loc < 0 {
-		if r.debugMode {
-			fmt.Printf("[GL Debug] Model uniform '%s' not registered\n", name)
-		}
+		//if r.debugMode {
+		//	fmt.Printf("[GL Debug] Model uniform '%s' not registered\n", name)
+		//}
 		return
 	}
 	gl.UniformMatrix4fv(loc, 1, false, &value[0])
 }
 
-func (r *Renderer_GL32) SetModelUniformMatrix3(name string, value []float32) {
+func (r *Renderer_GLES32) SetModelUniformMatrix3(name string, value []float32) {
 	loc, ok := r.modelShader.uniforms[name]
 	if !ok || loc < 0 {
-		if r.debugMode {
-			fmt.Printf("[GL Debug] Model uniform '%s' not registered\n", name)
-		}
+		//if r.debugMode {
+		//	fmt.Printf("[GL Debug] Model uniform '%s' not registered\n", name)
+		//}
 		return
 	}
 	gl.UniformMatrix3fv(loc, 1, false, &value[0])
 }
 
-func (r *Renderer_GL32) SetShadowMapUniformI(name string, val int) {
+func (r *Renderer_GLES32) SetShadowMapUniformI(name string, val int) {
 	loc, ok := r.shadowMapShader.uniforms[name]
 	if !ok || loc < 0 {
-		if r.debugMode {
-			fmt.Printf("[GL Debug] Shadow uniform '%s' not registered\n", name)
-		}
+		//if r.debugMode {
+		//	fmt.Printf("[GL Debug] Shadow uniform '%s' not registered\n", name)
+		//}
 		return
 	}
 	r.SetUniformISub(loc, int32(val))
 }
 
-func (r *Renderer_GL32) SetShadowMapUniformF(name string, values ...float32) {
+func (r *Renderer_GLES32) SetShadowMapUniformF(name string, values ...float32) {
 	loc, ok := r.shadowMapShader.uniforms[name]
 	if !ok || loc < 0 {
-		if r.debugMode {
-			fmt.Printf("[GL Debug] Shadow uniform '%s' not registered\n", name)
-		}
+		//if r.debugMode {
+		//	fmt.Printf("[GL Debug] Shadow uniform '%s' not registered\n", name)
+		//}
 		return
 	}
 	r.SetUniformFSub(loc, values...)
 }
 
-func (r *Renderer_GL32) SetShadowMapUniformFv(name string, values []float32) {
+func (r *Renderer_GLES32) SetShadowMapUniformFv(name string, values []float32) {
 	loc, ok := r.shadowMapShader.uniforms[name]
 	if !ok || loc < 0 {
-		if r.debugMode {
-			fmt.Printf("[GL Debug] Shadow uniform '%s' not registered\n", name)
-		}
+		//if r.debugMode {
+		//	fmt.Printf("[GL Debug] Shadow uniform '%s' not registered\n", name)
+		//}
 		return
 	}
 	r.SetUniformFvSub(loc, values)
 }
 
-func (r *Renderer_GL32) SetShadowMapUniformMatrix(name string, value []float32) {
+func (r *Renderer_GLES32) SetShadowMapUniformMatrix(name string, value []float32) {
 	loc, ok := r.shadowMapShader.uniforms[name]
 	if !ok || loc < 0 {
-		if r.debugMode {
-			fmt.Printf("[GL Debug] Shadow uniform '%s' not registered\n", name)
-		}
+		//if r.debugMode {
+		//	fmt.Printf("[GL Debug] Shadow uniform '%s' not registered\n", name)
+		//}
 		return
 	}
 	gl.UniformMatrix4fv(loc, 1, false, &value[0])
 }
 
-func (r *Renderer_GL32) SetShadowMapUniformMatrix3(name string, value []float32) {
+func (r *Renderer_GLES32) SetShadowMapUniformMatrix3(name string, value []float32) {
 	loc, ok := r.shadowMapShader.uniforms[name]
 	if !ok || loc < 0 {
-		if r.debugMode {
-			fmt.Printf("[GL Debug] Shadow uniform '%s' not registered\n", name)
-		}
+		//if r.debugMode {
+		//	fmt.Printf("[GL Debug] Shadow uniform '%s' not registered\n", name)
+		//}
 		return
 	}
 	gl.UniformMatrix3fv(loc, 1, false, &value[0])
@@ -1968,7 +1914,7 @@ func (r *Renderer_GL32) SetShadowMapUniformMatrix3(name string, value []float32)
 
 // Selects texture unit 0 as active and tells the cache it's dirty
 // Prevents the sprite renderer from desyncing during texture maintenance
-func (r *Renderer_GL32) SetActiveTexture0() {
+func (r *Renderer_GLES32) SetActiveTexture0() {
 	gl.ActiveTexture(gl.TEXTURE0)
 
 	if len(r.texCacheTexSerial) > 0 {
@@ -1977,8 +1923,8 @@ func (r *Renderer_GL32) SetActiveTexture0() {
 	}
 }
 
-func (r *Renderer_GL32) SetTextureSub(uMap map[string]int32, tMap map[string]int, name string, tex Texture) {
-	t := tex.(*Texture_GL32)
+func (r *Renderer_GLES32) SetTextureSub(uMap map[string]int32, tMap map[string]int, name string, tex Texture) {
+	t := tex.(*Texture_GLES32)
 	loc := uMap[name]
 
 	// Cached path for the sprite shader
@@ -2026,40 +1972,71 @@ func (r *Renderer_GL32) SetTextureSub(uMap map[string]int32, tMap map[string]int
 	r.SetUniformISub(loc, int32(fixedUnit))
 }
 
-func (r *Renderer_GL32) SetTexture(name string, tex Texture) {
+func (r *Renderer_GLES32) SetTexture(name string, tex Texture) {
 	r.SetTextureSub(r.spriteShader.uniforms, r.spriteShader.textures, name, tex)
 }
 
-func (r *Renderer_GL32) SetModelTexture(name string, tex Texture) {
+func (r *Renderer_GLES32) SetModelTexture(name string, tex Texture) {
 	r.SetTextureSub(r.modelShader.uniforms, r.modelShader.textures, name, tex)
 }
 
-func (r *Renderer_GL32) SetShadowMapTexture(name string, tex Texture) {
+func (r *Renderer_GLES32) SetShadowMapTexture(name string, tex Texture) {
 	r.SetTextureSub(r.shadowMapShader.uniforms, r.shadowMapShader.textures, name, tex)
 }
 
-func (r *Renderer_GL32) SetShadowFrameTexture(i uint32) {
-	gl.FramebufferTexture(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, r.fbo_shadow_cube_texture, 0)
+func (r *Renderer_GLES32) SetShadowFrameTexture(i uint32) {
+	// Backwards-compatible alias: treat i as combined index (light*6 + face)
+	r.SetShadowFrameCubeTexture(i)
 }
 
-func (r *Renderer_GL32) SetShadowFrameCubeTexture(i uint32) {
-	gl.FramebufferTexture(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, r.fbo_shadow_cube_texture, 0)
+func (r *Renderer_GLES32) SetShadowFrameCubeTexture(i uint32) {
+	// Interpret i as a combined index: lightIndex = i / 6, faceIndex = i % 6
+	lightIndex := int(i / 6)
+	faceIndex := int(i % 6)
+
+	// clamp lightIndex to available range
+	if lightIndex < 0 {
+		lightIndex = 0
+	}
+	if lightIndex >= len(r.fbo_shadow_cube_textures) {
+		lightIndex = len(r.fbo_shadow_cube_textures) - 1
+	}
+	if faceIndex < 0 {
+		faceIndex = 0
+	}
+	if faceIndex > 5 {
+		faceIndex = 5
+	}
+
+	tex := r.fbo_shadow_cube_textures[lightIndex]
+
+	// Attach the requested face of the cube map as the framebuffer depth attachment.
+	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo_shadow)
+
+	target := uint32(gl.TEXTURE_CUBE_MAP_POSITIVE_X) + uint32(faceIndex)
+	gl.FramebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_ATTACHMENT, target, tex, 0)
+
+	// Make sure draw/read buffers are set appropriately (depth-only FBO)
+	bufs := []uint32{gl.NONE}
+	gl.DrawBuffers(1, &bufs[0])
+	gl.ReadBuffer(gl.NONE)
+
+	// Clear the depth buffer for this face before rendering
+	gl.Clear(gl.DEPTH_BUFFER_BIT)
 }
 
-func (r *Renderer_GL32) SetVertexData(values ...float32) {
+func (r *Renderer_GLES32) SetVertexData(values ...float32) {
 	data := f32.Bytes(binary.LittleEndian, values...)
 	gl.BindBuffer(gl.ARRAY_BUFFER, r.vertexBuffer)
 	gl.BufferData(gl.ARRAY_BUFFER, len(data), unsafe.Pointer(&data[0]), gl.STATIC_DRAW)
-	// STREAM_DRAW was attempted here, but some users might be havign trouble with it
-	// https://github.com/ikemen-engine/Ikemen-GO/issues/3292
 }
 
-func (r *Renderer_GL32) SetModelVertexData(bufferIndex uint32, values []byte) {
+func (r *Renderer_GLES32) SetModelVertexData(bufferIndex uint32, values []byte) {
 	gl.BindBuffer(gl.ARRAY_BUFFER, r.modelVertexBuffer[bufferIndex])
 	gl.BufferData(gl.ARRAY_BUFFER, len(values), unsafe.Pointer(&values[0]), gl.STATIC_DRAW)
 }
 
-func (r *Renderer_GL32) SetModelIndexData(bufferIndex uint32, values ...uint32) {
+func (r *Renderer_GLES32) SetModelIndexData(bufferIndex uint32, values ...uint32) {
 	data := new(bytes.Buffer)
 	binary.Write(data, binary.LittleEndian, values)
 
@@ -2067,21 +2044,21 @@ func (r *Renderer_GL32) SetModelIndexData(bufferIndex uint32, values ...uint32) 
 	gl.BufferData(gl.ELEMENT_ARRAY_BUFFER, len(values)*4, unsafe.Pointer(&data.Bytes()[0]), gl.STATIC_DRAW)
 }
 
-func (r *Renderer_GL32) RenderQuad() {
+func (r *Renderer_GLES32) RenderQuad() {
 	gl.DrawArrays(gl.TRIANGLE_STRIP, 0, 4)
 }
 
-func (r *Renderer_GL32) RenderElements(mode PrimitiveMode, count, offset int) {
+func (r *Renderer_GLES32) RenderElements(mode PrimitiveMode, count, offset int) {
 	gl.DrawElementsWithOffset(r.MapPrimitiveMode(mode), int32(count), gl.UNSIGNED_INT, uintptr(offset))
 }
 
-func (r *Renderer_GL32) RenderShadowMapElements(mode PrimitiveMode, count, offset int) {
+func (r *Renderer_GLES32) RenderShadowMapElements(mode PrimitiveMode, count, offset int) {
 	r.RenderElements(mode, count, offset)
 }
 
-func (r *Renderer_GL32) RenderCubeMap(envTex Texture, cubeTex Texture) {
-	envTexture := envTex.(*Texture_GL32)
-	cubeTexture := cubeTex.(*Texture_GL32)
+func (r *Renderer_GLES32) RenderCubeMap(envTex Texture, cubeTex Texture) {
+	envTexture := envTex.(*Texture_GLES32)
+	cubeTexture := cubeTex.(*Texture_GLES32)
 	textureSize := cubeTexture.width
 
 	r.ChangeProgram(r.panoramaToCubeMapShader.program)
@@ -2114,9 +2091,9 @@ func (r *Renderer_GL32) RenderCubeMap(envTex Texture, cubeTex Texture) {
 	gl.GenerateMipmap(gl.TEXTURE_CUBE_MAP)
 }
 
-func (r *Renderer_GL32) RenderFilteredCubeMap(distribution int32, cubeTex Texture, filteredTex Texture, mipmapLevel, sampleCount int32, roughness float32) {
-	cubeTexture := cubeTex.(*Texture_GL32)
-	filteredTexture := filteredTex.(*Texture_GL32)
+func (r *Renderer_GLES32) RenderFilteredCubeMap(distribution int32, cubeTex Texture, filteredTex Texture, mipmapLevel, sampleCount int32, roughness float32) {
+	cubeTexture := cubeTex.(*Texture_GLES32)
+	filteredTexture := filteredTex.(*Texture_GLES32)
 	textureSize := filteredTexture.width
 	currentTextureSize := textureSize >> mipmapLevel
 
@@ -2162,9 +2139,9 @@ func (r *Renderer_GL32) RenderFilteredCubeMap(distribution int32, cubeTex Textur
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo)
 }
 
-func (r *Renderer_GL32) RenderLUT(distribution int32, cubeTex Texture, lutTex Texture, sampleCount int32) {
-	cubeTexture := cubeTex.(*Texture_GL32)
-	lutTexture := lutTex.(*Texture_GL32)
+func (r *Renderer_GLES32) RenderLUT(distribution int32, cubeTex Texture, lutTex Texture, sampleCount int32) {
+	cubeTexture := cubeTex.(*Texture_GLES32)
+	lutTexture := lutTex.(*Texture_GLES32)
 	textureSize := lutTexture.width
 
 	r.ChangeProgram(r.cubemapFilteringShader.program)
@@ -2209,19 +2186,19 @@ func (r *Renderer_GL32) RenderLUT(distribution int32, cubeTex Texture, lutTex Te
 	gl.BindFramebuffer(gl.FRAMEBUFFER, r.fbo)
 }
 
-func (r *Renderer_GL32) PerspectiveProjectionMatrix(angle, aspect, near, far float32) mgl.Mat4 {
+func (r *Renderer_GLES32) PerspectiveProjectionMatrix(angle, aspect, near, far float32) mgl.Mat4 {
 	return mgl.Perspective(angle, aspect, near, far)
 }
 
-func (r *Renderer_GL32) OrthographicProjectionMatrix(left, right, bottom, top, near, far float32) mgl.Mat4 {
+func (r *Renderer_GLES32) OrthographicProjectionMatrix(left, right, bottom, top, near, far float32) mgl.Mat4 {
 	ret := mgl.Ortho(left, right, bottom, top, near, far)
 	return ret
 }
 
-func (r *Renderer_GL32) NewWorkerThread() bool {
+func (r *Renderer_GLES32) NewWorkerThread() bool {
 	return false
 }
 
-func (r *Renderer_GL32) SetVSync(interval int) {
+func (r *Renderer_GLES32) SetVSync(interval int) {
 	sdl.GLSetSwapInterval(interval)
 }

--- a/src/render_vk.go
+++ b/src/render_vk.go
@@ -5487,7 +5487,7 @@ func (r *Renderer_VK) SetModelPipeline(eq BlendEquation, src, dst BlendFunc, dep
 	r.VKState.VulkanModelPipelineState.useVertColor = useVertColor
 	r.VKState.modelVertAttrOffset = vertAttrOffset
 }
-func (r *Renderer_VK) SetMeshOulinePipeline(invertFrontFace bool, meshOutline float32) {
+func (r *Renderer_VK) SetMeshOutlinePipeline(invertFrontFace bool, meshOutline float32) {
 	r.VKState.VulkanModelPipelineState.invertFrontFace = invertFrontFace
 	r.VKState.VulkanModelPipelineState.depthTest = true
 	r.VKState.VulkanModelPipelineState.depthMask = true

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -231,8 +231,9 @@ VSync             = 1
 MSAA              = 0
 ; Toggles centering initial window position.
 WindowCentered    = 1
-; Paths to the post-processing shaders (with name, without file extension).
+; Paths to external post-processing shaders (with name, without file extension).
 ; Multiple shaders can be defined as an array, with values separated by commas.
+; Shaders will be applied in the order they are declared.
 ExternalShaders   = 
 ; Toggles Window Scale mode between nearest (0) and bilinear (1).
 WindowScaleMode   = 1

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -198,9 +198,9 @@ SpeedTest           = 100
 [Video]
 ; Screen rendering mode.
 ; OpenGL ES 3.2 (Android only, default)
-; OpenGL 3.2 (desktop only, default)
+; OpenGL 3.3 (desktop only, default)
 ; Vulkan 1.3 (desktop only, experimental)
-RenderMode        = OpenGL 3.2
+RenderMode        = OpenGL 3.3
 ; Game native width and height.
 ; Recommended settings are:
 ; 640x480   Standard definition 4:3

--- a/src/script.go
+++ b/src/script.go
@@ -2297,9 +2297,9 @@ func systemScriptInit(l *lua.LState) {
 							}
 						}
 
-						// Init palettes if character is just joining the match
+						// Load palettes if character is just joining the match
 						if c[0].roundsExisted() == 0 {
-							c[0].initPalettes()
+							c[0].loadPalettes()
 						}
 
 						// Copy each other's command lists

--- a/src/script.go
+++ b/src/script.go
@@ -4968,7 +4968,7 @@ func systemScriptInit(l *lua.LState) {
 		return 0
 	})
 	luaRegister(l, "stopAllSound", func(l *lua.LState) int {
-		sys.stopAllCharSound()
+		sys.stopAllCharSounds()
 		return 0
 	})
 	luaRegister(l, "stopBgm", func(l *lua.LState) int {

--- a/src/shaders/cubemapFiltering.frag.glsl
+++ b/src/shaders/cubemapFiltering.frag.glsl
@@ -1,36 +1,31 @@
 #define MATH_PI 3.1415926535897932384626433832795
 
 #if __VERSION__ >= 450
-#extension GL_EXT_multiview : enable
-#define currentFace gl_ViewIndex
-layout(binding = 0)uniform samplerCube cubeMap;
-#define COMPAT_TEXTURE_CUBE_LOD textureLod
-layout(push_constant, std430) uniform u {
-	int sampleCount;
-	int distribution;
-	int width;
-	float roughness;
-	float intensityScale;
-	bool isLUT;
-};
-layout(location = 0) in vec2 texcoord;
-layout(location = 0) out vec4 FragColor;
+	// VULKAN PATH
+	#extension GL_EXT_multiview : enable
+	#define currentFace gl_ViewIndex
+	layout(binding = 0)uniform samplerCube cubeMap;
+	#define COMPAT_TEXTURE_CUBE_LOD textureLod
+	layout(push_constant, std430) uniform u {
+		int sampleCount;
+		int distribution;
+		int width;
+		float roughness;
+		float intensityScale;
+		bool isLUT;
+	};
+	layout(location = 0) in vec2 texcoord;
+	layout(location = 0) out vec4 FragColor;
 #else
-	#if __VERSION__ >= 130 || defined(GL_ES)
-		#define COMPAT_VARYING in
-		#define COMPAT_TEXTURE_CUBE_LOD textureLod
-		#ifdef GL_ES
-			precision highp float;
-			precision highp int;
-		#endif
-		out vec4 FragColor;
-	#else
-		#extension GL_EXT_gpu_shader4 : enable
-		#extension GL_ARB_shader_texture_lod : enable
-		#define COMPAT_VARYING varying
-		#define FragColor gl_FragColor
-		#define COMPAT_TEXTURE_CUBE_LOD textureCubeLod
+	// OPENGL / GLES PATH
+	#define COMPAT_VARYING in
+	#define COMPAT_TEXTURE_CUBE_LOD textureLod
+	#ifdef GL_ES
+		precision highp float;
+		precision highp int;
 	#endif
+	out vec4 FragColor;
+
 	uniform samplerCube cubeMap;
 	uniform int sampleCount, distribution, width, currentFace;
 	uniform float roughness, intensityScale;
@@ -131,7 +126,7 @@ MicrofacetDistributionSample Lambertian(vec2 xi, float roughness)
 
 	return lambertian;
 }
-#if __VERSION__ >= 130
+
 // Hammersley Points on the Hemisphere
 // CC BY 3.0 (Holger Dammertz)
 // http://holger.dammertz.org/stuff/notes_HammersleyOnHemisphere.html
@@ -148,23 +143,7 @@ float radicalInverse_VdC(uint bits)
 vec2 hammersley2d(int i, int N) {
 	return vec2(float(i)/float(N), radicalInverse_VdC(uint(i)));
 }
-#else
-float radicalInverse(int n, int base) {
-	float invBase = 1.0 / float(base);
-	float reversedDigits = 0.0;
-	float invBaseN = 1.0;
-	while (n > 0) {
-		int nextDigit = n % base;
-		reversedDigits = reversedDigits * base + float(nextDigit);
-		n = n / base;
-		invBaseN *= invBase;
-	}
-	return reversedDigits * invBaseN;
-}
-vec2 hammersley2d(int i, int N) {
-	return vec2(float(i)/float(N), radicalInverse(i, 2));
-}
-#endif
+
 // TBN generates a tangent bitangent normal coordinate frame from the normal
 // (the normal must be normalized)
 mat3 generateTBN(vec3 normal)

--- a/src/shaders/font.frag.glsl
+++ b/src/shaders/font.frag.glsl
@@ -1,29 +1,25 @@
 #if __VERSION__ >= 450
-#define COMPAT_TEXTURE texture
-#define COMPAT_FRAGCOLOR FragColor
-layout(location = 0) out vec4 FragColor;
-layout(location = 0) in vec2 fragTexCoord;
+	// VULKAN PATH
+	#define COMPAT_TEXTURE texture
+	#define COMPAT_FRAGCOLOR FragColor
+	layout(location = 0) out vec4 FragColor;
+	layout(location = 0) in vec2 fragTexCoord;
 
-layout(push_constant, std430) uniform u {
-	vec4 textColor;
-};
-layout(binding = 0) uniform sampler2D tex;
+	layout(push_constant, std430) uniform u {
+		vec4 textColor;
+	};
+	layout(binding = 0) uniform sampler2D tex;
 #else
-	#if __VERSION__ >= 130 || defined(GL_ES)
-		#ifdef GL_ES
-			precision highp float;
-			precision highp int;
-		#endif
-
-		#define COMPAT_VARYING in
-		#define COMPAT_TEXTURE texture
-		#define COMPAT_FRAGCOLOR FragColor
-		out vec4 FragColor;
-	#else
-		#define COMPAT_VARYING varying
-		#define COMPAT_TEXTURE texture2D
-		#define COMPAT_FRAGCOLOR gl_FragColor
+	// OPENGL / GLES PATH
+	#ifdef GL_ES
+		precision highp float;
+		precision highp int;
 	#endif
+
+	#define COMPAT_VARYING in
+	#define COMPAT_TEXTURE texture
+	#define COMPAT_FRAGCOLOR FragColor
+	out vec4 FragColor;
 
 	// These must be STANDALONE for RegisterUniforms to work in GLES
 	uniform vec4 textColor;

--- a/src/shaders/font.vert.glsl
+++ b/src/shaders/font.vert.glsl
@@ -1,18 +1,15 @@
 #if __VERSION__ >= 450
-layout(location = 0) in vec2 vert;
-layout(location = 1) in vec2 vertTexCoord;
-layout(push_constant, std430) uniform u {
-layout(offset = 16) vec2 resolution;
-};
-layout(location = 0) out vec2 fragTexCoord;
+	// VULKAN PATH
+	layout(location = 0) in vec2 vert;
+	layout(location = 1) in vec2 vertTexCoord;
+	layout(push_constant, std430) uniform u {
+	layout(offset = 16) vec2 resolution;
+	};
+	layout(location = 0) out vec2 fragTexCoord;
 #else
-	#if __VERSION__ >= 130
-		#define COMPAT_VARYING out
-		#define COMPAT_ATTRIBUTE in
-	#else
-		#define COMPAT_VARYING varying
-		#define COMPAT_ATTRIBUTE attribute
-	#endif
+	// OPENGL / GLES PATH
+	#define COMPAT_VARYING out
+	#define COMPAT_ATTRIBUTE in
 
 	uniform vec2 resolution;
 

--- a/src/shaders/ident.frag.glsl
+++ b/src/shaders/ident.frag.glsl
@@ -1,30 +1,26 @@
 #if __VERSION__ >= 450
-    #define COMPAT_TEXTURE texture
-    layout(push_constant, std430) uniform u {
-        layout(offset = 8) float CurrentTime; // Note: removed redundant 'uniform' keyword inside block
-    };
-    layout(binding = 0) uniform sampler2D Texture;
-    layout(location = 0) in vec2 texcoord;
-    layout(location = 0) out vec4 FragColor;
+	// VULKAN PATH
+	#define COMPAT_TEXTURE texture
+	layout(push_constant, std430) uniform u {
+		layout(offset = 8) float CurrentTime; // Note: removed redundant 'uniform' keyword inside block
+	};
+	layout(binding = 0) uniform sampler2D Texture;
+	layout(location = 0) in vec2 texcoord;
+	layout(location = 0) out vec4 FragColor;
 #else
-    #if __VERSION__ >= 130 || defined(GL_ES)
-        #define COMPAT_VARYING in
-        #define COMPAT_TEXTURE texture
-        #ifdef GL_ES
-            precision highp float;
-        #endif
-        out vec4 FragColor;
-    #else
-        #define COMPAT_VARYING varying
-        #define FragColor gl_FragColor
-        #define COMPAT_TEXTURE texture2D
-    #endif
+	// OPENGL / GLES PATH
+	#define COMPAT_VARYING in
+	#define COMPAT_TEXTURE texture
+	#ifdef GL_ES
+		precision highp float;
+	#endif
+	out vec4 FragColor;
 
-    uniform sampler2D Texture;
-    uniform float CurrentTime; // Keep it here for compatibility even if unused in main
-    COMPAT_VARYING vec2 texcoord;
+	uniform sampler2D Texture;
+	uniform float CurrentTime; // Keep it here for compatibility even if unused in main
+	COMPAT_VARYING vec2 texcoord;
 #endif
 
 void main(void) {
-    FragColor = COMPAT_TEXTURE(Texture, texcoord);
+	FragColor = COMPAT_TEXTURE(Texture, texcoord);
 }

--- a/src/shaders/ident.vert.glsl
+++ b/src/shaders/ident.vert.glsl
@@ -1,25 +1,22 @@
 #if __VERSION__ >= 450
-    layout(location = 0) in vec2 VertCoord;
-    layout(location = 0) out vec2 texcoord;
+	// VULKAN PATH
+	layout(location = 0) in vec2 VertCoord;
+	layout(location = 0) out vec2 texcoord;
 #else
-    #if __VERSION__ >= 130 || defined(GL_ES)
-        #define COMPAT_VARYING out
-        #define COMPAT_ATTRIBUTE in
-        #ifdef GL_ES
-            precision highp float;
-        #endif
-    #else
-        #define COMPAT_VARYING varying 
-        #define COMPAT_ATTRIBUTE attribute 
-    #endif
+	// OPENGL / GLES PATH
+	#define COMPAT_VARYING out
+	#define COMPAT_ATTRIBUTE in
+	#ifdef GL_ES
+		precision highp float;
+	#endif
 
-    uniform vec2 TextureSize; // Not used
-    COMPAT_ATTRIBUTE vec2 VertCoord;
-    COMPAT_VARYING vec2 texcoord; // TODO: Casing doesn't match Go
+	uniform vec2 TextureSize; // Not used
+	COMPAT_ATTRIBUTE vec2 VertCoord;
+	COMPAT_VARYING vec2 texcoord; // TODO: Casing doesn't match Go
 #endif
 
 void main() {
-    gl_Position = vec4(VertCoord, 0.0, 1.0);
-    // Standard quad-to-UV mapping
-    texcoord = (VertCoord + 1.0) / 2.0;
+	gl_Position = vec4(VertCoord, 0.0, 1.0);
+	// Standard quad-to-UV mapping
+	texcoord = (VertCoord + 1.0) / 2.0;
 }

--- a/src/shaders/model.frag.glsl
+++ b/src/shaders/model.frag.glsl
@@ -58,56 +58,37 @@
 	layout(location = 6) in vec4 lightSpacePos[4];
 	layout(location = 0) out vec4 FragColor;
 #else
-	// GLES / OPENGL PATH
-	#if __VERSION__ >= 130 || defined(GL_ES)
-		#ifdef GL_ES
-			#extension GL_EXT_texture_cube_map_array : enable
-		#else
-			#extension GL_ARB_texture_cube_map_array : enable
-		#endif
-		#define COMPAT_VARYING in
-		#define COMPAT_TEXTURE texture
-		#define COMPAT_TEXTURE_CUBE texture
-		#define COMPAT_TEXTURE_CUBE_LOD textureLod
-		#ifdef GL_ES
-			precision highp float;
-			precision highp int;
-		#endif
-		#ifdef ENABLE_SHADOW
-			#ifdef GL_ES
-			// Avoid sampler-array dynamic indexing on GLES by declaring 4 separate samplers
-			uniform samplerCube shadowCubeMap0;
-			uniform samplerCube shadowCubeMap1;
-			uniform samplerCube shadowCubeMap2;
-			uniform samplerCube shadowCubeMap3;
-			#else
-			uniform samplerCubeArray shadowCubeMap;
-			#define COMPAT_SHADOW_MAP_TEXTURE() texture(shadowCubeMap,vec4(1.0, -(xy.y*2.0-1.0),-(xy.x*2.0-1.0),index)).r
-			#define COMPAT_SHADOW_CUBE_MAP_TEXTURE() texture(shadowCubeMap,vec4(xyz,index)).r
-			#endif
-			const bool useShadowMap = true;
-		#else
-			const bool useShadowMap = false;
-		#endif
-		out vec4 FragColor;
+	// OPENGL / GLES PATH
+	#ifdef GL_ES
+		#extension GL_EXT_texture_cube_map_array : enable
 	#else
-		#extension GL_ARB_shader_texture_lod : enable
-		#ifdef ENABLE_SHADOW
-			uniform samplerCube shadowCubeMap[4];
-			#define COMPAT_SHADOW_MAP_TEXTURE() textureCube(shadowCubeMap[index],vec3(1.0, -(xy.y*2.0-1.0),-(xy.x*2.0-1.0))).r
-			#define COMPAT_SHADOW_CUBE_MAP_TEXTURE() textureCube(shadowCubeMap[index],xyz).r
-			const bool useShadowMap = true;
-		#else
-			#define COMPAT_SHADOW_MAP_TEXTURE() 1.0
-			#define COMPAT_SHADOW_CUBE_MAP_TEXTURE() 1.0
-			const bool useShadowMap = false;
-		#endif
-		#define COMPAT_VARYING varying
-		#define FragColor gl_FragColor
-		#define COMPAT_TEXTURE texture2D
-		#define COMPAT_TEXTURE_CUBE textureCube
-		#define COMPAT_TEXTURE_CUBE_LOD textureCubeLod
+		#extension GL_ARB_texture_cube_map_array : enable
 	#endif
+	#define COMPAT_VARYING in
+	#define COMPAT_TEXTURE texture
+	#define COMPAT_TEXTURE_CUBE texture
+	#define COMPAT_TEXTURE_CUBE_LOD textureLod
+	#ifdef GL_ES
+		precision highp float;
+		precision highp int;
+	#endif
+	#ifdef ENABLE_SHADOW
+		#ifdef GL_ES
+		// Avoid sampler-array dynamic indexing on GLES by declaring 4 separate samplers
+		uniform samplerCube shadowCubeMap0;
+		uniform samplerCube shadowCubeMap1;
+		uniform samplerCube shadowCubeMap2;
+		uniform samplerCube shadowCubeMap3;
+		#else
+		uniform samplerCubeArray shadowCubeMap;
+		#define COMPAT_SHADOW_MAP_TEXTURE() texture(shadowCubeMap,vec4(1.0, -(xy.y*2.0-1.0),-(xy.x*2.0-1.0),index)).r
+		#define COMPAT_SHADOW_CUBE_MAP_TEXTURE() texture(shadowCubeMap,vec4(xyz,index)).r
+		#endif
+		const bool useShadowMap = true;
+	#else
+		const bool useShadowMap = false;
+	#endif
+	out vec4 FragColor;
 
 	struct Light {
 		vec3 direction; float range;

--- a/src/shaders/model.vert.glsl
+++ b/src/shaders/model.vert.glsl
@@ -1,63 +1,58 @@
 #if __VERSION__ >= 450
-#define COMPAT_TEXTURE texture
-layout(binding = 0) uniform UniformBufferObject0 {
-	mat4 view, projection;
-	mat4 lightMatrices[4];
-	layout(offset = 688) vec3 cameraPosition;
-};
+	// VULKAN PATH
+	#define COMPAT_TEXTURE texture
+	layout(binding = 0) uniform UniformBufferObject0 {
+		mat4 view, projection;
+		mat4 lightMatrices[4];
+		layout(offset = 688) vec3 cameraPosition;
+	};
 
-layout(binding = 2) uniform UniformBufferObject2 {
-	mat4 model,normalMatrix;
-	int numJoints,numTargets,morphTargetTextureDimension,numVertices;
-	vec4 morphTargetWeight[2];
-	vec4 morphTargetOffset;
-	float meshOutline;
-};
+	layout(binding = 2) uniform UniformBufferObject2 {
+		mat4 model,normalMatrix;
+		int numJoints,numTargets,morphTargetTextureDimension,numVertices;
+		vec4 morphTargetWeight[2];
+		vec4 morphTargetOffset;
+		float meshOutline;
+	};
 
-layout(binding = 3) uniform sampler2D jointMatrices;
-layout(binding = 4) uniform sampler2D morphTargetValues;
+	layout(binding = 3) uniform sampler2D jointMatrices;
+	layout(binding = 4) uniform sampler2D morphTargetValues;
 
-layout (constant_id = 0) const bool useJoint0 = false;
-layout (constant_id = 1) const bool useJoint1 = false;
-layout (constant_id = 2) const bool useNormal = false;
-layout (constant_id = 3) const bool useTangent = false;
-layout (constant_id = 4) const bool useVertColor = false;
-layout (constant_id = 5) const bool useOutlineAttribute = false;
+	layout (constant_id = 0) const bool useJoint0 = false;
+	layout (constant_id = 1) const bool useJoint1 = false;
+	layout (constant_id = 2) const bool useNormal = false;
+	layout (constant_id = 3) const bool useTangent = false;
+	layout (constant_id = 4) const bool useVertColor = false;
+	layout (constant_id = 5) const bool useOutlineAttribute = false;
 
-layout(location = 0) in int vertexId;
-layout(location = 1) in vec3 position;
-layout(location = 2) in vec2 uv;
-layout(location = 3) in vec3 normalIn;
-layout(location = 4) in vec4 tangentIn;
-layout(location = 5) in vec4 vertColor;
-layout(location = 6) in vec4 joints_0;
-layout(location = 7) in vec4 weights_0;
-layout(location = 8) in vec4 joints_1;
-layout(location = 9) in vec4 weights_1;
-layout(location = 10) in vec4 outlineAttributeIn;
+	layout(location = 0) in int vertexId;
+	layout(location = 1) in vec3 position;
+	layout(location = 2) in vec2 uv;
+	layout(location = 3) in vec3 normalIn;
+	layout(location = 4) in vec4 tangentIn;
+	layout(location = 5) in vec4 vertColor;
+	layout(location = 6) in vec4 joints_0;
+	layout(location = 7) in vec4 weights_0;
+	layout(location = 8) in vec4 joints_1;
+	layout(location = 9) in vec4 weights_1;
+	layout(location = 10) in vec4 outlineAttributeIn;
 
-layout(location = 0) out vec3 normal;
-layout(location = 1) out vec3 tangent;
-layout(location = 2) out vec3 bitangent;
-layout(location = 3) out vec2 texcoord;
-layout(location = 4) out vec4 vColor;
-layout(location = 5) out vec3 worldSpacePos;
-layout(location = 6) out vec4 lightSpacePos[4];
+	layout(location = 0) out vec3 normal;
+	layout(location = 1) out vec3 tangent;
+	layout(location = 2) out vec3 bitangent;
+	layout(location = 3) out vec2 texcoord;
+	layout(location = 4) out vec4 vColor;
+	layout(location = 5) out vec3 worldSpacePos;
+	layout(location = 6) out vec4 lightSpacePos[4];
 #else
-	// GLES 3.2 / ANDROID PATH - Standard Uniforms
-	#if __VERSION__ >= 130 || defined(GL_ES)
-		#define COMPAT_VARYING out
-		#define COMPAT_ATTRIBUTE in
-		#define COMPAT_TEXTURE texture
-		#ifdef GL_ES
-			precision highp float;
-			precision highp int;
-			precision highp sampler2D;
-		#endif
-	#else
-		#define COMPAT_VARYING varying 
-		#define COMPAT_ATTRIBUTE attribute 
-		#define COMPAT_TEXTURE texture2D
+	// OPENGL / GLES PATH - Standard Uniforms
+	#define COMPAT_VARYING out
+	#define COMPAT_ATTRIBUTE in
+	#define COMPAT_TEXTURE texture
+	#ifdef GL_ES
+		precision highp float;
+		precision highp int;
+		precision highp sampler2D;
 	#endif
 
 	uniform mat4 model, view, projection, normalMatrix;

--- a/src/shaders/panoramaToCubeMap.frag.glsl
+++ b/src/shaders/panoramaToCubeMap.frag.glsl
@@ -1,26 +1,24 @@
 #define MATH_PI 3.1415926535897932384626433832795
 #define MATH_INV_PI (1.0 / MATH_PI)
+
 #if __VERSION__ >= 450
-#extension GL_EXT_multiview : enable
-#define COMPAT_TEXTURE texture
-#define currentFace gl_ViewIndex
-layout(location = 0) in vec2 texcoord;
-layout(binding = 0) uniform sampler2D panorama;
-layout(location = 0) out vec4 FragColor;
+	// VULKAN PATH
+	#extension GL_EXT_multiview : enable
+	#define COMPAT_TEXTURE texture
+	#define currentFace gl_ViewIndex
+	layout(location = 0) in vec2 texcoord;
+	layout(binding = 0) uniform sampler2D panorama;
+	layout(location = 0) out vec4 FragColor;
 #else
-	#if __VERSION__ >= 130 || defined(GL_ES)
-		#define COMPAT_VARYING in
-		#define COMPAT_TEXTURE texture
-		#ifdef GL_ES
-			precision highp float;
-			precision highp int;
-		#endif
-		out vec4 FragColor;
-	#else
-		#define COMPAT_VARYING varying
-		#define FragColor gl_FragColor
-		#define COMPAT_TEXTURE texture2D
+	// OPENGL / GLES PATH
+	#define COMPAT_VARYING in
+	#define COMPAT_TEXTURE texture
+	#ifdef GL_ES
+		precision highp float;
+		precision highp int;
 	#endif
+	out vec4 FragColor;
+
 	COMPAT_VARYING vec2 texcoord;
 	uniform int currentFace;
 	uniform sampler2D panorama;

--- a/src/shaders/shadow.frag.glsl
+++ b/src/shaders/shadow.frag.glsl
@@ -15,37 +15,34 @@ struct Light
 	float shadowBias;
 	float shadowMapFar;
 };
+
 #if __VERSION__ >= 450
-#define COMPAT_TEXTURE texture
-layout (constant_id = 3) const bool useTexture = false;
-layout(binding = 0) uniform EnvironmentUniform {
-	layout(offset = 1536) Light lights[4];
-};
-layout(binding = 1) uniform MaterialUniform {
-	mat3 texTransform;
-	vec4 baseColorFactor;
-	float ambientOcclusionStrength;
-	float alphaThreshold;
-	bool enableAlpha;
-};
-layout(binding = 5) uniform sampler2D tex;
-layout(location = 0) in vec4 FragPos;
-layout(location = 1) in float vColor;
-layout(location = 2) in vec2 texcoord;
-layout(location = 3) in flat int lightIndex;
+	// VULKAN PATH
+	#define COMPAT_TEXTURE texture
+	layout (constant_id = 3) const bool useTexture = false;
+	layout(binding = 0) uniform EnvironmentUniform {
+		layout(offset = 1536) Light lights[4];
+	};
+	layout(binding = 1) uniform MaterialUniform {
+		mat3 texTransform;
+		vec4 baseColorFactor;
+		float ambientOcclusionStrength;
+		float alphaThreshold;
+		bool enableAlpha;
+	};
+	layout(binding = 5) uniform sampler2D tex;
+	layout(location = 0) in vec4 FragPos;
+	layout(location = 1) in float vColor;
+	layout(location = 2) in vec2 texcoord;
+	layout(location = 3) in flat int lightIndex;
 #else
-	// GLES / OPENGL PATH
-	#if __VERSION__ >= 130 || defined(GL_ES)
-		#define COMPAT_VARYING in
-		#define COMPAT_TEXTURE texture
-		#ifdef GL_ES
-			precision highp float;
-			precision highp int;
-			precision highp sampler2DArray;
-		#endif
-	#else
-		#define COMPAT_VARYING varying
-		#define COMPAT_TEXTURE texture2D
+	// OPENGL / GLES PATH
+	#define COMPAT_VARYING in
+	#define COMPAT_TEXTURE texture
+	#ifdef GL_ES
+		precision highp float;
+		precision highp int;
+		precision highp sampler2DArray;
 	#endif
 
 	uniform sampler2D tex;

--- a/src/shaders/shadow.geo.glsl
+++ b/src/shaders/shadow.geo.glsl
@@ -1,48 +1,33 @@
-#if __VERSION__ >= 130
-    #define COMPAT_POS_IN(i) gl_in[i].gl_Position
-    layout(triangle_strip, max_vertices = 18) out;
-    uniform int layerOffset;
-    #define LAYER_OFFSET layerOffset
-    layout(triangles) in;
-    
-    in float vColorIn[];
-    in vec2 texcoordIn[];
-    in vec4 FragPosIn[];
+layout(triangle_strip, max_vertices = 18) out;
+uniform int layerOffset;
+#define LAYER_OFFSET layerOffset
+layout(triangles) in;
 
-    out vec4 FragPos;
-    out float vColor;
-    out vec2 texcoord;
-#else
-    #extension GL_EXT_geometry_shader4: enable
-    #define COMPAT_POS_IN(i) gl_PositionIn[i]
-    #define LAYER_OFFSET 0
+in float vColorIn[];
+in vec2 texcoordIn[];
+in vec4 FragPosIn[];
 
-    varying in float vColorIn[3];
-    varying in vec2 texcoordIn[3];
-    varying in vec4 FragPosIn[3];
-
-    varying out vec4 FragPos;
-    varying out float vColor;
-    varying out vec2 texcoord;
-#endif
+out vec4 FragPos;
+out float vColor;
+out vec2 texcoord;
 
 uniform int lightIndex;
 struct Light
 {
-    vec3 direction;
-    float range;
+	vec3 direction;
+	float range;
 
-    vec3 color;
-    float intensity;
+	vec3 color;
+	float intensity;
 
-    vec3 position;
-    float innerConeCos;
+	vec3 position;
+	float innerConeCos;
 
-    float outerConeCos;
-    int type;
+	float outerConeCos;
+	int type;
 
-    float shadowBias;
-    float shadowMapFar;
+	float shadowBias;
+	float shadowMapFar;
 };
 uniform Light lights[4];
 
@@ -53,30 +38,30 @@ const int LightType_Directional = 1;
 const int LightType_Point = 2;
 const int LightType_Spot = 3;
 void main() {
-    if(lights[lightIndex].type == LightType_Point){
-        for(int face = 0; face < 6; ++face)
-        {
-            gl_Layer = LAYER_OFFSET+face; // built-in variable that specifies to which face we render.
-            for(int i = 0; i < 3; ++i) // for each triangle vertex
-            {
-                FragPos = FragPosIn[i];
-                texcoord = texcoordIn[i];
-                vColor = vColorIn[i];
-                gl_Position = lightMatrices[lightIndex*6+face] * FragPosIn[i];
-                EmitVertex();
-            }    
-            EndPrimitive();
-        }
-    }else if(lights[lightIndex].type != LightType_None){
-        gl_Layer = LAYER_OFFSET;
-        for(int i = 0; i < 3; ++i) // for each triangle vertex
-        {
-            FragPos = FragPosIn[i];
-            texcoord = texcoordIn[i];
-            vColor = vColorIn[i];
-            gl_Position = lightMatrices[lightIndex*6] * FragPosIn[i];
-            EmitVertex();
-        }
-        EndPrimitive();
-    }
+	if(lights[lightIndex].type == LightType_Point){
+		for(int face = 0; face < 6; ++face)
+		{
+			gl_Layer = LAYER_OFFSET+face; // built-in variable that specifies to which face we render.
+			for(int i = 0; i < 3; ++i) // for each triangle vertex
+			{
+				FragPos = FragPosIn[i];
+				texcoord = texcoordIn[i];
+				vColor = vColorIn[i];
+				gl_Position = lightMatrices[lightIndex*6+face] * FragPosIn[i];
+				EmitVertex();
+			}    
+			EndPrimitive();
+		}
+	}else if(lights[lightIndex].type != LightType_None){
+		gl_Layer = LAYER_OFFSET;
+		for(int i = 0; i < 3; ++i) // for each triangle vertex
+		{
+			FragPos = FragPosIn[i];
+			texcoord = texcoordIn[i];
+			vColor = vColorIn[i];
+			gl_Position = lightMatrices[lightIndex*6] * FragPosIn[i];
+			EmitVertex();
+		}
+		EndPrimitive();
+	}
 } 

--- a/src/shaders/shadow.vert.glsl
+++ b/src/shaders/shadow.vert.glsl
@@ -1,79 +1,73 @@
 #if __VERSION__ >= 450
-#define GS_IN(x) x
-#extension GL_ARB_shader_viewport_layer_array  : enable
-#define COMPAT_TEXTURE texture
-layout (constant_id = 0) const bool useJoint0 = false;
-layout (constant_id = 1) const bool useJoint1 = false;
-layout (constant_id = 2) const bool useVertColor = false;
-struct Light
-{
-	vec3 direction;
-	float range;
+	// VULKAN PATH
+	#define GS_IN(x) x
+	#extension GL_ARB_shader_viewport_layer_array  : enable
+	#define COMPAT_TEXTURE texture
+	layout (constant_id = 0) const bool useJoint0 = false;
+	layout (constant_id = 1) const bool useJoint1 = false;
+	layout (constant_id = 2) const bool useVertColor = false;
 
-	vec3 color;
-	float intensity;
+	struct Light
+	{
+		vec3 direction;
+		float range;
 
-	vec3 position;
-	float innerConeCos;
+		vec3 color;
+		float intensity;
 
-	float outerConeCos;
-	int type;
+		vec3 position;
+		float innerConeCos;
 
-	float shadowBias;
-	float shadowMapFar;
-};
-layout(binding = 0) uniform UniformBufferObject0 {
-	mat4 lightMatrices[24];
-	Light lights[4];
-	vec4 layers[6];
-};
+		float outerConeCos;
+		int type;
 
-layout(binding = 2) uniform UniformBufferObject2 {
-	vec4 morphTargetWeight[2];
-	vec4 morphTargetOffset;
-	int numJoints,numTargets,morphTargetTextureDimension;
-};
+		float shadowBias;
+		float shadowMapFar;
+	};
+	layout(binding = 0) uniform UniformBufferObject0 {
+		mat4 lightMatrices[24];
+		Light lights[4];
+		vec4 layers[6];
+	};
 
-layout(binding = 3) uniform sampler2D jointMatrices;
-layout(binding = 4) uniform sampler2D morphTargetValues;
+	layout(binding = 2) uniform UniformBufferObject2 {
+		vec4 morphTargetWeight[2];
+		vec4 morphTargetOffset;
+		int numJoints,numTargets,morphTargetTextureDimension;
+	};
 
-layout(push_constant, std430) uniform u {
-	mat4 model;
-	int numVertices;
-};
+	layout(binding = 3) uniform sampler2D jointMatrices;
+	layout(binding = 4) uniform sampler2D morphTargetValues;
 
-//gl_VertexID is not available in 1.2
-layout(location = 0) in int vertexId;
-layout(location = 1) in vec3 position;
-layout(location = 2) in vec2 uv;
-layout(location = 3) in vec4 vertColor;
-layout(location = 4) in vec4 joints_0;
-layout(location = 5) in vec4 joints_1;
-layout(location = 6) in vec4 weights_0;
-layout(location = 7) in vec4 weights_1;
+	layout(push_constant, std430) uniform u {
+		mat4 model;
+		int numVertices;
+	};
 
-layout(location = 0) out vec4 FragPos;
-layout(location = 1) out float vColor;
-layout(location = 2) out vec2 texcoord;
-layout(location = 3) out flat int lightIndex;
+	//gl_VertexID is not available in 1.2
+	layout(location = 0) in int vertexId;
+	layout(location = 1) in vec3 position;
+	layout(location = 2) in vec2 uv;
+	layout(location = 3) in vec4 vertColor;
+	layout(location = 4) in vec4 joints_0;
+	layout(location = 5) in vec4 joints_1;
+	layout(location = 6) in vec4 weights_0;
+	layout(location = 7) in vec4 weights_1;
+
+	layout(location = 0) out vec4 FragPos;
+	layout(location = 1) out float vColor;
+	layout(location = 2) out vec2 texcoord;
+	layout(location = 3) out flat int lightIndex;
 
 #else
-	// GLES / OPENGL PATH
-	#if __VERSION__ >= 130 || defined(GL_ES)
-		#define COMPAT_VARYING out
-		#define COMPAT_ATTRIBUTE in
-		#define COMPAT_TEXTURE texture
-		#ifdef GL_ES
-			precision highp float;
-			#define GS_IN(x) x
-		#else
-			#define GS_IN(x) x##In
-		#endif
+	// OPENGL / GLES PATH
+	#define COMPAT_VARYING out
+	#define COMPAT_ATTRIBUTE in
+	#define COMPAT_TEXTURE texture
+	#ifdef GL_ES
+		precision highp float;
+		#define GS_IN(x) x
 	#else
-		#extension GL_EXT_gpu_shader4 : enable
-		#define COMPAT_VARYING varying 
-		#define COMPAT_ATTRIBUTE attribute 
-		#define COMPAT_TEXTURE texture2D
 		#define GS_IN(x) x##In
 	#endif
 
@@ -134,6 +128,7 @@ mat4 getJointMatrix(){
 	}
 	return ret;
 }
+
 void main() {
 	GS_IN(texcoord) = uv;
 	#if __VERSION__ >= 450

--- a/src/shaders/sprite.frag.glsl
+++ b/src/shaders/sprite.frag.glsl
@@ -19,19 +19,13 @@
 	layout(location = 0) out vec4 FragColor;
 #else
 	// OPENGL / GLES PATH
-	#if __VERSION__ >= 130 || defined(GL_ES)
-		#define COMPAT_VARYING in
-		#define COMPAT_TEXTURE texture
-		#ifdef GL_ES
-			precision highp float;
-			precision highp int;
-		#endif
-		out vec4 FragColor;
-	#else
-		#define COMPAT_VARYING varying
-		#define FragColor gl_FragColor
-		#define COMPAT_TEXTURE texture2D
+	#define COMPAT_VARYING in
+	#define COMPAT_TEXTURE texture
+	#ifdef GL_ES
+		precision highp float;
+		precision highp int;
 	#endif
+	out vec4 FragColor;
 
 	uniform sampler2D tex;
 	uniform sampler2D pal;

--- a/src/shaders/sprite.vert.glsl
+++ b/src/shaders/sprite.vert.glsl
@@ -1,41 +1,35 @@
 #if __VERSION__ >= 450
-    // VULKAN PATH
-    layout(binding = 0) uniform UniformBufferObject {
-        mat4 modelview, projection;
-    };
-    layout(location = 0) in vec2 position;
-    layout(location = 1) in vec2 uv;
-    layout(location = 0) out vec2 texcoord;
+	// VULKAN PATH
+	layout(binding = 0) uniform UniformBufferObject {
+		mat4 modelview, projection;
+	};
+	layout(location = 0) in vec2 position;
+	layout(location = 1) in vec2 uv;
+	layout(location = 0) out vec2 texcoord;
 #else
-    // OPENGL / GLES PATH
-    #if __VERSION__ >= 130 || defined(GL_ES)
-        #define COMPAT_VARYING out
-        #define COMPAT_ATTRIBUTE in
-        #define COMPAT_TEXTURE texture
-        #ifdef GL_ES
-            // Mandatory for GLES: High precision for vertex position math
-            precision highp float;
-            precision highp int;
-        #endif
-    #else
-        #define COMPAT_VARYING varying 
-        #define COMPAT_ATTRIBUTE attribute 
-        #define COMPAT_TEXTURE texture2D
-    #endif
+	// OPENGL / GLES PATH
+	#define COMPAT_VARYING out
+	#define COMPAT_ATTRIBUTE in
+	#define COMPAT_TEXTURE texture
+	#ifdef GL_ES
+		// Mandatory for GLES: High precision for vertex position math
+		precision highp float;
+		precision highp int;
+	#endif
 
-    uniform mat4 modelview, projection;
+	uniform mat4 modelview, projection;
 
-    COMPAT_ATTRIBUTE vec2 position;
-    COMPAT_ATTRIBUTE vec2 uv;
-    COMPAT_VARYING vec2 texcoord;
+	COMPAT_ATTRIBUTE vec2 position;
+	COMPAT_ATTRIBUTE vec2 uv;
+	COMPAT_VARYING vec2 texcoord;
 #endif
 
 void main(void) {
-    texcoord = uv;
-    gl_Position = projection * (modelview * vec4(position, 0.0, 1.0));
-    
-    #if __VERSION__ >= 450
-        // Vulkan's Y-axis is inverted compared to OpenGL
-        gl_Position.y = -gl_Position.y;
-    #endif
+	texcoord = uv;
+	gl_Position = projection * (modelview * vec4(position, 0.0, 1.0));
+	
+	#if __VERSION__ >= 450
+		// Vulkan's Y-axis is inverted compared to OpenGL
+		gl_Position.y = -gl_Position.y;
+	#endif
 }

--- a/src/sound.go
+++ b/src/sound.go
@@ -1078,7 +1078,7 @@ func (s *SoundChannels) New(ch int32, lowpriority bool, priority int32) *SoundCh
 	if ch >= 0 && ch < sys.cfg.Sound.WavChannels {
 		for i := s.count() - 1; i >= 0; i-- {
 			if s.channels[i].IsPlaying() && s.channels[i].sfx.channel == ch {
-				if (lowpriority && priority <= s.channels[i].sfx.priority) || priority < s.channels[i].sfx.priority {
+				if lowpriority || priority < s.channels[i].sfx.priority {
 					return nil
 				}
 				s.channels[i].Stop()

--- a/src/sound.go
+++ b/src/sound.go
@@ -47,7 +47,7 @@ func (n *Normalizer) Stream(samples [][2]float64) (s int, ok bool) {
 	// really long time and the below streamer.Stream method does not
 	// do a nil check. This should at least prevent crashes, but may
 	// lead to sound glitches.
-	if len(samples) <= 0 {
+	if n.streamer == nil || len(samples) <= 0 {
 		return 0, false
 	}
 	s, ok = n.streamer.Stream(samples)
@@ -64,6 +64,9 @@ func (n *Normalizer) Stream(samples [][2]float64) (s int, ok bool) {
 }
 
 func (n *Normalizer) Err() error {
+	if n.streamer == nil {
+		return nil
+	}
 	return n.streamer.Err()
 }
 

--- a/src/sound.go
+++ b/src/sound.go
@@ -95,6 +95,13 @@ func (n *NormalizerLR) process(mul float64, sam *float64) float64 {
 	return mul
 }
 
+// Safe wrapper for streamer operations
+func WithSpeakerLock(f func()) {
+	speaker.Lock()
+	defer speaker.Unlock()
+	f()
+}
+
 // ------------------------------------------------------------------
 // SwapSeeker - beep.StreamSeeker that can be swapped to in-memory
 // copy at runtime.
@@ -309,9 +316,9 @@ func newBgm() *Bgm {
 
 func (bgm *Bgm) Stop() {
 	if bgm.ctrl != nil {
-		speaker.Lock()
-		bgm.ctrl.Streamer = nil
-		speaker.Unlock()
+		WithSpeakerLock(func() {
+			bgm.ctrl.Streamer = nil
+		})
 	}
 	bgm.filename = ""
 }
@@ -332,9 +339,9 @@ func (bgm *Bgm) Open(filename string, loop, bgmVolume, bgmLoopStart, bgmLoopEnd,
 	bgm.freqmul = freqmul
 	// Starve the current music streamer
 	if bgm.ctrl != nil {
-		speaker.Lock()
-		bgm.ctrl.Streamer = nil
-		speaker.Unlock()
+		WithSpeakerLock(func() {
+			bgm.ctrl.Streamer = nil
+		})
 	}
 	// Special value "" is used to stop music
 	if filename == "" {
@@ -532,9 +539,9 @@ func (bgm *Bgm) SetPaused(pause bool) {
 	if bgm.ctrl == nil || bgm.ctrl.Paused == pause {
 		return
 	}
-	speaker.Lock()
-	bgm.ctrl.Paused = pause
-	speaker.Unlock()
+	WithSpeakerLock(func() {
+		bgm.ctrl.Paused = pause
+	})
 }
 
 func (bgm *Bgm) UpdateVolume() {
@@ -556,10 +563,10 @@ func (bgm *Bgm) UpdateVolume() {
 		volume = 1
 	}
 	silent := volume <= -5
-	speaker.Lock()
-	bgm.volctrl.Volume = volume
-	bgm.volctrl.Silent = silent
-	speaker.Unlock()
+	WithSpeakerLock(func() {
+		bgm.volctrl.Volume = volume
+		bgm.volctrl.Silent = silent
+	})
 }
 
 func (bgm *Bgm) SetFreqMul(freqmul float32) {
@@ -574,10 +581,10 @@ func (bgm *Bgm) SetFreqMul(freqmul float32) {
 			srcRate := bgm.sampleRate
 			dstRate := beep.SampleRate(float32(sys.cfg.Sound.SampleRate) / freqmul)
 			if resampler, ok := bgm.ctrl.Streamer.(*beep.Resampler); ok {
-				speaker.Lock()
-				resampler.SetRatio(float64(srcRate) / float64(dstRate))
-				bgm.freqmul = freqmul
-				speaker.Unlock()
+				WithSpeakerLock(func() {
+					resampler.SetRatio(float64(srcRate) / float64(dstRate))
+					bgm.freqmul = freqmul
+				})
 			}
 		}
 	}
@@ -603,9 +610,9 @@ func (bgm *Bgm) OpenFromStreamer(stream beep.Streamer, srcSampleRate beep.Sample
 
 	// Starve the current music streamer
 	if bgm.ctrl != nil {
-		speaker.Lock()
-		bgm.ctrl.Streamer = nil
-		speaker.Unlock()
+		WithSpeakerLock(func() {
+			bgm.ctrl.Streamer = nil
+		})
 	}
 	// Honor CLI flags just like normal Open()
 	if _, ok := sys.cmdFlags["-nomusic"]; ok {
@@ -627,23 +634,23 @@ func (bgm *Bgm) OpenFromStreamer(stream beep.Streamer, srcSampleRate beep.Sample
 }
 
 func (bgm *Bgm) SetLoopPoints(bgmLoopStart int, bgmLoopEnd int) {
-	// Set both at once, why not
 	if sl, ok := bgm.volctrl.Streamer.(*StreamLooper); ok {
 		if sl.loopstart != bgmLoopStart && sl.loopend != bgmLoopEnd {
-			speaker.Lock()
-			sl.loopstart = bgmLoopStart
-			sl.loopend = bgmLoopEnd
-			speaker.Unlock()
-			// Set one at a time
-		} else {
-			if sl.loopstart != bgmLoopStart {
-				speaker.Lock()
+			// Set both at once, why not
+			WithSpeakerLock(func() {
 				sl.loopstart = bgmLoopStart
-				speaker.Unlock()
-			} else if sl.loopend != bgmLoopEnd {
-				speaker.Lock()
 				sl.loopend = bgmLoopEnd
-				speaker.Unlock()
+			})
+		} else {
+			// Set one at a time
+			if sl.loopstart != bgmLoopStart {
+				WithSpeakerLock(func() {
+					sl.loopstart = bgmLoopStart
+				})
+			} else if sl.loopend != bgmLoopEnd {
+				WithSpeakerLock(func() {
+					sl.loopend = bgmLoopEnd
+				})
 			}
 		}
 	}
@@ -654,13 +661,13 @@ func (bgm *Bgm) Seek(positionSample int) {
 	if bgm.streamer == nil {
 		return
 	}
-	speaker.Lock()
 	// Reset to 0 if out of range
-	if positionSample < 0 || positionSample > bgm.streamer.Len() {
-		positionSample = 0
-	}
-	_ = bgm.streamer.Seek(positionSample)
-	speaker.Unlock()
+	WithSpeakerLock(func() {
+		if positionSample < 0 || positionSample > bgm.streamer.Len() {
+			positionSample = 0
+		}
+		_ = bgm.streamer.Seek(positionSample)
+	})
 }
 
 // ------------------------------------------------------------------
@@ -936,7 +943,10 @@ func (s *SoundChannel) Play(sound *Sound, group, number, loop int32, freqmul flo
 	resampler := beep.Resample(audioResampleQuality, srcRate, dstRate, s.sfx)
 	s.ctrl = &beep.Ctrl{Streamer: resampler}
 	s.streamer.Seek(startPosition)
-	sys.soundMixer.Add(s.ctrl)
+
+	WithSpeakerLock(func() {
+		sys.soundMixer.Add(s.ctrl)
+	})
 }
 
 func (s *SoundChannel) IsPlaying() bool {
@@ -947,16 +957,16 @@ func (s *SoundChannel) SetPaused(pause bool) {
 	if s.ctrl == nil || s.ctrl.Paused == pause {
 		return
 	}
-	speaker.Lock()
-	s.ctrl.Paused = pause
-	speaker.Unlock()
+	WithSpeakerLock(func() {
+		s.ctrl.Paused = pause
+	})
 }
 
 func (s *SoundChannel) Stop() {
 	if s.ctrl != nil {
-		speaker.Lock()
-		s.ctrl.Streamer = nil
-		speaker.Unlock()
+		WithSpeakerLock(func() {
+			s.ctrl.Streamer = nil
+		})
 	}
 	s.sound = nil
 }
@@ -999,10 +1009,10 @@ func (s *SoundChannel) SetFreqMul(freqmul float32) {
 			srcRate := s.sound.format.SampleRate
 			dstRate := beep.SampleRate(float32(sys.cfg.Sound.SampleRate) / freqmul)
 			if resampler, ok := s.ctrl.Streamer.(*beep.Resampler); ok {
-				speaker.Lock()
-				resampler.SetRatio(float64(srcRate) / float64(dstRate))
-				s.sfx.freqmul = freqmul
-				speaker.Unlock()
+				WithSpeakerLock(func() {
+					resampler.SetRatio(float64(srcRate) / float64(dstRate))
+					s.sfx.freqmul = freqmul
+				})
 			}
 		}
 	}
@@ -1012,20 +1022,20 @@ func (s *SoundChannel) SetLoopPoints(loopstart, loopend int) {
 	// Set both at once, why not
 	if sl, ok := s.sfx.streamer.(*StreamLooper); ok {
 		if sl.loopstart != loopstart && sl.loopend != loopend {
-			speaker.Lock()
-			sl.loopstart = loopstart
-			sl.loopend = loopend
-			speaker.Unlock()
+			WithSpeakerLock(func() {
+				sl.loopstart = loopstart
+				sl.loopend = loopend
+			})
 			// Set one at a time
 		} else {
 			if sl.loopstart != loopstart {
-				speaker.Lock()
-				sl.loopstart = loopstart
-				speaker.Unlock()
+				WithSpeakerLock(func() {
+					sl.loopstart = loopstart
+				})
 			} else if sl.loopend != loopend {
-				speaker.Lock()
-				sl.loopend = loopend
-				speaker.Unlock()
+				WithSpeakerLock(func() {
+					sl.loopend = loopend
+				})
 			}
 		}
 	}

--- a/src/sound.go
+++ b/src/sound.go
@@ -868,7 +868,6 @@ type SoundEffect struct {
 	ls, p    float32
 	x        *float32
 	priority int32
-	channel  int32
 	loop     int32
 	freqmul  float32
 	startPos int
@@ -910,6 +909,7 @@ type SoundChannel struct {
 	sfx               *SoundEffect
 	ctrl              *beep.Ctrl
 	sound             *Sound
+	channelNo         int32 // Logical channel assigned by char code
 	stopOnGetHit      bool
 	stopOnChangeState bool
 	group             int32
@@ -937,7 +937,7 @@ func (s *SoundChannel) Play(sound *Sound, group, number, loop int32, freqmul flo
 
 	// going to continue using our streamLooper which is now modified from beep.Loop2
 	looper := newStreamLooper(s.streamer, loopCount, loopStart, loopEnd)
-	s.sfx = &SoundEffect{streamer: looper, volume: 256, priority: 0, channel: -1, loop: int32(loopCount), freqmul: freqmul, startPos: startPosition}
+	s.sfx = &SoundEffect{streamer: looper, volume: 256, priority: 0, loop: int32(loopCount), freqmul: freqmul, startPos: startPosition}
 	srcRate := s.sound.format.SampleRate
 	dstRate := beep.SampleRate(float32(sys.cfg.Sound.SampleRate) / s.sfx.freqmul)
 	resampler := beep.Resample(audioResampleQuality, srcRate, dstRate, s.sfx)
@@ -988,12 +988,6 @@ func (s *SoundChannel) SetPan(p, ls float32, x *float32) {
 func (s *SoundChannel) SetPriority(priority int32) {
 	if s.ctrl != nil {
 		s.sfx.priority = priority
-	}
-}
-
-func (s *SoundChannel) SetChannel(channel int32) {
-	if s.ctrl != nil {
-		s.sfx.channel = channel
 	}
 }
 
@@ -1056,15 +1050,28 @@ func newSoundChannels(size int32) *SoundChannels {
 }
 
 func (s *SoundChannels) SetSize(size int32) {
-	if size > s.count() {
-		c := make([]SoundChannel, size-s.count())
-		v := make([]float32, size-s.count())
+	currentSize := s.count()
+
+	switch {
+	case size > currentSize:
+		// Add new channels
+		newSlotsCount := size - currentSize
+		c := make([]SoundChannel, newSlotsCount)
+		v := make([]float32, newSlotsCount)
+
+		// Initialize the new slots
+		for i := range c {
+			c[i].channelNo = -1
+		}
+
 		s.channels = append(s.channels, c...)
 		s.volResume = append(s.volResume, v...)
-	} else if size < s.count() {
-		for i := s.count() - 1; i >= size; i-- {
+	case size < currentSize:
+		// Remove channels
+		for i := currentSize - 1; i >= size; i-- {
 			s.channels[i].Stop()
 		}
+
 		s.channels = s.channels[:size]
 		s.volResume = s.volResume[:size]
 	}
@@ -1074,26 +1081,89 @@ func (s *SoundChannels) count() int32 {
 	return int32(len(s.channels))
 }
 
-func (s *SoundChannels) New(ch int32, lowpriority bool, priority int32) *SoundChannel {
-	if ch >= 0 && ch < sys.cfg.Sound.WavChannels {
-		for i := s.count() - 1; i >= 0; i-- {
-			if s.channels[i].IsPlaying() && s.channels[i].sfx.channel == ch {
-				if lowpriority || priority < s.channels[i].sfx.priority {
-					return nil
-				}
-				s.channels[i].Stop()
-				return &s.channels[i]
-			}
-		}
-	}
+// Returns a channel with the requested logical ID
+func (s *SoundChannels) Request(chNo int32, lowpriority bool, priority int32) *SoundChannel {
+	// Ensure capacity
 	if s.count() < sys.cfg.Sound.WavChannels {
 		s.SetSize(sys.cfg.Sound.WavChannels)
 	}
-	for i := sys.cfg.Sound.WavChannels - 1; i >= 0; i-- {
-		if !s.channels[i].IsPlaying() {
-			return &s.channels[i]
+
+	// Specific channel request
+	if chNo >= 0 && chNo < sys.cfg.Sound.WavChannels {
+		for i := range s.channels {
+			ch := &s.channels[i]
+			if ch.channelNo == chNo {
+				if ch.IsPlaying() {
+					// If slot is playing, check priority first
+					if lowpriority || ch.sfx != nil && priority < ch.sfx.priority {
+						return nil
+					}
+					ch.Stop()
+				}
+				ch.channelNo = chNo // Redundant but explicit
+				return ch
+			}
 		}
 	}
+
+	// Negative or invalid channel
+	// Look for any empty channel starting from the back
+	for i := int(s.count()) - 1; i >= 0; i-- {
+		ch := &s.channels[i]
+		if !ch.IsPlaying() {
+			ch.channelNo = -1 // Mark channel as undefined
+			return ch
+		}
+	}
+
+	// If "lowpriority" we don't even need to run the replacement code
+	if lowpriority {
+		return nil
+	}
+
+	// All channels full
+	// Replace the oldest sound. Negative channels are more likely to be replaced
+	var oldestNegativeIdx int = -1
+	var minTimeNegative int32 = math.MaxInt32
+	var oldestPositiveIdx int = -1
+	var minTimePositive int32 = math.MaxInt32
+
+	for i := 0; i < int(s.count()); i++ {
+		ch := &s.channels[i]
+		// We still take priority into account here
+		if ch.IsPlaying() && ch.sfx != nil && priority < ch.sfx.priority {
+			continue
+		}
+
+		if ch.channelNo < 0 {
+			if ch.timeStamp < minTimeNegative {
+				minTimeNegative = ch.timeStamp
+				oldestNegativeIdx = i
+			}
+		} else {
+			if ch.timeStamp < minTimePositive {
+				minTimePositive = ch.timeStamp
+				oldestPositiveIdx = i
+			}
+		}
+	}
+
+	// Kick out the oldest negative channel first
+	if oldestNegativeIdx != -1 {
+		ch := &s.channels[oldestNegativeIdx]
+		ch.Stop()
+		ch.channelNo = -1
+		return ch
+	} 
+	
+	// If no negative channels can be evicted, try the oldest positive one
+	if oldestPositiveIdx != -1 { 
+		ch := &s.channels[oldestPositiveIdx]
+		ch.Stop()
+		ch.channelNo = -1
+		return ch
+	}
+
 	return nil
 }
 
@@ -1109,7 +1179,7 @@ func (s *SoundChannels) reserveChannel() *SoundChannel {
 func (s *SoundChannels) Get(ch int32) *SoundChannel {
 	if ch >= 0 && ch < s.count() {
 		for i := range s.channels {
-			if s.channels[i].IsPlaying() && s.channels[i].sfx != nil && s.channels[i].sfx.channel == ch {
+			if s.channels[i].IsPlaying() && s.channels[i].sfx != nil && s.channels[i].channelNo == ch {
 				return &s.channels[i]
 			}
 		}

--- a/src/stage.go
+++ b/src/stage.go
@@ -4153,7 +4153,7 @@ func drawNode(mdl *Model, scene *Scene, layerNumber int, defaultLayerNumber int,
 		gfx.SetModelUniformF("meshOutline", 0)
 		gfx.RenderElements(mode, int(p.numIndices), int(p.elementBufferOffset))
 		if meshOutline > 0 {
-			gfx.SetMeshOulinePipeline(!reverseCull, meshOutline*outlineConst)
+			gfx.SetMeshOutlinePipeline(!reverseCull, meshOutline*outlineConst)
 			gfx.RenderElements(mode, int(p.numIndices), int(p.elementBufferOffset))
 		}
 

--- a/src/system.go
+++ b/src/system.go
@@ -1889,10 +1889,20 @@ func (s *System) resetGblEffect() {
 	s.specialFlag = 0
 }
 
-func (s *System) stopAllCharSound() {
+// Hard reset. Used between rounds
+func (s *System) clearAllCharSounds() {
 	for _, p := range s.chars {
 		for _, c := range p {
 			c.soundChannels.SetSize(0)
+		}
+	}
+}
+
+// Soft reset. Used during gameplay
+func (s *System) stopAllCharSounds() {
+	for _, p := range s.chars {
+		for _, c := range p {
+			c.soundChannels.StopAll()
 		}
 	}
 }
@@ -1936,7 +1946,7 @@ func (s *System) restoreAllVolume() {
 }
 
 func (s *System) clearMatchSound() {
-	s.stopAllCharSound()
+	s.clearAllCharSounds()
 	// Quiesce stage videos so no background decoding continues while mixer is empty,
 	// and mark them as detached so SetPlaying(true) can re-attach next frame.
 	if s.stage != nil {

--- a/src/system_sdl.go
+++ b/src/system_sdl.go
@@ -86,7 +86,7 @@ func (s *System) newWindow(w, h int) (*Window, error) {
 			sdl.GLSetAttribute(sdl.GL_ALPHA_SIZE, 0)
 			sdl.GLSetAttribute(sdl.GL_DEPTH_SIZE, 24)
 			windowFlags |= sdl.WINDOW_OPENGL
-		} else if renderName == "OpenGL 3.2" {
+		} else if renderName == "OpenGL 3.3" {
 			sdl.GLSetAttribute(sdl.GL_CONTEXT_PROFILE_MASK, sdl.GL_CONTEXT_PROFILE_CORE)
 			sdl.GLSetAttribute(sdl.GL_CONTEXT_MAJOR_VERSION, 3)
 			sdl.GLSetAttribute(sdl.GL_CONTEXT_MINOR_VERSION, 2)
@@ -384,7 +384,7 @@ func (w *Window) pollEvents() {
 		case sdl.WindowEvent:
 			if t.Event == sdl.WINDOWEVENT_EXPOSED {
 				renderName := gfx.GetName()
-				if renderName == "OpenGL 3.2" {
+				if renderName == "OpenGL 3.3" {
 					gfx.EndFrame()
 					w.SwapBuffers()
 				}

--- a/src/util_desktop.go
+++ b/src/util_desktop.go
@@ -64,16 +64,16 @@ func selectRenderer(cfgVal string) (Renderer, FontRenderer) {
 
 	// Now we proceed to init the render.
 	switch cfgVal {
-	case "OpenGL 3.2":
-		gfx = &Renderer_GL32{}
-		gfxFont = &FontRenderer_GL32{}
+	case "OpenGL 3.3":
+		gfx = &Renderer_GL33{}
+		gfxFont = &FontRenderer_GL33{}
 	case "Vulkan 1.3":
 		gfx = &Renderer_VK{}
 		gfxFont = &FontRenderer_VK{}
 	default:
-		fmt.Printf("Error: Invalid RenderMode '%s'. Defaulting to OpenGL 3.2.\n", cfgVal)
-		gfx = &Renderer_GL32{}
-		gfxFont = &FontRenderer_GL32{}
+		fmt.Printf("Error: Invalid RenderMode '%s'. Defaulting to OpenGL 3.3.\n", cfgVal)
+		gfx = &Renderer_GL33{}
+		gfxFont = &FontRenderer_GL33{}
 	}
 
 	return gfx, gfxFont

--- a/src/video_ffmpeg.go
+++ b/src/video_ffmpeg.go
@@ -185,7 +185,11 @@ func (bgv *bgVideo) Open(filename string, volume int, sm BgVideoScaleMode, sf Bg
 			dst := beep.SampleRate(sys.cfg.Sound.SampleRate)
 			resampler := beep.Resample(audioResampleQuality, bgv.audioSampleRate, dst, bgv.videoVol)
 			bgv.videoCtrl = &beep.Ctrl{Streamer: resampler, Paused: true} // start paused until SetPlaying(true)
-			sys.soundMixer.Add(bgv.videoCtrl)
+
+			WithSpeakerLock(func() {
+				sys.soundMixer.Add(bgv.videoCtrl)
+			})
+
 			bgv.inMixer = true
 			bgv.volume = volume
 			bgv.updateAudioVolume()
@@ -265,9 +269,9 @@ func (bgv *bgVideo) Open(filename string, volume int, sm BgVideoScaleMode, sf Bg
 		}
 		// Detach from mixer
 		if bgv.videoCtrl != nil {
-			speaker.Lock()
-			bgv.videoCtrl.Streamer = nil
-			speaker.Unlock()
+			WithSpeakerLock(func() {
+				bgv.videoCtrl.Streamer = nil
+			})
 		}
 		bgv.inMixer = false
 		close(bgv.frameBuffer)
@@ -422,9 +426,9 @@ func (bgv *bgVideo) Tick() error {
 			bgv.lastFrame = nil
 			// Keep audio path paused if it exists.
 			if bgv.videoCtrl != nil {
-				speaker.Lock()
-				bgv.videoCtrl.Paused = true
-				speaker.Unlock()
+				WithSpeakerLock(func() {
+					bgv.videoCtrl.Paused = true
+				})
 			}
 			return nil
 		}
@@ -462,9 +466,9 @@ func (bgv *bgVideo) SetPlaying(on bool) {
 		case <-bgv.done:
 			bgv.playing = false
 			if bgv.videoCtrl != nil {
-				speaker.Lock()
-				bgv.videoCtrl.Paused = true
-				speaker.Unlock()
+				WithSpeakerLock(func() {
+					bgv.videoCtrl.Paused = true
+				})
 			}
 			return
 		default:
@@ -476,7 +480,9 @@ func (bgv *bgVideo) SetPlaying(on bool) {
 	if on {
 		// Ensure we're attached to the mixer (it may have been cleared).
 		if bgv.videoCtrl != nil && !bgv.inMixer {
-			sys.soundMixer.Add(bgv.videoCtrl)
+			WithSpeakerLock(func() {
+				sys.soundMixer.Add(bgv.videoCtrl)
+			})
 			bgv.inMixer = true
 		}
 		// If we have not established a baseline PTS in this decode epoch,
@@ -493,9 +499,9 @@ func (bgv *bgVideo) SetPlaying(on bool) {
 	}
 	// Also pause/unpause the mixer-side ctrl for CPU savings.
 	if bgv.videoCtrl != nil {
-		speaker.Lock()
-		bgv.videoCtrl.Paused = !on
-		speaker.Unlock()
+		WithSpeakerLock(func() {
+			bgv.videoCtrl.Paused = !on
+		})
 	}
 }
 
@@ -674,10 +680,10 @@ func (bgv *bgVideo) updateAudioVolume() {
 		vol = 1
 	}
 	silent := vol <= -5
-	speaker.Lock()
-	bgv.videoVol.Volume = vol
-	bgv.videoVol.Silent = silent
-	speaker.Unlock()
+	WithSpeakerLock(func() {
+		bgv.videoVol.Volume = vol
+		bgv.videoVol.Silent = silent
+	})
 }
 
 // MixerCleared should be called when sys.soundMixer.Clear() is executed,


### PR DESCRIPTION
Fixes:
- Fixed typo in sound stopOnChangeState
- Fixed under parameter being left out of last refactor
- Linux palette path regression 
- Audio nil pointer crash
- Lock speaker in more places to attempt preventing future crashes
- Fixed bytecode jump instructions in ExplodVar and SoundVar
- Removed an incorrect palette fix that broke the color edit module

Refactor:
- Implemented separate OpenGL VAO's for sprites, models and post-processing. This reduces the number of calls to the GPU but also better insulates the different render modes from each other
- Replaced OpenGL 3.2 with 3.3, which has very similar hardware compatibility but is the definitive version of OpenGL 3.x
- Removed some GL2.1 code from shaders
- PlaySnd "lowpriority" now bypasses the sound priority comparison and acts like an infinitely low priority, thus remaining true to the documentation. Similar to "under" and "sprpriority"
- StopSnd channel = -2 will now stop all sounds for only the player in question
- When all channels are full and a new sound has to play, the engine will prioritize overriding older sounds. Older negative channels are more likely to be stopped than positive channels