### PR TITLE
feat: rollback replays, in-engine replay renaming and deletion

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -834,11 +834,11 @@ function main.f_warning(text, sec, background, overlay, titleData, textData, can
 	end
 end
 
-function main.f_drawInput(textData, text, sec, background, overlay)
-	local input = ''
+function main.f_drawInput(textData, text, sec, background, overlay, defaultInput)
+	local input = defaultInput or ''
 	resetKey()
 	while true do
-		if esc() or getInput(-1, sec.menu.cancel.key) then
+		if esc() then
 			input = ''
 			break
 		end
@@ -2609,6 +2609,68 @@ function main.f_clearShuffleTables()
 	start.lastStageIdx = nil
 end
 
+function main.f_deleteReplay(item, t)
+	if t[item] == nil or t[item].itemname == 'back' or not t[item].itemname:match('%.replay$') then
+		return t, item
+	end
+
+	local ok, err = os.remove(t[item].itemname)
+	if not ok then
+		print('Unable to delete replay: ' .. t[item].itemname .. (err and ' (' .. tostring(err) .. ')' or ''))
+		return t, item
+	end
+
+	sndPlay(motif.Snd, motif.replay_info.cancel.snd[1], motif.replay_info.cancel.snd[2])
+	resetKey()
+	table.remove(t, item)
+	item = math.max(1, math.min(item, #t))
+	return t, item
+end
+
+function main.f_renameReplay(item, t)
+	if t[item] == nil or t[item].itemname == 'back' or not t[item].itemname:match('%.replay$') then
+		return t, item
+	end
+	local oldPath, oldName, ext = t[item].itemname:match('^(.-)([^\\/]+)%.([^%.\\/]-)$')
+	if oldPath == nil or oldName == nil or ext == nil then
+		return t, item
+	end
+	sndPlay(motif.Snd, motif.replay_info.cursor.move.snd[1], motif.replay_info.cursor.move.snd[2])
+	local newName = main.f_drawInput(
+		motif.title_info.textinput.TextSpriteData,
+		motif.title_info.textinput.text.replay,
+		motif.replay_info,
+		motif.replaybgdef,
+		motif.title_info.textinput.overlay.RectData,
+		oldName
+	)
+	newName = (newName or ''):match('^%s*(.-)%s*$')
+	newName = newName:gsub('%.[Rr][Ee][Pp][Ll][Aa][Yy]$', '')
+	if newName == '' or newName == oldName then
+		sndPlay(motif.Snd, motif.replay_info.cancel.snd[1], motif.replay_info.cancel.snd[2])
+		return t, item
+	end
+	if newName:match('[\\/:%*%?"<>|]') then
+		sndPlay(motif.Snd, motif.replay_info.cancel.snd[1], motif.replay_info.cancel.snd[2])
+		return t, item
+	end
+	local newFile = oldPath .. newName .. '.' .. ext
+	if main.f_fileExists(newFile) then
+		sndPlay(motif.Snd, motif.replay_info.cancel.snd[1], motif.replay_info.cancel.snd[2])
+		return t, item
+	end
+	local ok, err = os.rename(t[item].itemname, newFile)
+	if not ok then
+		print('Unable to rename replay: ' .. t[item].itemname .. ' -> ' .. newFile .. (err and ' (' .. tostring(err) .. ')' or ''))
+		sndPlay(motif.Snd, motif.replay_info.cancel.snd[1], motif.replay_info.cancel.snd[2])
+		return t, item
+	end
+	sndPlay(motif.Snd, motif.replay_info.cursor.done.snd[1], motif.replay_info.cursor.done.snd[2])
+	t[item].itemname = newFile
+	t[item].displayname = newName
+	return t, item
+end
+
 --replay menu
 function main.f_replay()
 	local w = main.f_menuWindow(motif.replay_info.menu)
@@ -2643,6 +2705,15 @@ function main.f_replay()
 			sndPlay(motif.Snd, motif.replay_info.cancel.snd[1], motif.replay_info.cancel.snd[2])
 			main.f_fadeReset('fadeout', motif.replay_info)
 			main.close = true
+		elseif getKey('DELETE') then
+			t, item = main.f_deleteReplay(item, t)
+			local visibleItems = motif.replay_info.menu.window.visibleitems
+			if visibleItems == nil or visibleItems <= 0 then
+				visibleItems = #t
+			end
+			cursorPosY = math.max(1, math.min(cursorPosY, item, visibleItems))
+		elseif getKey('SPACE') then
+			t, item = main.f_renameReplay(item, t)
 		elseif getInput(-1, motif[main.group].menu.done.key) then
 			sndPlay(motif.Snd, motif[main.group].cursor.done.snd.default[1], motif[main.group].cursor.done.snd.default[2])
 			enterReplay(t[item].itemname)

--- a/src/input.go
+++ b/src/input.go
@@ -1883,8 +1883,37 @@ func (c *Command) GreaterCheckFail(i int, ibuf *InputBuffer) bool {
 	return false
 }
 
-// This defines the number of frames to store for the net buffer inputs (digital and analog)
-const NETBUF_NUM_FRAMES int32 = 32
+const (
+	// This defines the number of frames to store for the net buffer inputs (digital and analog)
+	NETBUF_NUM_FRAMES int32 = 32
+
+	// Replay files store the same payload for both delay-based and rollback netplay:
+	// 2 bytes of digital inputs followed by 6 bytes of signed analog axes per controller.
+	REPLAY_NUM_INPUTS  = MaxSimul * 2
+	REPLAY_INPUT_BYTES = 2 + 6
+)
+
+func writeReplayInput(w io.Writer, ibit InputBits, axes [6]int8) error {
+	var buf [REPLAY_INPUT_BYTES]byte
+	binary.LittleEndian.PutUint16(buf[:2], uint16(ibit))
+	for i := 0; i < len(axes); i++ {
+		buf[2+i] = byte(axes[i])
+	}
+	_, err := w.Write(buf[:])
+	return err
+}
+
+func readReplayInput(r io.Reader, ibit *InputBits, axes *[6]int8) error {
+	var buf [REPLAY_INPUT_BYTES]byte
+	if _, err := io.ReadFull(r, buf[:]); err != nil {
+		return err
+	}
+	*ibit = InputBits(int16(binary.LittleEndian.Uint16(buf[:2])))
+	for i := 0; i < len(axes); i++ {
+		axes[i] = int8(buf[2+i])
+	}
+	return nil
+}
 
 // NetBuffer holds the inputs that are sent between players
 type NetBuffer struct {
@@ -2458,8 +2487,11 @@ func (nc *NetConnection) Update() bool {
 				if nc.recording != nil {
 					for i := range nc.buf {
 						ringIdx := nc.time & (NETBUF_NUM_FRAMES - 1)
-						binary.Write(nc.recording, binary.LittleEndian, &nc.buf[i].buf[ringIdx])
-						binary.Write(nc.recording, binary.LittleEndian, &nc.buf[i].axisBuf[ringIdx])
+						if err := writeReplayInput(nc.recording, nc.buf[i].buf[ringIdx], nc.buf[i].axisBuf[ringIdx]); err != nil {
+							log.Printf("Error while writing replay input for controller %d: %v", i, err)
+							nc.recording = nil
+							break
+						}
 					}
 				}
 
@@ -2486,8 +2518,8 @@ func (nc *NetConnection) Update() bool {
 
 type ReplayFile struct {
 	file         *os.File
-	ibit         [MaxSimul * 2]InputBits
-	iaxes        [MaxSimul * 2][6]int8
+	ibit         [REPLAY_NUM_INPUTS]InputBits
+	iaxes        [REPLAY_NUM_INPUTS][6]int8
 	preMatchTime int32
 }
 
@@ -2565,28 +2597,16 @@ func (rf *ReplayFile) Update() bool {
 		sys.esc = true
 	} else {
 		if sys.oldNextAddTime > 0 {
-			// Clear everything first
-			for i := range rf.ibit {
-				rf.ibit[i] = 0
-			}
-			for i := 0; i < len(rf.iaxes); i++ {
-				for j := 0; j < len(rf.iaxes[i]); j++ {
-					rf.iaxes[i][j] = int8(0)
-				}
-			}
+			rf.ibit = [REPLAY_NUM_INPUTS]InputBits{}
+			rf.iaxes = [REPLAY_NUM_INPUTS][6]int8{}
 
-			// Read each player at a time, in the order of digital inputs, followed by each analog axis
 			for i := 0; i < len(rf.ibit); i++ {
-				// Read digital input (pointer)
-				if err := binary.Read(rf.file, binary.LittleEndian, &rf.ibit[i]); err != nil {
-					log.Printf("Error while reading digital input for controller %d: %v", i, err)
-					sys.esc = true
-					break
-				}
-
-				// Read analog input (pointer to all at once)
-				if err := binary.Read(rf.file, binary.LittleEndian, &rf.iaxes[i]); err != nil {
-					log.Printf("Error while reading analog input for controller %d: %v", i, err)
+				if err := readReplayInput(rf.file, &rf.ibit[i], &rf.iaxes[i]); err != nil {
+					if err == io.EOF || err == io.ErrUnexpectedEOF {
+						log.Printf("Closing replay file")
+					} else {
+						log.Printf("Error while reading replay input for controller %d: %v", i, err)
+					}
 					sys.esc = true
 					break
 				}

--- a/src/net.go
+++ b/src/net.go
@@ -6,12 +6,10 @@ import (
 	"hash/crc32"
 	"log"
 	"os"
-	"sort"
 	"strings"
 	"time"
 
 	ggpo "github.com/assemblaj/ggpo"
-	"golang.org/x/exp/maps"
 )
 
 type RollbackLogger struct {
@@ -87,6 +85,7 @@ type RollbackSession struct {
 	lastConfirmedInput  [MaxPlayerNo]InputBits
 	inputBits           []InputBits
 	inRollback          bool
+	replaySaved         bool
 }
 
 func (rs *RollbackSession) SetInput(time int32, player int, input InputBits, axes [6]int8) {
@@ -102,40 +101,75 @@ func (rs *RollbackSession) SetInput(time int32, player int, input InputBits, axe
 	rs.analogInputs[int(time)] = analogInputs
 }
 
-func (rs *RollbackSession) SaveReplay() {
-	if rs.recording != nil && len(rs.inputs) > 0 {
-		frames := maps.Keys(rs.inputs)
-		sort.Ints(frames)
-		lastFrame := frames[len(frames)-1]
+func (rs *RollbackSession) RecordReplayFrame(time int32, inputs []InputBits, axes [][6]int8) {
+	if _, ok := rs.inputs[int(time)]; !ok {
+		rs.inputs[int(time)] = [MaxPlayerNo]InputBits{}
+		rs.analogInputs[int(time)] = [MaxPlayerNo][6]int8{}
+	}
 
-		size := lastFrame * (MaxPlayerNo) * 4
-		buf := make([]byte, size)
-		offset := 0
+	inputFrame := rs.inputs[int(time)]
+	axisFrame := rs.analogInputs[int(time)]
 
-		for i := 0; i < lastFrame; i++ {
-			if _, ok := rs.inputs[i]; ok {
-				inputBuf := rs.inputToBytes(i)
-				copy(buf[offset:offset+len(inputBuf)], inputBuf)
-				offset += len(inputBuf)
-			} else {
-				inputBuf := []byte{}
-				for i := 0; i < MaxSimul*2+MaxAttachedChar; i++ {
-					inputBuf = append(inputBuf, writeI32(int32(0))...)
-				}
-				copy(buf[offset:offset+len(inputBuf)], inputBuf)
-				offset += len(inputBuf)
-			}
+	for i := 0; i < REPLAY_NUM_INPUTS; i++ {
+		if i < len(inputs) {
+			inputFrame[i] = inputs[i]
+		} else {
+			inputFrame[i] = 0
 		}
-		rs.recording.Write(buf)
+
+		if i < len(axes) {
+			axisFrame[i] = axes[i]
+		} else {
+			axisFrame[i] = [6]int8{}
+		}
+	}
+
+	rs.inputs[int(time)] = inputFrame
+	rs.analogInputs[int(time)] = axisFrame
+}
+
+func (rs *RollbackSession) TruncateReplayFrom(time int32) {
+	frame := int(time)
+	for t := range rs.inputs {
+		if t >= frame {
+			delete(rs.inputs, t)
+		}
+	}
+	for t := range rs.analogInputs {
+		if t >= frame {
+			delete(rs.analogInputs, t)
+		}
 	}
 }
 
-func (rs *RollbackSession) inputToBytes(time int) []byte {
-	buf := []byte{}
-	for i := 0; i < MaxSimul*2+MaxAttachedChar; i++ {
-		buf = append(buf, writeI16(int16(rs.inputs[time][i]))...)
+func (rs *RollbackSession) SaveReplay() {
+	if rs == nil || rs.recording == nil || rs.replaySaved {
+		return
 	}
-	return buf
+
+	// Never append the same rollback replay twice.
+	rs.replaySaved = true
+
+	frameCount := int(rs.netTime)
+	if frameCount <= 0 {
+		return
+	}
+
+	for frame := 0; frame < frameCount; frame++ {
+		inputFrame, okInputs := rs.inputs[frame]
+		axisFrame, okAxes := rs.analogInputs[frame]
+		if !okInputs || !okAxes {
+			log.Printf("Missing rollback replay frame %d; truncating replay at this point", frame)
+			break
+		}
+
+		for i := 0; i < REPLAY_NUM_INPUTS; i++ {
+			if err := writeReplayInput(rs.recording, inputFrame[i], axisFrame[i]); err != nil {
+				log.Printf("Error while writing rollback replay frame %d controller %d: %v", frame, i, err)
+				return
+			}
+		}
+	}
 }
 
 type LoopTimer struct {
@@ -273,16 +307,14 @@ func (r *RollbackSession) AdvanceFrame(flags int) {
 	// Get the confirmed inputs from the GGPO backend for the frame being simulated
 	var disconnectFlags int
 	inputs, ggpoerr := r.backend.SyncInput(&disconnectFlags)
-	sys.rollback.ggpoInputs, sys.rollback.ggpoAnalogInputs = decodeInputs(inputs)
-
-	if r.recording != nil {
-		r.SetInput(r.netTime, 0, sys.rollback.ggpoInputs[0], sys.rollback.ggpoAnalogInputs[0])
-		r.SetInput(r.netTime, 1, sys.rollback.ggpoInputs[1], sys.rollback.ggpoAnalogInputs[1])
-		r.netTime++
-	}
 
 	// Run frame again using confirmed inputs
 	if ggpoerr == nil {
+		sys.rollback.ggpoInputs, sys.rollback.ggpoAnalogInputs = decodeInputs(inputs)
+		if r.recording != nil {
+			r.RecordReplayFrame(r.netTime, sys.rollback.ggpoInputs, sys.rollback.ggpoAnalogInputs)
+			r.netTime++
+		}
 		if !sys.rollback.simulateFrame(&sys) {
 			return
 		}

--- a/src/resources/defaultMotif.ini
+++ b/src/resources/defaultMotif.ini
@@ -532,7 +532,7 @@
 	connecting.overlay.window = 
 	connecting.overlay.localcoord = 320, 240
 
-	; Controls screen rendered during adding new serverjoin IP address
+	; Controls screen rendered during adding new serverjoin IP address or renaming replays
 	textinput.font = f-6x9.def, 0, 1, 255, 255, 255, 255, -1
 	textinput.offset = 25, 33
 	textinput.scale = 1.0, 1.0
@@ -545,6 +545,7 @@
 	;;textinput.text = 
 	textinput.name.text = Enter Host display name, e.g. John.\nExisting entries can be removed with DELETE button.
 	textinput.address.text = Enter Host IP address, e.g. 127.0.0.1\nCopied text can be pasted with INSERT button.
+	textinput.replay.text = Rename replay. Use BACKSPACE to delete characters.\nExisting entries can be removed with DELETE button.
 	textinput.layerno = 0
 	textinput.window = 
 	textinput.localcoord = 320, 240

--- a/src/rollback.go
+++ b/src/rollback.go
@@ -167,16 +167,17 @@ func (rs *RollbackSystem) runFrame(s *System) bool {
 		var values [][]byte
 		disconnectFlags := 0
 		values, ggpoerr = rs.session.backend.SyncInput(&disconnectFlags)
-		rs.ggpoInputs, rs.ggpoAnalogInputs = decodeInputs(values)
-
-		// TODO: Why does this depend on the replay?
-		if rs.session.recording != nil {
-			rs.session.SetInput(rs.session.netTime, 0, rs.ggpoInputs[0], rs.ggpoAnalogInputs[0])
-			rs.session.SetInput(rs.session.netTime, 1, rs.ggpoInputs[1], rs.ggpoAnalogInputs[1])
-			rs.session.netTime++
-		}
 
 		if ggpoerr == nil {
+			rs.ggpoInputs, rs.ggpoAnalogInputs = decodeInputs(values)
+
+			// Record inputs against the rollback timeline. netTime is part of the saved state,
+			// so any confirmed re-simulation overwrites earlier speculative data for the same frame.
+			if rs.session.recording != nil {
+				rs.session.RecordReplayFrame(rs.session.netTime, rs.ggpoInputs, rs.ggpoAnalogInputs)
+				rs.session.netTime++
+			}
+
 			if !rs.simulateFrame(s) {
 				return false
 			}

--- a/src/script.go
+++ b/src/script.go
@@ -1909,6 +1909,7 @@ func systemScriptInit(l *lua.LState) {
 			sys.replayFile.Close()
 			sys.replayFile = nil
 		}
+		sys.uiResetTokenGuard()
 		return 0
 	})
 	//luaRegister(l, "fadeInActive", func(*lua.LState) int {

--- a/src/state.go
+++ b/src/state.go
@@ -283,6 +283,9 @@ func (gs *GameState) LoadState(stateID int) {
 	}
 
 	if sys.rollback.session != nil {
+		// Replay recording follows the rollback timeline.
+		// Any frames from the abandoned speculative future must be discarded before restoring the frame cursor.
+		sys.rollback.session.TruncateReplayFrom(gs.netTime)
 		sys.rollback.session.netTime = gs.netTime
 	}
 


### PR DESCRIPTION
* Fixes rollback replays (the same replay files should be compatible with both delay based and rollback netcode).
* Adds a way to delete and rename replay files in-game.