### PR TITLE
feat: add HitDefVar velocities

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -902,32 +902,6 @@ const (
 	OC_ex2_projvar_velmul_x
 	OC_ex2_projvar_velmul_y
 	OC_ex2_projvar_velmul_z
-	OC_ex2_hitdefvar_guard_dist_depth_bottom
-	OC_ex2_hitdefvar_guard_dist_depth_top
-	OC_ex2_hitdefvar_guard_dist_height_bottom
-	OC_ex2_hitdefvar_guard_dist_height_top
-	OC_ex2_hitdefvar_guard_dist_width_back
-	OC_ex2_hitdefvar_guard_dist_width_front
-	OC_ex2_hitdefvar_guard_pausetime
-	OC_ex2_hitdefvar_guard_shaketime
-	OC_ex2_hitdefvar_guard_sparkno
-	OC_ex2_hitdefvar_guarddamage
-	OC_ex2_hitdefvar_guardflag
-	OC_ex2_hitdefvar_guardsound_group
-	OC_ex2_hitdefvar_guardsound_number
-	OC_ex2_hitdefvar_hitdamage
-	OC_ex2_hitdefvar_hitflag
-	OC_ex2_hitdefvar_hitsound_group
-	OC_ex2_hitdefvar_hitsound_number
-	OC_ex2_hitdefvar_id
-	OC_ex2_hitdefvar_p1stateno
-	OC_ex2_hitdefvar_p2stateno
-	OC_ex2_hitdefvar_pausetime
-	OC_ex2_hitdefvar_priority
-	OC_ex2_hitdefvar_shaketime
-	OC_ex2_hitdefvar_sparkno
-	OC_ex2_hitdefvar_sparkx
-	OC_ex2_hitdefvar_sparky
 	OC_ex2_hitbyattr
 	OC_ex2_soundvar_group
 	OC_ex2_soundvar_number
@@ -1014,6 +988,58 @@ const (
 	OC_ex3_spritevar_width
 	OC_ex3_spritevar_xoffset
 	OC_ex3_spritevar_yoffset
+	OC_ex3_hitdefvar_guard_dist_depth_bottom
+	OC_ex3_hitdefvar_guard_dist_depth_top
+	OC_ex3_hitdefvar_guard_dist_height_bottom
+	OC_ex3_hitdefvar_guard_dist_height_top
+	OC_ex3_hitdefvar_guard_dist_width_back
+	OC_ex3_hitdefvar_guard_dist_width_front
+	OC_ex3_hitdefvar_guard_pausetime
+	OC_ex3_hitdefvar_guard_shaketime
+	OC_ex3_hitdefvar_guard_sparkno
+	OC_ex3_hitdefvar_guarddamage
+	OC_ex3_hitdefvar_guardflag
+	OC_ex3_hitdefvar_guardsound_group
+	OC_ex3_hitdefvar_guardsound_number
+	OC_ex3_hitdefvar_hitdamage
+	OC_ex3_hitdefvar_hitflag
+	OC_ex3_hitdefvar_hitsound_group
+	OC_ex3_hitdefvar_hitsound_number
+	OC_ex3_hitdefvar_id
+	OC_ex3_hitdefvar_p1stateno
+	OC_ex3_hitdefvar_p2stateno
+	OC_ex3_hitdefvar_pausetime
+	OC_ex3_hitdefvar_priority
+	OC_ex3_hitdefvar_shaketime
+	OC_ex3_hitdefvar_sparkno
+	OC_ex3_hitdefvar_sparkx
+	OC_ex3_hitdefvar_sparky
+	OC_ex3_hitdefvar_xaccel
+	OC_ex3_hitdefvar_yaccel
+	OC_ex3_hitdefvar_zaccel
+	OC_ex3_hitdefvar_ground_velocity_x
+	OC_ex3_hitdefvar_ground_velocity_y
+	OC_ex3_hitdefvar_ground_velocity_z
+	OC_ex3_hitdefvar_air_velocity_x
+	OC_ex3_hitdefvar_air_velocity_y
+	OC_ex3_hitdefvar_air_velocity_z
+	OC_ex3_hitdefvar_down_velocity_x
+	OC_ex3_hitdefvar_down_velocity_y
+	OC_ex3_hitdefvar_down_velocity_z
+	OC_ex3_hitdefvar_guard_velocity_x
+	OC_ex3_hitdefvar_guard_velocity_y
+	OC_ex3_hitdefvar_guard_velocity_z
+	OC_ex3_hitdefvar_airguard_velocity_x
+	OC_ex3_hitdefvar_airguard_velocity_y
+	OC_ex3_hitdefvar_airguard_velocity_z
+	OC_ex3_hitdefvar_ground_cornerpush_veloff
+	OC_ex3_hitdefvar_air_cornerpush_veloff
+	OC_ex3_hitdefvar_down_cornerpush_veloff
+	OC_ex3_hitdefvar_guard_cornerpush_veloff
+	OC_ex3_hitdefvar_airguard_cornerpush_veloff
+	OC_ex3_hitdefvar_fall_xvelocity
+	OC_ex3_hitdefvar_fall_yvelocity
+	OC_ex3_hitdefvar_fall_zvelocity
 )
 
 type StringPool struct {
@@ -4014,65 +4040,6 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushB(sys.sel.gameParams.PersistLife)
 	case OC_ex2_gamevar_persistmusic:
 		sys.bcStack.PushB(sys.sel.gameParams.PersistMusic)
-	// HitDefVar
-	case OC_ex2_hitdefvar_guard_dist_width_back:
-		sys.bcStack.PushF(c.hitdef.guard_dist_x[1] * (c.localscl / oc.localscl))
-	case OC_ex2_hitdefvar_guard_dist_width_front:
-		sys.bcStack.PushF(c.hitdef.guard_dist_x[0] * (c.localscl / oc.localscl))
-	case OC_ex2_hitdefvar_guard_dist_height_bottom:
-		sys.bcStack.PushF(c.hitdef.guard_dist_y[1] * (c.localscl / oc.localscl))
-	case OC_ex2_hitdefvar_guard_dist_height_top:
-		sys.bcStack.PushF(c.hitdef.guard_dist_y[0] * (c.localscl / oc.localscl))
-	case OC_ex2_hitdefvar_guard_dist_depth_bottom:
-		sys.bcStack.PushF(c.hitdef.guard_dist_z[1] * (c.localscl / oc.localscl))
-	case OC_ex2_hitdefvar_guard_dist_depth_top:
-		sys.bcStack.PushF(c.hitdef.guard_dist_z[0] * (c.localscl / oc.localscl))
-	case OC_ex2_hitdefvar_guard_pausetime:
-		sys.bcStack.PushI(c.hitdef.guard_pausetime[0])
-	case OC_ex2_hitdefvar_guard_shaketime:
-		sys.bcStack.PushI(c.hitdef.guard_pausetime[1])
-	case OC_ex2_hitdefvar_guard_sparkno:
-		sys.bcStack.PushI(c.hitdef.guard_sparkno)
-	case OC_ex2_hitdefvar_guarddamage:
-		sys.bcStack.PushI(c.hitdef.guarddamage)
-	case OC_ex2_hitdefvar_guardflag:
-		attr := be.ReadIntAt(i)
-		sys.bcStack.PushB(
-			c.hitdef.guardflag&attr != 0,
-		)
-	case OC_ex2_hitdefvar_guardsound_group:
-		sys.bcStack.PushI(c.hitdef.guardsound[0])
-	case OC_ex2_hitdefvar_guardsound_number:
-		sys.bcStack.PushI(c.hitdef.guardsound[1])
-	case OC_ex2_hitdefvar_hitdamage:
-		sys.bcStack.PushI(c.hitdef.hitdamage)
-	case OC_ex2_hitdefvar_hitflag:
-		attr := be.ReadIntAt(i)
-		sys.bcStack.PushB(
-			c.hitdef.hitflag&attr != 0,
-		)
-	case OC_ex2_hitdefvar_hitsound_group:
-		sys.bcStack.PushI(c.hitdef.hitsound[0])
-	case OC_ex2_hitdefvar_hitsound_number:
-		sys.bcStack.PushI(c.hitdef.hitsound[1])
-	case OC_ex2_hitdefvar_id:
-		sys.bcStack.PushI(c.hitdef.id)
-	case OC_ex2_hitdefvar_p1stateno:
-		sys.bcStack.PushI(c.hitdef.p1stateno)
-	case OC_ex2_hitdefvar_p2stateno:
-		sys.bcStack.PushI(c.hitdef.p2stateno)
-	case OC_ex2_hitdefvar_pausetime:
-		sys.bcStack.PushI(c.hitdef.pausetime[0])
-	case OC_ex2_hitdefvar_priority:
-		sys.bcStack.PushI(c.hitdef.priority)
-	case OC_ex2_hitdefvar_shaketime:
-		sys.bcStack.PushI(c.hitdef.pausetime[1])
-	case OC_ex2_hitdefvar_sparkno:
-		sys.bcStack.PushI(c.hitdef.sparkno)
-	case OC_ex2_hitdefvar_sparkx:
-		sys.bcStack.PushF(c.hitdef.sparkxy[0] * (c.localscl / oc.localscl))
-	case OC_ex2_hitdefvar_sparky:
-		sys.bcStack.PushF(c.hitdef.sparkxy[1] * (c.localscl / oc.localscl))
 	// HitByAttr
 	case OC_ex2_hitbyattr:
 		attr := be.ReadIntAt(i)
@@ -4209,6 +4176,117 @@ func (be BytecodeExp) run_ex3(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.analogAxes[4])
 	case OC_ex3_analog_righttrigger:
 		sys.bcStack.PushF(c.analogAxes[5])
+	// HitDefVar
+	case OC_ex3_hitdefvar_guard_dist_width_back:
+		sys.bcStack.PushF(c.hitdef.guard_dist_x[1] * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_guard_dist_width_front:
+		sys.bcStack.PushF(c.hitdef.guard_dist_x[0] * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_guard_dist_height_bottom:
+		sys.bcStack.PushF(c.hitdef.guard_dist_y[1] * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_guard_dist_height_top:
+		sys.bcStack.PushF(c.hitdef.guard_dist_y[0] * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_guard_dist_depth_bottom:
+		sys.bcStack.PushF(c.hitdef.guard_dist_z[1] * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_guard_dist_depth_top:
+		sys.bcStack.PushF(c.hitdef.guard_dist_z[0] * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_guard_pausetime:
+		sys.bcStack.PushI(c.hitdef.guard_pausetime[0])
+	case OC_ex3_hitdefvar_guard_shaketime:
+		sys.bcStack.PushI(c.hitdef.guard_pausetime[1])
+	case OC_ex3_hitdefvar_guard_sparkno:
+		sys.bcStack.PushI(c.hitdef.guard_sparkno)
+	case OC_ex3_hitdefvar_guarddamage:
+		sys.bcStack.PushI(c.hitdef.guarddamage)
+	case OC_ex3_hitdefvar_guardflag:
+		attr := be.ReadIntAt(i)
+		sys.bcStack.PushB(
+			c.hitdef.guardflag&attr != 0,
+		)
+	case OC_ex3_hitdefvar_guardsound_group:
+		sys.bcStack.PushI(c.hitdef.guardsound[0])
+	case OC_ex3_hitdefvar_guardsound_number:
+		sys.bcStack.PushI(c.hitdef.guardsound[1])
+	case OC_ex3_hitdefvar_hitdamage:
+		sys.bcStack.PushI(c.hitdef.hitdamage)
+	case OC_ex3_hitdefvar_hitflag:
+		attr := be.ReadIntAt(i)
+		sys.bcStack.PushB(
+			c.hitdef.hitflag&attr != 0,
+		)
+	case OC_ex3_hitdefvar_hitsound_group:
+		sys.bcStack.PushI(c.hitdef.hitsound[0])
+	case OC_ex3_hitdefvar_hitsound_number:
+		sys.bcStack.PushI(c.hitdef.hitsound[1])
+	case OC_ex3_hitdefvar_id:
+		sys.bcStack.PushI(c.hitdef.id)
+	case OC_ex3_hitdefvar_p1stateno:
+		sys.bcStack.PushI(c.hitdef.p1stateno)
+	case OC_ex3_hitdefvar_p2stateno:
+		sys.bcStack.PushI(c.hitdef.p2stateno)
+	case OC_ex3_hitdefvar_pausetime:
+		sys.bcStack.PushI(c.hitdef.pausetime[0])
+	case OC_ex3_hitdefvar_priority:
+		sys.bcStack.PushI(c.hitdef.priority)
+	case OC_ex3_hitdefvar_shaketime:
+		sys.bcStack.PushI(c.hitdef.pausetime[1])
+	case OC_ex3_hitdefvar_sparkno:
+		sys.bcStack.PushI(c.hitdef.sparkno)
+	case OC_ex3_hitdefvar_sparkx:
+		sys.bcStack.PushF(c.hitdef.sparkxy[0] * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_sparky:
+		sys.bcStack.PushF(c.hitdef.sparkxy[1] * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_xaccel:
+		sys.bcStack.PushF(c.hitdef.xaccel * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_yaccel:
+		sys.bcStack.PushF(c.hitdef.yaccel * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_zaccel:
+		sys.bcStack.PushF(c.hitdef.zaccel * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_ground_velocity_x:
+		sys.bcStack.PushF(c.hitdef.ground_velocity[0] * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_ground_velocity_y:
+		sys.bcStack.PushF(c.hitdef.ground_velocity[1] * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_ground_velocity_z:
+		sys.bcStack.PushF(c.hitdef.ground_velocity[2] * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_air_velocity_x:
+		sys.bcStack.PushF(c.hitdef.air_velocity[0] * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_air_velocity_y:
+		sys.bcStack.PushF(c.hitdef.air_velocity[1] * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_air_velocity_z:
+		sys.bcStack.PushF(c.hitdef.air_velocity[2] * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_down_velocity_x:
+		sys.bcStack.PushF(c.hitdef.down_velocity[0] * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_down_velocity_y:
+		sys.bcStack.PushF(c.hitdef.down_velocity[1] * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_down_velocity_z:
+		sys.bcStack.PushF(c.hitdef.down_velocity[2] * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_guard_velocity_x:
+		sys.bcStack.PushF(c.hitdef.guard_velocity[0] * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_guard_velocity_y:
+		sys.bcStack.PushF(c.hitdef.guard_velocity[1] * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_guard_velocity_z:
+		sys.bcStack.PushF(c.hitdef.guard_velocity[2] * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_airguard_velocity_x:
+		sys.bcStack.PushF(c.hitdef.airguard_velocity[0] * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_airguard_velocity_y:
+		sys.bcStack.PushF(c.hitdef.airguard_velocity[1] * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_airguard_velocity_z:
+		sys.bcStack.PushF(c.hitdef.airguard_velocity[2] * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_ground_cornerpush_veloff:
+		sys.bcStack.PushF(c.hitdef.ground_cornerpush_veloff * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_air_cornerpush_veloff:
+		sys.bcStack.PushF(c.hitdef.air_cornerpush_veloff * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_down_cornerpush_veloff:
+		sys.bcStack.PushF(c.hitdef.down_cornerpush_veloff * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_guard_cornerpush_veloff:
+		sys.bcStack.PushF(c.hitdef.guard_cornerpush_veloff * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_airguard_cornerpush_veloff:
+		sys.bcStack.PushF(c.hitdef.airguard_cornerpush_veloff * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_fall_xvelocity:
+		sys.bcStack.PushF(c.hitdef.fall_xvelocity * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_fall_yvelocity:
+		sys.bcStack.PushF(c.hitdef.fall_yvelocity * (c.localscl / oc.localscl))
+	case OC_ex3_hitdefvar_fall_zvelocity:
+		sys.bcStack.PushF(c.hitdef.fall_zvelocity * (c.localscl / oc.localscl))
 	// HelperVar
 	case OC_ex3_helpervar_clsnproxy, OC_ex3_helpervar_id, OC_ex3_helpervar_helpertype,
 		OC_ex3_helpervar_keyctrl, OC_ex3_helpervar_ownclsnscale, OC_ex3_helpervar_ownpal,

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2821,59 +2821,111 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		isFlag := false
 		switch param {
 		case "guard.dist.depth.bottom":
-			opc = OC_ex2_hitdefvar_guard_dist_depth_bottom
+			opc = OC_ex3_hitdefvar_guard_dist_depth_bottom
 		case "guard.dist.depth.top":
-			opc = OC_ex2_hitdefvar_guard_dist_depth_top
+			opc = OC_ex3_hitdefvar_guard_dist_depth_top
 		case "guard.dist.height.bottom":
-			opc = OC_ex2_hitdefvar_guard_dist_height_bottom
+			opc = OC_ex3_hitdefvar_guard_dist_height_bottom
 		case "guard.dist.height.top":
-			opc = OC_ex2_hitdefvar_guard_dist_height_top
+			opc = OC_ex3_hitdefvar_guard_dist_height_top
 		case "guard.dist.width.back":
-			opc = OC_ex2_hitdefvar_guard_dist_width_back
+			opc = OC_ex3_hitdefvar_guard_dist_width_back
 		case "guard.dist.width.front":
-			opc = OC_ex2_hitdefvar_guard_dist_width_front
+			opc = OC_ex3_hitdefvar_guard_dist_width_front
 		case "guard.pausetime":
-			opc = OC_ex2_hitdefvar_guard_pausetime
+			opc = OC_ex3_hitdefvar_guard_pausetime
 		case "guard.shaketime":
-			opc = OC_ex2_hitdefvar_guard_shaketime
+			opc = OC_ex3_hitdefvar_guard_shaketime
 		case "guard.sparkno":
-			opc = OC_ex2_hitdefvar_guard_sparkno
+			opc = OC_ex3_hitdefvar_guard_sparkno
 		case "guarddamage":
-			opc = OC_ex2_hitdefvar_guarddamage
+			opc = OC_ex3_hitdefvar_guarddamage
 		case "guardflag":
-			opc = OC_ex2_hitdefvar_guardflag
+			opc = OC_ex3_hitdefvar_guardflag
 			isFlag = true
 		case "guardsound.group":
-			opc = OC_ex2_hitdefvar_guardsound_group
+			opc = OC_ex3_hitdefvar_guardsound_group
 		case "guardsound.number":
-			opc = OC_ex2_hitdefvar_guardsound_number
+			opc = OC_ex3_hitdefvar_guardsound_number
 		case "hitdamage":
-			opc = OC_ex2_hitdefvar_hitdamage
+			opc = OC_ex3_hitdefvar_hitdamage
 		case "hitflag":
-			opc = OC_ex2_hitdefvar_hitflag
+			opc = OC_ex3_hitdefvar_hitflag
 			isFlag = true
 		case "hitsound.group":
-			opc = OC_ex2_hitdefvar_hitsound_group
+			opc = OC_ex3_hitdefvar_hitsound_group
 		case "hitsound.number":
-			opc = OC_ex2_hitdefvar_hitsound_number
+			opc = OC_ex3_hitdefvar_hitsound_number
 		case "id":
-			opc = OC_ex2_hitdefvar_id
+			opc = OC_ex3_hitdefvar_id
 		case "p1stateno":
-			opc = OC_ex2_hitdefvar_p1stateno
+			opc = OC_ex3_hitdefvar_p1stateno
 		case "p2stateno":
-			opc = OC_ex2_hitdefvar_p2stateno
+			opc = OC_ex3_hitdefvar_p2stateno
 		case "pausetime":
-			opc = OC_ex2_hitdefvar_pausetime
+			opc = OC_ex3_hitdefvar_pausetime
 		case "priority":
-			opc = OC_ex2_hitdefvar_priority
+			opc = OC_ex3_hitdefvar_priority
 		case "shaketime":
-			opc = OC_ex2_hitdefvar_shaketime
+			opc = OC_ex3_hitdefvar_shaketime
 		case "sparkno":
-			opc = OC_ex2_hitdefvar_sparkno
+			opc = OC_ex3_hitdefvar_sparkno
 		case "sparkx":
-			opc = OC_ex2_hitdefvar_sparkx
+			opc = OC_ex3_hitdefvar_sparkx
 		case "sparky":
-			opc = OC_ex2_hitdefvar_sparky
+			opc = OC_ex3_hitdefvar_sparky
+		case "xaccel":
+			opc = OC_ex3_hitdefvar_xaccel
+		case "yaccel":
+			opc = OC_ex3_hitdefvar_yaccel
+		case "zaccel":
+			opc = OC_ex3_hitdefvar_zaccel
+		case "ground.velocity.x":
+			opc = OC_ex3_hitdefvar_ground_velocity_x
+		case "ground.velocity.y":
+			opc = OC_ex3_hitdefvar_ground_velocity_y
+		case "ground.velocity.z":
+			opc = OC_ex3_hitdefvar_ground_velocity_z
+		case "air.velocity.x":
+			opc = OC_ex3_hitdefvar_air_velocity_x
+		case "air.velocity.y":
+			opc = OC_ex3_hitdefvar_air_velocity_y
+		case "air.velocity.z":
+			opc = OC_ex3_hitdefvar_air_velocity_z
+		case "down.velocity.x":
+			opc = OC_ex3_hitdefvar_down_velocity_x
+		case "down.velocity.y":
+			opc = OC_ex3_hitdefvar_down_velocity_y
+		case "down.velocity.z":
+			opc = OC_ex3_hitdefvar_down_velocity_z
+		case "guard.velocity.x":
+			opc = OC_ex3_hitdefvar_guard_velocity_x
+		case "guard.velocity.y":
+			opc = OC_ex3_hitdefvar_guard_velocity_y
+		case "guard.velocity.z":
+			opc = OC_ex3_hitdefvar_guard_velocity_z
+		case "airguard.velocity.x":
+			opc = OC_ex3_hitdefvar_airguard_velocity_x
+		case "airguard.velocity.y":
+			opc = OC_ex3_hitdefvar_airguard_velocity_y
+		case "airguard.velocity.z":
+			opc = OC_ex3_hitdefvar_airguard_velocity_z
+		case "ground.cornerpush.veloff":
+			opc = OC_ex3_hitdefvar_ground_cornerpush_veloff
+		case "air.cornerpush.veloff":
+			opc = OC_ex3_hitdefvar_air_cornerpush_veloff
+		case "down.cornerpush.veloff":
+			opc = OC_ex3_hitdefvar_down_cornerpush_veloff
+		case "guard.cornerpush.veloff":
+			opc = OC_ex3_hitdefvar_guard_cornerpush_veloff
+		case "airguard.cornerpush.veloff":
+			opc = OC_ex3_hitdefvar_airguard_cornerpush_veloff
+		case "fall.xvelocity":
+			opc = OC_ex3_hitdefvar_fall_xvelocity
+		case "fall.yvelocity":
+			opc = OC_ex3_hitdefvar_fall_yvelocity
+		case "fall.zvelocity":
+			opc = OC_ex3_hitdefvar_fall_zvelocity
 		default:
 			return bvNone(), Error("Invalid HitDefVar argument: " + c.token)
 		}
@@ -2882,7 +2934,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				if flg, err := flagSub(); err != nil {
 					return err
 				} else {
-					out.append(OC_ex2_)
+					out.append(OC_ex3_)
 					out.appendI32Op(opc, flg)
 					return nil
 				}
@@ -2890,7 +2942,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				return bvNone(), err
 			}
 		} else {
-			out.append(OC_ex2_)
+			out.append(OC_ex3_)
 			out.append(opc)
 		}
 	case "hitfall":

--- a/src/script.go
+++ b/src/script.go
@@ -8589,46 +8589,110 @@ func triggerFunctions(l *lua.LState) {
 	luaRegister(l, "hitDefVar", func(*lua.LState) int {
 		c := sys.debugWC
 		switch strings.ToLower(strArg(l, 1)) {
-		case "guardflag":
-			l.Push(flagLStr(c.hitdef.guardflag))
-		case "hitflag":
-			l.Push(flagLStr(c.hitdef.hitflag))
-		case "hitdamage":
-			l.Push(lua.LNumber(c.hitdef.hitdamage))
-		case "guarddamage":
-			l.Push(lua.LNumber(c.hitdef.guarddamage))
-		case "p1stateno":
-			l.Push(lua.LNumber(c.hitdef.p1stateno))
-		case "p2stateno":
-			l.Push(lua.LNumber(c.hitdef.p2stateno))
-		case "priority":
-			l.Push(lua.LNumber(c.hitdef.priority))
-		case "id":
-			l.Push(lua.LNumber(c.hitdef.id))
-		case "sparkno":
-			l.Push(lua.LNumber(c.hitdef.sparkno))
-		case "guard.sparkno":
-			l.Push(lua.LNumber(c.hitdef.guard_sparkno))
-		case "sparkx":
-			l.Push(lua.LNumber(c.hitdef.sparkxy[0]))
-		case "sparky":
-			l.Push(lua.LNumber(c.hitdef.sparkxy[1]))
-		case "pausetime":
-			l.Push(lua.LNumber(c.hitdef.pausetime[0]))
+		case "guard.dist.width.back":
+			l.Push(lua.LNumber(c.hitdef.guard_dist_x[1]))
+		case "guard.dist.width.front":
+			l.Push(lua.LNumber(c.hitdef.guard_dist_x[0]))
+		case "guard.dist.height.bottom":
+			l.Push(lua.LNumber(c.hitdef.guard_dist_y[1]))
+		case "guard.dist.height.top":
+			l.Push(lua.LNumber(c.hitdef.guard_dist_y[0]))
+		case "guard.dist.depth.bottom":
+			l.Push(lua.LNumber(c.hitdef.guard_dist_z[1]))
+		case "guard.dist.depth.top":
+			l.Push(lua.LNumber(c.hitdef.guard_dist_z[0]))
 		case "guard.pausetime":
 			l.Push(lua.LNumber(c.hitdef.guard_pausetime[0]))
-		case "shaketime":
-			l.Push(lua.LNumber(c.hitdef.pausetime[1]))
 		case "guard.shaketime":
 			l.Push(lua.LNumber(c.hitdef.guard_pausetime[1]))
-		case "hitsound.group":
-			l.Push(lua.LNumber(c.hitdef.hitsound[0]))
-		case "hitsound.number":
-			l.Push(lua.LNumber(c.hitdef.hitsound[1]))
+		case "guard.sparkno":
+			l.Push(lua.LNumber(c.hitdef.guard_sparkno))
+		case "guarddamage":
+			l.Push(lua.LNumber(c.hitdef.guarddamage))
+		case "guardflag":
+			l.Push(flagLStr(c.hitdef.guardflag))
 		case "guardsound.group":
 			l.Push(lua.LNumber(c.hitdef.guardsound[0]))
 		case "guardsound.number":
 			l.Push(lua.LNumber(c.hitdef.guardsound[1]))
+		case "hitdamage":
+			l.Push(lua.LNumber(c.hitdef.hitdamage))
+		case "hitflag":
+			l.Push(flagLStr(c.hitdef.hitflag))
+		case "hitsound.group":
+			l.Push(lua.LNumber(c.hitdef.hitsound[0]))
+		case "hitsound.number":
+			l.Push(lua.LNumber(c.hitdef.hitsound[1]))
+		case "id":
+			l.Push(lua.LNumber(c.hitdef.id))
+		case "p1stateno":
+			l.Push(lua.LNumber(c.hitdef.p1stateno))
+		case "p2stateno":
+			l.Push(lua.LNumber(c.hitdef.p2stateno))
+		case "pausetime":
+			l.Push(lua.LNumber(c.hitdef.pausetime[0]))
+		case "priority":
+			l.Push(lua.LNumber(c.hitdef.priority))
+		case "shaketime":
+			l.Push(lua.LNumber(c.hitdef.pausetime[1]))
+		case "sparkno":
+			l.Push(lua.LNumber(c.hitdef.sparkno))
+		case "sparkx":
+			l.Push(lua.LNumber(c.hitdef.sparkxy[0]))
+		case "sparky":
+			l.Push(lua.LNumber(c.hitdef.sparkxy[1]))
+		case "xaccel":
+			l.Push(lua.LNumber(c.hitdef.xaccel))
+		case "yaccel":
+			l.Push(lua.LNumber(c.hitdef.yaccel))
+		case "zaccel":
+			l.Push(lua.LNumber(c.hitdef.zaccel))
+		case "ground.velocity.x":
+			l.Push(lua.LNumber(c.hitdef.ground_velocity[0]))
+		case "ground.velocity.y":
+			l.Push(lua.LNumber(c.hitdef.ground_velocity[1]))
+		case "ground.velocity.z":
+			l.Push(lua.LNumber(c.hitdef.ground_velocity[2]))
+		case "air.velocity.x":
+			l.Push(lua.LNumber(c.hitdef.air_velocity[0]))
+		case "air.velocity.y":
+			l.Push(lua.LNumber(c.hitdef.air_velocity[1]))
+		case "air.velocity.z":
+			l.Push(lua.LNumber(c.hitdef.air_velocity[2]))
+		case "down.velocity.x":
+			l.Push(lua.LNumber(c.hitdef.down_velocity[0]))
+		case "down.velocity.y":
+			l.Push(lua.LNumber(c.hitdef.down_velocity[1]))
+		case "down.velocity.z":
+			l.Push(lua.LNumber(c.hitdef.down_velocity[2]))
+		case "guard.velocity.x":
+			l.Push(lua.LNumber(c.hitdef.guard_velocity[0]))
+		case "guard.velocity.y":
+			l.Push(lua.LNumber(c.hitdef.guard_velocity[1]))
+		case "guard.velocity.z":
+			l.Push(lua.LNumber(c.hitdef.guard_velocity[2]))
+		case "airguard.velocity.x":
+			l.Push(lua.LNumber(c.hitdef.airguard_velocity[0]))
+		case "airguard.velocity.y":
+			l.Push(lua.LNumber(c.hitdef.airguard_velocity[1]))
+		case "airguard.velocity.z":
+			l.Push(lua.LNumber(c.hitdef.airguard_velocity[2]))
+		case "ground.cornerpush.veloff":
+			l.Push(lua.LNumber(c.hitdef.ground_cornerpush_veloff))
+		case "air.cornerpush.veloff":
+			l.Push(lua.LNumber(c.hitdef.air_cornerpush_veloff))
+		case "down.cornerpush.veloff":
+			l.Push(lua.LNumber(c.hitdef.down_cornerpush_veloff))
+		case "guard.cornerpush.veloff":
+			l.Push(lua.LNumber(c.hitdef.guard_cornerpush_veloff))
+		case "airguard.cornerpush.veloff":
+			l.Push(lua.LNumber(c.hitdef.airguard_cornerpush_veloff))
+		case "fall.xvelocity":
+			l.Push(lua.LNumber(c.hitdef.fall_xvelocity))
+		case "fall.yvelocity":
+			l.Push(lua.LNumber(c.hitdef.fall_yvelocity))
+		case "fall.zvelocity":
+			l.Push(lua.LNumber(c.hitdef.fall_zvelocity))
 		default:
 			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}


### PR DESCRIPTION
Everything related to velocities has been added to HitDefVar.
HitDefVar was also moved to ex3 because ex2 was getting too big, and missing parts added to script.go.