### PR TITLE
feat(trigger): parentExist and getHitVar(teamside); fix projectile triggers

### DIFF
--- a/data/functions.zss
+++ b/data/functions.zss
@@ -185,7 +185,7 @@ if map(_iksys_comboCountFlag) = gameTime {
 [Function IkSys_ReceivedDamage() ret]
 let ret = 0;
 if receivedDamage != map(_iksys_receivedDamageCurr) {
-	if receivedDamage > 0 && getHitVar(playerNo) != 0 && playerId(getHitVar(playerId)),teamSide != teamSide {
+	if receivedDamage > 0 && getHitVar(teamSide) != teamSide {
 		map(_iksys_receivedDamageRet) := receivedDamage - map(_iksys_receivedDamageCurr);
 		map(_iksys_receivedDamageFlag) := gameTime;
 	}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -574,6 +574,7 @@ const (
 	OC_ex_gethitvar_playerid
 	OC_ex_gethitvar_playerno
 	OC_ex_gethitvar_projid
+	OC_ex_gethitvar_teamside
 	OC_ex_gethitvar_redlife
 	OC_ex_gethitvar_score
 	OC_ex_gethitvar_hitdamage
@@ -3197,6 +3198,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushB(c.ghv.keepstate)
 	case OC_ex_gethitvar_guardko:
 		sys.bcStack.PushB(c.ghv.guardko)
+	case OC_ex_gethitvar_teamside:
+		sys.bcStack.PushI(int32(c.ghv.teamside) + 1)
 	case OC_ex_ailevelf:
 		if c.asf(ASF_noailevel) {
 			sys.bcStack.PushI(0)
@@ -7330,12 +7333,12 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, paramID byte, exp []BytecodeExp) {
 		hd.affectteam = exp[0].evalI(c)
 	case hitDef_teamside:
 		n := exp[0].evalI(c)
-		if n > 2 {
-			hd.teamside = 2
-		} else if n < 0 {
-			hd.teamside = 0
+		if n < 0 || n > 2 {
+			// TODO: We should do this in more parameters
+			// This could also be more specific and use crun, but that's a minor issue
+			sys.appendToConsole(c.warn() + fmt.Sprintf("invalid HitDef teamside: %d", n))
 		} else {
-			hd.teamside = int(n)
+			hd.teamside = int(n-1)
 		}
 	case hitDef_id:
 		hd.id = Max(0, exp[0].evalI(c))
@@ -14055,11 +14058,13 @@ const (
 	getHitVarSet_hitcount
 	getHitVarSet_hitshaketime
 	getHitVarSet_hittime
-	getHitVarSet_id
+	getHitVarSet_playerid
 	getHitVarSet_playerno
+	getHitVarSet_projid
 	getHitVarSet_redlife
 	getHitVarSet_slidetime
 	getHitVarSet_standfriction
+	getHitVarSet_teamside
 	getHitVarSet_xvel
 	getHitVarSet_yvel
 	getHitVarSet_zvel
@@ -14143,16 +14148,20 @@ func (sc getHitVarSet) Run(c *Char, _ []int32) bool {
 			crun.ghv.hittime = exp[0].evalI(c)
 		case getHitVarSet_hitshaketime:
 			crun.ghv.hitshaketime = exp[0].evalI(c)
-		case getHitVarSet_id:
+		case getHitVarSet_playerid:
 			crun.ghv.playerid = exp[0].evalI(c)
 		case getHitVarSet_playerno:
-			crun.ghv.playerno = int(exp[0].evalI(c))
+			crun.ghv.playerno = int(exp[0].evalI(c))-1
+		case getHitVarSet_projid:
+			crun.ghv.projid = exp[0].evalI(c)
 		case getHitVarSet_redlife:
 			crun.ghv.redlife = exp[0].evalI(c)
 		case getHitVarSet_slidetime:
 			crun.ghv.slidetime = exp[0].evalI(c)
 		case getHitVarSet_standfriction:
 			crun.ghv.standfriction = exp[0].evalF(c)
+		case getHitVarSet_teamside:
+			crun.ghv.teamside = int(exp[0].evalI(c))-1
 		case getHitVarSet_xvel:
 			crun.ghv.xvel = exp[0].evalF(c) * redirscale
 		case getHitVarSet_yvel:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -967,6 +967,7 @@ const (
 	OC_ex2_defencemul
 	OC_ex2_guardcount
 	OC_ex2_airjumpcount
+	OC_ex2_parentexist
 )
 const (
 	OC_ex3_analog_leftx OpCode = iota
@@ -4154,6 +4155,8 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(c.guardCount)
 	case OC_ex2_airjumpcount:
 		sys.bcStack.PushI(c.airJumpCount)
+	case OC_ex2_parentexist:
+		sys.bcStack.PushB(c.parentExist())
 	default:
 		LogMessage("%v", be[*i-1])
 		c.panic("Invalid bytecode OpCode encountered")

--- a/src/char.go
+++ b/src/char.go
@@ -4556,6 +4556,10 @@ func (c *Char) parent(log bool) *Char {
 	return p
 }
 
+func (c *Char) parentExist() bool {
+	return c.parent(false) != nil
+}
+
 func (c *Char) root(log bool) *Char {
 	if c.helperIndex == 0 {
 		if log {

--- a/src/char.go
+++ b/src/char.go
@@ -5710,48 +5710,40 @@ func (c *Char) pauseTimeTrigger() int32 {
 	return p
 }
 
-func (c *Char) projCancelTime(pid BytecodeValue) BytecodeValue {
+func (c *Char) projTimeTrigger(pid BytecodeValue, match func(ProjContact) bool) BytecodeValue {
 	if pid.IsUndefined() {
 		return BytecodeUndefined()
 	}
+	gi := c.gi()
 	id := pid.ToI()
-	if (id > 0 && id != c.gi().pcid) || c.gi().pctype != PC_Cancel || c.helperIndex > 0 {
+	if c.helperIndex > 0 || (id > 0 && id != gi.pcid) || !match(gi.pctype) {
 		return BytecodeInt(-1)
 	}
-	return BytecodeInt(c.gi().pctime)
+	return BytecodeInt(gi.pctime)
+}
+
+func (c *Char) projCancelTime(pid BytecodeValue) BytecodeValue {
+	return c.projTimeTrigger(pid, func(pc ProjContact) bool {
+		return pc == PC_Cancel
+	})
 }
 
 func (c *Char) projContactTime(pid BytecodeValue) BytecodeValue {
-	if pid.IsUndefined() {
-		return BytecodeUndefined()
-	}
-	id := pid.ToI()
-	if (id > 0 && id != c.gi().pcid) || c.gi().pctype == PC_Cancel || c.helperIndex > 0 {
-		return BytecodeInt(-1)
-	}
-	return BytecodeInt(c.gi().pctime)
+	return c.projTimeTrigger(pid, func(pc ProjContact) bool {
+		return pc != PC_Cancel
+	})
 }
 
 func (c *Char) projGuardedTime(pid BytecodeValue) BytecodeValue {
-	if pid.IsUndefined() {
-		return BytecodeUndefined()
-	}
-	id := pid.ToI()
-	if (id > 0 && id != c.gi().pcid) || c.gi().pctype != PC_Guarded || c.helperIndex > 0 {
-		return BytecodeInt(-1)
-	}
-	return BytecodeInt(c.gi().pctime)
+	return c.projTimeTrigger(pid, func(pc ProjContact) bool {
+		return pc == PC_Guarded
+	})
 }
 
 func (c *Char) projHitTime(pid BytecodeValue) BytecodeValue {
-	if pid.IsUndefined() {
-		return BytecodeUndefined()
-	}
-	id := pid.ToI()
-	if (id > 0 && id != c.gi().pcid) || c.gi().pctype != PC_Hit || c.helperIndex > 0 {
-		return BytecodeInt(-1)
-	}
-	return BytecodeInt(c.gi().pctime)
+	return c.projTimeTrigger(pid, func(pc ProjContact) bool {
+		return pc == PC_Hit
+	})
 }
 
 func (c *Char) reversalDefAttr(attr int32) bool {

--- a/src/char.go
+++ b/src/char.go
@@ -706,7 +706,7 @@ func (hd *HitDef) reset(c *Char, proj *Projectile) {
 		hitflag:            int32(HF_H | HF_L | HF_A | HF_F),
 		guardflag:          0,
 		affectteam:         1,
-		teamside:           -1,
+		teamside:           -2,
 		animtype:           RA_Light,
 		air_animtype:       RA_Unknown,
 		priority:           4,
@@ -976,8 +976,8 @@ func (hd *HitDef) finalizeParams(c *Char, proj *Projectile) {
 		hd.maxdist[2], hd.mindist[2] = hd.snap[2], hd.snap[2]
 	}
 
-	if hd.teamside == -1 {
-		hd.teamside = c.teamside + 1
+	if hd.teamside < -1 || hd.teamside > 1 {
+		hd.teamside = c.teamside
 	}
 
 	if hd.p2clsncheck < 0 {
@@ -1110,6 +1110,7 @@ type GetHitVar struct {
 	keepstate           bool
 	standfriction       float32
 	crouchfriction      float32
+	teamside            int
 }
 
 // This is called every time the char gets hit
@@ -1133,6 +1134,7 @@ func (ghv *GetHitVar) reset(c *Char) {
 		playerno:       -2, // Because it returns with +1
 		playerid:       -1,
 		projid:         -1,
+		teamside:       -2, // See playerno
 		fall_animtype:  RA_Unknown,
 		fall_xvelocity: float32(math.NaN()),
 		fall_yvelocity: -4.5 / originLs,
@@ -10518,6 +10520,7 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 		getter.ghv.hitid = hd.id
 		getter.ghv.playerno = hd.playerno
 		getter.ghv.playerid = hd.playerid
+		getter.ghv.teamside = hd.teamside
 		getter.ghv.projid = hd.projid
 		getter.ghv.keepstate = hd.KeepState
 		getter.ghv.groundtype = hd.ground_type
@@ -10585,6 +10588,7 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 			ghv.hitid = hd.id
 			ghv.playerno = hd.playerno
 			ghv.playerid = hd.playerid
+			ghv.teamside = hd.teamside
 			ghv.projid = hd.projid
 			ghv.xaccel = hd.xaccel * scaleratio * -byf
 			ghv.yaccel = hd.yaccel * scaleratio
@@ -12851,9 +12855,8 @@ func (cl *CharList) hitDetectionPlayer(getter *Char) {
 			continue
 		}
 
-		if c.atktmp != 0 && c.id != getter.id && (c.hitdef.affectteam == 0 ||
-			((getter.teamside != c.hitdef.teamside-1) == (c.hitdef.affectteam > 0) && c.hitdef.teamside >= 0) ||
-			((getter.teamside != c.teamside) == (c.hitdef.affectteam > 0) && c.hitdef.teamside < 0)) {
+		if c.atktmp != 0 && c.id != getter.id &&
+			(c.hitdef.affectteam == 0 || (getter.teamside != c.hitdef.teamside) == (c.hitdef.affectteam > 0)) {
 
 			// Guard distance check
 			// Mugen uses < checks so that 0 does not trigger proximity guard at 0 distance
@@ -12980,6 +12983,7 @@ func (cl *CharList) hitDetectionPlayer(getter *Char) {
 								getter.ghv.hitid = c.hitdef.id
 								getter.ghv.playerno = c.playerNo
 								getter.ghv.playerid = c.id
+								getter.ghv.teamside = c.hitdef.teamside
 								getter.fallTime = 0
 
 								// Fall flag
@@ -13090,15 +13094,15 @@ func (cl *CharList) hitDetectionProjectile(getter *Char) {
 
 			// In Mugen, projectiles couldn't hit their root even with the proper affectteam
 			if i == getter.playerNo && getter.helperIndex == 0 &&
-				(getter.teamside == p.hitdef.teamside-1) && !p.platform {
+				(getter.teamside == p.hitdef.teamside) && !p.platform {
 				continue
 			}
 
 			// Teamside check
 			// Since the teamside parameter is new to Ikemen, we can make that one allow the projectile to hit the root
 			if p.hitdef.affectteam != 0 &&
-				((getter.teamside != p.hitdef.teamside-1) != (p.hitdef.affectteam > 0) ||
-					(getter.teamside == p.hitdef.teamside-1) != (p.hitdef.affectteam < 0)) {
+				((getter.teamside != p.hitdef.teamside) != (p.hitdef.affectteam > 0) ||
+					(getter.teamside == p.hitdef.teamside) != (p.hitdef.affectteam < 0)) {
 				continue
 			}
 
@@ -13170,7 +13174,7 @@ func (cl *CharList) hitDetectionProjectile(getter *Char) {
 
 			// Cancel a projectile with hitflag P
 			if getter.atktmp != 0 && (getter.hitdef.affectteam == 0 ||
-				(p.hitdef.teamside-1 != getter.teamside) == (getter.hitdef.affectteam > 0)) &&
+				(p.hitdef.teamside != getter.teamside) == (getter.hitdef.affectteam > 0)) &&
 				getter.hitdef.hitflag&int32(HF_P) != 0 &&
 				getter.projClsnCheck(p, 1, 2) &&
 				sys.zAxisOverlap(getter.pos[2], getter.hitdef.attack_depth[0], getter.hitdef.attack_depth[1], getter.localscl,

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2722,6 +2722,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			opc = OC_ex_gethitvar_projid
 		case "guardko":
 			opc = OC_ex_gethitvar_guardko
+		case "teamside":
+			opc = OC_ex_gethitvar_teamside
 		default:
 			return bvNone(), Error("Invalid GetHitVar argument: " + c.token)
 		}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -309,6 +309,7 @@ var triggerMap = map[string]int{
 	"p4name":            1,
 	"palno":             1,
 	"parentdist":        1,
+	"parentexist":       1,
 	"pi":                1,
 	"playeridexist":     1,
 	"pos":               1,
@@ -4067,6 +4068,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 		default:
 			return bvNone(), Error("Invalid ParentDist argument: " + c.token)
 		}
+	case "parentexist":
+		out.append(OC_ex2_, OC_ex2_parentexist)
 	case "pi":
 		bv = BytecodeFloat(float32(math.Pi))
 	case "e":

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -5218,6 +5218,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			if n != 0 && n != 1 && !sys.ignoreMostErrors {
 				return bvNone(), Error(trname + " must be compared against 0 or 1")
 			}
+			// Check if the second comparison exists (ProjContact[ID] = value, [oper] value2)
+			hasSecondComparison := c.token == ","
 			// Build the underlying Proj*Time(id) expression
 			// Build it as a single block to prevent the first '=' from interrupting the current redirection
 			// https://github.com/ikemen-engine/Ikemen-GO/issues/2123
@@ -5228,7 +5230,22 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			if err = c.evaluateComparison(&oldblock, in, false); err != nil {
 				return bvNone(), err
 			}
-			// "= 0" negates the generated time comparison
+			// For the second form, ensure negative time (no contact yet) isn't valid
+			if hasSecondComparison {
+				// Compile "pctime >= 0"
+				var guardblock BytecodeExp
+				guardblock.append(idExp...)
+				guardblock.append(opc)
+				guardblock.appendValue(BytecodeInt(0))
+				guardblock.append(OC_ge)
+				// Combine that with "oldblock"
+				var combined BytecodeExp
+				combined.append(guardblock...)
+				combined.append(oldblock...)
+				combined.append(OC_bland)
+				oldblock = combined
+			}
+			// "= 0" negates the generated result
 			if n == 0 {
 				oldblock.append(OC_blnot)
 			}

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -6664,12 +6664,16 @@ func (c *Compiler) getHitVarSet(is IniSection, sc *StateControllerBase, _ int8) 
 			getHitVarSet_hittime, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.paramValue(is, sc, "id",
-			getHitVarSet_id, VT_Int, 1, false); err != nil {
+		if err := c.paramValue(is, sc, "playerid",
+			getHitVarSet_playerid, VT_Int, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "playerno",
 			getHitVarSet_playerno, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "projid",
+			getHitVarSet_projid, VT_Int, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "redlife",
@@ -6682,6 +6686,10 @@ func (c *Compiler) getHitVarSet(is IniSection, sc *StateControllerBase, _ int8) 
 		}
 		if err := c.paramValue(is, sc, "slidetime",
 			getHitVarSet_slidetime, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "teamside",
+			getHitVarSet_teamside, VT_Int, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "xvel",

--- a/src/script.go
+++ b/src/script.go
@@ -8401,6 +8401,8 @@ func triggerFunctions(l *lua.LState) {
 			lv = lua.LNumber(c.ghv.playerid)
 		case "playerno":
 			lv = lua.LNumber(c.ghv.playerno + 1)
+		case "teamside":
+			lv = lua.LNumber(c.ghv.teamside + 1)
 		case "redlife":
 			lv = lua.LNumber(c.ghv.redlife)
 		case "score":


### PR DESCRIPTION
Features:
- `parentExist` trigger. Allows checking if a helper's parent is still in the game without triggering any debug warnings
- `getHitVar(teamside)` trigger. Returns the teamside of the last player/projectile that hit the char

Fixes:
- Fixed the initial projectile contact time of -1 not being accounted for in the old projectile triggers (ProjContact, etc)
- Fixed a source of potential missing ID warnings in functions.zss
- Fixes #3497
- Fixes #3501 

Refactor:
- HitDef teamside is now index 0 in source, like teamside itself