### PR TITLE
refactor: Rename MissOnReversalDef to IgnoreReversalDef

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -7305,7 +7305,7 @@ const (
 	hitDef_stand_friction
 	hitDef_crouch_friction
 	hitDef_keepstate
-	hitDef_missonreversaldef
+	hitDef_ignorereversaldef
 	hitDef_last = iota + afterImage_last + 1 - 1
 	hitDef_redirectid
 )
@@ -7683,8 +7683,8 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, paramID byte, exp []BytecodeExp) {
 		hd.CrouchFriction = exp[0].evalF(c)
 	case hitDef_keepstate:
 		hd.KeepState = exp[0].evalB(c)
-	case hitDef_missonreversaldef:
-		hd.MissOnReversalDef = Btoi(exp[0].evalB(c))
+	case hitDef_ignorereversaldef:
+		hd.IgnoreReversalDef = Btoi(exp[0].evalB(c))
 	default:
 		if isPalFXParam(paramID) {
 			palFX(sc).runSub(c, &hd.palfx, paramID, exp)

--- a/src/char.go
+++ b/src/char.go
@@ -681,7 +681,7 @@ type HitDef struct {
 	StandFriction              float32
 	CrouchFriction             float32
 	KeepState                  bool
-	MissOnReversalDef          int32
+	IgnoreReversalDef          int32
 }
 
 func (hd *HitDef) reset(c *Char, proj *Projectile) {
@@ -806,7 +806,7 @@ func (hd *HitDef) reset(c *Char, proj *Projectile) {
 		StandFriction:       float32(math.NaN()),
 		CrouchFriction:      float32(math.NaN()),
 		KeepState:           false,
-		MissOnReversalDef:   0,
+		IgnoreReversalDef:   0,
 
 		reversal_guardflag:     IErr,
 		reversal_guardflag_not: IErr,
@@ -10151,7 +10151,7 @@ func (c *Char) attrCheck(getter *Char, ghd *HitDef, gstyp StateType) bool {
 
 	// ReversalDef vs HitDef attributes check
 	if ghd.reversal_attr > 0 {
-		if c.hitdef.MissOnReversalDef > 0 {
+		if c.hitdef.IgnoreReversalDef > 0 {
 			return false
 		}
 		// Check HitDef validity

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -2255,8 +2255,8 @@ func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 		hitDef_crouch_friction, VT_Float, 1, false); err != nil {
 		return err
 	}
-	if err := c.paramValue(is, sc, "missonreversaldef",
-		hitDef_missonreversaldef, VT_Bool, 1, false); err != nil {
+	if err := c.paramValue(is, sc, "ignorereversaldef",
+		hitDef_ignorereversaldef, VT_Bool, 1, false); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
"MissOnReversalDef" was misleading because it did the exact opposite of miss; it _hit through_ ReversalDef.

I'm leaving it as an int32 instead of a bool because I'm planning on having multiple modes for it depending on the value used.