### PR TITLE
fix: Negative sprite numbers not accurate to Mugen, compiler error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ srcFiles=src/resources/defaultConfig.ini \
 	src/compiler_functions.go \
 	src/config.go \
 	src/dllsearch_windows.go \
+	src/fightscreen.go \
 	src/font.go \
 	src/font_gl33.go \
 	src/font_gles32.go \
@@ -24,7 +25,6 @@ srcFiles=src/resources/defaultConfig.ini \
 	src/iniutils.go \
 	src/input.go \
 	src/input_sdl.go \
-	src/lifebar.go \
 	src/main.go \
 	src/motif.go \
 	src/music.go \

--- a/src/anim.go
+++ b/src/anim.go
@@ -603,9 +603,9 @@ func (a *Animation) UpdateSprite() {
 				group, number = mn[0], mn[1]
 			}
 		}
-        //Mugen used int16 instead of uint16 by mistake, so this serves as a workaround that will please both past and future characters
+        //Mugen only nulls out -1, other negatives wrap around
 		if group != -1 && number != -1 {
-			    a.spr = a.sff.GetSprite(uint16(0+group), uint16(0+number))
+			    a.spr = a.sff.GetSprite(uint16(group), uint16(number))
 			if a.spr == nil {
 				// Log missing sprites
 				// We will save the history in the SFF itself so that each sprite is only mentioned once

--- a/src/anim.go
+++ b/src/anim.go
@@ -603,8 +603,9 @@ func (a *Animation) UpdateSprite() {
 				group, number = mn[0], mn[1]
 			}
 		}
-		if group >= 0 && number >= 0 {
-			a.spr = a.sff.GetSprite(uint16(group), uint16(number))
+        //Mugen used int16 instead of uint16 by mistake, so this serves as a workaround that will please both past and future characters
+		if group != -1 && number != -1 {
+			    a.spr = a.sff.GetSprite(uint16(0+group), uint16(0+number))
 			if a.spr == nil {
 				// Log missing sprites
 				// We will save the history in the SFF itself so that each sprite is only mentioned once


### PR DESCRIPTION
Fixes:
* Added a workaround that allows negative sprite numbers to display as they would on Mugen, useful for unusually coded compatibility animations.
* Fixes https://github.com/ikemen-engine/Ikemen-GO/issues/3232
* Corrected the makefile pointing to an outdated file name.