### PR TITLE
fix: Fix AllPalFX and BGPalFX being a frame late.

### DIFF
--- a/src/rollback.go
+++ b/src/rollback.go
@@ -220,9 +220,7 @@ func (rs *RollbackSystem) simulateFrame(s *System) bool {
 		return false
 	}
 
-	s.bgPalFX.step()
 	s.stage.action()
-
 	// If frame is ready to tick and not paused
 	//sys.stage.action()
 

--- a/src/stage.go
+++ b/src/stage.go
@@ -1799,30 +1799,6 @@ func (s *Stage) action() {
 
 	// Update BG elements
 	for i, b := range s.bg {
-		b.palfx.step()
-
-		// BGPalFX can step even if the stage is paused
-		if sys.bgPalFX.enable {
-			// TODO: Finish proper synthesization of bgPalFX into PalFX from bg element
-			// (Right now, bgPalFX just overrides all unique parameters from BG Elements' PalFX)
-			// for j := 0; j < 3; j++ {
-			// if sys.bgPalFX.invertall {
-			// b.palfx.eAdd[j] = -b.palfx.add[j] * (b.palfx.mul[j]/256) + 256 * (1-(b.palfx.mul[j]/256))
-			// b.palfx.eMul[j] = 256
-			// }
-			// b.palfx.eAdd[j] = int32((float32(b.palfx.eAdd[j])) * sys.bgPalFX.eColor)
-			// b.palfx.eMul[j] = int32(float32(b.palfx.eMul[j]) * sys.bgPalFX.eColor + 256*(1-sys.bgPalFX.eColor))
-			// }
-			// b.palfx.synthesize(sys.bgPalFX)
-			b.palfx.eAdd = sys.bgPalFX.eAdd
-			b.palfx.eMul = sys.bgPalFX.eMul
-			b.palfx.eColor = sys.bgPalFX.eColor
-			b.palfx.eHue = sys.bgPalFX.eHue
-			b.palfx.eInvertall = sys.bgPalFX.eInvertall
-			b.palfx.eInvertblend = sys.bgPalFX.eInvertblend
-			b.palfx.eAllowNeg = sys.bgPalFX.eAllowNeg
-		}
-
 		if canStep {
 			s.bg[i].bga.action(b.enabled)
 			if i > 0 && b.positionlink {
@@ -1847,6 +1823,38 @@ func (s *Stage) action() {
 			s.bg[i].anim.Action()
 		}
 	}
+}
+
+// Currently this function only exists so that the stage update sequence is similar to others. In the future it could run more tasks
+// Doing this allows characters to see "stageTime = 0"
+func (s *Stage) tick() {
+
+	// Update BG elements
+	for _, b := range s.bg {
+		b.palfx.step()
+
+		// BGPalFX can step even if the stage is paused
+		if sys.bgPalFX.enable {
+			// TODO: Finish proper synthesization of bgPalFX into PalFX from bg element
+			// (Right now, bgPalFX just overrides all unique parameters from BG Elements' PalFX)
+			// for j := 0; j < 3; j++ {
+			// if sys.bgPalFX.invertall {
+			// b.palfx.eAdd[j] = -b.palfx.add[j] * (b.palfx.mul[j]/256) + 256 * (1-(b.palfx.mul[j]/256))
+			// b.palfx.eMul[j] = 256
+			// }
+			// b.palfx.eAdd[j] = int32((float32(b.palfx.eAdd[j])) * sys.bgPalFX.eColor)
+			// b.palfx.eMul[j] = int32(float32(b.palfx.eMul[j]) * sys.bgPalFX.eColor + 256*(1-sys.bgPalFX.eColor))
+			// }
+			// b.palfx.synthesize(sys.bgPalFX)
+			b.palfx.eAdd = sys.bgPalFX.eAdd
+			b.palfx.eMul = sys.bgPalFX.eMul
+			b.palfx.eColor = sys.bgPalFX.eColor
+			b.palfx.eHue = sys.bgPalFX.eHue
+			b.palfx.eInvertall = sys.bgPalFX.eInvertall
+			b.palfx.eInvertblend = sys.bgPalFX.eInvertblend
+			b.palfx.eAllowNeg = sys.bgPalFX.eAllowNeg
+		}
+	}
 
 	// Update model PalFX
 	if s.model != nil {
@@ -1861,11 +1869,7 @@ func (s *Stage) action() {
 			s.model.pfx.eAllowNeg = sys.bgPalFX.eAllowNeg
 		}
 	}
-}
 
-// Currently this function only exists so that the stage update sequence is similar to others. In the future it could run more tasks
-// Doing this allows characters to see "stageTime = 0"
-func (s *Stage) tick() {
 	if s.paused() {
 		return
 	}

--- a/src/system.go
+++ b/src/system.go
@@ -2473,7 +2473,6 @@ func (s *System) action() {
 		// Z axis player limits
 		s.zmin = s.stage.topbound * s.stage.localscl
 		s.zmax = s.stage.botbound * s.stage.localscl
-		s.allPalFX.step()
 		//s.bgPalFX.step()
 		s.envShake.next()
 		if s.envcol_time > 0 {
@@ -2507,6 +2506,8 @@ func (s *System) action() {
 			s.specialFlag = (s.specialFlag&GSF_nokoslow | s.specialFlag&GSF_timerfreeze)
 		}
 		s.charList.action()
+		s.allPalFX.step()
+		s.bgPalFX.step()
 		s.nomusic = s.gsf(GSF_nomusic) && !sys.postMatchFlg
 	}
 
@@ -3638,9 +3639,7 @@ func (s *System) runMatch() (reload bool) {
 		}
 
 		// TODO: These probably ought to be in action() as well
-		s.bgPalFX.step()
 		s.stage.action()
-
 		// Update game state
 		s.action()
 


### PR DESCRIPTION
BGPalFX updates to what it should be while the game is paused, so it's a little tricky to spot that it's a frame late. I only noticed it by accident, myself.