### PR TITLE
fix: ProjVar TeamSide parity with TeamSide

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3970,7 +3970,7 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 			case OC_ex2_projvar_supermovetime:
 				sys.bcStack.PushI(p.supermovetime)
 			case OC_ex2_projvar_teamside:
-				sys.bcStack.PushI(int32(p.hitdef.teamside))
+				sys.bcStack.PushI(int32(p.hitdef.teamside) + 1)
 			case OC_ex2_projvar_time:
 				sys.bcStack.PushI(p.time)
 			case OC_ex2_projvar_vel_x:

--- a/src/script.go
+++ b/src/script.go
@@ -9677,7 +9677,7 @@ func triggerFunctions(l *lua.LState) {
 			case "supermovetime":
 				lv = lua.LNumber(p.supermovetime)
 			case "teamside":
-				lv = lua.LNumber(p.hitdef.teamside)
+				lv = lua.LNumber(p.hitdef.teamside + 1)
 			case "time":
 				lv = lua.LNumber(p.time)
 			case "vel x":


### PR DESCRIPTION
ProjVar TeamSide was returning 0 and 1, instead of 1 and 2 like the other TeamSide triggers.