### PR TITLE
refactor: runtime config for Wins and MaxDrawGames

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -535,36 +535,6 @@ function main.f_formatBySpec(fmt, specMap)
 	return out
 end
 
---update rounds to win variables
-main.roundsNumSingle = {}
-main.roundsNumSimul = {}
-main.roundsNumTag = {}
-main.maxDrawGames = {}
-function main.f_updateRoundsNum()
-	for i = 1, 2 do
-		if gameOption('Options.Match.Wins') == -1 then
-			main.roundsNumSingle[i] = getMatchWins(i)
-		else
-			main.roundsNumSingle[i] = gameOption('Options.Match.Wins')
-		end
-		if gameOption('Options.Simul.Match.Wins') == -1 then
-			main.roundsNumSimul[i] = getMatchWins(i)
-		else
-			main.roundsNumSimul[i] = gameOption('Options.Simul.Match.Wins')
-		end
-		if gameOption('Options.Tag.Match.Wins') == -1 then
-			main.roundsNumTag[i] = getMatchWins(i)
-		else
-			main.roundsNumTag[i] = gameOption('Options.Tag.Match.Wins')
-		end
-		if gameOption('Options.Match.MaxDrawGames') == -2 then
-			main.maxDrawGames[i] = getMatchMaxDrawGames(i)
-		else
-			main.maxDrawGames[i] = gameOption('Options.Match.MaxDrawGames')
-		end
-	end
-end
-
 --refresh screen every 0.02 during initial loading
 main.nextRefresh = os.clock() + 0.02
 function main.f_loadingRefresh()
@@ -593,14 +563,18 @@ function main.f_commandLine()
 	local ref = #main.t_selChars
 	local t_teamMode = {0, 0}
 	local t_numChars = {0, 0}
-	local t_matchWins = {single = main.roundsNumSingle, simul = main.roundsNumSimul, tag = main.roundsNumTag, draw = main.maxDrawGames}
+	local t_matchWins = {
+		draw = {gameOption('Options.Match.MaxDrawGames'), gameOption('Options.Match.MaxDrawGames')},
+		simul = {gameOption('Options.Simul.Match.Wins'), gameOption('Options.Simul.Match.Wins')},
+		single = {gameOption('Options.Match.Wins'), gameOption('Options.Match.Wins')},
+		tag = {gameOption('Options.Tag.Match.Wins'), gameOption('Options.Tag.Match.Wins')},
+	}
 	local roundTime = gameOption('Options.Time')
 	if getCommandLineValue("-loadmotif") == nil then
 		loadLifebar()
 	end
 	setLifebarElements({guardbar = gameOption('Options.GuardBreak'), stunbar = gameOption('Options.Dizzy'), redlifebar = gameOption('Options.RedLife')})
 	local frames = fightscreenvar("time.framespercount")
-	main.f_updateRoundsNum()
 	local t = {}
 	local t_assignedPals = {}
 	local flags = getCommandLineFlags()
@@ -793,8 +767,6 @@ if gameOption('Debug.DumpLuaTables') then main.f_printTable(motif, "debug/loadMo
 
 loadLifebar()
 main.f_loadingRefresh()
-main.timeFramesPerCount = fightscreenvar("time.framespercount")
-main.f_updateRoundsNum()
 
 --warning display
 function main.f_warning(text, sec, background, overlay, titleData, textData, cancel_snd, done_snd)
@@ -1531,10 +1503,10 @@ function main.f_default()
 	main.luaPath = 'external/script/default.lua' --path to script executed by start.f_selectMode()
 	main.makeRoster = false --if default roster for each match should be generated before first match
 	main.matchWins = { --amount of rounds to win for each team side and team mode
-		draw = main.maxDrawGames,
-		simul = main.roundsNumSimul,
-		single = main.roundsNumSingle,
-		tag = main.roundsNumTag,
+		draw = {gameOption('Options.Match.MaxDrawGames'), gameOption('Options.Match.MaxDrawGames')},
+		simul = {gameOption('Options.Simul.Match.Wins'), gameOption('Options.Simul.Match.Wins')},
+		single = {gameOption('Options.Match.Wins'), gameOption('Options.Match.Wins')},
+		tag = {gameOption('Options.Tag.Match.Wins'), gameOption('Options.Tag.Match.Wins')},,
 	}
 	main.motif = { --which motif elements should be rendered
 		challenger = false,
@@ -1580,8 +1552,8 @@ function main.f_default()
 	setHomeTeam(2) --http://mugenguild.com/forum/topics/ishometeam-triggers-169132.0.html
 	setLifebarElements(main.lifebar)
 	setMotifElements(main.motif)
-	setRoundTime(math.max(-1, main.roundTime * main.timeFramesPerCount))
-	setTimeFramesPerCount(main.timeFramesPerCount)
+	setRoundTime(math.max(-1, main.roundTime * fightscreenvar("time.framespercount")))
+	setTimeFramesPerCount(fightscreenvar("time.framespercount"))
 	setWinCount(1, 0)
 	setWinCount(2, 0)
 	textImgReset(motif.select_info.title.TextSpriteData)

--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -257,8 +257,6 @@ options.t_itemname = {
 			--modifyGameOption('Input.UiRepeatRate', 4)
 
 			loadLifebar(motif.files.fight)
-			main.timeFramesPerCount = fightscreenvar("time.framespercount")
-			main.f_updateRoundsNum()
 			setPlayers()
 			for _, v in ipairs(options.t_vardisplayPointers) do
 				v.vardisplay = options.f_vardisplay(v.itemname)
@@ -359,16 +357,14 @@ options.t_itemname = {
 	end,
 	--Rounds to Win (Single)
 	['roundsnumsingle'] = function(t, item, cursorPosY, moveTxt)
-		if getInput(-1, motif.option_info.menu.add.key) and main.roundsNumSingle[1] < 10 then
+		if getInput(-1, motif.option_info.menu.add.key) and gameOption('Options.Match.Wins') < 10 then
 			sndPlay(motif.Snd, motif.option_info.cursor.move.snd[1], motif.option_info.cursor.move.snd[2])
-			modifyGameOption('Options.Match.Wins', main.roundsNumSingle[1] + 1)
-			main.roundsNumSingle = {gameOption('Options.Match.Wins'), gameOption('Options.Match.Wins')}
+			modifyGameOption('Options.Match.Wins', gameOption('Options.Match.Wins') + 1)
 			t.items[item].vardisplay = gameOption('Options.Match.Wins')
 			options.modified = true
-		elseif getInput(-1, motif.option_info.menu.subtract.key) and main.roundsNumSingle[1] > 1 then
+		elseif getInput(-1, motif.option_info.menu.subtract.key) and gameOption('Options.Match.Wins') > 1 then
 			sndPlay(motif.Snd, motif.option_info.cursor.move.snd[1], motif.option_info.cursor.move.snd[2])
-			modifyGameOption('Options.Match.Wins', main.roundsNumSingle[1] - 1)
-			main.roundsNumSingle = {gameOption('Options.Match.Wins'), gameOption('Options.Match.Wins')}
+			modifyGameOption('Options.Match.Wins', gameOption('Options.Match.Wins') - 1)
 			t.items[item].vardisplay = gameOption('Options.Match.Wins')
 			options.modified = true
 		end
@@ -376,16 +372,14 @@ options.t_itemname = {
 	end,
 	--Max Draw Games
 	['maxdrawgames'] = function(t, item, cursorPosY, moveTxt)
-		if getInput(-1, motif.option_info.menu.add.key) and main.maxDrawGames[1] < 10 then
+		if getInput(-1, motif.option_info.menu.add.key) and gameOption('Options.Match.MaxDrawGames') < 10 then
 			sndPlay(motif.Snd, motif.option_info.cursor.move.snd[1], motif.option_info.cursor.move.snd[2])
-			modifyGameOption('Options.Match.MaxDrawGames', main.maxDrawGames[1] + 1)
-			main.maxDrawGames = {gameOption('Options.Match.MaxDrawGames'), gameOption('Options.Match.MaxDrawGames')}
+			modifyGameOption('Options.Match.MaxDrawGames', gameOption('Options.Match.MaxDrawGames') + 1)
 			t.items[item].vardisplay = gameOption('Options.Match.MaxDrawGames')
 			options.modified = true
-		elseif getInput(-1, motif.option_info.menu.subtract.key) and main.maxDrawGames[1] > 0 then
+		elseif getInput(-1, motif.option_info.menu.subtract.key) and gameOption('Options.Match.MaxDrawGames') > 0 then
 			sndPlay(motif.Snd, motif.option_info.cursor.move.snd[1], motif.option_info.cursor.move.snd[2])
-			modifyGameOption('Options.Match.MaxDrawGames', main.maxDrawGames[1] - 1)
-			main.maxDrawGames = {gameOption('Options.Match.MaxDrawGames'), gameOption('Options.Match.MaxDrawGames')}
+			modifyGameOption('Options.Match.MaxDrawGames', gameOption('Options.Match.MaxDrawGames') - 1)
 			t.items[item].vardisplay = gameOption('Options.Match.MaxDrawGames')
 			options.modified = true
 		end
@@ -562,16 +556,14 @@ options.t_itemname = {
 	end,
 	--Rounds to Win (Tag)
 	['roundsnumtag'] = function(t, item, cursorPosY, moveTxt)
-		if getInput(-1, motif.option_info.menu.add.key) and main.roundsNumTag[1] < 10 then
+		if getInput(-1, motif.option_info.menu.add.key) and gameOption('Options.Tag.Match.Wins') < 10 then
 			sndPlay(motif.Snd, motif.option_info.cursor.move.snd[1], motif.option_info.cursor.move.snd[2])
-			modifyGameOption('Options.Tag.Match.Wins', main.roundsNumTag[1] + 1)
-			main.roundsNumTag = {gameOption('Options.Tag.Match.Wins'), gameOption('Options.Tag.Match.Wins')}
+			modifyGameOption('Options.Tag.Match.Wins', gameOption('Options.Tag.Match.Wins') + 1)
 			t.items[item].vardisplay = gameOption('Options.Tag.Match.Wins')
 			options.modified = true
-		elseif getInput(-1, motif.option_info.menu.subtract.key) and main.roundsNumTag[1] > 1 then
+		elseif getInput(-1, motif.option_info.menu.subtract.key) and gameOption('Options.Tag.Match.Wins') > 1 then
 			sndPlay(motif.Snd, motif.option_info.cursor.move.snd[1], motif.option_info.cursor.move.snd[2])
-			modifyGameOption('Options.Tag.Match.Wins', main.roundsNumTag[1] - 1)
-			main.roundsNumTag = {gameOption('Options.Tag.Match.Wins'), gameOption('Options.Tag.Match.Wins')}
+			modifyGameOption('Options.Tag.Match.Wins', gameOption('Options.Tag.Match.Wins') - 1)
 			t.items[item].vardisplay = gameOption('Options.Tag.Match.Wins')
 			options.modified = true
 		end
@@ -623,16 +615,14 @@ options.t_itemname = {
 	end,
 	--Rounds to Win (Simul)
 	['roundsnumsimul'] = function(t, item, cursorPosY, moveTxt)
-		if getInput(-1, motif.option_info.menu.add.key) and main.roundsNumSimul[1] < 10 then
+		if getInput(-1, motif.option_info.menu.add.key) and gameOption('Options.Simul.Match.Wins') < 10 then
 			sndPlay(motif.Snd, motif.option_info.cursor.move.snd[1], motif.option_info.cursor.move.snd[2])
-			modifyGameOption('Options.Simul.Match.Wins', main.roundsNumSimul[1] + 1)
-			main.roundsNumSimul = {gameOption('Options.Simul.Match.Wins'), gameOption('Options.Simul.Match.Wins')}
+			modifyGameOption('Options.Simul.Match.Wins', gameOption('Options.Simul.Match.Wins') + 1)
 			t.items[item].vardisplay = gameOption('Options.Simul.Match.Wins')
 			options.modified = true
-		elseif getInput(-1, motif.option_info.menu.subtract.key) and main.roundsNumSimul[1] > 1 then
+		elseif getInput(-1, motif.option_info.menu.subtract.key) and gameOption('Options.Simul.Match.Wins') > 1 then
 			sndPlay(motif.Snd, motif.option_info.cursor.move.snd[1], motif.option_info.cursor.move.snd[2])
-			modifyGameOption('Options.Simul.Match.Wins', main.roundsNumSimul[1] - 1)
-			main.roundsNumSimul = {gameOption('Options.Simul.Match.Wins'), gameOption('Options.Simul.Match.Wins')}
+			modifyGameOption('Options.Simul.Match.Wins', gameOption('Options.Simul.Match.Wins') - 1)
 			t.items[item].vardisplay = gameOption('Options.Simul.Match.Wins')
 			options.modified = true
 		end
@@ -1588,7 +1578,7 @@ options.t_vardisplay = {
 		return gameOption('Sound.MasterVolume') .. '%'
 	end,
 	['maxdrawgames'] = function()
-		return main.maxDrawGames[1]
+		return gameOption('Options.Match.MaxDrawGames')
 	end,
 	['maxsimul'] = function()
 		return gameOption('Options.Simul.Max')
@@ -1669,13 +1659,13 @@ options.t_vardisplay = {
 		return gameOption('Video.GameWidth') .. 'x' .. gameOption('Video.GameHeight')
 	end,
 	['roundsnumsimul'] = function()
-		return main.roundsNumSimul[1]
+		return gameOption('Options.Simul.Match.Wins')
 	end,
 	['roundsnumsingle'] = function()
-		return main.roundsNumSingle[1]
+		return gameOption('Options.Match.Wins')
 	end,
 	['roundsnumtag'] = function()
-		return main.roundsNumTag[1]
+		return gameOption('Options.Tag.Match.Wins')
 	end,
 	['roundtime'] = function()
 		return options.f_definedDisplay(gameOption('Options.Time'), {[-1] = motif.option_info.menu.valuename.none}, gameOption('Options.Time'))

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -295,7 +295,7 @@ function start.f_setRounds(roundTime, t_rounds)
 	main.motif.winscreen = winscreen
 	setLifebarElements(main.lifebar)
 	-- Round time
-	local frames = main.timeFramesPerCount
+	local frames = fightscreenvar("time.framespercount")
 	local p1FramesMul = 1
 	local p2FramesMul = 1
 	if start.p[1].teamMode == 3 then -- Tag

--- a/src/config.go
+++ b/src/config.go
@@ -340,6 +340,7 @@ func (c *Config) initStruct() {
 // Normalize values
 func (c *Config) normalize() {
 	c.SetValueUpdate("Config.Players", int(Clamp(int32(c.Config.Players), 1, int32(MaxSimul)*2)))
+	c.SetValueUpdate("Options.Difficulty", int(Clamp(int32(c.Options.Difficulty), 1, 8)))
 	c.SetValueUpdate("Options.GameSpeed", int(Clamp(int32(c.Options.GameSpeed), -9, 9)))
 	c.SetValueUpdate("Options.GameSpeedStep", int(Clamp(int32(c.Options.GameSpeedStep), 1, 60)))
 	c.SetValueUpdate("Options.Simul.Max", int(Clamp(int32(c.Options.Simul.Max), int32(c.Options.Simul.Min), int32(MaxSimul))))

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -39,8 +39,8 @@ GameSpeed             = 0
 GameSpeedStep         = 5
 ; Rounds to win a match (can be overwritten by Team modes variants)
 Match.Wins            = 2
-; Max number of draw games allowed (-1 for infinite, -2 for fight.def setting)
-Match.MaxDrawGames    = -2
+; Max number of draw games allowed (-1 for infinite)
+Match.MaxDrawGames    = 1
 ; Starting credits (continues) count outside Attract Mode
 Credits               = 10
 ; Continuing without character selection screen

--- a/src/script.go
+++ b/src/script.go
@@ -2928,22 +2928,6 @@ func systemScriptInit(l *lua.LState) {
 		}
 		return 1
 	})
-	luaRegister(l, "getMatchMaxDrawGames", func(l *lua.LState) int {
-		tn := int(numArg(l, 1))
-		if tn < 1 || tn > 2 {
-			l.RaiseError("\nInvalid team side: %v\n", tn)
-		}
-		l.Push(lua.LNumber(sys.lifebar.ro.match_maxdrawgames[tn-1]))
-		return 1
-	})
-	luaRegister(l, "getMatchWins", func(l *lua.LState) int {
-		tn := int(numArg(l, 1))
-		if tn < 1 || tn > 2 {
-			l.RaiseError("\nInvalid team side: %v\n", tn)
-		}
-		l.Push(lua.LNumber(sys.lifebar.ro.match_wins[tn-1]))
-		return 1
-	})
 	luaRegister(l, "getRemapInput", func(l *lua.LState) int {
 		pn := int(numArg(l, 1))
 		if pn < 1 || pn > len(sys.inputRemap) {


### PR DESCRIPTION
Wins and MaxDrawGames settings now work at runtime instead of using static values assigned on startup (a change related to the upcoming config sync between host and peer).