### PR TITLE
feat(input): un-hardcode all special keys (excl.​ esc)

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -834,10 +834,14 @@ function main.f_drawInput(textData, text, sec, background, overlay, defaultInput
 			input = ''
 			break
 		end
-		if getKey('RETURN') then
+		if getKey(sec.textinput.confirm.keycode) then
 			break
-		elseif getKey('BACKSPACE') then
-			input = input:match('^(.-).?$')
+		elseif getKey(sec.textinput.trim.keycode) then
+			input = input:sub(2)
+		elseif getKey(sec.textinput.truncate.keycode) then
+			input = input:sub(1, -2)
+		elseif getKey(sec.textinput.paste.keycode) then
+			input = input .. getClipboardString()
 		else
 			input = input .. getKeyText()
 		end
@@ -1526,7 +1530,7 @@ function main.f_default()
 		draw = {gameOption('Options.Match.MaxDrawGames'), gameOption('Options.Match.MaxDrawGames')},
 		simul = {gameOption('Options.Simul.Match.Wins'), gameOption('Options.Simul.Match.Wins')},
 		single = {gameOption('Options.Match.Wins'), gameOption('Options.Match.Wins')},
-		tag = {gameOption('Options.Tag.Match.Wins'), gameOption('Options.Tag.Match.Wins')},,
+		tag = {gameOption('Options.Tag.Match.Wins'), gameOption('Options.Tag.Match.Wins')},
 	}
 	main.motif = { --which motif elements should be rendered
 		challenger = false,
@@ -2377,7 +2381,7 @@ function main.f_createMenu(tbl, bool_bgreset, bool_main, bool_f1, bool_del)
 					if not bool_main or esc() then
 						break
 					end
-				elseif bool_f1 and (getKey('F1') or gameOption('Config.FirstRun')) then
+				elseif bool_f1 and (getKey(motif.infobox.keycode) or gameOption('Config.FirstRun')) then
 					if gameOption('Config.FirstRun') then
 						modifyGameOption('Config.FirstRun', false)
 						options.f_saveCfg(false)
@@ -2396,7 +2400,7 @@ function main.f_createMenu(tbl, bool_bgreset, bool_main, bool_f1, bool_del)
 					sndPlay(motif.Snd, motif[main.group].cursor.done.snd.default[1], motif[main.group].cursor.done.snd.default[2])
 					main.f_fadeReset('fadeout', motif[main.group])
 					resetKey()
-				elseif bool_del and getKey('DELETE') then
+				elseif bool_del and getKey(motif[main.group].menu.item.delete.keycode) then
 					tbl.items = main.f_deleteIP(item, t)
 				elseif main.f_hiscoreDisplay(t[item].itemname) then
 					demoFrameCounter = 0
@@ -2647,7 +2651,7 @@ function main.f_renameReplay(item, t)
 	local newName = main.f_drawInput(
 		motif.title_info.textinput.TextSpriteData,
 		motif.title_info.textinput.text.replay,
-		motif.replay_info,
+		motif.title_info,
 		motif.replaybgdef,
 		motif.title_info.textinput.overlay.RectData,
 		oldName
@@ -2727,14 +2731,14 @@ function main.f_replay()
 			sndPlay(motif.Snd, motif.replay_info.cancel.snd[1], motif.replay_info.cancel.snd[2])
 			main.f_fadeReset('fadeout', motif.replay_info)
 			main.close = true
-		elseif getKey('DELETE') then
+		elseif getKey(motif.replay_info.menu.item.delete.keycode) then
 			t, item = main.f_deleteReplay(item, t)
 			local visibleItems = motif.replay_info.menu.window.visibleitems
 			if visibleItems == nil or visibleItems <= 0 then
 				visibleItems = #t
 			end
 			cursorPosY = math.max(1, math.min(cursorPosY, item, visibleItems))
-		elseif getKey('SPACE') then
+		elseif getKey(motif.replay_info.menu.item.rename.keycode) then
 			t, item = main.f_renameReplay(item, t)
 		elseif getInput(-1, motif[main.group].menu.done.key) then
 			sndPlay(motif.Snd, motif[main.group].cursor.done.snd.default[1], motif[main.group].cursor.done.snd.default[2])

--- a/external/script/menu.lua
+++ b/external/script/menu.lua
@@ -180,7 +180,7 @@ menu.t_itemname = {
 	end,
 	--Key Config
 	['keyboard'] = function(t, item, cursorPosY, moveTxt, sec)
-		if getInput(-1, sec.menu.done.key) --[[or getKey('F1')]] then
+		if getInput(-1, sec.menu.done.key) then
 			sndPlay(motif.Snd, sec.cursor.done.snd[1], sec.cursor.done.snd[2])
 			options.f_keyCfgInit('Keys', t.submenu[t.items[item].itemname].title)
 			menu.itemname = t.items[item].itemname
@@ -189,7 +189,7 @@ menu.t_itemname = {
 	end,
 	--Joystick Config
 	['gamepad'] = function(t, item, cursorPosY, moveTxt, sec)
-		if getInput(-1, sec.menu.done.key) --[[or getKey('F2')]] then
+		if getInput(-1, sec.menu.done.key) then
 			sndPlay(motif.Snd, sec.cursor.done.snd[1], sec.cursor.done.snd[2])
 			options.f_keyCfgInit('Joystick', t.submenu[t.items[item].itemname].title)
 			menu.itemname = t.items[item].itemname

--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -1180,7 +1180,7 @@ options.t_itemname = {
 	end,
 	--Key Config
 	['keyboard'] = function(t, item, cursorPosY, moveTxt)
-		if getInput(-1, motif.option_info.menu.done.key) --[[or getKey():match('^F[0-9]+$')]] then
+		if getInput(-1, motif.option_info.menu.done.key) then
 			sndPlay(motif.Snd, motif.option_info.cursor.done.snd[1], motif.option_info.cursor.done.snd[2])
 			options.f_keyCfgInit('Keys', t.submenu[t.items[item].itemname].title)
 			while true do
@@ -1193,7 +1193,7 @@ options.t_itemname = {
 	end,
 	--Joystick Config
 	['gamepad'] = function(t, item, cursorPosY, moveTxt)
-		if getInput(-1, motif.option_info.menu.done.key) --[[or getKey():match('^F[0-9]+$')]] then
+		if getInput(-1, motif.option_info.menu.done.key) then
 			sndPlay(motif.Snd, motif.option_info.cursor.done.snd[1], motif.option_info.cursor.done.snd[2])
 			if getCommandLineValue("-nojoy") == nil then
 				options.f_keyCfgInit('Joystick', t.submenu[t.items[item].itemname].title)
@@ -2153,9 +2153,9 @@ function options.f_keyCfg(cfgType, controller, bg, skipClear)
 			captureActive = false
 			item = resetIndex
 			cursorPosY = resetIndex
-		--spacebar (disable key)
-		elseif getKey('SPACE') then
-			key = 'SPACE'
+		-- unbind key
+		elseif getKey(motif.option_info.keymenu.unbind.keycode) then
+			key = '__UNBIND__'
 		--keyboard key detection
 		elseif cfgType == 'Keys' then
 			key = getKey()
@@ -2181,7 +2181,7 @@ function options.f_keyCfg(cfgType, controller, bg, skipClear)
 		forcedDir = 0
 		--other keyboard or gamepad key
 		if key ~= '' and key ~= 'nil' then
-			if key == 'SPACE' then
+			if key == '__UNBIND__' then
 				sndPlay(motif.Snd, motif.option_info.cursor.move.snd[1], motif.option_info.cursor.move.snd[2])
 				--decrease old button count
 				if t_keyList[joyNum][btn] ~= nil and t_keyList[joyNum][btn] > 1 then

--- a/src/input.go
+++ b/src/input.go
@@ -141,7 +141,7 @@ func OnKeyPressed(key Key, mk ModifierKey) {
 		if key == KeyF12 {
 			captureScreen()
 		}
-		if key == KeyF5 && sys.credits != -1 {
+		if key == StringToKeyLUT[sys.motif.AttractMode.Credits.KeyCode] && sys.credits != -1 {
 			sys.credits += 1
 			sys.motif.Snd.play(sys.motif.AttractMode.Credits.Snd, 100, 0, 0, 0, 0)
 		}

--- a/src/motif.go
+++ b/src/motif.go
@@ -303,6 +303,12 @@ type MenuProperties struct {
 			TextProperties
 			Active TextProperties `ini:"active"`
 		} `ini:"info"`
+		Delete struct { // only used by [Title Info], [Replay Info]
+			KeyCode string `ini:"keycode"`
+		} `ini:"delete"`
+		Rename struct { // only used by [Replay Info]
+			KeyCode string `ini:"keycode"`
+		} `ini:"rename"`
 	} `ini:"item"`
 	Window struct {
 		Margins struct {
@@ -349,6 +355,7 @@ type InfoBoxProperties struct {
 	Title   TextProperties    `ini:"title"`
 	Text    TextProperties    `ini:"text"`
 	Overlay OverlayProperties `ini:"overlay"`
+	KeyCode string          `ini:"keycode"`
 }
 
 type CellOverrideProperties struct {
@@ -625,6 +632,23 @@ type PlayerDialogueProperties struct {
 	Active AnimationProperties `ini:"active"`
 }
 
+type TextInputProperties struct {
+	TextMapProperties
+	Overlay OverlayProperties `ini:"overlay"`
+	Confirm struct {
+		KeyCode string `ini:"keycode"`
+	} `ini:"confirm"`
+	Trim struct {
+		KeyCode string `ini:"keycode"`
+	} `ini:"trim"`
+	Truncate struct {
+		KeyCode string `ini:"keycode"`
+	} `ini:"truncate"`
+	Paste struct {
+		KeyCode string `ini:"keycode"`
+	} `ini:"paste"`
+}
+
 type TitleInfoProperties struct {
 	FadeIn  FadeProperties `ini:"fadein"`
 	FadeOut FadeProperties `ini:"fadeout"`
@@ -652,10 +676,7 @@ type TitleInfoProperties struct {
 		TextMapProperties
 		Overlay OverlayProperties `ini:"overlay"`
 	} `ini:"connecting"`
-	TextInput struct {
-		TextMapProperties
-		Overlay OverlayProperties `ini:"overlay"`
-	} `ini:"textinput"`
+	TextInput TextInputProperties `ini:"textinput"`
 }
 
 type SelectInfoProperties struct {
@@ -1022,10 +1043,7 @@ type OptionInfoProperties struct {
 	Cancel struct {
 		Snd [2]int32 `ini:"snd" default:"-1,0"`
 	} `ini:"cancel"`
-	TextInput struct {
-		TextMapProperties
-		Overlay OverlayProperties `ini:"overlay"`
-	} `ini:"textinput"`
+	TextInput TextInputProperties `ini:"textinput"`
 	KeyMenu struct {
 		P1 struct {
 			MenuOffset [2]float32     `ini:"menuoffset"`
@@ -1035,6 +1053,9 @@ type OptionInfoProperties struct {
 			MenuOffset [2]float32     `ini:"menuoffset"`
 			Playerno   TextProperties `ini:"playerno"`
 		} `ini:"p2"`
+		Unbind struct {
+			KeyCode string `ini:"keycode"`
+		} `ini:"unbind"`
 		MenuProperties
 	} `ini:"keymenu"`
 	Itemname map[string]string `ini:"itemname"` // not used by [Option Info]
@@ -1139,7 +1160,11 @@ type AttractModeProperties struct {
 	Credits struct {
 		TextProperties
 		Snd [2]int32 `ini:"snd" default:"-1,0"`
+		KeyCode string `ini:"keycode"`
 	} `ini:"credits"`
+	Options struct {
+		KeyCode string `ini:"keycode"`
+	} `ini:"options"`
 	Logo struct {
 		Storyboard string `ini:"storyboard" lookup:"def,,data/"`
 	} `ini:"logo"`
@@ -1163,9 +1188,6 @@ type AttractModeProperties struct {
 		} `ini:"press"`
 		Timer TimerProperties `ini:"timer"`
 	} `ini:"start"`
-	Options struct {
-		KeyCode string `ini:"keycode"`
-	} `ini:"options"`
 }
 
 type ChallengerInfoProperties struct {

--- a/src/resources/defaultMotif.ini
+++ b/src/resources/defaultMotif.ini
@@ -335,6 +335,8 @@
 	;menu.item.active.bg.<itemname>.localcoord = 320, 240
 	;menu.item.active.bg.<itemname>.spacing = 0, 0
 
+	menu.item.delete.keycode = DELETE
+
 	menu.window.margins.y = 12, 8
 	menu.window.visibleitems = 5
 
@@ -556,6 +558,11 @@
 	textinput.overlay.window = 
 	textinput.overlay.localcoord = 320, 240
 
+	textinput.confirm.keycode = RETURN
+	textinput.trim.keycode = DELETE
+	textinput.truncate.keycode = BACKSPACE
+	textinput.paste.keycode = INSERT
+
 [TitleBgDef]
 	spr = 
 	bgclearcolor = 0, 0, 0
@@ -598,6 +605,8 @@
 	overlay.layerno = 0
 	overlay.window = 
 	overlay.localcoord = 320, 240
+
+	keycode = F1
 
 [Infobox Text]
 Welcome to I.K.E.M.E.N GO engine! (%s - %s)
@@ -3912,6 +3921,11 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	textinput.overlay.window = 
 	textinput.overlay.localcoord = 320, 240
 
+	textinput.confirm.keycode = RETURN
+	textinput.trim.keycode = DELETE
+	textinput.truncate.keycode = BACKSPACE
+	textinput.paste.keycode = INSERT
+
 	keymenu.p1.menuoffset = 39, 33
 
 	keymenu.p1.playerno.font = f-6x9.def, 0, 0, 0, 247, 247, 255, -1
@@ -4174,6 +4188,8 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	keymenu.done.key = a, b, c, x, y, z, s
 	keymenu.cancel.key = m
 
+	keymenu.unbind.keycode = SPACE
+
 	;keymenu.itemname.spacer = -
 	keymenu.itemname.configall = Config all
 	keymenu.itemname.up = Up
@@ -4329,6 +4345,9 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	;menu.item.active.bg.<itemname>.window = 
 	;menu.item.active.bg.<itemname>.localcoord = 320, 240
 	;menu.item.active.bg.<itemname>.spacing = 0, 0
+
+	menu.item.delete.keycode = DELETE
+	menu.item.rename.keycode = SPACE
 
 	menu.window.margins.y = 0, 0
 	menu.window.visibleitems = 13
@@ -5050,6 +5069,9 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	credits.localcoord = 320, 240
 
 	credits.snd = -1, 0
+	credits.keycode = F6
+
+	options.keycode = F11
 
 	; Defaults to storyboards declared under [Files], if not defined 
 	logo.storyboard = 
@@ -5113,8 +5135,6 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	start.timer.count = 60
 	start.timer.framespercount = 60
 	start.timer.displaytime = 10
-
-	options.keycode = F11
 
 [AttractBgDef]
 	spr = 

--- a/src/script.go
+++ b/src/script.go
@@ -3630,11 +3630,7 @@ func systemScriptInit(l *lua.LState) {
 		function getKeyText() end*/
 		s := ""
 		if sys.keyInput != KeyUnknown {
-			if sys.keyInput == KeyInsert {
-				s = sys.window.GetClipboardString()
-			} else {
-				s = sys.keyString
-			}
+			s = sys.keyString
 		}
 		l.Push(lua.LString(s))
 		return 1


### PR DESCRIPTION
unhardcode the following special keys, which are now bindable in (default)config.​ini under the [Input] section:
- space (UnbindKey & RenameReplayKey)
- return (TextInputConfirmKey)
- backspace (TextInputDeleteCharKey)
- insert (ClipboardPasteKey)
- f1 (MenuInfoboxKey)
- delete (DeleteSavedIPKey & DeleteReplayKey)

these allow multiple button bindings and even joystick bindings as well

requires new special input placeholders in the motif, which are (as of creating this pr:)
- %UNBIND_KEY%
- %RENAME_REPLAY_KEY%
- %TEXTINPUT_CONFIRM_KEY%
- %TEXTINPUT_DELETE_CHAR_KEY%%
- %CLIPBOARD_PASTE_KEY%
- %MENU_INFOBOX_KEY%
- %DELETE_SAVED_IP_KEY%
- %DELETE_REPLAY_KEY%

this is primarily to allow fullgame creators to change these to whatever they wish, and, in the case of space, allow it to be bound by players.​ to be clear, this does **not** touch debug keys in debug.​lua, as they can be disabled via Debug.AllowDebugKeys

as discussed in the discord server [here](https://discord.com/channels/233345562261323776/233363722934943744/1486112612914561137)

currently a draft as it is not known if i should make escape key behaviour bindable or tie more of the logic to the menu button (one example is netplay host/join screens, due to the textinput function) or not