### PR TITLE
fix: avoid invalid player lookup in IkSys_ReceivedDamage redirect path

### DIFF
--- a/data/functions.zss
+++ b/data/functions.zss
@@ -185,7 +185,7 @@ if map(_iksys_comboCountFlag) = gameTime {
 [Function IkSys_ReceivedDamage() ret]
 let ret = 0;
 if receivedDamage != map(_iksys_receivedDamageCurr) {
-	if receivedDamage > 0 && getHitVar(playerNo) != 0 && playerId(getHitVar(playerId)),teamSide != teamSide {
+	if receivedDamage > 0 && getHitVar(playerNo) != 0 && playerIdExist(getHitVar(playerId)) && playerId(getHitVar(playerId)),teamSide != teamSide {
 		map(_iksys_receivedDamageRet) := receivedDamage - map(_iksys_receivedDamageCurr);
 		map(_iksys_receivedDamageFlag) := gameTime;
 	}


### PR DESCRIPTION
Fixes #3497

When redirected hit data references a player id that no longer exists (for example short-lived helpers), `IkSys_ReceivedDamage()` evaluated `playerId(...)` directly and spammed debug logs.

This adds a `playerIdExist(getHitVar(playerId))` guard before dereferencing the redirected player, preventing invalid lookup noise while keeping the existing team-side filter logic unchanged.

Greetings, saschabuehrle