### PR TITLE
feat(options): PauseExitDelay; fixes

### DIFF
--- a/external/script/menu.lua
+++ b/external/script/menu.lua
@@ -99,8 +99,7 @@ menu.t_itemname = {
 		if getInput(-1, sec.menu.done.key) then
 			if menu.currentMenu[1] == menu.currentMenu[2] then
 				sndPlay(motif.Snd, sec.exit.snd[1], sec.exit.snd[2])
-				togglePause(false)
-				main.pauseMenu = false
+				menu.pauseExitDelay = gameOption('Input.PauseExitDelay')
 			else
 				sndPlay(motif.Snd, sec.cancel.snd[1], sec.cancel.snd[2])
 			end
@@ -288,14 +287,17 @@ function menu.f_createMenu(tbl, sec, bg, bool_main)
 		else
 			main.f_menuCommonDraw(t, tbl.item, tbl.cursorPosY, tbl.moveTxt, sec, bg, true)
 		end
+		-- Skip everything else during pause exit delay
+		if menu.pauseExitDelay >= 0 then
+			return
+		end
 		tbl.cursorPosY, tbl.moveTxt, tbl.item = main.f_menuCommonCalc(t, tbl.item, tbl.cursorPosY, tbl.moveTxt, sec, sec.cursor)
 		textImgReset(sec.title.TextSpriteData)
 		textImgSetText(sec.title.TextSpriteData, tbl.title)
 		if esc() or getInput(-1, sec.menu.cancel.key) then
 			if bool_main then
 				sndPlay(motif.Snd, sec.exit.snd[1], sec.exit.snd[2])
-				togglePause(false)
-				main.pauseMenu = false
+				menu.pauseExitDelay = gameOption('Input.PauseExitDelay')
 			else
 				sndPlay(motif.Snd, sec.cancel.snd[1], sec.cancel.snd[2])
 			end
@@ -583,6 +585,8 @@ function menu.f_init()
 	end
 end
 
+menu.pauseExitDelay = -1
+
 function menu.f_run()
 	local entry = nil
 	if menu.t_menuIndex ~= nil then
@@ -605,6 +609,17 @@ function menu.f_run()
 	end
 	--draw overlay
 	rectDraw(sec.overlay.RectData)
+	--pause exit delay
+	if menu.pauseExitDelay >= 0 then
+		if menu.pauseExitDelay > 0 then
+			menu.pauseExitDelay = menu.pauseExitDelay - 1
+		else
+			menu.pauseExitDelay = -1 --prevent retriggering at 0
+			togglePause(false)
+			main.pauseMenu = false
+			return false
+		end
+	end
 	--Button Config
 	if menu.itemname == 'keyboard' or menu.itemname == 'gamepad' then
 		if menu.itemname == 'keyboard' then

--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -256,6 +256,7 @@ options.t_itemname = {
 			--modifyGameOption('Input.XinputTriggerSensitivity', 0.5)
 			--modifyGameOption('Input.UiRepeatDelay', 30)
 			--modifyGameOption('Input.UiRepeatRate', 4)
+			--modifyGameOption('Input.PauseExitDelay', 10)
 
 			loadFightScreen(motif.files.fight)
 			setPlayers()

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -10097,18 +10097,20 @@ func (sc superPause) Run(c *Char, _ []int32) bool {
 	})
 
 	// Add super FX
-	if e, i := c.spawnExplod(); e != nil {
-		e.animNo = fx_anim
-		e.anim_ffx = fx_ffx
-		e.layerno = 1
-		e.ownpal = true
-		e.removetime = -2
-		e.pausemovetime = -1
-		e.supermovetime = -1
-		e.postype = PT_P1
-		e.relativePos = [3]float32{fx_pos[0], fx_pos[1], fx_pos[2]}
-		e.setPos(c)
-		c.commitExplod(i)
+	if fx_anim >= 0 {
+		if e, i := c.spawnExplod(); e != nil {
+			e.animNo = fx_anim
+			e.anim_ffx = fx_ffx
+			e.layerno = 1
+			e.ownpal = true
+			e.removetime = -2
+			e.pausemovetime = -1
+			e.supermovetime = -1
+			e.postype = PT_P1
+			e.relativePos = [3]float32{fx_pos[0], fx_pos[1], fx_pos[2]}
+			e.setPos(c)
+			c.commitExplod(i)
+		}
 	}
 
 	crun.setSuperPauseTime(t, mt, uh, p2defmul)

--- a/src/char.go
+++ b/src/char.go
@@ -9008,15 +9008,18 @@ func (c *Char) remapPal(pfx *PalFX, src [2]int32, dst [2]int32) {
 
 	// Perform palette remap
 	if plist.SwapPalMap(&pfx.remap) {
-		// For SFFv1, if remapping palette 1,1 remap whatever palette sprite 0,0 uses
+		// Always remap the requested source palette
+		plist.Remap(si, di)
+
+		// For SFFv1, remapping 1,1 should also remap whatever palettes sprites 0,0 and 9000,0 use
+		// TODO: Because 9000,0 is not hardcoded in Ikemen, this might create trouble for custom portraits
 		if src[0] == 1 && src[1] == 1 && c.gi().sff.header.Version[0] == 1 {
 			if spr := c.gi().sff.GetSprite(0, 0); spr != nil {
-				if spr.GetPal(&plist) != nil && spr.palidx >= 0 {
-					plist.Remap(spr.palidx, di)
-				}
+				plist.Remap(spr.palidx, di)
 			}
-		} else {
-			plist.Remap(si, di)
+			if spr := c.gi().sff.GetSprite(9000, 0); spr != nil {
+				plist.Remap(spr.palidx, di)
+			}
 		}
 
 		plist.SwapPalMap(&pfx.remap)

--- a/src/char.go
+++ b/src/char.go
@@ -1864,7 +1864,6 @@ func (e *Explod) setAnim() {
 		} else {
 			sys.appendToConsole(c.warn() + fmt.Sprintf("explod with ID %v called invalid action %v%v", e.id, strings.ToUpper(e.anim_ffx), e.animNo))
 		}
-		return
 	}
 	e.anim = a
 
@@ -7254,8 +7253,8 @@ func (c *Char) commitProjectile(p *Projectile, pt PosType, offx, offy, offz floa
 	p.anim = c.getSelfAnimSprite(p.animNo, p.anim_ffx, true)
 
 	if p.anim == nil && c.anim != nil {
-		// TODO: If Ikemenversion, the invalid animation probably ought to make explod disappear
-		sys.appendToConsole(c.warn() + fmt.Sprintf("projectile with ID %v called invalid action %v%v", p.id, strings.ToUpper(p.anim_ffx), p.animNo))
+		// TODO: If Ikemenversion, the invalid animation probably ought to make the projectile disappear
+		sys.appendToConsole(p.owner().warn() + fmt.Sprintf("projectile with ID %v called invalid action %v%v", p.id, strings.ToUpper(p.anim_ffx), p.animNo))
 		// The Mugen fallback is to copy the character's current animation
 		p.anim = &Animation{}
 		*p.anim = *c.anim

--- a/src/char.go
+++ b/src/char.go
@@ -5006,7 +5006,7 @@ func (c *Char) comboCount() int32 {
 	if c.teamside == -1 {
 		return 0
 	}
-	return sys.fightScreen.combos[c.teamside].truehits
+	return sys.fightScreen.combos[c.teamside].trueHits
 }
 
 func (c *Char) command(pn, i int) bool {
@@ -7179,10 +7179,8 @@ func (c *Char) hitAdd(h int32) {
 		for _, tid := range c.targets {
 			if t := sys.playerID(tid); t != nil {
 				t.receivedHits += h
+				c.addComboHits(h)
 				break
-				//if c.teamside != -1 {
-				//	sys.fightScreen.combos[c.teamside].truehits += h
-				//}
 			}
 		}
 	} else if c.teamside != -1 {
@@ -7192,11 +7190,20 @@ func (c *Char) hitAdd(h int32) {
 				// This is a bit of a workaround for backward compatibility only
 				if p[0].receivedHits != 0 || p[0].ss.moveType == MT_H {
 					p[0].receivedHits += h
-					//sys.fightScreen.combos[c.teamside].truehits += h
+					c.addComboHits(h)
 				}
 			}
 		}
 	}
+}
+
+// We track the combo separately from the enemy's received hits
+// So that if partners take turns doing hits to different enemies the combo still adds up
+func (c *Char) addComboHits(n int32) {
+	if c.teamside != 0 && c.teamside != 1 {
+		return
+	}
+	sys.fightScreen.combos[c.teamside].trueHits += n
 }
 
 // Always appends to preserve insertion order
@@ -10966,10 +10973,7 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 		if (ghvset || getter.csf(CSF_gethit)) && getter.hoverIdx < 0 &&
 			!(c.hitdef.air_type == HT_None && getter.ss.stateType == ST_A || getter.ss.stateType != ST_A && c.hitdef.ground_type == HT_None) {
 			getter.receivedHits += hd.numhits
-			// receivedHits is the only source of truth
-			//if c.teamside != -1 {
-			//	sys.fightScreen.combos[c.teamside].truehits += hd.numhits
-			//}
+			c.addComboHits(hd.numhits)
 		}
 		if !math.IsNaN(float64(hd.score[0])) && !c.asf(ASF_noscore) {
 			c.scoreAdd(hd.score[0])

--- a/src/config.go
+++ b/src/config.go
@@ -231,6 +231,7 @@ type Config struct {
 		XinputTriggerSensitivity   float32 `ini:"XinputTriggerSensitivity"`
 		UiRepeatDelay              int32   `ini:"UiRepeatDelay" sync:"host"`
 		UiRepeatRate               int32   `ini:"UiRepeatRate" sync:"host"`
+		PauseExitDelay             int32   `ini:"PauseExitDelay" sync:"host"`
 	} `ini:"Input"`
 	Keys     map[string]*KeysProperties `ini:"map:^(?i)Keys_P[0-9]+$" lua:"Keys"`
 	Joystick map[string]*KeysProperties `ini:"map:^(?i)Joystick_P[0-9]+$" lua:"Joystick"`

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -1750,9 +1750,9 @@ func (fa *FightScreenFace) step(charpn int, refFace *FightScreenFace) {
 	refgi := sys.cgi[charpn]
 	if refFace.old_spr[0] != group || refFace.old_spr[1] != number ||
 		refFace.old_pal[0] != refgi.remappedpal[0] || refFace.old_pal[1] != refgi.remappedpal[1] {
-		refFace.face = refgi.sff.getOwnPalSprite(uint16(group), uint16(number), &refgi.palettedata.palList)
-		refFace.old_spr = [...]int32{group, number}
-		refFace.old_pal = [...]int32{refgi.remappedpal[0], refgi.remappedpal[1]}
+		refFace.face = refgi.sff.cloneSpriteWithPal(uint16(group), uint16(number), &refgi.palettedata.palList)
+		refFace.old_spr = [2]int32{group, number}
+		refFace.old_pal = [2]int32{refgi.remappedpal[0], refgi.remappedpal[1]}
 	}
 
 	fa.bg.Action()

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -3150,7 +3150,9 @@ func (ro *FightScreenRound) act() bool {
 			return ro.fightDisplayPhase > 0
 		}
 	}
-	return sys.tickNextFrame()
+	// Because round state should step before characters, this should be tickFrame()
+	//return sys.tickNextFrame()
+	return sys.tickFrame()
 }
 
 /*

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -2301,14 +2301,15 @@ type FightScreenCombo struct {
 	hidespeed     float32
 	separator     string
 	places        int32
-	truehits      int32
-	shownhits     int32
-	showndmg      int32
-	shownpct      float32
+	trueHits      int32
+	shownHits     int32
+	shownDmg      int32
+	shownPct      float32
 	resttime      int32
 	counterX      float32
 	shaketime     int32
 	autoalign     bool
+	newCombo      bool
 }
 
 func newFightScreenCombo() *FightScreenCombo {
@@ -2372,12 +2373,22 @@ func (co *FightScreenCombo) step(hits, damage int32, percentage float32, dizzy b
 	co.bg.Action()
 	co.top.Action()
 
-	// Always save combo tally result for access by triggers
-	co.truehits = hits
+	// Allows a new identical combo to still retrigger later
+	if hits < 2 && co.shownHits >= 2 {
+		co.newCombo = true
+	}
+
+	// Reset team combo if no player was found getting hit
+	if hits == 0 {
+		co.trueHits = 0
+	}
+
+	// True hits are only updated by Char(). The live tally is only used for combo display behavior
+	//co.trueHits = hits
 
 	if co.resttime > 0 {
 		co.counterX -= co.counterX / co.showspeed
-	} else if co.truehits < 2 {
+	} else if co.trueHits < 2 {
 		co.counterX -= sys.fightScreen.fnt_scale * co.hidespeed * float32(sys.fightScreen.localcoord[0]) / 320
 		if co.counterX < co.start_x*2 {
 			co.counterX = co.start_x * 2
@@ -2388,14 +2399,16 @@ func (co *FightScreenCombo) step(hits, damage int32, percentage float32, dizzy b
 		co.shaketime--
 	}
 
+	// TODO: Most commercial games don't rely on the dizzy flag
+	// They keep the combo active as long as hits >= 2
 	if Abs(co.counterX) < 1 && !dizzy {
 		co.resttime--
 	}
 
 	// Update if number of hits or total damage change
-	if co.truehits >= 2 && (co.shownhits != co.truehits || co.showndmg != damage) {
+	if co.trueHits >= 2 && (co.newCombo || co.shownHits != co.trueHits || co.shownDmg != damage) {
 		// Reset visuals when hits changed
-		if co.shownhits != co.truehits {
+		if co.newCombo || co.shownHits != co.trueHits {
 			if co.counter_shake {
 				co.shaketime = co.counter_time
 			}
@@ -2409,15 +2422,16 @@ func (co *FightScreenCombo) step(hits, damage int32, percentage float32, dizzy b
 		// Time resets if either hits or damage changed
 		co.resttime = co.displaytime
 		// Update state
-		co.shownhits = co.truehits
-		co.showndmg = damage
-		co.shownpct = percentage
+		co.shownHits = co.trueHits
+		co.shownDmg = damage
+		co.shownPct = percentage
+		co.newCombo = false
 	}
 
 	// Multiple counter fonts
 	var cv int32
 	for k := range co.counter {
-		if k > cv && co.shownhits >= k {
+		if k > cv && co.shownHits >= k {
 			cv = k
 		}
 	}
@@ -2425,7 +2439,7 @@ func (co *FightScreenCombo) step(hits, damage int32, percentage float32, dizzy b
 	// Multiple text fonts
 	var tv int32
 	for k := range co.text {
-		if k > tv && co.shownhits >= k {
+		if k > tv && co.shownHits >= k {
 			tv = k
 		}
 	}
@@ -2439,10 +2453,10 @@ func (co *FightScreenCombo) step(hits, damage int32, percentage float32, dizzy b
 func (co *FightScreenCombo) reset() {
 	co.bg.Reset()
 	co.top.Reset()
-	co.truehits = 0
-	co.shownhits = 0
-	co.showndmg = 0
-	co.shownpct = 0
+	co.trueHits = 0
+	co.shownHits = 0
+	co.shownDmg = 0
+	co.shownPct = 0
 	co.resttime = 0
 	co.counterX = co.start_x * 2
 	co.shaketime = 0
@@ -2456,7 +2470,7 @@ func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 	// Multiple counter fonts according to combo hits
 	var cv int32
 	for k := range co.counter {
-		if k > cv && co.shownhits >= k {
+		if k > cv && co.shownHits >= k {
 			cv = k
 		}
 	}
@@ -2464,12 +2478,12 @@ func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 	// Multiple text fonts according to combo hits
 	var tv int32
 	for k := range co.text {
-		if k > tv && co.shownhits >= k {
+		if k > tv && co.shownHits >= k {
 			tv = k
 		}
 	}
 
-	counter := strings.Replace(co.counter[cv].text, "%i", fmt.Sprintf("%v", co.shownhits), 1)
+	counter := strings.Replace(co.counter[cv].text, "%i", fmt.Sprintf("%v", co.shownHits), 1)
 	x := float32(co.pos[0])
 	if side == 0 {
 		if co.start_x <= 0 {
@@ -2489,10 +2503,10 @@ func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 	co.bg.Draw(x+sys.fightScreen.offsetX, float32(co.pos[1]), layerno, sys.fightScreen.scale)
 	var length float32
 	if co.text[tv].font[0] >= 0 && getFont(f, co.text[tv].font[0]) != nil {
-		text := strings.Replace(co.text[tv].text, "%i", fmt.Sprintf("%v", co.shownhits), 1)
-		text = strings.Replace(text, "%d", fmt.Sprintf("%v", co.showndmg), 1)
+		text := strings.Replace(co.text[tv].text, "%i", fmt.Sprintf("%v", co.shownHits), 1)
+		text = strings.Replace(text, "%d", fmt.Sprintf("%v", co.shownDmg), 1)
 		// Truncate the percentage to avoid rounding to 100% unless the enemy is defeated
-		truncatedPct := math.Floor(float64(co.shownpct)*math.Pow10(int(co.places))) / math.Pow10(int(co.places))
+		truncatedPct := math.Floor(float64(co.shownPct)*math.Pow10(int(co.places))) / math.Pow10(int(co.places))
 		// Split float value
 		s := strings.Split(fmt.Sprintf("%.[2]*[1]f", truncatedPct, co.places), ".")
 		// Decimal separator
@@ -5126,31 +5140,7 @@ func (fs *FightScreen) step() {
 	if sys.paused && !sys.frameStepFlag {
 		return
 	}
-	/*
-		// Team order swapping moved to dedicated Tag functions
-		for ti, tm := range sys.tmode {
-			if tm == TM_Tag {
-				for i, v := range fs.teamOrder[ti] {
-					if sys.teamLeader[sys.chars[v][0].teamside] == sys.chars[v][0].playerNo && sys.chars[v][0].alive() {
-						if i != 0 {
-							if i == len(fs.teamOrder[ti])-1 {
-								fs.teamOrder[ti] = sliceMoveInt(fs.teamOrder[ti], i, 0)
-							} else {
-								last := len(fs.teamOrder[ti]) - 1
-								for n := last; n > 0; n-- {
-									if !sys.chars[fs.teamOrder[ti][n]][0].alive() {
-										last -= 1
-									}
-								}
-								fs.teamOrder[ti] = sliceMoveInt(fs.teamOrder[ti], 0, last)
-							}
-						}
-						break
-					}
-				}
-			}
-		}
-	*/
+	// Bars
 	for ti := range sys.tmode {
 		layout := fs.curLayout[ti]
 		for i, charpn := range fs.teamOrder[ti] {
@@ -5163,23 +5153,23 @@ func (fs *FightScreen) step() {
 			fs.guardBars[layout][index].step(charpn, fs.guardBars[layout][charpn], fs.snd)
 			// StunBar
 			fs.stunBars[layout][index].step(charpn, fs.stunBars[layout][charpn], fs.snd)
-			// FightScreenFace
+			// Face
 			fs.faces[layout][index].step(charpn, fs.faces[layout][charpn])
-			// FightScreenName
+			// Name
 			fs.names[layout][index].step()
 		}
 	}
-	// FightScreenWinIcon
+	// WinIcon
 	for i := range fs.winIcons {
 		fs.winIcons[i].step(sys.wins[i])
 	}
-	// FightScreenTime
+	// Time
 	fs.time.step()
-	// FightScreenCombo
 	cb, cd, cp, dz := [2]int32{}, [2]int32{}, [2]float32{}, [2]bool{}
 	targets := [2]int32{}
-	// Iterate through all players to see the combo status of each team
+	// Combo
 	for _, ch := range sys.chars {
+		// Iterate through all players to see the combo status of each team
 		for _, c := range ch {
 			if c.receivedHits > 0 && (c.teamside == 0 || c.teamside == 1) && (c.alive() || !c.scf(SCF_over_ko)) { // If alive or not alive but not in state 5150 yet
 				side := 1 - c.teamside
@@ -5202,11 +5192,11 @@ func (fs *FightScreen) step() {
 	for i := range fs.combos {
 		fs.combos[i].step(cb[i], cd[i], cp[i], dz[i]) // Combo hits, combo damage, combo damage percentage, dizzy flag
 	}
-	// FightScreenAction
+	// Action
 	for i := range fs.actions {
 		fs.actions[i].step(fs.teamOrder[i][0])
 	}
-	// FightScreenRatio
+	// Ratio
 	for ti, tm := range sys.tmode {
 		if tm == TM_Turns {
 			rl := sys.chars[ti][0].ocd().ratioLevel
@@ -5215,23 +5205,23 @@ func (fs *FightScreen) step() {
 			}
 		}
 	}
-	// FightScreenTimer
+	// Timer
 	fs.timer.step()
-	// FightScreenScore
+	// Score
 	for i := range fs.scores {
 		fs.scores[i].step()
 	}
-	// FightScreenMatch
+	// Match
 	fs.match.step()
-	// FightScreenAiLevel
+	// AiLevel
 	for i := range fs.aiLevels {
 		fs.aiLevels[i].step()
 	}
-	// FightScreenWinCount
+	// WinCount
 	for i := range fs.winCounts {
 		fs.winCounts[i].step()
 	}
-	// FightScreenMode
+	// Mode
 	if _, ok := fs.modes[sys.gameMode]; ok {
 		fs.modes[sys.gameMode].step()
 	}

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -5094,29 +5094,29 @@ func loadFightScreen(def string) (*FightScreen, error) {
 }
 
 func (fs *FightScreen) reload() error {
-	fs, err := loadFightScreen(fs.def)
+	new, err := loadFightScreen(fs.def)
 	if err != nil {
 		return err
 	}
-	fs.time.framespercount = fs.time.framespercount
-	//fs.round.match_wins = fs.round.match_wins
-	//fs.round.match_maxdrawgames = fs.round.match_maxdrawgames
-	fs.timer.active = fs.timer.active
-	fs.scores[0].active = fs.scores[0].active
-	fs.scores[1].active = fs.scores[1].active
-	fs.match.active = fs.match.active
-	fs.aiLevels[0].active = fs.aiLevels[0].active
-	fs.aiLevels[1].active = fs.aiLevels[1].active
-	fs.winCounts[0].active = fs.winCounts[0].active
-	fs.winCounts[1].active = fs.winCounts[1].active
-	fs.active = fs.active
-	fs.bars = fs.bars
-	fs.mode = fs.mode
-	fs.redlifebar = fs.redlifebar
-	fs.guardbar = fs.guardbar
-	fs.stunbar = fs.stunbar
-	//fs.fx_scale = fs.fx_scale
-	sys.fightScreen = *fs
+	new.time.framespercount = fs.time.framespercount
+	//new.round.match_wins = fs.round.match_wins
+	//new.round.match_maxdrawgames = fs.round.match_maxdrawgames
+	new.timer.active = fs.timer.active
+	new.scores[0].active = fs.scores[0].active
+	new.scores[1].active = fs.scores[1].active
+	new.match.active = fs.match.active
+	new.aiLevels[0].active = fs.aiLevels[0].active
+	new.aiLevels[1].active = fs.aiLevels[1].active
+	new.winCounts[0].active = fs.winCounts[0].active
+	new.winCounts[1].active = fs.winCounts[1].active
+	new.active = fs.active
+	new.bars = fs.bars
+	new.mode = fs.mode
+	new.redlifebar = fs.redlifebar
+	new.guardbar = fs.guardbar
+	new.stunbar = fs.stunbar
+	//new.fx_scale = fs.fx_scale
+	sys.fightScreen = *new
 	return nil
 }
 

--- a/src/font.go
+++ b/src/font.go
@@ -377,7 +377,7 @@ func LoadFntSff(f *Fnt, fontfile string, filename string) {
 	// Load sprites
 	var pal_default []uint32
 	for k, sprite := range sff.sprites {
-		s := sff.getOwnPalSprite(sprite.Group, sprite.Number, &sff.palList)
+		s := sff.cloneSpriteWithPal(sprite.Group, sprite.Number, &sff.palList)
 		if sprite.Group == 0 || f.BankType == "sprite" {
 			if f.images[int32(sprite.Group)] == nil {
 				f.images[int32(sprite.Group)] = make(map[rune]*FntCharImage)

--- a/src/image.go
+++ b/src/image.go
@@ -823,12 +823,20 @@ func newSprite() *Sprite {
 
 func (s *Sprite) shareCopy(src *Sprite) {
 	s.Pal = src.Pal
-	s.Tex = src.Tex
 	s.Size = src.Size
+
+	// Copy palette index if it's not defined yet
 	if s.palidx < 0 {
 		s.palidx = src.palidx
 	}
 	s.coldepth = src.coldepth
+
+	// We must defer copying the texture during the main thread
+	// Otherwise we can end up copying a nil texture over the good one or other race condition bugs
+	sys.mainThreadTask <- func() {
+		s.Tex = src.Tex
+	}
+
 	//s.paltemp = src.paltemp
 	//s.PalTex = src.PalTex
 }
@@ -1689,9 +1697,10 @@ func loadSff(filename string, char bool, isMainThread bool, isActPal bool) (*Sff
 		if size == 0 {
 			if int(indexOfPrevious) < i {
 				dst, src := spriteList[i], spriteList[int(indexOfPrevious)]
-				sys.mainThreadTask <- func() {
+				// Moved to shareCopy() itself
+				//sys.mainThreadTask <- func() {
 					dst.shareCopy(src)
-				}
+				//}
 			} else {
 				spriteList[i].palidx = 0 // index out of range
 			}
@@ -1860,7 +1869,11 @@ func preloadSff(filename string, char bool, preloadSpr map[[2]uint16]bool) (*Sff
 				base := int(indexOfPrevious)
 				copyPal := func(srcIdx int) {
 					dst, src := spriteList[i], spriteList[srcIdx]
-					sys.mainThreadTask <- func() { dst.shareCopy(src) }
+					// Since loadSff() works incorrectly with this condition, maybe having it here wasn't ideal either
+					// Preload caching tests also needed this copy to be instant
+					//sys.mainThreadTask <- func() {
+						dst.shareCopy(src)
+					//}
 					if spriteList[srcIdx].palidx < 0 || int(spriteList[srcIdx].palidx) >= len(pl.paletteMap) {
 						spriteList[i].palidx = 0
 					} else {
@@ -2091,7 +2104,8 @@ func (s *Sff) GetSprite(g, n uint16) *Sprite {
 	return s.sprites[[2]uint16{g, n}]
 }
 
-func (s *Sff) getOwnPalSprite(g, n uint16, pl *PaletteList) *Sprite {
+// Creates a copy of the sprite and its palette and returns a pointer to it
+func (s *Sff) cloneSpriteWithPal(g, n uint16, pl *PaletteList) *Sprite {
 	sys.runMainThreadTask() // Generate texture
 	sp := s.GetSprite(g, n)
 	if sp == nil {

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -387,6 +387,9 @@ XinputTriggerSensitivity   = 0.5
 UiRepeatDelay              = 30
 ; Repeat interval (in frames) after the delay
 UiRepeatRate               = 4
+; Frames to wait when exiting the pause menu.
+; Prevents the exit button press from also registering for the character.
+PauseExitDelay             = 10
 
 ; -------------------------------------------------------------------------------
 [Keys_P1]

--- a/src/system.go
+++ b/src/system.go
@@ -2449,6 +2449,12 @@ func (s *System) action() {
 	var x, y, scl float32 = s.cam.Pos[0], s.cam.Pos[1], s.cam.Scale / s.cam.BaseScale()
 	s.cam.ResetTracking()
 
+	// Update round state
+	// This is also reflected on characters (intros, win poses)
+	// It's important that this is placed after the tickFrame logic, or characters will not see every step of the sys.intro timer
+	// Update: In Mugen, the state change to win pose happens before the character code runs. It's evidence this should be placed before charList.action()
+	s.stepRoundState()
+
 	// Run "tick frame"
 	if s.tickFrame() {
 		// X axis player limits
@@ -2507,11 +2513,6 @@ func (s *System) action() {
 	// This function runs every tick
 	// It should be placed between "tick frame" and "tick next frame"
 	s.charUpdate()
-
-	// Update round state
-	// This is also reflected on characters (intros, win poses)
-	// It's important that this is placed after the tickFrame logic, or characters will not see every step of the sys.intro timer
-	s.stepRoundState()
 
 	// Update lifebars
 	// This must happen before hit detection for accurate display
@@ -2919,6 +2920,7 @@ func (s *System) stepRoundState() {
 						p[0].unsetSCF(SCF_over_alive)
 						//if !p[0].scf(SCF_standby) || p[0].teamside == -1 {
 						if p[0].activelyFighting() {
+							// In Mugen this ctrlSet happens in beginning of frame. More evidence all this code should run before character states
 							p[0].setCtrl(true)
 							if p[0].ss.no != 0 && !p[0].asf(ASF_nointroreset) {
 								p[0].selfState(0, -1, -1, 1, "") // Nor this one
@@ -2992,19 +2994,25 @@ func (s *System) stepRoundState() {
 			if s.winwaittime > 0 {
 				if s.intro == rs4t-1 {
 					for _, p := range s.chars {
-						if len(p) > 0 {
-							// Check if this player is ready to proceed to roundstate 4
-							// Maybe the "activelyFighting()" could be replaced with an AssertSpecial flag or such to ignore the win/lose states
-							// Mugen seems to skip this anim 5 check on time overs
-							// It also seems a bit pointless to begin with because the char has already turned by the time anim 5 starts
-							if p[0].scf(SCF_over_alive) || p[0].scf(SCF_over_ko) || !p[0].activelyFighting() ||
-								(p[0].scf(SCF_ctrl) && p[0].ss.moveType == MT_I && p[0].ss.stateType != ST_A && p[0].ss.stateType != ST_L && p[0].animNo != 5) {
-								continue
-							}
-							// Freeze timer if any player is not ready to proceed yet
-							s.intro = rs4t
-							break
+						if len(p) == 0 {
+							continue
 						}
+						// Check if this player is ready to proceed to roundstate 4
+						// Maybe the "activelyFighting()" could be replaced with an AssertSpecial flag or such to ignore the win/lose states
+						if !p[0].activelyFighting() {
+							continue
+						}
+						if p[0].scf(SCF_over_alive) || p[0].scf(SCF_over_ko) {
+							continue
+						}
+						// Mugen seems to skip this anim 5 check on time overs
+						// It also seems a bit pointless here to begin with because the char has already turned by the time anim 5 starts
+						if p[0].scf(SCF_ctrl) && p[0].ss.moveType == MT_I && p[0].ss.stateType == ST_S && p[0].animNo != 5 {
+							continue
+						}
+						// Freeze timer if any player is not ready to proceed yet
+						s.intro = rs4t
+						break
 					}
 				}
 			}
@@ -3063,8 +3071,10 @@ func (s *System) stepRoundState() {
 					continue
 				}
 				// TODO: These changestates ought to be unhardcoded
+				// TODO: They also happen 1 frame too early compared to Mugen
 				// Mugen only checks for readiness in the RoundState 4 loop above. It doesn't care in this one and forces characters into win poses no matter what
 				// HitPause is checked here but not in the other loop. Perhaps because changing states during hitpause in Mugen isn't quite safe
+				// These selfStates should happen in beginning of frame. Previously, Ikemen had them at end of frame
 				if !p[0].scf(SCF_over_alive) && p[0].alive() && p[0].activelyFighting() && !p[0].hitPause() {
 					p[0].setSCF(SCF_over_alive)
 					if p[0].win() {

--- a/src/system.go
+++ b/src/system.go
@@ -2514,9 +2514,9 @@ func (s *System) action() {
 	// It should be placed between "tick frame" and "tick next frame"
 	s.charUpdate()
 
-	// Update lifebars
-	// This must happen before hit detection for accurate display
-	// Allows a combo to still end if a character is hit in the same frame where it exits movetype H
+	// Update the fight screen
+	// Lifebar and combo must update after character states but before hit detection for accurate detection
+	// So that it allows a combo to still end if a character is hit in the same frame where it exits movetype H
 	s.fightScreen.step()
 
 	if s.tickNextFrame() {

--- a/src/system.go
+++ b/src/system.go
@@ -4291,6 +4291,10 @@ func (s *Select) AddChar(def string) *SelectChar {
 		sc.name = "dummyslot"
 		return nil
 	}
+	if strings.ToLower(defPathFromSelect) == "skipslot" {
+		sc.name = "skipslot"
+		return nil
+	}
 
 	// Helper to set missing characters to dummy slots and (always) print a warning
 	useDummy := func(reason string) *SelectChar {


### PR DESCRIPTION
Features:
- PauseExitDelay option. Adds a deliberate lag when exiting the pause menu to prevent the button press from also registering for the character

Fixes:
- Fixed regression where reloading fight screen would make some elements such as the guard and stun bars disappear
- Fixed characters sometimes being left in a crouching state before win poses start
- Moved roundState stepping to beginning of frame rather than the end
- Fixed a deliberately empty SuperPause animation still printing a debug warning
- Fixed RemapPal not remapping the lifebar portrait of some SFFv1 characters
- Fixed running from command line crashing due to race condition when remapping the color of linked sprites
- Fixed "failed to add char: skipslot" messages
- Fixed combo display not acting correctly when a combo is extended at the last moment
- Fixes #3482 
- Fixes #3490 
- Fixes https://discord.com/channels/233345562261323776/682025384849834018/1473309170819141732
- Fixes https://discord.com/channels/233345562261323776/233363722934943744/1491416410583203880
- Fixes https://discord.com/channels/233345562261323776/233363722934943744/1489980823921889516