### PR TITLE
feat: reverse debug cycling; fix regressions

### DIFF
--- a/data/demo.zss
+++ b/data/demo.zss
@@ -3,26 +3,26 @@
 #===============================================================================
 [Statedef +1]
 
+# Execute the following code during demo mode
+# See motif [Demo] section for more options
 ignoreHitPause if gameMode = "demo" && !isHelper {
 	assertSpecial{
-		flag: noLifeBarAction;
-		flag2: skipFightDisplay;
-		flag3: skipRoundDisplay;
-		flag4: skipKODisplay;
-		flag5: skipWinDisplay;
-		flag6: globalNoKO;
+		flag: globalNoKO;			# Players cannot be KO'd
+		flag2: roundNotSkip;		# Cannot skip character intros
+		flag3: skipFightDisplay;	# Do not show "Fight" screen
+		flag4: skipRoundDisplay;	# Do not show "Round" screen
+		flag5: noLifeBarAction;		# Hide lifebar actions
 	}
+	# Print text from the first player only
 	if playerNo = 1 {
 		text{
-			removetime: 1;
-			localcoord: fightScreenVar(info.localcoord.x), fightScreenVar(info.localcoord.y);
-			layerno: 2;
-			textspacing: 0, 25;
-			text: "https://ikemen-engine.github.io";
-			font: F 0;
-			bank: 0;
-			align: 0;
-			pos: fightScreenVar(info.localcoord.x) / 2, fightScreenVar(info.localcoord.y) - 48.0;
+			removetime: 1;									# Refresh every frame
+			layerno: 2;										# Draw on top of everything
+			text: "https://ikemen-engine.github.io";		# Message to print
+			font: -1;										# Use the debug font since it exists everywhere
+			align: 0;										# Center alignment
+			pos: screenWidth * 0.5, screenHeight * 0.95;	# Centered horizontally. Near bottom of screen
+			scale: 0.5, 0.5;
 		}
 	}
 }

--- a/external/script/debug.lua
+++ b/external/script/debug.lua
@@ -3,8 +3,9 @@
 --;===========================================================
 --key, ctrl, alt, shift, pause, debug key, function
 addHotkey('c', true, false, false, true, false, 'toggleClsnDisplay()')
-addHotkey('d', true, false, false, true, false, 'toggleDebugDisplay()')
-addHotkey('d', false, false, true, true, false, 'toggleDebugDisplay(true)')
+addHotkey('d', true, false, false, true, false, 'toggleDebugDisplay(nil, false)')
+addHotkey('d', true, false, true, true, false, 'toggleDebugDisplay(nil, true)')
+addHotkey('d', false, false, true, true, false, 'toggleDebugDisplay(true, nil)')
 addHotkey('w', true, false, false, true, false, 'toggleWireframeDisplay()')
 addHotkey('s', true, false, false, true, true, 'changeSpeed()')
 addHotkey('KP_PLUS', true, false, false, true, true, 'changeSpeed(0.01)')

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -12883,7 +12883,7 @@ func (sc text) Run(c *Char, _ []int32) bool {
 	// We skip SetLocalcoord for char texts
 	// Text logic assumes a 4:3 layout, so we add a correction factor for widescreen
 	aspectCorrection := (float32(sys.gameWidth) / float32(sys.gameHeight)) / (4.0 / 3.0)
-	ts.localScale = float32(c.gi().localcoord[0]) / 320.0 / aspectCorrection
+	ts.localScale = (320.0 / float32(c.gi().localcoord[0])) / aspectCorrection // Not crun here
 
 	var xpos, ypos, xvel, yvel, xmaxdist, ymaxdist, xacc, yacc float32 = 0, 0, 0, 0, 0, 0, 0, 0
 	var xscl, yscl float32 = 1, 1
@@ -12932,8 +12932,7 @@ func (sc text) Run(c *Char, _ []int32) bool {
 				lcy = exp[1].evalF(c)
 			}
 			if lcx > 0 && lcy > 0 {
-				// Texts local scale is actually completely different characters
-				ts.localScale = lcx / 320
+				ts.localScale = (320 / lcx) / aspectCorrection
 			}
 		case text_bank:
 			ts.bank = exp[0].evalI(c)
@@ -13208,7 +13207,7 @@ func (sc modifyText) Run(c *Char, _ []int32) bool {
 				}
 				if x > 0 && y > 0 {
 					eachText(func(ts *TextSprite) {
-						ts.localScale = 320 / x
+						ts.localScale = x / 320
 					})
 				}
 			case text_bank:
@@ -13240,34 +13239,34 @@ func (sc modifyText) Run(c *Char, _ []int32) bool {
 			case text_pos:
 				x := exp[0].evalF(c)
 				eachText(func(ts *TextSprite) {
-					ts.x = x/ts.localScale + float32(ts.offsetX)
+					ts.x = x * ts.localScale + float32(ts.offsetX)
 				})
 				if len(exp) > 1 {
 					y := exp[1].evalF(c)
 					eachText(func(ts *TextSprite) {
-						ts.y = y / ts.localScale
+						ts.y = y * ts.localScale
 					})
 				}
 			case text_velocity:
 				velx := exp[0].evalF(c)
 				eachText(func(ts *TextSprite) {
-					ts.xvel = velx / ts.localScale
+					ts.xvel = velx * ts.localScale
 				})
 				if len(exp) > 1 {
 					vely := exp[1].evalF(c)
 					eachText(func(ts *TextSprite) {
-						ts.yvel = vely / ts.localScale
+						ts.yvel = vely * ts.localScale
 					})
 				}
 			case text_maxdist:
 				xmaxdist := exp[0].evalF(c)
 				eachText(func(ts *TextSprite) {
-					ts.maxDist[0] = xmaxdist / ts.localScale
+					ts.maxDist[0] = xmaxdist * ts.localScale
 				})
 				if len(exp) > 1 {
 					ymaxdist := exp[1].evalF(c)
 					eachText(func(ts *TextSprite) {
-						ts.maxDist[1] = ymaxdist / ts.localScale
+						ts.maxDist[1] = ymaxdist * ts.localScale
 					})
 				}
 			case text_friction:
@@ -13283,12 +13282,12 @@ func (sc modifyText) Run(c *Char, _ []int32) bool {
 			case text_accel:
 				ax := exp[0].evalF(c)
 				eachText(func(ts *TextSprite) {
-					ts.accel[0] = ax / ts.localScale
+					ts.accel[0] = ax * ts.localScale
 				})
 				if len(exp) > 1 {
 					ay := exp[1].evalF(c)
 					eachText(func(ts *TextSprite) {
-						ts.accel[1] = ay / ts.localScale
+						ts.accel[1] = ay * ts.localScale
 					})
 				}
 			case text_angle:
@@ -13317,12 +13316,12 @@ func (sc modifyText) Run(c *Char, _ []int32) bool {
 			case text_scale:
 				x := exp[0].evalF(c)
 				eachText(func(ts *TextSprite) {
-					ts.xscl = x / ts.localScale
+					ts.xscl = x * ts.localScale
 				})
 				if len(exp) > 1 {
 					y := exp[1].evalF(c)
 					eachText(func(ts *TextSprite) {
-						ts.yscl = y / ts.localScale
+						ts.yscl = y * ts.localScale
 					})
 				}
 			case text_color:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -113,12 +113,16 @@ const (
 	OC_jmp
 	OC_jz
 	OC_jnz
-	OC_eq
-	OC_ne
-	OC_gt
-	OC_ge
-	OC_lt
-	OC_le
+	OC_eq // =
+	OC_ne // !=
+	OC_gt // >
+	OC_ge // >=
+	OC_lt // <
+	OC_le // <=
+	OC_range_ii // []
+	OC_range_ie // [)
+	OC_range_ei // (]
+	OC_range_ee // ()
 	OC_neg
 	OC_blnot
 	OC_bland
@@ -1478,6 +1482,53 @@ func (BytecodeExp) le(v1 *BytecodeValue, v2 BytecodeValue) {
 	}
 }
 
+// For some reason Mugen respects "undefined" in this one but not in greater/less than
+func (BytecodeExp) rangeCheck(v1 *BytecodeValue, min BytecodeValue, max BytecodeValue, op OpCode) {
+	if v1.IsUndefined() || min.IsUndefined() || max.IsUndefined() {
+		*v1 = BytecodeUndefined()
+		return
+	}
+
+	var minPass, maxPass bool
+
+	// Check if any of the values are floats to determine the precision needed
+	if ValueType(Min(int32(v1.vtype), Min(int32(min.vtype), int32(max.vtype)))) == VT_Float {
+		vF := v1.ToF()
+		minF := min.ToF()
+		maxF := max.ToF()
+
+		if op == OC_range_ii || op == OC_range_ie {
+			minPass = vF >= minF
+		} else {
+			minPass = vF > minF
+		}
+
+		if op == OC_range_ii || op == OC_range_ei {
+			maxPass = vF <= maxF
+		} else {
+			maxPass = vF < maxF
+		}
+	} else {
+		vI := v1.ToI()
+		minI := min.ToI()
+		maxI := max.ToI()
+
+		if op == OC_range_ii || op == OC_range_ie {
+			minPass = vI >= minI
+		} else {
+			minPass = vI > minI
+		}
+
+		if op == OC_range_ii || op == OC_range_ei {
+			maxPass = vI <= maxI
+		} else {
+			maxPass = vI < maxI
+		}
+	}
+
+	v1.SetB(minPass && maxPass)
+}
+
 func (BytecodeExp) eq(v1 *BytecodeValue, v2 BytecodeValue) {
 	//if v1.IsUndefined() || v2.IsUndefined() {
 	//	*v1 = BytecodeUndefined()
@@ -1791,7 +1842,8 @@ func (BytecodeExp) lerp(v1 *BytecodeValue, v2 BytecodeValue, v3 BytecodeValue) {
 func (be BytecodeExp) run(c *Char) BytecodeValue {
 	oc := c
 	for i := 1; i <= len(be); i++ {
-		switch be[i-1] {
+		opc := be[i-1]
+		switch opc {
 		case OC_jsf8:
 			if sys.bcStack.Top().IsUndefined() {
 				if be[i] == 0 {
@@ -1803,7 +1855,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 				i++
 			}
 		case OC_jz8, OC_jnz8:
-			if sys.bcStack.Top().ToB() == (be[i-1] == OC_jz8) {
+			if sys.bcStack.Top().ToB() == (opc == OC_jz8) {
 				i++
 				break
 			}
@@ -1815,7 +1867,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 				i += int(uint8(be[i])) + 1
 			}
 		case OC_jz, OC_jnz:
-			if sys.bcStack.Top().ToB() == (be[i-1] == OC_jz) {
+			if sys.bcStack.Top().ToB() == (opc == OC_jz) {
 				i += 4
 				break
 			}
@@ -1984,6 +2036,10 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 		case OC_le:
 			v2 := sys.bcStack.Pop()
 			be.le(sys.bcStack.Top(), v2)
+		case OC_range_ii, OC_range_ie, OC_range_ei, OC_range_ee:
+			v3 := sys.bcStack.Pop()
+			v2 := sys.bcStack.Pop()
+			be.rangeCheck(sys.bcStack.Top(), v2, v3, opc)
 		case OC_eq:
 			v2 := sys.bcStack.Pop()
 			be.eq(sys.bcStack.Top(), v2)

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1296,9 +1296,9 @@ func (be BytecodeExp) JumpToNext(i *int) {
 }
 
 func (BytecodeExp) neg(v *BytecodeValue) {
-	if v.IsUndefined() {
-		return
-	}
+	//if v.IsUndefined() {
+	//	return
+	//}
 	if v.vtype == VT_Float {
 		v.value *= -1
 	} else {
@@ -1308,16 +1308,16 @@ func (BytecodeExp) neg(v *BytecodeValue) {
 
 func (BytecodeExp) not(v *BytecodeValue) {
 	// The opposite of undefined is still undefined
-	if v.IsUndefined() {
-		return
-	}
+	//if v.IsUndefined() {
+	//	return
+	//}
 	v.SetI(^v.ToI())
 }
 
 func (BytecodeExp) blnot(v *BytecodeValue) {
-	if v.IsUndefined() {
-		return
-	}
+	//if v.IsUndefined() {
+	//	return
+	//}
 	v.SetB(!v.ToB())
 }
 
@@ -1327,10 +1327,10 @@ func (BytecodeExp) blnot(v *BytecodeValue) {
 // These bugs are not reproduced in Ikemen
 // TODO: Perhaps Ikemen characters should treat 0**-1 the same as 1/0
 func (BytecodeExp) pow(v1 *BytecodeValue, v2 BytecodeValue, pn int) {
-	if v1.IsUndefined() || v2.IsUndefined() {
-		*v1 = BytecodeUndefined()
-		return
-	}
+	//if v1.IsUndefined() || v2.IsUndefined() {
+	//	*v1 = BytecodeUndefined()
+	//	return
+	//}
 	if ValueType(Min(int32(v1.vtype), int32(v2.vtype))) == VT_Float || v2.ToF() < 0 {
 		// Float power
 		v1.SetF(Pow(v1.ToF(), v2.ToF()))
@@ -1364,10 +1364,10 @@ func (BytecodeExp) pow(v1 *BytecodeValue, v2 BytecodeValue, pn int) {
 }
 
 func (BytecodeExp) mul(v1 *BytecodeValue, v2 BytecodeValue) {
-	if v1.IsUndefined() || v2.IsUndefined() {
-		*v1 = BytecodeUndefined()
-		return
-	}
+	//if v1.IsUndefined() || v2.IsUndefined() {
+	//	*v1 = BytecodeUndefined()
+	//	return
+	//}
 	if ValueType(Min(int32(v1.vtype), int32(v2.vtype))) == VT_Float {
 		v1.SetF(v1.ToF() * v2.ToF())
 	} else {
@@ -1376,10 +1376,10 @@ func (BytecodeExp) mul(v1 *BytecodeValue, v2 BytecodeValue) {
 }
 
 func (BytecodeExp) div(v1 *BytecodeValue, v2 BytecodeValue) {
-	if v1.IsUndefined() || v2.IsUndefined() {
-		*v1 = BytecodeUndefined()
-		return
-	}
+	//if v1.IsUndefined() || v2.IsUndefined() {
+	//	*v1 = BytecodeUndefined()
+	//	return
+	//}
 	if v2.ToF() == 0 {
 		// Division by 0
 		*v1 = BytecodeUndefined()
@@ -1394,10 +1394,10 @@ func (BytecodeExp) div(v1 *BytecodeValue, v2 BytecodeValue) {
 }
 
 func (BytecodeExp) mod(v1 *BytecodeValue, v2 BytecodeValue) {
-	if v1.IsUndefined() || v2.IsUndefined() {
-		*v1 = BytecodeUndefined()
-		return
-	}
+	//if v1.IsUndefined() || v2.IsUndefined() {
+	//	*v1 = BytecodeUndefined()
+	//	return
+	//}
 	if v2.ToI() == 0 {
 		*v1 = BytecodeUndefined()
 		sys.printBytecodeError("Modulus by 0")
@@ -1407,10 +1407,10 @@ func (BytecodeExp) mod(v1 *BytecodeValue, v2 BytecodeValue) {
 }
 
 func (BytecodeExp) add(v1 *BytecodeValue, v2 BytecodeValue) {
-	if v1.IsUndefined() || v2.IsUndefined() {
-		*v1 = BytecodeUndefined()
-		return
-	}
+	//if v1.IsUndefined() || v2.IsUndefined() {
+	//	*v1 = BytecodeUndefined()
+	//	return
+	//}
 	if ValueType(Min(int32(v1.vtype), int32(v2.vtype))) == VT_Float {
 		v1.SetF(v1.ToF() + v2.ToF())
 	} else {
@@ -1419,10 +1419,10 @@ func (BytecodeExp) add(v1 *BytecodeValue, v2 BytecodeValue) {
 }
 
 func (BytecodeExp) sub(v1 *BytecodeValue, v2 BytecodeValue) {
-	if v1.IsUndefined() || v2.IsUndefined() {
-		*v1 = BytecodeUndefined()
-		return
-	}
+	//if v1.IsUndefined() || v2.IsUndefined() {
+	//	*v1 = BytecodeUndefined()
+	//	return
+	//}
 	if ValueType(Min(int32(v1.vtype), int32(v2.vtype))) == VT_Float {
 		v1.SetF(v1.ToF() - v2.ToF())
 	} else {
@@ -1431,10 +1431,10 @@ func (BytecodeExp) sub(v1 *BytecodeValue, v2 BytecodeValue) {
 }
 
 func (BytecodeExp) gt(v1 *BytecodeValue, v2 BytecodeValue) {
-	if v1.IsUndefined() || v2.IsUndefined() {
-		*v1 = BytecodeUndefined()
-		return
-	}
+	//if v1.IsUndefined() || v2.IsUndefined() {
+	//	*v1 = BytecodeUndefined()
+	//	return
+	//}
 	if ValueType(Min(int32(v1.vtype), int32(v2.vtype))) == VT_Float {
 		v1.SetB(v1.ToF() > v2.ToF())
 	} else {
@@ -1443,10 +1443,10 @@ func (BytecodeExp) gt(v1 *BytecodeValue, v2 BytecodeValue) {
 }
 
 func (BytecodeExp) ge(v1 *BytecodeValue, v2 BytecodeValue) {
-	if v1.IsUndefined() || v2.IsUndefined() {
-		*v1 = BytecodeUndefined()
-		return
-	}
+	//if v1.IsUndefined() || v2.IsUndefined() {
+	//	*v1 = BytecodeUndefined()
+	//	return
+	//}
 	if ValueType(Min(int32(v1.vtype), int32(v2.vtype))) == VT_Float {
 		v1.SetB(v1.ToF() >= v2.ToF())
 	} else {
@@ -1455,10 +1455,10 @@ func (BytecodeExp) ge(v1 *BytecodeValue, v2 BytecodeValue) {
 }
 
 func (BytecodeExp) lt(v1 *BytecodeValue, v2 BytecodeValue) {
-	if v1.IsUndefined() || v2.IsUndefined() {
-		*v1 = BytecodeUndefined()
-		return
-	}
+	//if v1.IsUndefined() || v2.IsUndefined() {
+	//	*v1 = BytecodeUndefined()
+	//	return
+	//}
 	if ValueType(Min(int32(v1.vtype), int32(v2.vtype))) == VT_Float {
 		v1.SetB(v1.ToF() < v2.ToF())
 	} else {
@@ -1467,10 +1467,10 @@ func (BytecodeExp) lt(v1 *BytecodeValue, v2 BytecodeValue) {
 }
 
 func (BytecodeExp) le(v1 *BytecodeValue, v2 BytecodeValue) {
-	if v1.IsUndefined() || v2.IsUndefined() {
-		*v1 = BytecodeUndefined()
-		return
-	}
+	//if v1.IsUndefined() || v2.IsUndefined() {
+	//	*v1 = BytecodeUndefined()
+	//	return
+	//}
 	if ValueType(Min(int32(v1.vtype), int32(v2.vtype))) == VT_Float {
 		v1.SetB(v1.ToF() <= v2.ToF())
 	} else {
@@ -1479,10 +1479,10 @@ func (BytecodeExp) le(v1 *BytecodeValue, v2 BytecodeValue) {
 }
 
 func (BytecodeExp) eq(v1 *BytecodeValue, v2 BytecodeValue) {
-	if v1.IsUndefined() || v2.IsUndefined() {
-		*v1 = BytecodeUndefined()
-		return
-	}
+	//if v1.IsUndefined() || v2.IsUndefined() {
+	//	*v1 = BytecodeUndefined()
+	//	return
+	//}
 	if ValueType(Min(int32(v1.vtype), int32(v2.vtype))) == VT_Float {
 		v1.SetB(v1.ToF() == v2.ToF())
 	} else {
@@ -1491,10 +1491,10 @@ func (BytecodeExp) eq(v1 *BytecodeValue, v2 BytecodeValue) {
 }
 
 func (BytecodeExp) ne(v1 *BytecodeValue, v2 BytecodeValue) {
-	if v1.IsUndefined() || v2.IsUndefined() {
-		*v1 = BytecodeUndefined()
-		return
-	}
+	//if v1.IsUndefined() || v2.IsUndefined() {
+	//	*v1 = BytecodeUndefined()
+	//	return
+	//}
 	if ValueType(Min(int32(v1.vtype), int32(v2.vtype))) == VT_Float {
 		v1.SetB(v1.ToF() != v2.ToF())
 	} else {
@@ -1503,70 +1503,71 @@ func (BytecodeExp) ne(v1 *BytecodeValue, v2 BytecodeValue) {
 }
 
 func (BytecodeExp) and(v1 *BytecodeValue, v2 BytecodeValue) {
-	if v1.IsUndefined() || v2.IsUndefined() {
-		*v1 = BytecodeUndefined()
-		return
-	}
+	// TODO: Ikemen characters could probably use these commented out logic branches instead of arbitrarily handling what "undefined" means
+	//if v1.IsUndefined() || v2.IsUndefined() {
+	//	*v1 = BytecodeUndefined()
+	//	return
+	//}
 	v1.SetI(v1.ToI() & v2.ToI())
 }
 
 func (BytecodeExp) xor(v1 *BytecodeValue, v2 BytecodeValue) {
 	// XOR always requires both operands to be known
-	if v1.IsUndefined() || v2.IsUndefined() {
-		*v1 = BytecodeUndefined()
-		return
-	}
+	//if v1.IsUndefined() || v2.IsUndefined() {
+	//	*v1 = BytecodeUndefined()
+	//	return
+	//}
 	v1.SetI(v1.ToI() ^ v2.ToI())
 }
 
 func (BytecodeExp) or(v1 *BytecodeValue, v2 BytecodeValue) {
 	// If one is undefined, use short-circuiting logic
-	if v1.IsUndefined() || v2.IsUndefined() {
-		switch {
-		case v1.IsUndefined() && v2.IsUndefined():
-			*v1 = BytecodeUndefined()
-		case !v1.IsUndefined() && v1.ToI() != 0:
-			v1.SetI(v1.ToI())
-		case !v2.IsUndefined() && v2.ToI() != 0:
-			v1.SetI(v2.ToI())
-		default:
-			*v1 = BytecodeUndefined()
-		}
-		return
-	}
+	//if v1.IsUndefined() || v2.IsUndefined() {
+	//	switch {
+	//	case v1.IsUndefined() && v2.IsUndefined():
+	//		*v1 = BytecodeUndefined()
+	//	case !v1.IsUndefined() && v1.ToI() != 0:
+	//		v1.SetI(v1.ToI())
+	//	case !v2.IsUndefined() && v2.ToI() != 0:
+	//		v1.SetI(v2.ToI())
+	//	default:
+	//		*v1 = BytecodeUndefined()
+	//	}
+	//	return
+	//}
 	v1.SetI(v1.ToI() | v2.ToI())
 }
 
 func (BytecodeExp) bland(v1 *BytecodeValue, v2 BytecodeValue) {
-	if v1.IsUndefined() || v2.IsUndefined() {
-		*v1 = BytecodeUndefined()
-		return
-	}
+	//if v1.IsUndefined() || v2.IsUndefined() {
+	//	*v1 = BytecodeUndefined()
+	//	return
+	//}
 	v1.SetB(v1.ToB() && v2.ToB())
 }
 
 func (BytecodeExp) blxor(v1 *BytecodeValue, v2 BytecodeValue) {
-	if v1.IsUndefined() || v2.IsUndefined() {
-		*v1 = BytecodeUndefined()
-		return
-	}
+	//if v1.IsUndefined() || v2.IsUndefined() {
+	//	*v1 = BytecodeUndefined()
+	//	return
+	//}
 	v1.SetB(v1.ToB() != v2.ToB())
 }
 
 func (BytecodeExp) blor(v1 *BytecodeValue, v2 BytecodeValue) {
-	if v1.IsUndefined() || v2.IsUndefined() {
-		switch {
-		case v1.IsUndefined() && v2.IsUndefined():
-			*v1 = BytecodeUndefined()
-		case !v1.IsUndefined() && v1.ToB():
-			v1.SetB(true)
-		case !v2.IsUndefined() && v2.ToB():
-			v1.SetB(true)
-		default:
-			*v1 = BytecodeUndefined()
-		}
-		return
-	}
+	//if v1.IsUndefined() || v2.IsUndefined() {
+	//	switch {
+	//	case v1.IsUndefined() && v2.IsUndefined():
+	//		*v1 = BytecodeUndefined()
+	//	case !v1.IsUndefined() && v1.ToB():
+	//		v1.SetB(true)
+	//	case !v2.IsUndefined() && v2.ToB():
+	//		v1.SetB(true)
+	//	default:
+	//		*v1 = BytecodeUndefined()
+	//	}
+	//	return
+	//}
 	v1.SetB(v1.ToB() || v2.ToB())
 }
 
@@ -1582,16 +1583,16 @@ func (BytecodeExp) abs(v1 *BytecodeValue) {
 }
 
 func (BytecodeExp) exp(v1 *BytecodeValue) {
-	if v1.IsUndefined() {
-		return
-	}
+	//if v1.IsUndefined() {
+	//	return
+	//}
 	v1.SetF(float32(math.Exp(v1.value)))
 }
 
 func (BytecodeExp) ln(v1 *BytecodeValue) {
-	if v1.IsUndefined() {
-		return
-	}
+	//if v1.IsUndefined() {
+	//	return
+	//}
 	if v1.value <= 0 {
 		*v1 = BytecodeUndefined()
 		sys.printBytecodeError("Invalid logarithm")
@@ -1601,10 +1602,10 @@ func (BytecodeExp) ln(v1 *BytecodeValue) {
 }
 
 func (BytecodeExp) log(v1 *BytecodeValue, v2 BytecodeValue) {
-	if v1.IsUndefined() || v2.IsUndefined() {
-		*v1 = BytecodeUndefined()
-		return
-	}
+	//if v1.IsUndefined() || v2.IsUndefined() {
+	//	*v1 = BytecodeUndefined()
+	//	return
+	//}
 	if v1.value <= 0 || v2.value <= 0 {
 		*v1 = BytecodeUndefined()
 		sys.printBytecodeError("Invalid logarithm")
@@ -1924,7 +1925,6 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			l := be.PeekLength(i)
 			sys.bcStack.Push(be[i+4 : i+4+l].run(c)) // Run from c (with redirections)
 			be.JumpToNext(&i)
-			continue
 		case OC_nordrun:
 			l := be.PeekLength(i)
 			sys.bcStack.Push(be[i+4 : i+4+l].run(oc)) // Run from oc (without redirections)
@@ -2037,9 +2037,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			v3 := sys.bcStack.Pop()
 			v2 := sys.bcStack.Pop()
 			cond := sys.bcStack.Top()
-			if cond.IsUndefined() {
-				*cond = BytecodeUndefined()
-			} else if cond.ToB() {
+			if cond.ToB() {
 				*cond = v2
 			} else {
 				*cond = v3

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -12881,9 +12881,12 @@ func (sc text) Run(c *Char, _ []int32) bool {
 	}
 
 	// We skip SetLocalcoord for char texts
-	ts.localScale = float32(c.gi().localcoord[0]) / 320 // Not crun here
+	// Text logic assumes a 4:3 layout, so we add a correction factor for widescreen
+	aspectCorrection := (float32(sys.gameWidth) / float32(sys.gameHeight)) / (4.0 / 3.0)
+	ts.localScale = float32(c.gi().localcoord[0]) / 320.0 / aspectCorrection
 
-	var x, y, xscl, yscl, xvel, yvel, xmaxdist, ymaxdist, xacc, yacc float32 = 0, 0, 1, 1, 0, 0, 0, 0, 0, 0
+	var xpos, ypos, xvel, yvel, xmaxdist, ymaxdist, xacc, yacc float32 = 0, 0, 0, 0, 0, 0, 0, 0
+	var xscl, yscl float32 = 1, 1
 	var fnt int = -1
 
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
@@ -12923,13 +12926,14 @@ func (sc text) Run(c *Char, _ []int32) bool {
 				}
 			}
 		case text_localcoord:
-			var x, y float32
-			x = exp[0].evalF(c)
+			var lcx, lcy float32
+			lcx = exp[0].evalF(c)
 			if len(exp) > 1 {
-				y = exp[1].evalF(c)
+				lcy = exp[1].evalF(c)
 			}
-			if x > 0 && y > 0 {
-				ts.localScale = 320 / x
+			if lcx > 0 && lcy > 0 {
+				// Texts local scale is actually completely different characters
+				ts.localScale = lcx / 320
 			}
 		case text_bank:
 			ts.bank = exp[0].evalI(c)
@@ -12943,9 +12947,9 @@ func (sc text) Run(c *Char, _ []int32) bool {
 		case text_textdelay:
 			ts.textDelay = exp[0].evalF(c)
 		case text_pos:
-			x = exp[0].evalF(c)
+			xpos = exp[0].evalF(c)
 			if len(exp) > 1 {
-				y = exp[1].evalF(c)
+				ypos = exp[1].evalF(c)
 			}
 		case text_velocity:
 			xvel = exp[0].evalF(c)
@@ -13008,7 +13012,7 @@ func (sc text) Run(c *Char, _ []int32) bool {
 		return true
 	})
 
-	ts.SetPos(x, y)
+	ts.SetPos(xpos, ypos)
 	ts.SetScale(xscl, yscl)
 	ts.SetVelocity(xvel, yvel)
 	ts.SetMaxDist(xmaxdist, ymaxdist)

--- a/src/char.go
+++ b/src/char.go
@@ -3265,11 +3265,14 @@ func (c *Char) init(n int, idx int) {
 		c.keyctrl = [4]bool{false, false, false, true}
 	}
 
+	// Initialize CNS variables
+	// TODO: If we make maps persist between matches, they should be here as well
+	c.initCnsVar()
+
 	// Set controller to CPU if applicable
 	if n >= 0 && n < len(sys.aiLevel) && sys.aiLevel[n] != 0 {
 		c.controller ^= -1
 	}
-	c.pushAffectTeam = 1
 	c.clearState()
 }
 
@@ -3292,6 +3295,7 @@ func (c *Char) clearState() {
 	c.fallTime = 0
 	c.makeDustSpacing = 0
 	c.hitStateChangeIdx = -1
+	c.pushAffectTeam = 1
 }
 
 func (c *Char) clsnOverlapTrigger(box1, pid, box2 int32) bool {
@@ -6502,7 +6506,6 @@ func (c *Char) newHelper() (h *Char) {
 	h.helperId = 0
 	h.ownpal = false
 	h.preserve = false
-	h.initCnsVar()
 	h.mapArray = make(map[string]float32)
 	h.remapSpr = make(RemapPreset)
 

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -925,8 +925,7 @@ func (c *Compiler) checkEquality(in *string) (not bool, err error) {
 	return
 }
 
-func (c *Compiler) intRange(in *string) (minop OpCode, maxop OpCode,
-	min, max int32, err error) {
+func (c *Compiler) intRange(in *string) (minop OpCode, maxop OpCode, min, max int32, err error) {
 	switch c.token {
 	case "(":
 		minop = OC_gt
@@ -1052,29 +1051,26 @@ func (c *Compiler) evaluateComparison(out *BytecodeExp, in *string,
 			if err != nil {
 				return err
 			}
-			if opc == OC_ne {
-				if minop == OC_gt {
-					minop = OC_le
-				} else {
-					minop = OC_lt
-				}
-				if maxop == OC_lt {
-					minop = OC_ge
-				} else {
-					minop = OC_gt
-				}
-			}
-			out.append(OC_dup)
+
 			out.appendValue(BytecodeInt(min))
-			out.append(minop)
-			out.append(OC_swap)
 			out.appendValue(BytecodeInt(max))
-			out.append(maxop)
-			if opc == OC_ne {
-				out.append(OC_blor)
+
+			var rop OpCode
+			if minop == OC_ge && maxop == OC_le {
+				rop = OC_range_ii
+			} else if minop == OC_ge && maxop == OC_lt {
+				rop = OC_range_ie
+			} else if minop == OC_gt && maxop == OC_le {
+				rop = OC_range_ei
 			} else {
-				out.append(OC_bland)
+				rop = OC_range_ee
 			}
+			out.append(rop)
+
+			if opc == OC_ne {
+				out.append(OC_blnot)
+			}
+
 			c.reverseOrder = comma || compare
 			return nil
 		}
@@ -5348,57 +5344,58 @@ func (c *Compiler) expRange(out *BytecodeExp, in *string,
 		return false, Error("Missing ']' or ')'")
 	}
 	c.token = c.tokenizer(in)
-	if bv.IsNone() || bv2.IsNone() || bv3.IsNone() {
-		var op1, op2, op3 OpCode
-		if opc == OC_ne {
-			if open == "(" {
-				op1 = OC_le
-			} else {
-				op1 = OC_lt
-			}
-			if close == ")" {
-				op2 = OC_ge
-			} else {
-				op2 = OC_gt
-			}
-			op3 = OC_blor
-		} else {
-			if open == "(" {
-				op1 = OC_gt
-			} else {
-				op1 = OC_ge
-			}
-			if close == ")" {
-				op2 = OC_lt
-			} else {
-				op2 = OC_le
-			}
-			op3 = OC_bland
-		}
+if bv.IsNone() || bv2.IsNone() || bv3.IsNone() {
 		out.appendValue(*bv)
-		out.append(OC_dup)
 		out.append(be2...)
 		out.appendValue(bv2)
-		out.append(op1)
-		out.append(OC_swap)
 		out.append(be3...)
 		out.appendValue(bv3)
-		out.append(op2)
-		out.append(op3)
+
+		var rop OpCode
+		if open == "[" && close == "]" {
+			rop = OC_range_ii
+		} else if open == "[" && close == ")" {
+			rop = OC_range_ie
+		} else if open == "(" && close == "]" {
+			rop = OC_range_ei
+		} else {
+			rop = OC_range_ee
+		}
+		out.append(rop)
+
+		if opc == OC_ne {
+			out.append(OC_blnot)
+		}
 		*bv = bvNone()
 	} else {
 		tmp := *bv
-		if open == "(" {
-			out.gt(&tmp, bv2)
+		var minPass, maxPass bool
+
+		if tmp.vtype == VT_Float || bv2.vtype == VT_Float || bv3.vtype == VT_Float {
+			if open == "[" {
+				minPass = tmp.ToF() >= bv2.ToF()
+			} else {
+				minPass = tmp.ToF() > bv2.ToF()
+			}
+			if close == "]" {
+				maxPass = tmp.ToF() <= bv3.ToF()
+			} else {
+				maxPass = tmp.ToF() < bv3.ToF()
+			}
 		} else {
-			out.ge(&tmp, bv2)
+			if open == "[" {
+				minPass = tmp.ToI() >= bv2.ToI()
+			} else {
+				minPass = tmp.ToI() > bv2.ToI()
+			}
+			if close == "]" {
+				maxPass = tmp.ToI() <= bv3.ToI()
+			} else {
+				maxPass = tmp.ToI() < bv3.ToI()
+			}
 		}
-		if close == ")" {
-			out.lt(bv, bv3)
-		} else {
-			out.le(bv, bv3)
-		}
-		bv.SetB(tmp.ToB() && bv.ToB())
+
+		bv.SetB(minPass && maxPass)
 		if opc == OC_ne {
 			bv.SetB(!bv.ToB())
 		}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1608,8 +1608,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		return bvNone(), _var(true, false)
 	case "sysfvar":
 		return bvNone(), _var(true, true)
-	case "ifelse", "cond":
-		cond := c.token == "cond"
+	case "ifelse":
 		if err := c.checkOpeningParenthesis(in); err != nil {
 			return bvNone(), err
 		}
@@ -1617,22 +1616,14 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 		if c.token != "," {
-			if cond {
-				return bvNone(), Error("Missing ',' in Cond")
-			} else {
-				return bvNone(), Error("Missing ',' in IfElse")
-			}
+			return bvNone(), Error("Missing ',' in IfElse")
 		}
 		c.token = c.tokenizer(in)
 		if bv2, err = c.expBoolOr(&be2, in); err != nil {
 			return bvNone(), err
 		}
 		if c.token != "," {
-			if cond {
-				return bvNone(), Error("Missing ',' in Cond")
-			} else {
-				return bvNone(), Error("Missing ',' in IfElse")
-			}
+			return bvNone(), Error("Missing ',' in IfElse")
 		}
 		c.token = c.tokenizer(in)
 		if bv3, err = c.expBoolOr(&be3, in); err != nil {
@@ -1642,29 +1633,6 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 		if bv1.IsNone() || bv2.IsNone() || bv3.IsNone() {
-			if cond {
-				be3.appendValue(bv3)
-				be2.appendValue(bv2)
-				if len(be3) > int(math.MaxUint8-1) {
-					be2.appendI32Op(OC_jmp, int32(len(be3)+1))
-				} else {
-					be2.append(OC_jmp8, OpCode(len(be3)+1))
-				}
-				be1.appendValue(bv1)
-				if len(be2) > int(math.MaxUint8-1) {
-					be1.appendI32Op(OC_jz, int32(len(be2)+1))
-				} else {
-					be1.append(OC_jz8, OpCode(len(be2)+1))
-				}
-				be1.append(OC_pop)
-				be1.append(be2...)
-				be1.append(OC_pop)
-				be1.append(be3...)
-				if rd {
-					out.appendI32Op(OC_run, int32(len(be1)))
-				}
-				out.append(be1...)
-			} else {
 				if rd {
 					out.append(OC_rdreset)
 				}
@@ -1675,9 +1643,65 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				out.append(be3...)
 				out.appendValue(bv3)
 				out.append(OC_ifelse)
-			}
 		} else {
 			if bv1.ToB() {
+				bv = bv2
+			} else {
+				bv = bv3
+			}
+		}
+	case "cond":
+		if err := c.checkOpeningParenthesis(in); err != nil {
+			return bvNone(), err
+		}
+		if bv1, err = c.expBoolOr(&be1, in); err != nil {
+			return bvNone(), err
+		}
+		if c.token != "," {
+			return bvNone(), Error("Missing ',' in Cond")
+		}
+		c.token = c.tokenizer(in)
+		if bv2, err = c.expBoolOr(&be2, in); err != nil {
+			return bvNone(), err
+		}
+		if c.token != "," {
+				return bvNone(), Error("Missing ',' in Cond")
+		}
+		c.token = c.tokenizer(in)
+		if bv3, err = c.expBoolOr(&be3, in); err != nil {
+			return bvNone(), err
+		}
+		if err := c.checkClosingParenthesis(); err != nil {
+			return bvNone(), err
+		}
+		if bv1.IsNone() || bv2.IsNone() || bv3.IsNone() {
+			// TODO: Cond is supposed to return undefined if the condition is undefined
+			// At the moment we have it returning the second option like IfElse does
+			be3.appendValue(bv3)
+			be2.appendValue(bv2)
+			if len(be3) > int(math.MaxUint8-1) {
+				be2.appendI32Op(OC_jmp, int32(len(be3)+1))
+			} else {
+				be2.append(OC_jmp8, OpCode(len(be3)+1))
+			}
+			be1.appendValue(bv1)
+			if len(be2) > int(math.MaxUint8-1) {
+				be1.appendI32Op(OC_jz, int32(len(be2)+1))
+			} else {
+				be1.append(OC_jz8, OpCode(len(be2)+1))
+			}
+			be1.append(OC_pop)
+			be1.append(be2...)
+			be1.append(OC_pop)
+			be1.append(be3...)
+			if rd {
+				out.appendI32Op(OC_run, int32(len(be1)))
+			}
+			out.append(be1...)
+		} else {
+			if bv1.IsUndefined() {
+				bv = bv1
+			} else if bv1.ToB() {
 				bv = bv2
 			} else {
 				bv = bv3

--- a/src/font.go
+++ b/src/font.go
@@ -796,27 +796,27 @@ func (ts *TextSprite) SetLocalcoord(lx, ly int32) {
 	if lx*3 > ly*4 {
 		v = float64(ly) * 4 / 3
 	}
-	ts.localScale = float32(v / 320)
+	ts.localScale = float32(320 / v)
 	ts.offsetX = -int32(math.Floor(float64(lx)/(v/320)-320) / 2)
 }
 
 func (ts *TextSprite) SetPos(x, y float32) {
 	ts.offsetInit[0] = x
 	ts.offsetInit[1] = y
-	ts.x = x/ts.localScale + float32(ts.offsetX)
-	ts.y = y / ts.localScale
+	ts.x = x * ts.localScale + float32(ts.offsetX)
+	ts.y = y * ts.localScale
 }
 
 func (ts *TextSprite) AddPos(x, y float32) {
-	ts.x += x / ts.localScale
-	ts.y += y / ts.localScale
+	ts.x += x * ts.localScale
+	ts.y += y * ts.localScale
 }
 
 func (ts *TextSprite) SetScale(xscl, yscl float32) {
 	ts.scaleInit[0] = xscl
 	ts.scaleInit[1] = yscl
-	ts.xscl = xscl / ts.localScale
-	ts.yscl = yscl / ts.localScale
+	ts.xscl = xscl * ts.localScale
+	ts.yscl = yscl * ts.localScale
 }
 
 func (ts *TextSprite) SetWindow(window [4]float32) {
@@ -824,10 +824,10 @@ func (ts *TextSprite) SetWindow(window [4]float32) {
 		return
 	}
 	ts.windowInit = window
-	x := window[0]/ts.localScale + float32(ts.offsetX)
-	y := window[1] / ts.localScale
-	w := (window[2] - window[0]) / ts.localScale
-	h := (window[3] - window[1]) / ts.localScale
+	x := window[0] * ts.localScale + float32(ts.offsetX)
+	y := window[1] * ts.localScale
+	w := (window[2] - window[0]) * ts.localScale
+	h := (window[3] - window[1]) * ts.localScale
 	ts.window[0] = int32((x + float32(sys.gameWidth-320)/2) * sys.widthScale)
 	// TODO: test if this truetype adjustment is needed
 	//ts.window[1] = int32((y + float32(sys.gameHeight-240)) * sys.heightScale)
@@ -857,19 +857,19 @@ func (ts *TextSprite) SetTextSpacing(xs, ys float32) {
 func (ts *TextSprite) SetVelocity(xvel, yvel float32) {
 	ts.velocityInit[0] = xvel
 	ts.velocityInit[1] = yvel
-	ts.xvel = xvel / ts.localScale
-	ts.yvel = yvel / ts.localScale
+	ts.xvel = xvel * ts.localScale
+	ts.yvel = yvel * ts.localScale
 	ts.vel = [2]float32{}
 }
 
 func (ts *TextSprite) SetMaxDist(x, y float32) {
-	ts.maxDist[0] = x / ts.localScale
-	ts.maxDist[1] = y / ts.localScale
+	ts.maxDist[0] = x * ts.localScale
+	ts.maxDist[1] = y * ts.localScale
 }
 
 func (ts *TextSprite) SetAccel(xacc, yacc float32) {
-	ts.accel[0] = xacc / ts.localScale
-	ts.accel[1] = yacc / ts.localScale
+	ts.accel[0] = xacc * ts.localScale
+	ts.accel[1] = yacc * ts.localScale
 }
 
 func (ts *TextSprite) IsFullyTyped() bool {
@@ -899,14 +899,14 @@ func (ts *TextSprite) getLineLength(windowWrap bool) int32 {
 	// Base "full screen" width in text space.
 	lcWidth := float32(sys.motif.Info.Localcoord[0])
 	if ts.localScale > 0 {
-		lcWidth = lcWidth / ts.localScale
+		lcWidth = lcWidth * ts.localScale
 	}
 	// Window boundaries expressed in text space.
 	var left, right float32
 	if windowWrap && ts.windowInit != [4]float32{0, 0, 0, 0} && ts.localScale > 0 {
 		// windowInit is in motif localcoords; convert to text space.
-		left = ts.windowInit[0]/ts.localScale + float32(ts.offsetX)
-		right = ts.windowInit[2]/ts.localScale + float32(ts.offsetX)
+		left = ts.windowInit[0] * ts.localScale + float32(ts.offsetX)
+		right = ts.windowInit[2] * ts.localScale + float32(ts.offsetX)
 	} else {
 		// No explicit window: use the whole localcoord width.
 		left = float32(ts.offsetX)
@@ -1243,7 +1243,7 @@ func (ts *TextSprite) Draw(ln int16) {
 	// "phantom pixel" adjustment to match mugen flipping behavior (extra pixel)
 	var phantomX float32
 	if ts.align == -1 {
-		phantomX = 1 / ts.localScale
+		phantomX = 1 * ts.localScale
 	}
 
 	lines := strings.Split(text, "\n")
@@ -1266,10 +1266,11 @@ func (ts *TextSprite) Draw(ln int16) {
 		xsoffset := xshear * (float32(ts.fnt.offset[1]) * ts.yscl)
 
 		// Adjust draw scale to the font's original localcoord
-		// We only multiply by localScale here because SetScale divides by it
-		//fntwscl := float32(ts.fnt.localcoord[0]) / (float32(sys.gameWidth) / 320)
-		//scaleRatio := 320.0 / fntwscl * ts.localScale
-		assetscale := float32(sys.gameWidth) / float32(ts.fnt.localcoord[0]) * ts.localScale
+		// TODO: There's a minor issue here where for instance if a 4:3 motif is used in 16:9 the fonts will still be scaled to 16:9
+		assetscale := float32(sys.gameWidth) / float32(ts.fnt.localcoord[0])
+
+		// We only divide by localScale here because SetScale multiplies by it
+		assetscale /= ts.localScale
 
 		// Draw the visible line
 		if ts.fnt.Type == "truetype" {

--- a/src/motif.go
+++ b/src/motif.go
@@ -2733,15 +2733,14 @@ func (m *Motif) drawLoading() {
 				m.Fnt[int(fontIdx)] = f
 				registerFontIndex(m.fntIndexByKey, fp.Font, fp.Height, int(fontIdx))
 
-				// Set font localcoord to the same as the motif
-				m.Fnt[int(fontIdx)].localcoord = sys.motif.Info.Localcoord
-
 				fp.Type = f.Type
 				fp.Size = f.Size
 				fp.Spacing = f.Spacing
 				fp.Offset = f.offset
 			}
 		}
+		// Set font localcoord to the same as the motif
+		m.Fnt[int(fontIdx)].localcoord = m.Info.Localcoord // Use the placeholder "m" data
 	}
 
 	// Build directly from the struct values so we don't need to populate everything.

--- a/src/script.go
+++ b/src/script.go
@@ -6986,9 +6986,14 @@ func systemScriptInit(l *lua.LState) {
 			sys.debugDisplay = !sys.debugDisplay
 			return 0
 		}
-		// Make a copy of runOrder
-		sorted := make([]*Char, len(sys.charList.runOrder))
-		copy(sorted, sys.charList.runOrder)
+		// Ctrl+Shift+D behavior: cycle players in reverse order
+		var reverse bool
+		if !nilArg(l, 2) {
+			reverse = boolArg(l, 2)
+		}
+		// Make a copy of creationOrder
+		sorted := make([]*Char, len(sys.charList.creationOrder))
+		copy(sorted, sys.charList.creationOrder)
 		// Sort the copy by player number and ID
 		sort.Slice(sorted, func(i, j int) bool {
 			if sorted[i].playerNo != sorted[j].playerNo {
@@ -6999,18 +7004,35 @@ func systemScriptInit(l *lua.LState) {
 		// Find reference char
 		var nextChar *Char
 		if sys.debugDisplay {
-			// Search for the first character that comes after the current one
-			for _, c := range sorted {
-				isLaterPlayer := c.playerNo > sys.debugRef[0]
-				isSamePlayerNewerID := c.playerNo == sys.debugRef[0] && c.id > sys.debugLastID
-				if isLaterPlayer || isSamePlayerNewerID {
-					nextChar = c
-					break
+			if reverse {
+				// Search backwards
+				for i := len(sorted) - 1; i >= 0; i-- {
+					c := sorted[i]
+					isEarlierPlayer := c.playerNo < sys.debugRef[0]
+					isSamePlayerLowerID := c.playerNo == sys.debugRef[0] && c.id < sys.debugLastID
+					if isEarlierPlayer || isSamePlayerLowerID {
+						nextChar = c
+						break
+					}
+				}
+			} else {
+				// Search for the first character that comes after the current one
+				for _, c := range sorted {
+					isLaterPlayer := c.playerNo > sys.debugRef[0]
+					isSamePlayerHigherID := c.playerNo == sys.debugRef[0] && c.id > sys.debugLastID
+					if isLaterPlayer || isSamePlayerHigherID {
+						nextChar = c
+						break
+					}
 				}
 			}
 		} else if len(sorted) > 0 {
 			// If display was off, start at the beginning of the sorted list
-			nextChar = sorted[0]
+			if reverse {
+				nextChar = sorted[len(sorted)-1]
+			} else {
+				nextChar = sorted[0]
+			}
 		}
 		// Update debug reference or disable debug
 		if nextChar != nil {

--- a/src/system.go
+++ b/src/system.go
@@ -2171,6 +2171,7 @@ func (s *System) resetRoundState() {
 	}
 	s.cam.ResetZoomdelay()
 
+	// Reset characters
 	for i, p := range s.chars {
 		if len(p) == 0 {
 			continue
@@ -4917,14 +4918,36 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 		}
 	}
 
-	p := newChar(pn, 0)
+	var p *Char
+	var cachestr = "New"
 	sys.workingChar = p // This should help compiler and bytecode stay consistent
 
-	if len(sys.chars[pn]) > 0 {
-		p.power = sys.chars[pn][0].power
-		p.guardPoints = sys.chars[pn][0].guardPoints
-		p.dizzyPoints = sys.chars[pn][0].dizzyPoints
+	// Same character from a previous match
+	if sys.chars[pn] != nil && len(sys.chars[pn]) > 0 {
+		if sys.chars[pn][0].gi().def == cdef && sys.chars[pn][0].ocd().existed {
+			p = sys.chars[pn][0]
+			cachestr = "Cached" // Actually more like "same"
+		}
 	}
+
+	// Brand new character
+	if p == nil {
+		p = newChar(pn, 0)
+
+		// These are already in char.load()
+		//sys.cgi[pn].sff = nil
+		//sys.cgi[pn].palettedata = nil
+
+		// TODO: Why do we do this here?
+		if len(sys.chars[pn]) > 0 {
+			p.power = sys.chars[pn][0].power
+			p.guardPoints = sys.chars[pn][0].guardPoints // And why do these two persist?
+			p.dizzyPoints = sys.chars[pn][0].dizzyPoints
+		}
+	}
+
+	// Flag "existed" just in case
+	p.ocd().existed = true
 
 	// Set new character parameters
 	if attached {
@@ -4940,11 +4963,7 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 		p.teamside = p.playerNo & 1
 	}
 
-	if !p.ocd().existed {
-		p.initCnsVar()
-		p.ocd().existed = true
-	}
-
+	// Commit character to system
 	sys.chars[pn] = make([]*Char, 1)
 	sys.chars[pn][0] = p
 
@@ -4972,9 +4991,9 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 
 	// Prepare success message
 	if attached {
-		tstr = fmt.Sprintf("New attached char loaded: %v", cdef)
+		tstr = fmt.Sprintf("%s attached char loaded: %v", cachestr, cdef)
 	} else {
-		tstr = fmt.Sprintf("New char loaded: %v", cdef)
+		tstr = fmt.Sprintf("%s char loaded: %v", cachestr, cdef)
 	}
 
 	selectPalno := 1


### PR DESCRIPTION
Features:
- Pressing ctrl+shift+D will now cycle debug mode in reverse order

Fixes:
- Fixed some loading fonts being scaled incorrectly
- Added "roundNotSkip" flag to demo.zss
- Updated demo.zss text positioning
- Reverted some undefined operations that went beyond what Mugen does
- Separated the range trigger logic from greater/less than so that they can have their own specific properties, namely respecting "undefined" values like Mugen
- Fixed char text "y = 240" always being considered bottom of screen regardless of aspect ratio
- Fixed char variables not persisting between matches
- Fixes #3407 

Refactor:
- Separated IfElse and Cond codes
- Inverted TextSprite local scale logic to match characters, stages and other things