### PR TITLE
feat: anim debug; fix: some regressions, RemapPal, Clsn comments, ProjHit, etc; refactoring

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -585,9 +585,9 @@ function main.f_commandLine()
 	}
 	local roundTime = gameOption('Options.Time')
 	if getCommandLineValue("-loadmotif") == nil then
-		loadLifebar()
+		loadFightScreen()
 	end
-	setLifebarElements({guardbar = gameOption('Options.GuardBreak'), stunbar = gameOption('Options.Dizzy'), redlifebar = gameOption('Options.RedLife')})
+	setFightScreenElements({guardbar = gameOption('Options.GuardBreak'), stunbar = gameOption('Options.Dizzy'), redlifebar = gameOption('Options.RedLife')})
 	local frames = fightScreenVar("time.framespercount")
 	local t = {}
 	local t_assignedPals = {}
@@ -794,7 +794,7 @@ main.t_unlockLua = {chars = {}, stages = {}, modes = {}}
 motif = loadMotif()
 if gameOption('Debug.DumpLuaTables') then main.f_printTable(motif, "debug/loadMotif.txt") end
 
-loadLifebar()
+loadFightScreen()
 main.f_loadingRefresh()
 
 local function showSessionWarning()
@@ -1531,7 +1531,7 @@ function main.f_default()
 	main.exitSelect = false --if "clearing" the mode (matchno == -1) should go back to main menu
 	main.forceChar = {nil, nil} --predefined P1/P2 characters
 	main.forceRosterSize = false --if roster size should be enforced even if there are not enough characters to fill it (not used but may be useful for external modules)
-	main.lifebar = { --which lifebar elements should be rendered (these defaults are overwritten by fight.def, depending on game mode)
+	main.fightscreen = { --which fight screen elements should be rendered (these defaults are overwritten by fight.def, depending on game mode)
 		active = true,
 		bars = true,
 		match = false,
@@ -1574,7 +1574,7 @@ function main.f_default()
 	main.orderSelect = {false, false} --if versus screen order selection should be active
 	main.persistLife = false --if life should be maintained after match
 	main.persistMusic = false --if the music that was playing previously should be stopped at the start of the match
-	main.persistRounds = false --if lifebar should use consecutive wins for round numbers
+	main.persistRounds = false --if fight screen should use consecutive wins for round numbers
 	main.quickContinue = false --if by default continuing should skip player selection
 	main.rankingCondition = false --if winning (clearing) whole mode is needed for rankings to be saved
 	main.resetScore = false --if loosing should set score for the next match to lose count
@@ -1597,7 +1597,7 @@ function main.f_default()
 	setConsecutiveWins(2, 0)
 	setGameMode('')
 	setHomeTeam(2) --http://mugenguild.com/forum/topics/ishometeam-triggers-169132.0.html
-	setLifebarElements(main.lifebar)
+	setFightScreenElements(main.fightscreen)
 	setMotifElements(main.motif)
 	setTimeFramesPerCount(fightScreenVar("time.framespercount"))
 	setRoundTime(math.max(-1, main.roundTime * fightScreenVar("time.framespercount")))
@@ -1622,8 +1622,8 @@ main.t_itemname = {
 		main.charparam.stage = true
 		main.charparam.time = true
 		main.exitSelect = true
-		--main.lifebar.p1score = true
-		--main.lifebar.p2ailevel = true
+		--main.fightscreen.p1score = true
+		--main.fightscreen.p2ailevel = true
 		main.makeRoster = true
 		main.motif.challenger = true
 		main.motif.continuescreen = true
@@ -1695,8 +1695,8 @@ main.t_itemname = {
 	end,
 	--FREE BATTLE (QUICK VS)
 	['freebattle'] = function()
-		--main.lifebar.p1score = true
-		--main.lifebar.p2ailevel = true
+		--main.fightscreen.p1score = true
+		--main.fightscreen.p2ailevel = true
 		main.motif.vsscreen = true
 		main.motif.victoryscreen = true
 		main.orderSelect[1] = true
@@ -1763,8 +1763,8 @@ main.t_itemname = {
 		main.coop = true
 		main.elimination = true
 		main.exitSelect = true
-		--main.lifebar.match = true
-		--main.lifebar.p2ailevel = true
+		--main.fightscreen.match = true
+		--main.fightscreen.p2ailevel = true
 		main.makeRoster = true
 		main.motif.losescreen = true
 		main.motif.winscreen = true
@@ -1804,8 +1804,8 @@ main.t_itemname = {
 		main.charparam.time = true
 		main.coop = true
 		main.exitSelect = true
-		--main.lifebar.p1score = true
-		--main.lifebar.p2ailevel = true
+		--main.fightscreen.p1score = true
+		--main.fightscreen.p2ailevel = true
 		main.makeRoster = true
 		main.motif.continuescreen = true
 		main.motif.vsscreen = true
@@ -1836,8 +1836,8 @@ main.t_itemname = {
 	--NETPLAY VERSUS
 	['netplayversus'] = function()
 		main.cpuSide[2] = false
-		--main.lifebar.p1wincount = true
-		--main.lifebar.p2wincount = true
+		--main.fightscreen.p1wincount = true
+		--main.fightscreen.p2wincount = true
 		main.motif.vsscreen = true
 		main.motif.victoryscreen = true
 		main.orderSelect[1] = true
@@ -1942,8 +1942,8 @@ main.t_itemname = {
 		main.dropDefeated = true
 		main.elimination = true
 		main.exitSelect = true
-		--main.lifebar.match = true
-		--main.lifebar.p2ailevel = true
+		--main.fightscreen.match = true
+		--main.fightscreen.p2ailevel = true
 		main.makeRoster = true
 		main.motif.hiscore = true
 		main.motif.losescreen = true
@@ -1989,8 +1989,8 @@ main.t_itemname = {
 		main.coop = true
 		main.elimination = true
 		main.exitSelect = true
-		--main.lifebar.match = true
-		--main.lifebar.p2ailevel = true
+		--main.fightscreen.match = true
+		--main.fightscreen.p2ailevel = true
 		main.makeRoster = true
 		main.motif.hiscore = true
 		main.motif.winscreen = true
@@ -2031,8 +2031,8 @@ main.t_itemname = {
 		main.charparam.time = true
 		main.coop = true
 		main.exitSelect = true
-		--main.lifebar.p1score = true
-		--main.lifebar.p2ailevel = true
+		--main.fightscreen.p1score = true
+		--main.fightscreen.p2ailevel = true
 		main.makeRoster = true
 		main.motif.continuescreen = true
 		main.motif.hiscore = true
@@ -2071,8 +2071,8 @@ main.t_itemname = {
 		main.charparam.stage = true
 		main.charparam.time = true
 		main.exitSelect = true
-		--main.lifebar.p2ailevel = true
-		--main.lifebar.timer = true
+		--main.fightscreen.p2ailevel = true
+		--main.fightscreen.timer = true
 		main.makeRoster = true
 		main.motif.continuescreen = true
 		main.motif.hiscore = true
@@ -2109,8 +2109,8 @@ main.t_itemname = {
 		if main.t_charDef[gameOption('Config.TrainingChar'):lower()] ~= nil then
 			main.forceChar[2] = {main.t_charDef[gameOption('Config.TrainingChar'):lower()]}
 		end
-		--main.lifebar.p1score = true
-		--main.lifebar.p2ailevel = true
+		--main.fightscreen.p1score = true
+		--main.fightscreen.p2ailevel = true
 		main.roundTime = -1
 		main.selectMenu[2] = true
 		if gameOption('Config.TrainingStage') == '' then
@@ -2140,8 +2140,8 @@ main.t_itemname = {
 	--VS MODE / TEAM VERSUS
 	['versus'] = function(t, item)
 		main.cpuSide[2] = false
-		--main.lifebar.p1wincount = true
-		--main.lifebar.p2wincount = true
+		--main.fightscreen.p1wincount = true
+		--main.fightscreen.p2wincount = true
 		main.motif.vsscreen = true
 		main.motif.victoryscreen = true
 		main.orderSelect[1] = true
@@ -2181,8 +2181,8 @@ main.t_itemname = {
 	['versuscoop'] = function()
 		main.coop = true
 		main.cpuSide[2] = false
-		--main.lifebar.p1wincount = true
-		--main.lifebar.p2wincount = true
+		--main.fightscreen.p1wincount = true
+		--main.fightscreen.p2wincount = true
 		main.motif.vsscreen = true
 		main.motif.victoryscreen = true
 		main.numSimul = {2, math.min(4, math.max(2, math.ceil(gameOption('Config.Players') / 2)))}
@@ -2202,8 +2202,8 @@ main.t_itemname = {
 	--WATCH
 	['watch'] = function()
 		main.cpuSide[1] = true
-		--main.lifebar.p1ailevel = true
-		--main.lifebar.p2ailevel = true
+		--main.fightscreen.p1ailevel = true
+		--main.fightscreen.p2ailevel = true
 		main.motif.vsscreen = true
 		main.motif.victoryscreen = true
 		main.selectMenu[2] = true
@@ -3127,7 +3127,7 @@ end
 function main.f_demoStart()
 	main.f_default()
 	local palState = {}
-	setLifebarElements({bars = motif.demo_mode.fight.bars.display})
+	setFightScreenElements({bars = motif.demo_mode.fight.bars.display})
 	setGameMode('demo')
 	for side = 1, 2 do
 		setTeamMode(side, 0, 1)

--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -257,7 +257,7 @@ options.t_itemname = {
 			--modifyGameOption('Input.UiRepeatDelay', 30)
 			--modifyGameOption('Input.UiRepeatRate', 4)
 
-			loadLifebar(motif.files.fight)
+			loadFightScreen(motif.files.fight)
 			setPlayers()
 			for _, v in ipairs(options.t_vardisplayPointers) do
 				v.vardisplay = options.f_vardisplay(v.itemname)

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -286,7 +286,7 @@ end
 
 --sets lifebar elements, round time, rounds to win
 function start.f_setRounds(roundTime, t_rounds)
-	setLifebarElements(main.lifebar)
+	setFightScreenElements(main.fightscreen)
 	-- Round time
 	local frames = fightScreenVar("time.framespercount")
 	local p1FramesMul = 1
@@ -333,8 +333,8 @@ function start.f_setRounds(roundTime, t_rounds)
 	end
 	--timer / score counter
 	local timer, t_score = start.f_prefightHUD()
-	setLifebarTimer(timer)
-	setLifebarScore(t_score[1], t_score[2])
+	setFightScreenTimer(timer)
+	setFightScreenScore(t_score[1], t_score[2])
 end
 
 local function f_listCharRefs(t)

--- a/src/anim.go
+++ b/src/anim.go
@@ -302,10 +302,11 @@ func ReadAnimation(sff *Sff, pal *PaletteList, lines []string, i *int) *Animatio
 				break
 			}
 			(*i)++
-			for n := int32(0); n < size && *i < len(lines); n++ {
+			for n := int32(0); n < size && *i < len(lines); {
 				line := strings.ToLower(strings.TrimSpace(
 					strings.SplitN(lines[*i], ";", 2)[0]))
 				if len(line) == 0 {
+					(*i)++
 					continue
 				}
 				if len(line) < 4 || line[:4] != "clsn" {
@@ -328,6 +329,7 @@ func ReadAnimation(sff *Sff, pal *PaletteList, lines []string, i *int) *Animatio
 				}
 				clsn[n][0], clsn[n][1], clsn[n][2], clsn[n][3] =
 					float32(l), float32(t), float32(r), float32(b)
+				n++
 				(*i)++
 			}
 			(*i)--

--- a/src/anim.go
+++ b/src/anim.go
@@ -603,6 +603,18 @@ func (a *Animation) UpdateSprite() {
 		}
 		if group >= 0 && number >= 0 {
 			a.spr = a.sff.GetSprite(uint16(group), uint16(number))
+			if a.spr == nil {
+				// Log missing sprites
+				// We will save the history in the SFF itself so that each sprite is only mentioned once
+				key := [2]uint16{uint16(group), uint16(number)}
+				if a.sff.debugMissing == nil {
+					a.sff.debugMissing = make(map[[2]uint16]bool)
+				}
+				if !a.sff.debugMissing[key] {
+					LogMessage("WARNING: Animation missing sprite %v,%v from %v", group, number, a.sff.filename)
+					a.sff.debugMissing[key] = true
+				}
+			}
 		} else {
 			a.spr = nil
 		}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3561,23 +3561,23 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		nameStr := be.ReadPoolStringAt(i)
 		sys.bcStack.PushB(sys.fightScreen.nameLow == nameStr)
 	case OC_ex2_fightscreenvar_round_ctrl_time:
-		sys.bcStack.PushI(sys.fightScreen.ro.ctrl_time)
+		sys.bcStack.PushI(sys.fightScreen.round.ctrl_time)
 	case OC_ex2_fightscreenvar_round_over_hittime:
-		sys.bcStack.PushI(sys.fightScreen.ro.over_hittime)
+		sys.bcStack.PushI(sys.fightScreen.round.over_hittime)
 	case OC_ex2_fightscreenvar_round_over_time:
-		sys.bcStack.PushI(sys.fightScreen.ro.over_time)
+		sys.bcStack.PushI(sys.fightScreen.round.over_time)
 	case OC_ex2_fightscreenvar_round_over_waittime:
-		sys.bcStack.PushI(sys.fightScreen.ro.over_waittime)
+		sys.bcStack.PushI(sys.fightScreen.round.over_waittime)
 	case OC_ex2_fightscreenvar_round_over_wintime:
-		sys.bcStack.PushI(sys.fightScreen.ro.over_wintime)
+		sys.bcStack.PushI(sys.fightScreen.round.over_wintime)
 	case OC_ex2_fightscreenvar_round_slow_time:
-		sys.bcStack.PushI(sys.fightScreen.ro.slow_time)
+		sys.bcStack.PushI(sys.fightScreen.round.slow_time)
 	case OC_ex2_fightscreenvar_round_start_waittime:
-		sys.bcStack.PushI(sys.fightScreen.ro.start_waittime)
+		sys.bcStack.PushI(sys.fightScreen.round.start_waittime)
 	case OC_ex2_fightscreenvar_round_callfight_time:
-		sys.bcStack.PushI(sys.fightScreen.ro.callfight_time)
+		sys.bcStack.PushI(sys.fightScreen.round.callfight_time)
 	case OC_ex2_fightscreenvar_time_framespercount:
-		sys.bcStack.PushI(sys.fightScreen.ti.framespercount)
+		sys.bcStack.PushI(sys.fightScreen.time.framespercount)
 	case OC_ex2_groundlevel:
 		sys.bcStack.PushF(c.groundLevel * (c.localscl / oc.localscl))
 	case OC_ex2_layerno:
@@ -3987,13 +3987,13 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		}
 	// FightScreenState
 	case OC_ex2_fightscreenstate_fightdisplay:
-		sys.bcStack.PushB(sys.fightScreen.ro.fightDisplayPhase == 1)
+		sys.bcStack.PushB(sys.fightScreen.round.fightDisplayPhase == 1)
 	case OC_ex2_fightscreenstate_kodisplay:
-		sys.bcStack.PushB(sys.fightScreen.ro.koDisplayPhase == 1)
+		sys.bcStack.PushB(sys.fightScreen.round.koDisplayPhase == 1)
 	case OC_ex2_fightscreenstate_rounddisplay:
-		sys.bcStack.PushB(sys.fightScreen.ro.roundDisplayPhase == 1)
+		sys.bcStack.PushB(sys.fightScreen.round.roundDisplayPhase == 1)
 	case OC_ex2_fightscreenstate_windisplay:
-		sys.bcStack.PushB(sys.fightScreen.ro.winDisplayPhase == 1)
+		sys.bcStack.PushB(sys.fightScreen.round.winDisplayPhase == 1)
 	// MotifState
 	case OC_ex2_motifstate_challenger:
 		sys.bcStack.PushB(sys.motif.ch.active)
@@ -11758,7 +11758,7 @@ func (sc lifebarAction) Run(c *Char, _ []int32) bool {
 	})
 
 	if msg.resttime < 0 {
-		msg.resttime = sys.fightScreen.ac[crun.teamside].displaytime
+		msg.resttime = sys.fightScreen.actions[crun.teamside].displaytime
 	}
 	msg.resttime = int32(float32(msg.resttime) * timemul)
 

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -4315,8 +4315,8 @@ func (be BytecodeExp) run_ex3(c *Char, i *int, oc *Char) {
 			sys.bcStack.PushB(c.preserve)
 		}
 	// SpriteVar
-	case OC_ex3_spritevar_group, OC_ex3_spritevar_height, OC_ex3_spritevar_width,
-		OC_ex3_spritevar_xoffset, OC_ex3_spritevar_yoffset:
+	case OC_ex3_spritevar_group, OC_ex3_spritevar_height, OC_ex3_spritevar_image,
+		OC_ex3_spritevar_width, OC_ex3_spritevar_xoffset, OC_ex3_spritevar_yoffset:
 		// Check for valid sprite
 		var spr *Sprite
 		if c.anim != nil {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6992,7 +6992,7 @@ func (sc gameMakeAnim) Run(c *Char, _ []int32) bool {
 		case gameMakeAnim_anim:
 			e.anim_ffx = exp[0].evalS()
 			e.animNo = exp[1].evalI(c)
-			e.anim = crun.getSelfAnimSprite(e.animNo, e.anim_ffx, e.ownpal, true)
+			e.anim = crun.getSelfAnimSprite(e.animNo, e.anim_ffx, e.ownpal)
 		}
 		return true
 	})
@@ -8330,13 +8330,13 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				var v2 int32
 				v1 = exp[0].evalS()
 				if len(exp) > 1 {
-					v2 = Max(-1, exp[1].evalI(c))
+					v2 = exp[1].evalI(c)
 				}
 				eachProj(func(p *Projectile) {
 					if p.animNo != v2 || p.anim_ffx != v1 { // TODO: This isn't required for chars, so maybe it shouldn't be here either
-						p.anim_ffx = v1 // TODO: These two should only be updated if the new animation is valid
-						p.animNo = v2
-						p.anim = c.getAnim(p.animNo, p.anim_ffx, true) // need to change anim ref too
+						p.anim_ffx = v1
+						p.animNo = v2 // If animation is invalid the projectile will be destroyed, so we can update this either way
+						p.anim = crun.getAnim(p.animNo, p.anim_ffx) // need to change anim ref too
 					}
 				})
 			case projectile_supermovetime:
@@ -14500,7 +14500,7 @@ func (sc modifyShadow) Run(c *Char, _ []int32) bool {
 		case modifyShadow_anim:
 			ffx := exp[0].evalS()
 			animNo := exp[1].evalI(c)
-			anim := c.getShadowReflectionSprite(animNo, animPN, spritePN, ffx, true, false, "ModifyShadow")
+			anim := c.getShadowReflectionSprite(animNo, animPN, spritePN, ffx, true, "ModifyShadow")
 			if anim != nil {
 				anim.Action() // Need to step for it to appear
 				crun.shadowAnim = anim
@@ -14593,7 +14593,7 @@ func (sc modifyReflection) Run(c *Char, _ []int32) bool {
 		case modifyReflection_anim:
 			ffx := exp[0].evalS()
 			animNo := exp[1].evalI(c)
-			anim := c.getShadowReflectionSprite(animNo, animPN, spritePN, ffx, true, false, "ModifyReflection")
+			anim := c.getShadowReflectionSprite(animNo, animPN, spritePN, ffx, true, "ModifyReflection")
 			if anim != nil {
 				anim.Action() // Need to step for it to appear
 				crun.reflectAnim = anim

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3552,32 +3552,32 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(c.indexTrigger())
 	case OC_ex2_fightscreenvar_info_author:
 		authStr := be.ReadPoolStringAt(i)
-		sys.bcStack.PushB(sys.lifebar.authorLow == authStr)
+		sys.bcStack.PushB(sys.fightScreen.authorLow == authStr)
 	case OC_ex2_fightscreenvar_info_localcoord_x:
-		sys.bcStack.PushI(sys.lifebar.localcoord[0])
+		sys.bcStack.PushI(sys.fightScreen.localcoord[0])
 	case OC_ex2_fightscreenvar_info_localcoord_y:
-		sys.bcStack.PushI(sys.lifebar.localcoord[1])
+		sys.bcStack.PushI(sys.fightScreen.localcoord[1])
 	case OC_ex2_fightscreenvar_info_name:
 		nameStr := be.ReadPoolStringAt(i)
-		sys.bcStack.PushB(sys.lifebar.nameLow == nameStr)
+		sys.bcStack.PushB(sys.fightScreen.nameLow == nameStr)
 	case OC_ex2_fightscreenvar_round_ctrl_time:
-		sys.bcStack.PushI(sys.lifebar.ro.ctrl_time)
+		sys.bcStack.PushI(sys.fightScreen.ro.ctrl_time)
 	case OC_ex2_fightscreenvar_round_over_hittime:
-		sys.bcStack.PushI(sys.lifebar.ro.over_hittime)
+		sys.bcStack.PushI(sys.fightScreen.ro.over_hittime)
 	case OC_ex2_fightscreenvar_round_over_time:
-		sys.bcStack.PushI(sys.lifebar.ro.over_time)
+		sys.bcStack.PushI(sys.fightScreen.ro.over_time)
 	case OC_ex2_fightscreenvar_round_over_waittime:
-		sys.bcStack.PushI(sys.lifebar.ro.over_waittime)
+		sys.bcStack.PushI(sys.fightScreen.ro.over_waittime)
 	case OC_ex2_fightscreenvar_round_over_wintime:
-		sys.bcStack.PushI(sys.lifebar.ro.over_wintime)
+		sys.bcStack.PushI(sys.fightScreen.ro.over_wintime)
 	case OC_ex2_fightscreenvar_round_slow_time:
-		sys.bcStack.PushI(sys.lifebar.ro.slow_time)
+		sys.bcStack.PushI(sys.fightScreen.ro.slow_time)
 	case OC_ex2_fightscreenvar_round_start_waittime:
-		sys.bcStack.PushI(sys.lifebar.ro.start_waittime)
+		sys.bcStack.PushI(sys.fightScreen.ro.start_waittime)
 	case OC_ex2_fightscreenvar_round_callfight_time:
-		sys.bcStack.PushI(sys.lifebar.ro.callfight_time)
+		sys.bcStack.PushI(sys.fightScreen.ro.callfight_time)
 	case OC_ex2_fightscreenvar_time_framespercount:
-		sys.bcStack.PushI(sys.lifebar.ti.framespercount)
+		sys.bcStack.PushI(sys.fightScreen.ti.framespercount)
 	case OC_ex2_groundlevel:
 		sys.bcStack.PushF(c.groundLevel * (c.localscl / oc.localscl))
 	case OC_ex2_layerno:
@@ -3987,13 +3987,13 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		}
 	// FightScreenState
 	case OC_ex2_fightscreenstate_fightdisplay:
-		sys.bcStack.PushB(sys.lifebar.ro.fightDisplayPhase == 1)
+		sys.bcStack.PushB(sys.fightScreen.ro.fightDisplayPhase == 1)
 	case OC_ex2_fightscreenstate_kodisplay:
-		sys.bcStack.PushB(sys.lifebar.ro.koDisplayPhase == 1)
+		sys.bcStack.PushB(sys.fightScreen.ro.koDisplayPhase == 1)
 	case OC_ex2_fightscreenstate_rounddisplay:
-		sys.bcStack.PushB(sys.lifebar.ro.roundDisplayPhase == 1)
+		sys.bcStack.PushB(sys.fightScreen.ro.roundDisplayPhase == 1)
 	case OC_ex2_fightscreenstate_windisplay:
-		sys.bcStack.PushB(sys.lifebar.ro.winDisplayPhase == 1)
+		sys.bcStack.PushB(sys.fightScreen.ro.winDisplayPhase == 1)
 	// MotifState
 	case OC_ex2_motifstate_challenger:
 		sys.bcStack.PushB(sys.motif.ch.active)
@@ -11706,7 +11706,7 @@ func (sc lifebarAction) Run(c *Char, _ []int32) bool {
 	snd := [2]int32{-1, 0}
 
 	// Initialize a text message with defaults
-	msg := newLbMsg(crun.teamside)
+	msg := newFSMsg(crun.teamside)
 
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
@@ -11758,11 +11758,11 @@ func (sc lifebarAction) Run(c *Char, _ []int32) bool {
 	})
 
 	if msg.resttime < 0 {
-		msg.resttime = sys.lifebar.ac[crun.teamside].displaytime
+		msg.resttime = sys.fightScreen.ac[crun.teamside].displaytime
 	}
 	msg.resttime = int32(float32(msg.resttime) * timemul)
 
-	sys.lifebar.appendAction(crun, msg, s_ffx, a_ffx, snd, spr, anim, top)
+	sys.fightScreen.appendAction(crun, msg, s_ffx, a_ffx, snd, spr, anim, top)
 	return false
 }
 
@@ -12974,7 +12974,7 @@ func (sc text) Run(c *Char, _ []int32) bool {
 
 			switch fflg {
 			case "f":
-				fntList = sys.lifebar.fnt
+				fntList = sys.fightScreen.fnt
 			case "m":
 				fntList = sys.motif.Fnt
 			}
@@ -12983,7 +12983,7 @@ func (sc text) Run(c *Char, _ []int32) bool {
 					ts.fnt = f
 					switch fflg {
 					case "f":
-						sourceLcx = sys.lifebar.localcoord[0]
+						sourceLcx = sys.fightScreen.localcoord[0]
 					case "m":
 						sourceLcx = sys.motif.Info.Localcoord[0]
 					default:
@@ -13178,7 +13178,7 @@ func (sc modifyText) Run(c *Char, _ []int32) bool {
 
 				switch fflg {
 				case "f":
-					fntList = sys.lifebar.fnt
+					fntList = sys.fightScreen.fnt
 				case "m":
 					fntList = sys.motif.Fnt
 				}
@@ -13189,7 +13189,7 @@ func (sc modifyText) Run(c *Char, _ []int32) bool {
 							ts.fnt = f
 							switch fflg {
 							case "f":
-								ts.scaleRatio = float32(c.gi().localcoord[0]) / float32(sys.lifebar.localcoord[0])
+								ts.scaleRatio = float32(c.gi().localcoord[0]) / float32(sys.fightScreen.localcoord[0])
 							case "m":
 								ts.scaleRatio = float32(c.gi().localcoord[0]) / float32(sys.motif.Info.Localcoord[0])
 							default:

--- a/src/char.go
+++ b/src/char.go
@@ -8984,7 +8984,7 @@ func (c *Char) remapPal(pfx *PalFX, src [2]int32, dst [2]int32) {
 	// TODO: Now that this actually works, we could make it optional via a new parameter
 	if srcDepth != dstDepth {
 		sys.appendToConsole(c.warn() + fmt.Sprintf(
-			" RemapPal color depth mismatch: %v,%v (%d colors) -> %v,%v (%d colors)",
+			"RemapPal color depth mismatch: %v,%v (%d colors) -> %v,%v (%d colors)",
 			src[0], src[1], srcDepth, dst[0], dst[1], dstDepth))
 		return
 	}
@@ -8996,16 +8996,15 @@ func (c *Char) remapPal(pfx *PalFX, src [2]int32, dst [2]int32) {
 
 	// Perform palette remap
 	if plist.SwapPalMap(&pfx.remap) {
-		plist.Remap(si, di)
-
-		// Remap palette 1, 1 in SFF v1
+		// For SFFv1, if remapping palette 1,1 remap whatever palette sprite 0,0 uses
 		if src[0] == 1 && src[1] == 1 && c.gi().sff.header.Version[0] == 1 {
 			if spr := c.gi().sff.GetSprite(0, 0); spr != nil {
-				plist.Remap(spr.palidx, di)
+				if spr.GetPal(&plist) != nil && spr.palidx >= 0 {
+					plist.Remap(spr.palidx, di)
+				}
 			}
-			if spr := c.gi().sff.GetSprite(9000, 0); spr != nil {
-				plist.Remap(spr.palidx, di)
-			}
+		} else {
+			plist.Remap(si, di)
 		}
 
 		plist.SwapPalMap(&pfx.remap)

--- a/src/char.go
+++ b/src/char.go
@@ -3654,7 +3654,7 @@ func (c *Char) load(def string) error {
 	// Load common constants
 	for _, key := range SortedKeys(sys.cfg.Common.Const) {
 		for _, v := range sys.cfg.Common.Const[key] {
-			if err := LoadFile(&v, []string{def, sys.motif.Def, sys.lifebar.def, "", "data/"}, func(filename string) error {
+			if err := LoadFile(&v, []string{def, sys.motif.Def, sys.fightScreen.def, "", "data/"}, func(filename string) error {
 				str, err = LoadText(filename)
 				if err != nil {
 					return err
@@ -3993,7 +3993,7 @@ func (c *Char) load(def string) error {
 	// Append common animations
 	for _, key := range SortedKeys(sys.cfg.Common.Air) {
 		for _, v := range sys.cfg.Common.Air[key] {
-			if err := LoadFile(&v, []string{def, sys.motif.Def, sys.lifebar.def, "", "data/"}, func(filename string) error {
+			if err := LoadFile(&v, []string{def, sys.motif.Def, sys.fightScreen.def, "", "data/"}, func(filename string) error {
 				txt, err := LoadText(filename)
 				if err != nil {
 					return err
@@ -5004,7 +5004,7 @@ func (c *Char) comboCount() int32 {
 	if c.teamside == -1 {
 		return 0
 	}
-	return sys.lifebar.co[c.teamside].combo
+	return sys.fightScreen.co[c.teamside].combo
 }
 
 func (c *Char) command(pn, i int) bool {
@@ -5894,9 +5894,9 @@ func (c *Char) updateTeamOrder(team []int) {
 
 	// Update lifebar order within its bounds
 	side := c.playerNo & 1
-	for i := range sys.lifebar.teamOrder[side] {
+	for i := range sys.fightScreen.teamOrder[side] {
 		if i < len(team) {
-			sys.lifebar.teamOrder[side][i] = team[i]
+			sys.fightScreen.teamOrder[side][i] = team[i]
 		}
 	}
 }
@@ -7170,7 +7170,7 @@ func (c *Char) hitAdd(h int32) {
 			if t := sys.playerID(tid); t != nil {
 				t.receivedHits += h
 				if c.teamside != -1 {
-					sys.lifebar.co[c.teamside].combo += h
+					sys.fightScreen.co[c.teamside].combo += h
 				}
 			}
 		}
@@ -7180,7 +7180,7 @@ func (c *Char) hitAdd(h int32) {
 			if len(p) > 0 && c.teamside == ^i&1 {
 				if p[0].receivedHits != 0 || p[0].ss.moveType == MT_H {
 					p[0].receivedHits += h
-					sys.lifebar.co[c.teamside].combo += h
+					sys.fightScreen.co[c.teamside].combo += h
 				}
 			}
 		}
@@ -8488,14 +8488,14 @@ func (c *Char) score() float32 {
 	if c.teamside == -1 {
 		return 0
 	}
-	return sys.lifebar.sc[c.teamside].scorePoints
+	return sys.fightScreen.sc[c.teamside].scorePoints
 }
 
 func (c *Char) scoreAdd(val float32) {
 	if val == 0 || c.teamside == -1 || c.asf(ASF_noscore) {
 		return
 	}
-	sys.lifebar.sc[c.teamside].scorePoints += val
+	sys.fightScreen.sc[c.teamside].scorePoints += val
 }
 
 func (c *Char) scoreTotal() float32 {
@@ -8520,7 +8520,7 @@ func (c *Char) consecutiveWins() int32 {
 }
 
 func (c *Char) dizzyEnabled() bool {
-	return sys.lifebar.stunbar
+	return sys.fightScreen.stunbar
 	/*
 		switch sys.tmode[c.playerNo&1] {
 		case TM_Single:
@@ -8538,7 +8538,7 @@ func (c *Char) dizzyEnabled() bool {
 }
 
 func (c *Char) guardBreakEnabled() bool {
-	return sys.lifebar.guardbar
+	return sys.fightScreen.guardbar
 	/*
 		switch sys.tmode[c.playerNo&1] {
 		case TM_Single:
@@ -8556,7 +8556,7 @@ func (c *Char) guardBreakEnabled() bool {
 }
 
 func (c *Char) redLifeEnabled() bool {
-	return sys.lifebar.redlifebar
+	return sys.fightScreen.redlifebar
 	/*
 			switch sys.tmode[c.playerNo&1] {
 			case TM_Single:
@@ -8859,7 +8859,7 @@ func (c *Char) inputWait() bool {
 		return true
 	}
 	// If after round "over.waittime" and the win poses have not started
-	if sys.intro <= -sys.lifebar.ro.over_waittime && sys.winposetime >= 0 {
+	if sys.intro <= -sys.fightScreen.ro.over_waittime && sys.winposetime >= 0 {
 		return true
 	}
 	return false
@@ -10952,7 +10952,7 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 			!(c.hitdef.air_type == HT_None && getter.ss.stateType == ST_A || getter.ss.stateType != ST_A && c.hitdef.ground_type == HT_None) {
 			getter.receivedHits += hd.numhits
 			if c.teamside != -1 {
-				sys.lifebar.co[c.teamside].combo += hd.numhits
+				sys.fightScreen.co[c.teamside].combo += hd.numhits
 			}
 		}
 		if !math.IsNaN(float64(hd.score[0])) && !c.asf(ASF_noscore) {
@@ -11224,7 +11224,7 @@ func (c *Char) actionPrepare() {
 					if c.scf(SCF_guard) && c.inguarddist && !c.inGuardState() && c.ss.stateType != ST_L && c.cmd[0].Buffer.Bb > 0 {
 						c.changeState(120, -1, -1, "") // Start guarding
 					} else if !c.asf(ASF_nojump) && c.ss.stateType == ST_S && c.cmd[0].Buffer.Ub > 0 &&
-						(!(sys.intro < 0 && sys.intro > -sys.lifebar.ro.over_waittime) || c.asf(ASF_postroundinput)) {
+						(!(sys.intro < 0 && sys.intro > -sys.fightScreen.ro.over_waittime) || c.asf(ASF_postroundinput)) {
 						if c.ss.no != 40 {
 							c.changeState(40, -1, -1, "") // Jump
 						}

--- a/src/char.go
+++ b/src/char.go
@@ -5004,7 +5004,7 @@ func (c *Char) comboCount() int32 {
 	if c.teamside == -1 {
 		return 0
 	}
-	return sys.fightScreen.combos[c.teamside].combo
+	return sys.fightScreen.combos[c.teamside].truehits
 }
 
 func (c *Char) command(pn, i int) bool {
@@ -7163,24 +7163,32 @@ func (c *Char) hitAdd(h int32) {
 	if h == 0 {
 		return
 	}
+
+	// Add to char-side counters
 	c.hitCount += h
 	c.uniqHitCount += h
+
+	// Add to enemy so it's reflected in the combo total
 	if len(c.targets) > 0 {
+		// Increase hits in the most recent target only
+		// Previously, Ikemen increased hits in every target, but Mugen doesn't do this correction and we can't assume that's what the user wants
 		for _, tid := range c.targets {
 			if t := sys.playerID(tid); t != nil {
 				t.receivedHits += h
-				if c.teamside != -1 {
-					sys.fightScreen.combos[c.teamside].combo += h
-				}
+				break
+				//if c.teamside != -1 {
+				//	sys.fightScreen.combos[c.teamside].truehits += h
+				//}
 			}
 		}
 	} else if c.teamside != -1 {
 		// In Mugen, HitAdd can increase combo count even without targets
 		for i, p := range sys.chars {
 			if len(p) > 0 && c.teamside == ^i&1 {
+				// This is a bit of a workaround for backward compatibility only
 				if p[0].receivedHits != 0 || p[0].ss.moveType == MT_H {
 					p[0].receivedHits += h
-					sys.fightScreen.combos[c.teamside].combo += h
+					//sys.fightScreen.combos[c.teamside].truehits += h
 				}
 			}
 		}
@@ -10951,9 +10959,10 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 		if (ghvset || getter.csf(CSF_gethit)) && getter.hoverIdx < 0 &&
 			!(c.hitdef.air_type == HT_None && getter.ss.stateType == ST_A || getter.ss.stateType != ST_A && c.hitdef.ground_type == HT_None) {
 			getter.receivedHits += hd.numhits
-			if c.teamside != -1 {
-				sys.fightScreen.combos[c.teamside].combo += hd.numhits
-			}
+			// receivedHits is the only source of truth
+			//if c.teamside != -1 {
+			//	sys.fightScreen.combos[c.teamside].truehits += hd.numhits
+			//}
 		}
 		if !math.IsNaN(float64(hd.score[0])) && !c.asf(ASF_noscore) {
 			c.scoreAdd(hd.score[0])

--- a/src/char.go
+++ b/src/char.go
@@ -3292,7 +3292,6 @@ func (c *Char) init(n int, idx int) {
 	}
 
 	// Initialize CNS variables
-	// TODO: If we make maps persist between matches, they should be here as well
 	c.initCnsVar()
 
 	// Init the map array
@@ -3303,6 +3302,12 @@ func (c *Char) init(n int, idx int) {
 	if n >= 0 && n < len(sys.aiLevel) && sys.aiLevel[n] != 0 {
 		c.controller ^= -1
 	}
+
+	// Default localcoord
+	c.localcoord = 320 / (float32(sys.gameWidth) / 320)
+	c.localscl = 320 / c.localcoord
+
+	// This first pass only initializes state to safe defaults. Will run again later after the character is fully set up
 	c.clearState()
 }
 
@@ -3466,13 +3471,11 @@ func (c *Char) load(def string) error {
 	// We don't nil the SFF so that loadSff() can reuse it if the same character is selected/reloaded
 	//gi.sff = nil
 
-	// Reset DEF file maps
-	c.mapDefault = make(map[string]float32)
-
 	// Default localcoord
 	gi.localcoord = [2]int32{320, 240}
-	c.localcoord = 320 / (float32(sys.gameWidth) / 320)
-	c.localscl = 320 / c.localcoord
+
+	// Reset DEF file maps
+	c.mapDefault = make(map[string]float32)
 
 	// Helper to resolve paths relative to the .def file's logical location
 	resolvePathRelativeToDef := func(pathInDefFile string) string {
@@ -6538,6 +6541,8 @@ func (c *Char) newHelper() (h *Char) {
 	h.parentId = c.id
 	h.controller = c.controller
 	h.teamside = c.teamside
+	h.localcoord = c.localcoord // These two are needed for clearState()
+	h.localscl = c.localscl
 	h.size = c.size
 	h.life, h.lifeMax = c.lifeMax, c.lifeMax
 	h.powerMax = c.powerMax
@@ -6554,7 +6559,7 @@ func (c *Char) newHelper() (h *Char) {
 
 // Init helper after reading the bytecode parameters
 func (c *Char) helperInit(h *Char, st int32, pt PosType, x, y, z float32, facing int32, rp [2]int32, extmap bool) {
-	p := c.helperPos(pt, [...]float32{x, y, z}, facing, &h.facing, h.localscl, false)
+	p := c.helperPos(pt, [3]float32{x, y, z}, facing, &h.facing, h.localscl, false)
 	h.setPosX(p[0], true)
 	h.setPosY(p[1], true)
 	h.setPosZ(p[2], true)
@@ -7224,8 +7229,8 @@ func (c *Char) commitProjectile(p *Projectile, pt PosType, offx, offy, offz floa
 	}
 
 	// Set starting position
-	pos := c.helperPos(pt, [...]float32{offx, offy, offz}, 1, &p.facing, p.localscl, true)
-	p.setAllPos([...]float32{pos[0], pos[1], pos[2]})
+	pos := c.helperPos(pt, [3]float32{offx, offy, offz}, 1, &p.facing, p.localscl, true)
+	p.setAllPos([3]float32{pos[0], pos[1], pos[2]})
 
 	// Clamp negative animations
 	if p.animNo < -2 {

--- a/src/char.go
+++ b/src/char.go
@@ -5004,7 +5004,7 @@ func (c *Char) comboCount() int32 {
 	if c.teamside == -1 {
 		return 0
 	}
-	return sys.fightScreen.co[c.teamside].combo
+	return sys.fightScreen.combos[c.teamside].combo
 }
 
 func (c *Char) command(pn, i int) bool {
@@ -7170,7 +7170,7 @@ func (c *Char) hitAdd(h int32) {
 			if t := sys.playerID(tid); t != nil {
 				t.receivedHits += h
 				if c.teamside != -1 {
-					sys.fightScreen.co[c.teamside].combo += h
+					sys.fightScreen.combos[c.teamside].combo += h
 				}
 			}
 		}
@@ -7180,7 +7180,7 @@ func (c *Char) hitAdd(h int32) {
 			if len(p) > 0 && c.teamside == ^i&1 {
 				if p[0].receivedHits != 0 || p[0].ss.moveType == MT_H {
 					p[0].receivedHits += h
-					sys.fightScreen.co[c.teamside].combo += h
+					sys.fightScreen.combos[c.teamside].combo += h
 				}
 			}
 		}
@@ -8488,14 +8488,14 @@ func (c *Char) score() float32 {
 	if c.teamside == -1 {
 		return 0
 	}
-	return sys.fightScreen.sc[c.teamside].scorePoints
+	return sys.fightScreen.scores[c.teamside].scorePoints
 }
 
 func (c *Char) scoreAdd(val float32) {
 	if val == 0 || c.teamside == -1 || c.asf(ASF_noscore) {
 		return
 	}
-	sys.fightScreen.sc[c.teamside].scorePoints += val
+	sys.fightScreen.scores[c.teamside].scorePoints += val
 }
 
 func (c *Char) scoreTotal() float32 {
@@ -8859,7 +8859,7 @@ func (c *Char) inputWait() bool {
 		return true
 	}
 	// If after round "over.waittime" and the win poses have not started
-	if sys.intro <= -sys.fightScreen.ro.over_waittime && sys.winposetime >= 0 {
+	if sys.intro <= -sys.fightScreen.round.over_waittime && sys.winposetime >= 0 {
 		return true
 	}
 	return false
@@ -10952,7 +10952,7 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 			!(c.hitdef.air_type == HT_None && getter.ss.stateType == ST_A || getter.ss.stateType != ST_A && c.hitdef.ground_type == HT_None) {
 			getter.receivedHits += hd.numhits
 			if c.teamside != -1 {
-				sys.fightScreen.co[c.teamside].combo += hd.numhits
+				sys.fightScreen.combos[c.teamside].combo += hd.numhits
 			}
 		}
 		if !math.IsNaN(float64(hd.score[0])) && !c.asf(ASF_noscore) {
@@ -11224,7 +11224,7 @@ func (c *Char) actionPrepare() {
 					if c.scf(SCF_guard) && c.inguarddist && !c.inGuardState() && c.ss.stateType != ST_L && c.cmd[0].Buffer.Bb > 0 {
 						c.changeState(120, -1, -1, "") // Start guarding
 					} else if !c.asf(ASF_nojump) && c.ss.stateType == ST_S && c.cmd[0].Buffer.Ub > 0 &&
-						(!(sys.intro < 0 && sys.intro > -sys.fightScreen.ro.over_waittime) || c.asf(ASF_postroundinput)) {
+						(!(sys.intro < 0 && sys.intro > -sys.fightScreen.round.over_waittime) || c.asf(ASF_postroundinput)) {
 						if c.ss.no != 40 {
 							c.changeState(40, -1, -1, "") // Jump
 						}

--- a/src/char.go
+++ b/src/char.go
@@ -5894,9 +5894,9 @@ func (c *Char) updateTeamOrder(team []int) {
 
 	// Update lifebar order within its bounds
 	side := c.playerNo & 1
-	for i := range sys.lifebar.order[side] {
+	for i := range sys.lifebar.teamOrder[side] {
 		if i < len(team) {
-			sys.lifebar.order[side][i] = team[i]
+			sys.lifebar.teamOrder[side][i] = team[i]
 		}
 	}
 }

--- a/src/char.go
+++ b/src/char.go
@@ -1857,8 +1857,13 @@ func (e *Explod) setAnim() {
 	}
 
 	// Get animation with sprite owner context
-	a := c.getAnimSprite(e.animNo, e.animPN, e.spritePN, e.anim_ffx, e.ownpal, true)
+	a := c.getAnimSprite(e.animNo, e.animPN, e.spritePN, e.anim_ffx, e.ownpal)
 	if a == nil {
+		if e.id < 0 {
+			sys.appendToConsole(c.warn() + fmt.Sprintf("system explod called invalid action %v%v", strings.ToUpper(e.anim_ffx), e.animNo))
+		} else {
+			sys.appendToConsole(c.warn() + fmt.Sprintf("explod with ID %v called invalid action %v%v", e.id, strings.ToUpper(e.anim_ffx), e.animNo))
+		}
 		return
 	}
 	e.anim = a
@@ -2490,26 +2495,32 @@ func (p *Projectile) update() {
 					if p.hitanim == -1 {
 						// Forcefully clear instead of reaching the fallback where invalid animation does nothing
 						p.anim = nil
-					} else if a := p.owner().getSelfAnimSprite(p.hitanim, p.hitanim_ffx, true, true); a != nil {
+					} else if a := p.owner().getSelfAnimSprite(p.hitanim, p.hitanim_ffx, true); a != nil {
 						p.anim = a
+					} else {
+						sys.appendToConsole(p.owner().warn() + fmt.Sprintf("projectile with ID %v called invalid action %v%v", p.id, strings.ToUpper(p.hitanim_ffx), p.hitanim))
 					}
 				}
 			case ProjCancel:
 				if p.cancelanim != p.animNo || p.cancelanim_ffx != p.anim_ffx {
 					if p.cancelanim == -1 {
 						p.anim = nil
-					} else if a := p.owner().getSelfAnimSprite(p.cancelanim, p.cancelanim_ffx, true, true); a != nil {
+					} else if a := p.owner().getSelfAnimSprite(p.cancelanim, p.cancelanim_ffx, true); a != nil {
 						p.anim = a
+					} else {
+						sys.appendToConsole(p.owner().warn() + fmt.Sprintf("projectile with ID %v called invalid action %v%v", p.id, strings.ToUpper(p.cancelanim_ffx), p.cancelanim))
 					}
 				}
 			case ProjRem:
 				if p.remanim != p.animNo || p.remanim_ffx != p.anim_ffx {
 					if p.remanim == -1 {
 						p.anim = nil
-					} else if a := p.owner().getSelfAnimSprite(p.remanim, p.remanim_ffx, true, true); a != nil {
+					} else if a := p.owner().getSelfAnimSprite(p.remanim, p.remanim_ffx, true); a != nil {
 						p.anim = a
+					} else {
 						// In Mugen, if remanim is invalid the projectile will keep the current one
 						// https://github.com/ikemen-engine/Ikemen-GO/issues/2584
+						sys.appendToConsole(p.owner().warn() + fmt.Sprintf("projectile with ID %v called invalid action %v%v", p.id, strings.ToUpper(p.remanim_ffx), p.remanim))
 					}
 				}
 			}
@@ -4316,13 +4327,14 @@ func (c *Char) clearHitDef() {
 
 func (c *Char) changeAnimEx(animNo int32, animPlayerNo int, spritePlayerNo int, ffx string) {
 	// Get the animation
-	a := c.getAnimSprite(animNo, animPlayerNo, spritePlayerNo, ffx, c.ownpal, false)
+	a := c.getAnimSprite(animNo, animPlayerNo, spritePlayerNo, ffx, c.ownpal)
 
 	// If invalid
 	// In Mugen, when switching between different animation tables (e.g. ChangeAnim2) and the destination doesn't exist,
 	// the character will change into whatever animation is in the same index as the table it is changing from
 	// We don't do that at the moment
 	if a == nil {
+		sys.appendToConsole(c.warn() + fmt.Sprintf("attempted to change to invalid action %v%v", strings.ToUpper(ffx), animNo))
 		return
 	}
 
@@ -6910,9 +6922,9 @@ func (c *Char) removeText(id, index int32) {
 }
 
 // Get animation and apply sprite owner properties to it
-func (c *Char) getAnimSprite(animNo int32, animPlayerNo, spritePlayerNo int, ffx string, ownpal bool, fx bool) *Animation {
+func (c *Char) getAnimSprite(animNo int32, animPlayerNo, spritePlayerNo int, ffx string, ownpal bool) *Animation {
 	// Get raw animation
-	a := sys.chars[animPlayerNo][0].getAnim(animNo, ffx, fx)
+	a := sys.chars[animPlayerNo][0].getAnim(animNo, ffx)
 	if a == nil {
 		return nil
 	}
@@ -6925,14 +6937,14 @@ func (c *Char) getAnimSprite(animNo int32, animPlayerNo, spritePlayerNo int, ffx
 
 // Calls getAnimSprite without the extra anim/sprite playerNo features
 // For projectiles essentially
-func (c *Char) getSelfAnimSprite(animNo int32, ffx string, ownpal bool, fx bool) *Animation {
-	a := c.getAnimSprite(animNo, c.playerNo, c.playerNo, ffx, ownpal, fx)
+func (c *Char) getSelfAnimSprite(animNo int32, ffx string, ownpal bool) *Animation {
+	a := c.getAnimSprite(animNo, c.playerNo, c.playerNo, ffx, ownpal)
 
 	return a
 }
 
 // Calls getAnimSprite with playerNo checks for Shadows and Reflections
-func (c *Char) getShadowReflectionSprite(animNo int32, animPlayerNo, spritePlayerNo int, ffx string, ownpal bool, fx bool, scname string) *Animation {
+func (c *Char) getShadowReflectionSprite(animNo int32, animPlayerNo, spritePlayerNo int, ffx string, ownpal bool, scname string) *Animation {
 	// Validate AnimPlayerNo
 	if animPlayerNo < 0 {
 		animPlayerNo = c.playerNo
@@ -6948,11 +6960,11 @@ func (c *Char) getShadowReflectionSprite(animNo int32, animPlayerNo, spritePlaye
 		spritePlayerNo = c.playerNo
 	}
 
-	return c.getAnimSprite(animNo, animPlayerNo, spritePlayerNo, ffx, ownpal, fx)
+	return c.getAnimSprite(animNo, animPlayerNo, spritePlayerNo, ffx, ownpal)
 }
 
 // Same old getAnim, but now without the FFX scale adjustment
-func (c *Char) getAnim(n int32, ffx string, fx bool) (a *Animation) {
+func (c *Char) getAnim(n int32, ffx string) (a *Animation) {
 	// Return empty but valid animation
 	if n == -2 {
 		return &Animation{}
@@ -6980,6 +6992,7 @@ func (c *Char) getAnim(n int32, ffx string, fx bool) (a *Animation) {
 		a = c.gi().animTable.get(n)
 	}
 
+	/*
 	// Log invalid animations
 	if a == nil {
 		if fx {
@@ -7005,6 +7018,7 @@ func (c *Char) getAnim(n int32, ffx string, fx bool) (a *Animation) {
 			LogMessage("%v%v", str, n)
 		}
 	}
+	*/
 
 	return
 }
@@ -7224,9 +7238,11 @@ func (c *Char) commitProjectile(p *Projectile, pt PosType, offx, offy, offz floa
 	}
 
 	// Get animation with sprite context
-	p.anim = c.getSelfAnimSprite(p.animNo, p.anim_ffx, true, true)
+	p.anim = c.getSelfAnimSprite(p.animNo, p.anim_ffx, true)
 
 	if p.anim == nil && c.anim != nil {
+		// TODO: If Ikemenversion, the invalid animation probably ought to make explod disappear
+		sys.appendToConsole(c.warn() + fmt.Sprintf("projectile with ID %v called invalid action %v%v", p.id, strings.ToUpper(p.anim_ffx), p.animNo))
 		// The Mugen fallback is to copy the character's current animation
 		p.anim = &Animation{}
 		*p.anim = *c.anim
@@ -10998,7 +11014,7 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 
 		if animNo >= 0 {
 			if e, i := c.spawnExplod(); e != nil {
-				//e.anim = c.getAnim(animNo, ffx, true)
+				//e.anim = c.getAnim(animNo, ffx)
 				e.animNo = animNo
 				e.anim_ffx = ffx
 				e.layerno = 1 // e.ontop = true

--- a/src/common.go
+++ b/src/common.go
@@ -1057,14 +1057,14 @@ func (l *Layout) Read(pre string, is IniSection) {
 	}
 }
 
-// Calculates the lifebar window local coordinates into real screen pixels,
+// Calculates the fight screen window local coordinates into real screen pixels,
 // taking the FightAspect ratio into account
 func (l *Layout) calcLBRect(window [4]int32) [4]int32 {
 	if window[2] == sys.scrrect[2] && window[3] == sys.scrrect[3] {
 		return sys.scrrect
 	}
 
-	baseScale := float32(sys.scrrect[2]) / float32(sys.lifebar.localcoord[0])
+	baseScale := float32(sys.scrrect[2]) / float32(sys.fightScreen.localcoord[0])
 	screenAspect := float32(sys.scrrect[2]) / float32(sys.scrrect[3])
 	fightAspect := sys.getFightAspect()
 	correction := fightAspect / screenAspect
@@ -1087,10 +1087,10 @@ func (l *Layout) DrawFaceSprite(x, y float32, ln int16, s *Sprite, fx *PalFX, fs
 		}
 		// TODO: test "phantom pixel"
 		if l.facing < 0 {
-			x += sys.lifebar.fnt_scale * sys.lifebar.scale
+			x += sys.fightScreen.fnt_scale * sys.fightScreen.scale
 		}
 		if l.vfacing < 0 {
-			y += sys.lifebar.fnt_scale * sys.lifebar.scale
+			y += sys.fightScreen.fnt_scale * sys.fightScreen.scale
 		}
 		if s.coldepth <= 8 && s.PalTex == nil {
 			s.PalTex = s.CachePalTex(s.Pal)
@@ -1099,7 +1099,7 @@ func (l *Layout) DrawFaceSprite(x, y float32, ln int16, s *Sprite, fx *PalFX, fs
 		xshear := -l.xshear
 		xsoffset := xshear * (float32(s.Offset[1]) * l.scale[1] * fscale)
 
-		s.Draw(x+l.offset[0]*sys.lifebar.scale-xsoffset, y+l.offset[1]*sys.lifebar.scale,
+		s.Draw(x+l.offset[0]*sys.fightScreen.scale-xsoffset, y+l.offset[1]*sys.fightScreen.scale,
 			l.scale[0]*float32(l.facing)*fscale, l.scale[1]*float32(l.vfacing)*fscale,
 			xshear, l.rot, int32(l.projection), l.fLength, fx, drawwindow)
 	}
@@ -1123,10 +1123,10 @@ func (l *Layout) DrawAnim(r *[4]int32, x, y, scl, xscl, yscl float32, ln int16, 
 		}
 		// TODO: test "phantom pixel"
 		if l.facing < 0 {
-			x += sys.lifebar.fnt_scale
+			x += sys.fightScreen.fnt_scale
 		}
 		if l.vfacing < 0 {
-			y += sys.lifebar.fnt_scale
+			y += sys.fightScreen.fnt_scale
 		}
 		// Xshear offset correction
 		xshear := -l.xshear
@@ -1150,18 +1150,18 @@ func (l *Layout) DrawText(x, y, scl float32, ln int16,
 		}
 		// TODO: test "phantom pixel"
 		if l.facing < 0 {
-			x += sys.lifebar.fnt_scale
+			x += sys.fightScreen.fnt_scale
 		}
 		if l.vfacing < 0 {
-			y += sys.lifebar.fnt_scale
+			y += sys.fightScreen.fnt_scale
 		}
 		// Xshear offset correction
 		xshear := -l.xshear
 		xsoffset := xshear * (float32(f.offset[1]) * l.scale[1] * scl)
 
 		f.Print(text, (x+l.offset[0]-xsoffset)*scl, (y+l.offset[1])*scl,
-			l.scale[0]*sys.lifebar.fnt_scale*float32(l.facing)*scl,
-			l.scale[1]*sys.lifebar.fnt_scale*float32(l.vfacing)*scl, xshear, l.rot,
+			l.scale[0]*sys.fightScreen.fnt_scale*float32(l.facing)*scl,
+			l.scale[1]*sys.fightScreen.fnt_scale*float32(l.vfacing)*scl, xshear, l.rot,
 			int32(l.projection), l.fLength, b, a, drawwindow, palfx, frgba)
 	}
 }
@@ -1296,7 +1296,7 @@ func ReadPalFX(pre string, is IniSection, pfx *PalFX) int32 {
 
 type AnimTextSnd struct {
 	snd         [2]int32
-	text        LbText
+	text        FSText
 	animLayout  AnimLayout
 	displaytime int32
 	cnt         int32
@@ -1321,7 +1321,7 @@ func ReadAnimTextSnd(pre string, is IniSection,
 func (ats *AnimTextSnd) Read(pre string, is IniSection, at AnimationTable,
 	ln int16, f map[int]*Fnt) {
 	is.ReadI32(pre+"snd", &ats.snd[0], &ats.snd[1])
-	ats.text = *readLbText(pre, is, "", ln, f, 0)
+	ats.text = *readFSText(pre, is, "", ln, f, 0)
 	ats.animLayout.lay = *newLayout(ln)
 	ats.animLayout.Read(pre, is, at, ln)
 	is.ReadI32(pre+"displaytime", &ats.displaytime)
@@ -1357,8 +1357,8 @@ func (ats *AnimTextSnd) Draw(x, y float32, layerno int16, f map[int]*Fnt, scale 
 			if ff == nil {
 				break
 			}
-			lineH := float32(ff.Size[1])*ats.text.lay.scale[1]*sys.lifebar.fnt_scale +
-				float32(ff.Spacing[1])*ats.text.lay.scale[1]*sys.lifebar.fnt_scale
+			lineH := float32(ff.Size[1])*ats.text.lay.scale[1]*sys.fightScreen.fnt_scale +
+				float32(ff.Spacing[1])*ats.text.lay.scale[1]*sys.fightScreen.fnt_scale
 			ats.text.lay.DrawText(x, y+float32(k)*lineH,
 				scale, layerno, v, ff, ats.text.font[1], ats.text.font[2], ats.text.palfx, ats.text.frgba)
 		}
@@ -1372,7 +1372,7 @@ func (ats *AnimTextSnd) NoSound() bool {
 // Check if Draw() function is worth calling
 func (ats *AnimTextSnd) HasDrawable() bool {
 	hasAnim := ats.animLayout.anim != nil && len(ats.animLayout.anim.frames) > 0
-	hasText := ats.text.font[0] >= 0 && len(ats.text.text) > 0 && getFont(sys.lifebar.fnt, ats.text.font[0]) != nil
+	hasText := ats.text.font[0] >= 0 && len(ats.text.text) > 0 && getFont(sys.fightScreen.fnt, ats.text.font[0]) != nil
 
 	return hasAnim || hasText
 }

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1208,6 +1208,7 @@ func (c *Compiler) readOldProjectileID(in *string, trname string, baseLen int, o
 	base := trname[:baseLen]
 	suffix := trname[baseLen:]
 
+	// Helper to process errors
 	invalid := func(msg string) (string, error) {
 		// Print error but proceed with ID 0
 		if sys.ignoreMostErrors {
@@ -1246,6 +1247,24 @@ func (c *Compiler) readOldProjectileID(in *string, trname string, baseLen int, o
 
 	out.appendValue(BytecodeInt(0))
 	return base, nil
+}
+
+// For the first half of "x = y, > z" legacy triggers
+func (c *Compiler) parseOldAnimElemStyle(in *string, name string) (int32, error) {
+	if not, err := c.checkEquality(in); err != nil {
+		return 0, err
+	} else if not && !sys.ignoreMostErrors {
+		// These triggers only support '=' operator in the first part
+		return 0, Error(name + " doesn't support '!=' operator")
+	}
+	if c.token == "-" {
+		return 0, Error(name + " doesn't support '-' operator")
+	}
+	n, err := c.integer2(in)
+	if err != nil {
+		return 0, err
+	}
+	return n, nil
 }
 
 // rd means Redirect
@@ -1391,7 +1410,6 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 	}
 	var be1, be2, be3 BytecodeExp
 	var bv1, bv2, bv3 BytecodeValue
-	var n int32
 	var be BytecodeExp
 	var opc OpCode
 	var err error
@@ -3966,21 +3984,15 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 	case "winhyper":
 		out.append(OC_ex_, OC_ex_winhyper)
 	case "animelem":
-		if not, err := c.checkEquality(in); err != nil {
-			return bvNone(), err
-		} else if not && !sys.ignoreMostErrors {
-			return bvNone(), Error("AnimElem doesn't support '!='")
-		}
-		if c.token == "-" {
-			return bvNone(), Error("'-' should not be used")
-		}
-		if n, err = c.integer2(in); err != nil {
+		n, err := c.parseOldAnimElemStyle(in, "AnimElem")
+		if err != nil {
 			return bvNone(), err
 		}
 		if n <= 0 {
 			return bvNone(), Error("AnimElem must be greater than 0")
 		}
 		be1.appendValue(BytecodeInt(n))
+		// TODO: This probably has the same redirection issue old projectile triggers had
 		if rd {
 			out.appendI32Op(OC_nordrun, int32(len(be1)))
 		}
@@ -3993,15 +4005,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		out.append(be...)
 		return bv, nil
 	case "timemod":
-		if not, err := c.checkEquality(in); err != nil {
-			return bvNone(), err
-		} else if not && !sys.ignoreMostErrors {
-			return bvNone(), Error("TimeMod doesn't support '!='")
-		}
-		if c.token == "-" {
-			return bvNone(), Error("'-' should not be used")
-		}
-		if n, err = c.integer2(in); err != nil {
+		n, err := c.parseOldAnimElemStyle(in, "TimeMod")
+		if err != nil {
 			return bvNone(), err
 		}
 		if n <= 0 {
@@ -5179,8 +5184,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		// projHit123, projGuarded456, projContact789
 		// These will be converted internally to the newer Proj*Time trigger OpCodes
 		l := len(c.token)
-		if l >= 7 && c.token[:7] == "projhit" ||
-			l >= 11 && (c.token[:11] == "projguarded" || c.token[:11] == "projcontact") {
+		if (l >= 7 && c.token[:7] == "projhit") ||
+			(l >= 11 && (c.token[:11] == "projguarded" || c.token[:11] == "projcontact")) {
 			trname, opc := c.token, OC_projhittime
 			var idExp BytecodeExp
 			// Determine contact type OpCode and compile projectile ID
@@ -5202,17 +5207,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 					opc = OC_projcontacttime
 				}
 			}
-			// Legacy projectile triggers only support '=' operator in the first part
-			if not, err := c.checkEquality(in); err != nil {
-				return bvNone(), err
-			} else if not && !sys.ignoreMostErrors {
-				return bvNone(), Error(trname + " doesn't support '!='")
-			}
-			// Reject malformed comparisons like "projhit = -1"
-			if c.token == "-" {
-				return bvNone(), Error("'-' should not be used")
-			}
-			if n, err = c.integer2(in); err != nil {
+			n, err := c.parseOldAnimElemStyle(in, trname)
+			if err != nil {
 				return bvNone(), err
 			}
 			// Mugen only allows 0 or 1 in the first comparison
@@ -5220,19 +5216,24 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 				return bvNone(), Error(trname + " must be compared against 0 or 1")
 			}
 			// Build the underlying Proj*Time(id) expression
-			if rd && len(idExp) > 0 {
-				out.appendI32Op(OC_nordrun, int32(len(idExp)))
-			}
-			out.append(idExp...)
-			out.append(opc)
-			// Optional second legacy form: ProjContact[ID] = value, [oper] value2
-			if err = c.evaluateComparison(out, in, false); err != nil {
+			// Build it as a single block to prevent the first '=' from interrupting the current redirection
+			// https://github.com/ikemen-engine/Ikemen-GO/issues/2123
+			var oldblock BytecodeExp
+			oldblock.append(idExp...)
+			oldblock.append(opc)
+			// Optional second form: ProjContact[ID] = value, [oper] value2
+			if err = c.evaluateComparison(&oldblock, in, false); err != nil {
 				return bvNone(), err
 			}
 			// "= 0" negates the generated time comparison
 			if n == 0 {
-				out.append(OC_blnot)
+				oldblock.append(OC_blnot)
 			}
+			// If we're inside a redirect, force the whole expression to execute in the redirected context
+			if rd {
+				out.appendI32Op(OC_run, int32(len(oldblock)))
+			}
+			out.append(oldblock...)
 			return bvNone(), nil
 		} else if len(c.token) >= 2 && c.token[0] == '$' && c.token != "$_" {
 			vi, ok := c.vars[c.token[1:]]

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1208,40 +1208,43 @@ func (c *Compiler) readOldProjectileID(in *string, trname string, baseLen int, o
 	base := trname[:baseLen]
 	suffix := trname[baseLen:]
 
-	// Documented suffix form: projcontact123
+	invalid := func(msg string) (string, error) {
+		// Print error but proceed with ID 0
+		if sys.ignoreMostErrors {
+			sys.appendToConsole("WARNING: " + sys.cgi[c.playerNo].nameLow +
+				fmt.Sprintf(": %v in state %v ", msg, c.stateNo))
+			out.appendValue(BytecodeInt(0))
+			return base, nil
+		}
+		// Otherwise just crash
+		return "", Error(msg)
+	}
+
+	// Only a fully numeric suffix is treated as an ID. Everything else falls back to an ID of 0
 	if len(suffix) > 0 {
 		for _, ch := range suffix {
 			if ch < '0' || ch > '9' {
-				return "", Error("Invalid projectile ID: " + suffix)
+				return invalid("Invalid projectile ID: " + suffix)
 			}
 		}
 		out.appendValue(BytecodeInt(Atoi(suffix)))
 		return base, nil
 	}
 
-	// Alternative undocumented form: projcontact(123)
-	// Unlike suffix form, we allow a full expression here
-	// https://github.com/ikemen-engine/Ikemen-GO/issues/1860
+	// Peek next token and put it back so it isn’t consumed
 	tok := c.tokenizer(in)
-	if tok != "(" {
-		if len(tok) > 0 {
-			*in = tok + " " + *in
-		}
-		out.appendValue(BytecodeInt(0))
-		return base, nil
+	if len(tok) > 0 {
+		// Add space to avoid merging tokens when putting it back
+		*in = tok + " " + *in
 	}
 
-	c.token = c.tokenizer(in)
-
-	bv, err := c.expBoolOr(out, in)
-	if err != nil {
-		return "", err
+	// Turns out using parentheses around the ID isn't valid either. It's just also considered gibberish and evaluated as 0
+	// https://github.com/ikemen-engine/Ikemen-GO/issues/1860
+	if tok == "(" {
+		return invalid("Projectile ID cannot have parentheses")
 	}
-	out.appendValue(bv)
 
-	if err := c.checkClosingParenthesis(); err != nil {
-		return "", err
-	}
+	out.appendValue(BytecodeInt(0))
 	return base, nil
 }
 

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -8058,7 +8058,7 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 	}
 	for _, key := range SortedKeys(sys.cfg.Common.Cmd) {
 		for _, v := range sys.cfg.Common.Cmd[key] {
-			if err := LoadFile(&v, []string{def, sys.motif.Def, sys.lifebar.def, "", "data/"}, func(filename string) error {
+			if err := LoadFile(&v, []string{def, sys.motif.Def, sys.fightScreen.def, "", "data/"}, func(filename string) error {
 				txt, err := LoadText(filename)
 				if err != nil {
 					return err
@@ -8235,7 +8235,7 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 	// Compile common states
 	for _, key := range SortedKeys(sys.cfg.Common.States) {
 		for _, v := range sys.cfg.Common.States[key] {
-			if err := c.stateCompile(states, v, []string{def, sys.motif.Def, sys.lifebar.def, "", "data/"},
+			if err := c.stateCompile(states, v, []string{def, sys.motif.Def, sys.fightScreen.def, "", "data/"},
 				false, constants); err != nil {
 				return nil, err
 			}

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -2301,14 +2301,13 @@ type FightScreenCombo struct {
 	hidespeed      float32
 	separator      string
 	places         int32
-	curhit, oldhit int32
-	curdmg, olddmg int32
-	curpct, oldpct float32
+	truehits       int32
+	shownhits      int32
+	showndmg       int32
+	shownpct       float32
 	resttime       int32
 	counterX       float32
 	shaketime      int32
-	combo          int32
-	tracker        int32
 	autoalign      bool
 }
 
@@ -2369,20 +2368,16 @@ func readFightScreenCombo(pre string, is IniSection,
 	return co
 }
 
-func (co *FightScreenCombo) step(combo, damage int32, percentage float32, dizzy bool) {
+func (co *FightScreenCombo) step(hits, damage int32, percentage float32, dizzy bool) {
 	co.bg.Action()
 	co.top.Action()
 
-	// Update team combo tracker
-	if combo > 0 {
-		combo = co.combo
-	} else {
-		co.combo = 0
-	}
+	// Always save combo tally result for access by triggers
+	co.truehits = hits
 
 	if co.resttime > 0 {
 		co.counterX -= co.counterX / co.showspeed
-	} else if combo < 2 {
+	} else if co.truehits < 2 {
 		co.counterX -= sys.fightScreen.fnt_scale * co.hidespeed * float32(sys.fightScreen.localcoord[0]) / 320
 		if co.counterX < co.start_x*2 {
 			co.counterX = co.start_x * 2
@@ -2398,32 +2393,31 @@ func (co *FightScreenCombo) step(combo, damage int32, percentage float32, dizzy 
 	}
 
 	// Update if number of hits or total damage change
-	if combo >= 2 {
-		if co.oldhit != combo || co.olddmg != damage {
+	if co.truehits >= 2 && (co.shownhits != co.truehits || co.showndmg != damage) {
+		// Reset visuals when hits changed
+		if co.shownhits != co.truehits {
+			if co.counter_shake {
+				co.shaketime = co.counter_time
+			}
 			for i := range co.counter {
 				co.counter[i].resetTxtPfx()
 			}
 			for i := range co.text {
 				co.text[i].resetTxtPfx()
 			}
-			co.curhit = combo
-			co.curdmg = damage
-			co.curpct = percentage
-			co.resttime = co.displaytime
-			co.tracker = co.combo
-			if co.counter_shake && co.oldhit != combo {
-				co.shaketime = co.counter_time
-			}
 		}
+		// Time resets if either hits or damage changed
+		co.resttime = co.displaytime
+		// Update state
+		co.shownhits = co.truehits
+		co.showndmg = damage
+		co.shownpct = percentage
 	}
-	co.oldhit = combo
-	co.olddmg = damage
-	co.oldpct = percentage
 
 	// Multiple counter fonts
 	var cv int32
 	for k := range co.counter {
-		if k > cv && co.tracker >= k {
+		if k > cv && co.shownhits >= k {
 			cv = k
 		}
 	}
@@ -2431,7 +2425,7 @@ func (co *FightScreenCombo) step(combo, damage int32, percentage float32, dizzy 
 	// Multiple text fonts
 	var tv int32
 	for k := range co.text {
-		if k > tv && co.tracker >= k {
+		if k > tv && co.shownhits >= k {
 			tv = k
 		}
 	}
@@ -2445,11 +2439,11 @@ func (co *FightScreenCombo) step(combo, damage int32, percentage float32, dizzy 
 func (co *FightScreenCombo) reset() {
 	co.bg.Reset()
 	co.top.Reset()
-	co.curhit, co.oldhit = 0, 0
-	co.curdmg, co.olddmg = 0, 0
-	co.curpct, co.oldpct = 0, 0
+	co.truehits = 0
+	co.shownhits = 0
+	co.showndmg = 0
+	co.shownpct = 0
 	co.resttime = 0
-	co.combo = 0
 	co.counterX = co.start_x * 2
 	co.shaketime = 0
 }
@@ -2462,7 +2456,7 @@ func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 	// Multiple counter fonts according to combo hits
 	var cv int32
 	for k := range co.counter {
-		if k > cv && co.tracker >= k {
+		if k > cv && co.shownhits >= k {
 			cv = k
 		}
 	}
@@ -2470,12 +2464,12 @@ func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 	// Multiple text fonts according to combo hits
 	var tv int32
 	for k := range co.text {
-		if k > tv && co.tracker >= k {
+		if k > tv && co.shownhits >= k {
 			tv = k
 		}
 	}
 
-	counter := strings.Replace(co.counter[cv].text, "%i", fmt.Sprintf("%v", co.curhit), 1)
+	counter := strings.Replace(co.counter[cv].text, "%i", fmt.Sprintf("%v", co.shownhits), 1)
 	x := float32(co.pos[0])
 	if side == 0 {
 		if co.start_x <= 0 {
@@ -2495,10 +2489,10 @@ func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 	co.bg.Draw(x+sys.fightScreen.offsetX, float32(co.pos[1]), layerno, sys.fightScreen.scale)
 	var length float32
 	if co.text[tv].font[0] >= 0 && getFont(f, co.text[tv].font[0]) != nil {
-		text := strings.Replace(co.text[tv].text, "%i", fmt.Sprintf("%v", co.curhit), 1)
-		text = strings.Replace(text, "%d", fmt.Sprintf("%v", co.curdmg), 1)
+		text := strings.Replace(co.text[tv].text, "%i", fmt.Sprintf("%v", co.shownhits), 1)
+		text = strings.Replace(text, "%d", fmt.Sprintf("%v", co.showndmg), 1)
 		// Truncate the percentage to avoid rounding to 100% unless the enemy is defeated
-		truncatedPct := math.Floor(float64(co.curpct)*math.Pow10(int(co.places))) / math.Pow10(int(co.places))
+		truncatedPct := math.Floor(float64(co.shownpct)*math.Pow10(int(co.places))) / math.Pow10(int(co.places))
 		// Split float value
 		s := strings.Split(fmt.Sprintf("%.[2]*[1]f", truncatedPct, co.places), ".")
 		// Decimal separator
@@ -5182,7 +5176,8 @@ func (fs *FightScreen) step() {
 	// FightScreenCombo
 	cb, cd, cp, dz := [2]int32{}, [2]int32{}, [2]float32{}, [2]bool{}
 	targets := [2]int32{}
-	for _, ch := range sys.chars { // Iterate through all players to see the combo status of each team
+	// Iterate through all players to see the combo status of each team
+	for _, ch := range sys.chars {
 		for _, c := range ch {
 			if c.receivedHits > 0 && (c.teamside == 0 || c.teamside == 1) && (c.alive() || !c.scf(SCF_over_ko)) { // If alive or not alive but not in state 5150 yet
 				side := 1 - c.teamside

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -2563,7 +2563,7 @@ type FSMsg struct {
 func newFSMsg(side int) *FSMsg {
 	return &FSMsg{
 		resttime:  -1,
-		counterX:  sys.fightScreen.ac[side].start_x * 2,
+		counterX:  sys.fightScreen.actions[side].start_x * 2,
 		fontNo:    -1,
 		fontBank:  -1,
 		fontAlign: IErr, // Default to the font's
@@ -4349,24 +4349,24 @@ type FightScreen struct {
 	fnt           map[int]*Fnt
 	curLayout     [2]int // Which layout each team is currently using. Single, Simul 3P, etc
 	teamOrder     [2][]int // Player order on each team. Because it can vary in Tag
-	lb            [8][]*LifeBar
-	pb            [8][]*PowerBar
-	gb            [8][]*GuardBar
-	sb            [8][]*StunBar
-	fa            [8][]*FightScreenFace
-	nm            [8][]*FightScreenName
-	wi            [2]*FightScreenWinIcon
-	ti            *FightScreenTime
-	co            [2]*FightScreenCombo
-	ac            [2]*FightScreenAction
-	ro            *FightScreenRound
-	ra            [2]*FightScreenRatio
-	tr            *FightScreenTimer
-	sc            [2]*FightScreenScore
-	ma            *FightScreenMatch
-	ai            [2]*FightScreenAiLevel
-	wc            [2]*FightScreenWinCount
-	mo            map[string]*FightScreenMode
+	lifeBars      [8][]*LifeBar
+	powerBars     [8][]*PowerBar
+	guardBars     [8][]*GuardBar
+	stunBars      [8][]*StunBar
+	faces         [8][]*FightScreenFace
+	names         [8][]*FightScreenName
+	winIcons      [2]*FightScreenWinIcon
+	time          *FightScreenTime // The normal round time
+	combos        [2]*FightScreenCombo
+	actions       [2]*FightScreenAction
+	round         *FightScreenRound
+	ratios        [2]*FightScreenRatio
+	timer         *FightScreenTimer // For Time Attack and such
+	scores        [2]*FightScreenScore
+	match         *FightScreenMatch
+	aiLevels      [2]*FightScreenAiLevel
+	winCounts     [2]*FightScreenWinCount
+	modes         map[string]*FightScreenMode
 	missing       map[string]int
 	active        bool
 	bars          bool
@@ -4394,22 +4394,22 @@ func loadFightScreen(def string) (*FightScreen, error) {
 		portraitScale: 1,
 		sff:           &Sff{},
 		snd:           &Snd{},
-		lb: [...][]*LifeBar{make([]*LifeBar, 2), make([]*LifeBar, 8),
+		lifeBars: [...][]*LifeBar{make([]*LifeBar, 2), make([]*LifeBar, 8),
 			make([]*LifeBar, 2), make([]*LifeBar, 8), make([]*LifeBar, 6),
 			make([]*LifeBar, 8), make([]*LifeBar, 6), make([]*LifeBar, 8)},
-		pb: [...][]*PowerBar{make([]*PowerBar, 2), make([]*PowerBar, 8),
+		powerBars: [...][]*PowerBar{make([]*PowerBar, 2), make([]*PowerBar, 8),
 			make([]*PowerBar, 2), make([]*PowerBar, 8), make([]*PowerBar, 6),
 			make([]*PowerBar, 8), make([]*PowerBar, 6), make([]*PowerBar, 8)},
-		gb: [...][]*GuardBar{make([]*GuardBar, 2), make([]*GuardBar, 8),
+		guardBars: [...][]*GuardBar{make([]*GuardBar, 2), make([]*GuardBar, 8),
 			make([]*GuardBar, 2), make([]*GuardBar, 8), make([]*GuardBar, 6),
 			make([]*GuardBar, 8), make([]*GuardBar, 6), make([]*GuardBar, 8)},
-		sb: [...][]*StunBar{make([]*StunBar, 2), make([]*StunBar, 8),
+		stunBars: [...][]*StunBar{make([]*StunBar, 2), make([]*StunBar, 8),
 			make([]*StunBar, 2), make([]*StunBar, 8), make([]*StunBar, 6),
 			make([]*StunBar, 8), make([]*StunBar, 6), make([]*StunBar, 8)},
-		fa: [...][]*FightScreenFace{make([]*FightScreenFace, 2), make([]*FightScreenFace, 8),
+		faces: [...][]*FightScreenFace{make([]*FightScreenFace, 2), make([]*FightScreenFace, 8),
 			make([]*FightScreenFace, 2), make([]*FightScreenFace, 8), make([]*FightScreenFace, 6),
 			make([]*FightScreenFace, 8), make([]*FightScreenFace, 6), make([]*FightScreenFace, 8)},
-		nm: [...][]*FightScreenName{make([]*FightScreenName, 2), make([]*FightScreenName, 8),
+		names: [...][]*FightScreenName{make([]*FightScreenName, 2), make([]*FightScreenName, 8),
 			make([]*FightScreenName, 2), make([]*FightScreenName, 8), make([]*FightScreenName, 6),
 			make([]*FightScreenName, 8), make([]*FightScreenName, 6), make([]*FightScreenName, 8)},
 		active:    true,
@@ -4633,91 +4633,91 @@ func loadFightScreen(def string) (*FightScreen, error) {
 		case "fightfx":
 			is.ReadF32("scale", &ffx.fx_scale)
 		case "lifebar":
-			if fs.lb[0][0] == nil {
-				fs.lb[0][0] = readLifeBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
+			if fs.lifeBars[0][0] == nil {
+				fs.lifeBars[0][0] = readLifeBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
 			}
-			if fs.lb[0][1] == nil {
-				fs.lb[0][1] = readLifeBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
+			if fs.lifeBars[0][1] == nil {
+				fs.lifeBars[0][1] = readLifeBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
 			}
 		case "powerbar":
-			if fs.pb[0][0] == nil {
-				fs.pb[0][0] = readPowerBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
+			if fs.powerBars[0][0] == nil {
+				fs.powerBars[0][0] = readPowerBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
 			}
-			if fs.pb[0][1] == nil {
-				fs.pb[0][1] = readPowerBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
+			if fs.powerBars[0][1] == nil {
+				fs.powerBars[0][1] = readPowerBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
 			}
 		case "guardbar":
-			if fs.gb[0][0] == nil {
-				fs.gb[0][0] = readGuardBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
+			if fs.guardBars[0][0] == nil {
+				fs.guardBars[0][0] = readGuardBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
 			}
-			if fs.gb[0][1] == nil {
-				fs.gb[0][1] = readGuardBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
+			if fs.guardBars[0][1] == nil {
+				fs.guardBars[0][1] = readGuardBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
 			}
 		case "stunbar":
-			if fs.sb[0][0] == nil {
-				fs.sb[0][0] = readStunBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
+			if fs.stunBars[0][0] == nil {
+				fs.stunBars[0][0] = readStunBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
 			}
-			if fs.sb[0][1] == nil {
-				fs.sb[0][1] = readStunBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
+			if fs.stunBars[0][1] == nil {
+				fs.stunBars[0][1] = readStunBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
 			}
 		case "face":
-			if fs.fa[0][0] == nil {
-				fs.fa[0][0] = readFightScreenFace("p1.", is, fs.sff, fs.animTable)
+			if fs.faces[0][0] == nil {
+				fs.faces[0][0] = readFightScreenFace("p1.", is, fs.sff, fs.animTable)
 			}
-			if fs.fa[0][1] == nil {
-				fs.fa[0][1] = readFightScreenFace("p2.", is, fs.sff, fs.animTable)
+			if fs.faces[0][1] == nil {
+				fs.faces[0][1] = readFightScreenFace("p2.", is, fs.sff, fs.animTable)
 			}
 		case "name":
-			if fs.nm[0][0] == nil {
-				fs.nm[0][0] = readFightScreenName("p1.", is, fs.sff, fs.animTable, fs.fnt)
+			if fs.names[0][0] == nil {
+				fs.names[0][0] = readFightScreenName("p1.", is, fs.sff, fs.animTable, fs.fnt)
 			}
-			if fs.nm[0][1] == nil {
-				fs.nm[0][1] = readFightScreenName("p2.", is, fs.sff, fs.animTable, fs.fnt)
+			if fs.names[0][1] == nil {
+				fs.names[0][1] = readFightScreenName("p2.", is, fs.sff, fs.animTable, fs.fnt)
 			}
 		case "turns ":
 			subname = strings.ToLower(subname)
 			switch {
 			case len(subname) >= 7 && subname[:7] == "lifebar":
-				if fs.lb[2][0] == nil {
-					fs.lb[2][0] = readLifeBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.lifeBars[2][0] == nil {
+					fs.lifeBars[2][0] = readLifeBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if fs.lb[2][1] == nil {
-					fs.lb[2][1] = readLifeBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.lifeBars[2][1] == nil {
+					fs.lifeBars[2][1] = readLifeBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
 				}
 			case len(subname) >= 8 && subname[:8] == "powerbar":
-				if fs.pb[2][0] == nil {
-					fs.pb[2][0] = readPowerBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.powerBars[2][0] == nil {
+					fs.powerBars[2][0] = readPowerBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if fs.pb[2][1] == nil {
-					fs.pb[2][1] = readPowerBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.powerBars[2][1] == nil {
+					fs.powerBars[2][1] = readPowerBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
 				}
 			case len(subname) >= 8 && subname[:8] == "guardbar":
-				if fs.gb[2][0] == nil {
-					fs.gb[2][0] = readGuardBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.guardBars[2][0] == nil {
+					fs.guardBars[2][0] = readGuardBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if fs.gb[2][1] == nil {
-					fs.gb[2][1] = readGuardBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.guardBars[2][1] == nil {
+					fs.guardBars[2][1] = readGuardBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
 				}
 			case len(subname) >= 7 && subname[:7] == "stunbar":
-				if fs.sb[2][0] == nil {
-					fs.sb[2][0] = readStunBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.stunBars[2][0] == nil {
+					fs.stunBars[2][0] = readStunBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if fs.sb[2][1] == nil {
-					fs.sb[2][1] = readStunBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.stunBars[2][1] == nil {
+					fs.stunBars[2][1] = readStunBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
 				}
 			case len(subname) >= 4 && subname[:4] == "face":
-				if fs.fa[2][0] == nil {
-					fs.fa[2][0] = readFightScreenFace("p1.", is, fs.sff, fs.animTable)
+				if fs.faces[2][0] == nil {
+					fs.faces[2][0] = readFightScreenFace("p1.", is, fs.sff, fs.animTable)
 				}
-				if fs.fa[2][1] == nil {
-					fs.fa[2][1] = readFightScreenFace("p2.", is, fs.sff, fs.animTable)
+				if fs.faces[2][1] == nil {
+					fs.faces[2][1] = readFightScreenFace("p2.", is, fs.sff, fs.animTable)
 				}
 			case len(subname) >= 4 && subname[:4] == "name":
-				if fs.nm[2][0] == nil {
-					fs.nm[2][0] = readFightScreenName("p1.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.names[2][0] == nil {
+					fs.names[2][0] = readFightScreenName("p1.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if fs.nm[2][1] == nil {
-					fs.nm[2][1] = readFightScreenName("p2.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.names[2][1] == nil {
+					fs.names[2][1] = readFightScreenName("p2.", is, fs.sff, fs.animTable, fs.fnt)
 				}
 			}
 		case "simul ", "simul_3p ", "simul_4p ", "tag ", "tag_3p ", "tag_4p ":
@@ -4737,244 +4737,244 @@ func loadFightScreen(def string) (*FightScreen, error) {
 			subname = strings.ToLower(subname)
 			switch {
 			case len(subname) >= 7 && subname[:7] == "lifebar":
-				if fs.lb[i][0] == nil {
-					fs.lb[i][0] = readLifeBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.lifeBars[i][0] == nil {
+					fs.lifeBars[i][0] = readLifeBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if fs.lb[i][1] == nil {
-					fs.lb[i][1] = readLifeBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.lifeBars[i][1] == nil {
+					fs.lifeBars[i][1] = readLifeBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if fs.lb[i][2] == nil {
-					fs.lb[i][2] = readLifeBar("p3.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.lifeBars[i][2] == nil {
+					fs.lifeBars[i][2] = readLifeBar("p3.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if fs.lb[i][3] == nil {
-					fs.lb[i][3] = readLifeBar("p4.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.lifeBars[i][3] == nil {
+					fs.lifeBars[i][3] = readLifeBar("p4.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if fs.lb[i][4] == nil {
-					fs.lb[i][4] = readLifeBar("p5.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.lifeBars[i][4] == nil {
+					fs.lifeBars[i][4] = readLifeBar("p5.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if fs.lb[i][5] == nil {
-					fs.lb[i][5] = readLifeBar("p6.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.lifeBars[i][5] == nil {
+					fs.lifeBars[i][5] = readLifeBar("p6.", is, fs.sff, fs.animTable, fs.fnt)
 				}
 				if i != 4 && i != 6 {
-					if fs.lb[i][6] == nil {
-						fs.lb[i][6] = readLifeBar("p7.", is, fs.sff, fs.animTable, fs.fnt)
+					if fs.lifeBars[i][6] == nil {
+						fs.lifeBars[i][6] = readLifeBar("p7.", is, fs.sff, fs.animTable, fs.fnt)
 					}
-					if fs.lb[i][7] == nil {
-						fs.lb[i][7] = readLifeBar("p8.", is, fs.sff, fs.animTable, fs.fnt)
+					if fs.lifeBars[i][7] == nil {
+						fs.lifeBars[i][7] = readLifeBar("p8.", is, fs.sff, fs.animTable, fs.fnt)
 					}
 				}
 			case len(subname) >= 8 && subname[:8] == "powerbar":
-				if fs.pb[i][0] == nil {
-					fs.pb[i][0] = readPowerBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.powerBars[i][0] == nil {
+					fs.powerBars[i][0] = readPowerBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if fs.pb[i][1] == nil {
-					fs.pb[i][1] = readPowerBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.powerBars[i][1] == nil {
+					fs.powerBars[i][1] = readPowerBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if fs.pb[i][2] == nil {
-					fs.pb[i][2] = readPowerBar("p3.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.powerBars[i][2] == nil {
+					fs.powerBars[i][2] = readPowerBar("p3.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if fs.pb[i][3] == nil {
-					fs.pb[i][3] = readPowerBar("p4.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.powerBars[i][3] == nil {
+					fs.powerBars[i][3] = readPowerBar("p4.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if fs.pb[i][4] == nil {
-					fs.pb[i][4] = readPowerBar("p5.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.powerBars[i][4] == nil {
+					fs.powerBars[i][4] = readPowerBar("p5.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if fs.pb[i][5] == nil {
-					fs.pb[i][5] = readPowerBar("p6.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.powerBars[i][5] == nil {
+					fs.powerBars[i][5] = readPowerBar("p6.", is, fs.sff, fs.animTable, fs.fnt)
 				}
 				if i != 4 && i != 6 {
-					if fs.pb[i][6] == nil {
-						fs.pb[i][6] = readPowerBar("p7.", is, fs.sff, fs.animTable, fs.fnt)
+					if fs.powerBars[i][6] == nil {
+						fs.powerBars[i][6] = readPowerBar("p7.", is, fs.sff, fs.animTable, fs.fnt)
 					}
-					if fs.pb[i][7] == nil {
-						fs.pb[i][7] = readPowerBar("p8.", is, fs.sff, fs.animTable, fs.fnt)
+					if fs.powerBars[i][7] == nil {
+						fs.powerBars[i][7] = readPowerBar("p8.", is, fs.sff, fs.animTable, fs.fnt)
 					}
 				}
 			case len(subname) >= 8 && subname[:8] == "guardbar":
-				if fs.gb[i][0] == nil {
-					fs.gb[i][0] = readGuardBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.guardBars[i][0] == nil {
+					fs.guardBars[i][0] = readGuardBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if fs.gb[i][1] == nil {
-					fs.gb[i][1] = readGuardBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.guardBars[i][1] == nil {
+					fs.guardBars[i][1] = readGuardBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if fs.gb[i][2] == nil {
-					fs.gb[i][2] = readGuardBar("p3.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.guardBars[i][2] == nil {
+					fs.guardBars[i][2] = readGuardBar("p3.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if fs.gb[i][3] == nil {
-					fs.gb[i][3] = readGuardBar("p4.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.guardBars[i][3] == nil {
+					fs.guardBars[i][3] = readGuardBar("p4.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if fs.gb[i][4] == nil {
-					fs.gb[i][4] = readGuardBar("p5.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.guardBars[i][4] == nil {
+					fs.guardBars[i][4] = readGuardBar("p5.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if fs.gb[i][5] == nil {
-					fs.gb[i][5] = readGuardBar("p6.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.guardBars[i][5] == nil {
+					fs.guardBars[i][5] = readGuardBar("p6.", is, fs.sff, fs.animTable, fs.fnt)
 				}
 				if i != 4 && i != 6 {
-					if fs.gb[i][6] == nil {
-						fs.gb[i][6] = readGuardBar("p7.", is, fs.sff, fs.animTable, fs.fnt)
+					if fs.guardBars[i][6] == nil {
+						fs.guardBars[i][6] = readGuardBar("p7.", is, fs.sff, fs.animTable, fs.fnt)
 					}
-					if fs.gb[i][7] == nil {
-						fs.gb[i][7] = readGuardBar("p8.", is, fs.sff, fs.animTable, fs.fnt)
+					if fs.guardBars[i][7] == nil {
+						fs.guardBars[i][7] = readGuardBar("p8.", is, fs.sff, fs.animTable, fs.fnt)
 					}
 				}
 			case len(subname) >= 7 && subname[:7] == "stunbar":
-				if fs.sb[i][0] == nil {
-					fs.sb[i][0] = readStunBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.stunBars[i][0] == nil {
+					fs.stunBars[i][0] = readStunBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if fs.sb[i][1] == nil {
-					fs.sb[i][1] = readStunBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.stunBars[i][1] == nil {
+					fs.stunBars[i][1] = readStunBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if fs.sb[i][2] == nil {
-					fs.sb[i][2] = readStunBar("p3.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.stunBars[i][2] == nil {
+					fs.stunBars[i][2] = readStunBar("p3.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if fs.sb[i][3] == nil {
-					fs.sb[i][3] = readStunBar("p4.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.stunBars[i][3] == nil {
+					fs.stunBars[i][3] = readStunBar("p4.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if fs.sb[i][4] == nil {
-					fs.sb[i][4] = readStunBar("p5.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.stunBars[i][4] == nil {
+					fs.stunBars[i][4] = readStunBar("p5.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if fs.sb[i][5] == nil {
-					fs.sb[i][5] = readStunBar("p6.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.stunBars[i][5] == nil {
+					fs.stunBars[i][5] = readStunBar("p6.", is, fs.sff, fs.animTable, fs.fnt)
 				}
 				if i != 4 && i != 6 {
-					if fs.sb[i][6] == nil {
-						fs.sb[i][6] = readStunBar("p7.", is, fs.sff, fs.animTable, fs.fnt)
+					if fs.stunBars[i][6] == nil {
+						fs.stunBars[i][6] = readStunBar("p7.", is, fs.sff, fs.animTable, fs.fnt)
 					}
-					if fs.sb[i][7] == nil {
-						fs.sb[i][7] = readStunBar("p8.", is, fs.sff, fs.animTable, fs.fnt)
+					if fs.stunBars[i][7] == nil {
+						fs.stunBars[i][7] = readStunBar("p8.", is, fs.sff, fs.animTable, fs.fnt)
 					}
 				}
 			case len(subname) >= 4 && subname[:4] == "face":
-				if fs.fa[i][0] == nil {
-					fs.fa[i][0] = readFightScreenFace("p1.", is, fs.sff, fs.animTable)
+				if fs.faces[i][0] == nil {
+					fs.faces[i][0] = readFightScreenFace("p1.", is, fs.sff, fs.animTable)
 				}
-				if fs.fa[i][1] == nil {
-					fs.fa[i][1] = readFightScreenFace("p2.", is, fs.sff, fs.animTable)
+				if fs.faces[i][1] == nil {
+					fs.faces[i][1] = readFightScreenFace("p2.", is, fs.sff, fs.animTable)
 				}
-				if fs.fa[i][2] == nil {
-					fs.fa[i][2] = readFightScreenFace("p3.", is, fs.sff, fs.animTable)
+				if fs.faces[i][2] == nil {
+					fs.faces[i][2] = readFightScreenFace("p3.", is, fs.sff, fs.animTable)
 				}
-				if fs.fa[i][3] == nil {
-					fs.fa[i][3] = readFightScreenFace("p4.", is, fs.sff, fs.animTable)
+				if fs.faces[i][3] == nil {
+					fs.faces[i][3] = readFightScreenFace("p4.", is, fs.sff, fs.animTable)
 				}
-				if fs.fa[i][4] == nil {
-					fs.fa[i][4] = readFightScreenFace("p5.", is, fs.sff, fs.animTable)
+				if fs.faces[i][4] == nil {
+					fs.faces[i][4] = readFightScreenFace("p5.", is, fs.sff, fs.animTable)
 				}
-				if fs.fa[i][5] == nil {
-					fs.fa[i][5] = readFightScreenFace("p6.", is, fs.sff, fs.animTable)
+				if fs.faces[i][5] == nil {
+					fs.faces[i][5] = readFightScreenFace("p6.", is, fs.sff, fs.animTable)
 				}
 				if i != 4 && i != 6 {
-					if fs.fa[i][6] == nil {
-						fs.fa[i][6] = readFightScreenFace("p7.", is, fs.sff, fs.animTable)
+					if fs.faces[i][6] == nil {
+						fs.faces[i][6] = readFightScreenFace("p7.", is, fs.sff, fs.animTable)
 					}
-					if fs.fa[i][7] == nil {
-						fs.fa[i][7] = readFightScreenFace("p8.", is, fs.sff, fs.animTable)
+					if fs.faces[i][7] == nil {
+						fs.faces[i][7] = readFightScreenFace("p8.", is, fs.sff, fs.animTable)
 					}
 				}
 			case len(subname) >= 4 && subname[:4] == "name":
-				if fs.nm[i][0] == nil {
-					fs.nm[i][0] = readFightScreenName("p1.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.names[i][0] == nil {
+					fs.names[i][0] = readFightScreenName("p1.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if fs.nm[i][1] == nil {
-					fs.nm[i][1] = readFightScreenName("p2.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.names[i][1] == nil {
+					fs.names[i][1] = readFightScreenName("p2.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if fs.nm[i][2] == nil {
-					fs.nm[i][2] = readFightScreenName("p3.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.names[i][2] == nil {
+					fs.names[i][2] = readFightScreenName("p3.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if fs.nm[i][3] == nil {
-					fs.nm[i][3] = readFightScreenName("p4.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.names[i][3] == nil {
+					fs.names[i][3] = readFightScreenName("p4.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if fs.nm[i][4] == nil {
-					fs.nm[i][4] = readFightScreenName("p5.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.names[i][4] == nil {
+					fs.names[i][4] = readFightScreenName("p5.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if fs.nm[i][5] == nil {
-					fs.nm[i][5] = readFightScreenName("p6.", is, fs.sff, fs.animTable, fs.fnt)
+				if fs.names[i][5] == nil {
+					fs.names[i][5] = readFightScreenName("p6.", is, fs.sff, fs.animTable, fs.fnt)
 				}
 				if i != 4 && i != 6 {
-					if fs.nm[i][6] == nil {
-						fs.nm[i][6] = readFightScreenName("p7.", is, fs.sff, fs.animTable, fs.fnt)
+					if fs.names[i][6] == nil {
+						fs.names[i][6] = readFightScreenName("p7.", is, fs.sff, fs.animTable, fs.fnt)
 					}
-					if fs.nm[i][7] == nil {
-						fs.nm[i][7] = readFightScreenName("p8.", is, fs.sff, fs.animTable, fs.fnt)
+					if fs.names[i][7] == nil {
+						fs.names[i][7] = readFightScreenName("p8.", is, fs.sff, fs.animTable, fs.fnt)
 					}
 				}
 			}
 		case "winicon":
-			if fs.wi[0] == nil {
-				fs.wi[0] = readFightScreenWinIcon("p1.", is, fs.sff, fs.animTable, fs.fnt)
+			if fs.winIcons[0] == nil {
+				fs.winIcons[0] = readFightScreenWinIcon("p1.", is, fs.sff, fs.animTable, fs.fnt)
 			}
-			if fs.wi[1] == nil {
-				fs.wi[1] = readFightScreenWinIcon("p2.", is, fs.sff, fs.animTable, fs.fnt)
+			if fs.winIcons[1] == nil {
+				fs.winIcons[1] = readFightScreenWinIcon("p2.", is, fs.sff, fs.animTable, fs.fnt)
 			}
 		case "time":
-			if fs.ti == nil {
-				fs.ti = readFightScreenTime(is, fs.sff, fs.animTable, fs.fnt)
+			if fs.time == nil {
+				fs.time = readFightScreenTime(is, fs.sff, fs.animTable, fs.fnt)
 			}
 		case "combo":
-			if fs.co[0] == nil {
+			if fs.combos[0] == nil {
 				if _, ok := is["team1.pos"]; ok {
-					fs.co[0] = readFightScreenCombo("team1.", is, fs.sff, fs.animTable, fs.fnt, 0)
+					fs.combos[0] = readFightScreenCombo("team1.", is, fs.sff, fs.animTable, fs.fnt, 0)
 				} else {
-					fs.co[0] = readFightScreenCombo("", is, fs.sff, fs.animTable, fs.fnt, 0)
+					fs.combos[0] = readFightScreenCombo("", is, fs.sff, fs.animTable, fs.fnt, 0)
 				}
 			}
-			if fs.co[1] == nil {
+			if fs.combos[1] == nil {
 				if _, ok := is["team2.pos"]; ok {
-					fs.co[1] = readFightScreenCombo("team2.", is, fs.sff, fs.animTable, fs.fnt, 1)
+					fs.combos[1] = readFightScreenCombo("team2.", is, fs.sff, fs.animTable, fs.fnt, 1)
 				} else {
-					fs.co[1] = readFightScreenCombo("", is, fs.sff, fs.animTable, fs.fnt, 1)
+					fs.combos[1] = readFightScreenCombo("", is, fs.sff, fs.animTable, fs.fnt, 1)
 				}
 			}
 		case "action":
-			if fs.ac[0] == nil {
-				fs.ac[0] = readFightScreenAction("team1.", is, fs.fnt)
+			if fs.actions[0] == nil {
+				fs.actions[0] = readFightScreenAction("team1.", is, fs.fnt)
 			}
-			if fs.ac[1] == nil {
-				fs.ac[1] = readFightScreenAction("team2.", is, fs.fnt)
+			if fs.actions[1] == nil {
+				fs.actions[1] = readFightScreenAction("team2.", is, fs.fnt)
 			}
 		case "round":
-			if fs.ro == nil {
-				fs.ro = readFightScreenRound(is, fs.sff, fs.animTable, fs.snd, fs.fnt)
+			if fs.round == nil {
+				fs.round = readFightScreenRound(is, fs.sff, fs.animTable, fs.snd, fs.fnt)
 			}
 		case "ratio":
-			if fs.ra[0] == nil {
-				fs.ra[0] = readFightScreenRatio("p1.", is, fs.sff, fs.animTable)
+			if fs.ratios[0] == nil {
+				fs.ratios[0] = readFightScreenRatio("p1.", is, fs.sff, fs.animTable)
 			}
-			if fs.ra[1] == nil {
-				fs.ra[1] = readFightScreenRatio("p2.", is, fs.sff, fs.animTable)
+			if fs.ratios[1] == nil {
+				fs.ratios[1] = readFightScreenRatio("p2.", is, fs.sff, fs.animTable)
 			}
 		case "timer":
-			if fs.tr == nil {
-				fs.tr = readFightScreenTimer(is, fs.sff, fs.animTable, fs.fnt)
+			if fs.timer == nil {
+				fs.timer = readFightScreenTimer(is, fs.sff, fs.animTable, fs.fnt)
 			}
 		case "score":
-			if fs.sc[0] == nil {
-				fs.sc[0] = readFightScreenScore("p1.", is, fs.sff, fs.animTable, fs.fnt)
+			if fs.scores[0] == nil {
+				fs.scores[0] = readFightScreenScore("p1.", is, fs.sff, fs.animTable, fs.fnt)
 			}
-			if fs.sc[1] == nil {
-				fs.sc[1] = readFightScreenScore("p2.", is, fs.sff, fs.animTable, fs.fnt)
+			if fs.scores[1] == nil {
+				fs.scores[1] = readFightScreenScore("p2.", is, fs.sff, fs.animTable, fs.fnt)
 			}
 		case "match":
-			if fs.ma == nil {
-				fs.ma = readFightScreenMatch(is, fs.sff, fs.animTable, fs.fnt)
+			if fs.match == nil {
+				fs.match = readFightScreenMatch(is, fs.sff, fs.animTable, fs.fnt)
 			}
 		case "ailevel":
-			if fs.ai[0] == nil {
-				fs.ai[0] = readFightScreenAiLevel("p1.", is, fs.sff, fs.animTable, fs.fnt)
+			if fs.aiLevels[0] == nil {
+				fs.aiLevels[0] = readFightScreenAiLevel("p1.", is, fs.sff, fs.animTable, fs.fnt)
 			}
-			if fs.ai[1] == nil {
-				fs.ai[1] = readFightScreenAiLevel("p2.", is, fs.sff, fs.animTable, fs.fnt)
+			if fs.aiLevels[1] == nil {
+				fs.aiLevels[1] = readFightScreenAiLevel("p2.", is, fs.sff, fs.animTable, fs.fnt)
 			}
 		case "wincount":
-			if fs.wc[0] == nil {
-				fs.wc[0] = readFightScreenWinCount("p1.", is, fs.sff, fs.animTable, fs.fnt)
+			if fs.winCounts[0] == nil {
+				fs.winCounts[0] = readFightScreenWinCount("p1.", is, fs.sff, fs.animTable, fs.fnt)
 			}
-			if fs.wc[1] == nil {
-				fs.wc[1] = readFightScreenWinCount("p2.", is, fs.sff, fs.animTable, fs.fnt)
+			if fs.winCounts[1] == nil {
+				fs.winCounts[1] = readFightScreenWinCount("p2.", is, fs.sff, fs.animTable, fs.fnt)
 			}
 		case "mode":
-			if fs.mo == nil {
-				fs.mo = readFightScreenMode(is, fs.sff, fs.animTable, fs.fnt)
+			if fs.modes == nil {
+				fs.modes = readFightScreenMode(is, fs.sff, fs.animTable, fs.fnt)
 			}
 		}
 	}
@@ -4995,82 +4995,82 @@ func loadFightScreen(def string) (*FightScreen, error) {
 	sort.Strings(keys)
 	for _, k := range keys {
 		if strings.Contains(k, " lifebar") {
-			for i := 3; i < len(fs.lb); i++ {
+			for i := 3; i < len(fs.lifeBars); i++ {
 				if i == fs.missing[k] {
-					for j := 0; j < len(fs.lb[i]); j++ {
+					for j := 0; j < len(fs.lifeBars[i]); j++ {
 						if i == 6 || i == 7 {
-							fs.lb[i][j] = fs.lb[3][j]
+							fs.lifeBars[i][j] = fs.lifeBars[3][j]
 						} else {
-							fs.lb[i][j] = fs.lb[1][j]
+							fs.lifeBars[i][j] = fs.lifeBars[1][j]
 						}
 					}
 				}
 			}
 		} else if strings.Contains(k, " powerbar") {
-			for i := 1; i < len(fs.pb); i++ {
+			for i := 1; i < len(fs.powerBars); i++ {
 				if i == fs.missing[k] {
 					for j := 0; j < 2; j++ {
 						switch i {
 						case 4, 5:
-							fs.pb[i][j] = fs.pb[1][j]
+							fs.powerBars[i][j] = fs.powerBars[1][j]
 						case 6, 7:
-							fs.pb[i][j] = fs.pb[3][j]
+							fs.powerBars[i][j] = fs.powerBars[3][j]
 						default:
-							fs.pb[i][j] = fs.pb[0][j]
+							fs.powerBars[i][j] = fs.powerBars[0][j]
 						}
 					}
 				}
 			}
 		} else if strings.Contains(k, " guardbar") {
-			for i := 1; i < len(fs.gb); i++ {
+			for i := 1; i < len(fs.guardBars); i++ {
 				if i == fs.missing[k] {
 					for j := 0; j < 2; j++ {
 						switch i {
 						case 4, 5:
-							fs.gb[i][j] = fs.gb[1][j]
+							fs.guardBars[i][j] = fs.guardBars[1][j]
 						case 6, 7:
-							fs.gb[i][j] = fs.gb[3][j]
+							fs.guardBars[i][j] = fs.guardBars[3][j]
 						default:
-							fs.gb[i][j] = fs.gb[0][j]
+							fs.guardBars[i][j] = fs.guardBars[0][j]
 						}
 					}
 				}
 			}
 		} else if strings.Contains(k, " stunbar") {
-			for i := 1; i < len(fs.sb); i++ {
+			for i := 1; i < len(fs.stunBars); i++ {
 				if i == fs.missing[k] {
 					for j := 0; j < 2; j++ {
 						switch i {
 						case 4, 5:
-							fs.sb[i][j] = fs.sb[1][j]
+							fs.stunBars[i][j] = fs.stunBars[1][j]
 						case 6, 7:
-							fs.sb[i][j] = fs.sb[3][j]
+							fs.stunBars[i][j] = fs.stunBars[3][j]
 						default:
-							fs.sb[i][j] = fs.sb[0][j]
+							fs.stunBars[i][j] = fs.stunBars[0][j]
 						}
 					}
 				}
 			}
 		} else if strings.Contains(k, " face") {
-			for i := 3; i < len(fs.fa); i++ {
+			for i := 3; i < len(fs.faces); i++ {
 				if i == fs.missing[k] {
-					for j := 0; j < len(fs.fa[i]); j++ {
+					for j := 0; j < len(fs.faces[i]); j++ {
 						if i == 6 || i == 7 {
-							fs.fa[i][j] = fs.fa[3][j]
+							fs.faces[i][j] = fs.faces[3][j]
 						} else {
-							fs.fa[i][j] = fs.fa[1][j]
+							fs.faces[i][j] = fs.faces[1][j]
 						}
 					}
 				}
 			}
 		} else if strings.Contains(k, " name") {
-			for i := 3; i < len(fs.nm); i++ {
+			for i := 3; i < len(fs.names); i++ {
 				if i == fs.missing[k] {
-					for j := 0; j < len(fs.nm[i]); j++ {
+					for j := 0; j < len(fs.names[i]); j++ {
 						if i == 6 || i == 7 {
-							fs.nm[i][j] = fs.nm[3][j]
+							fs.names[i][j] = fs.names[3][j]
 						} else {
-							fs.nm[i][j] = fs.nm[1][j]
+							fs.names[i][j] = fs.names[1][j]
 						}
 					}
 				}
@@ -5089,8 +5089,8 @@ func loadFightScreen(def string) (*FightScreen, error) {
 			for _, i := range teamModeIndices {
 				if i < len(fs.lb) {
 					// Replace with Single lifebars
-					fs.lb[i][0] = fs.lb[0][0]
-					fs.lb[i][1] = fs.lb[0][1]
+					fs.lifeBars[i][0] = fs.lifeBars[0][0]
+					fs.lifeBars[i][1] = fs.lifeBars[0][1]
 				}
 			}
 		}
@@ -5104,17 +5104,17 @@ func (fs *FightScreen) reload() error {
 	if err != nil {
 		return err
 	}
-	fs.ti.framespercount = fs.ti.framespercount
-	//fs.ro.match_wins = fs.ro.match_wins
-	//fs.ro.match_maxdrawgames = fs.ro.match_maxdrawgames
-	fs.tr.active = fs.tr.active
-	fs.sc[0].active = fs.sc[0].active
-	fs.sc[1].active = fs.sc[1].active
-	fs.ma.active = fs.ma.active
-	fs.ai[0].active = fs.ai[0].active
-	fs.ai[1].active = fs.ai[1].active
-	fs.wc[0].active = fs.wc[0].active
-	fs.wc[1].active = fs.wc[1].active
+	fs.time.framespercount = fs.time.framespercount
+	//fs.round.match_wins = fs.round.match_wins
+	//fs.round.match_maxdrawgames = fs.round.match_maxdrawgames
+	fs.timer.active = fs.timer.active
+	fs.scores[0].active = fs.scores[0].active
+	fs.scores[1].active = fs.scores[1].active
+	fs.match.active = fs.match.active
+	fs.aiLevels[0].active = fs.aiLevels[0].active
+	fs.aiLevels[1].active = fs.aiLevels[1].active
+	fs.winCounts[0].active = fs.winCounts[0].active
+	fs.winCounts[1].active = fs.winCounts[1].active
 	fs.active = fs.active
 	fs.bars = fs.bars
 	fs.mode = fs.mode
@@ -5160,25 +5160,25 @@ func (fs *FightScreen) step() {
 		for i, charpn := range fs.teamOrder[ti] {
 			index := i*2+ti
 			// LifeBar
-			fs.lb[layout][index].step(charpn, fs.lb[layout][charpn])
+			fs.lifeBars[layout][index].step(charpn, fs.lifeBars[layout][charpn])
 			// PowerBar
-			fs.pb[layout][index].step(charpn, fs.pb[layout][charpn], fs.snd)
+			fs.powerBars[layout][index].step(charpn, fs.powerBars[layout][charpn], fs.snd)
 			// GuardBar
-			fs.gb[layout][index].step(charpn, fs.gb[layout][charpn], fs.snd)
+			fs.guardBars[layout][index].step(charpn, fs.guardBars[layout][charpn], fs.snd)
 			// StunBar
-			fs.sb[layout][index].step(charpn, fs.sb[layout][charpn], fs.snd)
+			fs.stunBars[layout][index].step(charpn, fs.stunBars[layout][charpn], fs.snd)
 			// FightScreenFace
-			fs.fa[layout][index].step(charpn, fs.fa[layout][charpn])
+			fs.faces[layout][index].step(charpn, fs.faces[layout][charpn])
 			// FightScreenName
-			fs.nm[layout][index].step()
+			fs.names[layout][index].step()
 		}
 	}
 	// FightScreenWinIcon
-	for i := range fs.wi {
-		fs.wi[i].step(sys.wins[i])
+	for i := range fs.winIcons {
+		fs.winIcons[i].step(sys.wins[i])
 	}
 	// FightScreenTime
-	fs.ti.step()
+	fs.time.step()
 	// FightScreenCombo
 	cb, cd, cp, dz := [2]int32{}, [2]int32{}, [2]float32{}, [2]bool{}
 	targets := [2]int32{}
@@ -5202,41 +5202,41 @@ func (fs *FightScreen) step() {
 			cp[side] /= float32(targets[side]) // Divide damage percentage by number of valid enemies
 		}
 	}
-	for i := range fs.co {
-		fs.co[i].step(cb[i], cd[i], cp[i], dz[i]) // Combo hits, combo damage, combo damage percentage, dizzy flag
+	for i := range fs.combos {
+		fs.combos[i].step(cb[i], cd[i], cp[i], dz[i]) // Combo hits, combo damage, combo damage percentage, dizzy flag
 	}
 	// FightScreenAction
-	for i := range fs.ac {
-		fs.ac[i].step(fs.teamOrder[i][0])
+	for i := range fs.actions {
+		fs.actions[i].step(fs.teamOrder[i][0])
 	}
 	// FightScreenRatio
 	for ti, tm := range sys.tmode {
 		if tm == TM_Turns {
 			rl := sys.chars[ti][0].ocd().ratioLevel
 			if rl > 0 {
-				fs.ra[ti].step(rl - 1)
+				fs.ratios[ti].step(rl - 1)
 			}
 		}
 	}
 	// FightScreenTimer
-	fs.tr.step()
+	fs.timer.step()
 	// FightScreenScore
-	for i := range fs.sc {
-		fs.sc[i].step()
+	for i := range fs.scores {
+		fs.scores[i].step()
 	}
 	// FightScreenMatch
-	fs.ma.step()
+	fs.match.step()
 	// FightScreenAiLevel
-	for i := range fs.ai {
-		fs.ai[i].step()
+	for i := range fs.aiLevels {
+		fs.aiLevels[i].step()
 	}
 	// FightScreenWinCount
-	for i := range fs.wc {
-		fs.wc[i].step()
+	for i := range fs.winCounts {
+		fs.winCounts[i].step()
 	}
 	// FightScreenMode
-	if _, ok := fs.mo[sys.gameMode]; ok {
-		fs.mo[sys.gameMode].step()
+	if _, ok := fs.modes[sys.gameMode]; ok {
+		fs.modes[sys.gameMode].step()
 	}
 }
 
@@ -5273,7 +5273,7 @@ func (fs *FightScreen) reset() {
 		if tm == TM_Simul || tm == TM_Tag {
 			num[ti] = int(math.Min(8, float64(sys.numSimul[ti])*2))
 		} else {
-			num[ti] = len(fs.lb[fs.curLayout[ti]])
+			num[ti] = len(fs.lifeBars[fs.curLayout[ti]])
 		}
 
 		fs.teamOrder[ti] = []int{}
@@ -5283,63 +5283,63 @@ func (fs *FightScreen) reset() {
 	}
 
 	// Reset fight screen elements
-	for i := range fs.lb {
-		for j := range fs.lb[i] {
-			fs.lb[i][j].reset()
+	for i := range fs.lifeBars {
+		for j := range fs.lifeBars[i] {
+			fs.lifeBars[i][j].reset()
 		}
 	}
-	for i := range fs.pb {
-		for j := range fs.pb[i] {
-			fs.pb[i][j].reset()
+	for i := range fs.powerBars {
+		for j := range fs.powerBars[i] {
+			fs.powerBars[i][j].reset()
 		}
 	}
-	for i := range fs.gb {
-		for j := range fs.gb[i] {
-			fs.gb[i][j].reset()
+	for i := range fs.guardBars {
+		for j := range fs.guardBars[i] {
+			fs.guardBars[i][j].reset()
 		}
 	}
-	for i := range fs.sb {
-		for j := range fs.sb[i] {
-			fs.sb[i][j].reset()
+	for i := range fs.stunBars {
+		for j := range fs.stunBars[i] {
+			fs.stunBars[i][j].reset()
 		}
 	}
-	for i := range fs.fa {
-		for j := range fs.fa[i] {
-			fs.fa[i][j].reset()
+	for i := range fs.faces {
+		for j := range fs.faces[i] {
+			fs.faces[i][j].reset()
 		}
 	}
-	for i := range fs.nm {
-		for j := range fs.nm[i] {
-			fs.nm[i][j].reset()
+	for i := range fs.names {
+		for j := range fs.names[i] {
+			fs.names[i][j].reset()
 		}
 	}
-	for i := range fs.wi {
-		fs.wi[i].reset()
+	for i := range fs.winIcons {
+		fs.winIcons[i].reset()
 	}
-	fs.ti.reset()
-	for i := range fs.co {
-		fs.co[i].reset()
+	fs.time.reset()
+	for i := range fs.combos {
+		fs.combos[i].reset()
 	}
-	for i := range fs.ac {
-		fs.ac[i].reset(fs.teamOrder[i][0])
+	for i := range fs.actions {
+		fs.actions[i].reset(fs.teamOrder[i][0])
 	}
-	fs.ro.reset()
-	for i := range fs.ra {
-		fs.ra[i].reset()
+	fs.round.reset()
+	for i := range fs.ratios {
+		fs.ratios[i].reset()
 	}
-	fs.tr.reset()
-	for i := range fs.sc {
-		fs.sc[i].reset()
+	fs.timer.reset()
+	for i := range fs.scores {
+		fs.scores[i].reset()
 	}
-	fs.ma.reset()
-	for i := range fs.ai {
-		fs.ai[i].reset()
+	fs.match.reset()
+	for i := range fs.aiLevels {
+		fs.aiLevels[i].reset()
 	}
-	for i := range fs.wc {
-		fs.wc[i].reset()
+	for i := range fs.winCounts {
+		fs.winCounts[i].reset()
 	}
-	if _, ok := fs.mo[sys.gameMode]; ok {
-		fs.mo[sys.gameMode].reset()
+	if _, ok := fs.modes[sys.gameMode]; ok {
+		fs.modes[sys.gameMode].reset()
 	}
 }
 
@@ -5375,7 +5375,7 @@ func (fs *FightScreen) draw(layerno int16) {
 				if c.asf(ASF_nolifebardisplay) {
 					return
 				}
-				fs.lb[layout][barpn].bgDraw(layerno)
+				fs.lifeBars[layout][barpn].bgDraw(layerno)
 			})
 
 			// LifeBar bars
@@ -5385,7 +5385,7 @@ func (fs *FightScreen) draw(layerno int16) {
 					return
 				}
 				// Use the definition at [layout][barpn] and the runtime values (combo damage etc) stored at [layout][charpn]
-				fs.lb[layout][barpn].draw(layerno, charpn, fs.lb[layout][charpn], fs.fnt)
+				fs.lifeBars[layout][barpn].draw(layerno, charpn, fs.lifeBars[layout][charpn], fs.fnt)
 			})
 
 			// PowerBar backgrounds
@@ -5399,7 +5399,7 @@ func (fs *FightScreen) draw(layerno int16) {
 				if slot != 0 && (tm == TM_Simul || tm == TM_Tag) && sys.cfg.Options.Team.PowerShare {
 					return
 				}
-				fs.pb[layout][barpn].bgDraw(layerno, barpn)
+				fs.powerBars[layout][barpn].bgDraw(layerno, barpn)
 			})
 
 			// PowerBar bars
@@ -5413,7 +5413,7 @@ func (fs *FightScreen) draw(layerno int16) {
 				if slot != 0 && (tm == TM_Simul || tm == TM_Tag) && sys.cfg.Options.Team.PowerShare {
 					return
 				}
-				fs.pb[layout][barpn].draw(layerno, charpn, fs.pb[layout][charpn], fs.fnt)
+				fs.powerBars[layout][barpn].draw(layerno, charpn, fs.powerBars[layout][charpn], fs.fnt)
 			})
 
 			// GuardBar
@@ -5422,8 +5422,8 @@ func (fs *FightScreen) draw(layerno int16) {
 				if !c.guardBreakEnabled() || c.asf(ASF_noguardbardisplay) {
 					return
 				}
-				fs.gb[layout][barpn].bgDraw(layerno)
-				fs.gb[layout][barpn].draw(layerno, charpn, fs.gb[layout][charpn], fs.fnt)
+				fs.guardBars[layout][barpn].bgDraw(layerno)
+				fs.guardBars[layout][barpn].draw(layerno, charpn, fs.guardBars[layout][charpn], fs.fnt)
 			})
 
 			// StunBar
@@ -5432,8 +5432,8 @@ func (fs *FightScreen) draw(layerno int16) {
 				if !c.dizzyEnabled() || c.asf(ASF_nostunbardisplay) {
 					return
 				}
-				fs.sb[layout][barpn].bgDraw(layerno)
-				fs.sb[layout][barpn].draw(layerno, charpn, fs.sb[layout][charpn], fs.fnt)
+				fs.stunBars[layout][barpn].bgDraw(layerno)
+				fs.stunBars[layout][barpn].draw(layerno, charpn, fs.stunBars[layout][charpn], fs.fnt)
 			})
 
 			// FightScreenFace
@@ -5443,12 +5443,12 @@ func (fs *FightScreen) draw(layerno int16) {
 					return
 				}
 				// Draw Turns teammates from the first bar only
-				if slot == 0 && len(fs.fa[layout]) > 0 {
-					fs.fa[layout][side].drawTeammates(layerno, charpn)
+				if slot == 0 && len(fs.faces[layout]) > 0 {
+					fs.faces[layout][side].drawTeammates(layerno, charpn)
 				}
 				// Draw active players
-				fs.fa[layout][barpn].bgDraw(layerno)
-				fs.fa[layout][barpn].draw(layerno, charpn, fs.fa[layout][charpn])
+				fs.faces[layout][barpn].bgDraw(layerno)
+				fs.faces[layout][barpn].draw(layerno, charpn, fs.faces[layout][charpn])
 			})
 
 			// FightScreenName
@@ -5458,12 +5458,12 @@ func (fs *FightScreen) draw(layerno int16) {
 					return
 				}
 				// Draw Turns teammates from the first bar only
-				if slot == 0 && len(fs.nm[layout]) > 0 {
-					fs.nm[layout][side].drawTeammates(layerno, charpn, fs.fnt, side)
+				if slot == 0 && len(fs.names[layout]) > 0 {
+					fs.names[layout][side].drawTeammates(layerno, charpn, fs.fnt, side)
 				}
 				// Draw active players
-				fs.nm[layout][barpn].bgDraw(layerno)
-				fs.nm[layout][barpn].draw(layerno, charpn, fs.fnt, side)
+				fs.names[layout][barpn].bgDraw(layerno)
+				fs.names[layout][barpn].draw(layerno, charpn, fs.fnt, side)
 			})
 
 			// FightScreenRatio
@@ -5471,75 +5471,75 @@ func (fs *FightScreen) draw(layerno int16) {
 				if sys.tmode[side] == TM_Turns {
 					rl := sys.chars[side][0].ocd().ratioLevel
 					if rl > 0 && !sys.chars[side][0].asf(ASF_nofacedisplay) {
-						fs.ra[side].bgDraw(layerno)
-						fs.ra[side].draw(layerno, rl-1)
+						fs.ratios[side].bgDraw(layerno)
+						fs.ratios[side].draw(layerno, rl-1)
 					}
 				}
 			}
 
 			// FightScreenTime
-			fs.ti.bgDraw(layerno)
-			fs.ti.draw(layerno, fs.fnt)
+			fs.time.bgDraw(layerno)
+			fs.time.draw(layerno, fs.fnt)
 
 			// FightScreenWinIcon
 			// These are only one per team, so we don't use forEach()
-			for i := len(fs.wi) - 1; i >= 0; i-- {
+			for i := len(fs.winIcons) - 1; i >= 0; i-- {
 				if !sys.chars[i][0].asf(ASF_nowinicondisplay) {
-					fs.wi[i].draw(layerno, fs.fnt, i)
+					fs.winIcons[i].draw(layerno, fs.fnt, i)
 				}
 			}
 
 			// FightScreenTimer
-			fs.tr.bgDraw(layerno)
-			fs.tr.draw(layerno, fs.fnt)
+			fs.timer.bgDraw(layerno)
+			fs.timer.draw(layerno, fs.fnt)
 
 			// FightScreenScore
-			for i := len(fs.sc) - 1; i >= 0; i-- {
-				fs.sc[i].bgDraw(layerno)
-				fs.sc[i].draw(layerno, fs.fnt, i)
+			for i := len(fs.scores) - 1; i >= 0; i-- {
+				fs.scores[i].bgDraw(layerno)
+				fs.scores[i].draw(layerno, fs.fnt, i)
 			}
 
 			// FightScreenMatch
-			fs.ma.bgDraw(layerno)
-			fs.ma.draw(layerno, fs.fnt)
+			fs.match.bgDraw(layerno)
+			fs.match.draw(layerno, fs.fnt)
 
 			// FightScreenAiLevel
-			for i := len(fs.ai) - 1; i >= 0; i-- {
-				fs.ai[i].bgDraw(layerno)
-				fs.ai[i].draw(layerno, fs.fnt, sys.aiLevel[sys.chars[i][0].playerNo])
+			for i := len(fs.aiLevels) - 1; i >= 0; i-- {
+				fs.aiLevels[i].bgDraw(layerno)
+				fs.aiLevels[i].draw(layerno, fs.fnt, sys.aiLevel[sys.chars[i][0].playerNo])
 			}
 
 			// FightScreenWinCount
-			for i := len(fs.wc) - 1; i >= 0; i-- {
-				fs.wc[i].bgDraw(layerno)
-				fs.wc[i].draw(layerno, fs.fnt, i)
+			for i := len(fs.winCounts) - 1; i >= 0; i-- {
+				fs.winCounts[i].bgDraw(layerno)
+				fs.winCounts[i].draw(layerno, fs.fnt, i)
 			}
 		}
 
 		// FightScreenCombo
-		for i := len(fs.co) - 1; i >= 0; i-- {
+		for i := len(fs.combos) - 1; i >= 0; i-- {
 			if !sys.chars[i][0].asf(ASF_nocombodisplay) {
-				fs.co[i].draw(layerno, fs.fnt, i)
+				fs.combos[i].draw(layerno, fs.fnt, i)
 			}
 		}
 
 		// FightScreenAction
-		for i := len(fs.ac) - 1; i >= 0; i-- {
+		for i := len(fs.actions) - 1; i >= 0; i-- {
 			if !sys.chars[i][0].asf(ASF_nolifebaraction) {
-				fs.ac[i].draw(layerno, fs.fnt, i)
+				fs.actions[i].draw(layerno, fs.fnt, i)
 			}
 		}
 
 		// FightScreenMode
-		if _, ok := fs.mo[sys.gameMode]; ok {
-			fs.mo[sys.gameMode].bgDraw(layerno)
-			fs.mo[sys.gameMode].draw(layerno, fs.fnt)
+		if _, ok := fs.modes[sys.gameMode]; ok {
+			fs.modes[sys.gameMode].bgDraw(layerno)
+			fs.modes[sys.gameMode].draw(layerno, fs.fnt)
 		}
 	}
 
 	if fs.active {
 		// FightScreenRound
-		fs.ro.draw(layerno, fs.fnt)
+		fs.round.draw(layerno, fs.fnt)
 	}
 }
 
@@ -5645,7 +5645,7 @@ func (fs *FightScreen) appendAction(c *Char, msg *FSMsg, s_ffx, a_ffx string, sn
 	}
 
 	// Select side of screen
-	teammsg := fs.ac[c.teamside]
+	teammsg := fs.actions[c.teamside]
 
 	// If adding a new message while exceeding the maximum number allowed, make the oldest message go away faster
 	var count int32

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -78,7 +78,7 @@ func newFightFx() *FightFx {
 	return &FightFx{
 		sff:        &Sff{},
 		fx_scale:   1.0,
-		localcoord: sys.lifebar.localcoord,
+		localcoord: sys.fightScreen.localcoord,
 	}
 }
 
@@ -191,7 +191,7 @@ func loadFightFx(def string, isGlobal bool, isMainThread bool) error {
 	return nil
 }
 
-type LbText struct {
+type FSText struct {
 	font       [8]int32 // to match Lua arg count regardless
 	text       string
 	lay        Layout
@@ -201,8 +201,8 @@ type LbText struct {
 	pfxinit    int32
 }
 
-func newLbText(align int32) *LbText {
-	return &LbText{
+func newFSText(align int32) *FSText {
+	return &FSText{
 		font:  [...]int32{-1, 0, align, 255, 255, 255, 255, -1},
 		palfx: newPalFX(),
 		frgba: [...]float32{1.0, 1.0, 1.0, 1.0},
@@ -220,14 +220,14 @@ func getFont(f map[int]*Fnt, idx int32) *Fnt {
 	return nil
 }
 
-func readLbText(pre string, is IniSection, str string, ln int16, f map[int]*Fnt, align int32) *LbText {
-	txt := newLbText(align)
+func readFSText(pre string, is IniSection, str string, ln int16, f map[int]*Fnt, align int32) *FSText {
+	txt := newFSText(align)
 
 	txt.font[3], txt.font[4], txt.font[5], txt.font[6], txt.font[7] = -1, -1, -1, 255, -1
 	is.ReadI32(pre+"font", &txt.font[0], &txt.font[1], &txt.font[2],
 		&txt.font[3], &txt.font[4], &txt.font[5], &txt.font[6], &txt.font[7])
 	if txt.font[0] >= 0 && getFont(f, txt.font[0]) == nil {
-		LogMessage("Undefined font %v referenced by lifebar parameter: %v", txt.font[0], pre+"font")
+		LogMessage("Undefined font %v referenced by fight screen parameter: %v", txt.font[0], pre+"font")
 		txt.font[0] = -1
 	}
 	if _, ok := is[pre+"text"]; ok {
@@ -243,26 +243,26 @@ func readLbText(pre string, is IniSection, str string, ln int16, f map[int]*Fnt,
 	return txt
 }
 
-func (txt *LbText) SetColor(r, g, b, a int32) {
+func (txt *FSText) SetColor(r, g, b, a int32) {
 	txt.forcecolor = true
 	txt.palfx.setColor(r, g, b)
 	txt.frgba = [...]float32{float32(r) / 255, float32(g) / 255,
 		float32(b) / 255, float32(a) / 255}
 }
 
-func (txt *LbText) step() {
+func (txt *FSText) step() {
 	if txt.palfx != nil && !txt.forcecolor {
 		txt.palfx.step()
 	}
 }
 
-func (txt *LbText) resetTxtPfx() {
+func (txt *FSText) resetTxtPfx() {
 	txt.palfx.time = txt.pfxinit
 }
 
-type LbBgTextSnd struct {
+type FSBgTextSnd struct {
 	pos         [2]int32
-	text        LbText
+	text        FSText
 	bg          AnimLayout
 	time        int32
 	displaytime int32
@@ -271,15 +271,15 @@ type LbBgTextSnd struct {
 	timer       int32
 }
 
-func newLbBgTextSnd() LbBgTextSnd {
-	return LbBgTextSnd{snd: [2]int32{-1}}
+func newFSBgTextSnd() FSBgTextSnd {
+	return FSBgTextSnd{snd: [2]int32{-1}}
 }
 
-func readLbBgTextSnd(pre string, is IniSection, sff *Sff, at AnimationTable, ln int16, f map[int]*Fnt) LbBgTextSnd {
-	bts := newLbBgTextSnd()
+func readFSBgTextSnd(pre string, is IniSection, sff *Sff, at AnimationTable, ln int16, f map[int]*Fnt) FSBgTextSnd {
+	bts := newFSBgTextSnd()
 
 	is.ReadI32(pre+"pos", &bts.pos[0], &bts.pos[1])
-	bts.text = *readLbText(pre+"text.", is, "", ln, f, 0)
+	bts.text = *readFSText(pre+"text.", is, "", ln, f, 0)
 	bts.bg = ReadAnimLayout(pre+"bg.", is, sff, at, ln)
 	is.ReadI32(pre+"time", &bts.time)
 	is.ReadI32(pre+"displaytime", &bts.displaytime)
@@ -289,7 +289,7 @@ func readLbBgTextSnd(pre string, is IniSection, sff *Sff, at AnimationTable, ln 
 	return bts
 }
 
-func (bts *LbBgTextSnd) step(snd *Snd) {
+func (bts *FSBgTextSnd) step(snd *Snd) {
 	if bts.timer == bts.sndtime {
 		snd.play(bts.snd, 100, 0, 0, 0, 0)
 	}
@@ -300,27 +300,27 @@ func (bts *LbBgTextSnd) step(snd *Snd) {
 	bts.text.step()
 }
 
-func (bts *LbBgTextSnd) reset() {
+func (bts *FSBgTextSnd) reset() {
 	bts.timer = 0
 	bts.bg.Reset()
 	bts.text.resetTxtPfx()
 }
 
-func (bts *LbBgTextSnd) bgDraw(layerno int16) {
+func (bts *FSBgTextSnd) bgDraw(layerno int16) {
 	if bts.timer > bts.time && bts.timer <= bts.time+bts.displaytime {
-		bts.bg.Draw(float32(bts.pos[0])+sys.lifebar.offsetX, float32(bts.pos[1]), layerno, sys.lifebar.scale)
+		bts.bg.Draw(float32(bts.pos[0])+sys.fightScreen.offsetX, float32(bts.pos[1]), layerno, sys.fightScreen.scale)
 	}
 }
 
-func (bts *LbBgTextSnd) draw(layerno int16, f map[int]*Fnt) {
+func (bts *FSBgTextSnd) draw(layerno int16, f map[int]*Fnt) {
 	if bts.timer > bts.time && bts.timer <= bts.time+bts.displaytime &&
 		bts.text.font[0] >= 0 && getFont(f, bts.text.font[0]) != nil {
-		bts.text.lay.DrawText(float32(bts.pos[0])+sys.lifebar.offsetX, float32(bts.pos[1]), sys.lifebar.scale, layerno,
+		bts.text.lay.DrawText(float32(bts.pos[0])+sys.fightScreen.offsetX, float32(bts.pos[1]), sys.fightScreen.scale, layerno,
 			bts.text.text, getFont(f, bts.text.font[0]), bts.text.font[1], bts.text.font[2], bts.text.palfx, bts.text.frgba)
 	}
 }
 
-// Reads multiple lifebar values e.g. multiple front elements
+// Reads multiple bar values e.g. multiple front elements
 func readMultipleValues(pre string, name string, is IniSection, sff *Sff, at AnimationTable) map[int32]*AnimLayout {
 	result := make(map[int32]*AnimLayout)
 	r, _ := regexp.Compile(pre + name + "[0-9]+\\.")
@@ -362,8 +362,8 @@ func readMultipleValuesF(pre string, name string, is IniSection, sff *Sff, at An
 }
 
 // Text version of readMultipleValues
-func readMultipleLbText(pre string, name string, is IniSection, fmtstr string, ln int16, f map[int]*Fnt, align int32) map[int32]*LbText {
-	result := make(map[int32]*LbText)
+func readMultipleFSText(pre string, name string, is IniSection, fmtstr string, ln int16, f map[int]*Fnt, align int32) map[int32]*FSText {
+	result := make(map[int32]*FSText)
 	r, _ := regexp.Compile(pre + name + "[0-9]+\\.")
 	for k := range is {
 		if r.MatchString(k) {
@@ -372,7 +372,7 @@ func readMultipleLbText(pre string, name string, is IniSection, fmtstr string, l
 			if len(submatchall) >= 1 {
 				v := Atoi(submatchall[len(submatchall)-1])
 				if _, ok := result[v]; !ok {
-					result[v] = readLbText(pre+name+fmt.Sprintf("%v", v)+".", is, fmtstr, ln, f, align)
+					result[v] = readFSText(pre+name+fmt.Sprintf("%v", v)+".", is, fmtstr, ln, f, align)
 				}
 			}
 		}
@@ -403,7 +403,7 @@ func calcBarFillRect(pos int32, range_ [2]int32, offset, scale, screenScale, mid
 	return
 }
 
-type HealthBar struct {
+type LifeBar struct {
 	pos        [2]int32
 	range_x    [2]int32
 	range_y    [2]int32
@@ -417,8 +417,8 @@ type HealthBar struct {
 	shift      AnimLayout
 	warn       AnimLayout
 	warn_range [2]int32
-	value      map[int32]*LbText
-	red_value  map[int32]*LbText
+	value      map[int32]*FSText
+	red_value  map[int32]*FSText
 	toplife    float32
 	oldlife    float32
 	midlife    float32
@@ -433,15 +433,15 @@ type HealthBar struct {
 	scalefill  bool
 }
 
-func newHealthBar() *HealthBar {
-	return &HealthBar{
+func newLifeBar() *LifeBar {
+	return &LifeBar{
 		oldlife:    1,
 		midlife:    1,
 		midlifeMin: 1,
 		red:        make(map[int32]*AnimLayout),
 		front:      make(map[float32]*AnimLayout),
-		value:      make(map[int32]*LbText),
-		red_value:  make(map[int32]*LbText),
+		value:      make(map[int32]*FSText),
+		red_value:  make(map[int32]*FSText),
 		mid_freeze: true,
 		mid_delay:  30,
 		mid_mult:   1.0,
@@ -449,187 +449,187 @@ func newHealthBar() *HealthBar {
 	}
 }
 
-func readHealthBar(pre string, is IniSection, sff *Sff, at AnimationTable, f map[int]*Fnt) *HealthBar {
-	hb := newHealthBar()
+func readLifeBar(pre string, is IniSection, sff *Sff, at AnimationTable, f map[int]*Fnt) *LifeBar {
+	lb := newLifeBar()
 
-	is.ReadI32(pre+"pos", &hb.pos[0], &hb.pos[1])
-	is.ReadI32(pre+"range.x", &hb.range_x[0], &hb.range_x[1])
-	is.ReadI32(pre+"range.y", &hb.range_y[0], &hb.range_y[1])
+	is.ReadI32(pre+"pos", &lb.pos[0], &lb.pos[1])
+	is.ReadI32(pre+"range.x", &lb.range_x[0], &lb.range_x[1])
+	is.ReadI32(pre+"range.y", &lb.range_y[0], &lb.range_y[1])
 
 	// Single value layouts
-	hb.bg0 = ReadAnimLayout(pre+"bg0.", is, sff, at, 0)
-	hb.bg1 = ReadAnimLayout(pre+"bg1.", is, sff, at, 0)
-	hb.bg2 = ReadAnimLayout(pre+"bg2.", is, sff, at, 0)
-	hb.top = ReadAnimLayout(pre+"top.", is, sff, at, 0)
-	hb.mid = ReadAnimLayout(pre+"mid.", is, sff, at, 0)
-	hb.shift = ReadAnimLayout(pre+"shift.", is, sff, at, 0)
-	hb.warn = ReadAnimLayout(pre+"warn.", is, sff, at, 0)
+	lb.bg0 = ReadAnimLayout(pre+"bg0.", is, sff, at, 0)
+	lb.bg1 = ReadAnimLayout(pre+"bg1.", is, sff, at, 0)
+	lb.bg2 = ReadAnimLayout(pre+"bg2.", is, sff, at, 0)
+	lb.top = ReadAnimLayout(pre+"top.", is, sff, at, 0)
+	lb.mid = ReadAnimLayout(pre+"mid.", is, sff, at, 0)
+	lb.shift = ReadAnimLayout(pre+"shift.", is, sff, at, 0)
+	lb.warn = ReadAnimLayout(pre+"warn.", is, sff, at, 0)
 
 	// Multiple value layouts
-	hb.front = readMultipleValuesF(pre, "front", is, sff, at)
-	if _, ok := hb.front[0]; !ok { // Set a value for 0 if it's missing
+	lb.front = readMultipleValuesF(pre, "front", is, sff, at)
+	if _, ok := lb.front[0]; !ok { // Set a value for 0 if it's missing
 		tmp := ReadAnimLayout(pre+"front.", is, sff, at, 0)
-		hb.front[0] = &tmp
+		lb.front[0] = &tmp
 	}
 
-	hb.red = readMultipleValues(pre, "red", is, sff, at)
-	if _, ok := hb.red[0]; !ok {
+	lb.red = readMultipleValues(pre, "red", is, sff, at)
+	if _, ok := lb.red[0]; !ok {
 		tmp := ReadAnimLayout(pre+"red.", is, sff, at, 0)
-		hb.red[0] = &tmp
+		lb.red[0] = &tmp
 	}
 
 	// Text fields
-	hb.value[0] = readLbText(pre+"value.", is, "%d", 0, f, 0)
-	for k, v := range readMultipleLbText(pre, "value", is, "%d", 0, f, 0) {
-		hb.value[k] = v
+	lb.value[0] = readFSText(pre+"value.", is, "%d", 0, f, 0)
+	for k, v := range readMultipleFSText(pre, "value", is, "%d", 0, f, 0) {
+		lb.value[k] = v
 	}
 
-	hb.red_value[0] = readLbText(pre+"red.value.", is, "%d", 0, f, 0)
-	for k, v := range readMultipleLbText(pre, "red.value", is, "%d", 0, f, 0) {
-		hb.red_value[k] = v
+	lb.red_value[0] = readFSText(pre+"red.value.", is, "%d", 0, f, 0)
+	for k, v := range readMultipleFSText(pre, "red.value", is, "%d", 0, f, 0) {
+		lb.red_value[k] = v
 	}
 
 	// Other fields
-	is.ReadBool("mid.shift", &hb.mid_shift)
-	is.ReadBool("mid.freeze", &hb.mid_freeze)
-	is.ReadI32("mid.delay", &hb.mid_delay)
-	is.ReadF32("mid.mult", &hb.mid_mult)
-	is.ReadF32("mid.steps", &hb.mid_steps)
-	hb.mid_steps = Max(1, hb.mid_steps)
+	is.ReadBool("mid.shift", &lb.mid_shift)
+	is.ReadBool("mid.freeze", &lb.mid_freeze)
+	is.ReadI32("mid.delay", &lb.mid_delay)
+	is.ReadF32("mid.mult", &lb.mid_mult)
+	is.ReadF32("mid.steps", &lb.mid_steps)
+	lb.mid_steps = Max(1, lb.mid_steps)
 
-	is.ReadI32(pre+"warn.range", &hb.warn_range[0], &hb.warn_range[1])
-	is.ReadBool(pre+"scalefill", &hb.scalefill)
+	is.ReadI32(pre+"warn.range", &lb.warn_range[0], &lb.warn_range[1])
+	is.ReadBool(pre+"scalefill", &lb.scalefill)
 
-	return hb
+	return lb
 }
 
-func (hb *HealthBar) step(charpn int, hbr *HealthBar) {
+func (lb *LifeBar) step(charpn int, lbr *LifeBar) {
 	refChar := sys.chars[charpn][0]
 	var life float32 = float32(refChar.life) / float32(refChar.lifeMax)
 	var redVal int32 = refChar.redLife - refChar.life
 	var getHit bool = (refChar.receivedHits != 0 || refChar.ss.moveType == MT_H) && !refChar.scf(SCF_over_ko)
 
-	if hbr.toplife > life {
-		hbr.toplife += (life - hbr.toplife) / 2
+	if lbr.toplife > life {
+		lbr.toplife += (life - lbr.toplife) / 2
 	} else {
-		hbr.toplife = life
+		lbr.toplife = life
 	}
 
 	// Element shifting gradient
-	hb.shift.anim.srcAlpha = int16(255 * (1 - life))
-	hb.shift.anim.dstAlpha = int16(255 * life)
+	lb.shift.anim.srcAlpha = int16(255 * (1 - life))
+	lb.shift.anim.dstAlpha = int16(255 * life)
 
-	if !hb.mid_freeze && getHit && !hb.gethit && len(hb.mid.anim.frames) > 0 {
-		hbr.mlifetime = hb.mid_delay
-		hbr.midlife = hbr.oldlife
-		hbr.midlifeMin = hbr.oldlife
+	if !lb.mid_freeze && getHit && !lb.gethit && len(lb.mid.anim.frames) > 0 {
+		lbr.mlifetime = lb.mid_delay
+		lbr.midlife = lbr.oldlife
+		lbr.midlifeMin = lbr.oldlife
 	}
-	hb.gethit = getHit
-	if hb.mid_freeze && getHit && len(hb.mid.anim.frames) > 0 {
-		if hbr.mlifetime < hb.mid_delay {
-			hbr.mlifetime = hb.mid_delay
-			hbr.midlife = hbr.oldlife
-			hbr.midlifeMin = hbr.oldlife
+	lb.gethit = getHit
+	if lb.mid_freeze && getHit && len(lb.mid.anim.frames) > 0 {
+		if lbr.mlifetime < lb.mid_delay {
+			lbr.mlifetime = lb.mid_delay
+			lbr.midlife = lbr.oldlife
+			lbr.midlifeMin = lbr.oldlife
 		}
 	} else {
-		if hbr.mlifetime > 0 {
-			hbr.mlifetime--
+		if lbr.mlifetime > 0 {
+			lbr.mlifetime--
 		}
-		if len(hb.mid.anim.frames) > 0 && hbr.mlifetime <= 0 && life < hbr.midlifeMin {
-			hbr.midlifeMin += (life - hbr.midlifeMin) * (1 / (12 - (life-hbr.midlifeMin)*144)) * hb.mid_mult
-			if hbr.midlifeMin < life {
-				hbr.midlifeMin = life
+		if len(lb.mid.anim.frames) > 0 && lbr.mlifetime <= 0 && life < lbr.midlifeMin {
+			lbr.midlifeMin += (life - lbr.midlifeMin) * (1 / (12 - (life-lbr.midlifeMin)*144)) * lb.mid_mult
+			if lbr.midlifeMin < life {
+				lbr.midlifeMin = life
 			}
 		} else {
-			hbr.midlifeMin = life
+			lbr.midlifeMin = life
 		}
-		if (len(hb.mid.anim.frames) == 0 || hbr.mlifetime <= 0) && hbr.midlife > hbr.midlifeMin {
-			hbr.midlife += (hbr.midlifeMin - hbr.midlife) / hb.mid_steps
+		if (len(lb.mid.anim.frames) == 0 || lbr.mlifetime <= 0) && lbr.midlife > lbr.midlifeMin {
+			lbr.midlife += (lbr.midlifeMin - lbr.midlife) / lb.mid_steps
 		}
-		hbr.oldlife = life
+		lbr.oldlife = life
 	}
 
-	mlmin := Max(hbr.midlifeMin, life)
-	if hbr.midlife < mlmin {
-		hbr.midlife += (mlmin - hbr.midlife) / 2
+	mlmin := Max(lbr.midlifeMin, life)
+	if lbr.midlife < mlmin {
+		lbr.midlife += (mlmin - lbr.midlife) / 2
 	}
 
-	hb.bg0.Action()
-	hb.bg1.Action()
-	hb.bg2.Action()
-	hb.top.Action()
-	hb.mid.Action()
+	lb.bg0.Action()
+	lb.bg1.Action()
+	lb.bg2.Action()
+	lb.top.Action()
+	lb.mid.Action()
 	// Multiple front elements - red life
 	if refChar.redLifeEnabled() {
 		var rv int32
-		for k := range hb.red {
+		for k := range lb.red {
 			if k > rv && redVal >= k {
 				rv = k
 			}
 		}
-		hb.red[rv].Action()
+		lb.red[rv].Action()
 
 		// Multiple red_value fonts - life
 		var rv2 int32
-		for k := range hb.red_value {
+		for k := range lb.red_value {
 			if k > rv2 && redVal >= k {
 				rv2 = k
 			}
 		}
-		hb.red_value[rv2].step()
+		lb.red_value[rv2].step()
 	}
 
 	// Multiple front elements - life
 	var fv float32
-	for k := range hb.front {
+	for k := range lb.front {
 		if k > fv && life >= k/100 {
 			fv = k
 		}
 	}
-	hb.front[fv].Action()
+	lb.front[fv].Action()
 
-	hb.shift.Action()
-	hb.warn.Action()
+	lb.shift.Action()
+	lb.warn.Action()
 
 	// Multiple value fonts - life
 	var fv2 int32
-	for k := range hb.value {
+	for k := range lb.value {
 		if k > fv2 && life >= float32(k)/100 {
 			fv2 = k
 		}
 	}
-	hb.value[fv2].step()
+	lb.value[fv2].step()
 }
 
-func (hb *HealthBar) reset() {
-	hb.bg0.Reset()
-	hb.bg1.Reset()
-	hb.bg2.Reset()
-	hb.top.Reset()
-	hb.mid.Reset()
-	for i := range hb.front {
-		hb.front[i].Reset()
+func (lb *LifeBar) reset() {
+	lb.bg0.Reset()
+	lb.bg1.Reset()
+	lb.bg2.Reset()
+	lb.top.Reset()
+	lb.mid.Reset()
+	for i := range lb.front {
+		lb.front[i].Reset()
 	}
 
-	hb.shift.Reset()
-	hb.shift.anim.transType = TT_add // Since default is AIR transparency
-	hb.shift.anim.srcAlpha = 0
-	hb.shift.anim.dstAlpha = 255
+	lb.shift.Reset()
+	lb.shift.anim.transType = TT_add // Since default is AIR transparency
+	lb.shift.anim.srcAlpha = 0
+	lb.shift.anim.dstAlpha = 255
 
-	for i := range hb.red {
-		hb.red[i].Reset()
+	for i := range lb.red {
+		lb.red[i].Reset()
 	}
 
-	hb.warn.Reset()
+	lb.warn.Reset()
 }
 
-func (hb *HealthBar) bgDraw(layerno int16) {
-	hb.bg0.Draw(float32(hb.pos[0])+sys.lifebar.offsetX, float32(hb.pos[1])+sys.lifebar.offsetY, layerno, sys.lifebar.scale)
-	hb.bg1.Draw(float32(hb.pos[0])+sys.lifebar.offsetX, float32(hb.pos[1])+sys.lifebar.offsetY, layerno, sys.lifebar.scale)
-	hb.bg2.Draw(float32(hb.pos[0])+sys.lifebar.offsetX, float32(hb.pos[1])+sys.lifebar.offsetY, layerno, sys.lifebar.scale)
+func (lb *LifeBar) bgDraw(layerno int16) {
+	lb.bg0.Draw(float32(lb.pos[0])+sys.fightScreen.offsetX, float32(lb.pos[1])+sys.fightScreen.offsetY, layerno, sys.fightScreen.scale)
+	lb.bg1.Draw(float32(lb.pos[0])+sys.fightScreen.offsetX, float32(lb.pos[1])+sys.fightScreen.offsetY, layerno, sys.fightScreen.scale)
+	lb.bg2.Draw(float32(lb.pos[0])+sys.fightScreen.offsetX, float32(lb.pos[1])+sys.fightScreen.offsetY, layerno, sys.fightScreen.scale)
 }
 
-func (hb *HealthBar) draw(layerno int16, charpn int, hbr *HealthBar, f map[int]*Fnt) {
+func (lb *LifeBar) draw(layerno int16, charpn int, lbr *LifeBar, f map[int]*Fnt) {
 	// Get reference values
 	refChar := sys.chars[charpn][0]
 	life := float32(refChar.life) / float32(refChar.lifeMax)
@@ -642,50 +642,50 @@ func (hb *HealthBar) draw(layerno int16, charpn int, hbr *HealthBar, f map[int]*
 	getBarClipRect := func(life float32) [4]int32 {
 		r := sys.scrrect
 
-		if hb.scalefill {
+		if lb.scalefill {
 			life = 1
 		}
 
-		if hb.range_x != [2]int32{0, 0} {
-			r[0], r[2] = calcBarFillRect(hb.pos[0], hb.range_x, sys.lifebar.offsetX, sys.lifebar.scale, sys.widthScale, MidPosX, life)
+		if lb.range_x != [2]int32{0, 0} {
+			r[0], r[2] = calcBarFillRect(lb.pos[0], lb.range_x, sys.fightScreen.offsetX, sys.fightScreen.scale, sys.widthScale, MidPosX, life)
 		}
 
-		if hb.range_y != [2]int32{0, 0} {
-			r[1], r[3] = calcBarFillRect(hb.pos[1], hb.range_y, sys.lifebar.offsetY, sys.lifebar.scale, sys.heightScale, MidPosY, life)
+		if lb.range_y != [2]int32{0, 0} {
+			r[1], r[3] = calcBarFillRect(lb.pos[1], lb.range_y, sys.fightScreen.offsetY, sys.fightScreen.scale, sys.heightScale, MidPosY, life)
 		}
 		return r
 	}
 
 	// This is already handled by step()
 	// It makes the mid layer misbehave between rounds
-	//if len(hb.mid.anim.frames) == 0 || life > hbr.midlife {
-	//	life = hbr.midlife
+	//if len(lb.mid.anim.frames) == 0 || life > lbr.midlife {
+	//	life = lbr.midlife
 	//}
 
 	// Draw the three rectangles: top, mid, and red
-	lr, mr, rr := getBarClipRect(hbr.toplife), getBarClipRect(hbr.midlife), getBarClipRect(redlife)
+	lr, mr, rr := getBarClipRect(lbr.toplife), getBarClipRect(lbr.midlife), getBarClipRect(redlife)
 
 	var (
 		lxs, mxs, rxs float32 = 1.0, 1.0, 1.0
 		lys, mys, rys float32 = 1.0, 1.0, 1.0
 	)
-	if hb.scalefill { // Scale the sprite's size instead of adjusting the rectangle
-		v := [3]float32{hbr.toplife, hbr.midlife, redlife}
-		if hb.range_y != [2]int32{0, 0} {
+	if lb.scalefill { // Scale the sprite's size instead of adjusting the rectangle
+		v := [3]float32{lbr.toplife, lbr.midlife, redlife}
+		if lb.range_y != [2]int32{0, 0} {
 			lys, mys, rys = v[0], v[1], v[2]
 		} else {
 			lxs, mxs, rxs = v[0], v[1], v[2]
 		}
 	} else {
-		if hb.range_y != [2]int32{0, 0} {
-			if hb.range_y[0] < hb.range_y[1] {
+		if lb.range_y != [2]int32{0, 0} {
+			if lb.range_y[0] < lb.range_y[1] {
 				mr[1] += lr[3]
 				rr[1] += lr[3]
 			}
 			mr[3] -= Min(mr[3], lr[3])
 			rr[3] -= Min(rr[3], lr[3])
 		} else {
-			if hb.range_x[0] < hb.range_x[1] {
+			if lb.range_x[0] < lb.range_x[1] {
 				mr[0] += lr[2]
 				rr[0] += lr[2]
 			}
@@ -697,86 +697,86 @@ func (hb *HealthBar) draw(layerno int16, charpn int, hbr *HealthBar, f map[int]*
 	// Draw red life
 	if refChar.redLifeEnabled() {
 		var rv int32
-		for k := range hb.red {
+		for k := range lb.red {
 			if k > rv && redval >= k {
 				rv = k
 			}
 		}
-		hb.red[rv].lay.DrawAnim(&rr, float32(hb.pos[0])+sys.lifebar.offsetX, float32(hb.pos[1])+sys.lifebar.offsetY, sys.lifebar.scale, rxs, rys,
-			layerno, hb.red[rv].anim, hb.red[rv].palfx)
+		lb.red[rv].lay.DrawAnim(&rr, float32(lb.pos[0])+sys.fightScreen.offsetX, float32(lb.pos[1])+sys.fightScreen.offsetY, sys.fightScreen.scale, rxs, rys,
+			layerno, lb.red[rv].anim, lb.red[rv].palfx)
 
-		if hb.red_value[0].font[0] >= 0 && getFont(f, hb.red_value[0].font[0]) != nil {
+		if lb.red_value[0].font[0] >= 0 && getFont(f, lb.red_value[0].font[0]) != nil {
 			// Multiple red_value fonts according to redval
 			var rv2 int32
-			for k := range hb.red_value {
+			for k := range lb.red_value {
 				if k > rv2 && redval >= k {
 					rv2 = k
 				}
 			}
-			text := strings.Replace(hb.red_value[rv2].text, "%d", fmt.Sprintf("%v", refChar.redLife), 1)
+			text := strings.Replace(lb.red_value[rv2].text, "%d", fmt.Sprintf("%v", refChar.redLife), 1)
 			text = strings.Replace(text, "%p", fmt.Sprintf("%v", math.Round(float64(redlife)*100)), 1)
-			hb.red_value[rv2].lay.DrawText(
-				float32(hb.pos[0])+sys.lifebar.offsetX,
-				float32(hb.pos[1])+sys.lifebar.offsetY, sys.lifebar.scale,
+			lb.red_value[rv2].lay.DrawText(
+				float32(lb.pos[0])+sys.fightScreen.offsetX,
+				float32(lb.pos[1])+sys.fightScreen.offsetY, sys.fightScreen.scale,
 				layerno,
 				text,
-				getFont(f, hb.red_value[rv2].font[0]),
-				hb.red_value[rv2].font[1],
-				hb.red_value[rv2].font[2],
-				hb.red_value[rv2].palfx,
-				hb.red_value[rv2].frgba,
+				getFont(f, lb.red_value[rv2].font[0]),
+				lb.red_value[rv2].font[1],
+				lb.red_value[rv2].font[2],
+				lb.red_value[rv2].palfx,
+				lb.red_value[rv2].frgba,
 			)
 		}
 	}
 
-	hb.mid.lay.DrawAnim(&mr, float32(hb.pos[0])+sys.lifebar.offsetX, float32(hb.pos[1])+sys.lifebar.offsetY, sys.lifebar.scale, mxs, mys,
-		layerno, hb.mid.anim, hb.mid.palfx)
+	lb.mid.lay.DrawAnim(&mr, float32(lb.pos[0])+sys.fightScreen.offsetX, float32(lb.pos[1])+sys.fightScreen.offsetY, sys.fightScreen.scale, mxs, mys,
+		layerno, lb.mid.anim, lb.mid.palfx)
 
-	if hb.mid_shift {
-		hb.shift.lay.DrawAnim(&mr, float32(hb.pos[0])+sys.lifebar.offsetX, float32(hb.pos[1])+sys.lifebar.offsetY, sys.lifebar.scale, mxs, mys,
-			layerno, hb.shift.anim, hb.shift.palfx)
+	if lb.mid_shift {
+		lb.shift.lay.DrawAnim(&mr, float32(lb.pos[0])+sys.fightScreen.offsetX, float32(lb.pos[1])+sys.fightScreen.offsetY, sys.fightScreen.scale, mxs, mys,
+			layerno, lb.shift.anim, lb.shift.palfx)
 	}
 
 	// Multiple front elements
 	var fv float32
-	for k := range hb.front {
+	for k := range lb.front {
 		if k > fv && life >= k/100 {
 			fv = k
 		}
 	}
-	hb.front[fv].lay.DrawAnim(&lr, float32(hb.pos[0])+sys.lifebar.offsetX, float32(hb.pos[1])+sys.lifebar.offsetY, sys.lifebar.scale, lxs, lys,
-		layerno, hb.front[fv].anim, hb.front[fv].palfx)
+	lb.front[fv].lay.DrawAnim(&lr, float32(lb.pos[0])+sys.fightScreen.offsetX, float32(lb.pos[1])+sys.fightScreen.offsetY, sys.fightScreen.scale, lxs, lys,
+		layerno, lb.front[fv].anim, lb.front[fv].palfx)
 
-	hb.shift.lay.DrawAnim(&lr, float32(hb.pos[0])+sys.lifebar.offsetX, float32(hb.pos[1])+sys.lifebar.offsetY, sys.lifebar.scale, lxs, lys,
-		layerno, hb.shift.anim, hb.shift.palfx)
+	lb.shift.lay.DrawAnim(&lr, float32(lb.pos[0])+sys.fightScreen.offsetX, float32(lb.pos[1])+sys.fightScreen.offsetY, sys.fightScreen.scale, lxs, lys,
+		layerno, lb.shift.anim, lb.shift.palfx)
 
-	if hb.value[0].font[0] >= 0 && getFont(f, hb.value[0].font[0]) != nil {
+	if lb.value[0].font[0] >= 0 && getFont(f, lb.value[0].font[0]) != nil {
 		// Multiple value fonts according to life value
 		var fv2 int32
-		for k := range hb.value {
+		for k := range lb.value {
 			if k > fv2 && life >= float32(k)/100 {
 				fv2 = k
 			}
 		}
-		text := strings.Replace(hb.value[fv2].text, "%d", fmt.Sprintf("%v", refChar.life), 1)
+		text := strings.Replace(lb.value[fv2].text, "%d", fmt.Sprintf("%v", refChar.life), 1)
 		text = strings.Replace(text, "%p", fmt.Sprintf("%v", math.Round(float64(life)*100)), 1)
-		hb.value[fv2].lay.DrawText(
-			float32(hb.pos[0])+sys.lifebar.offsetX,
-			float32(hb.pos[1])+sys.lifebar.offsetY, sys.lifebar.scale,
+		lb.value[fv2].lay.DrawText(
+			float32(lb.pos[0])+sys.fightScreen.offsetX,
+			float32(lb.pos[1])+sys.fightScreen.offsetY, sys.fightScreen.scale,
 			layerno,
 			text,
-			getFont(f, hb.value[fv2].font[0]),
-			hb.value[fv2].font[1],
-			hb.value[fv2].font[2],
-			hb.value[fv2].palfx,
-			hb.value[fv2].frgba,
+			getFont(f, lb.value[fv2].font[0]),
+			lb.value[fv2].font[1],
+			lb.value[fv2].font[2],
+			lb.value[fv2].palfx,
+			lb.value[fv2].frgba,
 		)
 	}
 
-	hb.top.Draw(float32(hb.pos[0])+sys.lifebar.offsetX, float32(hb.pos[1])+sys.lifebar.offsetY, layerno, sys.lifebar.scale)
+	lb.top.Draw(float32(lb.pos[0])+sys.fightScreen.offsetX, float32(lb.pos[1])+sys.fightScreen.offsetY, layerno, sys.fightScreen.scale)
 
-	if life <= float32(hb.warn_range[0])/100 && life >= float32(hb.warn_range[1])/100 {
-		hb.warn.Draw(float32(hb.pos[0])+sys.lifebar.offsetX, float32(hb.pos[1])+sys.lifebar.offsetY, layerno, sys.lifebar.scale)
+	if life <= float32(lb.warn_range[0])/100 && life >= float32(lb.warn_range[1])/100 {
+		lb.warn.Draw(float32(lb.pos[0])+sys.fightScreen.offsetX, float32(lb.pos[1])+sys.fightScreen.offsetY, layerno, sys.fightScreen.scale)
 	}
 }
 
@@ -791,9 +791,9 @@ type PowerBar struct {
 	mid              AnimLayout
 	front            map[int32]*AnimLayout
 	shift            AnimLayout
-	counter          map[int32]*LbText
+	counter          map[int32]*FSText
 	counter_rounding int32
-	value            map[int32]*LbText
+	value            map[int32]*FSText
 	value_rounding   int32
 	level_snd        [9][2]int32
 	levelmax_snd     [2]int32
@@ -809,9 +809,9 @@ func newPowerBar() *PowerBar {
 	newBar := &PowerBar{
 		front:            make(map[int32]*AnimLayout),
 		bg0:              make(map[int32]*AnimLayout),
-		counter:          make(map[int32]*LbText),
+		counter:          make(map[int32]*FSText),
 		counter_rounding: 1000,
-		value:            make(map[int32]*LbText),
+		value:            make(map[int32]*FSText),
 		value_rounding:   1,
 		levelmax_snd:     [2]int32{-1, -1},
 	}
@@ -866,12 +866,12 @@ func readPowerBar(pre string, is IniSection, sff *Sff, at AnimationTable, f map[
 		return result
 	}
 
-	readMultipleLbTexts := func(name, fmtstr string) map[int32]*LbText {
-		result := make(map[int32]*LbText)
+	readMultipleFSTexts := func(name, fmtstr string) map[int32]*FSText {
+		result := make(map[int32]*FSText)
 		keys := readPBKeys(name)
 
 		for k, keyStr := range keys {
-			result[k] = readLbText(pre+name+keyStr+".", is, fmtstr, 0, f, 0)
+			result[k] = readFSText(pre+name+keyStr+".", is, fmtstr, 0, f, 0)
 		}
 		return result
 	}
@@ -893,14 +893,14 @@ func readPowerBar(pre string, is IniSection, sff *Sff, at AnimationTable, f map[
 		pb.front[0] = &tmp
 	}
 
-	// Lifebar power counter
+	// Power counter
 	pb.shift = ReadAnimLayout(pre+"shift.", is, sff, at, 0)
-	pb.counter[0] = readLbText(pre+"counter.", is, "%i", 0, f, 0)
-	for k, v := range readMultipleLbTexts("counter", "%i") {
+	pb.counter[0] = readFSText(pre+"counter.", is, "%i", 0, f, 0)
+	for k, v := range readMultipleFSTexts("counter", "%i") {
 		pb.counter[k] = v
 	}
-	pb.value[0] = readLbText(pre+"value.", is, "%d", 0, f, 0)
-	for k, v := range readMultipleLbTexts("value", "%d") {
+	pb.value[0] = readFSText(pre+"value.", is, "%d", 0, f, 0)
+	for k, v := range readMultipleFSTexts("value", "%d") {
 		pb.value[k] = v
 	}
 
@@ -1052,9 +1052,9 @@ func (pb *PowerBar) bgDraw(layerno int16, charpn int) {
 	pbval := sys.chars[charpn][0].getPower()
 	refChar := sys.chars[charpn][0]
 	fv := resolvePBKey(pb.bg0, pbval, refChar.powerMax)
-	pb.bg0[fv].Draw(float32(pb.pos[0])+sys.lifebar.offsetX, float32(pb.pos[1])+sys.lifebar.offsetY, layerno, sys.lifebar.scale)
-	pb.bg1.Draw(float32(pb.pos[0])+sys.lifebar.offsetX, float32(pb.pos[1])+sys.lifebar.offsetY, layerno, sys.lifebar.scale)
-	pb.bg2.Draw(float32(pb.pos[0])+sys.lifebar.offsetX, float32(pb.pos[1])+sys.lifebar.offsetY, layerno, sys.lifebar.scale)
+	pb.bg0[fv].Draw(float32(pb.pos[0])+sys.fightScreen.offsetX, float32(pb.pos[1])+sys.fightScreen.offsetY, layerno, sys.fightScreen.scale)
+	pb.bg1.Draw(float32(pb.pos[0])+sys.fightScreen.offsetX, float32(pb.pos[1])+sys.fightScreen.offsetY, layerno, sys.fightScreen.scale)
+	pb.bg2.Draw(float32(pb.pos[0])+sys.fightScreen.offsetX, float32(pb.pos[1])+sys.fightScreen.offsetY, layerno, sys.fightScreen.scale)
 }
 
 func (pb *PowerBar) draw(layerno int16, charpn int, pbr *PowerBar, f map[int]*Fnt) {
@@ -1077,11 +1077,11 @@ func (pb *PowerBar) draw(layerno int16, charpn int, pbr *PowerBar, f map[int]*Fn
 		}
 
 		if pb.range_x != [2]int32{0, 0} {
-			r[0], r[2] = calcBarFillRect(pb.pos[0], pb.range_x, sys.lifebar.offsetX, sys.lifebar.scale, sys.widthScale, MidPosX, power)
+			r[0], r[2] = calcBarFillRect(pb.pos[0], pb.range_x, sys.fightScreen.offsetX, sys.fightScreen.scale, sys.widthScale, MidPosX, power)
 		}
 
 		if pb.range_y != [2]int32{0, 0} {
-			r[1], r[3] = calcBarFillRect(pb.pos[1], pb.range_y, sys.lifebar.offsetY, sys.lifebar.scale, sys.heightScale, MidPosY, power)
+			r[1], r[3] = calcBarFillRect(pb.pos[1], pb.range_y, sys.fightScreen.offsetY, sys.fightScreen.scale, sys.heightScale, MidPosY, power)
 		}
 		return r
 	}
@@ -1111,15 +1111,15 @@ func (pb *PowerBar) draw(layerno int16, charpn int, pbr *PowerBar, f map[int]*Fn
 			mr[2] -= Min(mr[2], pr[2])
 		}
 	}
-	pb.mid.lay.DrawAnim(&mr, float32(pb.pos[0])+sys.lifebar.offsetX, float32(pb.pos[1])+sys.lifebar.offsetY, sys.lifebar.scale, mxs, mys,
+	pb.mid.lay.DrawAnim(&mr, float32(pb.pos[0])+sys.fightScreen.offsetX, float32(pb.pos[1])+sys.fightScreen.offsetY, sys.fightScreen.scale, mxs, mys,
 		layerno, pb.mid.anim, pb.mid.palfx)
 
 	// Multiple front elements
 	fv := resolvePBKey(pb.front, pbval, refChar.powerMax)
-	pb.front[fv].lay.DrawAnim(&pr, float32(pb.pos[0])+sys.lifebar.offsetX, float32(pb.pos[1])+sys.lifebar.offsetY, sys.lifebar.scale, pxs, pys,
+	pb.front[fv].lay.DrawAnim(&pr, float32(pb.pos[0])+sys.fightScreen.offsetX, float32(pb.pos[1])+sys.fightScreen.offsetY, sys.fightScreen.scale, pxs, pys,
 		layerno, pb.front[fv].anim, pb.front[fv].palfx)
 
-	pb.shift.lay.DrawAnim(&pr, float32(pb.pos[0])+sys.lifebar.offsetX, float32(pb.pos[1])+sys.lifebar.offsetY, sys.lifebar.scale, pxs, pys,
+	pb.shift.lay.DrawAnim(&pr, float32(pb.pos[0])+sys.fightScreen.offsetX, float32(pb.pos[1])+sys.fightScreen.offsetY, sys.fightScreen.scale, pxs, pys,
 		layerno, pb.shift.anim, pb.shift.palfx)
 
 	// Powerbar text.
@@ -1128,9 +1128,9 @@ func (pb *PowerBar) draw(layerno int16, charpn int, pbr *PowerBar, f map[int]*Fn
 		cv := resolvePBKey(pb.counter, pbval, refChar.powerMax)
 
 		pb.counter[cv].lay.DrawText(
-			float32(pb.pos[0])+sys.lifebar.offsetX,
-			float32(pb.pos[1])+sys.lifebar.offsetY,
-			sys.lifebar.scale,
+			float32(pb.pos[0])+sys.fightScreen.offsetX,
+			float32(pb.pos[1])+sys.fightScreen.offsetY,
+			sys.fightScreen.scale,
 			layerno,
 			strings.Replace(pb.counter[cv].text, "%i", fmt.Sprintf("%v", pbval/pb.counter_rounding), 1),
 			getFont(f, pb.counter[cv].font[0]),
@@ -1149,9 +1149,9 @@ func (pb *PowerBar) draw(layerno int16, charpn int, pbr *PowerBar, f map[int]*Fn
 		text = strings.Replace(text, "%p", fmt.Sprintf("%v", math.Round(float64(power)*100)), 1)
 
 		pb.value[cv2].lay.DrawText(
-			float32(pb.pos[0])+sys.lifebar.offsetX,
-			float32(pb.pos[1])+sys.lifebar.offsetY,
-			sys.lifebar.scale,
+			float32(pb.pos[0])+sys.fightScreen.offsetX,
+			float32(pb.pos[1])+sys.fightScreen.offsetY,
+			sys.fightScreen.scale,
 			layerno,
 			text,
 			getFont(f, pb.value[cv2].font[0]),
@@ -1161,7 +1161,7 @@ func (pb *PowerBar) draw(layerno int16, charpn int, pbr *PowerBar, f map[int]*Fn
 			pb.value[cv2].frgba,
 		)
 	}
-	pb.top.Draw(float32(pb.pos[0])+sys.lifebar.offsetX, float32(pb.pos[1])+sys.lifebar.offsetY, layerno, sys.lifebar.scale)
+	pb.top.Draw(float32(pb.pos[0])+sys.fightScreen.offsetX, float32(pb.pos[1])+sys.fightScreen.offsetY, layerno, sys.fightScreen.scale)
 }
 
 type GuardBar struct {
@@ -1175,7 +1175,7 @@ type GuardBar struct {
 	mid         AnimLayout
 	warn        AnimLayout
 	warn_range  [2]int32
-	value       map[int32]*LbText
+	value       map[int32]*FSText
 	front       map[float32]*AnimLayout
 	shift       AnimLayout
 	midpower    float32
@@ -1187,7 +1187,7 @@ type GuardBar struct {
 func newGuardBar() (gb *GuardBar) {
 	gb = &GuardBar{
 		front: make(map[float32]*AnimLayout),
-		value: make(map[int32]*LbText),
+		value: make(map[int32]*FSText),
 	}
 	return
 }
@@ -1213,8 +1213,8 @@ func readGuardBar(pre string, is IniSection,
 	}
 
 	gb.shift = ReadAnimLayout(pre+"shift.", is, sff, at, 0)
-	gb.value[0] = readLbText(pre+"value.", is, "%d", 0, f, 0)
-	for k, v := range readMultipleLbText(pre, "value", is, "%d", 0, f, 0) {
+	gb.value[0] = readFSText(pre+"value.", is, "%d", 0, f, 0)
+	for k, v := range readMultipleFSText(pre, "value", is, "%d", 0, f, 0) {
 		gb.value[k] = v
 	}
 	is.ReadI32(pre+"warn.range", &gb.warn_range[0], &gb.warn_range[1])
@@ -1296,18 +1296,18 @@ func (gb *GuardBar) reset() {
 
 func (gb *GuardBar) bgDraw(layerno int16) {
 	// Handled in outer loop
-	//if !sys.lifebar.guardbar {
+	//if !sys.fightScreen.guardbar {
 	//	return
 	//}
 
-	gb.bg0.Draw(float32(gb.pos[0])+sys.lifebar.offsetX, float32(gb.pos[1])+sys.lifebar.offsetY, layerno, sys.lifebar.scale)
-	gb.bg1.Draw(float32(gb.pos[0])+sys.lifebar.offsetX, float32(gb.pos[1])+sys.lifebar.offsetY, layerno, sys.lifebar.scale)
-	gb.bg2.Draw(float32(gb.pos[0])+sys.lifebar.offsetX, float32(gb.pos[1])+sys.lifebar.offsetY, layerno, sys.lifebar.scale)
+	gb.bg0.Draw(float32(gb.pos[0])+sys.fightScreen.offsetX, float32(gb.pos[1])+sys.fightScreen.offsetY, layerno, sys.fightScreen.scale)
+	gb.bg1.Draw(float32(gb.pos[0])+sys.fightScreen.offsetX, float32(gb.pos[1])+sys.fightScreen.offsetY, layerno, sys.fightScreen.scale)
+	gb.bg2.Draw(float32(gb.pos[0])+sys.fightScreen.offsetX, float32(gb.pos[1])+sys.fightScreen.offsetY, layerno, sys.fightScreen.scale)
 }
 
 func (gb *GuardBar) draw(layerno int16, charpn int, gbr *GuardBar, f map[int]*Fnt) {
 	// Handled in outer loop
-	//if !sys.lifebar.guardbar {
+	//if !sys.fightScreen.guardbar {
 	//	return
 	//}
 
@@ -1327,11 +1327,11 @@ func (gb *GuardBar) draw(layerno int16, charpn int, gbr *GuardBar, f map[int]*Fn
 		}
 
 		if gb.range_x != [2]int32{0, 0} {
-			r[0], r[2] = calcBarFillRect(gb.pos[0], gb.range_x, sys.lifebar.offsetX, sys.lifebar.scale, sys.widthScale, MidPosX, points)
+			r[0], r[2] = calcBarFillRect(gb.pos[0], gb.range_x, sys.fightScreen.offsetX, sys.fightScreen.scale, sys.widthScale, MidPosX, points)
 		}
 
 		if gb.range_y != [2]int32{0, 0} {
-			r[1], r[3] = calcBarFillRect(gb.pos[1], gb.range_y, sys.lifebar.offsetY, sys.lifebar.scale, sys.heightScale, MidPosY, points)
+			r[1], r[3] = calcBarFillRect(gb.pos[1], gb.range_y, sys.fightScreen.offsetY, sys.fightScreen.scale, sys.heightScale, MidPosY, points)
 		}
 		return r
 	}
@@ -1362,7 +1362,7 @@ func (gb *GuardBar) draw(layerno int16, charpn int, gbr *GuardBar, f map[int]*Fn
 			mr[2] -= Min(mr[2], pr[2])
 		}
 	}
-	gb.mid.lay.DrawAnim(&mr, float32(gb.pos[0])+sys.lifebar.offsetX, float32(gb.pos[1])+sys.lifebar.offsetY, sys.lifebar.scale, mxs, mys,
+	gb.mid.lay.DrawAnim(&mr, float32(gb.pos[0])+sys.fightScreen.offsetX, float32(gb.pos[1])+sys.fightScreen.offsetY, sys.fightScreen.scale, mxs, mys,
 		layerno, gb.mid.anim, gb.mid.palfx)
 
 	// Multiple front elements
@@ -1372,10 +1372,10 @@ func (gb *GuardBar) draw(layerno int16, charpn int, gbr *GuardBar, f map[int]*Fn
 			mv = k
 		}
 	}
-	gb.front[mv].lay.DrawAnim(&pr, float32(gb.pos[0])+sys.lifebar.offsetX, float32(gb.pos[1])+sys.lifebar.offsetY, sys.lifebar.scale, pxs, pys,
+	gb.front[mv].lay.DrawAnim(&pr, float32(gb.pos[0])+sys.fightScreen.offsetX, float32(gb.pos[1])+sys.fightScreen.offsetY, sys.fightScreen.scale, pxs, pys,
 		layerno, gb.front[mv].anim, gb.front[mv].palfx)
 
-	gb.shift.lay.DrawAnim(&pr, float32(gb.pos[0])+sys.lifebar.offsetX, float32(gb.pos[1])+sys.lifebar.offsetY, sys.lifebar.scale, pxs, pys,
+	gb.shift.lay.DrawAnim(&pr, float32(gb.pos[0])+sys.fightScreen.offsetX, float32(gb.pos[1])+sys.fightScreen.offsetY, sys.fightScreen.scale, pxs, pys,
 		layerno, gb.shift.anim, gb.shift.palfx)
 
 	if gb.value[0].font[0] >= 0 && getFont(f, gb.value[0].font[0]) != nil {
@@ -1389,9 +1389,9 @@ func (gb *GuardBar) draw(layerno int16, charpn int, gbr *GuardBar, f map[int]*Fn
 		text := strings.Replace(gb.value[mv2].text, "%d", fmt.Sprintf("%v", refChar.guardPoints), 1)
 		text = strings.Replace(text, "%p", fmt.Sprintf("%v", math.Round(float64(points)*100)), 1)
 		gb.value[mv2].lay.DrawText(
-			float32(gb.pos[0])+sys.lifebar.offsetX,
-			float32(gb.pos[1])+sys.lifebar.offsetY,
-			sys.lifebar.scale,
+			float32(gb.pos[0])+sys.fightScreen.offsetX,
+			float32(gb.pos[1])+sys.fightScreen.offsetY,
+			sys.fightScreen.scale,
 			layerno,
 			text,
 			getFont(f, gb.value[mv2].font[0]),
@@ -1403,10 +1403,10 @@ func (gb *GuardBar) draw(layerno int16, charpn int, gbr *GuardBar, f map[int]*Fn
 	}
 
 	if points <= float32(gb.warn_range[0])/100 && points >= float32(gb.warn_range[1])/100 {
-		gb.warn.Draw(float32(gb.pos[0])+sys.lifebar.offsetX, float32(gb.pos[1])+sys.lifebar.offsetY, layerno, sys.lifebar.scale)
+		gb.warn.Draw(float32(gb.pos[0])+sys.fightScreen.offsetX, float32(gb.pos[1])+sys.fightScreen.offsetY, layerno, sys.fightScreen.scale)
 	}
 
-	gb.top.Draw(float32(gb.pos[0])+sys.lifebar.offsetX, float32(gb.pos[1])+sys.lifebar.offsetY, layerno, sys.lifebar.scale)
+	gb.top.Draw(float32(gb.pos[0])+sys.fightScreen.offsetX, float32(gb.pos[1])+sys.fightScreen.offsetY, layerno, sys.fightScreen.scale)
 }
 
 type StunBar struct {
@@ -1420,7 +1420,7 @@ type StunBar struct {
 	mid         AnimLayout
 	warn_range  [2]int32
 	warn        AnimLayout
-	value       map[int32]*LbText
+	value       map[int32]*FSText
 	front       map[float32]*AnimLayout
 	shift       AnimLayout
 	midpower    float32
@@ -1432,7 +1432,7 @@ type StunBar struct {
 func newStunBar() (sb *StunBar) {
 	sb = &StunBar{
 		front: make(map[float32]*AnimLayout),
-		value: make(map[int32]*LbText),
+		value: make(map[int32]*FSText),
 	}
 	return
 }
@@ -1458,8 +1458,8 @@ func readStunBar(pre string, is IniSection,
 	}
 
 	sb.shift = ReadAnimLayout(pre+"shift.", is, sff, at, 0)
-	sb.value[0] = readLbText(pre+"value.", is, "%d", 0, f, 0)
-	for k, v := range readMultipleLbText(pre, "value", is, "%d", 0, f, 0) {
+	sb.value[0] = readFSText(pre+"value.", is, "%d", 0, f, 0)
+	for k, v := range readMultipleFSText(pre, "value", is, "%d", 0, f, 0) {
 		sb.value[k] = v
 	}
 	is.ReadI32(pre+"warn.range", &sb.warn_range[0], &sb.warn_range[1])
@@ -1539,18 +1539,18 @@ func (sb *StunBar) reset() {
 
 func (sb *StunBar) bgDraw(layerno int16) {
 	// Handled in outer loop
-	//if !sys.lifebar.stunbar {
+	//if !sys.fightScreen.stunbar {
 	//	return
 	//}
 
-	sb.bg0.Draw(float32(sb.pos[0])+sys.lifebar.offsetX, float32(sb.pos[1])+sys.lifebar.offsetY, layerno, sys.lifebar.scale)
-	sb.bg1.Draw(float32(sb.pos[0])+sys.lifebar.offsetX, float32(sb.pos[1])+sys.lifebar.offsetY, layerno, sys.lifebar.scale)
-	sb.bg2.Draw(float32(sb.pos[0])+sys.lifebar.offsetX, float32(sb.pos[1])+sys.lifebar.offsetY, layerno, sys.lifebar.scale)
+	sb.bg0.Draw(float32(sb.pos[0])+sys.fightScreen.offsetX, float32(sb.pos[1])+sys.fightScreen.offsetY, layerno, sys.fightScreen.scale)
+	sb.bg1.Draw(float32(sb.pos[0])+sys.fightScreen.offsetX, float32(sb.pos[1])+sys.fightScreen.offsetY, layerno, sys.fightScreen.scale)
+	sb.bg2.Draw(float32(sb.pos[0])+sys.fightScreen.offsetX, float32(sb.pos[1])+sys.fightScreen.offsetY, layerno, sys.fightScreen.scale)
 }
 
 func (sb *StunBar) draw(layerno int16, charpn int, sbr *StunBar, f map[int]*Fnt) {
 	// Handled in outer loop
-	//if !sys.lifebar.stunbar {
+	//if !sys.fightScreen.stunbar {
 	//	return
 	//}
 
@@ -1570,11 +1570,11 @@ func (sb *StunBar) draw(layerno int16, charpn int, sbr *StunBar, f map[int]*Fnt)
 		}
 
 		if sb.range_x != [2]int32{0, 0} {
-			r[0], r[2] = calcBarFillRect(sb.pos[0], sb.range_x, sys.lifebar.offsetX, sys.lifebar.scale, sys.widthScale, MidPosX, points)
+			r[0], r[2] = calcBarFillRect(sb.pos[0], sb.range_x, sys.fightScreen.offsetX, sys.fightScreen.scale, sys.widthScale, MidPosX, points)
 		}
 
 		if sb.range_y != [2]int32{0, 0} {
-			r[1], r[3] = calcBarFillRect(sb.pos[1], sb.range_y, sys.lifebar.offsetY, sys.lifebar.scale, sys.heightScale, MidPosY, points)
+			r[1], r[3] = calcBarFillRect(sb.pos[1], sb.range_y, sys.fightScreen.offsetY, sys.fightScreen.scale, sys.heightScale, MidPosY, points)
 		}
 		return r
 	}
@@ -1605,7 +1605,7 @@ func (sb *StunBar) draw(layerno int16, charpn int, sbr *StunBar, f map[int]*Fnt)
 			mr[2] -= Min(mr[2], pr[2])
 		}
 	}
-	sb.mid.lay.DrawAnim(&mr, float32(sb.pos[0])+sys.lifebar.offsetX, float32(sb.pos[1])+sys.lifebar.offsetY, sys.lifebar.scale, mxs, mys,
+	sb.mid.lay.DrawAnim(&mr, float32(sb.pos[0])+sys.fightScreen.offsetX, float32(sb.pos[1])+sys.fightScreen.offsetY, sys.fightScreen.scale, mxs, mys,
 		layerno, sb.mid.anim, sb.mid.palfx)
 
 	// Multiple front elements
@@ -1615,10 +1615,10 @@ func (sb *StunBar) draw(layerno int16, charpn int, sbr *StunBar, f map[int]*Fnt)
 			mv = k
 		}
 	}
-	sb.front[mv].lay.DrawAnim(&pr, float32(sb.pos[0])+sys.lifebar.offsetX, float32(sb.pos[1])+sys.lifebar.offsetY, sys.lifebar.scale, pxs, pys,
+	sb.front[mv].lay.DrawAnim(&pr, float32(sb.pos[0])+sys.fightScreen.offsetX, float32(sb.pos[1])+sys.fightScreen.offsetY, sys.fightScreen.scale, pxs, pys,
 		layerno, sb.front[mv].anim, sb.front[mv].palfx)
 
-	sb.shift.lay.DrawAnim(&pr, float32(sb.pos[0])+sys.lifebar.offsetX, float32(sb.pos[1])+sys.lifebar.offsetY, sys.lifebar.scale, pxs, pys,
+	sb.shift.lay.DrawAnim(&pr, float32(sb.pos[0])+sys.fightScreen.offsetX, float32(sb.pos[1])+sys.fightScreen.offsetY, sys.fightScreen.scale, pxs, pys,
 		layerno, sb.shift.anim, sb.shift.palfx)
 
 	if sb.value[0].font[0] >= 0 && getFont(f, sb.value[0].font[0]) != nil {
@@ -1632,9 +1632,9 @@ func (sb *StunBar) draw(layerno int16, charpn int, sbr *StunBar, f map[int]*Fnt)
 		text := strings.Replace(sb.value[mv2].text, "%d", fmt.Sprintf("%v", refChar.dizzyPoints), 1)
 		text = strings.Replace(text, "%p", fmt.Sprintf("%v", math.Round(float64(points)*100)), 1)
 		sb.value[mv2].lay.DrawText(
-			float32(sb.pos[0])+sys.lifebar.offsetX,
-			float32(sb.pos[1])+sys.lifebar.offsetY,
-			sys.lifebar.scale,
+			float32(sb.pos[0])+sys.fightScreen.offsetX,
+			float32(sb.pos[1])+sys.fightScreen.offsetY,
+			sys.fightScreen.scale,
 			layerno,
 			text,
 			getFont(f, sb.value[mv2].font[0]),
@@ -1646,13 +1646,13 @@ func (sb *StunBar) draw(layerno int16, charpn int, sbr *StunBar, f map[int]*Fnt)
 	}
 
 	if points >= float32(sb.warn_range[0])/100 && points <= float32(sb.warn_range[1])/100 {
-		sb.warn.Draw(float32(sb.pos[0])+sys.lifebar.offsetX, float32(sb.pos[1])+sys.lifebar.offsetY, layerno, sys.lifebar.scale)
+		sb.warn.Draw(float32(sb.pos[0])+sys.fightScreen.offsetX, float32(sb.pos[1])+sys.fightScreen.offsetY, layerno, sys.fightScreen.scale)
 	}
 
-	sb.top.Draw(float32(sb.pos[0])+sys.lifebar.offsetX, float32(sb.pos[1])+sys.lifebar.offsetY, layerno, sys.lifebar.scale)
+	sb.top.Draw(float32(sb.pos[0])+sys.fightScreen.offsetX, float32(sb.pos[1])+sys.fightScreen.offsetY, layerno, sys.fightScreen.scale)
 }
 
-type LifeBarFace struct {
+type FightScreenFace struct {
 	pos                    [2]int32
 	bg                     AnimLayout
 	bg0                    AnimLayout
@@ -1686,8 +1686,8 @@ type LifeBarFace struct {
 	teammate_face_pfx      []*PalFX
 }
 
-func newLifeBarFace() *LifeBarFace {
-	return &LifeBarFace{
+func newFightScreenFace() *FightScreenFace {
+	return &FightScreenFace{
 		face_spr:               [2]int32{-1},
 		teammate_face_spr:      [2]int32{-1},
 		face_palshare:          true,
@@ -1697,8 +1697,8 @@ func newLifeBarFace() *LifeBarFace {
 	}
 }
 
-func readLifeBarFace(pre string, is IniSection, sff *Sff, at AnimationTable) *LifeBarFace {
-	fa := newLifeBarFace()
+func readFightScreenFace(pre string, is IniSection, sff *Sff, at AnimationTable) *FightScreenFace {
+	fa := newFightScreenFace()
 
 	is.ReadI32(pre+"pos", &fa.pos[0], &fa.pos[1])
 	fa.bg = ReadAnimLayout(pre+"bg.", is, sff, at, 0)
@@ -1735,7 +1735,7 @@ func readLifeBarFace(pre string, is IniSection, sff *Sff, at AnimationTable) *Li
 	return fa
 }
 
-func (fa *LifeBarFace) step(charpn int, refFace *LifeBarFace) {
+func (fa *FightScreenFace) step(charpn int, refFace *FightScreenFace) {
 	refChar := sys.chars[charpn][0]
 	group, number := fa.face_spr[0], fa.face_spr[1]
 	if refChar != nil && refChar.anim != nil {
@@ -1769,7 +1769,7 @@ func (fa *LifeBarFace) step(charpn int, refFace *LifeBarFace) {
 	fa.teammate_ko.Action()
 }
 
-func (fa *LifeBarFace) reset() {
+func (fa *FightScreenFace) reset() {
 	fa.bg.Reset()
 	fa.bg0.Reset()
 	fa.bg1.Reset()
@@ -1788,14 +1788,14 @@ func (fa *LifeBarFace) reset() {
 	}
 }
 
-func (fa *LifeBarFace) bgDraw(layerno int16) {
-	fa.bg.Draw(float32(fa.pos[0])+sys.lifebar.offsetX, float32(fa.pos[1]), layerno, sys.lifebar.scale)
-	fa.bg0.Draw(float32(fa.pos[0])+sys.lifebar.offsetX, float32(fa.pos[1]), layerno, sys.lifebar.scale)
-	fa.bg1.Draw(float32(fa.pos[0])+sys.lifebar.offsetX, float32(fa.pos[1]), layerno, sys.lifebar.scale)
-	fa.bg2.Draw(float32(fa.pos[0])+sys.lifebar.offsetX, float32(fa.pos[1]), layerno, sys.lifebar.scale)
+func (fa *FightScreenFace) bgDraw(layerno int16) {
+	fa.bg.Draw(float32(fa.pos[0])+sys.fightScreen.offsetX, float32(fa.pos[1]), layerno, sys.fightScreen.scale)
+	fa.bg0.Draw(float32(fa.pos[0])+sys.fightScreen.offsetX, float32(fa.pos[1]), layerno, sys.fightScreen.scale)
+	fa.bg1.Draw(float32(fa.pos[0])+sys.fightScreen.offsetX, float32(fa.pos[1]), layerno, sys.fightScreen.scale)
+	fa.bg2.Draw(float32(fa.pos[0])+sys.fightScreen.offsetX, float32(fa.pos[1]), layerno, sys.fightScreen.scale)
 }
 
-func (fa *LifeBarFace) draw(layerno int16, charpn int, refFace *LifeBarFace) {
+func (fa *FightScreenFace) draw(layerno int16, charpn int, refFace *FightScreenFace) {
 	refChar := sys.chars[charpn][0]
 
 	if refFace.face != nil {
@@ -1831,12 +1831,12 @@ func (fa *LifeBarFace) draw(layerno int16, charpn int, refFace *LifeBarFace) {
 		}
 
 		// Draw the actual face sprite
-		fa.face_lay.DrawFaceSprite((float32(fa.pos[0])+sys.lifebar.offsetX)*sys.lifebar.scale, float32(fa.pos[1])*sys.lifebar.scale, layerno,
-			refFace.face, fa.face_pfx, sys.cgi[charpn].portraitscale*sys.lifebar.portraitScale, &fa.face_lay.window)
+		fa.face_lay.DrawFaceSprite((float32(fa.pos[0])+sys.fightScreen.offsetX)*sys.fightScreen.scale, float32(fa.pos[1])*sys.fightScreen.scale, layerno,
+			refFace.face, fa.face_pfx, sys.cgi[charpn].portraitscale*sys.fightScreen.portraitScale, &fa.face_lay.window)
 
 		// Draw KO layer
 		if !refChar.alive() {
-			fa.ko.Draw(float32(fa.pos[0])+sys.lifebar.offsetX, float32(fa.pos[1]), layerno, sys.lifebar.scale)
+			fa.ko.Draw(float32(fa.pos[0])+sys.fightScreen.offsetX, float32(fa.pos[1]), layerno, sys.fightScreen.scale)
 		}
 
 		// Restore original system brightness
@@ -1844,10 +1844,10 @@ func (fa *LifeBarFace) draw(layerno int16, charpn int, refFace *LifeBarFace) {
 	}
 
 	// Draw top layer
-	fa.top.Draw(float32(fa.pos[0])+sys.lifebar.offsetX, float32(fa.pos[1]), layerno, sys.lifebar.scale)
+	fa.top.Draw(float32(fa.pos[0])+sys.fightScreen.offsetX, float32(fa.pos[1]), layerno, sys.fightScreen.scale)
 }
 
-func (fa *LifeBarFace) drawTeammates(layerno int16, charpn int) {
+func (fa *FightScreenFace) drawTeammates(layerno int16, charpn int) {
 	if len(fa.teammate_face) == 0 {
 		return
 	}
@@ -1894,10 +1894,10 @@ func (fa *LifeBarFace) drawTeammates(layerno int16, charpn int) {
 		}
 
 		// Draw backgrounds
-		fa.teammate_bg.Draw((x + sys.lifebar.offsetX), y, layerno, sys.lifebar.scale)
-		fa.teammate_bg0.Draw((x + sys.lifebar.offsetX), y, layerno, sys.lifebar.scale)
-		fa.teammate_bg1.Draw((x + sys.lifebar.offsetX), y, layerno, sys.lifebar.scale)
-		fa.teammate_bg2.Draw((x + sys.lifebar.offsetX), y, layerno, sys.lifebar.scale)
+		fa.teammate_bg.Draw((x + sys.fightScreen.offsetX), y, layerno, sys.fightScreen.scale)
+		fa.teammate_bg0.Draw((x + sys.fightScreen.offsetX), y, layerno, sys.fightScreen.scale)
+		fa.teammate_bg1.Draw((x + sys.fightScreen.offsetX), y, layerno, sys.fightScreen.scale)
+		fa.teammate_bg2.Draw((x + sys.fightScreen.offsetX), y, layerno, sys.fightScreen.scale)
 
 		// Fetch the PalFX for this member
 		pfx := fa.teammate_face_pfx[i]
@@ -1907,12 +1907,12 @@ func (fa *LifeBarFace) drawTeammates(layerno int16, charpn int) {
 		//}
 
 		// Draw face
-		fa.teammate_face_lay.DrawFaceSprite((x+sys.lifebar.offsetX)*sys.lifebar.scale, y*sys.lifebar.scale, layerno,
-			fa.teammate_face[i], pfx, fa.teammate_scale[i]*sys.lifebar.portraitScale, &fa.teammate_face_lay.window)
+		fa.teammate_face_lay.DrawFaceSprite((x+sys.fightScreen.offsetX)*sys.fightScreen.scale, y*sys.fightScreen.scale, layerno,
+			fa.teammate_face[i], pfx, fa.teammate_scale[i]*sys.fightScreen.portraitScale, &fa.teammate_face_lay.window)
 
 		// Draw KO layer
 		if i < fa.numko {
-			fa.teammate_ko.Draw((x + sys.lifebar.offsetX), y, layerno, sys.lifebar.scale)
+			fa.teammate_ko.Draw((x + sys.fightScreen.offsetX), y, layerno, sys.fightScreen.scale)
 		}
 
 		// Shift offset back toward the anchor
@@ -1924,42 +1924,42 @@ func (fa *LifeBarFace) drawTeammates(layerno int16, charpn int) {
 	sys.brightness = oldBright
 }
 
-type LifeBarName struct {
+type FightScreenName struct {
 	pos                   [2]int32
-	name                  LbText
+	name                  FSText
 	bg                    AnimLayout
 	top                   AnimLayout
 	teammate_pos          [2]int32
 	teammate_spacing      [2]int32
-	teammate_name         LbText
+	teammate_name         FSText
 	teammate_name_strings []string
 	teammate_bg           AnimLayout
 	numko                 int32
 	teammate_ko_hide      bool
 }
 
-func newLifeBarName() *LifeBarName {
-	return &LifeBarName{}
+func newFightScreenName() *FightScreenName {
+	return &FightScreenName{}
 }
 
-func readLifeBarName(pre string, is IniSection, sff *Sff, at AnimationTable, f map[int]*Fnt) *LifeBarName {
-	nm := newLifeBarName()
+func readFightScreenName(pre string, is IniSection, sff *Sff, at AnimationTable, f map[int]*Fnt) *FightScreenName {
+	nm := newFightScreenName()
 
 	is.ReadI32(pre+"pos", &nm.pos[0], &nm.pos[1])
-	nm.name = *readLbText(pre+"name.", is, "", 0, f, 0)
+	nm.name = *readFSText(pre+"name.", is, "", 0, f, 0)
 	nm.bg = ReadAnimLayout(pre+"bg.", is, sff, at, 0)
 	nm.top = ReadAnimLayout(pre+"top.", is, sff, at, 0)
 
 	// Teammates
 	is.ReadI32(pre+"teammate.pos", &nm.teammate_pos[0], &nm.teammate_pos[1])
 	is.ReadI32(pre+"teammate.spacing", &nm.teammate_spacing[0], &nm.teammate_spacing[1])
-	nm.teammate_name = *readLbText(pre+"teammate.name.", is, "", 0, f, 0)
+	nm.teammate_name = *readFSText(pre+"teammate.name.", is, "", 0, f, 0)
 	nm.teammate_bg = ReadAnimLayout(pre+"teammate.bg.", is, sff, at, 0)
 	is.ReadBool(pre+"teammate.ko.hide", &nm.teammate_ko_hide)
 	return nm
 }
 
-func (nm *LifeBarName) step() {
+func (nm *FightScreenName) step() {
 	nm.bg.Action()
 	nm.teammate_bg.Action()
 	nm.top.Action()
@@ -1967,26 +1967,26 @@ func (nm *LifeBarName) step() {
 	nm.teammate_name.step()
 }
 
-func (nm *LifeBarName) reset() {
+func (nm *FightScreenName) reset() {
 	nm.bg.Reset()
 	nm.teammate_bg.Reset()
 	nm.top.Reset()
 }
 
-func (nm *LifeBarName) bgDraw(layerno int16) {
-	nm.bg.Draw(float32(nm.pos[0])+sys.lifebar.offsetX, float32(nm.pos[1]), layerno, sys.lifebar.scale)
+func (nm *FightScreenName) bgDraw(layerno int16) {
+	nm.bg.Draw(float32(nm.pos[0])+sys.fightScreen.offsetX, float32(nm.pos[1]), layerno, sys.fightScreen.scale)
 }
 
-func (nm *LifeBarName) draw(layerno int16, charpn int, f map[int]*Fnt, side int) {
+func (nm *FightScreenName) draw(layerno int16, charpn int, f map[int]*Fnt, side int) {
 	if nm.name.font[0] >= 0 && getFont(f, nm.name.font[0]) != nil {
-		nm.name.lay.DrawText((float32(nm.pos[0]) + sys.lifebar.offsetX), float32(nm.pos[1]), sys.lifebar.scale, layerno,
+		nm.name.lay.DrawText((float32(nm.pos[0]) + sys.fightScreen.offsetX), float32(nm.pos[1]), sys.fightScreen.scale, layerno,
 			sys.cgi[charpn].lifebarname, getFont(f, nm.name.font[0]), nm.name.font[1], nm.name.font[2], nm.name.palfx, nm.name.frgba)
 	}
 
-	nm.top.Draw(float32(nm.pos[0])+sys.lifebar.offsetX, float32(nm.pos[1]), layerno, sys.lifebar.scale)
+	nm.top.Draw(float32(nm.pos[0])+sys.fightScreen.offsetX, float32(nm.pos[1]), layerno, sys.fightScreen.scale)
 }
 
-func (nm *LifeBarName) drawTeammates(layerno int16, charpn int, f map[int]*Fnt, side int) {
+func (nm *FightScreenName) drawTeammates(layerno int16, charpn int, f map[int]*Fnt, side int) {
 	if len(nm.teammate_name_strings) == 0 {
 		return
 	}
@@ -2018,11 +2018,11 @@ func (nm *LifeBarName) drawTeammates(layerno int16, charpn int, f map[int]*Fnt, 
 		}
 
 		// Draw background
-		nm.teammate_bg.Draw((x + sys.lifebar.offsetX), y, layerno, sys.lifebar.scale)
+		nm.teammate_bg.Draw((x + sys.fightScreen.offsetX), y, layerno, sys.fightScreen.scale)
 
 		// Draw pre-compiled name text
 		if nm.teammate_name.font[0] >= 0 && getFont(f, nm.teammate_name.font[0]) != nil {
-			nm.teammate_name.lay.DrawText((x + sys.lifebar.offsetX), y, sys.lifebar.scale, layerno,
+			nm.teammate_name.lay.DrawText((x + sys.fightScreen.offsetX), y, sys.fightScreen.scale, layerno,
 				nm.teammate_name_strings[i], getFont(f, nm.teammate_name.font[0]),
 				nm.teammate_name.font[1], nm.teammate_name.font[2], nm.teammate_name.palfx, nm.teammate_name.frgba)
 		}
@@ -2035,11 +2035,11 @@ func (nm *LifeBarName) drawTeammates(layerno int16, charpn int, f map[int]*Fnt, 
 	// TODO: Confirm it teammates are really supposed to not have "top" layer
 }
 
-type LifeBarWinIcon struct {
+type FightScreenWinIcon struct {
 	pos         [2]int32
 	iconoffset  [2]int32
 	useiconupto int32
-	counter     LbText
+	counter     FSText
 	bg0         AnimLayout
 	top         AnimLayout
 	icon        [WT_NumTypes]AnimLayout
@@ -2050,17 +2050,17 @@ type LifeBarWinIcon struct {
 	addedC      *Animation
 }
 
-func newLifeBarWinIcon() *LifeBarWinIcon {
-	return &LifeBarWinIcon{useiconupto: 4}
+func newFightScreenWinIcon() *FightScreenWinIcon {
+	return &FightScreenWinIcon{useiconupto: 4}
 }
 
-func readLifeBarWinIcon(pre string, is IniSection, sff *Sff, at AnimationTable, f map[int]*Fnt) *LifeBarWinIcon {
-	wi := newLifeBarWinIcon()
+func readFightScreenWinIcon(pre string, is IniSection, sff *Sff, at AnimationTable, f map[int]*Fnt) *FightScreenWinIcon {
+	wi := newFightScreenWinIcon()
 
 	is.ReadI32(pre+"pos", &wi.pos[0], &wi.pos[1])
 	is.ReadI32(pre+"iconoffset", &wi.iconoffset[0], &wi.iconoffset[1])
 	is.ReadI32("useiconupto", &wi.useiconupto)
-	wi.counter = *readLbText(pre+"counter.", is, "%i", 0, f, 0)
+	wi.counter = *readFSText(pre+"counter.", is, "%i", 0, f, 0)
 	wi.bg0 = ReadAnimLayout(pre+"bg0.", is, sff, at, 0)
 	wi.top = ReadAnimLayout(pre+"top.", is, sff, at, 0)
 	wi.icon[WT_Normal] = ReadAnimLayout(pre+"n.", is, sff, at, 0)
@@ -2076,7 +2076,7 @@ func readLifeBarWinIcon(pre string, is IniSection, sff *Sff, at AnimationTable, 
 	return wi
 }
 
-func (wi *LifeBarWinIcon) add(wt WinType) {
+func (wi *FightScreenWinIcon) add(wt WinType) {
 	wi.wins = append(wi.wins, wt)
 	if wt >= WT_PNormal && wt < WT_CNormal {
 		wi.addedP = &Animation{}
@@ -2094,7 +2094,7 @@ func (wi *LifeBarWinIcon) add(wt WinType) {
 	wi.added.Reset()
 }
 
-func (wi *LifeBarWinIcon) step(numwin int32) {
+func (wi *FightScreenWinIcon) step(numwin int32) {
 	wi.bg0.Action()
 	wi.top.Action()
 	if int(numwin) < len(wi.wins) {
@@ -2115,7 +2115,7 @@ func (wi *LifeBarWinIcon) step(numwin int32) {
 	}
 }
 
-func (wi *LifeBarWinIcon) reset() {
+func (wi *FightScreenWinIcon) reset() {
 	wi.bg0.Reset()
 	wi.top.Reset()
 	for i := range wi.icon {
@@ -2125,11 +2125,11 @@ func (wi *LifeBarWinIcon) reset() {
 	wi.added, wi.addedP, wi.addedC = nil, nil, nil
 }
 
-func (wi *LifeBarWinIcon) clear() {
+func (wi *FightScreenWinIcon) clear() {
 	wi.wins = nil
 }
 
-func (wi *LifeBarWinIcon) draw(layerno int16, f map[int]*Fnt, side int) {
+func (wi *FightScreenWinIcon) draw(layerno int16, f map[int]*Fnt, side int) {
 	bg0num := sys.matchWins[side&1]
 
 	// Already handled when sys.matchWins is defined
@@ -2140,14 +2140,14 @@ func (wi *LifeBarWinIcon) draw(layerno int16, f map[int]*Fnt, side int) {
 	iconLimit := Min(wi.useiconupto, bg0num)
 
 	for i := 0; i < int(iconLimit); i++ {
-		wi.bg0.Draw(float32(wi.pos[0]+wi.iconoffset[0]*int32(i))+sys.lifebar.offsetX,
-			float32(wi.pos[1]+wi.iconoffset[1]*int32(i)), layerno, sys.lifebar.scale)
+		wi.bg0.Draw(float32(wi.pos[0]+wi.iconoffset[0]*int32(i))+sys.fightScreen.offsetX,
+			float32(wi.pos[1]+wi.iconoffset[1]*int32(i)), layerno, sys.fightScreen.scale)
 	}
 
 	if len(wi.wins) > int(wi.useiconupto) {
 		// Use the generic win count icon if icon limit exceeded
 		if wi.counter.font[0] >= 0 && getFont(f, wi.counter.font[0]) != nil {
-			wi.counter.lay.DrawText(float32(wi.pos[0])+sys.lifebar.offsetX, float32(wi.pos[1]), sys.lifebar.scale,
+			wi.counter.lay.DrawText(float32(wi.pos[0])+sys.fightScreen.offsetX, float32(wi.pos[1]), sys.fightScreen.scale,
 				layerno, strings.Replace(wi.counter.text, "%i", fmt.Sprintf("%v", len(wi.wins)), 1),
 				getFont(f, wi.counter.font[0]), wi.counter.font[1], wi.counter.font[2], wi.counter.palfx, wi.counter.frgba)
 		}
@@ -2163,15 +2163,15 @@ func (wi *LifeBarWinIcon) draw(layerno int16, f map[int]*Fnt, side int) {
 				wt -= WT_CNormal
 				cl = true
 			}
-			wi.icon[wt].Draw(float32(wi.pos[0]+wi.iconoffset[0]*int32(i))+sys.lifebar.offsetX,
-				float32(wi.pos[1]+wi.iconoffset[1]*int32(i)), layerno, sys.lifebar.scale)
+			wi.icon[wt].Draw(float32(wi.pos[0]+wi.iconoffset[0]*int32(i))+sys.fightScreen.offsetX,
+				float32(wi.pos[1]+wi.iconoffset[1]*int32(i)), layerno, sys.fightScreen.scale)
 			if pf {
-				wi.icon[WT_Perfect].Draw(float32(wi.pos[0]+wi.iconoffset[0]*int32(i))+sys.lifebar.offsetX,
-					float32(wi.pos[1]+wi.iconoffset[1]*int32(i)), layerno, sys.lifebar.scale)
+				wi.icon[WT_Perfect].Draw(float32(wi.pos[0]+wi.iconoffset[0]*int32(i))+sys.fightScreen.offsetX,
+					float32(wi.pos[1]+wi.iconoffset[1]*int32(i)), layerno, sys.fightScreen.scale)
 			}
 			if cl {
-				wi.icon[WT_Clutch].Draw(float32(wi.pos[0]+wi.iconoffset[0]*int32(i))+sys.lifebar.offsetX,
-					float32(wi.pos[1]+wi.iconoffset[1]*int32(i)), layerno, sys.lifebar.scale)
+				wi.icon[WT_Clutch].Draw(float32(wi.pos[0]+wi.iconoffset[0]*int32(i))+sys.fightScreen.offsetX,
+					float32(wi.pos[1]+wi.iconoffset[1]*int32(i)), layerno, sys.fightScreen.scale)
 			}
 		}
 		if wi.added != nil {
@@ -2184,49 +2184,49 @@ func (wi *LifeBarWinIcon) draw(layerno int16, f map[int]*Fnt, side int) {
 				cl = true
 			}
 			wi.icon[wt].lay.DrawAnim(&wi.icon[wt].lay.window,
-				float32(wi.pos[0]+wi.iconoffset[0]*int32(i))+sys.lifebar.offsetX,
-				float32(wi.pos[1]+wi.iconoffset[1]*int32(i)), sys.lifebar.scale, 1, 1, layerno, wi.added, nil)
+				float32(wi.pos[0]+wi.iconoffset[0]*int32(i))+sys.fightScreen.offsetX,
+				float32(wi.pos[1]+wi.iconoffset[1]*int32(i)), sys.fightScreen.scale, 1, 1, layerno, wi.added, nil)
 			if pf {
 				wi.icon[WT_Perfect].lay.DrawAnim(&wi.icon[WT_Perfect].lay.window,
-					float32(wi.pos[0]+wi.iconoffset[0]*int32(i))+sys.lifebar.offsetX,
-					float32(wi.pos[1]+wi.iconoffset[1]*int32(i)), sys.lifebar.scale, 1, 1, layerno, wi.addedP, nil)
+					float32(wi.pos[0]+wi.iconoffset[0]*int32(i))+sys.fightScreen.offsetX,
+					float32(wi.pos[1]+wi.iconoffset[1]*int32(i)), sys.fightScreen.scale, 1, 1, layerno, wi.addedP, nil)
 			}
 			if cl {
 				wi.icon[WT_Clutch].lay.DrawAnim(&wi.icon[WT_Clutch].lay.window,
-					float32(wi.pos[0]+wi.iconoffset[0]*int32(i))+sys.lifebar.offsetX,
-					float32(wi.pos[1]+wi.iconoffset[1]*int32(i)), sys.lifebar.scale, 1, 1, layerno, wi.addedC, nil)
+					float32(wi.pos[0]+wi.iconoffset[0]*int32(i))+sys.fightScreen.offsetX,
+					float32(wi.pos[1]+wi.iconoffset[1]*int32(i)), sys.fightScreen.scale, 1, 1, layerno, wi.addedC, nil)
 			}
 		}
 	}
 
 	for i := 0; i < int(iconLimit); i++ {
-		wi.top.Draw(float32(wi.pos[0]+wi.iconoffset[0]*int32(i))+sys.lifebar.offsetX,
-			float32(wi.pos[1]+wi.iconoffset[1]*int32(i)), layerno, sys.lifebar.scale)
+		wi.top.Draw(float32(wi.pos[0]+wi.iconoffset[0]*int32(i))+sys.fightScreen.offsetX,
+			float32(wi.pos[1]+wi.iconoffset[1]*int32(i)), layerno, sys.fightScreen.scale)
 	}
 }
 
-type LifeBarTime struct {
+type FightScreenTime struct {
 	pos            [2]int32
-	counter        map[int32]*LbText
+	counter        map[int32]*FSText
 	bg             AnimLayout
 	top            AnimLayout
 	framespercount int32 // The original value as read in fight.def
 	activeIdx      int32
 }
 
-func newLifeBarTime() *LifeBarTime {
-	return &LifeBarTime{
-		counter:        make(map[int32]*LbText),
+func newFightScreenTime() *FightScreenTime {
+	return &FightScreenTime{
+		counter:        make(map[int32]*FSText),
 		framespercount: 60,
 	}
 }
 
-func readLifeBarTime(is IniSection, sff *Sff, at AnimationTable, f map[int]*Fnt) *LifeBarTime {
-	ti := newLifeBarTime()
+func readFightScreenTime(is IniSection, sff *Sff, at AnimationTable, f map[int]*Fnt) *FightScreenTime {
+	ti := newFightScreenTime()
 
 	is.ReadI32("pos", &ti.pos[0], &ti.pos[1])
-	ti.counter[0] = readLbText("counter.", is, "", 0, f, 0)
-	for k, v := range readMultipleLbText("", "counter", is, "", 0, f, 0) {
+	ti.counter[0] = readFSText("counter.", is, "", 0, f, 0)
+	for k, v := range readMultipleFSText("", "counter", is, "", 0, f, 0) {
 		ti.counter[k] = v
 	}
 	ti.bg = ReadAnimLayout("bg.", is, sff, at, 0)
@@ -2235,22 +2235,22 @@ func readLifeBarTime(is IniSection, sff *Sff, at AnimationTable, f map[int]*Fnt)
 	return ti
 }
 
-func (ti *LifeBarTime) step() {
+func (ti *FightScreenTime) step() {
 	ti.bg.Action()
 	ti.top.Action()
 	ti.counter[ti.activeIdx].step()
 }
 
-func (ti *LifeBarTime) reset() {
+func (ti *FightScreenTime) reset() {
 	ti.bg.Reset()
 	ti.top.Reset()
 }
 
-func (ti *LifeBarTime) bgDraw(layerno int16) {
-	ti.bg.Draw(float32(ti.pos[0])+sys.lifebar.offsetX, float32(ti.pos[1]), layerno, sys.lifebar.scale)
+func (ti *FightScreenTime) bgDraw(layerno int16) {
+	ti.bg.Draw(float32(ti.pos[0])+sys.fightScreen.offsetX, float32(ti.pos[1]), layerno, sys.fightScreen.scale)
 }
 
-func (ti *LifeBarTime) draw(layerno int16, f map[int]*Fnt) {
+func (ti *FightScreenTime) draw(layerno int16, f map[int]*Fnt) {
 	if sys.curFramesPerCount > 0 &&
 		ti.counter[0].font[0] >= 0 && getFont(f, ti.counter[0].font[0]) != nil {
 		var timeval int32 = -1
@@ -2279,21 +2279,21 @@ func (ti *LifeBarTime) draw(layerno int16, f map[int]*Fnt) {
 			}
 		}
 		ti.activeIdx = tv
-		ti.counter[tv].lay.DrawText(float32(ti.pos[0])+sys.lifebar.offsetX, float32(ti.pos[1]), sys.lifebar.scale, layerno,
+		ti.counter[tv].lay.DrawText(float32(ti.pos[0])+sys.fightScreen.offsetX, float32(ti.pos[1]), sys.fightScreen.scale, layerno,
 			time, getFont(f, ti.counter[tv].font[0]), ti.counter[tv].font[1], ti.counter[tv].font[2], ti.counter[tv].palfx,
 			ti.counter[tv].frgba)
 	}
-	ti.top.Draw(float32(ti.pos[0])+sys.lifebar.offsetX, float32(ti.pos[1]), layerno, sys.lifebar.scale)
+	ti.top.Draw(float32(ti.pos[0])+sys.fightScreen.offsetX, float32(ti.pos[1]), layerno, sys.fightScreen.scale)
 }
 
-type LifeBarCombo struct {
+type FightScreenCombo struct {
 	pos            [2]int32
 	start_x        float32
-	counter        map[int32]*LbText
+	counter        map[int32]*FSText
 	counter_shake  bool
 	counter_time   int32
 	counter_mult   float32
-	text           map[int32]*LbText
+	text           map[int32]*FSText
 	bg             AnimLayout
 	top            AnimLayout
 	displaytime    int32
@@ -2312,30 +2312,30 @@ type LifeBarCombo struct {
 	autoalign      bool
 }
 
-func newLifeBarCombo() *LifeBarCombo {
-	return &LifeBarCombo{
+func newFightScreenCombo() *FightScreenCombo {
+	return &FightScreenCombo{
 		displaytime:  90,
 		showspeed:    8,
 		hidespeed:    4,
-		counter:      make(map[int32]*LbText),
+		counter:      make(map[int32]*FSText),
 		counter_time: 7,
 		counter_mult: 1.0 / 20,
-		text:         make(map[int32]*LbText),
+		text:         make(map[int32]*FSText),
 		autoalign:    true,
 	}
 }
 
-func readLifeBarCombo(pre string, is IniSection,
-	sff *Sff, at AnimationTable, f map[int]*Fnt, side int) *LifeBarCombo {
-	co := newLifeBarCombo()
+func readFightScreenCombo(pre string, is IniSection,
+	sff *Sff, at AnimationTable, f map[int]*Fnt, side int) *FightScreenCombo {
+	co := newFightScreenCombo()
 	is.ReadI32(pre+"pos", &co.pos[0], &co.pos[1])
 	is.ReadF32(pre+"start.x", &co.start_x)
 	if side == 1 {
 		// mugen 1.0 implementation reuses winmugen code where both sides shared the same values
 		if pre == "team2." {
-			co.start_x = float32(sys.lifebar.localcoord[0]) - co.start_x
+			co.start_x = float32(sys.fightScreen.localcoord[0]) - co.start_x
 		} else {
-			co.pos[0] = sys.lifebar.localcoord[0] - co.pos[0]
+			co.pos[0] = sys.fightScreen.localcoord[0] - co.pos[0]
 		}
 	}
 	var align int32
@@ -2346,15 +2346,15 @@ func readLifeBarCombo(pre string, is IniSection,
 			align = -1
 		}
 	}
-	co.counter[0] = readLbText(pre+"counter.", is, "%i", 2, f, align)
-	for k, v := range readMultipleLbText(pre, "counter", is, "%i", 2, f, align) {
+	co.counter[0] = readFSText(pre+"counter.", is, "%i", 2, f, align)
+	for k, v := range readMultipleFSText(pre, "counter", is, "%i", 2, f, align) {
 		co.counter[k] = v
 	}
 	is.ReadBool(pre+"counter.shake", &co.counter_shake)
 	is.ReadI32(pre+"counter.time", &co.counter_time)
 	is.ReadF32(pre+"counter.mult", &co.counter_mult)
-	co.text[0] = readLbText(pre+"text.", is, "", 2, f, align)
-	for k, v := range readMultipleLbText(pre, "text", is, "", 2, f, align) {
+	co.text[0] = readFSText(pre+"text.", is, "", 2, f, align)
+	for k, v := range readMultipleFSText(pre, "text", is, "", 2, f, align) {
 		co.text[k] = v
 	}
 	co.bg = ReadAnimLayout(pre+"bg0.", is, sff, at, 2)
@@ -2369,7 +2369,7 @@ func readLifeBarCombo(pre string, is IniSection,
 	return co
 }
 
-func (co *LifeBarCombo) step(combo, damage int32, percentage float32, dizzy bool) {
+func (co *FightScreenCombo) step(combo, damage int32, percentage float32, dizzy bool) {
 	co.bg.Action()
 	co.top.Action()
 
@@ -2383,7 +2383,7 @@ func (co *LifeBarCombo) step(combo, damage int32, percentage float32, dizzy bool
 	if co.resttime > 0 {
 		co.counterX -= co.counterX / co.showspeed
 	} else if combo < 2 {
-		co.counterX -= sys.lifebar.fnt_scale * co.hidespeed * float32(sys.lifebar.localcoord[0]) / 320
+		co.counterX -= sys.fightScreen.fnt_scale * co.hidespeed * float32(sys.fightScreen.localcoord[0]) / 320
 		if co.counterX < co.start_x*2 {
 			co.counterX = co.start_x * 2
 		}
@@ -2442,7 +2442,7 @@ func (co *LifeBarCombo) step(combo, damage int32, percentage float32, dizzy bool
 	}
 }
 
-func (co *LifeBarCombo) reset() {
+func (co *FightScreenCombo) reset() {
 	co.bg.Reset()
 	co.top.Reset()
 	co.curhit, co.oldhit = 0, 0
@@ -2454,7 +2454,7 @@ func (co *LifeBarCombo) reset() {
 	co.shaketime = 0
 }
 
-func (co *LifeBarCombo) draw(layerno int16, f map[int]*Fnt, side int) {
+func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 	if co.resttime <= 0 && co.counterX == co.start_x*2 {
 		return
 	}
@@ -2484,7 +2484,7 @@ func (co *LifeBarCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 		if co.counter[cv].font[0] >= 0 && co.autoalign {
 			if ff := getFont(f, co.counter[cv].font[0]); ff != nil {
 				x += float32(ff.TextWidth(counter, co.counter[cv].font[1], 0)) *
-					co.counter[cv].lay.scale[0] * sys.lifebar.fnt_scale
+					co.counter[cv].lay.scale[0] * sys.fightScreen.fnt_scale
 			}
 		}
 	} else {
@@ -2492,7 +2492,7 @@ func (co *LifeBarCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 			x -= co.counterX
 		}
 	}
-	co.bg.Draw(x+sys.lifebar.offsetX, float32(co.pos[1]), layerno, sys.lifebar.scale)
+	co.bg.Draw(x+sys.fightScreen.offsetX, float32(co.pos[1]), layerno, sys.fightScreen.scale)
 	var length float32
 	if co.text[tv].font[0] >= 0 && getFont(f, co.text[tv].font[0]) != nil {
 		text := strings.Replace(co.text[tv].text, "%i", fmt.Sprintf("%v", co.curhit), 1)
@@ -2513,38 +2513,38 @@ func (co *LifeBarCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 		for k, v := range strings.Split(text, "\\n") {
 			if side == 1 && co.autoalign {
 				if ff := getFont(f, co.text[tv].font[0]); ff != nil {
-					if lt := float32(ff.TextWidth(v, co.text[tv].font[1], 0)) * co.text[tv].lay.scale[0] * sys.lifebar.fnt_scale; lt > length {
+					if lt := float32(ff.TextWidth(v, co.text[tv].font[1], 0)) * co.text[tv].lay.scale[0] * sys.fightScreen.fnt_scale; lt > length {
 						length = lt
 					}
 				}
 			}
-			co.text[tv].lay.DrawText(x+sys.lifebar.offsetX, float32(co.pos[1])+
+			co.text[tv].lay.DrawText(x+sys.fightScreen.offsetX, float32(co.pos[1])+
 				func() float32 {
 					if ff := getFont(f, co.text[tv].font[0]); ff != nil {
-						return float32(ff.Size[1])*co.text[tv].lay.scale[1]*sys.lifebar.fnt_scale +
-							float32(ff.Spacing[1])*co.text[tv].lay.scale[1]*sys.lifebar.fnt_scale
+						return float32(ff.Size[1])*co.text[tv].lay.scale[1]*sys.fightScreen.fnt_scale +
+							float32(ff.Spacing[1])*co.text[tv].lay.scale[1]*sys.fightScreen.fnt_scale
 					}
 					return 0
 				}()*float32(k),
-				sys.lifebar.scale, layerno, v, getFont(f, co.text[tv].font[0]), co.text[tv].font[1], co.text[tv].font[2],
+				sys.fightScreen.scale, layerno, v, getFont(f, co.text[tv].font[0]), co.text[tv].font[1], co.text[tv].font[2],
 				co.text[tv].palfx, co.text[tv].frgba)
 		}
 	}
 	if co.counter[cv].font[0] >= 0 && getFont(f, co.counter[cv].font[0]) != nil {
 		if side == 0 && co.autoalign {
 			if ff := getFont(f, co.counter[cv].font[0]); ff != nil {
-				length = float32(ff.TextWidth(counter, co.counter[cv].font[1], 0)) * co.counter[cv].lay.scale[0] * sys.lifebar.fnt_scale
+				length = float32(ff.TextWidth(counter, co.counter[cv].font[1], 0)) * co.counter[cv].lay.scale[0] * sys.fightScreen.fnt_scale
 			}
 		}
 
 		z := 1 + float32(co.shaketime)*co.counter_mult*float32(math.Sin(float64(co.shaketime)*(math.Pi/2.5)))
-		co.counter[cv].lay.DrawText((x-length+sys.lifebar.offsetX)/z, float32(co.pos[1])/z, z*sys.lifebar.scale, layerno,
+		co.counter[cv].lay.DrawText((x-length+sys.fightScreen.offsetX)/z, float32(co.pos[1])/z, z*sys.fightScreen.scale, layerno,
 			counter, getFont(f, co.counter[cv].font[0]), co.counter[cv].font[1], co.counter[cv].font[2], co.counter[cv].palfx, co.counter[cv].frgba)
 	}
-	co.top.Draw(x+sys.lifebar.offsetX, float32(co.pos[1]), layerno, sys.lifebar.scale)
+	co.top.Draw(x+sys.fightScreen.offsetX, float32(co.pos[1]), layerno, sys.fightScreen.scale)
 }
 
-type LbMsg struct {
+type FSMsg struct {
 	resttime     int32
 	agetimer     int32
 	counterX     float32
@@ -2560,10 +2560,10 @@ type LbMsg struct {
 	del          bool
 }
 
-func newLbMsg(side int) *LbMsg {
-	return &LbMsg{
+func newFSMsg(side int) *FSMsg {
+	return &FSMsg{
 		resttime:  -1,
-		counterX:  sys.lifebar.ac[side].start_x * 2,
+		counterX:  sys.fightScreen.ac[side].start_x * 2,
 		fontNo:    -1,
 		fontBank:  -1,
 		fontAlign: IErr, // Default to the font's
@@ -2571,7 +2571,7 @@ func newLbMsg(side int) *LbMsg {
 	}
 }
 
-func insertLbMsg(array []*LbMsg, value *LbMsg, index int) []*LbMsg {
+func insertFSMsg(array []*FSMsg, value *FSMsg, index int) []*FSMsg {
 	// Remove one empty index before appending the new one
 	// This reduces the chance of an empty space pushing older messages
 	if index == 0 {
@@ -2599,31 +2599,31 @@ func insertLbMsg(array []*LbMsg, value *LbMsg, index int) []*LbMsg {
 	if index == len(array) {
 		array = append(array, value)
 	} else {
-		array = append(array[:index], append([]*LbMsg{value}, array[index:]...)...)
+		array = append(array[:index], append([]*FSMsg{value}, array[index:]...)...)
 	}
 	return array
 }
 
-func removeLbMsg(array []*LbMsg, index int) []*LbMsg {
+func removeFSMsg(array []*FSMsg, index int) []*FSMsg {
 	return SliceDelete(array, index)
 }
 
-type LifeBarAction struct {
+type FightScreenAction struct {
 	oldleader   int
 	pos         [2]int32
 	spacing     [2]int32
 	start_x     float32
-	text        LbText
+	text        FSText
 	displaytime int32
 	showspeed   float32
 	hidespeed   float32
-	messages    []*LbMsg
+	messages    []*FSMsg
 	is          IniSection
 	max         int32
 }
 
-func newLifeBarAction() *LifeBarAction {
-	return &LifeBarAction{
+func newFightScreenAction() *FightScreenAction {
+	return &FightScreenAction{
 		displaytime: 90,
 		showspeed:   8,
 		hidespeed:   4,
@@ -2632,16 +2632,16 @@ func newLifeBarAction() *LifeBarAction {
 	}
 }
 
-func readLifeBarAction(pre string, is IniSection, f map[int]*Fnt) *LifeBarAction {
-	ac := newLifeBarAction()
+func readFightScreenAction(pre string, is IniSection, f map[int]*Fnt) *FightScreenAction {
+	ac := newFightScreenAction()
 	ac.is = is
 	is.ReadI32(pre+"pos", &ac.pos[0], &ac.pos[1])
 	is.ReadI32(pre+"spacing", &ac.spacing[0], &ac.spacing[1])
 	is.ReadF32(pre+"start.x", &ac.start_x)
 	if pre == "team2." {
-		ac.start_x = float32(sys.lifebar.localcoord[0]) - ac.start_x
+		ac.start_x = float32(sys.fightScreen.localcoord[0]) - ac.start_x
 	}
-	ac.text = *readLbText(pre+"text.", is, "", 2, f, 0)
+	ac.text = *readFSText(pre+"text.", is, "", 2, f, 0)
 	is.ReadI32(pre+"displaytime", &ac.displaytime)
 	is.ReadF32(pre+"showspeed", &ac.showspeed)
 	ac.showspeed = Max(1, ac.showspeed)
@@ -2650,7 +2650,7 @@ func readLifeBarAction(pre string, is IniSection, f map[int]*Fnt) *LifeBarAction
 	return ac
 }
 
-func (ac *LifeBarAction) step(leader int) {
+func (ac *FightScreenAction) step(leader int) {
 	if ac.oldleader != leader {
 		ac.oldleader = leader
 	}
@@ -2663,7 +2663,7 @@ func (ac *LifeBarAction) step(leader int) {
 		if v.resttime > 0 {
 			v.counterX -= v.counterX / ac.showspeed
 		} else {
-			v.counterX -= sys.lifebar.fnt_scale * ac.hidespeed * float32(sys.lifebar.localcoord[0]) / 320
+			v.counterX -= sys.fightScreen.fnt_scale * ac.hidespeed * float32(sys.fightScreen.localcoord[0]) / 320
 			if v.counterX < ac.start_x*2 {
 				v.del = true
 			}
@@ -2674,17 +2674,17 @@ func (ac *LifeBarAction) step(leader int) {
 		v.agetimer++
 	}
 	if len(ac.messages) > 0 && ac.messages[len(ac.messages)-1].del {
-		ac.messages = removeLbMsg(ac.messages, len(ac.messages)-1)
+		ac.messages = removeFSMsg(ac.messages, len(ac.messages)-1)
 	}
 	ac.text.step()
 }
 
-func (ac *LifeBarAction) reset(leader int) {
+func (ac *FightScreenAction) reset(leader int) {
 	ac.oldleader = leader
-	ac.messages = []*LbMsg{}
+	ac.messages = []*FSMsg{}
 }
 
-func (ac *LifeBarAction) draw(layerno int16, f map[int]*Fnt, side int) {
+func (ac *FightScreenAction) draw(layerno int16, f map[int]*Fnt, side int) {
 	for k, v := range ac.messages {
 		if v.resttime <= 0 && v.counterX == ac.start_x*2 {
 			continue
@@ -2704,15 +2704,15 @@ func (ac *LifeBarAction) draw(layerno int16, f map[int]*Fnt, side int) {
 		// https://github.com/ikemen-engine/Ikemen-GO/issues/2166
 		// Draw background
 		if v.bg.anim.spr != nil {
-			v.bg.Draw(x+sys.lifebar.offsetX+float32(k)*float32(ac.spacing[0]),
+			v.bg.Draw(x+sys.fightScreen.offsetX+float32(k)*float32(ac.spacing[0]),
 				float32(ac.pos[1])+float32(k)*float32(ac.spacing[1]),
-				layerno, sys.lifebar.scale)
+				layerno, sys.fightScreen.scale)
 		}
 		// Draw animation/sprite
 		if v.front.anim.spr != nil {
-			v.front.Draw(x+sys.lifebar.offsetX+float32(k)*float32(ac.spacing[0]),
+			v.front.Draw(x+sys.fightScreen.offsetX+float32(k)*float32(ac.spacing[0]),
 				float32(ac.pos[1])+float32(k)*float32(ac.spacing[1]),
-				layerno, sys.lifebar.scale)
+				layerno, sys.fightScreen.scale)
 		}
 		// Draw text
 		if v.text != "" && ac.text.font[0] >= 0 {
@@ -2757,9 +2757,9 @@ func (ac *LifeBarAction) draw(layerno int16, f map[int]*Fnt, side int) {
 					palfx = pf
 				}
 
-				ac.text.lay.DrawText(x+sys.lifebar.offsetX+float32(k)*float32(ac.spacing[0]),
+				ac.text.lay.DrawText(x+sys.fightScreen.offsetX+float32(k)*float32(ac.spacing[0]),
 					float32(ac.pos[1])+float32(k)*float32(ac.spacing[1]),
-					sys.lifebar.scale, layerno, v.text, ff, bank, align,
+					sys.fightScreen.scale, layerno, v.text, ff, bank, align,
 					palfx, frgba)
 			}
 		}
@@ -2772,83 +2772,83 @@ type ResultAnnouncement struct {
 	bg   [2][32]AnimLayout
 }
 
-type LifeBarRound struct {
-	snd               *Snd
-	pos               [2]int32
-	start_waittime    int32
-	round_time        int32
-	round_sndtime     int32
-	roundDisplayTimer int32
-	roundDisplayPhase int32
-	round             [9]AnimTextSnd
-	round_default     AnimTextSnd
-	round_default_top AnimLayout
-	round_default_bg  [32]AnimLayout
-	round_single      AnimTextSnd
-	round_single_top  AnimLayout
-	round_single_bg   [32]AnimLayout
-	round_final       AnimTextSnd
-	round_final_top   AnimLayout
-	round_final_bg    [32]AnimLayout
-	fight_time        int32
-	fight_sndtime     int32
-	fightDisplayTimer int32
-	fightDisplayPhase int32
-	fight             AnimTextSnd
-	fight_top         AnimLayout
-	fight_bg          [32]AnimLayout
-	ctrl_time         int32
-	ko_time           int32
-	ko_sndtime        int32
-	koDisplayTimer    int32
-	koDisplayPhase    int32
-	dko_time          int32
-	dko_sndtime       int32
-	dko_showdraw      bool
-	to_time           int32
-	to_sndtime        int32
-	ko, dko, to       AnimTextSnd
-	ko_top            AnimLayout
-	ko_bg             [32]AnimLayout
-	dko_top           AnimLayout
-	dko_bg            [32]AnimLayout
-	to_top            AnimLayout
-	to_bg             [32]AnimLayout
-	slow_time         int32
-	slow_fadetime     int32
-	slow_speed        float32
-	over_waittime     int32
-	over_hittime      int32
-	over_wintime      int32
-	over_forcewintime int32
-	over_time         int32
-	win_time          int32
-	win_sndtime       int32
-	winDisplayTimer   int32
-	winDisplayPhase   int32
-	win               [4]ResultAnnouncement
-	aiLose            [4]ResultAnnouncement
-	aiWin             [4]ResultAnnouncement
-	aiWinExists       [2][4]bool
-	aiLoseExists      [2][4]bool
-	drawgame          AnimTextSnd
-	drawgame_top      AnimLayout
-	drawgame_bg       [32]AnimLayout
-	timerActive       bool
-	winType           [WT_NumTypes * 2]LbBgTextSnd
-	fadeIn            *Fade
-	fadeOut           *Fade
-	shutterTimer      int32
-	shutter_time      int32
-	shutter_col       uint32
-	callfight_time    int32
-	clutch_threshold  int32
+type FightScreenRound struct {
+	snd                 *Snd
+	pos                 [2]int32
+	start_waittime      int32
+	round_time          int32
+	round_sndtime       int32
+	roundDisplayTimer   int32
+	roundDisplayPhase   int32
+	round               [9]AnimTextSnd
+	round_default       AnimTextSnd
+	round_default_top   AnimLayout
+	round_default_bg    [32]AnimLayout
+	round_single        AnimTextSnd
+	round_single_top    AnimLayout
+	round_single_bg     [32]AnimLayout
+	round_final         AnimTextSnd
+	round_final_top     AnimLayout
+	round_final_bg      [32]AnimLayout
+	fight_time          int32
+	fight_sndtime       int32
+	fightDisplayTimer   int32
+	fightDisplayPhase   int32
+	fight               AnimTextSnd
+	fight_top           AnimLayout
+	fight_bg            [32]AnimLayout
+	ctrl_time           int32
+	ko_time             int32
+	ko_sndtime          int32
+	koDisplayTimer      int32
+	koDisplayPhase      int32
+	dko_time            int32
+	dko_sndtime         int32
+	dko_showdraw        bool
+	to_time             int32
+	to_sndtime          int32
+	ko, dko, to         AnimTextSnd
+	ko_top              AnimLayout
+	ko_bg               [32]AnimLayout
+	dko_top             AnimLayout
+	dko_bg              [32]AnimLayout
+	to_top              AnimLayout
+	to_bg               [32]AnimLayout
+	slow_time           int32
+	slow_fadetime       int32
+	slow_speed          float32
+	over_waittime       int32
+	over_hittime        int32
+	over_wintime        int32
+	over_forcewintime   int32
+	over_time           int32
+	win_time            int32
+	win_sndtime         int32
+	winDisplayTimer     int32
+	winDisplayPhase     int32
+	win                 [4]ResultAnnouncement
+	aiLose              [4]ResultAnnouncement
+	aiWin               [4]ResultAnnouncement
+	aiWinExists         [2][4]bool
+	aiLoseExists        [2][4]bool
+	drawgame            AnimTextSnd
+	drawgame_top        AnimLayout
+	drawgame_bg         [32]AnimLayout
+	timerActive         bool
+	winType             [WT_NumTypes * 2]FSBgTextSnd
+	fadeIn              *Fade
+	fadeOut             *Fade
+	shutterTimer        int32
+	shutter_time        int32
+	shutter_col         uint32
+	callfight_time      int32
+	clutch_threshold    int32
 	//match_wins          [2]int32 // Handled by system
 	//match_maxdrawgames  [2]int32 // Handled by system
 }
 
-func newLifeBarRound(snd *Snd) *LifeBarRound {
-	return &LifeBarRound{
+func newFightScreenRound(snd *Snd) *FightScreenRound {
+	return &FightScreenRound{
 		snd:               snd,
 		start_waittime:    30,
 		ctrl_time:         30,
@@ -2878,7 +2878,7 @@ func readLbFade(pre string, is IniSection, sff *Sff, at AnimationTable) *Fade {
 	is.ReadI32(pre+"anim", &anim)
 	fp.animData = NewAnim(sff, "-1,0, 0,0, -1")
 	//fp.animData.SetLocalcoord(float32(sys.scrrect[2]), float32(sys.scrrect[3]))
-	fp.animData.SetLocalcoord(float32(sys.lifebar.localcoord[0]), float32(sys.lifebar.localcoord[1]))
+	fp.animData.SetLocalcoord(float32(sys.fightScreen.localcoord[0]), float32(sys.fightScreen.localcoord[1]))
 	fp.animData.SetPos(0, 0)   // TODO: use fp.animData.Reset() instead
 	fp.animData.SetScale(1, 1) // TODO: use fp.animData.Reset() instead
 	//fp.animData.Reset() // TODO: comment out pos and scale adjustments
@@ -2890,9 +2890,9 @@ func readLbFade(pre string, is IniSection, sff *Sff, at AnimationTable) *Fade {
 	return fp
 }
 
-func readLifeBarRound(is IniSection,
-	sff *Sff, at AnimationTable, snd *Snd, f map[int]*Fnt) *LifeBarRound {
-	ro := newLifeBarRound(snd)
+func readFightScreenRound(is IniSection,
+	sff *Sff, at AnimationTable, snd *Snd, f map[int]*Fnt) *FightScreenRound {
+	ro := newFightScreenRound(snd)
 
 	is.ReadI32("pos", &ro.pos[0], &ro.pos[1])
 	//is.ReadI32("match.wins", &ro.match_wins[0], &ro.match_wins[1]) // Replaced by ingame options
@@ -3074,26 +3074,26 @@ func readLifeBarRound(is IniSection,
 	for i := range ro.drawgame_bg {
 		ro.drawgame_bg[i] = ReadAnimLayout(fmt.Sprintf("draw.bg%v.", i), is, sff, at, 1)
 	}
-	ro.winType[WT_Normal] = readLbBgTextSnd("p1.n.", is, sff, at, 0, f)
-	ro.winType[WT_Special] = readLbBgTextSnd("p1.s.", is, sff, at, 0, f)
-	ro.winType[WT_Hyper] = readLbBgTextSnd("p1.h.", is, sff, at, 0, f)
-	ro.winType[WT_Cheese] = readLbBgTextSnd("p1.c.", is, sff, at, 0, f)
-	ro.winType[WT_Time] = readLbBgTextSnd("p1.t.", is, sff, at, 0, f)
-	ro.winType[WT_Throw] = readLbBgTextSnd("p1.throw.", is, sff, at, 0, f)
-	ro.winType[WT_Suicide] = readLbBgTextSnd("p1.suicide.", is, sff, at, 0, f)
-	ro.winType[WT_Teammate] = readLbBgTextSnd("p1.teammate.", is, sff, at, 0, f)
-	ro.winType[WT_Perfect] = readLbBgTextSnd("p1.perfect.", is, sff, at, 0, f)
-	ro.winType[WT_Clutch] = readLbBgTextSnd("p1.clutch.", is, sff, at, 0, f)
-	ro.winType[WT_Normal+WT_NumTypes] = readLbBgTextSnd("p2.n.", is, sff, at, 0, f)
-	ro.winType[WT_Special+WT_NumTypes] = readLbBgTextSnd("p2.s.", is, sff, at, 0, f)
-	ro.winType[WT_Hyper+WT_NumTypes] = readLbBgTextSnd("p2.h.", is, sff, at, 0, f)
-	ro.winType[WT_Cheese+WT_NumTypes] = readLbBgTextSnd("p2.c.", is, sff, at, 0, f)
-	ro.winType[WT_Time+WT_NumTypes] = readLbBgTextSnd("p2.t.", is, sff, at, 0, f)
-	ro.winType[WT_Throw+WT_NumTypes] = readLbBgTextSnd("p2.throw.", is, sff, at, 0, f)
-	ro.winType[WT_Suicide+WT_NumTypes] = readLbBgTextSnd("p2.suicide.", is, sff, at, 0, f)
-	ro.winType[WT_Teammate+WT_NumTypes] = readLbBgTextSnd("p2.teammate.", is, sff, at, 0, f)
-	ro.winType[WT_Perfect+WT_NumTypes] = readLbBgTextSnd("p2.perfect.", is, sff, at, 0, f)
-	ro.winType[WT_Clutch+WT_NumTypes] = readLbBgTextSnd("p2.clutch.", is, sff, at, 0, f)
+	ro.winType[WT_Normal] = readFSBgTextSnd("p1.n.", is, sff, at, 0, f)
+	ro.winType[WT_Special] = readFSBgTextSnd("p1.s.", is, sff, at, 0, f)
+	ro.winType[WT_Hyper] = readFSBgTextSnd("p1.h.", is, sff, at, 0, f)
+	ro.winType[WT_Cheese] = readFSBgTextSnd("p1.c.", is, sff, at, 0, f)
+	ro.winType[WT_Time] = readFSBgTextSnd("p1.t.", is, sff, at, 0, f)
+	ro.winType[WT_Throw] = readFSBgTextSnd("p1.throw.", is, sff, at, 0, f)
+	ro.winType[WT_Suicide] = readFSBgTextSnd("p1.suicide.", is, sff, at, 0, f)
+	ro.winType[WT_Teammate] = readFSBgTextSnd("p1.teammate.", is, sff, at, 0, f)
+	ro.winType[WT_Perfect] = readFSBgTextSnd("p1.perfect.", is, sff, at, 0, f)
+	ro.winType[WT_Clutch] = readFSBgTextSnd("p1.clutch.", is, sff, at, 0, f)
+	ro.winType[WT_Normal+WT_NumTypes] = readFSBgTextSnd("p2.n.", is, sff, at, 0, f)
+	ro.winType[WT_Special+WT_NumTypes] = readFSBgTextSnd("p2.s.", is, sff, at, 0, f)
+	ro.winType[WT_Hyper+WT_NumTypes] = readFSBgTextSnd("p2.h.", is, sff, at, 0, f)
+	ro.winType[WT_Cheese+WT_NumTypes] = readFSBgTextSnd("p2.c.", is, sff, at, 0, f)
+	ro.winType[WT_Time+WT_NumTypes] = readFSBgTextSnd("p2.t.", is, sff, at, 0, f)
+	ro.winType[WT_Throw+WT_NumTypes] = readFSBgTextSnd("p2.throw.", is, sff, at, 0, f)
+	ro.winType[WT_Suicide+WT_NumTypes] = readFSBgTextSnd("p2.suicide.", is, sff, at, 0, f)
+	ro.winType[WT_Teammate+WT_NumTypes] = readFSBgTextSnd("p2.teammate.", is, sff, at, 0, f)
+	ro.winType[WT_Perfect+WT_NumTypes] = readFSBgTextSnd("p2.perfect.", is, sff, at, 0, f)
+	ro.winType[WT_Clutch+WT_NumTypes] = readFSBgTextSnd("p2.clutch.", is, sff, at, 0, f)
 	ro.fadeIn = readLbFade("fadein.", is, sff, at)
 	ro.fadeOut = readLbFade("fadeout.", is, sff, at)
 	is.ReadI32("shutter.time", &ro.shutter_time)
@@ -3106,12 +3106,12 @@ func readLifeBarRound(is IniSection,
 	return ro
 }
 
-func (ro *LifeBarRound) overTime() int32 {
+func (ro *FightScreenRound) overTime() int32 {
 	return Max(ro.over_time, ro.fadeOut.time)
 }
 
 // Check is sys.intro timer should step
-func (ro *LifeBarRound) act() bool {
+func (ro *FightScreenRound) act() bool {
 	// Early exits
 	if (sys.paused && !sys.frameStepFlag) || sys.gsf(GSF_roundfreeze) {
 		return false
@@ -3162,7 +3162,7 @@ func (ro *LifeBarRound) act() bool {
 /*
 // Check if current round animation can be skipped
 // This prevents cutting an animation after it's already running
-func (ro *LifeBarRound) canSkipPhase(phase int) bool {
+func (ro *FightScreenRound) canSkipPhase(phase int) bool {
 	if phase < len(ro.waitTimer) && phase < len(ro.waitSoundTimer) && phase < len(ro.drawTimer) {
 		return ro.waitTimer[phase] >= 0 && ro.waitSoundTimer[phase] >= 0 && ro.drawTimer[phase] <= 0
 	}
@@ -3171,7 +3171,7 @@ func (ro *LifeBarRound) canSkipPhase(phase int) bool {
 */
 
 // Consists of round and fight calls
-func (ro *LifeBarRound) handleRoundIntro() {
+func (ro *FightScreenRound) handleRoundIntro() {
 	// Previously skipping the char intros took us to the fight call, like Mugen
 	// Most games go to the round call instead so this was changed
 	//if sys.introSkipped && !sys.dialogueFlg {
@@ -3323,7 +3323,7 @@ func (ro *LifeBarRound) handleRoundIntro() {
 }
 
 // Consists of KO screen and winner messages
-func (ro *LifeBarRound) handleRoundOutro() {
+func (ro *FightScreenRound) handleRoundOutro() {
 	if ro.timerActive {
 		if sys.matchTime-sys.timerCount[sys.round-1] > 0 {
 			sys.timerCount[sys.round-1] = sys.matchTime - sys.timerCount[sys.round-1]
@@ -3378,7 +3378,7 @@ func (ro *LifeBarRound) handleRoundOutro() {
 		// It's not even related to the over.hittime parameter
 		// This is probably always unwanted, but we'll limit it to "mugenversion" for now
 		var delay int32
-		if sys.lifebar.ikemenver[0] == 0 && sys.lifebar.ikemenver[1] == 0 {
+		if sys.fightScreen.ikemenver[0] == 0 && sys.fightScreen.ikemenver[1] == 0 {
 			delay = 10
 		}
 
@@ -3484,7 +3484,7 @@ func (ro *LifeBarRound) handleRoundOutro() {
 	}
 }
 
-func (ro *LifeBarRound) reset() {
+func (ro *FightScreenRound) reset() {
 	ro.shutterTimer = 0
 	ro.fadeOut.reset()
 	ro.fadeIn.init(ro.fadeIn, true)
@@ -3548,7 +3548,7 @@ func (ro *LifeBarRound) reset() {
 	ro.winDisplayPhase = 0
 }
 
-func (ro *LifeBarRound) draw(layerno int16, f map[int]*Fnt) {
+func (ro *FightScreenRound) draw(layerno int16, f map[int]*Fnt) {
 	// Temporarily override system brightness
 	oldBright := sys.brightness
 	sys.brightness = 1.0
@@ -3558,10 +3558,10 @@ func (ro *LifeBarRound) draw(layerno int16, f map[int]*Fnt) {
 		// Draw default round background
 		for i := range ro.round_default_bg {
 			ro.round_default_bg[i].Draw(
-				float32(ro.pos[0])+sys.lifebar.offsetX,
+				float32(ro.pos[0])+sys.fightScreen.offsetX,
 				float32(ro.pos[1]),
 				layerno,
-				sys.lifebar.scale,
+				sys.fightScreen.scale,
 			)
 		}
 
@@ -3579,10 +3579,10 @@ func (ro *LifeBarRound) draw(layerno int16, f map[int]*Fnt) {
 			// Single round
 			for i := range ro.round_single_bg {
 				ro.round_single_bg[i].Draw(
-					float32(ro.pos[0])+sys.lifebar.offsetX,
+					float32(ro.pos[0])+sys.fightScreen.offsetX,
 					float32(ro.pos[1]),
 					layerno,
-					sys.lifebar.scale,
+					sys.fightScreen.scale,
 				)
 			}
 			round_ref = ro.round_single
@@ -3591,10 +3591,10 @@ func (ro *LifeBarRound) draw(layerno int16, f map[int]*Fnt) {
 			// Final round
 			for i := range ro.round_final_bg {
 				ro.round_final_bg[i].Draw(
-					float32(ro.pos[0])+sys.lifebar.offsetX,
+					float32(ro.pos[0])+sys.fightScreen.offsetX,
 					float32(ro.pos[1]),
 					layerno,
-					sys.lifebar.scale,
+					sys.fightScreen.scale,
 				)
 			}
 			round_ref = ro.round_final
@@ -3614,7 +3614,7 @@ func (ro *LifeBarRound) draw(layerno int16, f map[int]*Fnt) {
 		}
 
 		// Draw default round
-		ro.round_default.Draw(float32(ro.pos[0])+sys.lifebar.offsetX, float32(ro.pos[1]), layerno, f, sys.lifebar.scale)
+		ro.round_default.Draw(float32(ro.pos[0])+sys.fightScreen.offsetX, float32(ro.pos[1]), layerno, f, sys.fightScreen.scale)
 
 		// Restore default text
 		ro.round_default.text.text = tmp
@@ -3626,7 +3626,7 @@ func (ro *LifeBarRound) draw(layerno int16, f map[int]*Fnt) {
 		round_ref.text.text = OldSprintf(tmp, roundNum)
 
 		// Draw round-specific elements
-		round_ref.Draw(float32(ro.pos[0])+sys.lifebar.offsetX, float32(ro.pos[1]), layerno, f, sys.lifebar.scale)
+		round_ref.Draw(float32(ro.pos[0])+sys.fightScreen.offsetX, float32(ro.pos[1]), layerno, f, sys.fightScreen.scale)
 
 		// Restore round_ref text
 		round_ref.text.text = tmp
@@ -3636,26 +3636,26 @@ func (ro *LifeBarRound) draw(layerno int16, f map[int]*Fnt) {
 		case sys.roundIsSingle() && ro.round_single_top.anim != nil && len(ro.round_single_top.anim.frames) > 0:
 			// Single round
 			ro.round_single_top.Draw(
-				float32(ro.pos[0])+sys.lifebar.offsetX,
+				float32(ro.pos[0])+sys.fightScreen.offsetX,
 				float32(ro.pos[1]),
 				layerno,
-				sys.lifebar.scale,
+				sys.fightScreen.scale,
 			)
 		case sys.roundIsFinal() && ro.round_final_top.anim != nil && len(ro.round_final_top.anim.frames) > 0:
 			// Final round
 			ro.round_final_top.Draw(
-				float32(ro.pos[0])+sys.lifebar.offsetX,
+				float32(ro.pos[0])+sys.fightScreen.offsetX,
 				float32(ro.pos[1]),
 				layerno,
-				sys.lifebar.scale,
+				sys.fightScreen.scale,
 			)
 		default:
 			// Normal round
 			ro.round_default_top.Draw(
-				float32(ro.pos[0])+sys.lifebar.offsetX,
+				float32(ro.pos[0])+sys.fightScreen.offsetX,
 				float32(ro.pos[1]),
 				layerno,
-				sys.lifebar.scale,
+				sys.fightScreen.scale,
 			)
 		}
 	}
@@ -3663,10 +3663,10 @@ func (ro *LifeBarRound) draw(layerno int16, f map[int]*Fnt) {
 	// "Fight!" animations
 	if ro.fightDisplayPhase == 1 {
 		for i := range ro.fight_bg {
-			ro.fight_bg[i].Draw(float32(ro.pos[0])+sys.lifebar.offsetX, float32(ro.pos[1]), layerno, sys.lifebar.scale)
+			ro.fight_bg[i].Draw(float32(ro.pos[0])+sys.fightScreen.offsetX, float32(ro.pos[1]), layerno, sys.fightScreen.scale)
 		}
-		ro.fight.Draw(float32(ro.pos[0])+sys.lifebar.offsetX, float32(ro.pos[1]), layerno, f, sys.lifebar.scale)
-		ro.fight_top.Draw(float32(ro.pos[0])+sys.lifebar.offsetX, float32(ro.pos[1]), layerno, sys.lifebar.scale)
+		ro.fight.Draw(float32(ro.pos[0])+sys.fightScreen.offsetX, float32(ro.pos[1]), layerno, f, sys.fightScreen.scale)
+		ro.fight_top.Draw(float32(ro.pos[0])+sys.fightScreen.offsetX, float32(ro.pos[1]), layerno, sys.fightScreen.scale)
 	}
 
 	// KO animations
@@ -3677,7 +3677,7 @@ func (ro *LifeBarRound) draw(layerno int16, f map[int]*Fnt) {
 		var time int32
 
 		var delay int32
-		if sys.lifebar.ikemenver[0] == 0 && sys.lifebar.ikemenver[1] == 0 {
+		if sys.fightScreen.ikemenver[0] == 0 && sys.fightScreen.ikemenver[1] == 0 {
 			delay = 10
 		}
 
@@ -3695,10 +3695,10 @@ func (ro *LifeBarRound) draw(layerno int16, f map[int]*Fnt) {
 
 		if ro.koDisplayTimer >= time+delay {
 			for i := range bg {
-				bg[i].Draw(float32(ro.pos[0])+sys.lifebar.offsetX, float32(ro.pos[1]), layerno, sys.lifebar.scale)
+				bg[i].Draw(float32(ro.pos[0])+sys.fightScreen.offsetX, float32(ro.pos[1]), layerno, sys.fightScreen.scale)
 			}
-			ats.Draw(float32(ro.pos[0])+sys.lifebar.offsetX, float32(ro.pos[1]), layerno, f, sys.lifebar.scale)
-			top.Draw(float32(ro.pos[0])+sys.lifebar.offsetX, float32(ro.pos[1]), layerno, sys.lifebar.scale)
+			ats.Draw(float32(ro.pos[0])+sys.fightScreen.offsetX, float32(ro.pos[1]), layerno, f, sys.fightScreen.scale)
+			top.Draw(float32(ro.pos[0])+sys.fightScreen.offsetX, float32(ro.pos[1]), layerno, sys.fightScreen.scale)
 		}
 	}
 
@@ -3711,10 +3711,10 @@ func (ro *LifeBarRound) draw(layerno int16, f map[int]*Fnt) {
 		lt := wt ^ 1
 		if sys.finishType == FT_TODraw || (sys.finishType == FT_DKO && ro.dko_showdraw) {
 			for i := range ro.drawgame_bg {
-				ro.drawgame_bg[i].Draw(float32(ro.pos[0])+sys.lifebar.offsetX, float32(ro.pos[1]), layerno, sys.lifebar.scale)
+				ro.drawgame_bg[i].Draw(float32(ro.pos[0])+sys.fightScreen.offsetX, float32(ro.pos[1]), layerno, sys.fightScreen.scale)
 			}
-			ro.drawgame.Draw(float32(ro.pos[0])+sys.lifebar.offsetX, float32(ro.pos[1]), layerno, f, sys.lifebar.scale)
-			ro.drawgame_top.Draw(float32(ro.pos[0])+sys.lifebar.offsetX, float32(ro.pos[1]), layerno, sys.lifebar.scale)
+			ro.drawgame.Draw(float32(ro.pos[0])+sys.fightScreen.offsetX, float32(ro.pos[1]), layerno, f, sys.fightScreen.scale)
+			ro.drawgame_top.Draw(float32(ro.pos[0])+sys.fightScreen.offsetX, float32(ro.pos[1]), layerno, sys.fightScreen.scale)
 		} else if sys.winTeam >= 0 {
 			isPlayerWin, isAiWin := false, false
 			for i := wt; i < len(sys.chars); i += 2 {
@@ -3755,7 +3755,7 @@ func (ro *LifeBarRound) draw(layerno int16, f map[int]*Fnt) {
 			}
 			// BGs
 			for i := range res.bg[activeTeam] {
-				res.bg[activeTeam][i].Draw(float32(ro.pos[0])+sys.lifebar.offsetX, float32(ro.pos[1]), layerno, sys.lifebar.scale)
+				res.bg[activeTeam][i].Draw(float32(ro.pos[0])+sys.fightScreen.offsetX, float32(ro.pos[1]), layerno, sys.fightScreen.scale)
 			}
 			// Text
 			oldTxt := res.text[activeTeam].text.text
@@ -3773,10 +3773,10 @@ func (ro *LifeBarRound) draw(layerno int16, f map[int]*Fnt) {
 			if len(args) > 0 {
 				res.text[activeTeam].text.text = OldSprintf(oldTxt, args...)
 			}
-			res.text[activeTeam].Draw(float32(ro.pos[0])+sys.lifebar.offsetX, float32(ro.pos[1]), layerno, f, sys.lifebar.scale)
+			res.text[activeTeam].Draw(float32(ro.pos[0])+sys.fightScreen.offsetX, float32(ro.pos[1]), layerno, f, sys.fightScreen.scale)
 			res.text[activeTeam].text.text = oldTxt
 			// Top
-			res.top[activeTeam].Draw(float32(ro.pos[0])+sys.lifebar.offsetX, float32(ro.pos[1]), layerno, sys.lifebar.scale)
+			res.top[activeTeam].Draw(float32(ro.pos[0])+sys.fightScreen.offsetX, float32(ro.pos[1]), layerno, sys.fightScreen.scale)
 		}
 		// Perfect and other special win types
 		if sys.winTeam >= 0 {
@@ -3856,20 +3856,20 @@ func (ro *LifeBarRound) draw(layerno int16, f map[int]*Fnt) {
 	}
 }
 
-type LifeBarRatio struct {
+type FightScreenRatio struct {
 	pos  [2]int32
 	icon [4]AnimLayout
 	bg   AnimLayout
 	top  AnimLayout
 }
 
-func newLifeBarRatio() *LifeBarRatio {
-	return &LifeBarRatio{}
+func newFightScreenRatio() *FightScreenRatio {
+	return &FightScreenRatio{}
 }
 
-func readLifeBarRatio(pre string, is IniSection,
-	sff *Sff, at AnimationTable) *LifeBarRatio {
-	ra := newLifeBarRatio()
+func readFightScreenRatio(pre string, is IniSection,
+	sff *Sff, at AnimationTable) *FightScreenRatio {
+	ra := newFightScreenRatio()
 	is.ReadI32(pre+"pos", &ra.pos[0], &ra.pos[1])
 	ra.icon[0] = ReadAnimLayout(pre+"level1.", is, sff, at, 0)
 	ra.icon[1] = ReadAnimLayout(pre+"level2.", is, sff, at, 0)
@@ -3879,46 +3879,46 @@ func readLifeBarRatio(pre string, is IniSection,
 	return ra
 }
 
-func (ra *LifeBarRatio) step(num int32) {
+func (ra *FightScreenRatio) step(num int32) {
 	ra.icon[num].Action()
 	ra.bg.Action()
 }
 
-func (ra *LifeBarRatio) reset() {
+func (ra *FightScreenRatio) reset() {
 	for i := range ra.icon {
 		ra.icon[i].Reset()
 	}
 	ra.bg.Reset()
 }
 
-func (ra *LifeBarRatio) bgDraw(layerno int16) {
-	ra.bg.Draw(float32(ra.pos[0])+sys.lifebar.offsetX, float32(ra.pos[1]), layerno, sys.lifebar.scale)
+func (ra *FightScreenRatio) bgDraw(layerno int16) {
+	ra.bg.Draw(float32(ra.pos[0])+sys.fightScreen.offsetX, float32(ra.pos[1]), layerno, sys.fightScreen.scale)
 }
 
-func (ra *LifeBarRatio) draw(layerno int16, num int32) {
-	ra.icon[num].Draw(float32(ra.pos[0])+sys.lifebar.offsetX,
-		float32(ra.pos[1]), layerno, sys.lifebar.scale)
-	ra.top.Draw(float32(ra.pos[0])+sys.lifebar.offsetX, float32(ra.pos[1]), layerno, sys.lifebar.scale)
+func (ra *FightScreenRatio) draw(layerno int16, num int32) {
+	ra.icon[num].Draw(float32(ra.pos[0])+sys.fightScreen.offsetX,
+		float32(ra.pos[1]), layerno, sys.fightScreen.scale)
+	ra.top.Draw(float32(ra.pos[0])+sys.fightScreen.offsetX, float32(ra.pos[1]), layerno, sys.fightScreen.scale)
 }
 
-type LifeBarTimer struct {
+type FightScreenTimer struct {
 	pos     [2]int32
-	text    LbText
+	text    FSText
 	bg      AnimLayout
 	top     AnimLayout
 	enabled map[string]bool
 	active  bool
 }
 
-func newLifeBarTimer() *LifeBarTimer {
-	return &LifeBarTimer{enabled: make(map[string]bool)}
+func newFightScreenTimer() *FightScreenTimer {
+	return &FightScreenTimer{enabled: make(map[string]bool)}
 }
 
-func readLifeBarTimer(is IniSection, sff *Sff, at AnimationTable, f map[int]*Fnt) *LifeBarTimer {
-	tr := newLifeBarTimer()
+func readFightScreenTimer(is IniSection, sff *Sff, at AnimationTable, f map[int]*Fnt) *FightScreenTimer {
+	tr := newFightScreenTimer()
 
 	is.ReadI32("pos", &tr.pos[0], &tr.pos[1])
-	tr.text = *readLbText("text.", is, "", 0, f, 0)
+	tr.text = *readFSText("text.", is, "", 0, f, 0)
 	tr.bg = ReadAnimLayout("bg.", is, sff, at, 0)
 	tr.top = ReadAnimLayout("top.", is, sff, at, 0)
 	for k := range is {
@@ -3933,24 +3933,24 @@ func readLifeBarTimer(is IniSection, sff *Sff, at AnimationTable, f map[int]*Fnt
 	return tr
 }
 
-func (tr *LifeBarTimer) step() {
+func (tr *FightScreenTimer) step() {
 	tr.bg.Action()
 	tr.top.Action()
 	tr.text.step()
 }
 
-func (tr *LifeBarTimer) reset() {
+func (tr *FightScreenTimer) reset() {
 	tr.bg.Reset()
 	tr.top.Reset()
 }
 
-func (tr *LifeBarTimer) bgDraw(layerno int16) {
+func (tr *FightScreenTimer) bgDraw(layerno int16) {
 	if tr.active {
-		tr.bg.Draw(float32(tr.pos[0])+sys.lifebar.offsetX, float32(tr.pos[1]), layerno, sys.lifebar.scale)
+		tr.bg.Draw(float32(tr.pos[0])+sys.fightScreen.offsetX, float32(tr.pos[1]), layerno, sys.fightScreen.scale)
 	}
 }
 
-func (tr *LifeBarTimer) draw(layerno int16, f map[int]*Fnt) {
+func (tr *FightScreenTimer) draw(layerno int16, f map[int]*Fnt) {
 	if tr.active && sys.curFramesPerCount > 0 &&
 		tr.text.font[0] >= 0 && getFont(f, tr.text.font[0]) != nil {
 		text := tr.text.text
@@ -3972,15 +3972,15 @@ func (tr *LifeBarTimer) draw(layerno int16, f map[int]*Fnt) {
 		text = strings.Replace(text, "%m", ms, 1)
 		text = strings.Replace(text, "%s", ss, 1)
 		text = strings.Replace(text, "%x", xs, 1)
-		tr.text.lay.DrawText(float32(tr.pos[0])+sys.lifebar.offsetX, float32(tr.pos[1]), sys.lifebar.scale, layerno,
+		tr.text.lay.DrawText(float32(tr.pos[0])+sys.fightScreen.offsetX, float32(tr.pos[1]), sys.fightScreen.scale, layerno,
 			text, getFont(f, tr.text.font[0]), tr.text.font[1], tr.text.font[2], tr.text.palfx, tr.text.frgba)
-		tr.top.Draw(float32(tr.pos[0])+sys.lifebar.offsetX, float32(tr.pos[1]), layerno, sys.lifebar.scale)
+		tr.top.Draw(float32(tr.pos[0])+sys.fightScreen.offsetX, float32(tr.pos[1]), layerno, sys.fightScreen.scale)
 	}
 }
 
-type LifeBarScore struct {
+type FightScreenScore struct {
 	pos         [2]int32
-	text        LbText
+	text        FSText
 	bg          AnimLayout
 	top         AnimLayout
 	separator   [2]string
@@ -3993,15 +3993,15 @@ type LifeBarScore struct {
 	active      bool
 }
 
-func newLifeBarScore() *LifeBarScore {
-	return &LifeBarScore{separator: [2]string{"", "."}, enabled: make(map[string]bool)}
+func newFightScreenScore() *FightScreenScore {
+	return &FightScreenScore{separator: [2]string{"", "."}, enabled: make(map[string]bool)}
 }
 
-func readLifeBarScore(pre string, is IniSection, sff *Sff, at AnimationTable, f map[int]*Fnt) *LifeBarScore {
-	sc := newLifeBarScore()
+func readFightScreenScore(pre string, is IniSection, sff *Sff, at AnimationTable, f map[int]*Fnt) *FightScreenScore {
+	sc := newFightScreenScore()
 
 	is.ReadI32(pre+"pos", &sc.pos[0], &sc.pos[1])
-	sc.text = *readLbText(pre+"text.", is, "", 0, f, 0)
+	sc.text = *readFSText(pre+"text.", is, "", 0, f, 0)
 	sc.separator[0], _, _ = is.getText("format.integer.separator")
 	sc.separator[1], _, _ = is.getText("format.decimal.separator")
 	is.ReadI32("format.integer.pad", &sc.pad)
@@ -4022,25 +4022,25 @@ func readLifeBarScore(pre string, is IniSection, sff *Sff, at AnimationTable, f 
 	return sc
 }
 
-func (sc *LifeBarScore) step() {
+func (sc *FightScreenScore) step() {
 	sc.bg.Action()
 	sc.top.Action()
 	sc.text.step()
 }
 
-func (sc *LifeBarScore) reset() {
+func (sc *FightScreenScore) reset() {
 	sc.bg.Reset()
 	sc.top.Reset()
 	sc.scorePoints = 0
 }
 
-func (sc *LifeBarScore) bgDraw(layerno int16) {
+func (sc *FightScreenScore) bgDraw(layerno int16) {
 	if sc.active {
-		sc.bg.Draw(float32(sc.pos[0])+sys.lifebar.offsetX, float32(sc.pos[1]), layerno, sys.lifebar.scale)
+		sc.bg.Draw(float32(sc.pos[0])+sys.fightScreen.offsetX, float32(sc.pos[1]), layerno, sys.fightScreen.scale)
 	}
 }
 
-func (sc *LifeBarScore) draw(layerno int16, f map[int]*Fnt, side int) {
+func (sc *FightScreenScore) draw(layerno int16, f map[int]*Fnt, side int) {
 	if sc.active && sc.text.font[0] >= 0 && getFont(f, sc.text.font[0]) != nil {
 		text := sc.text.text
 		total := sys.chars[side][0].scoreTotal()
@@ -4073,30 +4073,30 @@ func (sc *LifeBarScore) draw(layerno int16, f map[int]*Fnt, side int) {
 		}
 		// replace %s with formatted string
 		text = strings.Replace(text, "%s", s[0]+ds+s[1], 1)
-		sc.text.lay.DrawText(float32(sc.pos[0])+sys.lifebar.offsetX, float32(sc.pos[1]), sys.lifebar.scale, layerno,
+		sc.text.lay.DrawText(float32(sc.pos[0])+sys.fightScreen.offsetX, float32(sc.pos[1]), sys.fightScreen.scale, layerno,
 			text, getFont(f, sc.text.font[0]), sc.text.font[1], sc.text.font[2], sc.text.palfx, sc.text.frgba)
-		sc.top.Draw(float32(sc.pos[0])+sys.lifebar.offsetX, float32(sc.pos[1]), layerno, sys.lifebar.scale)
+		sc.top.Draw(float32(sc.pos[0])+sys.fightScreen.offsetX, float32(sc.pos[1]), layerno, sys.fightScreen.scale)
 	}
 }
 
-type LifeBarMatch struct {
+type FightScreenMatch struct {
 	pos     [2]int32
-	text    LbText
+	text    FSText
 	bg      AnimLayout
 	top     AnimLayout
 	enabled map[string]bool
 	active  bool
 }
 
-func newLifeBarMatch() *LifeBarMatch {
-	return &LifeBarMatch{enabled: make(map[string]bool)}
+func newFightScreenMatch() *FightScreenMatch {
+	return &FightScreenMatch{enabled: make(map[string]bool)}
 }
 
-func readLifeBarMatch(is IniSection, sff *Sff, at AnimationTable, f map[int]*Fnt) *LifeBarMatch {
-	ma := newLifeBarMatch()
+func readFightScreenMatch(is IniSection, sff *Sff, at AnimationTable, f map[int]*Fnt) *FightScreenMatch {
+	ma := newFightScreenMatch()
 
 	is.ReadI32("pos", &ma.pos[0], &ma.pos[1])
-	ma.text = *readLbText("text.", is, "", 0, f, 0)
+	ma.text = *readFSText("text.", is, "", 0, f, 0)
 	ma.bg = ReadAnimLayout("bg.", is, sff, at, 0)
 	ma.top = ReadAnimLayout("top.", is, sff, at, 0)
 	for k := range is {
@@ -4111,36 +4111,36 @@ func readLifeBarMatch(is IniSection, sff *Sff, at AnimationTable, f map[int]*Fnt
 	return ma
 }
 
-func (ma *LifeBarMatch) step() {
+func (ma *FightScreenMatch) step() {
 	ma.bg.Action()
 	ma.top.Action()
 	ma.text.step()
 }
 
-func (ma *LifeBarMatch) reset() {
+func (ma *FightScreenMatch) reset() {
 	ma.bg.Reset()
 	ma.top.Reset()
 }
 
-func (ma *LifeBarMatch) bgDraw(layerno int16) {
+func (ma *FightScreenMatch) bgDraw(layerno int16) {
 	if ma.active {
-		ma.bg.Draw(float32(ma.pos[0])+sys.lifebar.offsetX, float32(ma.pos[1]), layerno, sys.lifebar.scale)
+		ma.bg.Draw(float32(ma.pos[0])+sys.fightScreen.offsetX, float32(ma.pos[1]), layerno, sys.fightScreen.scale)
 	}
 }
 
-func (ma *LifeBarMatch) draw(layerno int16, f map[int]*Fnt) {
+func (ma *FightScreenMatch) draw(layerno int16, f map[int]*Fnt) {
 	if ma.active && ma.text.font[0] >= 0 && getFont(f, ma.text.font[0]) != nil {
 		text := ma.text.text
 		text = strings.Replace(text, "%s", fmt.Sprintf("%v", sys.match), 1)
-		ma.text.lay.DrawText(float32(ma.pos[0])+sys.lifebar.offsetX, float32(ma.pos[1]), sys.lifebar.scale, layerno,
+		ma.text.lay.DrawText(float32(ma.pos[0])+sys.fightScreen.offsetX, float32(ma.pos[1]), sys.fightScreen.scale, layerno,
 			text, getFont(f, ma.text.font[0]), ma.text.font[1], ma.text.font[2], ma.text.palfx, ma.text.frgba)
-		ma.top.Draw(float32(ma.pos[0])+sys.lifebar.offsetX, float32(ma.pos[1]), layerno, sys.lifebar.scale)
+		ma.top.Draw(float32(ma.pos[0])+sys.fightScreen.offsetX, float32(ma.pos[1]), layerno, sys.fightScreen.scale)
 	}
 }
 
-type LifeBarAiLevel struct {
+type FightScreenAiLevel struct {
 	pos       [2]int32
-	text      LbText
+	text      FSText
 	bg        AnimLayout
 	top       AnimLayout
 	separator string
@@ -4149,15 +4149,15 @@ type LifeBarAiLevel struct {
 	active    bool
 }
 
-func newLifeBarAiLevel() *LifeBarAiLevel {
-	return &LifeBarAiLevel{separator: ".", enabled: make(map[string]bool)}
+func newFightScreenAiLevel() *FightScreenAiLevel {
+	return &FightScreenAiLevel{separator: ".", enabled: make(map[string]bool)}
 }
 
-func readLifeBarAiLevel(pre string, is IniSection, sff *Sff, at AnimationTable, f map[int]*Fnt) *LifeBarAiLevel {
-	ai := newLifeBarAiLevel()
+func readFightScreenAiLevel(pre string, is IniSection, sff *Sff, at AnimationTable, f map[int]*Fnt) *FightScreenAiLevel {
+	ai := newFightScreenAiLevel()
 
 	is.ReadI32(pre+"pos", &ai.pos[0], &ai.pos[1])
-	ai.text = *readLbText(pre+"text.", is, "", 0, f, 0)
+	ai.text = *readFSText(pre+"text.", is, "", 0, f, 0)
 	ai.separator, _, _ = is.getText("format.decimal.separator")
 	is.ReadI32("format.decimal.places", &ai.places)
 	ai.bg = ReadAnimLayout(pre+"bg.", is, sff, at, 0)
@@ -4174,24 +4174,24 @@ func readLifeBarAiLevel(pre string, is IniSection, sff *Sff, at AnimationTable, 
 	return ai
 }
 
-func (ai *LifeBarAiLevel) step() {
+func (ai *FightScreenAiLevel) step() {
 	ai.bg.Action()
 	ai.top.Action()
 	ai.text.step()
 }
 
-func (ai *LifeBarAiLevel) reset() {
+func (ai *FightScreenAiLevel) reset() {
 	ai.bg.Reset()
 	ai.top.Reset()
 }
 
-func (ai *LifeBarAiLevel) bgDraw(layerno int16) {
+func (ai *FightScreenAiLevel) bgDraw(layerno int16) {
 	if ai.active {
-		ai.bg.Draw(float32(ai.pos[0])+sys.lifebar.offsetX, float32(ai.pos[1]), layerno, sys.lifebar.scale)
+		ai.bg.Draw(float32(ai.pos[0])+sys.fightScreen.offsetX, float32(ai.pos[1]), layerno, sys.fightScreen.scale)
 	}
 }
 
-func (ai *LifeBarAiLevel) draw(layerno int16, f map[int]*Fnt, ailv float32) {
+func (ai *FightScreenAiLevel) draw(layerno int16, f map[int]*Fnt, ailv float32) {
 	if ai.active && ailv > 0 && ai.text.font[0] >= 0 && getFont(f, ai.text.font[0]) != nil {
 		text := ai.text.text
 		// split float value
@@ -4210,15 +4210,15 @@ func (ai *LifeBarAiLevel) draw(layerno int16, f map[int]*Fnt, ailv float32) {
 		// percentage value
 		p := ailv / 8 * 100
 		text = strings.Replace(text, "%p", fmt.Sprintf("%.0f", p), 1)
-		ai.text.lay.DrawText(float32(ai.pos[0])+sys.lifebar.offsetX, float32(ai.pos[1]), sys.lifebar.scale, layerno,
+		ai.text.lay.DrawText(float32(ai.pos[0])+sys.fightScreen.offsetX, float32(ai.pos[1]), sys.fightScreen.scale, layerno,
 			text, getFont(f, ai.text.font[0]), ai.text.font[1], ai.text.font[2], ai.text.palfx, ai.text.frgba)
-		ai.top.Draw(float32(ai.pos[0])+sys.lifebar.offsetX, float32(ai.pos[1]), layerno, sys.lifebar.scale)
+		ai.top.Draw(float32(ai.pos[0])+sys.fightScreen.offsetX, float32(ai.pos[1]), layerno, sys.fightScreen.scale)
 	}
 }
 
-type LifeBarWinCount struct {
+type FightScreenWinCount struct {
 	pos     [2]int32
-	text    LbText
+	text    FSText
 	bg      AnimLayout
 	top     AnimLayout
 	wins    int32
@@ -4226,15 +4226,15 @@ type LifeBarWinCount struct {
 	active  bool
 }
 
-func newLifeBarWinCount() *LifeBarWinCount {
-	return &LifeBarWinCount{enabled: make(map[string]bool)}
+func newFightScreenWinCount() *FightScreenWinCount {
+	return &FightScreenWinCount{enabled: make(map[string]bool)}
 }
 
-func readLifeBarWinCount(pre string, is IniSection, sff *Sff, at AnimationTable, f map[int]*Fnt) *LifeBarWinCount {
-	wc := newLifeBarWinCount()
+func readFightScreenWinCount(pre string, is IniSection, sff *Sff, at AnimationTable, f map[int]*Fnt) *FightScreenWinCount {
+	wc := newFightScreenWinCount()
 
 	is.ReadI32(pre+"pos", &wc.pos[0], &wc.pos[1])
-	wc.text = *readLbText(pre+"text.", is, "", 0, f, 0)
+	wc.text = *readFSText(pre+"text.", is, "", 0, f, 0)
 	wc.bg = ReadAnimLayout(pre+"bg.", is, sff, at, 0)
 	wc.top = ReadAnimLayout(pre+"top.", is, sff, at, 0)
 	for k := range is {
@@ -4249,53 +4249,53 @@ func readLifeBarWinCount(pre string, is IniSection, sff *Sff, at AnimationTable,
 	return wc
 }
 
-func (wc *LifeBarWinCount) step() {
+func (wc *FightScreenWinCount) step() {
 	wc.bg.Action()
 	wc.top.Action()
 	wc.text.step()
 }
 
-func (wc *LifeBarWinCount) reset() {
+func (wc *FightScreenWinCount) reset() {
 	wc.bg.Reset()
 	wc.top.Reset()
 }
 
-func (wc *LifeBarWinCount) bgDraw(layerno int16) {
+func (wc *FightScreenWinCount) bgDraw(layerno int16) {
 	if wc.active {
-		wc.bg.Draw(float32(wc.pos[0])+sys.lifebar.offsetX, float32(wc.pos[1]), layerno, sys.lifebar.scale)
+		wc.bg.Draw(float32(wc.pos[0])+sys.fightScreen.offsetX, float32(wc.pos[1]), layerno, sys.fightScreen.scale)
 	}
 }
 
-func (wc *LifeBarWinCount) draw(layerno int16, f map[int]*Fnt, side int) {
+func (wc *FightScreenWinCount) draw(layerno int16, f map[int]*Fnt, side int) {
 	if wc.active && wc.text.font[0] >= 0 && getFont(f, wc.text.font[0]) != nil {
 		text := wc.text.text
 		text = strings.Replace(text, "%s", fmt.Sprintf("%v", wc.wins), 1)
-		wc.text.lay.DrawText(float32(wc.pos[0])+sys.lifebar.offsetX, float32(wc.pos[1]), sys.lifebar.scale, layerno,
+		wc.text.lay.DrawText(float32(wc.pos[0])+sys.fightScreen.offsetX, float32(wc.pos[1]), sys.fightScreen.scale, layerno,
 			text, getFont(f, wc.text.font[0]), wc.text.font[1], wc.text.font[2], wc.text.palfx, wc.text.frgba)
-		wc.top.Draw(float32(wc.pos[0])+sys.lifebar.offsetX, float32(wc.pos[1]), layerno, sys.lifebar.scale)
+		wc.top.Draw(float32(wc.pos[0])+sys.fightScreen.offsetX, float32(wc.pos[1]), layerno, sys.fightScreen.scale)
 	}
 }
 
-type LifeBarMode struct {
+type FightScreenMode struct {
 	pos  [2]int32
-	text LbText
+	text FSText
 	bg   AnimLayout
 	top  AnimLayout
 }
 
-func newLifeBarMode() *LifeBarMode {
-	return &LifeBarMode{}
+func newFightScreenMode() *FightScreenMode {
+	return &FightScreenMode{}
 }
 
-func readLifeBarMode(is IniSection,
-	sff *Sff, at AnimationTable, f map[int]*Fnt) map[string]*LifeBarMode {
-	mo := make(map[string]*LifeBarMode)
+func readFightScreenMode(is IniSection,
+	sff *Sff, at AnimationTable, f map[int]*Fnt) map[string]*FightScreenMode {
+	mo := make(map[string]*FightScreenMode)
 	for k := range is {
 		sp := strings.Split(k, ".")
 		if _, ok := mo[sp[0]]; !ok {
-			mo[sp[0]] = newLifeBarMode()
+			mo[sp[0]] = newFightScreenMode()
 			is.ReadI32(sp[0]+".pos", &mo[sp[0]].pos[0], &mo[sp[0]].pos[1])
-			mo[sp[0]].text = *readLbText(sp[0]+".text.", is, "", 0, f, 0)
+			mo[sp[0]].text = *readFSText(sp[0]+".text.", is, "", 0, f, 0)
 			mo[sp[0]].bg = ReadAnimLayout(sp[0]+".bg.", is, sff, at, 0)
 			mo[sp[0]].top = ReadAnimLayout(sp[0]+".top.", is, sff, at, 0)
 		}
@@ -4303,32 +4303,32 @@ func readLifeBarMode(is IniSection,
 	return mo
 }
 
-func (mo *LifeBarMode) step() {
+func (mo *FightScreenMode) step() {
 	mo.bg.Action()
 	mo.top.Action()
 	mo.text.step()
 }
 
-func (mo *LifeBarMode) reset() {
+func (mo *FightScreenMode) reset() {
 	mo.bg.Reset()
 	mo.top.Reset()
 }
 
-func (mo *LifeBarMode) bgDraw(layerno int16) {
-	if sys.lifebar.mode {
-		mo.bg.Draw(float32(mo.pos[0])+sys.lifebar.offsetX, float32(mo.pos[1]), layerno, sys.lifebar.scale)
+func (mo *FightScreenMode) bgDraw(layerno int16) {
+	if sys.fightScreen.mode {
+		mo.bg.Draw(float32(mo.pos[0])+sys.fightScreen.offsetX, float32(mo.pos[1]), layerno, sys.fightScreen.scale)
 	}
 }
 
-func (mo *LifeBarMode) draw(layerno int16, f map[int]*Fnt) {
-	if sys.lifebar.mode && mo.text.font[0] >= 0 && getFont(f, mo.text.font[0]) != nil {
-		mo.text.lay.DrawText(float32(mo.pos[0])+sys.lifebar.offsetX, float32(mo.pos[1]), sys.lifebar.scale, layerno,
+func (mo *FightScreenMode) draw(layerno int16, f map[int]*Fnt) {
+	if sys.fightScreen.mode && mo.text.font[0] >= 0 && getFont(f, mo.text.font[0]) != nil {
+		mo.text.lay.DrawText(float32(mo.pos[0])+sys.fightScreen.offsetX, float32(mo.pos[1]), sys.fightScreen.scale, layerno,
 			mo.text.text, getFont(f, mo.text.font[0]), mo.text.font[1], mo.text.font[2], mo.text.palfx, mo.text.frgba)
-		mo.top.Draw(float32(mo.pos[0])+sys.lifebar.offsetX, float32(mo.pos[1]), layerno, sys.lifebar.scale)
+		mo.top.Draw(float32(mo.pos[0])+sys.fightScreen.offsetX, float32(mo.pos[1]), layerno, sys.fightScreen.scale)
 	}
 }
 
-type Lifebar struct {
+type FightScreen struct {
 	def           string
 	name          string
 	nameLow       string
@@ -4349,24 +4349,24 @@ type Lifebar struct {
 	fnt           map[int]*Fnt
 	curLayout     [2]int // Which layout each team is currently using. Single, Simul 3P, etc
 	teamOrder     [2][]int // Player order on each team. Because it can vary in Tag
-	hb            [8][]*HealthBar
+	lb            [8][]*LifeBar
 	pb            [8][]*PowerBar
 	gb            [8][]*GuardBar
 	sb            [8][]*StunBar
-	fa            [8][]*LifeBarFace
-	nm            [8][]*LifeBarName
-	wi            [2]*LifeBarWinIcon
-	ti            *LifeBarTime
-	co            [2]*LifeBarCombo
-	ac            [2]*LifeBarAction
-	ro            *LifeBarRound
-	ra            [2]*LifeBarRatio
-	tr            *LifeBarTimer
-	sc            [2]*LifeBarScore
-	ma            *LifeBarMatch
-	ai            [2]*LifeBarAiLevel
-	wc            [2]*LifeBarWinCount
-	mo            map[string]*LifeBarMode
+	fa            [8][]*FightScreenFace
+	nm            [8][]*FightScreenName
+	wi            [2]*FightScreenWinIcon
+	ti            *FightScreenTime
+	co            [2]*FightScreenCombo
+	ac            [2]*FightScreenAction
+	ro            *FightScreenRound
+	ra            [2]*FightScreenRatio
+	tr            *FightScreenTimer
+	sc            [2]*FightScreenScore
+	ma            *FightScreenMatch
+	ai            [2]*FightScreenAiLevel
+	wc            [2]*FightScreenWinCount
+	mo            map[string]*FightScreenMode
 	missing       map[string]int
 	active        bool
 	bars          bool
@@ -4379,24 +4379,24 @@ type Lifebar struct {
 	fx_limit      int
 }
 
-func loadLifebar(def string) (*Lifebar, error) {
+func loadFightScreen(def string) (*FightScreen, error) {
 	if def == "" {
-		sys.lifebar.resolvePath()
-		def = sys.lifebar.def
+		sys.fightScreen.resolvePath()
+		def = sys.fightScreen.def
 	}
 	str, err := LoadText(def)
 	if err != nil {
 		return nil, err
 	}
-	l := &Lifebar{
+	fs := &FightScreen{
 		localcoord:    [2]int32{320, 240},
 		scale:         1,
 		portraitScale: 1,
 		sff:           &Sff{},
 		snd:           &Snd{},
-		hb: [...][]*HealthBar{make([]*HealthBar, 2), make([]*HealthBar, 8),
-			make([]*HealthBar, 2), make([]*HealthBar, 8), make([]*HealthBar, 6),
-			make([]*HealthBar, 8), make([]*HealthBar, 6), make([]*HealthBar, 8)},
+		lb: [...][]*LifeBar{make([]*LifeBar, 2), make([]*LifeBar, 8),
+			make([]*LifeBar, 2), make([]*LifeBar, 8), make([]*LifeBar, 6),
+			make([]*LifeBar, 8), make([]*LifeBar, 6), make([]*LifeBar, 8)},
 		pb: [...][]*PowerBar{make([]*PowerBar, 2), make([]*PowerBar, 8),
 			make([]*PowerBar, 2), make([]*PowerBar, 8), make([]*PowerBar, 6),
 			make([]*PowerBar, 8), make([]*PowerBar, 6), make([]*PowerBar, 8)},
@@ -4406,20 +4406,20 @@ func loadLifebar(def string) (*Lifebar, error) {
 		sb: [...][]*StunBar{make([]*StunBar, 2), make([]*StunBar, 8),
 			make([]*StunBar, 2), make([]*StunBar, 8), make([]*StunBar, 6),
 			make([]*StunBar, 8), make([]*StunBar, 6), make([]*StunBar, 8)},
-		fa: [...][]*LifeBarFace{make([]*LifeBarFace, 2), make([]*LifeBarFace, 8),
-			make([]*LifeBarFace, 2), make([]*LifeBarFace, 8), make([]*LifeBarFace, 6),
-			make([]*LifeBarFace, 8), make([]*LifeBarFace, 6), make([]*LifeBarFace, 8)},
-		nm: [...][]*LifeBarName{make([]*LifeBarName, 2), make([]*LifeBarName, 8),
-			make([]*LifeBarName, 2), make([]*LifeBarName, 8), make([]*LifeBarName, 6),
-			make([]*LifeBarName, 8), make([]*LifeBarName, 6), make([]*LifeBarName, 8)},
+		fa: [...][]*FightScreenFace{make([]*FightScreenFace, 2), make([]*FightScreenFace, 8),
+			make([]*FightScreenFace, 2), make([]*FightScreenFace, 8), make([]*FightScreenFace, 6),
+			make([]*FightScreenFace, 8), make([]*FightScreenFace, 6), make([]*FightScreenFace, 8)},
+		nm: [...][]*FightScreenName{make([]*FightScreenName, 2), make([]*FightScreenName, 8),
+			make([]*FightScreenName, 2), make([]*FightScreenName, 8), make([]*FightScreenName, 6),
+			make([]*FightScreenName, 8), make([]*FightScreenName, 6), make([]*FightScreenName, 8)},
 		active:    true,
 		bars:      true,
 		mode:      true,
 		fnt_scale: 1,
 		fx_limit:  3,
 	}
-	l.fnt = make(map[int]*Fnt)
-	l.missing = map[string]int{
+	fs.fnt = make(map[int]*Fnt)
+	fs.missing = map[string]int{
 		"[tag lifebar]": 3, "[simul_3p lifebar]": 4, "[simul_4p lifebar]": 5,
 		"[tag_3p lifebar]": 6, "[tag_4p lifebar]": 7, "[simul powerbar]": 1,
 		"[turns powerbar]": 2, "[tag powerbar]": 3, "[simul_3p powerbar]": 4,
@@ -4437,37 +4437,37 @@ func loadLifebar(def string) (*Lifebar, error) {
 		"[wincount]": -1, "[mode]": -1,
 	}
 	strc := strings.ToLower(strings.TrimSpace(str))
-	for k := range l.missing {
+	for k := range fs.missing {
 		strc = strings.Replace(strc, ";"+k, "", -1)
 		if strings.Contains(strc, k) {
-			delete(l.missing, k)
+			delete(fs.missing, k)
 		} else {
 			str += "\n" + k
 		}
 	}
 
 	lines, lnidx := SplitAndTrim(str, "\n"), 0
-	l.animTable = ReadAnimationTable(l.sff, &l.sff.palList, lines, &lnidx)
+	fs.animTable = ReadAnimationTable(fs.sff, &fs.sff.palList, lines, &lnidx)
 	lnidx = 0
 	filesflg := true
 
-	// Pre-scan [info] to initialize lifebar localcoord/scale before any FightFX load
+	// Pre-scan [info] to initialize fight screen localcoord/scale before any FightFX load
 	pre := 0
 	for pre < len(lines) {
-		// If lifebar doesn't have localcoord assigned we're using screenpack localcoord
-		l.localcoord[0], l.localcoord[1] = sys.motif.Info.Localcoord[0], sys.motif.Info.Localcoord[1]
+		// If fight screen doesn't have localcoord assigned we're using screenpack localcoord
+		fs.localcoord[0], fs.localcoord[1] = sys.motif.Info.Localcoord[0], sys.motif.Info.Localcoord[1]
 		is, name, _ := ReadIniSection(lines, &pre)
 		if name == "info" {
-			is.ReadI32("localcoord", &l.localcoord[0], &l.localcoord[1])
+			is.ReadI32("localcoord", &fs.localcoord[0], &fs.localcoord[1])
 			break
 		}
 	}
-	l.setLifebarScale()
-	// Seed sys.lifebar with values used during loading (before the final assignment)
-	sys.lifebar.localcoord = l.localcoord
-	sys.lifebar.offsetX = l.offsetX
-	sys.lifebar.scale = l.scale
-	sys.lifebar.portraitScale = l.portraitScale
+	fs.setScale()
+	// Seed sys.fightScreen with values used during loading (before the final assignment)
+	sys.fightScreen.localcoord = fs.localcoord
+	sys.fightScreen.offsetX = fs.offsetX
+	sys.fightScreen.scale = fs.scale
+	sys.fightScreen.portraitScale = fs.portraitScale
 
 	// Load Common FX first
 	for _, key := range SortedKeys(sys.cfg.Common.Fx) {
@@ -4483,7 +4483,7 @@ func loadLifebar(def string) (*Lifebar, error) {
 		}
 	}
 
-	// Prepare lifebar FightFX
+	// Prepare fight screen FightFX
 	ffx := newFightFx()
 	ffx.isGlobal = true
 
@@ -4493,19 +4493,19 @@ func loadLifebar(def string) (*Lifebar, error) {
 		case "info":
 			var b bool
 			if is.ReadBool("doubleres", &b) {
-				l.fnt_scale = 0.5
+				fs.fnt_scale = 0.5
 			}
-			l.name, _, _ = is.getText("name")
-			l.nameLow = strings.ToLower(l.name)
-			l.author, _, _ = is.getText("author")
-			l.authorLow = strings.ToLower(l.author)
+			fs.name, _, _ = is.getText("name")
+			fs.nameLow = strings.ToLower(fs.name)
+			fs.author, _, _ = is.getText("author")
+			fs.authorLow = strings.ToLower(fs.author)
 			// Read MugenVersion
 			if str, ok := is["mugenversion"]; ok {
-				l.mugenver, l.mugenverF = ParseMugenVersion(str)
+				fs.mugenver, fs.mugenverF = ParseMugenVersion(str)
 			}
 			// Read IkemenVersion
 			if str, ok := is["ikemenversion"]; ok {
-				l.ikemenver, l.ikemenverF = ParseIkemenVersion(str)
+				fs.ikemenver, fs.ikemenverF = ParseIkemenVersion(str)
 			}
 			// Localcoord/scale already pre-initialized above to unblock early FightFX
 		case "files":
@@ -4517,7 +4517,7 @@ func loadLifebar(def string) (*Lifebar, error) {
 						if err != nil {
 							return err
 						}
-						*l.sff = *s
+						*fs.sff = *s
 						return nil
 					}); err != nil {
 					return nil, err
@@ -4528,7 +4528,7 @@ func loadLifebar(def string) (*Lifebar, error) {
 						if err != nil {
 							return err
 						}
-						*l.snd = *s
+						*fs.snd = *s
 						return nil
 					}); err != nil {
 					return nil, err
@@ -4563,7 +4563,7 @@ func loadLifebar(def string) (*Lifebar, error) {
 					}); err != nil {
 					return nil, err
 				}
-				for i := 1; i <= l.fx_limit; i++ {
+				for i := 1; i <= fs.fx_limit; i++ {
 					if err := is.LoadFile(fmt.Sprintf("fx%v", i), []string{def, sys.motif.Def, "", "data/"},
 						func(filename string) error {
 							if err := loadFightFx(filename, true, true); err != nil {
@@ -4621,9 +4621,9 @@ func loadLifebar(def string) (*Lifebar, error) {
 							}
 							if fnt, err := loadFnt(filename, h); err != nil {
 								LogMessage("Failed to load %v (lifebar font%v): %v", filename, i, err)
-								l.fnt[i] = newFnt()
+								fs.fnt[i] = newFnt()
 							} else {
-								l.fnt[i] = fnt
+								fs.fnt[i] = fnt
 							}
 							return nil
 						},
@@ -4633,91 +4633,91 @@ func loadLifebar(def string) (*Lifebar, error) {
 		case "fightfx":
 			is.ReadF32("scale", &ffx.fx_scale)
 		case "lifebar":
-			if l.hb[0][0] == nil {
-				l.hb[0][0] = readHealthBar("p1.", is, l.sff, l.animTable, l.fnt)
+			if fs.lb[0][0] == nil {
+				fs.lb[0][0] = readLifeBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
 			}
-			if l.hb[0][1] == nil {
-				l.hb[0][1] = readHealthBar("p2.", is, l.sff, l.animTable, l.fnt)
+			if fs.lb[0][1] == nil {
+				fs.lb[0][1] = readLifeBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
 			}
 		case "powerbar":
-			if l.pb[0][0] == nil {
-				l.pb[0][0] = readPowerBar("p1.", is, l.sff, l.animTable, l.fnt)
+			if fs.pb[0][0] == nil {
+				fs.pb[0][0] = readPowerBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
 			}
-			if l.pb[0][1] == nil {
-				l.pb[0][1] = readPowerBar("p2.", is, l.sff, l.animTable, l.fnt)
+			if fs.pb[0][1] == nil {
+				fs.pb[0][1] = readPowerBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
 			}
 		case "guardbar":
-			if l.gb[0][0] == nil {
-				l.gb[0][0] = readGuardBar("p1.", is, l.sff, l.animTable, l.fnt)
+			if fs.gb[0][0] == nil {
+				fs.gb[0][0] = readGuardBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
 			}
-			if l.gb[0][1] == nil {
-				l.gb[0][1] = readGuardBar("p2.", is, l.sff, l.animTable, l.fnt)
+			if fs.gb[0][1] == nil {
+				fs.gb[0][1] = readGuardBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
 			}
 		case "stunbar":
-			if l.sb[0][0] == nil {
-				l.sb[0][0] = readStunBar("p1.", is, l.sff, l.animTable, l.fnt)
+			if fs.sb[0][0] == nil {
+				fs.sb[0][0] = readStunBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
 			}
-			if l.sb[0][1] == nil {
-				l.sb[0][1] = readStunBar("p2.", is, l.sff, l.animTable, l.fnt)
+			if fs.sb[0][1] == nil {
+				fs.sb[0][1] = readStunBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
 			}
 		case "face":
-			if l.fa[0][0] == nil {
-				l.fa[0][0] = readLifeBarFace("p1.", is, l.sff, l.animTable)
+			if fs.fa[0][0] == nil {
+				fs.fa[0][0] = readFightScreenFace("p1.", is, fs.sff, fs.animTable)
 			}
-			if l.fa[0][1] == nil {
-				l.fa[0][1] = readLifeBarFace("p2.", is, l.sff, l.animTable)
+			if fs.fa[0][1] == nil {
+				fs.fa[0][1] = readFightScreenFace("p2.", is, fs.sff, fs.animTable)
 			}
 		case "name":
-			if l.nm[0][0] == nil {
-				l.nm[0][0] = readLifeBarName("p1.", is, l.sff, l.animTable, l.fnt)
+			if fs.nm[0][0] == nil {
+				fs.nm[0][0] = readFightScreenName("p1.", is, fs.sff, fs.animTable, fs.fnt)
 			}
-			if l.nm[0][1] == nil {
-				l.nm[0][1] = readLifeBarName("p2.", is, l.sff, l.animTable, l.fnt)
+			if fs.nm[0][1] == nil {
+				fs.nm[0][1] = readFightScreenName("p2.", is, fs.sff, fs.animTable, fs.fnt)
 			}
 		case "turns ":
 			subname = strings.ToLower(subname)
 			switch {
 			case len(subname) >= 7 && subname[:7] == "lifebar":
-				if l.hb[2][0] == nil {
-					l.hb[2][0] = readHealthBar("p1.", is, l.sff, l.animTable, l.fnt)
+				if fs.lb[2][0] == nil {
+					fs.lb[2][0] = readLifeBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if l.hb[2][1] == nil {
-					l.hb[2][1] = readHealthBar("p2.", is, l.sff, l.animTable, l.fnt)
+				if fs.lb[2][1] == nil {
+					fs.lb[2][1] = readLifeBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
 				}
 			case len(subname) >= 8 && subname[:8] == "powerbar":
-				if l.pb[2][0] == nil {
-					l.pb[2][0] = readPowerBar("p1.", is, l.sff, l.animTable, l.fnt)
+				if fs.pb[2][0] == nil {
+					fs.pb[2][0] = readPowerBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if l.pb[2][1] == nil {
-					l.pb[2][1] = readPowerBar("p2.", is, l.sff, l.animTable, l.fnt)
+				if fs.pb[2][1] == nil {
+					fs.pb[2][1] = readPowerBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
 				}
 			case len(subname) >= 8 && subname[:8] == "guardbar":
-				if l.gb[2][0] == nil {
-					l.gb[2][0] = readGuardBar("p1.", is, l.sff, l.animTable, l.fnt)
+				if fs.gb[2][0] == nil {
+					fs.gb[2][0] = readGuardBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if l.gb[2][1] == nil {
-					l.gb[2][1] = readGuardBar("p2.", is, l.sff, l.animTable, l.fnt)
+				if fs.gb[2][1] == nil {
+					fs.gb[2][1] = readGuardBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
 				}
 			case len(subname) >= 7 && subname[:7] == "stunbar":
-				if l.sb[2][0] == nil {
-					l.sb[2][0] = readStunBar("p1.", is, l.sff, l.animTable, l.fnt)
+				if fs.sb[2][0] == nil {
+					fs.sb[2][0] = readStunBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if l.sb[2][1] == nil {
-					l.sb[2][1] = readStunBar("p2.", is, l.sff, l.animTable, l.fnt)
+				if fs.sb[2][1] == nil {
+					fs.sb[2][1] = readStunBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
 				}
 			case len(subname) >= 4 && subname[:4] == "face":
-				if l.fa[2][0] == nil {
-					l.fa[2][0] = readLifeBarFace("p1.", is, l.sff, l.animTable)
+				if fs.fa[2][0] == nil {
+					fs.fa[2][0] = readFightScreenFace("p1.", is, fs.sff, fs.animTable)
 				}
-				if l.fa[2][1] == nil {
-					l.fa[2][1] = readLifeBarFace("p2.", is, l.sff, l.animTable)
+				if fs.fa[2][1] == nil {
+					fs.fa[2][1] = readFightScreenFace("p2.", is, fs.sff, fs.animTable)
 				}
 			case len(subname) >= 4 && subname[:4] == "name":
-				if l.nm[2][0] == nil {
-					l.nm[2][0] = readLifeBarName("p1.", is, l.sff, l.animTable, l.fnt)
+				if fs.nm[2][0] == nil {
+					fs.nm[2][0] = readFightScreenName("p1.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if l.nm[2][1] == nil {
-					l.nm[2][1] = readLifeBarName("p2.", is, l.sff, l.animTable, l.fnt)
+				if fs.nm[2][1] == nil {
+					fs.nm[2][1] = readFightScreenName("p2.", is, fs.sff, fs.animTable, fs.fnt)
 				}
 			}
 		case "simul ", "simul_3p ", "simul_4p ", "tag ", "tag_3p ", "tag_4p ":
@@ -4737,347 +4737,347 @@ func loadLifebar(def string) (*Lifebar, error) {
 			subname = strings.ToLower(subname)
 			switch {
 			case len(subname) >= 7 && subname[:7] == "lifebar":
-				if l.hb[i][0] == nil {
-					l.hb[i][0] = readHealthBar("p1.", is, l.sff, l.animTable, l.fnt)
+				if fs.lb[i][0] == nil {
+					fs.lb[i][0] = readLifeBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if l.hb[i][1] == nil {
-					l.hb[i][1] = readHealthBar("p2.", is, l.sff, l.animTable, l.fnt)
+				if fs.lb[i][1] == nil {
+					fs.lb[i][1] = readLifeBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if l.hb[i][2] == nil {
-					l.hb[i][2] = readHealthBar("p3.", is, l.sff, l.animTable, l.fnt)
+				if fs.lb[i][2] == nil {
+					fs.lb[i][2] = readLifeBar("p3.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if l.hb[i][3] == nil {
-					l.hb[i][3] = readHealthBar("p4.", is, l.sff, l.animTable, l.fnt)
+				if fs.lb[i][3] == nil {
+					fs.lb[i][3] = readLifeBar("p4.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if l.hb[i][4] == nil {
-					l.hb[i][4] = readHealthBar("p5.", is, l.sff, l.animTable, l.fnt)
+				if fs.lb[i][4] == nil {
+					fs.lb[i][4] = readLifeBar("p5.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if l.hb[i][5] == nil {
-					l.hb[i][5] = readHealthBar("p6.", is, l.sff, l.animTable, l.fnt)
+				if fs.lb[i][5] == nil {
+					fs.lb[i][5] = readLifeBar("p6.", is, fs.sff, fs.animTable, fs.fnt)
 				}
 				if i != 4 && i != 6 {
-					if l.hb[i][6] == nil {
-						l.hb[i][6] = readHealthBar("p7.", is, l.sff, l.animTable, l.fnt)
+					if fs.lb[i][6] == nil {
+						fs.lb[i][6] = readLifeBar("p7.", is, fs.sff, fs.animTable, fs.fnt)
 					}
-					if l.hb[i][7] == nil {
-						l.hb[i][7] = readHealthBar("p8.", is, l.sff, l.animTable, l.fnt)
+					if fs.lb[i][7] == nil {
+						fs.lb[i][7] = readLifeBar("p8.", is, fs.sff, fs.animTable, fs.fnt)
 					}
 				}
 			case len(subname) >= 8 && subname[:8] == "powerbar":
-				if l.pb[i][0] == nil {
-					l.pb[i][0] = readPowerBar("p1.", is, l.sff, l.animTable, l.fnt)
+				if fs.pb[i][0] == nil {
+					fs.pb[i][0] = readPowerBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if l.pb[i][1] == nil {
-					l.pb[i][1] = readPowerBar("p2.", is, l.sff, l.animTable, l.fnt)
+				if fs.pb[i][1] == nil {
+					fs.pb[i][1] = readPowerBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if l.pb[i][2] == nil {
-					l.pb[i][2] = readPowerBar("p3.", is, l.sff, l.animTable, l.fnt)
+				if fs.pb[i][2] == nil {
+					fs.pb[i][2] = readPowerBar("p3.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if l.pb[i][3] == nil {
-					l.pb[i][3] = readPowerBar("p4.", is, l.sff, l.animTable, l.fnt)
+				if fs.pb[i][3] == nil {
+					fs.pb[i][3] = readPowerBar("p4.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if l.pb[i][4] == nil {
-					l.pb[i][4] = readPowerBar("p5.", is, l.sff, l.animTable, l.fnt)
+				if fs.pb[i][4] == nil {
+					fs.pb[i][4] = readPowerBar("p5.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if l.pb[i][5] == nil {
-					l.pb[i][5] = readPowerBar("p6.", is, l.sff, l.animTable, l.fnt)
+				if fs.pb[i][5] == nil {
+					fs.pb[i][5] = readPowerBar("p6.", is, fs.sff, fs.animTable, fs.fnt)
 				}
 				if i != 4 && i != 6 {
-					if l.pb[i][6] == nil {
-						l.pb[i][6] = readPowerBar("p7.", is, l.sff, l.animTable, l.fnt)
+					if fs.pb[i][6] == nil {
+						fs.pb[i][6] = readPowerBar("p7.", is, fs.sff, fs.animTable, fs.fnt)
 					}
-					if l.pb[i][7] == nil {
-						l.pb[i][7] = readPowerBar("p8.", is, l.sff, l.animTable, l.fnt)
+					if fs.pb[i][7] == nil {
+						fs.pb[i][7] = readPowerBar("p8.", is, fs.sff, fs.animTable, fs.fnt)
 					}
 				}
 			case len(subname) >= 8 && subname[:8] == "guardbar":
-				if l.gb[i][0] == nil {
-					l.gb[i][0] = readGuardBar("p1.", is, l.sff, l.animTable, l.fnt)
+				if fs.gb[i][0] == nil {
+					fs.gb[i][0] = readGuardBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if l.gb[i][1] == nil {
-					l.gb[i][1] = readGuardBar("p2.", is, l.sff, l.animTable, l.fnt)
+				if fs.gb[i][1] == nil {
+					fs.gb[i][1] = readGuardBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if l.gb[i][2] == nil {
-					l.gb[i][2] = readGuardBar("p3.", is, l.sff, l.animTable, l.fnt)
+				if fs.gb[i][2] == nil {
+					fs.gb[i][2] = readGuardBar("p3.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if l.gb[i][3] == nil {
-					l.gb[i][3] = readGuardBar("p4.", is, l.sff, l.animTable, l.fnt)
+				if fs.gb[i][3] == nil {
+					fs.gb[i][3] = readGuardBar("p4.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if l.gb[i][4] == nil {
-					l.gb[i][4] = readGuardBar("p5.", is, l.sff, l.animTable, l.fnt)
+				if fs.gb[i][4] == nil {
+					fs.gb[i][4] = readGuardBar("p5.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if l.gb[i][5] == nil {
-					l.gb[i][5] = readGuardBar("p6.", is, l.sff, l.animTable, l.fnt)
+				if fs.gb[i][5] == nil {
+					fs.gb[i][5] = readGuardBar("p6.", is, fs.sff, fs.animTable, fs.fnt)
 				}
 				if i != 4 && i != 6 {
-					if l.gb[i][6] == nil {
-						l.gb[i][6] = readGuardBar("p7.", is, l.sff, l.animTable, l.fnt)
+					if fs.gb[i][6] == nil {
+						fs.gb[i][6] = readGuardBar("p7.", is, fs.sff, fs.animTable, fs.fnt)
 					}
-					if l.gb[i][7] == nil {
-						l.gb[i][7] = readGuardBar("p8.", is, l.sff, l.animTable, l.fnt)
+					if fs.gb[i][7] == nil {
+						fs.gb[i][7] = readGuardBar("p8.", is, fs.sff, fs.animTable, fs.fnt)
 					}
 				}
 			case len(subname) >= 7 && subname[:7] == "stunbar":
-				if l.sb[i][0] == nil {
-					l.sb[i][0] = readStunBar("p1.", is, l.sff, l.animTable, l.fnt)
+				if fs.sb[i][0] == nil {
+					fs.sb[i][0] = readStunBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if l.sb[i][1] == nil {
-					l.sb[i][1] = readStunBar("p2.", is, l.sff, l.animTable, l.fnt)
+				if fs.sb[i][1] == nil {
+					fs.sb[i][1] = readStunBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if l.sb[i][2] == nil {
-					l.sb[i][2] = readStunBar("p3.", is, l.sff, l.animTable, l.fnt)
+				if fs.sb[i][2] == nil {
+					fs.sb[i][2] = readStunBar("p3.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if l.sb[i][3] == nil {
-					l.sb[i][3] = readStunBar("p4.", is, l.sff, l.animTable, l.fnt)
+				if fs.sb[i][3] == nil {
+					fs.sb[i][3] = readStunBar("p4.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if l.sb[i][4] == nil {
-					l.sb[i][4] = readStunBar("p5.", is, l.sff, l.animTable, l.fnt)
+				if fs.sb[i][4] == nil {
+					fs.sb[i][4] = readStunBar("p5.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if l.sb[i][5] == nil {
-					l.sb[i][5] = readStunBar("p6.", is, l.sff, l.animTable, l.fnt)
+				if fs.sb[i][5] == nil {
+					fs.sb[i][5] = readStunBar("p6.", is, fs.sff, fs.animTable, fs.fnt)
 				}
 				if i != 4 && i != 6 {
-					if l.sb[i][6] == nil {
-						l.sb[i][6] = readStunBar("p7.", is, l.sff, l.animTable, l.fnt)
+					if fs.sb[i][6] == nil {
+						fs.sb[i][6] = readStunBar("p7.", is, fs.sff, fs.animTable, fs.fnt)
 					}
-					if l.sb[i][7] == nil {
-						l.sb[i][7] = readStunBar("p8.", is, l.sff, l.animTable, l.fnt)
+					if fs.sb[i][7] == nil {
+						fs.sb[i][7] = readStunBar("p8.", is, fs.sff, fs.animTable, fs.fnt)
 					}
 				}
 			case len(subname) >= 4 && subname[:4] == "face":
-				if l.fa[i][0] == nil {
-					l.fa[i][0] = readLifeBarFace("p1.", is, l.sff, l.animTable)
+				if fs.fa[i][0] == nil {
+					fs.fa[i][0] = readFightScreenFace("p1.", is, fs.sff, fs.animTable)
 				}
-				if l.fa[i][1] == nil {
-					l.fa[i][1] = readLifeBarFace("p2.", is, l.sff, l.animTable)
+				if fs.fa[i][1] == nil {
+					fs.fa[i][1] = readFightScreenFace("p2.", is, fs.sff, fs.animTable)
 				}
-				if l.fa[i][2] == nil {
-					l.fa[i][2] = readLifeBarFace("p3.", is, l.sff, l.animTable)
+				if fs.fa[i][2] == nil {
+					fs.fa[i][2] = readFightScreenFace("p3.", is, fs.sff, fs.animTable)
 				}
-				if l.fa[i][3] == nil {
-					l.fa[i][3] = readLifeBarFace("p4.", is, l.sff, l.animTable)
+				if fs.fa[i][3] == nil {
+					fs.fa[i][3] = readFightScreenFace("p4.", is, fs.sff, fs.animTable)
 				}
-				if l.fa[i][4] == nil {
-					l.fa[i][4] = readLifeBarFace("p5.", is, l.sff, l.animTable)
+				if fs.fa[i][4] == nil {
+					fs.fa[i][4] = readFightScreenFace("p5.", is, fs.sff, fs.animTable)
 				}
-				if l.fa[i][5] == nil {
-					l.fa[i][5] = readLifeBarFace("p6.", is, l.sff, l.animTable)
+				if fs.fa[i][5] == nil {
+					fs.fa[i][5] = readFightScreenFace("p6.", is, fs.sff, fs.animTable)
 				}
 				if i != 4 && i != 6 {
-					if l.fa[i][6] == nil {
-						l.fa[i][6] = readLifeBarFace("p7.", is, l.sff, l.animTable)
+					if fs.fa[i][6] == nil {
+						fs.fa[i][6] = readFightScreenFace("p7.", is, fs.sff, fs.animTable)
 					}
-					if l.fa[i][7] == nil {
-						l.fa[i][7] = readLifeBarFace("p8.", is, l.sff, l.animTable)
+					if fs.fa[i][7] == nil {
+						fs.fa[i][7] = readFightScreenFace("p8.", is, fs.sff, fs.animTable)
 					}
 				}
 			case len(subname) >= 4 && subname[:4] == "name":
-				if l.nm[i][0] == nil {
-					l.nm[i][0] = readLifeBarName("p1.", is, l.sff, l.animTable, l.fnt)
+				if fs.nm[i][0] == nil {
+					fs.nm[i][0] = readFightScreenName("p1.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if l.nm[i][1] == nil {
-					l.nm[i][1] = readLifeBarName("p2.", is, l.sff, l.animTable, l.fnt)
+				if fs.nm[i][1] == nil {
+					fs.nm[i][1] = readFightScreenName("p2.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if l.nm[i][2] == nil {
-					l.nm[i][2] = readLifeBarName("p3.", is, l.sff, l.animTable, l.fnt)
+				if fs.nm[i][2] == nil {
+					fs.nm[i][2] = readFightScreenName("p3.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if l.nm[i][3] == nil {
-					l.nm[i][3] = readLifeBarName("p4.", is, l.sff, l.animTable, l.fnt)
+				if fs.nm[i][3] == nil {
+					fs.nm[i][3] = readFightScreenName("p4.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if l.nm[i][4] == nil {
-					l.nm[i][4] = readLifeBarName("p5.", is, l.sff, l.animTable, l.fnt)
+				if fs.nm[i][4] == nil {
+					fs.nm[i][4] = readFightScreenName("p5.", is, fs.sff, fs.animTable, fs.fnt)
 				}
-				if l.nm[i][5] == nil {
-					l.nm[i][5] = readLifeBarName("p6.", is, l.sff, l.animTable, l.fnt)
+				if fs.nm[i][5] == nil {
+					fs.nm[i][5] = readFightScreenName("p6.", is, fs.sff, fs.animTable, fs.fnt)
 				}
 				if i != 4 && i != 6 {
-					if l.nm[i][6] == nil {
-						l.nm[i][6] = readLifeBarName("p7.", is, l.sff, l.animTable, l.fnt)
+					if fs.nm[i][6] == nil {
+						fs.nm[i][6] = readFightScreenName("p7.", is, fs.sff, fs.animTable, fs.fnt)
 					}
-					if l.nm[i][7] == nil {
-						l.nm[i][7] = readLifeBarName("p8.", is, l.sff, l.animTable, l.fnt)
+					if fs.nm[i][7] == nil {
+						fs.nm[i][7] = readFightScreenName("p8.", is, fs.sff, fs.animTable, fs.fnt)
 					}
 				}
 			}
 		case "winicon":
-			if l.wi[0] == nil {
-				l.wi[0] = readLifeBarWinIcon("p1.", is, l.sff, l.animTable, l.fnt)
+			if fs.wi[0] == nil {
+				fs.wi[0] = readFightScreenWinIcon("p1.", is, fs.sff, fs.animTable, fs.fnt)
 			}
-			if l.wi[1] == nil {
-				l.wi[1] = readLifeBarWinIcon("p2.", is, l.sff, l.animTable, l.fnt)
+			if fs.wi[1] == nil {
+				fs.wi[1] = readFightScreenWinIcon("p2.", is, fs.sff, fs.animTable, fs.fnt)
 			}
 		case "time":
-			if l.ti == nil {
-				l.ti = readLifeBarTime(is, l.sff, l.animTable, l.fnt)
+			if fs.ti == nil {
+				fs.ti = readFightScreenTime(is, fs.sff, fs.animTable, fs.fnt)
 			}
 		case "combo":
-			if l.co[0] == nil {
+			if fs.co[0] == nil {
 				if _, ok := is["team1.pos"]; ok {
-					l.co[0] = readLifeBarCombo("team1.", is, l.sff, l.animTable, l.fnt, 0)
+					fs.co[0] = readFightScreenCombo("team1.", is, fs.sff, fs.animTable, fs.fnt, 0)
 				} else {
-					l.co[0] = readLifeBarCombo("", is, l.sff, l.animTable, l.fnt, 0)
+					fs.co[0] = readFightScreenCombo("", is, fs.sff, fs.animTable, fs.fnt, 0)
 				}
 			}
-			if l.co[1] == nil {
+			if fs.co[1] == nil {
 				if _, ok := is["team2.pos"]; ok {
-					l.co[1] = readLifeBarCombo("team2.", is, l.sff, l.animTable, l.fnt, 1)
+					fs.co[1] = readFightScreenCombo("team2.", is, fs.sff, fs.animTable, fs.fnt, 1)
 				} else {
-					l.co[1] = readLifeBarCombo("", is, l.sff, l.animTable, l.fnt, 1)
+					fs.co[1] = readFightScreenCombo("", is, fs.sff, fs.animTable, fs.fnt, 1)
 				}
 			}
 		case "action":
-			if l.ac[0] == nil {
-				l.ac[0] = readLifeBarAction("team1.", is, l.fnt)
+			if fs.ac[0] == nil {
+				fs.ac[0] = readFightScreenAction("team1.", is, fs.fnt)
 			}
-			if l.ac[1] == nil {
-				l.ac[1] = readLifeBarAction("team2.", is, l.fnt)
+			if fs.ac[1] == nil {
+				fs.ac[1] = readFightScreenAction("team2.", is, fs.fnt)
 			}
 		case "round":
-			if l.ro == nil {
-				l.ro = readLifeBarRound(is, l.sff, l.animTable, l.snd, l.fnt)
+			if fs.ro == nil {
+				fs.ro = readFightScreenRound(is, fs.sff, fs.animTable, fs.snd, fs.fnt)
 			}
 		case "ratio":
-			if l.ra[0] == nil {
-				l.ra[0] = readLifeBarRatio("p1.", is, l.sff, l.animTable)
+			if fs.ra[0] == nil {
+				fs.ra[0] = readFightScreenRatio("p1.", is, fs.sff, fs.animTable)
 			}
-			if l.ra[1] == nil {
-				l.ra[1] = readLifeBarRatio("p2.", is, l.sff, l.animTable)
+			if fs.ra[1] == nil {
+				fs.ra[1] = readFightScreenRatio("p2.", is, fs.sff, fs.animTable)
 			}
 		case "timer":
-			if l.tr == nil {
-				l.tr = readLifeBarTimer(is, l.sff, l.animTable, l.fnt)
+			if fs.tr == nil {
+				fs.tr = readFightScreenTimer(is, fs.sff, fs.animTable, fs.fnt)
 			}
 		case "score":
-			if l.sc[0] == nil {
-				l.sc[0] = readLifeBarScore("p1.", is, l.sff, l.animTable, l.fnt)
+			if fs.sc[0] == nil {
+				fs.sc[0] = readFightScreenScore("p1.", is, fs.sff, fs.animTable, fs.fnt)
 			}
-			if l.sc[1] == nil {
-				l.sc[1] = readLifeBarScore("p2.", is, l.sff, l.animTable, l.fnt)
+			if fs.sc[1] == nil {
+				fs.sc[1] = readFightScreenScore("p2.", is, fs.sff, fs.animTable, fs.fnt)
 			}
 		case "match":
-			if l.ma == nil {
-				l.ma = readLifeBarMatch(is, l.sff, l.animTable, l.fnt)
+			if fs.ma == nil {
+				fs.ma = readFightScreenMatch(is, fs.sff, fs.animTable, fs.fnt)
 			}
 		case "ailevel":
-			if l.ai[0] == nil {
-				l.ai[0] = readLifeBarAiLevel("p1.", is, l.sff, l.animTable, l.fnt)
+			if fs.ai[0] == nil {
+				fs.ai[0] = readFightScreenAiLevel("p1.", is, fs.sff, fs.animTable, fs.fnt)
 			}
-			if l.ai[1] == nil {
-				l.ai[1] = readLifeBarAiLevel("p2.", is, l.sff, l.animTable, l.fnt)
+			if fs.ai[1] == nil {
+				fs.ai[1] = readFightScreenAiLevel("p2.", is, fs.sff, fs.animTable, fs.fnt)
 			}
 		case "wincount":
-			if l.wc[0] == nil {
-				l.wc[0] = readLifeBarWinCount("p1.", is, l.sff, l.animTable, l.fnt)
+			if fs.wc[0] == nil {
+				fs.wc[0] = readFightScreenWinCount("p1.", is, fs.sff, fs.animTable, fs.fnt)
 			}
-			if l.wc[1] == nil {
-				l.wc[1] = readLifeBarWinCount("p2.", is, l.sff, l.animTable, l.fnt)
+			if fs.wc[1] == nil {
+				fs.wc[1] = readFightScreenWinCount("p2.", is, fs.sff, fs.animTable, fs.fnt)
 			}
 		case "mode":
-			if l.mo == nil {
-				l.mo = readLifeBarMode(is, l.sff, l.animTable, l.fnt)
+			if fs.mo == nil {
+				fs.mo = readFightScreenMode(is, fs.sff, fs.animTable, fs.fnt)
 			}
 		}
 	}
 	sys.ffx["f"] = ffx
 	// fightfx scale
 	//if math.IsNaN(float64(sys.ffx["f"].fx_scale)) {
-	//	sys.ffx["f"].fx_scale = float32(l.localcoord[0]) / 320
+	//	sys.ffx["f"].fx_scale = float32(fs.localcoord[0]) / 320
 	//}
 	// Now calculated in each animation call
 	//for _, a := range sys.ffx["f"].animTable {
 	//	a.start_scale = [...]float32{sys.ffx["f"].fx_scale, sys.ffx["f"].fx_scale}
 	//}
 	// Iterate over map in a stable iteration order
-	keys := make([]string, 0, len(l.missing))
-	for k := range l.missing {
+	keys := make([]string, 0, len(fs.missing))
+	for k := range fs.missing {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 	for _, k := range keys {
 		if strings.Contains(k, " lifebar") {
-			for i := 3; i < len(l.hb); i++ {
-				if i == l.missing[k] {
-					for j := 0; j < len(l.hb[i]); j++ {
+			for i := 3; i < len(fs.lb); i++ {
+				if i == fs.missing[k] {
+					for j := 0; j < len(fs.lb[i]); j++ {
 						if i == 6 || i == 7 {
-							l.hb[i][j] = l.hb[3][j]
+							fs.lb[i][j] = fs.lb[3][j]
 						} else {
-							l.hb[i][j] = l.hb[1][j]
+							fs.lb[i][j] = fs.lb[1][j]
 						}
 					}
 				}
 			}
 		} else if strings.Contains(k, " powerbar") {
-			for i := 1; i < len(l.pb); i++ {
-				if i == l.missing[k] {
+			for i := 1; i < len(fs.pb); i++ {
+				if i == fs.missing[k] {
 					for j := 0; j < 2; j++ {
 						switch i {
 						case 4, 5:
-							l.pb[i][j] = l.pb[1][j]
+							fs.pb[i][j] = fs.pb[1][j]
 						case 6, 7:
-							l.pb[i][j] = l.pb[3][j]
+							fs.pb[i][j] = fs.pb[3][j]
 						default:
-							l.pb[i][j] = l.pb[0][j]
+							fs.pb[i][j] = fs.pb[0][j]
 						}
 					}
 				}
 			}
 		} else if strings.Contains(k, " guardbar") {
-			for i := 1; i < len(l.gb); i++ {
-				if i == l.missing[k] {
+			for i := 1; i < len(fs.gb); i++ {
+				if i == fs.missing[k] {
 					for j := 0; j < 2; j++ {
 						switch i {
 						case 4, 5:
-							l.gb[i][j] = l.gb[1][j]
+							fs.gb[i][j] = fs.gb[1][j]
 						case 6, 7:
-							l.gb[i][j] = l.gb[3][j]
+							fs.gb[i][j] = fs.gb[3][j]
 						default:
-							l.gb[i][j] = l.gb[0][j]
+							fs.gb[i][j] = fs.gb[0][j]
 						}
 					}
 				}
 			}
 		} else if strings.Contains(k, " stunbar") {
-			for i := 1; i < len(l.sb); i++ {
-				if i == l.missing[k] {
+			for i := 1; i < len(fs.sb); i++ {
+				if i == fs.missing[k] {
 					for j := 0; j < 2; j++ {
 						switch i {
 						case 4, 5:
-							l.sb[i][j] = l.sb[1][j]
+							fs.sb[i][j] = fs.sb[1][j]
 						case 6, 7:
-							l.sb[i][j] = l.sb[3][j]
+							fs.sb[i][j] = fs.sb[3][j]
 						default:
-							l.sb[i][j] = l.sb[0][j]
+							fs.sb[i][j] = fs.sb[0][j]
 						}
 					}
 				}
 			}
 		} else if strings.Contains(k, " face") {
-			for i := 3; i < len(l.fa); i++ {
-				if i == l.missing[k] {
-					for j := 0; j < len(l.fa[i]); j++ {
+			for i := 3; i < len(fs.fa); i++ {
+				if i == fs.missing[k] {
+					for j := 0; j < len(fs.fa[i]); j++ {
 						if i == 6 || i == 7 {
-							l.fa[i][j] = l.fa[3][j]
+							fs.fa[i][j] = fs.fa[3][j]
 						} else {
-							l.fa[i][j] = l.fa[1][j]
+							fs.fa[i][j] = fs.fa[1][j]
 						}
 					}
 				}
 			}
 		} else if strings.Contains(k, " name") {
-			for i := 3; i < len(l.nm); i++ {
-				if i == l.missing[k] {
-					for j := 0; j < len(l.nm[i]); j++ {
+			for i := 3; i < len(fs.nm); i++ {
+				if i == fs.missing[k] {
+					for j := 0; j < len(fs.nm[i]); j++ {
 						if i == 6 || i == 7 {
-							l.nm[i][j] = l.nm[3][j]
+							fs.nm[i][j] = fs.nm[3][j]
 						} else {
-							l.nm[i][j] = l.nm[1][j]
+							fs.nm[i][j] = fs.nm[1][j]
 						}
 					}
 				}
 			}
 		}
 	}
-	l.def = def
+	fs.def = def
 
 	/*
 		// TODO: This is a hack
@@ -5087,46 +5087,46 @@ func loadLifebar(def string) (*Lifebar, error) {
 			teamModeIndices := []int{1, 3, 4, 5, 6, 7} // Simul, Tag, and their 3P/4P variants
 
 			for _, i := range teamModeIndices {
-				if i < len(l.hb) {
+				if i < len(fs.lb) {
 					// Replace with Single lifebars
-					l.hb[i][0] = l.hb[0][0]
-					l.hb[i][1] = l.hb[0][1]
+					fs.lb[i][0] = fs.lb[0][0]
+					fs.lb[i][1] = fs.lb[0][1]
 				}
 			}
 		}
 	*/
 
-	return l, nil
+	return fs, nil
 }
 
-func (l *Lifebar) reloadLifebar() error {
-	lb, err := loadLifebar(l.def)
+func (fs *FightScreen) reload() error {
+	fs, err := loadFightScreen(fs.def)
 	if err != nil {
 		return err
 	}
-	lb.ti.framespercount = l.ti.framespercount
-	//lb.ro.match_wins = l.ro.match_wins
-	//lb.ro.match_maxdrawgames = l.ro.match_maxdrawgames
-	lb.tr.active = l.tr.active
-	lb.sc[0].active = l.sc[0].active
-	lb.sc[1].active = l.sc[1].active
-	lb.ma.active = l.ma.active
-	lb.ai[0].active = l.ai[0].active
-	lb.ai[1].active = l.ai[1].active
-	lb.wc[0].active = l.wc[0].active
-	lb.wc[1].active = l.wc[1].active
-	lb.active = l.active
-	lb.bars = l.bars
-	lb.mode = l.mode
-	lb.redlifebar = l.redlifebar
-	lb.guardbar = l.guardbar
-	lb.stunbar = l.stunbar
-	// lb.fx_scale = l.fx_scale
-	sys.lifebar = *lb
+	fs.ti.framespercount = fs.ti.framespercount
+	//fs.ro.match_wins = fs.ro.match_wins
+	//fs.ro.match_maxdrawgames = fs.ro.match_maxdrawgames
+	fs.tr.active = fs.tr.active
+	fs.sc[0].active = fs.sc[0].active
+	fs.sc[1].active = fs.sc[1].active
+	fs.ma.active = fs.ma.active
+	fs.ai[0].active = fs.ai[0].active
+	fs.ai[1].active = fs.ai[1].active
+	fs.wc[0].active = fs.wc[0].active
+	fs.wc[1].active = fs.wc[1].active
+	fs.active = fs.active
+	fs.bars = fs.bars
+	fs.mode = fs.mode
+	fs.redlifebar = fs.redlifebar
+	fs.guardbar = fs.guardbar
+	fs.stunbar = fs.stunbar
+	//fs.fx_scale = fs.fx_scale
+	sys.fightScreen = *fs
 	return nil
 }
 
-func (l *Lifebar) step() {
+func (fs *FightScreen) step() {
 	if sys.paused && !sys.frameStepFlag {
 		return
 	}
@@ -5134,19 +5134,19 @@ func (l *Lifebar) step() {
 		// Team order swapping moved to dedicated Tag functions
 		for ti, tm := range sys.tmode {
 			if tm == TM_Tag {
-				for i, v := range l.teamOrder[ti] {
+				for i, v := range fs.teamOrder[ti] {
 					if sys.teamLeader[sys.chars[v][0].teamside] == sys.chars[v][0].playerNo && sys.chars[v][0].alive() {
 						if i != 0 {
-							if i == len(l.teamOrder[ti])-1 {
-								l.teamOrder[ti] = sliceMoveInt(l.teamOrder[ti], i, 0)
+							if i == len(fs.teamOrder[ti])-1 {
+								fs.teamOrder[ti] = sliceMoveInt(fs.teamOrder[ti], i, 0)
 							} else {
-								last := len(l.teamOrder[ti]) - 1
+								last := len(fs.teamOrder[ti]) - 1
 								for n := last; n > 0; n-- {
-									if !sys.chars[l.teamOrder[ti][n]][0].alive() {
+									if !sys.chars[fs.teamOrder[ti][n]][0].alive() {
 										last -= 1
 									}
 								}
-								l.teamOrder[ti] = sliceMoveInt(l.teamOrder[ti], 0, last)
+								fs.teamOrder[ti] = sliceMoveInt(fs.teamOrder[ti], 0, last)
 							}
 						}
 						break
@@ -5156,30 +5156,30 @@ func (l *Lifebar) step() {
 		}
 	*/
 	for ti := range sys.tmode {
-		layout := l.curLayout[ti]
-		for i, charpn := range l.teamOrder[ti] {
+		layout := fs.curLayout[ti]
+		for i, charpn := range fs.teamOrder[ti] {
 			index := i*2+ti
-			// HealthBar
-			l.hb[layout][index].step(charpn, l.hb[layout][charpn])
+			// LifeBar
+			fs.lb[layout][index].step(charpn, fs.lb[layout][charpn])
 			// PowerBar
-			l.pb[layout][index].step(charpn, l.pb[layout][charpn], l.snd)
+			fs.pb[layout][index].step(charpn, fs.pb[layout][charpn], fs.snd)
 			// GuardBar
-			l.gb[layout][index].step(charpn, l.gb[layout][charpn], l.snd)
+			fs.gb[layout][index].step(charpn, fs.gb[layout][charpn], fs.snd)
 			// StunBar
-			l.sb[layout][index].step(charpn, l.sb[layout][charpn], l.snd)
-			// LifeBarFace
-			l.fa[layout][index].step(charpn, l.fa[layout][charpn])
-			// LifeBarName
-			l.nm[layout][index].step()
+			fs.sb[layout][index].step(charpn, fs.sb[layout][charpn], fs.snd)
+			// FightScreenFace
+			fs.fa[layout][index].step(charpn, fs.fa[layout][charpn])
+			// FightScreenName
+			fs.nm[layout][index].step()
 		}
 	}
-	// LifeBarWinIcon
-	for i := range l.wi {
-		l.wi[i].step(sys.wins[i])
+	// FightScreenWinIcon
+	for i := range fs.wi {
+		fs.wi[i].step(sys.wins[i])
 	}
-	// LifeBarTime
-	l.ti.step()
-	// LifeBarCombo
+	// FightScreenTime
+	fs.ti.step()
+	// FightScreenCombo
 	cb, cd, cp, dz := [2]int32{}, [2]int32{}, [2]float32{}, [2]bool{}
 	targets := [2]int32{}
 	for _, ch := range sys.chars { // Iterate through all players to see the combo status of each team
@@ -5202,173 +5202,172 @@ func (l *Lifebar) step() {
 			cp[side] /= float32(targets[side]) // Divide damage percentage by number of valid enemies
 		}
 	}
-	for i := range l.co {
-		l.co[i].step(cb[i], cd[i], cp[i], dz[i]) // Combo hits, combo damage, combo damage percentage, dizzy flag
+	for i := range fs.co {
+		fs.co[i].step(cb[i], cd[i], cp[i], dz[i]) // Combo hits, combo damage, combo damage percentage, dizzy flag
 	}
-	// LifeBarAction
-	for i := range l.ac {
-		l.ac[i].step(l.teamOrder[i][0])
+	// FightScreenAction
+	for i := range fs.ac {
+		fs.ac[i].step(fs.teamOrder[i][0])
 	}
-	// LifeBarRatio
+	// FightScreenRatio
 	for ti, tm := range sys.tmode {
 		if tm == TM_Turns {
 			rl := sys.chars[ti][0].ocd().ratioLevel
 			if rl > 0 {
-				l.ra[ti].step(rl - 1)
+				fs.ra[ti].step(rl - 1)
 			}
 		}
 	}
-	// LifeBarTimer
-	l.tr.step()
-	// LifeBarScore
-	for i := range l.sc {
-		l.sc[i].step()
+	// FightScreenTimer
+	fs.tr.step()
+	// FightScreenScore
+	for i := range fs.sc {
+		fs.sc[i].step()
 	}
-	// LifeBarMatch
-	l.ma.step()
-	// LifeBarAiLevel
-	for i := range l.ai {
-		l.ai[i].step()
+	// FightScreenMatch
+	fs.ma.step()
+	// FightScreenAiLevel
+	for i := range fs.ai {
+		fs.ai[i].step()
 	}
-	// LifeBarWinCount
-	for i := range l.wc {
-		l.wc[i].step()
+	// FightScreenWinCount
+	for i := range fs.wc {
+		fs.wc[i].step()
 	}
-	// LifeBarMode
-	if _, ok := l.mo[sys.gameMode]; ok {
-		l.mo[sys.gameMode].step()
+	// FightScreenMode
+	if _, ok := fs.mo[sys.gameMode]; ok {
+		fs.mo[sys.gameMode].step()
 	}
 }
 
-// Resets lifebar as well as prepares team mode configuration for each player
-func (l *Lifebar) reset() {
+// Resets fight screen as well as prepares team mode configuration for each player
+func (fs *FightScreen) reset() {
 	var num [2]int
 
 	// Update team mode layout for each player
 	for ti, tm := range sys.tmode {
-		l.curLayout[ti] = int(tm)
+		fs.curLayout[ti] = int(tm)
 		if tm == TM_Simul {
 			if sys.numSimul[ti] == 3 {
-				l.curLayout[ti] = 4 // Simul_3P (6)
+				fs.curLayout[ti] = 4 // Simul_3P (6)
 			} else if sys.numSimul[ti] >= 4 {
-				l.curLayout[ti] = 5 // Simul_4P (8)
+				fs.curLayout[ti] = 5 // Simul_4P (8)
 			} else {
-				l.curLayout[ti] = 1 // Simul (8)
+				fs.curLayout[ti] = 1 // Simul (8)
 			}
 		} else if tm == TM_Tag {
 			if sys.numSimul[ti] == 3 {
-				l.curLayout[ti] = 6 // Tag_3P (6)
+				fs.curLayout[ti] = 6 // Tag_3P (6)
 			} else if sys.numSimul[ti] >= 4 {
-				l.curLayout[ti] = 7 // Tag_4P (8)
+				fs.curLayout[ti] = 7 // Tag_4P (8)
 			} else {
-				l.curLayout[ti] = 3 // Tag (8)
+				fs.curLayout[ti] = 3 // Tag (8)
 			}
 		} else if tm == TM_Turns {
-			l.curLayout[ti] = 2 // Turns (2)
+			fs.curLayout[ti] = 2 // Turns (2)
 		} else {
-			l.curLayout[ti] = 0 // Single (2)
+			fs.curLayout[ti] = 0 // Single (2)
 		}
 
 		// Set maximum number of lifebars
 		if tm == TM_Simul || tm == TM_Tag {
 			num[ti] = int(math.Min(8, float64(sys.numSimul[ti])*2))
 		} else {
-			num[ti] = len(l.hb[l.curLayout[ti]])
+			num[ti] = len(fs.lb[fs.curLayout[ti]])
 		}
 
-		l.teamOrder[ti] = []int{}
+		fs.teamOrder[ti] = []int{}
 		for i := ti; i < num[ti]; i += 2 {
-			l.teamOrder[ti] = append(l.teamOrder[ti], i)
+			fs.teamOrder[ti] = append(fs.teamOrder[ti], i)
 		}
 	}
 
-	// Reset lifebar elements
-	for i := range l.hb {
-		for j := range l.hb[i] {
-			l.hb[i][j].reset()
+	// Reset fight screen elements
+	for i := range fs.lb {
+		for j := range fs.lb[i] {
+			fs.lb[i][j].reset()
 		}
 	}
-	for i := range l.pb {
-		for j := range l.pb[i] {
-			l.pb[i][j].reset()
+	for i := range fs.pb {
+		for j := range fs.pb[i] {
+			fs.pb[i][j].reset()
 		}
 	}
-	for i := range l.gb {
-		for j := range l.gb[i] {
-			l.gb[i][j].reset()
+	for i := range fs.gb {
+		for j := range fs.gb[i] {
+			fs.gb[i][j].reset()
 		}
 	}
-	for i := range l.sb {
-		for j := range l.sb[i] {
-			l.sb[i][j].reset()
+	for i := range fs.sb {
+		for j := range fs.sb[i] {
+			fs.sb[i][j].reset()
 		}
 	}
-	for i := range l.fa {
-		for j := range l.fa[i] {
-			l.fa[i][j].reset()
+	for i := range fs.fa {
+		for j := range fs.fa[i] {
+			fs.fa[i][j].reset()
 		}
 	}
-	for i := range l.nm {
-		for j := range l.nm[i] {
-			l.nm[i][j].reset()
+	for i := range fs.nm {
+		for j := range fs.nm[i] {
+			fs.nm[i][j].reset()
 		}
 	}
-	for i := range l.wi {
-		l.wi[i].reset()
+	for i := range fs.wi {
+		fs.wi[i].reset()
 	}
-	l.ti.reset()
-	for i := range l.co {
-		l.co[i].reset()
+	fs.ti.reset()
+	for i := range fs.co {
+		fs.co[i].reset()
 	}
-	for i := range l.ac {
-		l.ac[i].reset(l.teamOrder[i][0])
+	for i := range fs.ac {
+		fs.ac[i].reset(fs.teamOrder[i][0])
 	}
-	l.ro.reset()
-	for i := range l.ra {
-		l.ra[i].reset()
+	fs.ro.reset()
+	for i := range fs.ra {
+		fs.ra[i].reset()
 	}
-	l.tr.reset()
-	for i := range l.sc {
-		l.sc[i].reset()
+	fs.tr.reset()
+	for i := range fs.sc {
+		fs.sc[i].reset()
 	}
-	l.ma.reset()
-	for i := range l.ai {
-		l.ai[i].reset()
+	fs.ma.reset()
+	for i := range fs.ai {
+		fs.ai[i].reset()
 	}
-	for i := range l.wc {
-		l.wc[i].reset()
+	for i := range fs.wc {
+		fs.wc[i].reset()
 	}
-	if _, ok := l.mo[sys.gameMode]; ok {
-		l.mo[sys.gameMode].reset()
+	if _, ok := fs.mo[sys.gameMode]; ok {
+		fs.mo[sys.gameMode].reset()
 	}
 }
 
-func (l *Lifebar) draw(layerno int16) {
+func (fs *FightScreen) draw(layerno int16) {
 	if sys.postMatchFlg {
 		return
 	}
-	if !sys.lifebarHide && l.active && !sys.dialogueBarsFlg && (!sys.motif.me.active || !sys.motif.PauseMenu["pause_menu"].HideBars) {
+	if !sys.lifebarHide && fs.active && !sys.dialogueBarsFlg && (!sys.motif.me.active || !sys.motif.PauseMenu["pause_menu"].HideBars) {
 		// Helper to run a function for each active player's bars
 		// We will iterate backwards so that player 1 is drawn last and on top
 		forEach := func(fn func(side, layout, slot, barpn, charpn int)) {
-			// Iterate player slots globally, back to front
 			// We iterate slots first so that the order becomes P8-...-P1 instead of P8-P6-P4-P2-P7-P5-P3-P1
 			for slot := MaxSimul - 1; slot >= 0; slot-- {
 				// Process that slot for each team
 				for side := len(sys.tmode) - 1; side >= 0; side-- {
-					if slot >= len(l.teamOrder[side]) {
+					if slot >= len(fs.teamOrder[side]) {
 						continue
 					}
-					layout := l.curLayout[side]
+					layout := fs.curLayout[side]
 					barpn := slot*2 + side
-					charpn := l.teamOrder[side][slot]
+					charpn := fs.teamOrder[side][slot]
 					fn(side, layout, slot, barpn, charpn)
 				}
 			}
 		}
 
-		if !sys.gsf(GSF_nobardisplay) && l.bars {
-			// HealthBar backgrounds
+		if !sys.gsf(GSF_nobardisplay) && fs.bars {
+			// LifeBar backgrounds
 			// We split backgrounds and bars for the sake of backward compatibility
 			// https://github.com/ikemen-engine/Ikemen-GO/issues/3461
 			forEach(func(side, layout, slot, barpn, charpn int) {
@@ -5376,17 +5375,17 @@ func (l *Lifebar) draw(layerno int16) {
 				if c.asf(ASF_nolifebardisplay) {
 					return
 				}
-				l.hb[layout][barpn].bgDraw(layerno)
+				fs.lb[layout][barpn].bgDraw(layerno)
 			})
 
-			// HealthBar bars
+			// LifeBar bars
 			forEach(func(side, layout, slot, barpn, charpn int) {
 				c := sys.chars[charpn][0]
 				if c.asf(ASF_nolifebardisplay) {
 					return
 				}
 				// Use the definition at [layout][barpn] and the runtime values (combo damage etc) stored at [layout][charpn]
-				l.hb[layout][barpn].draw(layerno, charpn, l.hb[layout][charpn], l.fnt)
+				fs.lb[layout][barpn].draw(layerno, charpn, fs.lb[layout][charpn], fs.fnt)
 			})
 
 			// PowerBar backgrounds
@@ -5400,7 +5399,7 @@ func (l *Lifebar) draw(layerno int16) {
 				if slot != 0 && (tm == TM_Simul || tm == TM_Tag) && sys.cfg.Options.Team.PowerShare {
 					return
 				}
-				l.pb[layout][barpn].bgDraw(layerno, barpn)
+				fs.pb[layout][barpn].bgDraw(layerno, barpn)
 			})
 
 			// PowerBar bars
@@ -5414,7 +5413,7 @@ func (l *Lifebar) draw(layerno int16) {
 				if slot != 0 && (tm == TM_Simul || tm == TM_Tag) && sys.cfg.Options.Team.PowerShare {
 					return
 				}
-				l.pb[layout][barpn].draw(layerno, charpn, l.pb[layout][charpn], l.fnt)
+				fs.pb[layout][barpn].draw(layerno, charpn, fs.pb[layout][charpn], fs.fnt)
 			})
 
 			// GuardBar
@@ -5423,8 +5422,8 @@ func (l *Lifebar) draw(layerno int16) {
 				if !c.guardBreakEnabled() || c.asf(ASF_noguardbardisplay) {
 					return
 				}
-				l.gb[layout][barpn].bgDraw(layerno)
-				l.gb[layout][barpn].draw(layerno, charpn, l.gb[layout][charpn], l.fnt)
+				fs.gb[layout][barpn].bgDraw(layerno)
+				fs.gb[layout][barpn].draw(layerno, charpn, fs.gb[layout][charpn], fs.fnt)
 			})
 
 			// StunBar
@@ -5433,131 +5432,131 @@ func (l *Lifebar) draw(layerno int16) {
 				if !c.dizzyEnabled() || c.asf(ASF_nostunbardisplay) {
 					return
 				}
-				l.sb[layout][barpn].bgDraw(layerno)
-				l.sb[layout][barpn].draw(layerno, charpn, l.sb[layout][charpn], l.fnt)
+				fs.sb[layout][barpn].bgDraw(layerno)
+				fs.sb[layout][barpn].draw(layerno, charpn, fs.sb[layout][charpn], fs.fnt)
 			})
 
-			// LifeBarFace
+			// FightScreenFace
 			forEach(func(side, layout, slot, barpn, charpn int) {
 				c := sys.chars[charpn][0]
 				if c.asf(ASF_nofacedisplay) {
 					return
 				}
 				// Draw Turns teammates from the first bar only
-				if slot == 0 && len(l.fa[layout]) > 0 {
-					l.fa[layout][side].drawTeammates(layerno, charpn)
+				if slot == 0 && len(fs.fa[layout]) > 0 {
+					fs.fa[layout][side].drawTeammates(layerno, charpn)
 				}
 				// Draw active players
-				l.fa[layout][barpn].bgDraw(layerno)
-				l.fa[layout][barpn].draw(layerno, charpn, l.fa[layout][charpn])
+				fs.fa[layout][barpn].bgDraw(layerno)
+				fs.fa[layout][barpn].draw(layerno, charpn, fs.fa[layout][charpn])
 			})
 
-			// LifeBarName
+			// FightScreenName
 			forEach(func(side, layout, slot, barpn, charpn int) {
 				c := sys.chars[charpn][0]
 				if c.asf(ASF_nonamedisplay) {
 					return
 				}
 				// Draw Turns teammates from the first bar only
-				if slot == 0 && len(l.nm[layout]) > 0 {
-					l.nm[layout][side].drawTeammates(layerno, charpn, l.fnt, side)
+				if slot == 0 && len(fs.nm[layout]) > 0 {
+					fs.nm[layout][side].drawTeammates(layerno, charpn, fs.fnt, side)
 				}
 				// Draw active players
-				l.nm[layout][barpn].bgDraw(layerno)
-				l.nm[layout][barpn].draw(layerno, charpn, l.fnt, side)
+				fs.nm[layout][barpn].bgDraw(layerno)
+				fs.nm[layout][barpn].draw(layerno, charpn, fs.fnt, side)
 			})
 
-			// LifeBarRatio
+			// FightScreenRatio
 			for side := len(sys.tmode) - 1; side >= 0; side-- {
 				if sys.tmode[side] == TM_Turns {
 					rl := sys.chars[side][0].ocd().ratioLevel
 					if rl > 0 && !sys.chars[side][0].asf(ASF_nofacedisplay) {
-						l.ra[side].bgDraw(layerno)
-						l.ra[side].draw(layerno, rl-1)
+						fs.ra[side].bgDraw(layerno)
+						fs.ra[side].draw(layerno, rl-1)
 					}
 				}
 			}
 
-			// LifeBarTime
-			l.ti.bgDraw(layerno)
-			l.ti.draw(layerno, l.fnt)
+			// FightScreenTime
+			fs.ti.bgDraw(layerno)
+			fs.ti.draw(layerno, fs.fnt)
 
-			// LifeBarWinIcon
+			// FightScreenWinIcon
 			// These are only one per team, so we don't use forEach()
-			for i := len(l.wi) - 1; i >= 0; i-- {
+			for i := len(fs.wi) - 1; i >= 0; i-- {
 				if !sys.chars[i][0].asf(ASF_nowinicondisplay) {
-					l.wi[i].draw(layerno, l.fnt, i)
+					fs.wi[i].draw(layerno, fs.fnt, i)
 				}
 			}
 
-			// LifeBarTimer
-			l.tr.bgDraw(layerno)
-			l.tr.draw(layerno, l.fnt)
+			// FightScreenTimer
+			fs.tr.bgDraw(layerno)
+			fs.tr.draw(layerno, fs.fnt)
 
-			// LifeBarScore
-			for i := len(l.sc) - 1; i >= 0; i-- {
-				l.sc[i].bgDraw(layerno)
-				l.sc[i].draw(layerno, l.fnt, i)
+			// FightScreenScore
+			for i := len(fs.sc) - 1; i >= 0; i-- {
+				fs.sc[i].bgDraw(layerno)
+				fs.sc[i].draw(layerno, fs.fnt, i)
 			}
 
-			// LifeBarMatch
-			l.ma.bgDraw(layerno)
-			l.ma.draw(layerno, l.fnt)
+			// FightScreenMatch
+			fs.ma.bgDraw(layerno)
+			fs.ma.draw(layerno, fs.fnt)
 
-			// LifeBarAiLevel
-			for i := len(l.ai) - 1; i >= 0; i-- {
-				l.ai[i].bgDraw(layerno)
-				l.ai[i].draw(layerno, l.fnt, sys.aiLevel[sys.chars[i][0].playerNo])
+			// FightScreenAiLevel
+			for i := len(fs.ai) - 1; i >= 0; i-- {
+				fs.ai[i].bgDraw(layerno)
+				fs.ai[i].draw(layerno, fs.fnt, sys.aiLevel[sys.chars[i][0].playerNo])
 			}
 
-			// LifeBarWinCount
-			for i := len(l.wc) - 1; i >= 0; i-- {
-				l.wc[i].bgDraw(layerno)
-				l.wc[i].draw(layerno, l.fnt, i)
+			// FightScreenWinCount
+			for i := len(fs.wc) - 1; i >= 0; i-- {
+				fs.wc[i].bgDraw(layerno)
+				fs.wc[i].draw(layerno, fs.fnt, i)
 			}
 		}
 
-		// LifeBarCombo
-		for i := len(l.co) - 1; i >= 0; i-- {
+		// FightScreenCombo
+		for i := len(fs.co) - 1; i >= 0; i-- {
 			if !sys.chars[i][0].asf(ASF_nocombodisplay) {
-				l.co[i].draw(layerno, l.fnt, i)
+				fs.co[i].draw(layerno, fs.fnt, i)
 			}
 		}
 
-		// LifeBarAction
-		for i := len(l.ac) - 1; i >= 0; i-- {
+		// FightScreenAction
+		for i := len(fs.ac) - 1; i >= 0; i-- {
 			if !sys.chars[i][0].asf(ASF_nolifebaraction) {
-				l.ac[i].draw(layerno, l.fnt, i)
+				fs.ac[i].draw(layerno, fs.fnt, i)
 			}
 		}
 
-		// LifeBarMode
-		if _, ok := l.mo[sys.gameMode]; ok {
-			l.mo[sys.gameMode].bgDraw(layerno)
-			l.mo[sys.gameMode].draw(layerno, l.fnt)
+		// FightScreenMode
+		if _, ok := fs.mo[sys.gameMode]; ok {
+			fs.mo[sys.gameMode].bgDraw(layerno)
+			fs.mo[sys.gameMode].draw(layerno, fs.fnt)
 		}
 	}
 
-	if l.active {
-		// LifeBarRound
-		l.ro.draw(layerno, l.fnt)
+	if fs.active {
+		// FightScreenRound
+		fs.ro.draw(layerno, fs.fnt)
 	}
 }
 
-func (l *Lifebar) setLifebarScale() {
+func (fs *FightScreen) setScale() {
 	// Calculate viewport for a 4:3 aspect ratio
-	viewport43 := getViewport(float64(l.localcoord[0]), float64(l.localcoord[1]), 4, 3)
+	viewport43 := getViewport(float64(fs.localcoord[0]), float64(fs.localcoord[1]), 4, 3)
 
 	// Calculate viewport based on the game's configured width and height
-	viewport := getViewport(float64(l.localcoord[0]), float64(l.localcoord[1]), float64(sys.gameWidth), float64(sys.gameHeight))
+	viewport := getViewport(float64(fs.localcoord[0]), float64(fs.localcoord[1]), float64(sys.gameWidth), float64(sys.gameHeight))
 
-	localW := float32(l.localcoord[0])
+	localW := float32(fs.localcoord[0])
 	calcScale := float32(viewport[2]) / localW
 	calcOffsetX := (float32(viewport43[2]) - localW*calcScale) / 2
 
-	l.offsetX = float32(calcOffsetX * calcScale)
-	l.scale = 320.0 / float32(viewport43[2]) * calcScale
-	l.portraitScale = localW / float32(viewport43[2]) * calcScale
+	fs.offsetX = float32(calcOffsetX * calcScale)
+	fs.scale = 320.0 / float32(viewport43[2]) * calcScale
+	fs.portraitScale = localW / float32(viewport43[2]) * calcScale
 }
 
 func readMotifFightFromDef(def string) string {
@@ -5595,9 +5594,9 @@ func readMotifFightFromDef(def string) string {
 	return fight
 }
 
-func (l *Lifebar) resolvePath() {
+func (fs *FightScreen) resolvePath() {
 	var v string
-	if x, ok := sys.cmdFlags["-lifebar"]; ok {
+	if x, ok := sys.cmdFlags["-fight"]; ok {
 		v = x
 	} else {
 		// Prefer already-parsed value.
@@ -5614,17 +5613,17 @@ func (l *Lifebar) resolvePath() {
 	}
 	resolved := SearchFile(v, []string{"", filepath.ToSlash(filepath.Dir(sys.motif.Def)) + "/", "data/"})
 	if FileExist(resolved) != "" {
-		l.def = filepath.ToSlash(resolved)
+		fs.def = filepath.ToSlash(resolved)
 		return
 	}
-	l.def = v
+	fs.def = v
 }
 
-func (l *Lifebar) appendAction(c *Char, msg *LbMsg, s_ffx, a_ffx string, snd, spr [2]int32, anim int32, top bool) {
+func (fs *FightScreen) appendAction(c *Char, msg *FSMsg, s_ffx, a_ffx string, snd, spr [2]int32, anim int32, top bool) {
 	if c.teamside < 0 {
 		return
 	}
-	if _, ok := l.missing["[action]"]; ok {
+	if _, ok := fs.missing["[action]"]; ok {
 		return
 	}
 
@@ -5636,7 +5635,7 @@ func (l *Lifebar) appendAction(c *Char, msg *LbMsg, s_ffx, a_ffx string, snd, sp
 				sys.soundChannels.Play(s, snd[0], snd[1], 100, 0, 0, 0, 0)
 			}
 		} else {
-			l.snd.play(snd, 100, 0, 0, 0, 0)
+			fs.snd.play(snd, 100, 0, 0, 0, 0)
 		}
 	}
 
@@ -5646,7 +5645,7 @@ func (l *Lifebar) appendAction(c *Char, msg *LbMsg, s_ffx, a_ffx string, snd, sp
 	}
 
 	// Select side of screen
-	teammsg := l.ac[c.teamside]
+	teammsg := fs.ac[c.teamside]
 
 	// If adding a new message while exceeding the maximum number allowed, make the oldest message go away faster
 	var count int32
@@ -5674,7 +5673,7 @@ func (l *Lifebar) appendAction(c *Char, msg *LbMsg, s_ffx, a_ffx string, snd, sp
 	if !top {
 		for k, v := range teammsg.messages {
 			if v.del {
-				teammsg.messages = removeLbMsg(teammsg.messages, k)
+				teammsg.messages = removeFSMsg(teammsg.messages, k)
 				break
 			}
 			index++
@@ -5697,11 +5696,11 @@ func (l *Lifebar) appendAction(c *Char, msg *LbMsg, s_ffx, a_ffx string, snd, sp
 	}
 
 	// Read background
-	msg.bg = ReadAnimLayout(fmt.Sprintf("team%v.bg.", c.teamside+1), teammsg.is, l.sff, l.animTable, 2)
+	msg.bg = ReadAnimLayout(fmt.Sprintf("team%v.bg.", c.teamside+1), teammsg.is, fs.sff, fs.animTable, 2)
 
-	// Default to lifebar assets
-	sff := l.sff
-	at := l.animTable
+	// Default to fight screen assets
+	sff := fs.sff
+	at := fs.animTable
 	var alscale float32 = 1.0
 
 	// Use animation prefixes to change asset source
@@ -5710,13 +5709,13 @@ func (l *Lifebar) appendAction(c *Char, msg *LbMsg, s_ffx, a_ffx string, snd, sp
 			// Use the character
 			sff = sys.cgi[c.playerNo].sff
 			at = sys.cgi[c.playerNo].animTable
-			alscale = float32(sys.lifebar.localcoord[0]) / float32(sys.chars[c.playerNo][0].localcoord)
+			alscale = float32(sys.fightScreen.localcoord[0]) / float32(sys.chars[c.playerNo][0].localcoord)
 		} else if sys.ffx[a_ffx] != nil {
 			// Use common FX
 			fx := sys.ffx[a_ffx]
 			sff = fx.sff
 			at = fx.animTable
-			alscale = fx.fx_scale * float32(sys.lifebar.localcoord[0]) / float32(fx.localcoord[0])
+			alscale = fx.fx_scale * float32(sys.fightScreen.localcoord[0]) / float32(fx.localcoord[0])
 		}
 	}
 
@@ -5729,5 +5728,5 @@ func (l *Lifebar) appendAction(c *Char, msg *LbMsg, s_ffx, a_ffx string, snd, sp
 	}
 
 	// Insert new message
-	teammsg.messages = insertLbMsg(teammsg.messages, msg, index)
+	teammsg.messages = insertFSMsg(teammsg.messages, msg, index)
 }

--- a/src/image.go
+++ b/src/image.go
@@ -1530,6 +1530,7 @@ type Sff struct {
 	sprites  map[[2]uint16]*Sprite
 	palList  PaletteList
 	filename string
+	debugMissing map[[2]uint16]bool // Sprites not found by animations
 }
 
 func newSff() (s *Sff) {

--- a/src/iniutils.go
+++ b/src/iniutils.go
@@ -2081,13 +2081,14 @@ func SetAnim(obj interface{}, fVal, structVal, parent reflect.Value, sffOverride
 	}
 
 	// animNew
-	a := NewAnim(sffPtr, fmt.Sprintf("%d,%d, 0,0, -1", spr[0], spr[1]))
+	var a *Anim
 	if animData, exists := animMap[anim]; exists {
+		a = NewAnim(nil, "")
 		a.anim = animData
 	} else if hasSpr {
-		//a.anim.SetAnimElem(1, 0)
-		a.anim.UpdateSprite()
+		a = NewAnim(sffPtr, fmt.Sprintf("%d,%d, 0,0, -1", spr[0], spr[1]))
 	} else {
+		a = NewAnim(nil, "")
 		a.anim = nil
 	}
 	// animSetLocalcoord
@@ -2671,7 +2672,13 @@ func PopulateDataPointers(obj interface{}, rootLocalcoord [2]int32) {
 				// If it's *Anim
 				if kind == reflect.Ptr && fVal.Type().AssignableTo(animPtrType) {
 					if fVal.IsNil() && fVal.CanSet() {
-						SetAnim(obj, fVal, v, parent, effectiveSffForThisStruct)
+						curType := v.Type()
+						animCharPreloadType := reflect.TypeOf(AnimationCharPreloadProperties{})
+						animStagePreloadType := reflect.TypeOf(AnimationStagePreloadProperties{})
+						// Skip these or we'll end up trying to draw them from the motif SFF
+						if curType != animCharPreloadType && curType != animStagePreloadType {
+							SetAnim(obj, fVal, v, parent, effectiveSffForThisStruct)
+						}
 					}
 					continue
 				}

--- a/src/iniutils.go
+++ b/src/iniutils.go
@@ -2087,6 +2087,8 @@ func SetAnim(obj interface{}, fVal, structVal, parent reflect.Value, sffOverride
 		a.anim = animData
 	} else if hasSpr {
 		a = NewAnim(sffPtr, fmt.Sprintf("%d,%d, 0,0, -1", spr[0], spr[1]))
+		//a.anim.SetAnimElem(1, 0)
+		a.anim.UpdateSprite()
 	} else {
 		a = NewAnim(nil, "")
 		a.anim = nil

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -5341,147 +5341,196 @@ func (l *Lifebar) draw(layerno int16) {
 		return
 	}
 	if !sys.lifebarHide && l.active && !sys.dialogueBarsFlg && (!sys.motif.me.active || !sys.motif.PauseMenu["pause_menu"].HideBars) {
+		// Helper to run a function for each active player's bars
+		// We will iterate backwards so that player 1 is drawn last and on top
+		forEach := func(fn func(side, slot, pno, index int)) {
+			// Iterate player slots globally, back to front
+			// We iterate slots first so that the order becomes P8-...-P1 instead of P8-P6-P4-P2-P7-P5-P3-P1
+			for slot := MaxSimul - 1; slot >= 0; slot-- {
+				// Iterate each team within the slot
+				for side := len(sys.tmode) - 1; side >= 0; side-- {
+					if slot >= len(l.order[side]) {
+						continue
+					}
+					pno := l.order[side][slot]
+					index := slot*2 + side
+					fn(side, slot, pno, index)
+				}
+			}
+		}
+
 		if !sys.gsf(GSF_nobardisplay) && l.bars {
-			// HealthBar
-			// We will iterate all of these backwards so that player 1 is drawn last and on top
-			for ti := len(sys.tmode) - 1; ti >= 0; ti-- {
-				for i, v := range l.order[ti] {
-					index := i*2 + ti
-					if !sys.chars[v][0].asf(ASF_nolifebardisplay) {
-						l.hb[l.ref[ti]][index].bgDraw(layerno)
-						l.hb[l.ref[ti]][index].draw(layerno, v, l.hb[l.ref[ti]][v], l.fnt)
-					}
+			// HealthBar backgrounds
+			// We split backgrounds and bars for the sake of backward compatibility
+			// https://github.com/ikemen-engine/Ikemen-GO/issues/3461
+			forEach(func(side, slot, pno, index int) {
+				c := sys.chars[pno][0]
+				if c.asf(ASF_nolifebardisplay) {
+					return
 				}
-			}
-			// PowerBar
-			for ti := len(sys.tmode) - 1; ti >= 0; ti-- {
-				tm := sys.tmode[ti]
-				for i, v := range l.order[ti] {
-					index := i*2 + ti
-					if sys.cfg.Options.Team.PowerShare && (tm == TM_Simul || tm == TM_Tag) {
-						// Draw player 1 or 2 bars
-						if i == 0 && !sys.chars[v][0].asf(ASF_nopowerbardisplay) {
-							l.pb[l.ref[ti]][index].bgDraw(layerno, index)
-							l.pb[l.ref[ti]][index].draw(layerno, index, l.pb[l.ref[ti]][index], l.fnt)
-						}
-					} else {
-						// Draw everyone's bars
-						if !sys.chars[v][0].asf(ASF_nopowerbardisplay) {
-							l.pb[l.ref[ti]][index].bgDraw(layerno, index)
-							l.pb[l.ref[ti]][index].draw(layerno, v, l.pb[l.ref[ti]][v], l.fnt)
-						}
-					}
+				l.hb[l.ref[side]][index].bgDraw(layerno)
+			})
+
+			// HealthBar bars
+			forEach(func(side, slot, pno, index int) {
+				c := sys.chars[pno][0]
+				if c.asf(ASF_nolifebardisplay) {
+					return
 				}
-			}
+				l.hb[l.ref[side]][index].draw(layerno, pno, l.hb[l.ref[side]][pno], l.fnt)
+			})
+
+			// PowerBar backgrounds
+			forEach(func(side, slot, pno, index int) {
+				c := sys.chars[pno][0]
+				if c.asf(ASF_nopowerbardisplay) {
+					return
+				}
+				// If sharing is enabled, draw only the first bar
+				tm := sys.tmode[side]
+				if slot != 0 && (tm == TM_Simul || tm == TM_Tag) && sys.cfg.Options.Team.PowerShare {
+					return
+				}
+				l.pb[l.ref[side]][index].bgDraw(layerno, index)
+			})
+
+			// PowerBar bars
+			forEach(func(side, slot, pno, index int) {
+				c := sys.chars[pno][0]
+				if c.asf(ASF_nopowerbardisplay) {
+					return
+				}
+				// If sharing is enabled, draw only the first bar
+				tm := sys.tmode[side]
+				if slot != 0 && (tm == TM_Simul || tm == TM_Tag) && sys.cfg.Options.Team.PowerShare {
+					return
+				}
+				l.pb[l.ref[side]][index].draw(layerno, pno, l.pb[l.ref[side]][pno], l.fnt)
+			})
+
 			// GuardBar
-			for ti := len(sys.tmode) - 1; ti >= 0; ti-- {
-				for i, v := range l.order[ti] {
-					index := i*2 + ti
-					if sys.chars[v][0].guardBreakEnabled() && !sys.chars[v][0].asf(ASF_noguardbardisplay) {
-						l.gb[l.ref[ti]][index].bgDraw(layerno)
-						l.gb[l.ref[ti]][index].draw(layerno, v, l.gb[l.ref[ti]][v], l.fnt)
-					}
+			forEach(func(side, slot, pno, index int) {
+				c := sys.chars[pno][0]
+				if !c.guardBreakEnabled() || c.asf(ASF_noguardbardisplay) {
+					return
 				}
-			}
+				l.gb[l.ref[side]][index].bgDraw(layerno)
+				l.gb[l.ref[side]][index].draw(layerno, pno, l.gb[l.ref[side]][pno], l.fnt)
+			})
+
 			// StunBar
-			for ti := len(sys.tmode) - 1; ti >= 0; ti-- {
-				for i, v := range l.order[ti] {
-					index := i*2 + ti
-					if sys.chars[v][0].dizzyEnabled() && !sys.chars[v][0].asf(ASF_nostunbardisplay) {
-						l.sb[l.ref[ti]][index].bgDraw(layerno)
-						l.sb[l.ref[ti]][index].draw(layerno, v, l.sb[l.ref[ti]][v], l.fnt)
-					}
+			forEach(func(side, slot, pno, index int) {
+				c := sys.chars[pno][0]
+				if !c.dizzyEnabled() || c.asf(ASF_nostunbardisplay) {
+					return
 				}
-			}
+				l.sb[l.ref[side]][index].bgDraw(layerno)
+				l.sb[l.ref[side]][index].draw(layerno, pno, l.sb[l.ref[side]][pno], l.fnt)
+			})
+
 			// LifeBarFace
-			for ti := len(sys.tmode) - 1; ti >= 0; ti-- {
-				for i, v := range l.order[ti] {
-					if !sys.chars[v][0].asf(ASF_nofacedisplay) {
-						// Draw Turns teammates from the first bar only
-						if i == 0 && len(l.fa[l.ref[ti]]) > 0 {
-							l.fa[l.ref[ti]][ti].drawTeammates(layerno, v)
-						}
-						// Draw active players
-						index := i*2 + ti
-						l.fa[l.ref[ti]][index].bgDraw(layerno)
-						l.fa[l.ref[ti]][index].draw(layerno, v, l.fa[l.ref[ti]][v])
-					}
+			forEach(func(side, slot, pno, index int) {
+				c := sys.chars[pno][0]
+				if c.asf(ASF_nofacedisplay) {
+					return
 				}
-			}
+				// Draw Turns teammates from the first bar only
+				ref := l.ref[side]
+				if slot == 0 && len(l.fa[ref]) > 0 {
+					l.fa[ref][side].drawTeammates(layerno, pno)
+				}
+				// Draw active players
+				l.fa[ref][index].bgDraw(layerno)
+				l.fa[ref][index].draw(layerno, pno, l.fa[ref][pno])
+			})
+
 			// LifeBarName
-			for ti := len(sys.tmode) - 1; ti >= 0; ti-- {
-				for i, v := range l.order[ti] {
-					if !sys.chars[v][0].asf(ASF_nonamedisplay) {
-						// Draw Turns teammates from the first bar only
-						if i == 0 && len(l.nm[l.ref[ti]]) > 0 {
-							l.nm[l.ref[ti]][ti].drawTeammates(layerno, v, l.fnt, ti)
-						}
-						// Draw active players
-						index := i*2 + ti
-						l.nm[l.ref[ti]][index].bgDraw(layerno)
-						l.nm[l.ref[ti]][index].draw(layerno, v, l.fnt, ti)
+			forEach(func(side, slot, pno, index int) {
+				c := sys.chars[pno][0]
+				if c.asf(ASF_nonamedisplay) {
+					return
+				}
+				// Draw Turns teammates from the first bar only
+				ref := l.ref[side]
+				if slot == 0 && len(l.nm[ref]) > 0 {
+					l.nm[ref][side].drawTeammates(layerno, pno, l.fnt, side)
+				}
+				// Draw active players
+				l.nm[ref][index].bgDraw(layerno)
+				l.nm[ref][index].draw(layerno, pno, l.fnt, side)
+			})
+
+			// LifeBarRatio
+			for side := len(sys.tmode) - 1; side >= 0; side-- {
+				if sys.tmode[side] == TM_Turns {
+					rl := sys.chars[side][0].ocd().ratioLevel
+					if rl > 0 && !sys.chars[side][0].asf(ASF_nofacedisplay) {
+						l.ra[side].bgDraw(layerno)
+						l.ra[side].draw(layerno, rl-1)
 					}
 				}
 			}
+
 			// LifeBarTime
 			l.ti.bgDraw(layerno)
 			l.ti.draw(layerno, l.fnt)
+
 			// LifeBarWinIcon
+			// These are only one per team, so we don't use forEach()
 			for i := len(l.wi) - 1; i >= 0; i-- {
 				if !sys.chars[i][0].asf(ASF_nowinicondisplay) {
 					l.wi[i].draw(layerno, l.fnt, i)
 				}
 			}
-			// LifeBarRatio
-			for ti := len(sys.tmode) - 1; ti >= 0; ti-- {
-				tm := sys.tmode[ti]
-				if tm == TM_Turns {
-					if rl := sys.chars[ti][0].ocd().ratioLevel; rl > 0 && !sys.chars[ti][0].asf(ASF_nofacedisplay) {
-						l.ra[ti].bgDraw(layerno)
-						l.ra[ti].draw(layerno, rl-1)
-					}
-				}
-			}
+
 			// LifeBarTimer
 			l.tr.bgDraw(layerno)
 			l.tr.draw(layerno, l.fnt)
+
 			// LifeBarScore
 			for i := len(l.sc) - 1; i >= 0; i-- {
 				l.sc[i].bgDraw(layerno)
 				l.sc[i].draw(layerno, l.fnt, i)
 			}
+
 			// LifeBarMatch
 			l.ma.bgDraw(layerno)
 			l.ma.draw(layerno, l.fnt)
+
 			// LifeBarAiLevel
 			for i := len(l.ai) - 1; i >= 0; i-- {
 				l.ai[i].bgDraw(layerno)
 				l.ai[i].draw(layerno, l.fnt, sys.aiLevel[sys.chars[i][0].playerNo])
 			}
+
 			// LifeBarWinCount
 			for i := len(l.wc) - 1; i >= 0; i-- {
 				l.wc[i].bgDraw(layerno)
 				l.wc[i].draw(layerno, l.fnt, i)
 			}
 		}
+
 		// LifeBarCombo
 		for i := len(l.co) - 1; i >= 0; i-- {
 			if !sys.chars[i][0].asf(ASF_nocombodisplay) {
 				l.co[i].draw(layerno, l.fnt, i)
 			}
 		}
+
 		// LifeBarAction
 		for i := len(l.ac) - 1; i >= 0; i-- {
 			if !sys.chars[i][0].asf(ASF_nolifebaraction) {
 				l.ac[i].draw(layerno, l.fnt, i)
 			}
 		}
+
 		// LifeBarMode
 		if _, ok := l.mo[sys.gameMode]; ok {
 			l.mo[sys.gameMode].bgDraw(layerno)
 			l.mo[sys.gameMode].draw(layerno, l.fnt)
 		}
 	}
+
 	if l.active {
 		// LifeBarRound
 		l.ro.draw(layerno, l.fnt)

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -3286,16 +3286,19 @@ func (ro *LifeBarRound) handleRoundIntro() {
 	// Fight call
 	if ro.fightDisplayPhase < 2 { // A bit redundant but matches the other screens
 		if ro.fightDisplayPhase == 0 {
-			// Handle delay between Round and Fight (callfight.time)
-			if ro.roundDisplayPhase == 2 && ro.fightDisplayTimer >= ro.callfight_time {
-				ro.fight.Reset()
-				ro.fight_top.Reset()
-				ro.fightDisplayPhase = 1
-				ro.fightDisplayTimer = 0 // Reset timer so we can reuse it for the actual Fight display
-				sys.timerCount = append(sys.timerCount, sys.matchTime)
-				ro.timerActive = true
-			} else {
-				ro.fightDisplayTimer++
+			// Handle delay between Round and Fight
+			// Fight will start "callfight.time" frames after Round has started
+			if ro.roundDisplayPhase > 0 {
+				if ro.fightDisplayTimer >= ro.callfight_time {
+					ro.fight.Reset()
+					ro.fight_top.Reset()
+					ro.fightDisplayPhase = 1
+					ro.fightDisplayTimer = 0 // Reset timer so we can reuse it for the actual Fight display
+					sys.timerCount = append(sys.timerCount, sys.matchTime)
+					ro.timerActive = true
+				} else {
+					ro.fightDisplayTimer++
+				}
 			}
 		} else if ro.fightDisplayPhase == 1 {
 			// Active phase

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -503,8 +503,8 @@ func readHealthBar(pre string, is IniSection, sff *Sff, at AnimationTable, f map
 	return hb
 }
 
-func (hb *HealthBar) step(ref int, hbr *HealthBar) {
-	refChar := sys.chars[ref][0]
+func (hb *HealthBar) step(charpn int, hbr *HealthBar) {
+	refChar := sys.chars[charpn][0]
 	var life float32 = float32(refChar.life) / float32(refChar.lifeMax)
 	var redVal int32 = refChar.redLife - refChar.life
 	var getHit bool = (refChar.receivedHits != 0 || refChar.ss.moveType == MT_H) && !refChar.scf(SCF_over_ko)
@@ -629,9 +629,9 @@ func (hb *HealthBar) bgDraw(layerno int16) {
 	hb.bg2.Draw(float32(hb.pos[0])+sys.lifebar.offsetX, float32(hb.pos[1])+sys.lifebar.offsetY, layerno, sys.lifebar.scale)
 }
 
-func (hb *HealthBar) draw(layerno int16, ref int, hbr *HealthBar, f map[int]*Fnt) {
+func (hb *HealthBar) draw(layerno int16, charpn int, hbr *HealthBar, f map[int]*Fnt) {
 	// Get reference values
-	refChar := sys.chars[ref][0]
+	refChar := sys.chars[charpn][0]
 	life := float32(refChar.life) / float32(refChar.lifeMax)
 	redlife := float32(refChar.redLife) / float32(refChar.lifeMax)
 	redval := refChar.redLife - refChar.life
@@ -952,9 +952,9 @@ func resolvePBKey[T any](m map[int32]T, pbval int32, max int32) int32 {
 	return choice
 }
 
-func (pb *PowerBar) step(ref int, pbr *PowerBar, snd *Snd) {
+func (pb *PowerBar) step(charpn int, pbr *PowerBar, snd *Snd) {
 	// Get reference values
-	refChar := sys.chars[ref][0]
+	refChar := sys.chars[charpn][0]
 	pbval := refChar.getPower()
 	power := float32(pbval) / float32(refChar.powerMax)
 	level := pbval / 1000
@@ -1048,17 +1048,17 @@ func (pb *PowerBar) reset() {
 	pb.shift.anim.dstAlpha = 255
 }
 
-func (pb *PowerBar) bgDraw(layerno int16, ref int) {
-	pbval := sys.chars[ref][0].getPower()
-	refChar := sys.chars[ref][0]
+func (pb *PowerBar) bgDraw(layerno int16, charpn int) {
+	pbval := sys.chars[charpn][0].getPower()
+	refChar := sys.chars[charpn][0]
 	fv := resolvePBKey(pb.bg0, pbval, refChar.powerMax)
 	pb.bg0[fv].Draw(float32(pb.pos[0])+sys.lifebar.offsetX, float32(pb.pos[1])+sys.lifebar.offsetY, layerno, sys.lifebar.scale)
 	pb.bg1.Draw(float32(pb.pos[0])+sys.lifebar.offsetX, float32(pb.pos[1])+sys.lifebar.offsetY, layerno, sys.lifebar.scale)
 	pb.bg2.Draw(float32(pb.pos[0])+sys.lifebar.offsetX, float32(pb.pos[1])+sys.lifebar.offsetY, layerno, sys.lifebar.scale)
 }
 
-func (pb *PowerBar) draw(layerno int16, ref int, pbr *PowerBar, f map[int]*Fnt) {
-	refChar := sys.chars[ref][0]
+func (pb *PowerBar) draw(layerno int16, charpn int, pbr *PowerBar, f map[int]*Fnt) {
+	refChar := sys.chars[charpn][0]
 	pbval := refChar.getPower()
 	power := float32(pbval) / float32(refChar.powerMax)
 	level := pbval / 1000
@@ -1224,8 +1224,8 @@ func readGuardBar(pre string, is IniSection,
 	return gb
 }
 
-func (gb *GuardBar) step(ref int, gbr *GuardBar, snd *Snd) {
-	refChar := sys.chars[ref][0]
+func (gb *GuardBar) step(charpn int, gbr *GuardBar, snd *Snd) {
+	refChar := sys.chars[charpn][0]
 	if !refChar.guardBreakEnabled() {
 		return
 	}
@@ -1305,13 +1305,13 @@ func (gb *GuardBar) bgDraw(layerno int16) {
 	gb.bg2.Draw(float32(gb.pos[0])+sys.lifebar.offsetX, float32(gb.pos[1])+sys.lifebar.offsetY, layerno, sys.lifebar.scale)
 }
 
-func (gb *GuardBar) draw(layerno int16, ref int, gbr *GuardBar, f map[int]*Fnt) {
+func (gb *GuardBar) draw(layerno int16, charpn int, gbr *GuardBar, f map[int]*Fnt) {
 	// Handled in outer loop
 	//if !sys.lifebar.guardbar {
 	//	return
 	//}
 
-	refChar := sys.chars[ref][0]
+	refChar := sys.chars[charpn][0]
 	points := float32(refChar.guardPoints) / float32(refChar.guardPointsMax)
 	if gb.invertfill {
 		points = 1 - points
@@ -1469,8 +1469,8 @@ func readStunBar(pre string, is IniSection,
 	return sb
 }
 
-func (sb *StunBar) step(ref int, sbr *StunBar, snd *Snd) {
-	refChar := sys.chars[ref][0]
+func (sb *StunBar) step(charpn int, sbr *StunBar, snd *Snd) {
+	refChar := sys.chars[charpn][0]
 	if !refChar.dizzyEnabled() {
 		return
 	}
@@ -1548,13 +1548,13 @@ func (sb *StunBar) bgDraw(layerno int16) {
 	sb.bg2.Draw(float32(sb.pos[0])+sys.lifebar.offsetX, float32(sb.pos[1])+sys.lifebar.offsetY, layerno, sys.lifebar.scale)
 }
 
-func (sb *StunBar) draw(layerno int16, ref int, sbr *StunBar, f map[int]*Fnt) {
+func (sb *StunBar) draw(layerno int16, charpn int, sbr *StunBar, f map[int]*Fnt) {
 	// Handled in outer loop
 	//if !sys.lifebar.stunbar {
 	//	return
 	//}
 
-	refChar := sys.chars[ref][0]
+	refChar := sys.chars[charpn][0]
 	points := float32(refChar.dizzyPoints) / float32(refChar.dizzyPointsMax)
 	if sb.invertfill {
 		points = 1 - points
@@ -1735,8 +1735,8 @@ func readLifeBarFace(pre string, is IniSection, sff *Sff, at AnimationTable) *Li
 	return fa
 }
 
-func (fa *LifeBarFace) step(ref int, refFace *LifeBarFace) {
-	refChar := sys.chars[ref][0]
+func (fa *LifeBarFace) step(charpn int, refFace *LifeBarFace) {
+	refChar := sys.chars[charpn][0]
 	group, number := fa.face_spr[0], fa.face_spr[1]
 	if refChar != nil && refChar.anim != nil {
 		if mg, ok := refChar.anim.remap[group]; ok {
@@ -1747,11 +1747,12 @@ func (fa *LifeBarFace) step(ref int, refFace *LifeBarFace) {
 	}
 
 	// Update sprite only when necessary
+	refgi := sys.cgi[charpn]
 	if refFace.old_spr[0] != group || refFace.old_spr[1] != number ||
-		refFace.old_pal[0] != sys.cgi[ref].remappedpal[0] || refFace.old_pal[1] != sys.cgi[ref].remappedpal[1] {
-		refFace.face = sys.cgi[ref].sff.getOwnPalSprite(uint16(group), uint16(number), &sys.cgi[ref].palettedata.palList)
+		refFace.old_pal[0] != refgi.remappedpal[0] || refFace.old_pal[1] != refgi.remappedpal[1] {
+		refFace.face = refgi.sff.getOwnPalSprite(uint16(group), uint16(number), &refgi.palettedata.palList)
 		refFace.old_spr = [...]int32{group, number}
-		refFace.old_pal = [...]int32{sys.cgi[ref].remappedpal[0], sys.cgi[ref].remappedpal[1]}
+		refFace.old_pal = [...]int32{refgi.remappedpal[0], refgi.remappedpal[1]}
 	}
 
 	fa.bg.Action()
@@ -1794,8 +1795,8 @@ func (fa *LifeBarFace) bgDraw(layerno int16) {
 	fa.bg2.Draw(float32(fa.pos[0])+sys.lifebar.offsetX, float32(fa.pos[1]), layerno, sys.lifebar.scale)
 }
 
-func (fa *LifeBarFace) draw(layerno int16, ref int, refFace *LifeBarFace) {
-	refChar := sys.chars[ref][0]
+func (fa *LifeBarFace) draw(layerno int16, charpn int, refFace *LifeBarFace) {
+	refChar := sys.chars[charpn][0]
 
 	if refFace.face != nil {
 		// Get player current PalFX if applicable
@@ -1816,7 +1817,7 @@ func (fa *LifeBarFace) draw(layerno int16, ref int, refFace *LifeBarFace) {
 				}
 			}
 			// Retrieve that palette
-			palList := &sys.cgi[ref].palettedata.palList
+			palList := &sys.cgi[charpn].palettedata.palList
 			charPal := palList.Get(palIdx)
 			// Update portrait palette and cache
 			refFace.face.Pal = charPal
@@ -1831,7 +1832,7 @@ func (fa *LifeBarFace) draw(layerno int16, ref int, refFace *LifeBarFace) {
 
 		// Draw the actual face sprite
 		fa.face_lay.DrawFaceSprite((float32(fa.pos[0])+sys.lifebar.offsetX)*sys.lifebar.scale, float32(fa.pos[1])*sys.lifebar.scale, layerno,
-			refFace.face, fa.face_pfx, sys.cgi[ref].portraitscale*sys.lifebar.portraitScale, &fa.face_lay.window)
+			refFace.face, fa.face_pfx, sys.cgi[charpn].portraitscale*sys.lifebar.portraitScale, &fa.face_lay.window)
 
 		// Draw KO layer
 		if !refChar.alive() {
@@ -1846,17 +1847,17 @@ func (fa *LifeBarFace) draw(layerno int16, ref int, refFace *LifeBarFace) {
 	fa.top.Draw(float32(fa.pos[0])+sys.lifebar.offsetX, float32(fa.pos[1]), layerno, sys.lifebar.scale)
 }
 
-func (fa *LifeBarFace) drawTeammates(layerno int16, ref int) {
+func (fa *LifeBarFace) drawTeammates(layerno int16, charpn int) {
 	if len(fa.teammate_face) == 0 {
 		return
 	}
 
 	// We could check this, but not checking it forces our code to be cleaner
-	//if sys.tmode[sys.chars[ref][0].teamside] != TM_Turns {
+	//if sys.tmode[sys.chars[charpn][0].teamside] != TM_Turns {
 	//	return
 	//}
 
-	refChar := sys.chars[ref][0]
+	refChar := sys.chars[charpn][0]
 
 	// Reset system brightness if player initiated SuperPause (cancel "darken" parameter)
 	oldBright := sys.brightness
@@ -1976,16 +1977,16 @@ func (nm *LifeBarName) bgDraw(layerno int16) {
 	nm.bg.Draw(float32(nm.pos[0])+sys.lifebar.offsetX, float32(nm.pos[1]), layerno, sys.lifebar.scale)
 }
 
-func (nm *LifeBarName) draw(layerno int16, ref int, f map[int]*Fnt, side int) {
+func (nm *LifeBarName) draw(layerno int16, charpn int, f map[int]*Fnt, side int) {
 	if nm.name.font[0] >= 0 && getFont(f, nm.name.font[0]) != nil {
 		nm.name.lay.DrawText((float32(nm.pos[0]) + sys.lifebar.offsetX), float32(nm.pos[1]), sys.lifebar.scale, layerno,
-			sys.cgi[ref].lifebarname, getFont(f, nm.name.font[0]), nm.name.font[1], nm.name.font[2], nm.name.palfx, nm.name.frgba)
+			sys.cgi[charpn].lifebarname, getFont(f, nm.name.font[0]), nm.name.font[1], nm.name.font[2], nm.name.palfx, nm.name.frgba)
 	}
 
 	nm.top.Draw(float32(nm.pos[0])+sys.lifebar.offsetX, float32(nm.pos[1]), layerno, sys.lifebar.scale)
 }
 
-func (nm *LifeBarName) drawTeammates(layerno int16, ref int, f map[int]*Fnt, side int) {
+func (nm *LifeBarName) drawTeammates(layerno int16, charpn int, f map[int]*Fnt, side int) {
 	if len(nm.teammate_name_strings) == 0 {
 		return
 	}
@@ -4346,8 +4347,8 @@ type Lifebar struct {
 	sff           *Sff
 	snd           *Snd
 	fnt           map[int]*Fnt
-	ref           [2]int
-	order         [2][]int
+	curLayout     [2]int // Which layout each team is currently using. Single, Simul 3P, etc
+	teamOrder     [2][]int // Player order on each team. Because it can vary in Tag
 	hb            [8][]*HealthBar
 	pb            [8][]*PowerBar
 	gb            [8][]*GuardBar
@@ -5133,19 +5134,19 @@ func (l *Lifebar) step() {
 		// Team order swapping moved to dedicated Tag functions
 		for ti, tm := range sys.tmode {
 			if tm == TM_Tag {
-				for i, v := range l.order[ti] {
+				for i, v := range l.teamOrder[ti] {
 					if sys.teamLeader[sys.chars[v][0].teamside] == sys.chars[v][0].playerNo && sys.chars[v][0].alive() {
 						if i != 0 {
-							if i == len(l.order[ti])-1 {
-								l.order[ti] = sliceMoveInt(l.order[ti], i, 0)
+							if i == len(l.teamOrder[ti])-1 {
+								l.teamOrder[ti] = sliceMoveInt(l.teamOrder[ti], i, 0)
 							} else {
-								last := len(l.order[ti]) - 1
+								last := len(l.teamOrder[ti]) - 1
 								for n := last; n > 0; n-- {
-									if !sys.chars[l.order[ti][n]][0].alive() {
+									if !sys.chars[l.teamOrder[ti][n]][0].alive() {
 										last -= 1
 									}
 								}
-								l.order[ti] = sliceMoveInt(l.order[ti], 0, last)
+								l.teamOrder[ti] = sliceMoveInt(l.teamOrder[ti], 0, last)
 							}
 						}
 						break
@@ -5155,19 +5156,21 @@ func (l *Lifebar) step() {
 		}
 	*/
 	for ti := range sys.tmode {
-		for i, v := range l.order[ti] {
+		layout := l.curLayout[ti]
+		for i, charpn := range l.teamOrder[ti] {
+			index := i*2+ti
 			// HealthBar
-			l.hb[l.ref[ti]][i*2+ti].step(v, l.hb[l.ref[ti]][v])
+			l.hb[layout][index].step(charpn, l.hb[layout][charpn])
 			// PowerBar
-			l.pb[l.ref[ti]][i*2+ti].step(v, l.pb[l.ref[ti]][v], l.snd)
+			l.pb[layout][index].step(charpn, l.pb[layout][charpn], l.snd)
 			// GuardBar
-			l.gb[l.ref[ti]][i*2+ti].step(v, l.gb[l.ref[ti]][v], l.snd)
+			l.gb[layout][index].step(charpn, l.gb[layout][charpn], l.snd)
 			// StunBar
-			l.sb[l.ref[ti]][i*2+ti].step(v, l.sb[l.ref[ti]][v], l.snd)
+			l.sb[layout][index].step(charpn, l.sb[layout][charpn], l.snd)
 			// LifeBarFace
-			l.fa[l.ref[ti]][i*2+ti].step(v, l.fa[l.ref[ti]][v])
+			l.fa[layout][index].step(charpn, l.fa[layout][charpn])
 			// LifeBarName
-			l.nm[l.ref[ti]][i*2+ti].step()
+			l.nm[layout][index].step()
 		}
 	}
 	// LifeBarWinIcon
@@ -5204,7 +5207,7 @@ func (l *Lifebar) step() {
 	}
 	// LifeBarAction
 	for i := range l.ac {
-		l.ac[i].step(l.order[i][0])
+		l.ac[i].step(l.teamOrder[i][0])
 	}
 	// LifeBarRatio
 	for ti, tm := range sys.tmode {
@@ -5241,44 +5244,45 @@ func (l *Lifebar) step() {
 func (l *Lifebar) reset() {
 	var num [2]int
 
-	// Update team mode reference for each player
+	// Update team mode layout for each player
 	for ti, tm := range sys.tmode {
-		l.ref[ti] = int(tm)
+		l.curLayout[ti] = int(tm)
 		if tm == TM_Simul {
 			if sys.numSimul[ti] == 3 {
-				l.ref[ti] = 4 // Simul_3P (6)
+				l.curLayout[ti] = 4 // Simul_3P (6)
 			} else if sys.numSimul[ti] >= 4 {
-				l.ref[ti] = 5 // Simul_4P (8)
+				l.curLayout[ti] = 5 // Simul_4P (8)
 			} else {
-				l.ref[ti] = 1 // Simul (8)
+				l.curLayout[ti] = 1 // Simul (8)
 			}
 		} else if tm == TM_Tag {
 			if sys.numSimul[ti] == 3 {
-				l.ref[ti] = 6 // Tag_3P (6)
+				l.curLayout[ti] = 6 // Tag_3P (6)
 			} else if sys.numSimul[ti] >= 4 {
-				l.ref[ti] = 7 // Tag_4P (8)
+				l.curLayout[ti] = 7 // Tag_4P (8)
 			} else {
-				l.ref[ti] = 3 // Tag (8)
+				l.curLayout[ti] = 3 // Tag (8)
 			}
 		} else if tm == TM_Turns {
-			l.ref[ti] = 2 // Turns (2)
+			l.curLayout[ti] = 2 // Turns (2)
 		} else {
-			l.ref[ti] = 0 // Single (2)
+			l.curLayout[ti] = 0 // Single (2)
 		}
 
 		// Set maximum number of lifebars
 		if tm == TM_Simul || tm == TM_Tag {
 			num[ti] = int(math.Min(8, float64(sys.numSimul[ti])*2))
 		} else {
-			num[ti] = len(l.hb[l.ref[ti]])
+			num[ti] = len(l.hb[l.curLayout[ti]])
 		}
 
-		l.order[ti] = []int{}
+		l.teamOrder[ti] = []int{}
 		for i := ti; i < num[ti]; i += 2 {
-			l.order[ti] = append(l.order[ti], i)
+			l.teamOrder[ti] = append(l.teamOrder[ti], i)
 		}
 	}
 
+	// Reset lifebar elements
 	for i := range l.hb {
 		for j := range l.hb[i] {
 			l.hb[i][j].reset()
@@ -5317,7 +5321,7 @@ func (l *Lifebar) reset() {
 		l.co[i].reset()
 	}
 	for i := range l.ac {
-		l.ac[i].reset(l.order[i][0])
+		l.ac[i].reset(l.teamOrder[i][0])
 	}
 	l.ro.reset()
 	for i := range l.ra {
@@ -5346,18 +5350,19 @@ func (l *Lifebar) draw(layerno int16) {
 	if !sys.lifebarHide && l.active && !sys.dialogueBarsFlg && (!sys.motif.me.active || !sys.motif.PauseMenu["pause_menu"].HideBars) {
 		// Helper to run a function for each active player's bars
 		// We will iterate backwards so that player 1 is drawn last and on top
-		forEach := func(fn func(side, slot, pno, index int)) {
+		forEach := func(fn func(side, layout, slot, barpn, charpn int)) {
 			// Iterate player slots globally, back to front
 			// We iterate slots first so that the order becomes P8-...-P1 instead of P8-P6-P4-P2-P7-P5-P3-P1
 			for slot := MaxSimul - 1; slot >= 0; slot-- {
-				// Iterate each team within the slot
+				// Process that slot for each team
 				for side := len(sys.tmode) - 1; side >= 0; side-- {
-					if slot >= len(l.order[side]) {
+					if slot >= len(l.teamOrder[side]) {
 						continue
 					}
-					pno := l.order[side][slot]
-					index := slot*2 + side
-					fn(side, slot, pno, index)
+					layout := l.curLayout[side]
+					barpn := slot*2 + side
+					charpn := l.teamOrder[side][slot]
+					fn(side, layout, slot, barpn, charpn)
 				}
 			}
 		}
@@ -5366,26 +5371,27 @@ func (l *Lifebar) draw(layerno int16) {
 			// HealthBar backgrounds
 			// We split backgrounds and bars for the sake of backward compatibility
 			// https://github.com/ikemen-engine/Ikemen-GO/issues/3461
-			forEach(func(side, slot, pno, index int) {
-				c := sys.chars[pno][0]
+			forEach(func(side, layout, slot, barpn, charpn int) {
+				c := sys.chars[charpn][0]
 				if c.asf(ASF_nolifebardisplay) {
 					return
 				}
-				l.hb[l.ref[side]][index].bgDraw(layerno)
+				l.hb[layout][barpn].bgDraw(layerno)
 			})
 
 			// HealthBar bars
-			forEach(func(side, slot, pno, index int) {
-				c := sys.chars[pno][0]
+			forEach(func(side, layout, slot, barpn, charpn int) {
+				c := sys.chars[charpn][0]
 				if c.asf(ASF_nolifebardisplay) {
 					return
 				}
-				l.hb[l.ref[side]][index].draw(layerno, pno, l.hb[l.ref[side]][pno], l.fnt)
+				// Use the definition at [layout][barpn] and the runtime values (combo damage etc) stored at [layout][charpn]
+				l.hb[layout][barpn].draw(layerno, charpn, l.hb[layout][charpn], l.fnt)
 			})
 
 			// PowerBar backgrounds
-			forEach(func(side, slot, pno, index int) {
-				c := sys.chars[pno][0]
+			forEach(func(side, layout, slot, barpn, charpn int) {
+				c := sys.chars[charpn][0]
 				if c.asf(ASF_nopowerbardisplay) {
 					return
 				}
@@ -5394,12 +5400,12 @@ func (l *Lifebar) draw(layerno int16) {
 				if slot != 0 && (tm == TM_Simul || tm == TM_Tag) && sys.cfg.Options.Team.PowerShare {
 					return
 				}
-				l.pb[l.ref[side]][index].bgDraw(layerno, index)
+				l.pb[layout][barpn].bgDraw(layerno, barpn)
 			})
 
 			// PowerBar bars
-			forEach(func(side, slot, pno, index int) {
-				c := sys.chars[pno][0]
+			forEach(func(side, layout, slot, barpn, charpn int) {
+				c := sys.chars[charpn][0]
 				if c.asf(ASF_nopowerbardisplay) {
 					return
 				}
@@ -5408,59 +5414,57 @@ func (l *Lifebar) draw(layerno int16) {
 				if slot != 0 && (tm == TM_Simul || tm == TM_Tag) && sys.cfg.Options.Team.PowerShare {
 					return
 				}
-				l.pb[l.ref[side]][index].draw(layerno, pno, l.pb[l.ref[side]][pno], l.fnt)
+				l.pb[layout][barpn].draw(layerno, charpn, l.pb[layout][charpn], l.fnt)
 			})
 
 			// GuardBar
-			forEach(func(side, slot, pno, index int) {
-				c := sys.chars[pno][0]
+			forEach(func(side, layout, slot, barpn, charpn int) {
+				c := sys.chars[charpn][0]
 				if !c.guardBreakEnabled() || c.asf(ASF_noguardbardisplay) {
 					return
 				}
-				l.gb[l.ref[side]][index].bgDraw(layerno)
-				l.gb[l.ref[side]][index].draw(layerno, pno, l.gb[l.ref[side]][pno], l.fnt)
+				l.gb[layout][barpn].bgDraw(layerno)
+				l.gb[layout][barpn].draw(layerno, charpn, l.gb[layout][charpn], l.fnt)
 			})
 
 			// StunBar
-			forEach(func(side, slot, pno, index int) {
-				c := sys.chars[pno][0]
+			forEach(func(side, layout, slot, barpn, charpn int) {
+				c := sys.chars[charpn][0]
 				if !c.dizzyEnabled() || c.asf(ASF_nostunbardisplay) {
 					return
 				}
-				l.sb[l.ref[side]][index].bgDraw(layerno)
-				l.sb[l.ref[side]][index].draw(layerno, pno, l.sb[l.ref[side]][pno], l.fnt)
+				l.sb[layout][barpn].bgDraw(layerno)
+				l.sb[layout][barpn].draw(layerno, charpn, l.sb[layout][charpn], l.fnt)
 			})
 
 			// LifeBarFace
-			forEach(func(side, slot, pno, index int) {
-				c := sys.chars[pno][0]
+			forEach(func(side, layout, slot, barpn, charpn int) {
+				c := sys.chars[charpn][0]
 				if c.asf(ASF_nofacedisplay) {
 					return
 				}
 				// Draw Turns teammates from the first bar only
-				ref := l.ref[side]
-				if slot == 0 && len(l.fa[ref]) > 0 {
-					l.fa[ref][side].drawTeammates(layerno, pno)
+				if slot == 0 && len(l.fa[layout]) > 0 {
+					l.fa[layout][side].drawTeammates(layerno, charpn)
 				}
 				// Draw active players
-				l.fa[ref][index].bgDraw(layerno)
-				l.fa[ref][index].draw(layerno, pno, l.fa[ref][pno])
+				l.fa[layout][barpn].bgDraw(layerno)
+				l.fa[layout][barpn].draw(layerno, charpn, l.fa[layout][charpn])
 			})
 
 			// LifeBarName
-			forEach(func(side, slot, pno, index int) {
-				c := sys.chars[pno][0]
+			forEach(func(side, layout, slot, barpn, charpn int) {
+				c := sys.chars[charpn][0]
 				if c.asf(ASF_nonamedisplay) {
 					return
 				}
 				// Draw Turns teammates from the first bar only
-				ref := l.ref[side]
-				if slot == 0 && len(l.nm[ref]) > 0 {
-					l.nm[ref][side].drawTeammates(layerno, pno, l.fnt, side)
+				if slot == 0 && len(l.nm[layout]) > 0 {
+					l.nm[layout][side].drawTeammates(layerno, charpn, l.fnt, side)
 				}
 				// Draw active players
-				l.nm[ref][index].bgDraw(layerno)
-				l.nm[ref][index].draw(layerno, pno, l.fnt, side)
+				l.nm[layout][barpn].bgDraw(layerno)
+				l.nm[layout][barpn].draw(layerno, charpn, l.fnt, side)
 			})
 
 			// LifeBarRatio

--- a/src/lifebar.go
+++ b/src/lifebar.go
@@ -2978,9 +2978,8 @@ func readLifeBarRound(is IniSection,
 		ro.slow_fadetime = ro.slow_time
 	}
 	is.ReadF32("slow.speed", &ro.slow_speed)
-	if ro.slow_speed > 1 {
-		ro.slow_speed = 1
-	}
+	// A speed over 1 defeats the purpose, 0 freezes the game, and negative is not safe
+	ro.slow_speed = Clamp(ro.slow_speed, 0.01, 1)
 	is.ReadI32("over.hittime", &ro.over_hittime)
 	if ro.over_hittime < 1 {
 		ro.over_hittime = 1

--- a/src/main.go
+++ b/src/main.go
@@ -265,7 +265,7 @@ func processCommandLine() {
 -h -?                   Help
 -log <logfile>          Records match data to <logfile>
 -r <path>               Loads motif <path>. eg. -r motifdir or -r motifdir/system.def
--lifebar <path>         Loads lifebar <path>. eg. -lifebar data/fight.def
+-fight <path>           Loads fight screen <path>. eg. -fight data/fight.def
 -storyboard <path>      Loads storyboard <path>. eg. -storyboard chars/kfm/intro.def
 -windowed               Starts in windowed mode (disables fullscreen)
 -width <num>            Sets game width

--- a/src/motif.go
+++ b/src/motif.go
@@ -3132,7 +3132,7 @@ func (m *Motif) act() {
 
 		// Dialogue
 		// Normal start: right before "Fight" in round 1, or at match end.
-		introStart := sys.round == 1 && sys.intro == sys.lifebar.ro.ctrl_time
+		introStart := sys.round == 1 && sys.intro == sys.fightScreen.ro.ctrl_time
 		matchEndStart := sys.shouldStartMatchEndDialogue()
 		normalStart := introStart || matchEndStart
 		// Forced start: ignore normal timing.
@@ -3428,8 +3428,8 @@ func (ch *MotifChallenger) init(m *Motif) {
 		sys.credits--
 	}
 
-	ch.lifebarActive = sys.lifebar.active
-	sys.lifebar.active = false
+	ch.lifebarActive = sys.fightScreen.active
+	sys.fightScreen.active = false
 
 	m.ChallengerBgDef.BGDef.Reset()
 	m.ChallengerInfo.Bg.AnimData.Reset()
@@ -3473,7 +3473,7 @@ func (ch *MotifChallenger) step(m *Motif) {
 			m.fadeOut.reset()
 		}
 		ch.active = false
-		sys.lifebar.active = ch.lifebarActive
+		sys.fightScreen.active = ch.lifebarActive
 		sys.endMatch = true
 		return
 	}
@@ -3831,7 +3831,7 @@ func (de *MotifDemo) init(m *Motif) {
 	de.counter = 0
 
 	// Override lifebar fading
-	m.DemoMode.FadeIn.FadeData.init(sys.lifebar.ro.fadeIn, true)
+	m.DemoMode.FadeIn.FadeData.init(sys.fightScreen.ro.fadeIn, true)
 
 	de.active = true
 	de.initialized = true
@@ -3841,15 +3841,15 @@ func (de *MotifDemo) step(m *Motif) {
 	if de.endTimer == -1 {
 		cancel := (m.AttractMode.Enabled && sys.credits > 0) || (!m.AttractMode.Enabled && sys.uiRawInput(m.DemoMode.Cancel.Key, -1))
 		if de.counter == m.DemoMode.Fight.EndTime || cancel {
-			startFadeOut(m.DemoMode.FadeOut.FadeData, sys.lifebar.ro.fadeOut, false, m.fadePolicy)
-			de.endTimer = de.counter + sys.lifebar.ro.fadeOut.timeRemaining
+			startFadeOut(m.DemoMode.FadeOut.FadeData, sys.fightScreen.ro.fadeOut, false, m.fadePolicy)
+			de.endTimer = de.counter + sys.fightScreen.ro.fadeOut.timeRemaining
 		}
 	}
 
 	// Check if the sequence has ended
 	if de.endTimer != -1 && de.counter >= de.endTimer {
-		if sys.lifebar.ro.fadeOut != nil {
-			sys.lifebar.ro.fadeOut.reset()
+		if sys.fightScreen.ro.fadeOut != nil {
+			sys.fightScreen.ro.fadeOut.reset()
 		}
 		de.active = false
 		sys.endMatch = true
@@ -4292,8 +4292,8 @@ func (di *MotifDialogue) init(m *Motif, matchEnd bool) {
 	di.atMatchEnd = matchEnd
 	// Match-end dialogue owns the transition into the post-match fade.
 	// If fade was already armed before we got here, cancel ongoing fadeout.
-	if matchEnd && sys.lifebar.ro.fadeOut.isActive() {
-		sys.lifebar.ro.fadeOut.reset()
+	if matchEnd && sys.fightScreen.ro.fadeOut.isActive() {
+		sys.fightScreen.ro.fadeOut.reset()
 	}
 	if !sys.skipMotifScaling() {
 		sys.setGameSize(sys.scrrect[2], sys.scrrect[3])
@@ -4328,8 +4328,8 @@ func (di *MotifDialogue) finish(m *Motif) {
 	if matchEnd {
 		di.matchEndDone = true
 		di.atMatchEnd = false
-		if !sys.lifebar.ro.fadeOut.isActive() {
-			sys.lifebar.ro.fadeOut.init(sys.lifebar.ro.fadeOut, false)
+		if !sys.fightScreen.ro.fadeOut.isActive() {
+			sys.fightScreen.ro.fadeOut.init(sys.fightScreen.ro.fadeOut, false)
 		}
 	}
 }

--- a/src/motif.go
+++ b/src/motif.go
@@ -3132,7 +3132,7 @@ func (m *Motif) act() {
 
 		// Dialogue
 		// Normal start: right before "Fight" in round 1, or at match end.
-		introStart := sys.round == 1 && sys.intro == sys.fightScreen.ro.ctrl_time
+		introStart := sys.round == 1 && sys.intro == sys.fightScreen.round.ctrl_time
 		matchEndStart := sys.shouldStartMatchEndDialogue()
 		normalStart := introStart || matchEndStart
 		// Forced start: ignore normal timing.
@@ -3831,7 +3831,7 @@ func (de *MotifDemo) init(m *Motif) {
 	de.counter = 0
 
 	// Override lifebar fading
-	m.DemoMode.FadeIn.FadeData.init(sys.fightScreen.ro.fadeIn, true)
+	m.DemoMode.FadeIn.FadeData.init(sys.fightScreen.round.fadeIn, true)
 
 	de.active = true
 	de.initialized = true
@@ -3841,15 +3841,15 @@ func (de *MotifDemo) step(m *Motif) {
 	if de.endTimer == -1 {
 		cancel := (m.AttractMode.Enabled && sys.credits > 0) || (!m.AttractMode.Enabled && sys.uiRawInput(m.DemoMode.Cancel.Key, -1))
 		if de.counter == m.DemoMode.Fight.EndTime || cancel {
-			startFadeOut(m.DemoMode.FadeOut.FadeData, sys.fightScreen.ro.fadeOut, false, m.fadePolicy)
-			de.endTimer = de.counter + sys.fightScreen.ro.fadeOut.timeRemaining
+			startFadeOut(m.DemoMode.FadeOut.FadeData, sys.fightScreen.round.fadeOut, false, m.fadePolicy)
+			de.endTimer = de.counter + sys.fightScreen.round.fadeOut.timeRemaining
 		}
 	}
 
 	// Check if the sequence has ended
 	if de.endTimer != -1 && de.counter >= de.endTimer {
-		if sys.fightScreen.ro.fadeOut != nil {
-			sys.fightScreen.ro.fadeOut.reset()
+		if sys.fightScreen.round.fadeOut != nil {
+			sys.fightScreen.round.fadeOut.reset()
 		}
 		de.active = false
 		sys.endMatch = true
@@ -4292,8 +4292,8 @@ func (di *MotifDialogue) init(m *Motif, matchEnd bool) {
 	di.atMatchEnd = matchEnd
 	// Match-end dialogue owns the transition into the post-match fade.
 	// If fade was already armed before we got here, cancel ongoing fadeout.
-	if matchEnd && sys.fightScreen.ro.fadeOut.isActive() {
-		sys.fightScreen.ro.fadeOut.reset()
+	if matchEnd && sys.fightScreen.round.fadeOut.isActive() {
+		sys.fightScreen.round.fadeOut.reset()
 	}
 	if !sys.skipMotifScaling() {
 		sys.setGameSize(sys.scrrect[2], sys.scrrect[3])
@@ -4328,8 +4328,8 @@ func (di *MotifDialogue) finish(m *Motif) {
 	if matchEnd {
 		di.matchEndDone = true
 		di.atMatchEnd = false
-		if !sys.fightScreen.ro.fadeOut.isActive() {
-			sys.fightScreen.ro.fadeOut.init(sys.fightScreen.ro.fadeOut, false)
+		if !sys.fightScreen.round.fadeOut.isActive() {
+			sys.fightScreen.round.fadeOut.init(sys.fightScreen.round.fadeOut, false)
 		}
 	}
 }

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -17,7 +17,7 @@ Const   = data/common.const
 ; Common states (CNS or ZSS)
 States  = data/functions.zss, data/action.zss, data/demo.zss, data/dizzy.zss, data/guardbreak.zss, data/score.zss, data/system.zss, data/tag.zss, data/training.zss
 ; Common packs of graphic and/or sound effects called during the match by using
-; a specific prefix before animation and sound numbers (like lifebar fightfx)
+; a specific prefix before animation and sound numbers (like fight screen fightfx)
 Fx      = data/gofx/gofx.def
 ; External modules (no need to add modules placed in external/mods directory)
 Modules = 

--- a/src/script.go
+++ b/src/script.go
@@ -2753,8 +2753,8 @@ func systemScriptInit(l *lua.LState) {
 			sys.scoreRounds = [][2]float32{}
 
 			// Reset lifebars
-			for i := range sys.fightScreen.wi {
-				sys.fightScreen.wi[i].clear()
+			for i := range sys.fightScreen.winIcons {
+				sys.fightScreen.winIcons[i].clear()
 			}
 
 			sys.draws = 0
@@ -2904,8 +2904,8 @@ func systemScriptInit(l *lua.LState) {
 					if sys.tmode[i] == TM_Turns && sys.effectiveLoss[i] {
 						sys.roundsExisted[i] = 0
 						// Increment number of lifebar KO portraits to render
-						sys.fightScreen.fa[TM_Turns][i].numko++
-						sys.fightScreen.nm[TM_Turns][i].numko++
+						sys.fightScreen.faces[TM_Turns][i].numko++
+						sys.fightScreen.names[TM_Turns][i].numko++
 					}
 				}
 
@@ -5461,7 +5461,7 @@ func systemScriptInit(l *lua.LState) {
 		if tn < 1 || tn > 2 {
 			l.RaiseError("\nInvalid team side: %v\n", tn)
 		}
-		sys.fightScreen.sc[tn-1].scorePoints = 0
+		sys.fightScreen.scores[tn-1].scorePoints = 0
 		return 0
 	})
 	luaRegister(l, "resetTokenGuard", func(*lua.LState) int {
@@ -5968,27 +5968,27 @@ func systemScriptInit(l *lua.LState) {
 				case "hidebars": // enabled depending on [Dialogue Info] motif settings
 					sys.fightScreen.hidebars = lua.LVAsBool(value)
 				case "match":
-					sys.fightScreen.ma.active = lua.LVAsBool(value)
+					sys.fightScreen.match.active = lua.LVAsBool(value)
 				case "mode": // enabled by default
 					sys.fightScreen.mode = lua.LVAsBool(value)
 				case "p1ailevel":
-					sys.fightScreen.ai[0].active = lua.LVAsBool(value)
+					sys.fightScreen.aiLevels[0].active = lua.LVAsBool(value)
 				case "p1score":
-					sys.fightScreen.sc[0].active = lua.LVAsBool(value)
+					sys.fightScreen.scores[0].active = lua.LVAsBool(value)
 				case "p1wincount":
-					sys.fightScreen.wc[0].active = lua.LVAsBool(value)
+					sys.fightScreen.winCounts[0].active = lua.LVAsBool(value)
 				case "p2ailevel":
-					sys.fightScreen.ai[1].active = lua.LVAsBool(value)
+					sys.fightScreen.aiLevels[1].active = lua.LVAsBool(value)
 				case "p2score":
-					sys.fightScreen.sc[1].active = lua.LVAsBool(value)
+					sys.fightScreen.scores[1].active = lua.LVAsBool(value)
 				case "p2wincount":
-					sys.fightScreen.wc[1].active = lua.LVAsBool(value)
+					sys.fightScreen.winCounts[1].active = lua.LVAsBool(value)
 				case "redlifebar": // enabled depending on config.ini
 					sys.fightScreen.redlifebar = lua.LVAsBool(value)
 				case "stunbar": // enabled depending on config.ini
 					sys.fightScreen.stunbar = lua.LVAsBool(value)
 				case "timer":
-					sys.fightScreen.tr.active = lua.LVAsBool(value)
+					sys.fightScreen.timer.active = lua.LVAsBool(value)
 				default:
 					l.RaiseError("\nInvalid table key: %v\n", k)
 				}
@@ -5997,26 +5997,26 @@ func systemScriptInit(l *lua.LState) {
 			}
 		})
 		// elements enabled via fight.def, depending on game mode
-		if _, ok := sys.fightScreen.ma.enabled[sys.gameMode]; ok {
-			sys.fightScreen.ma.active = sys.fightScreen.ma.enabled[sys.gameMode]
+		if _, ok := sys.fightScreen.match.enabled[sys.gameMode]; ok {
+			sys.fightScreen.match.active = sys.fightScreen.match.enabled[sys.gameMode]
 		}
-		for _, v := range sys.fightScreen.ai {
+		for _, v := range sys.fightScreen.aiLevels {
 			if _, ok := v.enabled[sys.gameMode]; ok {
 				v.active = v.enabled[sys.gameMode]
 			}
 		}
-		for _, v := range sys.fightScreen.sc {
+		for _, v := range sys.fightScreen.scores {
 			if _, ok := v.enabled[sys.gameMode]; ok {
 				v.active = v.enabled[sys.gameMode]
 			}
 		}
-		for _, v := range sys.fightScreen.wc {
+		for _, v := range sys.fightScreen.winCounts {
 			if _, ok := v.enabled[sys.gameMode]; ok {
 				v.active = v.enabled[sys.gameMode]
 			}
 		}
-		if _, ok := sys.fightScreen.tr.enabled[sys.gameMode]; ok {
-			sys.fightScreen.tr.active = sys.fightScreen.tr.enabled[sys.gameMode]
+		if _, ok := sys.fightScreen.timer.enabled[sys.gameMode]; ok {
+			sys.fightScreen.timer.active = sys.fightScreen.timer.enabled[sys.gameMode]
 		}
 		return 0
 	})
@@ -6268,7 +6268,7 @@ func systemScriptInit(l *lua.LState) {
 		if tn < 1 || tn > 2 {
 			l.RaiseError("\nInvalid team side: %v\n", tn)
 		}
-		sys.fightScreen.wc[tn-1].wins = int32(numArg(l, 2))
+		sys.fightScreen.winCounts[tn-1].wins = int32(numArg(l, 2))
 		return 0
 	})
 	//luaRegister(l, "sffCacheDelete", func(l *lua.LState) int {
@@ -8134,13 +8134,13 @@ func triggerFunctions(l *lua.LState) {
 	luaRegister(l, "fightScreenState", func(*lua.LState) int {
 		switch strings.ToLower(strArg(l, 1)) {
 		case "fightdisplay":
-			l.Push(lua.LBool(sys.fightScreen.ro.fightDisplayPhase == 1))
+			l.Push(lua.LBool(sys.fightScreen.round.fightDisplayPhase == 1))
 		case "kodisplay":
-			l.Push(lua.LBool(sys.fightScreen.ro.koDisplayPhase == 1))
+			l.Push(lua.LBool(sys.fightScreen.round.koDisplayPhase == 1))
 		case "rounddisplay":
-			l.Push(lua.LBool(sys.fightScreen.ro.roundDisplayPhase == 1))
+			l.Push(lua.LBool(sys.fightScreen.round.roundDisplayPhase == 1))
 		case "windisplay":
-			l.Push(lua.LBool(sys.fightScreen.ro.winDisplayPhase == 1))
+			l.Push(lua.LBool(sys.fightScreen.round.winDisplayPhase == 1))
 		default:
 			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}
@@ -8157,23 +8157,23 @@ func triggerFunctions(l *lua.LState) {
 		case "info.author":
 			l.Push(lua.LString(sys.fightScreen.author))
 		case "round.ctrl.time":
-			l.Push(lua.LNumber(sys.fightScreen.ro.ctrl_time))
+			l.Push(lua.LNumber(sys.fightScreen.round.ctrl_time))
 		case "round.over.hittime":
-			l.Push(lua.LNumber(sys.fightScreen.ro.over_hittime))
+			l.Push(lua.LNumber(sys.fightScreen.round.over_hittime))
 		case "round.over.time":
-			l.Push(lua.LNumber(sys.fightScreen.ro.over_time))
+			l.Push(lua.LNumber(sys.fightScreen.round.over_time))
 		case "round.over.waittime":
-			l.Push(lua.LNumber(sys.fightScreen.ro.over_waittime))
+			l.Push(lua.LNumber(sys.fightScreen.round.over_waittime))
 		case "round.over.wintime":
-			l.Push(lua.LNumber(sys.fightScreen.ro.over_wintime))
+			l.Push(lua.LNumber(sys.fightScreen.round.over_wintime))
 		case "round.slow.time":
-			l.Push(lua.LNumber(sys.fightScreen.ro.slow_time))
+			l.Push(lua.LNumber(sys.fightScreen.round.slow_time))
 		case "round.start.waittime":
-			l.Push(lua.LNumber(sys.fightScreen.ro.start_waittime))
+			l.Push(lua.LNumber(sys.fightScreen.round.start_waittime))
 		case "round.callfight.time":
-			l.Push(lua.LNumber(sys.fightScreen.ro.callfight_time))
+			l.Push(lua.LNumber(sys.fightScreen.round.callfight_time))
 		case "time.framespercount":
-			l.Push(lua.LNumber(sys.fightScreen.ti.framespercount))
+			l.Push(lua.LNumber(sys.fightScreen.time.framespercount))
 		default:
 			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}

--- a/src/script.go
+++ b/src/script.go
@@ -2753,8 +2753,8 @@ func systemScriptInit(l *lua.LState) {
 			sys.scoreRounds = [][2]float32{}
 
 			// Reset lifebars
-			for i := range sys.lifebar.wi {
-				sys.lifebar.wi[i].clear()
+			for i := range sys.fightScreen.wi {
+				sys.fightScreen.wi[i].clear()
 			}
 
 			sys.draws = 0
@@ -2846,8 +2846,8 @@ func systemScriptInit(l *lua.LState) {
 					if sys.reloadStageFlg {
 						sys.stage = nil
 					}
-					if sys.reloadLifebarFlg {
-						if err := sys.lifebar.reloadLifebar(); err != nil {
+					if sys.reloadFightScreenFlg {
+						if err := sys.fightScreen.reload(); err != nil {
 							l.RaiseError(err.Error())
 						}
 					}
@@ -2904,8 +2904,8 @@ func systemScriptInit(l *lua.LState) {
 					if sys.tmode[i] == TM_Turns && sys.effectiveLoss[i] {
 						sys.roundsExisted[i] = 0
 						// Increment number of lifebar KO portraits to render
-						sys.lifebar.fa[TM_Turns][i].numko++
-						sys.lifebar.nm[TM_Turns][i].numko++
+						sys.fightScreen.fa[TM_Turns][i].numko++
+						sys.fightScreen.nm[TM_Turns][i].numko++
 					}
 				}
 
@@ -4035,20 +4035,20 @@ func systemScriptInit(l *lua.LState) {
 		l.Push(iniToLuaTable(l, iniFile))
 		return 1
 	})
-	luaRegister(l, "loadLifebar", func(l *lua.LState) int {
-		/*Load the lifebar definition.
-		@function loadLifebar
-		@tparam[opt] string defPath Lifebar def file path. If empty or omitted, uses default.
-		function loadLifebar(defPath) end*/
+	luaRegister(l, "loadFightScreen", func(l *lua.LState) int {
+		/*Load the fight screen definition.
+		@function loadFightScreen
+		@tparam[opt] string defPath FightScreen def file path. If empty or omitted, uses default.
+		function loadFightScreen(defPath) end*/
 		def := ""
 		if !nilArg(l, 1) {
 			def = strArg(l, 1)
 		}
-		lb, err := loadLifebar(def)
+		fs, err := loadFightScreen(def)
 		if err != nil {
-			l.RaiseError("\nCan't load lifebar %v: %v\n", def, err.Error())
+			l.RaiseError("\nCan't load fight screen %v: %v\n", def, err.Error())
 		}
-		sys.lifebar = *lb
+		sys.fightScreen = *fs
 		return 0
 	})
 	luaRegister(l, "loadMotif", func(l *lua.LState) int {
@@ -5342,7 +5342,7 @@ func systemScriptInit(l *lua.LState) {
 		return 0
 	})
 	luaRegister(l, "reload", func(*lua.LState) int {
-		/*Schedule reloading of characters, stage and lifebar.
+		/*Schedule reloading of characters, stage and fight screen.
 		@function reload
 		function reload() end*/
 		sys.reloadFlg = true
@@ -5350,7 +5350,7 @@ func systemScriptInit(l *lua.LState) {
 			sys.reloadCharSlot[i] = true
 		}
 		sys.reloadStageFlg = true
-		sys.reloadLifebarFlg = true
+		sys.reloadFightScreenFlg = true
 		return 0
 	})
 	luaRegister(l, "remapInput", func(l *lua.LState) int {
@@ -5461,7 +5461,7 @@ func systemScriptInit(l *lua.LState) {
 		if tn < 1 || tn > 2 {
 			l.RaiseError("\nInvalid team side: %v\n", tn)
 		}
-		sys.lifebar.sc[tn-1].scorePoints = 0
+		sys.fightScreen.sc[tn-1].scorePoints = 0
 		return 0
 	})
 	luaRegister(l, "resetTokenGuard", func(*lua.LState) int {
@@ -5938,9 +5938,9 @@ func systemScriptInit(l *lua.LState) {
 		}
 		return 0
 	})
-	luaRegister(l, "setLifebarElements", func(*lua.LState) int {
-		/*Force enable/disable of lifebar elements.
-		@function setLifebarElements
+	luaRegister(l, "setFightScreenElements", func(*lua.LState) int {
+		/*Force enable/disable of fight screen elements.
+		@function setFightScreenElements
 		@tparam table elements Table of boolean flags (keys are case-insensitive):
 		  - `active` (boolean) enable lifebar drawing
 		  - `bars` (boolean) main life bars
@@ -5954,41 +5954,41 @@ func systemScriptInit(l *lua.LState) {
 		  - `redlifebar` (boolean) red life bar
 		  - `stunbar` (boolean) stun bar
 		  - `timer` (boolean) round timer
-		function setLifebarElements(elements) end*/
+		function setFightScreenElements(elements) end*/
 		tableArg(l, 1).ForEach(func(key, value lua.LValue) {
 			switch k := key.(type) {
 			case lua.LString:
 				switch strings.ToLower(string(k)) {
 				case "active": // enabled by default
-					sys.lifebar.active = lua.LVAsBool(value)
+					sys.fightScreen.active = lua.LVAsBool(value)
 				case "bars": // enabled by default
-					sys.lifebar.bars = lua.LVAsBool(value)
+					sys.fightScreen.bars = lua.LVAsBool(value)
 				case "guardbar": // enabled depending on config.ini
-					sys.lifebar.guardbar = lua.LVAsBool(value)
+					sys.fightScreen.guardbar = lua.LVAsBool(value)
 				case "hidebars": // enabled depending on [Dialogue Info] motif settings
-					sys.lifebar.hidebars = lua.LVAsBool(value)
+					sys.fightScreen.hidebars = lua.LVAsBool(value)
 				case "match":
-					sys.lifebar.ma.active = lua.LVAsBool(value)
+					sys.fightScreen.ma.active = lua.LVAsBool(value)
 				case "mode": // enabled by default
-					sys.lifebar.mode = lua.LVAsBool(value)
+					sys.fightScreen.mode = lua.LVAsBool(value)
 				case "p1ailevel":
-					sys.lifebar.ai[0].active = lua.LVAsBool(value)
+					sys.fightScreen.ai[0].active = lua.LVAsBool(value)
 				case "p1score":
-					sys.lifebar.sc[0].active = lua.LVAsBool(value)
+					sys.fightScreen.sc[0].active = lua.LVAsBool(value)
 				case "p1wincount":
-					sys.lifebar.wc[0].active = lua.LVAsBool(value)
+					sys.fightScreen.wc[0].active = lua.LVAsBool(value)
 				case "p2ailevel":
-					sys.lifebar.ai[1].active = lua.LVAsBool(value)
+					sys.fightScreen.ai[1].active = lua.LVAsBool(value)
 				case "p2score":
-					sys.lifebar.sc[1].active = lua.LVAsBool(value)
+					sys.fightScreen.sc[1].active = lua.LVAsBool(value)
 				case "p2wincount":
-					sys.lifebar.wc[1].active = lua.LVAsBool(value)
+					sys.fightScreen.wc[1].active = lua.LVAsBool(value)
 				case "redlifebar": // enabled depending on config.ini
-					sys.lifebar.redlifebar = lua.LVAsBool(value)
+					sys.fightScreen.redlifebar = lua.LVAsBool(value)
 				case "stunbar": // enabled depending on config.ini
-					sys.lifebar.stunbar = lua.LVAsBool(value)
+					sys.fightScreen.stunbar = lua.LVAsBool(value)
 				case "timer":
-					sys.lifebar.tr.active = lua.LVAsBool(value)
+					sys.fightScreen.tr.active = lua.LVAsBool(value)
 				default:
 					l.RaiseError("\nInvalid table key: %v\n", k)
 				}
@@ -5997,46 +5997,46 @@ func systemScriptInit(l *lua.LState) {
 			}
 		})
 		// elements enabled via fight.def, depending on game mode
-		if _, ok := sys.lifebar.ma.enabled[sys.gameMode]; ok {
-			sys.lifebar.ma.active = sys.lifebar.ma.enabled[sys.gameMode]
+		if _, ok := sys.fightScreen.ma.enabled[sys.gameMode]; ok {
+			sys.fightScreen.ma.active = sys.fightScreen.ma.enabled[sys.gameMode]
 		}
-		for _, v := range sys.lifebar.ai {
+		for _, v := range sys.fightScreen.ai {
 			if _, ok := v.enabled[sys.gameMode]; ok {
 				v.active = v.enabled[sys.gameMode]
 			}
 		}
-		for _, v := range sys.lifebar.sc {
+		for _, v := range sys.fightScreen.sc {
 			if _, ok := v.enabled[sys.gameMode]; ok {
 				v.active = v.enabled[sys.gameMode]
 			}
 		}
-		for _, v := range sys.lifebar.wc {
+		for _, v := range sys.fightScreen.wc {
 			if _, ok := v.enabled[sys.gameMode]; ok {
 				v.active = v.enabled[sys.gameMode]
 			}
 		}
-		if _, ok := sys.lifebar.tr.enabled[sys.gameMode]; ok {
-			sys.lifebar.tr.active = sys.lifebar.tr.enabled[sys.gameMode]
+		if _, ok := sys.fightScreen.tr.enabled[sys.gameMode]; ok {
+			sys.fightScreen.tr.active = sys.fightScreen.tr.enabled[sys.gameMode]
 		}
 		return 0
 	})
-	luaRegister(l, "setLifebarScore", func(*lua.LState) int {
-		/*Set initial lifebar scores for both teams.
-		@function setLifebarScore
+	luaRegister(l, "setFightScreenScore", func(*lua.LState) int {
+		/*Set initial fight screen scores for both teams.
+		@function setFightScreenScore
 		@tparam float32 p1Score Starting score for team 1.
 		@tparam[opt] float32 p2Score Starting score for team 2 (defaults to 0 if omitted).
-		function setLifebarScore(p1Score, p2Score) end*/
+		function setFightScreenScore(p1Score, p2Score) end*/
 		sys.scoreStart[0] = float32(numArg(l, 1))
 		if !nilArg(l, 2) {
 			sys.scoreStart[1] = float32(numArg(l, 2))
 		}
 		return 0
 	})
-	luaRegister(l, "setLifebarTimer", func(*lua.LState) int {
-		/*Set initial round timer value displayed on the lifebar.
-		@function setLifebarTimer
+	luaRegister(l, "setFightScreenTimer", func(*lua.LState) int {
+		/*Set initial round timer value displayed on the fight screen.
+		@function setFightScreenTimer
 		@tparam int32 time Initial timer value.
-		function setLifebarTimer(time) end*/
+		function setFightScreenTimer(time) end*/
 		sys.timerStart = int32(numArg(l, 1))
 		return 0
 	})
@@ -6268,7 +6268,7 @@ func systemScriptInit(l *lua.LState) {
 		if tn < 1 || tn > 2 {
 			l.RaiseError("\nInvalid team side: %v\n", tn)
 		}
-		sys.lifebar.wc[tn-1].wins = int32(numArg(l, 2))
+		sys.fightScreen.wc[tn-1].wins = int32(numArg(l, 2))
 		return 0
 	})
 	//luaRegister(l, "sffCacheDelete", func(l *lua.LState) int {
@@ -8134,13 +8134,13 @@ func triggerFunctions(l *lua.LState) {
 	luaRegister(l, "fightScreenState", func(*lua.LState) int {
 		switch strings.ToLower(strArg(l, 1)) {
 		case "fightdisplay":
-			l.Push(lua.LBool(sys.lifebar.ro.fightDisplayPhase == 1))
+			l.Push(lua.LBool(sys.fightScreen.ro.fightDisplayPhase == 1))
 		case "kodisplay":
-			l.Push(lua.LBool(sys.lifebar.ro.koDisplayPhase == 1))
+			l.Push(lua.LBool(sys.fightScreen.ro.koDisplayPhase == 1))
 		case "rounddisplay":
-			l.Push(lua.LBool(sys.lifebar.ro.roundDisplayPhase == 1))
+			l.Push(lua.LBool(sys.fightScreen.ro.roundDisplayPhase == 1))
 		case "windisplay":
-			l.Push(lua.LBool(sys.lifebar.ro.winDisplayPhase == 1))
+			l.Push(lua.LBool(sys.fightScreen.ro.winDisplayPhase == 1))
 		default:
 			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}
@@ -8149,31 +8149,31 @@ func triggerFunctions(l *lua.LState) {
 	luaRegister(l, "fightScreenVar", func(*lua.LState) int {
 		switch strings.ToLower(strArg(l, 1)) {
 		case "info.name":
-			l.Push(lua.LString(sys.lifebar.name))
+			l.Push(lua.LString(sys.fightScreen.name))
 		case "info.localcoord.x":
-			l.Push(lua.LNumber(sys.lifebar.localcoord[0]))
+			l.Push(lua.LNumber(sys.fightScreen.localcoord[0]))
 		case "info.localcoord.y":
-			l.Push(lua.LNumber(sys.lifebar.localcoord[1]))
+			l.Push(lua.LNumber(sys.fightScreen.localcoord[1]))
 		case "info.author":
-			l.Push(lua.LString(sys.lifebar.author))
+			l.Push(lua.LString(sys.fightScreen.author))
 		case "round.ctrl.time":
-			l.Push(lua.LNumber(sys.lifebar.ro.ctrl_time))
+			l.Push(lua.LNumber(sys.fightScreen.ro.ctrl_time))
 		case "round.over.hittime":
-			l.Push(lua.LNumber(sys.lifebar.ro.over_hittime))
+			l.Push(lua.LNumber(sys.fightScreen.ro.over_hittime))
 		case "round.over.time":
-			l.Push(lua.LNumber(sys.lifebar.ro.over_time))
+			l.Push(lua.LNumber(sys.fightScreen.ro.over_time))
 		case "round.over.waittime":
-			l.Push(lua.LNumber(sys.lifebar.ro.over_waittime))
+			l.Push(lua.LNumber(sys.fightScreen.ro.over_waittime))
 		case "round.over.wintime":
-			l.Push(lua.LNumber(sys.lifebar.ro.over_wintime))
+			l.Push(lua.LNumber(sys.fightScreen.ro.over_wintime))
 		case "round.slow.time":
-			l.Push(lua.LNumber(sys.lifebar.ro.slow_time))
+			l.Push(lua.LNumber(sys.fightScreen.ro.slow_time))
 		case "round.start.waittime":
-			l.Push(lua.LNumber(sys.lifebar.ro.start_waittime))
+			l.Push(lua.LNumber(sys.fightScreen.ro.start_waittime))
 		case "round.callfight.time":
-			l.Push(lua.LNumber(sys.lifebar.ro.callfight_time))
+			l.Push(lua.LNumber(sys.fightScreen.ro.callfight_time))
 		case "time.framespercount":
-			l.Push(lua.LNumber(sys.lifebar.ti.framespercount))
+			l.Push(lua.LNumber(sys.fightScreen.ti.framespercount))
 		default:
 			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}

--- a/src/stage.go
+++ b/src/stage.go
@@ -279,6 +279,8 @@ func readBackGround(is IniSection, link *backGround,
 			if a := at.get(bg.actionno); a != nil {
 				bg.anim = a
 				hasAnim = true
+			} else {
+				return nil, Error(fmt.Sprint("Missing action: %d", bg.actionno))
 			}
 		}
 		if hasAnim {
@@ -290,6 +292,7 @@ func readBackGround(is IniSection, link *backGround,
 			if is.readI32ForStage("spriteno", &g, &n) {
 				bg.anim.frames = []AnimFrame{*newAnimFrame()}
 				bg.anim.frames[0].Group, bg.anim.frames[0].Number = g, n
+				// To return an error for a missing sprite we'd need to read the SFF, which would slow this down
 			}
 			if is.ReadI32("mask", &tmp) {
 				if tmp != 0 {

--- a/src/state.go
+++ b/src/state.go
@@ -121,7 +121,7 @@ type GameState struct {
 	workpal        []uint32
 	keyConfig      []KeyConfig
 	joystickConfig []KeyConfig
-	lifebar        Lifebar
+	fightScreen    FightScreen
 	motif          Motif
 	storyboard     Storyboard
 	cgi            [MaxPlayerNo]CharGlobalInfo
@@ -137,7 +137,7 @@ type GameState struct {
 	//stringPool      [MaxPlayerNo]StringPool // Only mutated while compiling
 	dialogueFlg bool
 
-	// LifeBar
+	// FightScreen
 	timerCount []int32
 
 	commandLists []*CommandList
@@ -205,7 +205,7 @@ func (gs *GameState) LoadState(stateID int) {
 	sys.workpal = make([]uint32, len(gs.workpal)) //arena.MakeSlice[uint32](a, len(gs.workpal), len(gs.workpal))
 	copy(sys.workpal, gs.workpal)
 
-	sys.lifebar = gs.lifebar.Clone(a)
+	sys.fightScreen = gs.fightScreen.Clone(a)
 	sys.motif = gs.motif.Clone(a, gs.postMatchFlg)
 
 	// Storyboard: only rollback-touch it when it was actually running.
@@ -315,7 +315,7 @@ func (gs *GameState) SaveState(stateID int) {
 	gs.workpal = make([]uint32, len(sys.workpal)) //arena.MakeSlice[uint32](a, len(sys.workpal), len(sys.workpal))
 	copy(gs.workpal, sys.workpal)
 
-	gs.lifebar = sys.lifebar.Clone(a)
+	gs.fightScreen = sys.fightScreen.Clone(a)
 	gs.motif = sys.motif.Clone(a, sys.postMatchFlg)
 
 	// Storyboard: only rollback-save while active.

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -468,141 +468,141 @@ func (cl *CommandList) Clone(a *arena.Arena) (result CommandList) {
 	return
 }
 
-func (l *Lifebar) Clone(a *arena.Arena) (result Lifebar) {
-	result = *l
+func (fs *FightScreen) Clone(a *arena.Arena) (result FightScreen) {
+	result = *fs
 
 	// Round
-	if l.ro != nil {
-		result.ro = &LifeBarRound{} // Shallow copy
-		*result.ro = *l.ro
+	if fs.ro != nil {
+		result.ro = &FightScreenRound{} // Shallow copy
+		*result.ro = *fs.ro
 		// Fade state
-		result.ro.fadeIn = l.ro.fadeIn.Clone(a)
-		result.ro.fadeOut = l.ro.fadeOut.Clone(a)
+		result.ro.fadeIn = fs.ro.fadeIn.Clone(a)
+		result.ro.fadeOut = fs.ro.fadeOut.Clone(a)
 	}
 
 	// WinCount
-	for i := 0; i < len(l.wc); i++ {
-		if l.wc[i] != nil {
-			result.wc[i] = arena.New[LifeBarWinCount](a)
-			*result.wc[i] = *l.wc[i]
+	for i := 0; i < len(fs.wc); i++ {
+		if fs.wc[i] != nil {
+			result.wc[i] = arena.New[FightScreenWinCount](a)
+			*result.wc[i] = *fs.wc[i]
 		}
 	}
 
 	// Combo
-	for i := 0; i < len(l.co); i++ {
-		if l.co[i] != nil {
-			result.co[i] = arena.New[LifeBarCombo](a)
-			*result.co[i] = *l.co[i]
+	for i := 0; i < len(fs.co); i++ {
+		if fs.co[i] != nil {
+			result.co[i] = arena.New[FightScreenCombo](a)
+			*result.co[i] = *fs.co[i]
 		}
 	}
 
 	// Score
-	for i := 0; i < len(l.sc); i++ {
-		if l.sc[i] != nil {
-			result.sc[i] = arena.New[LifeBarScore](a)
-			*result.sc[i] = *l.sc[i]
+	for i := 0; i < len(fs.sc); i++ {
+		if fs.sc[i] != nil {
+			result.sc[i] = arena.New[FightScreenScore](a)
+			*result.sc[i] = *fs.sc[i]
 		}
 	}
 
 	// We probably don't need a deep copy of these
 	/*
 		//UIT
-		if l.ti != nil {
-			result.ti = arena.New[LifeBarTime](a)
-			*result.ti = *l.ti
+		if fs.ti != nil {
+			result.ti = arena.New[FightScreenTime](a)
+			*result.ti = *fs.ti
 		}
 		//
 
 		// Not UIT adding anyway
-		if l.ma != nil {
-			result.ma = arena.New[LifeBarMatch](a)
-			*result.ma = *l.ma
+		if fs.ma != nil {
+			result.ma = arena.New[FightScreenMatch](a)
+			*result.ma = *fs.ma
 		}
 
-		for i := 0; i < len(l.ai); i++ {
-			result.ai[i] = arena.New[LifeBarAiLevel](a)
-			*result.ai[i] = *l.ai[i]
+		for i := 0; i < len(fs.ai); i++ {
+			result.ai[i] = arena.New[FightScreenAiLevel](a)
+			*result.ai[i] = *fs.ai[i]
 		}
 
-		if l.tr != nil {
-			result.tr = arena.New[LifeBarTimer](a)
-			*result.tr = *l.tr
+		if fs.tr != nil {
+			result.tr = arena.New[FightScreenTimer](a)
+			*result.tr = *fs.tr
 		}
 		//
 
 		// Order
 		for i := range result.order {
-			result.order[i] = arena.MakeSlice[int](a, len(l.order[i]), len(l.order[i]))
-			copy(result.order[i], l.order[i])
+			result.order[i] = arena.MakeSlice[int](a, len(fs.order[i]), len(fs.order[i]))
+			copy(result.order[i], fs.order[i])
 		}
 
 		// HealthBar
 		for i := range result.hb {
-			result.hb[i] = arena.MakeSlice[*HealthBar](a, len(l.hb[i]), len(l.hb[i]))
-			for j := 0; j < len(l.hb[i]); j++ {
+			result.hb[i] = arena.MakeSlice[*HealthBar](a, len(fs.hb[i]), len(fs.hb[i]))
+			for j := 0; j < len(fs.hb[i]); j++ {
 				result.hb[i][j] = arena.New[HealthBar](a)
-				*result.hb[i][j] = *l.hb[i][j]
+				*result.hb[i][j] = *fs.hb[i][j]
 			}
 		}
 
 		// PowerBar
 		for i := range result.pb {
-			result.pb[i] = arena.MakeSlice[*PowerBar](a, len(l.pb[i]), len(l.pb[i]))
-			for j := 0; j < len(l.pb[i]); j++ {
+			result.pb[i] = arena.MakeSlice[*PowerBar](a, len(fs.pb[i]), len(fs.pb[i]))
+			for j := 0; j < len(fs.pb[i]); j++ {
 				result.pb[i][j] = arena.New[PowerBar](a)
-				*result.pb[i][j] = *l.pb[i][j]
+				*result.pb[i][j] = *fs.pb[i][j]
 			}
 		}
 
 		// GuardBar
 		for i := range result.gb {
-			result.gb[i] = arena.MakeSlice[*GuardBar](a, len(l.gb[i]), len(l.gb[i]))
-			for j := 0; j < len(l.gb[i]); j++ {
+			result.gb[i] = arena.MakeSlice[*GuardBar](a, len(fs.gb[i]), len(fs.gb[i]))
+			for j := 0; j < len(fs.gb[i]); j++ {
 				result.gb[i][j] = arena.New[GuardBar](a)
-				*result.gb[i][j] = *l.gb[i][j]
+				*result.gb[i][j] = *fs.gb[i][j]
 			}
 		}
 
 		// StunBar
 		for i := range result.sb {
-			result.sb[i] = arena.MakeSlice[*StunBar](a, len(l.sb[i]), len(l.sb[i]))
-			for j := 0; j < len(l.sb[i]); j++ {
+			result.sb[i] = arena.MakeSlice[*StunBar](a, len(fs.sb[i]), len(fs.sb[i]))
+			for j := 0; j < len(fs.sb[i]); j++ {
 				result.sb[i][j] = arena.New[StunBar](a)
-				*result.sb[i][j] = *l.sb[i][j]
+				*result.sb[i][j] = *fs.sb[i][j]
 			}
 		}
 
 		// Face
 		for i := range result.fa {
-			result.fa[i] = arena.MakeSlice[*LifeBarFace](a, len(l.fa[i]), len(l.fa[i]))
-			for j := 0; j < len(l.fa[i]); j++ {
-				result.fa[i][j] = arena.New[LifeBarFace](a)
-				*result.fa[i][j] = *l.fa[i][j]
+			result.fa[i] = arena.MakeSlice[*FightScreenFace](a, len(fs.fa[i]), len(fs.fa[i]))
+			for j := 0; j < len(fs.fa[i]); j++ {
+				result.fa[i][j] = arena.New[FightScreenFace](a)
+				*result.fa[i][j] = *fs.fa[i][j]
 			}
 		}
 
 		// Name
 		for i := range result.nm {
-			result.nm[i] = arena.MakeSlice[*LifeBarName](a, len(l.nm[i]), len(l.nm[i]))
-			for j := 0; j < len(l.nm[i]); j++ {
-				result.nm[i][j] = arena.New[LifeBarName](a)
-				*result.nm[i][j] = *l.nm[i][j]
+			result.nm[i] = arena.MakeSlice[*FightScreenName](a, len(fs.nm[i]), len(fs.nm[i]))
+			for j := 0; j < len(fs.nm[i]); j++ {
+				result.nm[i][j] = arena.New[FightScreenName](a)
+				*result.nm[i][j] = *fs.nm[i][j]
 			}
 		}
 	*/
 
 	// Action
 	for i := range result.ac {
-		if l.ac[i] != nil {
-			result.ac[i] = arena.New[LifeBarAction](a)
+		if fs.ac[i] != nil {
+			result.ac[i] = arena.New[FightScreenAction](a)
 
-			*result.ac[i] = *l.ac[i]
+			*result.ac[i] = *fs.ac[i]
 
-			if l.ac[i].messages != nil {
-				result.ac[i].messages = arena.MakeSlice[*LbMsg](a, len(l.ac[i].messages), len(l.ac[i].messages))
-				for j := 0; j < len(l.ac[i].messages); j++ {
-					result.ac[i].messages[j] = arena.New[LbMsg](a)
-					*result.ac[i].messages[j] = *l.ac[i].messages[j]
+			if fs.ac[i].messages != nil {
+				result.ac[i].messages = arena.MakeSlice[*FSMsg](a, len(fs.ac[i].messages), len(fs.ac[i].messages))
+				for j := 0; j < len(fs.ac[i].messages); j++ {
+					result.ac[i].messages[j] = arena.New[FSMsg](a)
+					*result.ac[i].messages[j] = *fs.ac[i].messages[j]
 				}
 			}
 		}

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -472,35 +472,35 @@ func (fs *FightScreen) Clone(a *arena.Arena) (result FightScreen) {
 	result = *fs
 
 	// Round
-	if fs.ro != nil {
-		result.ro = &FightScreenRound{} // Shallow copy
-		*result.ro = *fs.ro
+	if fs.round != nil {
+		result.round = &FightScreenRound{} // Shallow copy
+		*result.round = *fs.round
 		// Fade state
-		result.ro.fadeIn = fs.ro.fadeIn.Clone(a)
-		result.ro.fadeOut = fs.ro.fadeOut.Clone(a)
+		result.round.fadeIn = fs.round.fadeIn.Clone(a)
+		result.round.fadeOut = fs.round.fadeOut.Clone(a)
 	}
 
 	// WinCount
-	for i := 0; i < len(fs.wc); i++ {
-		if fs.wc[i] != nil {
-			result.wc[i] = arena.New[FightScreenWinCount](a)
-			*result.wc[i] = *fs.wc[i]
+	for i := 0; i < len(fs.winCounts); i++ {
+		if fs.winCounts[i] != nil {
+			result.winCounts[i] = arena.New[FightScreenWinCount](a)
+			*result.winCounts[i] = *fs.winCounts[i]
 		}
 	}
 
 	// Combo
-	for i := 0; i < len(fs.co); i++ {
-		if fs.co[i] != nil {
-			result.co[i] = arena.New[FightScreenCombo](a)
-			*result.co[i] = *fs.co[i]
+	for i := 0; i < len(fs.combos); i++ {
+		if fs.combos[i] != nil {
+			result.combos[i] = arena.New[FightScreenCombo](a)
+			*result.combos[i] = *fs.combos[i]
 		}
 	}
 
 	// Score
-	for i := 0; i < len(fs.sc); i++ {
-		if fs.sc[i] != nil {
-			result.sc[i] = arena.New[FightScreenScore](a)
-			*result.sc[i] = *fs.sc[i]
+	for i := 0; i < len(fs.scores); i++ {
+		if fs.scores[i] != nil {
+			result.scores[i] = arena.New[FightScreenScore](a)
+			*result.scores[i] = *fs.scores[i]
 		}
 	}
 
@@ -520,8 +520,8 @@ func (fs *FightScreen) Clone(a *arena.Arena) (result FightScreen) {
 		}
 
 		for i := 0; i < len(fs.ai); i++ {
-			result.ai[i] = arena.New[FightScreenAiLevel](a)
-			*result.ai[i] = *fs.ai[i]
+			result.aiLevels[i] = arena.New[FightScreenAiLevel](a)
+			*result.aiLevels[i] = *fs.aiLevels[i]
 		}
 
 		if fs.tr != nil {
@@ -574,35 +574,35 @@ func (fs *FightScreen) Clone(a *arena.Arena) (result FightScreen) {
 
 		// Face
 		for i := range result.fa {
-			result.fa[i] = arena.MakeSlice[*FightScreenFace](a, len(fs.fa[i]), len(fs.fa[i]))
-			for j := 0; j < len(fs.fa[i]); j++ {
-				result.fa[i][j] = arena.New[FightScreenFace](a)
-				*result.fa[i][j] = *fs.fa[i][j]
+			result.faces[i] = arena.MakeSlice[*FightScreenFace](a, len(fs.faces[i]), len(fs.faces[i]))
+			for j := 0; j < len(fs.faces[i]); j++ {
+				result.faces[i][j] = arena.New[FightScreenFace](a)
+				*result.faces[i][j] = *fs.faces[i][j]
 			}
 		}
 
 		// Name
 		for i := range result.nm {
-			result.nm[i] = arena.MakeSlice[*FightScreenName](a, len(fs.nm[i]), len(fs.nm[i]))
-			for j := 0; j < len(fs.nm[i]); j++ {
-				result.nm[i][j] = arena.New[FightScreenName](a)
-				*result.nm[i][j] = *fs.nm[i][j]
+			result.names[i] = arena.MakeSlice[*FightScreenName](a, len(fs.names[i]), len(fs.names[i]))
+			for j := 0; j < len(fs.names[i]); j++ {
+				result.names[i][j] = arena.New[FightScreenName](a)
+				*result.names[i][j] = *fs.names[i][j]
 			}
 		}
 	*/
 
 	// Action
-	for i := range result.ac {
-		if fs.ac[i] != nil {
-			result.ac[i] = arena.New[FightScreenAction](a)
+	for i := range result.actions {
+		if fs.actions[i] != nil {
+			result.actions[i] = arena.New[FightScreenAction](a)
 
-			*result.ac[i] = *fs.ac[i]
+			*result.actions[i] = *fs.actions[i]
 
-			if fs.ac[i].messages != nil {
-				result.ac[i].messages = arena.MakeSlice[*FSMsg](a, len(fs.ac[i].messages), len(fs.ac[i].messages))
-				for j := 0; j < len(fs.ac[i].messages); j++ {
-					result.ac[i].messages[j] = arena.New[FSMsg](a)
-					*result.ac[i].messages[j] = *fs.ac[i].messages[j]
+			if fs.actions[i].messages != nil {
+				result.actions[i].messages = arena.MakeSlice[*FSMsg](a, len(fs.actions[i].messages), len(fs.actions[i].messages))
+				for j := 0; j < len(fs.actions[i].messages); j++ {
+					result.actions[i].messages[j] = arena.New[FSMsg](a)
+					*result.actions[i].messages[j] = *fs.actions[i].messages[j]
 				}
 			}
 		}

--- a/src/stats.go
+++ b/src/stats.go
@@ -213,6 +213,6 @@ func (s *StatsLog) nextRound() {
 	// Record the round into the current stats match.
 	// We fill timers later in finalizeMatch.
 	roundIdx := sys.round
-	roundScore := [2]int32{int32(sys.lifebar.sc[0].scorePoints), int32(sys.lifebar.sc[1].scorePoints)}
+	roundScore := [2]int32{int32(sys.fightScreen.sc[0].scorePoints), int32(sys.fightScreen.sc[1].scorePoints)}
 	s.addRound(roundIdx, 0, roundScore, fighters)
 }

--- a/src/stats.go
+++ b/src/stats.go
@@ -213,6 +213,6 @@ func (s *StatsLog) nextRound() {
 	// Record the round into the current stats match.
 	// We fill timers later in finalizeMatch.
 	roundIdx := sys.round
-	roundScore := [2]int32{int32(sys.fightScreen.sc[0].scorePoints), int32(sys.fightScreen.sc[1].scorePoints)}
+	roundScore := [2]int32{int32(sys.fightScreen.scores[0].scorePoints), int32(sys.fightScreen.scores[1].scorePoints)}
 	s.addRound(roundIdx, 0, roundScore, fighters)
 }

--- a/src/system.go
+++ b/src/system.go
@@ -1545,12 +1545,12 @@ func (s *System) screenWidth() float32 {
 }
 
 func (s *System) roundEnded() bool {
-	return s.intro < -s.fightScreen.ro.over_hittime
+	return s.intro < -s.fightScreen.round.over_hittime
 }
 
 // Characters cannot hurt each other between fight screen timers over.hittime and over.waittime
 func (s *System) roundNoDamage() bool {
-	return sys.intro < 0 && sys.intro <= -sys.fightScreen.ro.over_hittime && sys.intro >= -sys.fightScreen.ro.over_waittime
+	return sys.intro < 0 && sys.intro <= -sys.fightScreen.round.over_hittime && sys.intro >= -sys.fightScreen.round.over_waittime
 }
 
 // Gametime is the sum of the match time and the screenpack time
@@ -1572,15 +1572,15 @@ func (s *System) gameTime() int32 {
 // That causes more harm than good and is not clearly stated in the documentation, so Ikemen changes it
 func (s *System) roundState() int32 {
 	switch {
-	case sys.intro > sys.fightScreen.ro.ctrl_time+1 || sys.postMatchFlg:
+	case sys.intro > sys.fightScreen.round.ctrl_time+1 || sys.postMatchFlg:
 		return 0
-	//case sys.fightScreen.ro.current == 0:
+	//case sys.fightScreen.round.current == 0:
 	case sys.intro > 0:
 		return 1
 	//case sys.intro >= 0 || sys.finishType == FT_NotYet:
 	case sys.intro == 0 || sys.finishType == FT_NotYet:
 		return 2
-	case sys.intro < -sys.fightScreen.ro.over_waittime:
+	case sys.intro < -sys.fightScreen.round.over_waittime:
 		return 4
 	default:
 		return 3
@@ -1589,23 +1589,23 @@ func (s *System) roundState() int32 {
 
 func (s *System) introState() int32 {
 	switch {
-	case s.intro > s.fightScreen.ro.ctrl_time+1:
+	case s.intro > s.fightScreen.round.ctrl_time+1:
 		// Pre-intro [RoundState = 0]
 		return 1
-	case (s.motif.di.active && s.dialogueForce == 0) || s.intro == s.fightScreen.ro.ctrl_time+1:
+	case (s.motif.di.active && s.dialogueForce == 0) || s.intro == s.fightScreen.round.ctrl_time+1:
 		// Player intros [RoundState = 1]
 		return 2
-	case s.intro == s.fightScreen.ro.ctrl_time:
+	case s.intro == s.fightScreen.round.ctrl_time:
 		// Dialogue detection (s.motif.di.active is detectable 1 frame later)
 		if s.motif.isDialogueSet() {
 			return 2
 		}
 		// Round announcement
 		return 3
-	case s.intro > 0 && s.intro < s.fightScreen.ro.ctrl_time:
+	case s.intro > 0 && s.intro < s.fightScreen.round.ctrl_time:
 		// Fight called
 		// Used to check both these conditions, but refactors revealed that was probably wrong
-		//s.fightScreen.ro.fight_timing.animTimer == -1 || (s.intro > 0 && s.intro < s.fightScreen.ro.ctrl_time)
+		//s.fightScreen.round.fight_timing.animTimer == -1 || (s.intro > 0 && s.intro < s.fightScreen.round.ctrl_time)
 		return 4
 	default:
 		// Not applicable
@@ -1624,10 +1624,10 @@ func (s *System) outroState() int32 {
 	case s.winposetime <= 0:
 		// Player win states
 		return 4
-	case sys.intro <= -sys.fightScreen.ro.over_waittime && sys.winposetime > 0:
+	case sys.intro <= -sys.fightScreen.round.over_waittime && sys.winposetime > 0:
 		// Players lose control, but the round has not yet entered win states
 		return 3
-	case s.intro < -s.fightScreen.ro.over_hittime || sys.fightScreen.ro.over_hittime == 1:
+	case s.intro < -s.fightScreen.round.over_hittime || sys.fightScreen.round.over_hittime == 1:
 		// Players still have control, but the match outcome can no longer be changed
 		return 2
 	case s.intro < 0:
@@ -1640,11 +1640,11 @@ func (s *System) outroState() int32 {
 }
 
 func (s *System) roundOver() bool {
-	return s.intro < -(s.fightScreen.ro.over_waittime + s.fightScreen.ro.overTime())
+	return s.intro < -(s.fightScreen.round.over_waittime + s.fightScreen.round.overTime())
 }
 
 func (s *System) roundStateTicks() int32 {
-	return s.intro + s.fightScreen.ro.over_waittime + s.fightScreen.ro.overTime()
+	return s.intro + s.fightScreen.round.over_waittime + s.fightScreen.round.overTime()
 }
 
 // Check if the match consists of a single round
@@ -2137,11 +2137,11 @@ func (s *System) resetRoundState() {
 	s.winTrigger = [...]WinType{WT_Normal, WT_Normal}
 	s.effectiveLoss = [2]bool{false, false}
 	s.lastHitter = [2]int{-1, -1}
-	s.slowtime = s.fightScreen.ro.slow_time
-	s.winposetime = s.fightScreen.ro.over_wintime
-	s.winwaittime = s.fightScreen.ro.over_waittime + s.fightScreen.ro.over_forcewintime
+	s.slowtime = s.fightScreen.round.slow_time
+	s.winposetime = s.fightScreen.round.over_wintime
+	s.winwaittime = s.fightScreen.round.over_waittime + s.fightScreen.round.over_forcewintime
 	s.winskipped = false
-	s.intro = s.fightScreen.ro.start_waittime + s.fightScreen.ro.ctrl_time + 1
+	s.intro = s.fightScreen.round.start_waittime + s.fightScreen.round.ctrl_time + 1
 	s.curRoundTime = s.maxRoundTime
 	s.curPlayTime = 0
 	// Mugen resets the starting ID between matches but not between rounds
@@ -2385,19 +2385,19 @@ func (s *System) runIntroSkip() {
 	}
 
 	// If too late to skip intros
-	if s.intro <= s.fightScreen.ro.ctrl_time || s.fightScreen.ro.roundDisplayPhase >= 1 { // Latter is probably redundant
+	if s.intro <= s.fightScreen.round.ctrl_time || s.fightScreen.round.roundDisplayPhase >= 1 { // Latter is probably redundant
 		return
 	}
 
 	// Start shutter effect on button press
-	if s.fightScreen.ro.shutterTimer == 0 && s.anyButton() {
-		s.fightScreen.ro.shutterTimer = s.fightScreen.ro.shutter_time * 2 // Open + close time
+	if s.fightScreen.round.shutterTimer == 0 && s.anyButton() {
+		s.fightScreen.round.shutterTimer = s.fightScreen.round.shutter_time * 2 // Open + close time
 	}
 
 	// Skip intros when signal from shutter animation arrives
 	if s.introSkipCall {
 		s.introSkipCall = false
-		s.intro = s.fightScreen.ro.ctrl_time
+		s.intro = s.fightScreen.round.ctrl_time
 
 		// SkipRoundDisplay and SkipFightDisplay flags must be preserved during intro skip frame
 		kept := (s.specialFlag & GSF_skiprounddisplay) | (s.specialFlag & GSF_skipfightdisplay)
@@ -2568,8 +2568,8 @@ func (s *System) action() {
 		// KO slowdown
 		if st := s.getSlowtime(); st > 0 {
 			if !s.gsf(GSF_nokoslow) {
-				base := s.fightScreen.ro.slow_speed
-				fade := s.fightScreen.ro.slow_fadetime
+				base := s.fightScreen.round.slow_speed
+				fade := s.fightScreen.round.slow_fadetime
 				spd *= base
 				if st < fade {
 					ratio := float32(fade-st) / float32(fade)
@@ -2827,7 +2827,7 @@ func (s *System) timeTotal() int32 {
 	for _, v := range s.timerRounds {
 		t += v
 	}
-	if s.fightScreen.ro.timerActive {
+	if s.fightScreen.round.timerActive {
 		t += s.timeElapsed()
 	}
 	return t
@@ -2860,7 +2860,7 @@ func (s *System) shouldStartMatchEndDialogue() bool {
 	if s.motif.di.active || s.motif.di.initialized {
 		return false
 	}
-	return s.intro+s.fightScreen.ro.over_waittime+s.fightScreen.ro.over_time <= 0
+	return s.intro+s.fightScreen.round.over_waittime+s.fightScreen.round.over_time <= 0
 }
 
 func (s *System) holdPostMatchForDialogue() bool {
@@ -2873,7 +2873,7 @@ func (s *System) holdPostMatchForDialogue() bool {
 	if s.shouldStartMatchEndDialogue() {
 		return true
 	}
-	if s.motif.di.matchEndDone && s.fightScreen.ro.fadeOut.isActive() {
+	if s.motif.di.matchEndDone && s.fightScreen.round.fadeOut.isActive() {
 		return true
 	}
 	return false
@@ -2882,12 +2882,12 @@ func (s *System) holdPostMatchForDialogue() bool {
 // Step sys.intro timer and execute related tasks
 func (s *System) stepRoundState() {
 	// Freeze round state if round animations cannot advance
-	if !s.fightScreen.ro.act() {
+	if !s.fightScreen.round.act() {
 		return
 	}
 
 	// Fading
-	if !(s.fightScreen.ro.fadeOut.isActive() || s.fightScreen.ro.fadeIn.isActive()) {
+	if !(s.fightScreen.round.fadeOut.isActive() || s.fightScreen.round.fadeIn.isActive()) {
 		if s.motif.fadeOut.isActive() {
 			s.motif.fadeOut.step()
 		} else if s.motif.fadeIn.isActive() {
@@ -2896,13 +2896,13 @@ func (s *System) stepRoundState() {
 	}
 
 	// Intros
-	if s.intro > s.fightScreen.ro.ctrl_time {
+	if s.intro > s.fightScreen.round.ctrl_time {
 		s.intro--
-		if s.gsf(GSF_intro) && s.intro <= s.fightScreen.ro.ctrl_time {
-			s.intro = s.fightScreen.ro.ctrl_time + 1
+		if s.gsf(GSF_intro) && s.intro <= s.fightScreen.round.ctrl_time {
+			s.intro = s.fightScreen.round.ctrl_time + 1
 		}
 	} else if s.intro > 0 {
-		if s.intro == s.fightScreen.ro.ctrl_time {
+		if s.intro == s.fightScreen.round.ctrl_time {
 			for _, p := range s.chars {
 				if len(p) > 0 {
 					if p[0].activelyFighting() && !p[0].asf(ASF_nointroreset) {
@@ -2941,13 +2941,13 @@ func (s *System) stepRoundState() {
 
 	// Post round
 	if s.roundEnded() || s.roundEndDecision() {
-		rs4t := -s.fightScreen.ro.over_waittime
-		fadeoutStart := rs4t - 2 - s.fightScreen.ro.overTime() + s.fightScreen.ro.fadeOut.time
+		rs4t := -s.fightScreen.round.over_waittime
+		fadeoutStart := rs4t - 2 - s.fightScreen.round.overTime() + s.fightScreen.round.fadeOut.time
 		matchEndDialoguePending := s.matchEndDialoguePending()
 
 		s.intro--
 
-		if s.intro == -s.fightScreen.ro.over_hittime && s.finishType != FT_NotYet {
+		if s.intro == -s.fightScreen.round.over_hittime && s.finishType != FT_NotYet {
 			// Consecutive wins counter
 			winner := [2]bool{s.effectiveLoss[1], s.effectiveLoss[0]}
 			if !winner[0] || !winner[1] ||
@@ -2972,8 +2972,8 @@ func (s *System) stepRoundState() {
 		}
 		// Match-end dialogue takes priority over the round transition until it finishes.
 		if matchEndDialoguePending && !s.motif.di.active && !s.motif.di.matchEndDone {
-			if s.fightScreen.ro.fadeOut.isActive() {
-				s.fightScreen.ro.fadeOut.reset()
+			if s.fightScreen.round.fadeOut.isActive() {
+				s.fightScreen.round.fadeOut.reset()
 			}
 		}
 
@@ -2982,8 +2982,8 @@ func (s *System) stepRoundState() {
 		if !matchEndDialoguePending &&
 			s.intro == fadeoutStart &&
 			(!s.gsf(GSF_roundnotover) || s.winskipped) &&
-			!s.motif.di.active && !s.fightScreen.ro.fadeOut.isActive() {
-			s.fightScreen.ro.fadeOut.init(s.fightScreen.ro.fadeOut, false)
+			!s.motif.di.active && !s.fightScreen.round.fadeOut.isActive() {
+			s.fightScreen.round.fadeOut.init(s.fightScreen.round.fadeOut, false)
 		}
 
 		// Before win poses
@@ -3033,15 +3033,15 @@ func (s *System) stepRoundState() {
 			if winner[0] || winner[1] {
 				for i, win := range winner {
 					if win {
-						s.fightScreen.wi[i].add(s.winType[i])
+						s.fightScreen.winIcons[i].add(s.winType[i])
 						if s.matchOver() {
 							// In a draw game both players go back to 0 wins
 							if winner[0] == winner[1] {
-								s.fightScreen.wc[0].wins = 0
-								s.fightScreen.wc[1].wins = 0
+								s.fightScreen.winCounts[0].wins = 0
+								s.fightScreen.winCounts[1].wins = 0
 							} else {
 								if s.wins[i] >= s.matchWins[i] {
-									s.fightScreen.wc[i].wins++
+									s.fightScreen.winCounts[i].wins++
 								}
 							}
 						}
@@ -3106,7 +3106,7 @@ func (s *System) roundEndDecision() bool {
 	}
 
 	checkClutch := func(team int) bool {
-		clutchRatio := float32(s.fightScreen.ro.clutch_threshold) / 100.0
+		clutchRatio := float32(s.fightScreen.round.clutch_threshold) / 100.0
 		for i := team; i < MaxSimul*2; i += 2 {
 			if len(s.chars[i]) > 0 {
 				char := s.chars[i][0]
@@ -3698,7 +3698,7 @@ func (s *System) runMatch() (reload bool) {
 			break
 		}
 
-		if s.endMatch && !s.fightScreen.ro.fadeOut.isActive() {
+		if s.endMatch && !s.fightScreen.round.fadeOut.isActive() {
 			break
 		}
 
@@ -3857,7 +3857,7 @@ func (s *System) runNextRound() bool {
 		}
 		s.clearAllSound()
 		s.statsLog.nextRound()
-		s.scoreRounds = append(s.scoreRounds, [2]float32{s.fightScreen.sc[0].scorePoints, s.fightScreen.sc[1].scorePoints})
+		s.scoreRounds = append(s.scoreRounds, [2]float32{s.fightScreen.scores[0].scorePoints, s.fightScreen.scores[1].scorePoints})
 
 		if !s.matchOver() &&
 			!(s.tmode[0] == TM_Turns && s.effectiveLoss[0]) &&
@@ -5097,9 +5097,9 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 
 	// Prepare fight screen portraits and names for Turns mode
 	if !attached {
-		if pn < len(sys.fightScreen.fa[sys.tmode[pn&1]]) && sys.tmode[pn&1] == TM_Turns && sys.round == 1 {
-			fa := sys.fightScreen.fa[sys.tmode[pn&1]][pn]
-			nm := sys.fightScreen.nm[sys.tmode[pn&1]][pn]
+		if pn < len(sys.fightScreen.faces[sys.tmode[pn&1]]) && sys.tmode[pn&1] == TM_Turns && sys.round == 1 {
+			fa := sys.fightScreen.faces[sys.tmode[pn&1]][pn]
+			nm := sys.fightScreen.names[sys.tmode[pn&1]][pn]
 			l.prepareTurnsFaces(pn, fa, nm, teamChars)
 		}
 	}

--- a/src/system.go
+++ b/src/system.go
@@ -103,7 +103,7 @@ type SystemStateVars struct {
 	roundResetMatchStart    bool
 	reloadFlg               bool
 	reloadStageFlg          bool
-	reloadLifebarFlg        bool
+	reloadFightScreenFlg    bool
 	reloadCharSlot          [MaxPlayerNo]bool
 	turbo                   float32
 	drawScale               float32
@@ -232,7 +232,7 @@ type System struct {
 	charSoundChannels   [MaxPlayerNo]SoundChannels
 	allPalFX            *PalFX
 	bgPalFX             *PalFX
-	lifebar             Lifebar
+	fightScreen         FightScreen
 	motif               Motif
 	storyboard          Storyboard
 	cfg                 Config
@@ -1545,12 +1545,12 @@ func (s *System) screenWidth() float32 {
 }
 
 func (s *System) roundEnded() bool {
-	return s.intro < -s.lifebar.ro.over_hittime
+	return s.intro < -s.fightScreen.ro.over_hittime
 }
 
-// Characters cannot hurt each other between lifebar timers over.hittime and over.waittime
+// Characters cannot hurt each other between fight screen timers over.hittime and over.waittime
 func (s *System) roundNoDamage() bool {
-	return sys.intro < 0 && sys.intro <= -sys.lifebar.ro.over_hittime && sys.intro >= -sys.lifebar.ro.over_waittime
+	return sys.intro < 0 && sys.intro <= -sys.fightScreen.ro.over_hittime && sys.intro >= -sys.fightScreen.ro.over_waittime
 }
 
 // Gametime is the sum of the match time and the screenpack time
@@ -1572,15 +1572,15 @@ func (s *System) gameTime() int32 {
 // That causes more harm than good and is not clearly stated in the documentation, so Ikemen changes it
 func (s *System) roundState() int32 {
 	switch {
-	case sys.intro > sys.lifebar.ro.ctrl_time+1 || sys.postMatchFlg:
+	case sys.intro > sys.fightScreen.ro.ctrl_time+1 || sys.postMatchFlg:
 		return 0
-	//case sys.lifebar.ro.current == 0:
+	//case sys.fightScreen.ro.current == 0:
 	case sys.intro > 0:
 		return 1
 	//case sys.intro >= 0 || sys.finishType == FT_NotYet:
 	case sys.intro == 0 || sys.finishType == FT_NotYet:
 		return 2
-	case sys.intro < -sys.lifebar.ro.over_waittime:
+	case sys.intro < -sys.fightScreen.ro.over_waittime:
 		return 4
 	default:
 		return 3
@@ -1589,23 +1589,23 @@ func (s *System) roundState() int32 {
 
 func (s *System) introState() int32 {
 	switch {
-	case s.intro > s.lifebar.ro.ctrl_time+1:
+	case s.intro > s.fightScreen.ro.ctrl_time+1:
 		// Pre-intro [RoundState = 0]
 		return 1
-	case (s.motif.di.active && s.dialogueForce == 0) || s.intro == s.lifebar.ro.ctrl_time+1:
+	case (s.motif.di.active && s.dialogueForce == 0) || s.intro == s.fightScreen.ro.ctrl_time+1:
 		// Player intros [RoundState = 1]
 		return 2
-	case s.intro == s.lifebar.ro.ctrl_time:
+	case s.intro == s.fightScreen.ro.ctrl_time:
 		// Dialogue detection (s.motif.di.active is detectable 1 frame later)
 		if s.motif.isDialogueSet() {
 			return 2
 		}
 		// Round announcement
 		return 3
-	case s.intro > 0 && s.intro < s.lifebar.ro.ctrl_time:
+	case s.intro > 0 && s.intro < s.fightScreen.ro.ctrl_time:
 		// Fight called
 		// Used to check both these conditions, but refactors revealed that was probably wrong
-		//s.lifebar.ro.fight_timing.animTimer == -1 || (s.intro > 0 && s.intro < s.lifebar.ro.ctrl_time)
+		//s.fightScreen.ro.fight_timing.animTimer == -1 || (s.intro > 0 && s.intro < s.fightScreen.ro.ctrl_time)
 		return 4
 	default:
 		// Not applicable
@@ -1624,10 +1624,10 @@ func (s *System) outroState() int32 {
 	case s.winposetime <= 0:
 		// Player win states
 		return 4
-	case sys.intro <= -sys.lifebar.ro.over_waittime && sys.winposetime > 0:
+	case sys.intro <= -sys.fightScreen.ro.over_waittime && sys.winposetime > 0:
 		// Players lose control, but the round has not yet entered win states
 		return 3
-	case s.intro < -s.lifebar.ro.over_hittime || sys.lifebar.ro.over_hittime == 1:
+	case s.intro < -s.fightScreen.ro.over_hittime || sys.fightScreen.ro.over_hittime == 1:
 		// Players still have control, but the match outcome can no longer be changed
 		return 2
 	case s.intro < 0:
@@ -1640,11 +1640,11 @@ func (s *System) outroState() int32 {
 }
 
 func (s *System) roundOver() bool {
-	return s.intro < -(s.lifebar.ro.over_waittime + s.lifebar.ro.overTime())
+	return s.intro < -(s.fightScreen.ro.over_waittime + s.fightScreen.ro.overTime())
 }
 
 func (s *System) roundStateTicks() int32 {
-	return s.intro + s.lifebar.ro.over_waittime + s.lifebar.ro.overTime()
+	return s.intro + s.fightScreen.ro.over_waittime + s.fightScreen.ro.overTime()
 }
 
 // Check if the match consists of a single round
@@ -2123,10 +2123,10 @@ func (s *System) resetRoundState() {
 	s.paused = false
 	s.introSkipCall = false
 	s.roundResetFlg = false
-	s.reloadFlg, s.reloadStageFlg, s.reloadLifebarFlg = false, false, false
+	s.reloadFlg, s.reloadStageFlg, s.reloadFightScreenFlg = false, false, false
 
 	s.resetGblEffect()
-	s.lifebar.reset()
+	s.fightScreen.reset()
 	s.motif.reset()
 	s.saveStateFlag = false
 	s.loadStateFlag = false
@@ -2137,11 +2137,11 @@ func (s *System) resetRoundState() {
 	s.winTrigger = [...]WinType{WT_Normal, WT_Normal}
 	s.effectiveLoss = [2]bool{false, false}
 	s.lastHitter = [2]int{-1, -1}
-	s.slowtime = s.lifebar.ro.slow_time
-	s.winposetime = s.lifebar.ro.over_wintime
-	s.winwaittime = s.lifebar.ro.over_waittime + s.lifebar.ro.over_forcewintime
+	s.slowtime = s.fightScreen.ro.slow_time
+	s.winposetime = s.fightScreen.ro.over_wintime
+	s.winwaittime = s.fightScreen.ro.over_waittime + s.fightScreen.ro.over_forcewintime
 	s.winskipped = false
-	s.intro = s.lifebar.ro.start_waittime + s.lifebar.ro.ctrl_time + 1
+	s.intro = s.fightScreen.ro.start_waittime + s.fightScreen.ro.ctrl_time + 1
 	s.curRoundTime = s.maxRoundTime
 	s.curPlayTime = 0
 	// Mugen resets the starting ID between matches but not between rounds
@@ -2385,19 +2385,19 @@ func (s *System) runIntroSkip() {
 	}
 
 	// If too late to skip intros
-	if s.intro <= s.lifebar.ro.ctrl_time || s.lifebar.ro.roundDisplayPhase >= 1 { // Latter is probably redundant
+	if s.intro <= s.fightScreen.ro.ctrl_time || s.fightScreen.ro.roundDisplayPhase >= 1 { // Latter is probably redundant
 		return
 	}
 
 	// Start shutter effect on button press
-	if s.lifebar.ro.shutterTimer == 0 && s.anyButton() {
-		s.lifebar.ro.shutterTimer = s.lifebar.ro.shutter_time * 2 // Open + close time
+	if s.fightScreen.ro.shutterTimer == 0 && s.anyButton() {
+		s.fightScreen.ro.shutterTimer = s.fightScreen.ro.shutter_time * 2 // Open + close time
 	}
 
 	// Skip intros when signal from shutter animation arrives
 	if s.introSkipCall {
 		s.introSkipCall = false
-		s.intro = s.lifebar.ro.ctrl_time
+		s.intro = s.fightScreen.ro.ctrl_time
 
 		// SkipRoundDisplay and SkipFightDisplay flags must be preserved during intro skip frame
 		kept := (s.specialFlag & GSF_skiprounddisplay) | (s.specialFlag & GSF_skipfightdisplay)
@@ -2516,7 +2516,7 @@ func (s *System) action() {
 	// Update lifebars
 	// This must happen before hit detection for accurate display
 	// Allows a combo to still end if a character is hit in the same frame where it exits movetype H
-	s.lifebar.step()
+	s.fightScreen.step()
 
 	if s.tickNextFrame() {
 		s.globalCollision() // This could perhaps happen during "tick frame" instead? Would need more testing
@@ -2568,8 +2568,8 @@ func (s *System) action() {
 		// KO slowdown
 		if st := s.getSlowtime(); st > 0 {
 			if !s.gsf(GSF_nokoslow) {
-				base := s.lifebar.ro.slow_speed
-				fade := s.lifebar.ro.slow_fadetime
+				base := s.fightScreen.ro.slow_speed
+				fade := s.fightScreen.ro.slow_fadetime
 				spd *= base
 				if st < fade {
 					ratio := float32(fade-st) / float32(fade)
@@ -2827,7 +2827,7 @@ func (s *System) timeTotal() int32 {
 	for _, v := range s.timerRounds {
 		t += v
 	}
-	if s.lifebar.ro.timerActive {
+	if s.fightScreen.ro.timerActive {
 		t += s.timeElapsed()
 	}
 	return t
@@ -2860,7 +2860,7 @@ func (s *System) shouldStartMatchEndDialogue() bool {
 	if s.motif.di.active || s.motif.di.initialized {
 		return false
 	}
-	return s.intro+s.lifebar.ro.over_waittime+s.lifebar.ro.over_time <= 0
+	return s.intro+s.fightScreen.ro.over_waittime+s.fightScreen.ro.over_time <= 0
 }
 
 func (s *System) holdPostMatchForDialogue() bool {
@@ -2873,7 +2873,7 @@ func (s *System) holdPostMatchForDialogue() bool {
 	if s.shouldStartMatchEndDialogue() {
 		return true
 	}
-	if s.motif.di.matchEndDone && s.lifebar.ro.fadeOut.isActive() {
+	if s.motif.di.matchEndDone && s.fightScreen.ro.fadeOut.isActive() {
 		return true
 	}
 	return false
@@ -2882,12 +2882,12 @@ func (s *System) holdPostMatchForDialogue() bool {
 // Step sys.intro timer and execute related tasks
 func (s *System) stepRoundState() {
 	// Freeze round state if round animations cannot advance
-	if !s.lifebar.ro.act() {
+	if !s.fightScreen.ro.act() {
 		return
 	}
 
 	// Fading
-	if !(s.lifebar.ro.fadeOut.isActive() || s.lifebar.ro.fadeIn.isActive()) {
+	if !(s.fightScreen.ro.fadeOut.isActive() || s.fightScreen.ro.fadeIn.isActive()) {
 		if s.motif.fadeOut.isActive() {
 			s.motif.fadeOut.step()
 		} else if s.motif.fadeIn.isActive() {
@@ -2896,13 +2896,13 @@ func (s *System) stepRoundState() {
 	}
 
 	// Intros
-	if s.intro > s.lifebar.ro.ctrl_time {
+	if s.intro > s.fightScreen.ro.ctrl_time {
 		s.intro--
-		if s.gsf(GSF_intro) && s.intro <= s.lifebar.ro.ctrl_time {
-			s.intro = s.lifebar.ro.ctrl_time + 1
+		if s.gsf(GSF_intro) && s.intro <= s.fightScreen.ro.ctrl_time {
+			s.intro = s.fightScreen.ro.ctrl_time + 1
 		}
 	} else if s.intro > 0 {
-		if s.intro == s.lifebar.ro.ctrl_time {
+		if s.intro == s.fightScreen.ro.ctrl_time {
 			for _, p := range s.chars {
 				if len(p) > 0 {
 					if p[0].activelyFighting() && !p[0].asf(ASF_nointroreset) {
@@ -2941,13 +2941,13 @@ func (s *System) stepRoundState() {
 
 	// Post round
 	if s.roundEnded() || s.roundEndDecision() {
-		rs4t := -s.lifebar.ro.over_waittime
-		fadeoutStart := rs4t - 2 - s.lifebar.ro.overTime() + s.lifebar.ro.fadeOut.time
+		rs4t := -s.fightScreen.ro.over_waittime
+		fadeoutStart := rs4t - 2 - s.fightScreen.ro.overTime() + s.fightScreen.ro.fadeOut.time
 		matchEndDialoguePending := s.matchEndDialoguePending()
 
 		s.intro--
 
-		if s.intro == -s.lifebar.ro.over_hittime && s.finishType != FT_NotYet {
+		if s.intro == -s.fightScreen.ro.over_hittime && s.finishType != FT_NotYet {
 			// Consecutive wins counter
 			winner := [2]bool{s.effectiveLoss[1], s.effectiveLoss[0]}
 			if !winner[0] || !winner[1] ||
@@ -2972,8 +2972,8 @@ func (s *System) stepRoundState() {
 		}
 		// Match-end dialogue takes priority over the round transition until it finishes.
 		if matchEndDialoguePending && !s.motif.di.active && !s.motif.di.matchEndDone {
-			if s.lifebar.ro.fadeOut.isActive() {
-				s.lifebar.ro.fadeOut.reset()
+			if s.fightScreen.ro.fadeOut.isActive() {
+				s.fightScreen.ro.fadeOut.reset()
 			}
 		}
 
@@ -2982,8 +2982,8 @@ func (s *System) stepRoundState() {
 		if !matchEndDialoguePending &&
 			s.intro == fadeoutStart &&
 			(!s.gsf(GSF_roundnotover) || s.winskipped) &&
-			!s.motif.di.active && !s.lifebar.ro.fadeOut.isActive() {
-			s.lifebar.ro.fadeOut.init(s.lifebar.ro.fadeOut, false)
+			!s.motif.di.active && !s.fightScreen.ro.fadeOut.isActive() {
+			s.fightScreen.ro.fadeOut.init(s.fightScreen.ro.fadeOut, false)
 		}
 
 		// Before win poses
@@ -3033,15 +3033,15 @@ func (s *System) stepRoundState() {
 			if winner[0] || winner[1] {
 				for i, win := range winner {
 					if win {
-						s.lifebar.wi[i].add(s.winType[i])
+						s.fightScreen.wi[i].add(s.winType[i])
 						if s.matchOver() {
 							// In a draw game both players go back to 0 wins
 							if winner[0] == winner[1] {
-								s.lifebar.wc[0].wins = 0
-								s.lifebar.wc[1].wins = 0
+								s.fightScreen.wc[0].wins = 0
+								s.fightScreen.wc[1].wins = 0
 							} else {
 								if s.wins[i] >= s.matchWins[i] {
-									s.lifebar.wc[i].wins++
+									s.fightScreen.wc[i].wins++
 								}
 							}
 						}
@@ -3106,7 +3106,7 @@ func (s *System) roundEndDecision() bool {
 	}
 
 	checkClutch := func(team int) bool {
-		clutchRatio := float32(s.lifebar.ro.clutch_threshold) / 100.0
+		clutchRatio := float32(s.fightScreen.ro.clutch_threshold) / 100.0
 		for i := team; i < MaxSimul*2; i += 2 {
 			if len(s.chars[i]) > 0 {
 				char := s.chars[i][0]
@@ -3286,8 +3286,8 @@ func (s *System) draw(x, y, scl float32) {
 		// Draw character sprites with special under flag
 		s.spriteList.draw(0, true, x, y, scl*s.cam.BaseScale())
 
-		// Draw lifebar layer -1
-		s.lifebar.draw(-1)
+		// Draw fight screen layer -1
+		s.fightScreen.draw(-1)
 
 		// Draw char texts layer -1
 		s.drawCharTexts(-1)
@@ -3339,8 +3339,8 @@ func (s *System) draw(x, y, scl float32) {
 		//	fade(rect, 0, 255)
 		//}
 
-		// Draw lifebar layer 0
-		s.lifebar.draw(0)
+		// Draw fight screen layer 0
+		s.fightScreen.draw(0)
 
 		// Draw char texts layer 0
 		s.drawCharTexts(0)
@@ -3363,8 +3363,8 @@ func (s *System) draw(x, y, scl float32) {
 		}
 	}
 
-	// Draw lifebar layer 1
-	s.lifebar.draw(1)
+	// Draw fight screen layer 1
+	s.fightScreen.draw(1)
 
 	// Draw char texts layer 1
 	s.drawCharTexts(1)
@@ -3375,8 +3375,8 @@ func (s *System) draw(x, y, scl float32) {
 	// Draw character sprites in layer 1 (old "ontop")
 	s.spriteList.draw(1, false, x, y, scl*s.cam.BaseScale())
 
-	// Draw lifebar layer 2
-	s.lifebar.draw(2)
+	// Draw fight screen layer 2
+	s.fightScreen.draw(2)
 
 	// Draw char texts layer 2
 	s.drawCharTexts(2)
@@ -3698,7 +3698,7 @@ func (s *System) runMatch() (reload bool) {
 			break
 		}
 
-		if s.endMatch && !s.lifebar.ro.fadeOut.isActive() {
+		if s.endMatch && !s.fightScreen.ro.fadeOut.isActive() {
 			break
 		}
 
@@ -3857,7 +3857,7 @@ func (s *System) runNextRound() bool {
 		}
 		s.clearAllSound()
 		s.statsLog.nextRound()
-		s.scoreRounds = append(s.scoreRounds, [2]float32{s.lifebar.sc[0].scorePoints, s.lifebar.sc[1].scorePoints})
+		s.scoreRounds = append(s.scoreRounds, [2]float32{s.fightScreen.sc[0].scorePoints, s.fightScreen.sc[1].scorePoints})
 
 		if !s.matchOver() &&
 			!(s.tmode[0] == TM_Turns && s.effectiveLoss[0]) &&
@@ -5095,11 +5095,11 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 	}
 	sys.cgi[pn].palno = int32(selectPalno)
 
-	// Prepare lifebar portraits and names for Turns mode
+	// Prepare fight screen portraits and names for Turns mode
 	if !attached {
-		if pn < len(sys.lifebar.fa[sys.tmode[pn&1]]) && sys.tmode[pn&1] == TM_Turns && sys.round == 1 {
-			fa := sys.lifebar.fa[sys.tmode[pn&1]][pn]
-			nm := sys.lifebar.nm[sys.tmode[pn&1]][pn]
+		if pn < len(sys.fightScreen.fa[sys.tmode[pn&1]]) && sys.tmode[pn&1] == TM_Turns && sys.round == 1 {
+			fa := sys.fightScreen.fa[sys.tmode[pn&1]][pn]
+			nm := sys.fightScreen.nm[sys.tmode[pn&1]][pn]
 			l.prepareTurnsFaces(pn, fa, nm, teamChars)
 		}
 	}
@@ -5110,7 +5110,7 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 	return 1
 }
 
-func (l *Loader) prepareTurnsFaces(pn int, fa *LifeBarFace, nm *LifeBarName, teamChars []int) {
+func (l *Loader) prepareTurnsFaces(pn int, fa *FightScreenFace, nm *FightScreenName, teamChars []int) {
 	// Reset face and name KO's
 	off := int32(0)
 	if sys.sel.gameParams != nil {
@@ -5119,7 +5119,7 @@ func (l *Loader) prepareTurnsFaces(pn int, fa *LifeBarFace, nm *LifeBarName, tea
 	if off < 0 {
 		off = 0
 	}
-	// Clamp to valid range so lifebar teammate rotation doesn't misbehave
+	// Clamp to valid range so fight screen teammate rotation doesn't misbehave
 	if len(teamChars) == 0 {
 		fa.numko = 0
 		nm.numko = 0
@@ -5287,8 +5287,8 @@ func (l *Loader) load() {
 		}
 	}
 
-	// Update lifebar scale
-	sys.lifebar.setLifebarScale()
+	// Update fight screen scale
+	sys.fightScreen.setScale()
 	//sys.motif.setMotifScale()
 
 	/*


### PR DESCRIPTION
Features:
- Added generic error logging to command line when any animation tries to call a missing sprite

Fixes:
- Enforce a minimum KO slow.time
- Fixed issue where if sprite 0,0 was shared, RemapPal could result in an out of bounds crash
- Split life and power drawing into two steps: backgrounds and bars. This preserves the new Ikemen drawing order while staying backward compatible with lifebars that share one background for both teams
- Fixed regression where callfight.time timer would only start after the round call was over
- Fixed a commented out Clsn line preventing the following lines from being read
- Made old projectile triggers (ProjHit etc) more accurate to Mugen. Parentheses form such as ProjHit(1200) is not valid, but rather any unrecognized characters make ID fall back to 0 (any)
- Fixed invalid opcode crash when using the spriteVar(image) trigger
- Fixed for instance "root,projcontact1451 = 1, = 1" not working from the root context
- Fixed issue where helpers would initialize with local scale 0 and thus produce some divisions by 0
- Fixes #2123
- Fixes #3447
- Fixes https://discord.com/channels/233345562261323776/282927929548210177/1487887522401882133
- Fixes #3461 
- Fixes #3466  
- Fixes https://discord.com/channels/233345562261323776/233363722934943744/1489506039396175893

Refactor:
- Invalid char animation errors now print exactly where they happened (char, explod, projectile)
- Adjusted motif code to fix debug prints from the new debug system
- Backgrounds will no longer compile if they reference a missing animation
- Renamed lifebar.go and related structs to fight screen (official term for it)
- Renamed more lifebar variables to be more explicit
- Removed some redundancy that had accumulated in combo counter code