### PR TITLE
feat: Zoom endLag, fight screen leaderOnTop, duplicate warnings; fixes; refactoring

### DIFF
--- a/src/anim.go
+++ b/src/anim.go
@@ -1062,28 +1062,35 @@ func (a *Animation) ShadowDraw(window *[4]int32, x, y, xscl, yscl, vscl, rxadd f
 	//}
 }
 
-type AnimationTable map[int32]*Animation
-
-func NewAnimationTable() AnimationTable {
-	return AnimationTable(make(map[int32]*Animation))
+type AnimationTable struct {
+	anims    map[int32]*Animation
+	filename string
 }
 
-func (at AnimationTable) readAction(sff *Sff, pal *PaletteList,
-	lines []string, i *int) *Animation {
+func NewAnimationTable() AnimationTable {
+	return AnimationTable{
+		anims:    make(map[int32]*Animation),
+	}
+}
+
+func (at AnimationTable) readAction(sff *Sff, pal *PaletteList, lines []string, i *int, log bool) *Animation {
 	for *i < len(lines) {
 		no, a := ReadAction(sff, pal, lines, i)
 		if a != nil {
 			// In case of duplicate action numbers, just use the first one
 			// Even if first one is "Copy Action"
-			if existing := at[no]; existing != nil {
+			if existing := at.anims[no]; existing != nil {
+				if log {
+					LogMessage("WARNING: Duplicate action key in %v: %v (ignored)", at.filename, no)
+				}
 				return existing
 			}
 			// Store the new animation in the table.
-			at[no] = a
+			at.anims[no] = a
 			// Recursive logic until we find a non-empty animation
 			// If the current action is empty, we attempt to copy the very next action found in the file
 			for len(a.frames) == 0 && *i < len(lines) && a.copyAction < 0 {
-				if a2 := at.readAction(sff, pal, lines, i); a2 != nil {
+				if a2 := at.readAction(sff, pal, lines, i, log); a2 != nil {
 					*a = *a2
 					break
 				}
@@ -1098,16 +1105,18 @@ func (at AnimationTable) readAction(sff *Sff, pal *PaletteList,
 	return nil
 }
 
-func ReadAnimationTable(sff *Sff, pal *PaletteList, lines []string, i *int) AnimationTable {
+func ReadAnimationTable(filename string, sff *Sff, pal *PaletteList,
+	lines []string, i *int, log bool) AnimationTable {
 	at := NewAnimationTable()
-	for at.readAction(sff, pal, lines, i) != nil {
+	at.filename = filename
+	for at.readAction(sff, pal, lines, i, log) != nil {
 	}
 	at.resolveCopyAction()
 	return at
 }
 
 func (at AnimationTable) get(no int32) *Animation {
-	a := at[no]
+	a := at.anims[no]
 	if a == nil {
 		return a
 	}
@@ -1121,10 +1130,10 @@ func (at AnimationTable) resolveCopyAction() {
 	// Track actions that fail to resolve
 	var toDelete []int32
 
-	for no, a := range at {
+	for no, a := range at.anims {
 		// Limit the chain depth to 8 to prevent infinite loops from circular references
 		for loops := 0; a.copyAction >= 0 && loops < 8; loops++ {
-			target := at[a.copyAction]
+			target := at.anims[a.copyAction]
 
 			// If the target is missing or it's a self-reference, break the link to stop
 			if target == nil || target == a {
@@ -1153,7 +1162,7 @@ func (at AnimationTable) resolveCopyAction() {
 
 	// Purge the ghost animations from the table
 	for _, no := range toDelete {
-		delete(at, no)
+		delete(at.anims, no)
 	}
 }
 

--- a/src/bgdef.go
+++ b/src/bgdef.go
@@ -82,9 +82,11 @@ func loadBGDef(sff *Sff, model *Model, def string, bgname string, startlayer int
 			s.modelScale = [3]float32{scale[0], scale[1], scale[2]}
 		}
 	}
+
 	s.sff = sff
 	s.model = model
-	s.animTable = ReadAnimationTable(s.sff, &s.sff.palList, lines, &i)
+	s.animTable = ReadAnimationTable(def, s.sff, &s.sff.palList, lines, &i, true)
+
 	var bglink *backGround
 	for _, bgsec := range defmap[bgname] {
 		if len(s.bg) > 0 && s.bg[len(s.bg)-1].positionlink {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -962,6 +962,7 @@ const (
 	OC_ex2_zoomvar_pos_x
 	OC_ex2_zoomvar_pos_y
 	OC_ex2_zoomvar_lag
+	OC_ex2_zoomvar_endlag
 	OC_ex2_zoomvar_time
 	OC_ex2_projclsnoverlap
 	OC_ex2_attackmul
@@ -4136,15 +4137,17 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	case OC_ex2_xshear:
 		sys.bcStack.PushF(c.xshear)
 	case OC_ex2_zoomvar_scale:
-		sys.bcStack.PushF(sys.drawScale)
+		sys.bcStack.PushF(sys.zoom.curScale)
 	case OC_ex2_zoomvar_pos_x:
-		sys.bcStack.PushF(sys.zoomPosCur[0])
+		sys.bcStack.PushF(sys.zoom.curPos[0] / oc.localscl)
 	case OC_ex2_zoomvar_pos_y:
-		sys.bcStack.PushF(sys.zoomPosCur[1])
+		sys.bcStack.PushF(sys.zoom.curPos[1] / oc.localscl)
 	case OC_ex2_zoomvar_lag:
-		sys.bcStack.PushF(sys.zoomLag)
+		sys.bcStack.PushF(sys.zoom.lag)
+	case OC_ex2_zoomvar_endlag:
+		sys.bcStack.PushF(sys.zoom.endLag)
 	case OC_ex2_zoomvar_time:
-		sys.bcStack.PushI(sys.enableZoomtime)
+		sys.bcStack.PushI(sys.zoom.time)
 	case OC_ex2_projclsnoverlap:
 		boxType := sys.bcStack.Pop().ToI()
 		targetID := sys.bcStack.Pop().ToI()
@@ -11240,8 +11243,9 @@ const (
 	zoom_pos byte = iota
 	zoom_scale
 	zoom_lag
-	zoom_camerabound
+	zoom_endlag
 	zoom_time
+	zoom_camerabound
 	zoom_stagebound
 )
 
@@ -11251,6 +11255,7 @@ func (sc zoom) Run(c *Char, _ []int32) bool {
 	t := int32(1)
 	scl := float32(1)
 	lag := float32(0)
+	endlag := float32(0)
 
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
@@ -11265,29 +11270,38 @@ func (sc zoom) Run(c *Char, _ []int32) bool {
 				sys.appendToConsole(c.warn() + fmt.Sprintf("invalid Zoom scale value: %v", scl))
 				scl = 1
 			}
-		case zoom_camerabound:
-			sys.zoomCameraBound = exp[0].evalB(c)
-		case zoom_stagebound:
-			sys.zoomStageBound = exp[0].evalB(c)
 		case zoom_lag:
 			lag = exp[0].evalF(c)
 			if lag < 0 || lag > 1 {
 				sys.appendToConsole(c.warn() + fmt.Sprintf("clamped invalid Zoom lag value: %v", lag))
-				lag = Clamp(lag, 0, 1)
+				lag = Clamp(lag, float32(0), float32(1))
+			}
+		case zoom_endlag:
+			endlag = exp[0].evalF(c)
+			if endlag < 0 || endlag > 1 {
+				sys.appendToConsole(c.warn() + fmt.Sprintf("clamped invalid Zoom endlag value: %v", endlag))
+				endlag = Clamp(endlag, float32(0), float32(1))
 			}
 		case zoom_time:
 			t = exp[0].evalI(c)
+		case zoom_camerabound:
+			sys.zoom.cameraBound = exp[0].evalB(c)
+		case zoom_stagebound:
+			sys.zoom.stageBound = exp[0].evalB(c)
 		}
 		return true
 	})
 
 	// This old calculation is both less accurate to Mugen and less intuitive to work with
-	// sys.zoomPos[0] = sys.zoomScale * pos[0]
-	sys.zoomPos[0] = pos[0]
-	sys.zoomPos[1] = pos[1]
-	sys.zoomScale = scl
-	sys.zoomLag = lag
-	sys.enableZoomtime = t
+	// sys.zoom.pos[0] = sys.zoom.scale * pos[0]
+	sys.zoom.pos = pos
+	sys.zoom.scale = scl
+	sys.zoom.lag = lag
+	sys.zoom.endLag = endlag
+	sys.zoom.time = t
+	sys.zoom.active = true
+
+	// "Current" values are not reset, for the sake of continuity between effects
 
 	return false
 }

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -4138,11 +4138,11 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	case OC_ex2_zoomvar_scale:
 		sys.bcStack.PushF(sys.drawScale)
 	case OC_ex2_zoomvar_pos_x:
-		sys.bcStack.PushF(sys.zoomPosXLag)
+		sys.bcStack.PushF(sys.zoomPosCur[0])
 	case OC_ex2_zoomvar_pos_y:
-		sys.bcStack.PushF(sys.zoomPosYLag)
+		sys.bcStack.PushF(sys.zoomPosCur[1])
 	case OC_ex2_zoomvar_lag:
-		sys.bcStack.PushF(sys.zoomlag)
+		sys.bcStack.PushF(sys.zoomLag)
 	case OC_ex2_zoomvar_time:
 		sys.bcStack.PushI(sys.enableZoomtime)
 	case OC_ex2_projclsnoverlap:
@@ -11246,8 +11246,12 @@ const (
 )
 
 func (sc zoom) Run(c *Char, _ []int32) bool {
+	// Defaults
 	pos := [2]float32{0, 0}
 	t := int32(1)
+	scl := float32(1)
+	lag := float32(0)
+
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
 		case zoom_pos:
@@ -11256,23 +11260,35 @@ func (sc zoom) Run(c *Char, _ []int32) bool {
 				pos[1] = exp[1].evalF(c) * c.localscl
 			}
 		case zoom_scale:
-			sys.zoomScale = exp[0].evalF(c)
+			scl = exp[0].evalF(c)
+			if scl <= 0 {
+				sys.appendToConsole(c.warn() + fmt.Sprintf("invalid Zoom scale value: %v", scl))
+				scl = 1
+			}
 		case zoom_camerabound:
 			sys.zoomCameraBound = exp[0].evalB(c)
 		case zoom_stagebound:
 			sys.zoomStageBound = exp[0].evalB(c)
 		case zoom_lag:
-			sys.zoomlag = exp[0].evalF(c)
+			lag = exp[0].evalF(c)
+			if lag < 0 || lag > 1 {
+				sys.appendToConsole(c.warn() + fmt.Sprintf("clamped invalid Zoom lag value: %v", lag))
+				lag = Clamp(lag, 0, 1)
+			}
 		case zoom_time:
 			t = exp[0].evalI(c)
 		}
 		return true
 	})
+
 	// This old calculation is both less accurate to Mugen and less intuitive to work with
 	// sys.zoomPos[0] = sys.zoomScale * pos[0]
 	sys.zoomPos[0] = pos[0]
 	sys.zoomPos[1] = pos[1]
+	sys.zoomScale = scl
+	sys.zoomLag = lag
 	sys.enableZoomtime = t
+
 	return false
 }
 

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -7335,8 +7335,8 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, paramID byte, exp []BytecodeExp) {
 		n := exp[0].evalI(c)
 		if n < 0 || n > 2 {
 			// TODO: We should do this in more parameters
-			// This could also be more specific and use crun, but that's a minor issue
-			sys.appendToConsole(c.warn() + fmt.Sprintf("invalid HitDef teamside: %d", n))
+			// This could also be more specific and use crun, but right now adding that to runSub is more trouble than it's worth
+			sys.appendToConsole(c.warn() + fmt.Sprintf("invalid teamside: %d", n))
 		} else {
 			hd.teamside = int(n - 1)
 		}
@@ -8446,15 +8446,13 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				})
 			case hitDef_teamside:
 				v1 := exp[0].evalI(c)
-				eachProj(func(p *Projectile) {
-					if v1 > 2 {
-						p.hitdef.teamside = 2
-					} else if v1 < 0 {
-						p.hitdef.teamside = 0
-					} else {
-						p.hitdef.teamside = int(v1)
-					}
-				})
+				if v1 < 0 || v1 > 2 {
+					sys.appendToConsole(crun.warn() + fmt.Sprintf("invalid teamside: %d", v1))
+				} else {
+					eachProj(func(p *Projectile) {
+						p.hitdef.teamside = int(v1 - 1)
+					})
+				}
 			case hitDef_id:
 				v1 := Max(0, exp[0].evalI(c))
 				eachProj(func(p *Projectile) {

--- a/src/char.go
+++ b/src/char.go
@@ -3979,14 +3979,22 @@ func (c *Char) load(def string) error {
 	}
 
 	// Read animations
-	str = ""
+	var animFilename string
+	gi.animTable = NewAnimationTable()
+
 	if len(anim) > 0 {
 		anim_resolved := resolvePathRelativeToDef(anim)
-		if LoadFile(&anim_resolved, []string{def, "", sys.motif.Def, "data/"}, func(filename string) error {
-			var err_air error
-			str, err_air = LoadText(filename)
-			if err_air != nil {
-				return err_air
+		if err := LoadFile(&anim_resolved, []string{def, "", sys.motif.Def, "data/"}, func(filename string) error {
+			str, err := LoadText(filename)
+			if err != nil {
+				return err
+			}
+
+			animFilename = filename
+			gi.animTable.filename = filename
+
+			lines, i := SplitAndTrim(str, "\n"), 0
+			for gi.animTable.readAction(gi.sff, &gi.palettedata.palList, lines, &i, true) != nil {
 			}
 			return nil
 		}); err != nil {
@@ -3994,7 +4002,7 @@ func (c *Char) load(def string) error {
 		}
 	}
 
-	// Append common animations
+	// Read and merge common animations
 	for _, key := range SortedKeys(sys.cfg.Common.Air) {
 		for _, v := range sys.cfg.Common.Air[key] {
 			if err := LoadFile(&v, []string{def, sys.motif.Def, sys.fightScreen.def, "", "data/"}, func(filename string) error {
@@ -4002,7 +4010,20 @@ func (c *Char) load(def string) error {
 				if err != nil {
 					return err
 				}
-				str += "\n" + txt
+
+				// Create a temporary table for finer control and local error logging
+				tmp := NewAnimationTable()
+				tmp.filename = filename
+				lines, i := SplitAndTrim(txt, "\n"), 0
+				for tmp.readAction(gi.sff, &gi.palettedata.palList, lines, &i, true) != nil {
+				}
+
+				// Merge temporary table with the char's
+				for no, a := range tmp.anims {
+					if gi.animTable.anims[no] == nil {
+						gi.animTable.anims[no] = a
+					}
+				}
 				return nil
 			}); err != nil {
 				return err
@@ -4010,9 +4031,12 @@ func (c *Char) load(def string) error {
 		}
 	}
 
-	// Load animations
-	lines, i := SplitAndTrim(str, "\n"), 0
-	gi.animTable = ReadAnimationTable(gi.sff, &gi.palettedata.palList, lines, &i)
+	// Resolve Copy Action after all sources have been merged
+	// This only works because we didn't use ReadAnimationTable here, which would've done it per file
+	gi.animTable.resolveCopyAction()
+
+	// Final merged table keeps the main filename
+	gi.animTable.filename = animFilename
 
 	// Load sounds
 	if len(sound) > 0 {
@@ -6987,7 +7011,7 @@ func (c *Char) getAnim(n int32, ffx string) (a *Animation) {
 	}
 
 	if current_ffx != "" && current_ffx != "s" {
-		if sys.ffx[current_ffx] != nil && sys.ffx[current_ffx].animTable != nil {
+		if sys.ffx[current_ffx] != nil && sys.ffx[current_ffx].animTable.anims != nil {
 			a = sys.ffx[current_ffx].animTable.get(n)
 		}
 	} else {

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -4324,6 +4324,10 @@ func (c *Compiler) zoom(is IniSection, sc *StateControllerBase, _ int8) (StateCo
 			zoom_lag, VT_Float, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "endlag",
+			zoom_endlag, VT_Float, 1, false); err != nil {
+			return err
+		}
 		if err := c.paramValue(is, sc, "camerabound",
 			zoom_camerabound, VT_Bool, 1, false); err != nil {
 			return err

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -431,6 +431,7 @@ type LifeBar struct {
 	mid_steps  float32
 	gethit     bool
 	scalefill  bool
+	leaderontop bool
 }
 
 func newLifeBar() *LifeBar {
@@ -499,6 +500,7 @@ func readLifeBar(pre string, is IniSection, sff *Sff, at AnimationTable, f map[i
 
 	is.ReadI32(pre+"warn.range", &lb.warn_range[0], &lb.warn_range[1])
 	is.ReadBool(pre+"scalefill", &lb.scalefill)
+	is.ReadBool("leaderontop", &lb.leaderontop)
 
 	return lb
 }
@@ -803,6 +805,7 @@ type PowerBar struct {
 	prevPower        int32
 	levelbars        bool
 	scalefill        bool
+	leaderontop      bool
 }
 
 func newPowerBar() *PowerBar {
@@ -930,6 +933,7 @@ func readPowerBar(pre string, is IniSection, sff *Sff, at AnimationTable, f map[
 
 	is.ReadBool(pre+"levelbars", &pb.levelbars)
 	is.ReadBool(pre+"scalefill", &pb.scalefill)
+	is.ReadBool("leaderontop", &pb.leaderontop)
 
 	return pb
 }
@@ -1182,6 +1186,7 @@ type GuardBar struct {
 	midpowerMin float32
 	invertfill  bool
 	scalefill   bool
+	leaderontop bool
 }
 
 func newGuardBar() (gb *GuardBar) {
@@ -1221,6 +1226,7 @@ func readGuardBar(pre string, is IniSection,
 	gb.warn = ReadAnimLayout(pre+"warn.", is, sff, at, 0)
 	is.ReadBool(pre+"invertfill", &gb.invertfill)
 	is.ReadBool(pre+"scalefill", &gb.scalefill)
+	is.ReadBool("leaderontop", &gb.leaderontop)
 	return gb
 }
 
@@ -1427,6 +1433,7 @@ type StunBar struct {
 	midpowerMin float32
 	invertfill  bool
 	scalefill   bool
+	leaderontop bool
 }
 
 func newStunBar() (sb *StunBar) {
@@ -1466,6 +1473,7 @@ func readStunBar(pre string, is IniSection,
 	sb.warn = ReadAnimLayout(pre+"warn.", is, sff, at, 0)
 	is.ReadBool(pre+"invertfill", &sb.invertfill)
 	is.ReadBool(pre+"scalefill", &sb.scalefill)
+	is.ReadBool("leaderontop", &sb.leaderontop)
 	return sb
 }
 
@@ -1684,6 +1692,7 @@ type FightScreenFace struct {
 	old_pal                [2]int32
 	face_pfx               *PalFX
 	teammate_face_pfx      []*PalFX
+	leaderontop            bool
 }
 
 func newFightScreenFace() *FightScreenFace {
@@ -1712,6 +1721,7 @@ func readFightScreenFace(pre string, is IniSection, sff *Sff, at AnimationTable)
 	fa.face_lay = *ReadLayout(pre+"face.", is, 0)
 	is.ReadBool(pre+"face.palshare", &fa.face_palshare)
 	is.ReadBool(pre+"face.palfxshare", &fa.face_palfxshare)
+	is.ReadBool("leaderontop", &fa.leaderontop)
 
 	// Teammates
 	is.ReadI32(pre+"teammate.pos", &fa.teammate_pos[0], &fa.teammate_pos[1])
@@ -1936,6 +1946,7 @@ type FightScreenName struct {
 	teammate_bg           AnimLayout
 	numko                 int32
 	teammate_ko_hide      bool
+	leaderontop           bool
 }
 
 func newFightScreenName() *FightScreenName {
@@ -1946,6 +1957,7 @@ func readFightScreenName(pre string, is IniSection, sff *Sff, at AnimationTable,
 	nm := newFightScreenName()
 
 	is.ReadI32(pre+"pos", &nm.pos[0], &nm.pos[1])
+	is.ReadBool("leaderontop", &nm.leaderontop)
 	nm.name = *readFSText(pre+"name.", is, "", 0, f, 0)
 	nm.bg = ReadAnimLayout(pre+"bg.", is, sff, at, 0)
 	nm.top = ReadAnimLayout(pre+"top.", is, sff, at, 0)
@@ -4501,10 +4513,6 @@ func loadFightScreen(def string) (*FightScreen, error) {
 		is, name, subname := ReadIniSection(lines, &lnidx)
 		switch name {
 		case "info":
-			var b bool
-			if is.ReadBool("doubleres", &b) {
-				fs.fnt_scale = 0.5
-			}
 			fs.name, _, _ = is.getText("name")
 			fs.nameLow = strings.ToLower(fs.name)
 			fs.author, _, _ = is.getText("author")
@@ -4516,6 +4524,11 @@ func loadFightScreen(def string) (*FightScreen, error) {
 			// Read IkemenVersion
 			if str, ok := is["ikemenversion"]; ok {
 				fs.ikemenver, fs.ikemenverF = ParseIkemenVersion(str)
+			}
+			var b bool
+			is.ReadBool("doubleres", &b)
+			if b {
+				fs.fnt_scale = 0.5
 			}
 			// Localcoord/scale already pre-initialized above to unblock early FightFX
 		case "files":
@@ -5331,193 +5344,194 @@ func (fs *FightScreen) reset() {
 }
 
 func (fs *FightScreen) draw(layerno int16) {
+	// Do not draw anything during victory and such screens
 	if sys.postMatchFlg {
 		return
 	}
-	if !sys.lifebarHide && fs.active && !sys.dialogueBarsFlg && (!sys.motif.me.active || !sys.motif.PauseMenu["pause_menu"].HideBars) {
-		// Helper to run a function for each active player's bars
-		// We will iterate backwards so that player 1 is drawn last and on top
-		forEach := func(fn func(side, layout, slot, barpn, charpn int)) {
-			// We iterate slots first so that the order becomes P8-...-P1 instead of P8-P6-P4-P2-P7-P5-P3-P1
-			for slot := MaxSimul - 1; slot >= 0; slot-- {
-				// Process that slot for each team
-				for side := len(sys.tmode) - 1; side >= 0; side-- {
-					if slot >= len(fs.teamOrder[side]) {
-						continue
-					}
-					layout := fs.curLayout[side]
-					barpn := slot*2 + side
-					charpn := fs.teamOrder[side][slot]
-					fn(side, layout, slot, barpn, charpn)
+
+	pauseHide := sys.motif.me.active && sys.motif.PauseMenu["pause_menu"].HideBars
+
+	if !sys.lifebarHide && fs.active && !sys.dialogueBarsFlg && !pauseHide {
+		// Helper to run a function for each active player's bars for one side
+		forEachMember := func(side int, leaderontop bool, fn func(layout, slot, barpn, charpn int)) {
+			layout := fs.curLayout[side]
+
+			slotStart, slotEnd, slotStep := 0, MaxSimul, 1
+			if leaderontop {
+				slotStart, slotEnd, slotStep = MaxSimul-1, -1, -1
+			}
+
+			for slot := slotStart; slot != slotEnd; slot += slotStep {
+				if slot >= len(fs.teamOrder[side]) {
+					continue
 				}
+				barpn := slot*2 + side
+				charpn := fs.teamOrder[side][slot]
+				fn(layout, slot, barpn, charpn)
 			}
 		}
 
 		if !sys.gsf(GSF_nobardisplay) && fs.bars {
-			// LifeBar backgrounds
-			// We split backgrounds and bars for the sake of backward compatibility
-			// https://github.com/ikemen-engine/Ikemen-GO/issues/3461
-			forEach(func(side, layout, slot, barpn, charpn int) {
-				c := sys.chars[charpn][0]
-				if c.asf(ASF_nolifebardisplay) {
-					return
-				}
-				fs.lifeBars[layout][barpn].bgDraw(layerno)
-			})
+			// LifeBar
+			for side := 0; side < len(sys.tmode); side++ {
+				layout := fs.curLayout[side]
+				leaderontop := fs.lifeBars[layout][side].leaderontop
+				forEachMember(side, leaderontop, func(layout, slot, barpn, charpn int) {
+					c := sys.chars[charpn][0]
+					if c.asf(ASF_nolifebardisplay) {
+						return
+					}
+					fs.lifeBars[layout][barpn].bgDraw(layerno)
+					fs.lifeBars[layout][barpn].draw(layerno, charpn, fs.lifeBars[layout][charpn], fs.fnt)
+				})
+			}
 
-			// LifeBar bars
-			forEach(func(side, layout, slot, barpn, charpn int) {
-				c := sys.chars[charpn][0]
-				if c.asf(ASF_nolifebardisplay) {
-					return
-				}
-				// Use the definition at [layout][barpn] and the runtime values (combo damage etc) stored at [layout][charpn]
-				fs.lifeBars[layout][barpn].draw(layerno, charpn, fs.lifeBars[layout][charpn], fs.fnt)
-			})
-
-			// PowerBar backgrounds
-			forEach(func(side, layout, slot, barpn, charpn int) {
-				c := sys.chars[charpn][0]
-				if c.asf(ASF_nopowerbardisplay) {
-					return
-				}
-				// If sharing is enabled, draw only the first bar
-				tm := sys.tmode[side]
-				if slot != 0 && (tm == TM_Simul || tm == TM_Tag) && sys.cfg.Options.Team.PowerShare {
-					return
-				}
-				fs.powerBars[layout][barpn].bgDraw(layerno, barpn)
-			})
-
-			// PowerBar bars
-			forEach(func(side, layout, slot, barpn, charpn int) {
-				c := sys.chars[charpn][0]
-				if c.asf(ASF_nopowerbardisplay) {
-					return
-				}
-				// If sharing is enabled, draw only the first bar
-				tm := sys.tmode[side]
-				if slot != 0 && (tm == TM_Simul || tm == TM_Tag) && sys.cfg.Options.Team.PowerShare {
-					return
-				}
-				fs.powerBars[layout][barpn].draw(layerno, charpn, fs.powerBars[layout][charpn], fs.fnt)
-			})
+			// PowerBar
+			for side := 0; side < len(sys.tmode); side++ {
+				layout := fs.curLayout[side]
+				leaderontop := fs.powerBars[layout][side].leaderontop
+				forEachMember(side, leaderontop, func(layout, slot, barpn, charpn int) {
+					c := sys.chars[charpn][0]
+					if c.asf(ASF_nopowerbardisplay) {
+						return
+					}
+					tm := sys.tmode[side]
+					if slot != 0 && (tm == TM_Simul || tm == TM_Tag) && sys.cfg.Options.Team.PowerShare {
+						return
+					}
+					fs.powerBars[layout][barpn].bgDraw(layerno, barpn)
+					fs.powerBars[layout][barpn].draw(layerno, charpn, fs.powerBars[layout][charpn], fs.fnt)
+				})
+			}
 
 			// GuardBar
-			forEach(func(side, layout, slot, barpn, charpn int) {
-				c := sys.chars[charpn][0]
-				if !c.guardBreakEnabled() || c.asf(ASF_noguardbardisplay) {
-					return
-				}
-				fs.guardBars[layout][barpn].bgDraw(layerno)
-				fs.guardBars[layout][barpn].draw(layerno, charpn, fs.guardBars[layout][charpn], fs.fnt)
-			})
+			for side := 0; side < len(sys.tmode); side++ {
+				layout := fs.curLayout[side]
+				leaderontop := fs.guardBars[layout][side].leaderontop
+				forEachMember(side, leaderontop, func(layout, slot, barpn, charpn int) {
+					c := sys.chars[charpn][0]
+					if !c.guardBreakEnabled() || c.asf(ASF_noguardbardisplay) {
+						return
+					}
+					fs.guardBars[layout][barpn].bgDraw(layerno)
+					fs.guardBars[layout][barpn].draw(layerno, charpn, fs.guardBars[layout][charpn], fs.fnt)
+				})
+			}
 
 			// StunBar
-			forEach(func(side, layout, slot, barpn, charpn int) {
-				c := sys.chars[charpn][0]
-				if !c.dizzyEnabled() || c.asf(ASF_nostunbardisplay) {
-					return
-				}
-				fs.stunBars[layout][barpn].bgDraw(layerno)
-				fs.stunBars[layout][barpn].draw(layerno, charpn, fs.stunBars[layout][charpn], fs.fnt)
-			})
+			for side := 0; side < len(sys.tmode); side++ {
+				layout := fs.curLayout[side]
+				leaderontop := fs.stunBars[layout][side].leaderontop
+				forEachMember(side, leaderontop, func(layout, slot, barpn, charpn int) {
+					c := sys.chars[charpn][0]
+					if !c.dizzyEnabled() || c.asf(ASF_nostunbardisplay) {
+						return
+					}
+					fs.stunBars[layout][barpn].bgDraw(layerno)
+					fs.stunBars[layout][barpn].draw(layerno, charpn, fs.stunBars[layout][charpn], fs.fnt)
+				})
+			}
 
-			// FightScreenFace
-			forEach(func(side, layout, slot, barpn, charpn int) {
-				c := sys.chars[charpn][0]
-				if c.asf(ASF_nofacedisplay) {
-					return
-				}
-				// Draw Turns teammates from the first bar only
-				if slot == 0 && len(fs.faces[layout]) > 0 {
-					fs.faces[layout][side].drawTeammates(layerno, charpn)
-				}
-				// Draw active players
-				fs.faces[layout][barpn].bgDraw(layerno)
-				fs.faces[layout][barpn].draw(layerno, charpn, fs.faces[layout][charpn])
-			})
+			// Face
+			for side := 0; side < len(sys.tmode); side++ {
+				layout := fs.curLayout[side]
+				leaderontop := fs.faces[layout][side].leaderontop
+				forEachMember(side, leaderontop, func(layout, slot, barpn, charpn int) {
+					c := sys.chars[charpn][0]
+					if c.asf(ASF_nofacedisplay) {
+						return
+					}
+					// Draw Turns teammates from the first bar only
+					if slot == 0 {
+						fs.faces[layout][side].drawTeammates(layerno, charpn)
+					}
+					fs.faces[layout][barpn].bgDraw(layerno)
+					fs.faces[layout][barpn].draw(layerno, charpn, fs.faces[layout][charpn])
+				})
+			}
 
-			// FightScreenName
-			forEach(func(side, layout, slot, barpn, charpn int) {
-				c := sys.chars[charpn][0]
-				if c.asf(ASF_nonamedisplay) {
-					return
-				}
-				// Draw Turns teammates from the first bar only
-				if slot == 0 && len(fs.names[layout]) > 0 {
-					fs.names[layout][side].drawTeammates(layerno, charpn, fs.fnt, side)
-				}
-				// Draw active players
-				fs.names[layout][barpn].bgDraw(layerno)
-				fs.names[layout][barpn].draw(layerno, charpn, fs.fnt, side)
-			})
+			// Name
+			for side := 0; side < len(sys.tmode); side++ {
+				layout := fs.curLayout[side]
+				leaderontop := fs.names[layout][side].leaderontop
+				forEachMember(side, leaderontop, func(layout, slot, barpn, charpn int) {
+					c := sys.chars[charpn][0]
+					if c.asf(ASF_nonamedisplay) {
+						return
+					}
+					// Draw Turns teammates from the first bar only
+					if slot == 0 {
+						fs.names[layout][side].drawTeammates(layerno, charpn, fs.fnt, side)
+					}
+					fs.names[layout][barpn].bgDraw(layerno)
+					fs.names[layout][barpn].draw(layerno, charpn, fs.fnt, side)
+				})
+			}
 
-			// FightScreenRatio
-			for side := len(sys.tmode) - 1; side >= 0; side-- {
-				if sys.tmode[side] == TM_Turns {
-					rl := sys.chars[side][0].ocd().ratioLevel
-					if rl > 0 && !sys.chars[side][0].asf(ASF_nofacedisplay) {
-						fs.ratios[side].bgDraw(layerno)
-						fs.ratios[side].draw(layerno, rl-1)
+			// Ratio
+			for i := 0; i < len(sys.tmode); i++ {
+				if sys.tmode[i] == TM_Turns {
+					rl := sys.chars[i][0].ocd().ratioLevel
+					if rl > 0 && !sys.chars[i][0].asf(ASF_nofacedisplay) {
+						fs.ratios[i].bgDraw(layerno)
+						fs.ratios[i].draw(layerno, rl-1)
 					}
 				}
 			}
 
-			// FightScreenTime
+			// Time
 			fs.time.bgDraw(layerno)
 			fs.time.draw(layerno, fs.fnt)
 
-			// FightScreenWinIcon
-			// These are only one per team, so we don't use forEach()
-			for i := len(fs.winIcons) - 1; i >= 0; i-- {
+			// WinIcon
+			for i := 0; i < len(fs.winIcons); i++ {
 				if !sys.chars[i][0].asf(ASF_nowinicondisplay) {
 					fs.winIcons[i].draw(layerno, fs.fnt, i)
 				}
 			}
 
-			// FightScreenTimer
+			// Timer
 			fs.timer.bgDraw(layerno)
 			fs.timer.draw(layerno, fs.fnt)
 
-			// FightScreenScore
-			for i := len(fs.scores) - 1; i >= 0; i-- {
+			// Score
+			for i := 0; i < len(fs.scores); i++ {
 				fs.scores[i].bgDraw(layerno)
 				fs.scores[i].draw(layerno, fs.fnt, i)
 			}
 
-			// FightScreenMatch
+			// Match
 			fs.match.bgDraw(layerno)
 			fs.match.draw(layerno, fs.fnt)
 
-			// FightScreenAiLevel
-			for i := len(fs.aiLevels) - 1; i >= 0; i-- {
+			// AiLevel
+			for i := 0; i < len(fs.aiLevels); i++ {
 				fs.aiLevels[i].bgDraw(layerno)
 				fs.aiLevels[i].draw(layerno, fs.fnt, sys.aiLevel[sys.chars[i][0].playerNo])
 			}
 
-			// FightScreenWinCount
-			for i := len(fs.winCounts) - 1; i >= 0; i-- {
+			// WinCount
+			for i := 0; i < len(fs.winCounts); i++ {
 				fs.winCounts[i].bgDraw(layerno)
 				fs.winCounts[i].draw(layerno, fs.fnt, i)
 			}
 		}
 
-		// FightScreenCombo
-		for i := len(fs.combos) - 1; i >= 0; i-- {
+		// Combo
+		for i := 0; i < len(fs.combos); i++ {
 			if !sys.chars[i][0].asf(ASF_nocombodisplay) {
 				fs.combos[i].draw(layerno, fs.fnt, i)
 			}
 		}
 
-		// FightScreenAction
-		for i := len(fs.actions) - 1; i >= 0; i-- {
+		// Action
+		for i := 0; i < len(fs.actions); i++ {
 			if !sys.chars[i][0].asf(ASF_nolifebaraction) {
 				fs.actions[i].draw(layerno, fs.fnt, i)
 			}
 		}
 
-		// FightScreenMode
+		// Mode
 		if _, ok := fs.modes[sys.gameMode]; ok {
 			fs.modes[sys.gameMode].bgDraw(layerno)
 			fs.modes[sys.gameMode].draw(layerno, fs.fnt)
@@ -5525,7 +5539,7 @@ func (fs *FightScreen) draw(layerno int16) {
 	}
 
 	if fs.active {
-		// FightScreenRound
+		// Round
 		fs.round.draw(layerno, fs.fnt)
 	}
 }

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -5352,94 +5352,113 @@ func (fs *FightScreen) draw(layerno int16) {
 	pauseHide := sys.motif.me.active && sys.motif.PauseMenu["pause_menu"].HideBars
 
 	if !sys.lifebarHide && fs.active && !sys.dialogueBarsFlg && !pauseHide {
-		// Helper to run a function for each active player's bars for one side
-		forEachMember := func(side int, leaderontop bool, fn func(layout, slot, barpn, charpn int)) {
-			layout := fs.curLayout[side]
-
-			slotStart, slotEnd, slotStep := 0, MaxSimul, 1
+		// Helper to determine whether to iterate elements forward or backward (drawing order)
+		iterationOrder := func(leaderontop bool) (int, int, int) {
 			if leaderontop {
-				slotStart, slotEnd, slotStep = MaxSimul-1, -1, -1
+				return MaxSimul - 1, -1, -1
 			}
-
-			for slot := slotStart; slot != slotEnd; slot += slotStep {
-				if slot >= len(fs.teamOrder[side]) {
-					continue
-				}
-				barpn := slot*2 + side
-				charpn := fs.teamOrder[side][slot]
-				fn(layout, slot, barpn, charpn)
-			}
+			return 0, MaxSimul, 1
 		}
 
 		if !sys.gsf(GSF_nobardisplay) && fs.bars {
 			// LifeBar
 			for side := 0; side < len(sys.tmode); side++ {
 				layout := fs.curLayout[side]
-				leaderontop := fs.lifeBars[layout][side].leaderontop
-				forEachMember(side, leaderontop, func(layout, slot, barpn, charpn int) {
+				slotStart, slotEnd, slotStep := iterationOrder(fs.lifeBars[layout][side].leaderontop)
+
+				for slot := slotStart; slot != slotEnd; slot += slotStep {
+					if slot >= len(fs.teamOrder[side]) {
+						continue
+					}
+					barpn := slot*2 + side
+					charpn := fs.teamOrder[side][slot]
 					c := sys.chars[charpn][0]
 					if c.asf(ASF_nolifebardisplay) {
-						return
+						continue
 					}
 					fs.lifeBars[layout][barpn].bgDraw(layerno)
 					fs.lifeBars[layout][barpn].draw(layerno, charpn, fs.lifeBars[layout][charpn], fs.fnt)
-				})
+				}
 			}
 
 			// PowerBar
 			for side := 0; side < len(sys.tmode); side++ {
 				layout := fs.curLayout[side]
-				leaderontop := fs.powerBars[layout][side].leaderontop
-				forEachMember(side, leaderontop, func(layout, slot, barpn, charpn int) {
+				slotStart, slotEnd, slotStep := iterationOrder(fs.powerBars[layout][side].leaderontop)
+
+				for slot := slotStart; slot != slotEnd; slot += slotStep {
+					if slot >= len(fs.teamOrder[side]) {
+						continue
+					}
+					barpn := slot*2 + side
+					charpn := fs.teamOrder[side][slot]
 					c := sys.chars[charpn][0]
 					if c.asf(ASF_nopowerbardisplay) {
-						return
+						continue
 					}
 					tm := sys.tmode[side]
 					if slot != 0 && (tm == TM_Simul || tm == TM_Tag) && sys.cfg.Options.Team.PowerShare {
-						return
+						continue
 					}
 					fs.powerBars[layout][barpn].bgDraw(layerno, barpn)
 					fs.powerBars[layout][barpn].draw(layerno, charpn, fs.powerBars[layout][charpn], fs.fnt)
-				})
+				}
 			}
 
 			// GuardBar
 			for side := 0; side < len(sys.tmode); side++ {
 				layout := fs.curLayout[side]
-				leaderontop := fs.guardBars[layout][side].leaderontop
-				forEachMember(side, leaderontop, func(layout, slot, barpn, charpn int) {
+				slotStart, slotEnd, slotStep := iterationOrder(fs.guardBars[layout][side].leaderontop)
+
+				for slot := slotStart; slot != slotEnd; slot += slotStep {
+					if slot >= len(fs.teamOrder[side]) {
+						continue
+					}
+					barpn := slot*2 + side
+					charpn := fs.teamOrder[side][slot]
 					c := sys.chars[charpn][0]
 					if !c.guardBreakEnabled() || c.asf(ASF_noguardbardisplay) {
-						return
+						continue
 					}
 					fs.guardBars[layout][barpn].bgDraw(layerno)
 					fs.guardBars[layout][barpn].draw(layerno, charpn, fs.guardBars[layout][charpn], fs.fnt)
-				})
+				}
 			}
 
 			// StunBar
 			for side := 0; side < len(sys.tmode); side++ {
 				layout := fs.curLayout[side]
-				leaderontop := fs.stunBars[layout][side].leaderontop
-				forEachMember(side, leaderontop, func(layout, slot, barpn, charpn int) {
+				slotStart, slotEnd, slotStep := iterationOrder(fs.stunBars[layout][side].leaderontop)
+
+				for slot := slotStart; slot != slotEnd; slot += slotStep {
+					if slot >= len(fs.teamOrder[side]) {
+						continue
+					}
+					barpn := slot*2 + side
+					charpn := fs.teamOrder[side][slot]
 					c := sys.chars[charpn][0]
 					if !c.dizzyEnabled() || c.asf(ASF_nostunbardisplay) {
-						return
+						continue
 					}
 					fs.stunBars[layout][barpn].bgDraw(layerno)
 					fs.stunBars[layout][barpn].draw(layerno, charpn, fs.stunBars[layout][charpn], fs.fnt)
-				})
+				}
 			}
 
 			// Face
 			for side := 0; side < len(sys.tmode); side++ {
 				layout := fs.curLayout[side]
-				leaderontop := fs.faces[layout][side].leaderontop
-				forEachMember(side, leaderontop, func(layout, slot, barpn, charpn int) {
+				slotStart, slotEnd, slotStep := iterationOrder(fs.faces[layout][side].leaderontop)
+
+				for slot := slotStart; slot != slotEnd; slot += slotStep {
+					if slot >= len(fs.teamOrder[side]) {
+						continue
+					}
+					barpn := slot*2 + side
+					charpn := fs.teamOrder[side][slot]
 					c := sys.chars[charpn][0]
 					if c.asf(ASF_nofacedisplay) {
-						return
+						continue
 					}
 					// Draw Turns teammates from the first bar only
 					if slot == 0 {
@@ -5447,17 +5466,23 @@ func (fs *FightScreen) draw(layerno int16) {
 					}
 					fs.faces[layout][barpn].bgDraw(layerno)
 					fs.faces[layout][barpn].draw(layerno, charpn, fs.faces[layout][charpn])
-				})
+				}
 			}
 
 			// Name
 			for side := 0; side < len(sys.tmode); side++ {
 				layout := fs.curLayout[side]
-				leaderontop := fs.names[layout][side].leaderontop
-				forEachMember(side, leaderontop, func(layout, slot, barpn, charpn int) {
+				slotStart, slotEnd, slotStep := iterationOrder(fs.names[layout][side].leaderontop)
+
+				for slot := slotStart; slot != slotEnd; slot += slotStep {
+					if slot >= len(fs.teamOrder[side]) {
+						continue
+					}
+					barpn := slot*2 + side
+					charpn := fs.teamOrder[side][slot]
 					c := sys.chars[charpn][0]
 					if c.asf(ASF_nonamedisplay) {
-						return
+						continue
 					}
 					// Draw Turns teammates from the first bar only
 					if slot == 0 {
@@ -5465,7 +5490,7 @@ func (fs *FightScreen) draw(layerno int16) {
 					}
 					fs.names[layout][barpn].bgDraw(layerno)
 					fs.names[layout][barpn].draw(layerno, charpn, fs.fnt, side)
-				})
+				}
 			}
 
 			// Ratio

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -154,7 +154,7 @@ func loadFightFx(def string, isGlobal bool, isMainThread bool) error {
 							return err
 						}
 						lines, i := SplitAndTrim(str, "\n"), 0
-						ffx.animTable = ReadAnimationTable(ffx.sff, &ffx.sff.palList, lines, &i)
+						ffx.animTable = ReadAnimationTable(filename, ffx.sff, &ffx.sff.palList, lines, &i, true)
 						return nil
 					}); err != nil {
 					return err
@@ -2890,7 +2890,7 @@ func readLbFade(pre string, is IniSection, sff *Sff, at AnimationTable) *Fade {
 	fp.animData.SetPos(0, 0)   // TODO: use fp.animData.Reset() instead
 	fp.animData.SetScale(1, 1) // TODO: use fp.animData.Reset() instead
 	//fp.animData.Reset() // TODO: comment out pos and scale adjustments
-	if animData, exists := at[anim]; exists {
+	if animData, exists := at.anims[anim]; exists {
 		fp.animData.anim = animData
 	} else {
 		fp.animData.anim = nil
@@ -4457,7 +4457,7 @@ func loadFightScreen(def string) (*FightScreen, error) {
 	}
 
 	lines, lnidx := SplitAndTrim(str, "\n"), 0
-	fs.animTable = ReadAnimationTable(fs.sff, &fs.sff.palList, lines, &lnidx)
+	fs.animTable = ReadAnimationTable(def, fs.sff, &fs.sff.palList, lines, &lnidx, true)
 	lnidx = 0
 	filesflg := true
 
@@ -4561,7 +4561,7 @@ func loadFightScreen(def string) (*FightScreen, error) {
 							return err
 						}
 						lines, i := SplitAndTrim(str, "\n"), 0
-						ffx.animTable = ReadAnimationTable(ffx.sff, &ffx.sff.palList, lines, &i)
+						ffx.animTable = ReadAnimationTable(filename, ffx.sff, &ffx.sff.palList, lines, &i, true)
 						return nil
 					}); err != nil {
 					return nil, err

--- a/src/image.go
+++ b/src/image.go
@@ -1624,6 +1624,7 @@ func loadSff(filename string, char bool, isMainThread bool, isActPal bool) (*Sff
 		return binary.Read(f, binary.LittleEndian, x)
 	}
 
+	// Load palettes
 	if s.header.Version[0] != 1 {
 		uniquePals := make(map[[2]uint16]int)
 		for i := 0; i < int(s.header.NumberOfPalettes); i++ {
@@ -1645,10 +1646,10 @@ func loadSff(filename string, char bool, isMainThread bool, isActPal bool) (*Sff
 			}
 			var pal []uint32
 			var idx int
-			if old, ok := uniquePals[[...]uint16{gn_[0], gn_[1]}]; ok {
+			if old, ok := uniquePals[[2]uint16{gn_[0], gn_[1]}]; ok {
 				idx = old
 				pal = s.palList.Get(old)
-				LogMessage("%v duplicated palette: %v,%v (%v/%v)", filename, gn_[0], gn_[1], i+1, s.header.NumberOfPalettes)
+				LogMessage("WARNING: Duplicate palette key in %v: %v,%v (%v/%v)", filename, gn_[0], gn_[1], i+1, s.header.NumberOfPalettes)
 			} else if plSize == 0 {
 				idx = int(link)
 				pal = s.palList.Get(idx)
@@ -1661,7 +1662,7 @@ func loadSff(filename string, char bool, isMainThread bool, isActPal bool) (*Sff
 				}
 				idx = i
 			}
-			uniquePals[[...]uint16{gn_[0], gn_[1]}] = idx
+			uniquePals[[2]uint16{gn_[0], gn_[1]}] = idx
 			s.palList.SetSource(i, pal)
 			s.palList.PalTable[[...]uint16{gn_[0], gn_[1]}] = idx
 			// Number of colors as specified in the SFF
@@ -1674,6 +1675,7 @@ func loadSff(filename string, char bool, isMainThread bool, isActPal bool) (*Sff
 			}
 		}
 	}
+	// Load sprites
 	spriteList := make([]*Sprite, int(s.header.NumberOfSprites))
 	var prev *Sprite
 	shofs := int64(s.header.FirstSpriteHeaderOffset)
@@ -1724,10 +1726,10 @@ func loadSff(filename string, char bool, isMainThread bool, isActPal bool) (*Sff
 			}
 			prev = spriteList[i]
 		}
-		if s.sprites[[...]uint16{spriteList[i].Group, spriteList[i].Number}] ==
-			nil {
-			s.sprites[[...]uint16{spriteList[i].Group, spriteList[i].Number}] =
-				spriteList[i]
+		if s.sprites[[2]uint16{spriteList[i].Group, spriteList[i].Number}] != nil {
+			LogMessage("WARNING: Duplicate sprite key in %v: %v,%v (index %v ignored)", filename, spriteList[i].Group, spriteList[i].Number, i)
+		} else {
+			s.sprites[[2]uint16{spriteList[i].Group, spriteList[i].Number}] = spriteList[i]
 		}
 		if s.header.Version[0] == 1 {
 			shofs = int64(xofs)

--- a/src/iniutils.go
+++ b/src/iniutils.go
@@ -2082,7 +2082,7 @@ func SetAnim(obj interface{}, fVal, structVal, parent reflect.Value, sffOverride
 
 	// animNew
 	var a *Anim
-	if animData, exists := animMap[anim]; exists {
+	if animData, exists := animMap.anims[anim]; exists {
 		a = NewAnim(nil, "")
 		a.anim = animData
 	} else if hasSpr {

--- a/src/model.go
+++ b/src/model.go
@@ -362,9 +362,9 @@ func loadEnvironment(filepath string) (*Environment, error) {
 	env.GGXTexture = &GLTFTexture{}
 	env.GGXLUT = &GLTFTexture{}
 	if hdrImg, ok := img.(hdr.Image); ok {
-		size := img.Bounds().Max.X * img.Bounds().Max.Y * 3
-		data := make([]float32, size, size)
 		bounds := img.Bounds()
+		size := bounds.Max.X * bounds.Max.Y * 3
+		data := make([]float32, 0, size)
 		for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
 			for x := bounds.Min.X; x < bounds.Max.X; x++ {
 				color := hdrImg.HDRAt(x, y)
@@ -380,7 +380,7 @@ func loadEnvironment(filepath string) (*Environment, error) {
 				return
 			}
 			lowestMipLevel := int32(4)
-			env.hdrTexture.tex = gfx.newHDRTexture(int32(img.Bounds().Max.X), int32(img.Bounds().Max.Y))
+			env.hdrTexture.tex = gfx.newHDRTexture(int32(bounds.Max.X), int32(bounds.Max.Y))
 
 			env.hdrTexture.tex.SetPixelData(data)
 			env.cubeMapTexture.tex = gfx.newCubeMapTexture(256, true, 0)

--- a/src/motif.go
+++ b/src/motif.go
@@ -1847,7 +1847,7 @@ func loadMotif(def string) (*Motif, error) {
 		return nil, err
 	}
 	lines, i := SplitAndTrim(str, "\n"), 0
-	m.AnimTable = ReadAnimationTable(m.Sff, &m.Sff.palList, lines, &i)
+	m.AnimTable = ReadAnimationTable(m.Def, m.Sff, &m.Sff.palList, lines, &i, true)
 	i = 0
 
 	m.overrideParams()

--- a/src/rollback.go
+++ b/src/rollback.go
@@ -220,10 +220,6 @@ func (rs *RollbackSystem) simulateFrame(s *System) bool {
 		return false
 	}
 
-	s.stage.action()
-	// If frame is ready to tick and not paused
-	//sys.stage.action()
-
 	// Update game state
 	s.action()
 

--- a/src/rollback.go
+++ b/src/rollback.go
@@ -262,26 +262,6 @@ func (rs *RollbackSystem) updateEvents(s *System) bool {
 	return true
 }
 
-func (rs *RollbackSystem) updateCamera(s *System) {
-	if !s.frameSkip {
-		scl := s.cam.Scale / s.cam.BaseScale()
-		if s.enableZoomtime > 0 {
-			if !s.debugPaused() {
-				s.zoomPosXLag += ((s.zoomPos[0] - s.zoomPosXLag) * (1 - s.zoomlag))
-				s.zoomPosYLag += ((s.zoomPos[1] - s.zoomPosYLag) * (1 - s.zoomlag))
-				s.drawScale = s.drawScale / (s.drawScale + (s.zoomScale*scl-s.drawScale)*s.zoomlag) * s.zoomScale * scl
-			}
-		} else {
-			s.zoomlag = 0
-			s.zoomPosXLag = 0
-			s.zoomPosYLag = 0
-			s.zoomScale = 1
-			s.zoomPos = [2]float32{0, 0}
-			s.drawScale = s.cam.Scale
-		}
-	}
-}
-
 func getAIInputs(player int) []byte {
 	var ib InputBits
 	ib.SetInputAI(player)

--- a/src/script.go
+++ b/src/script.go
@@ -3924,17 +3924,17 @@ func systemScriptInit(l *lua.LState) {
 			return 0
 		}
 		lines, i := SplitAndTrim(NormalizeNewlines(raw), "\n"), 0
-		at := ReadAnimationTable(sff, &sff.palList, lines, &i)
+		at := ReadAnimationTable(def, sff, &sff.palList, lines, &i, true)
 		// Build Lua table with NUMERIC keys (so it prints like [110] => userdata ...)
 		tbl := l.NewTable()
 		// Deterministic iteration order
-		keys := make([]int, 0, len(at))
-		for k := range at {
+		keys := make([]int, 0, len(at.anims))
+		for k := range at.anims {
 			keys = append(keys, int(k))
 		}
 		sort.Ints(keys)
 		for _, ki := range keys {
-			anim := at[int32(ki)]
+			anim := at.anims[int32(ki)]
 			if anim == nil {
 				continue
 			}

--- a/src/script.go
+++ b/src/script.go
@@ -9442,6 +9442,10 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LNumber(sys.debugWC.rdDistZ(sys.debugWC.parent(true), sys.debugWC).ToI()))
 		return 1
 	})
+	luaRegister(l, "parentExist", func(*lua.LState) int {
+		l.Push(lua.LBool(sys.debugWC.parentExist()))
+		return 1
+	})
 	luaRegister(l, "pauseTime", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.pauseTimeTrigger()))
 		return 1
@@ -9993,7 +9997,7 @@ func triggerFunctions(l *lua.LState) {
 		// Handle returns
 		if bg != nil {
 			switch strings.ToLower(vname) {
-			case "anim":
+			case "actionno":
 				ln = lua.LNumber(bg.actionno)
 			case "delta.x":
 				ln = lua.LNumber(bg.delta[0])

--- a/src/script.go
+++ b/src/script.go
@@ -10367,11 +10367,11 @@ func triggerFunctions(l *lua.LState) {
 		case "scale":
 			ln = lua.LNumber(sys.drawScale)
 		case "pos.x":
-			ln = lua.LNumber(sys.zoomPosXLag)
+			ln = lua.LNumber(sys.zoomPosCur[0])
 		case "pos.y":
-			ln = lua.LNumber(sys.zoomPosYLag)
+			ln = lua.LNumber(sys.zoomPosCur[1])
 		case "lag":
-			ln = lua.LNumber(sys.zoomlag)
+			ln = lua.LNumber(sys.zoomLag)
 		case "time":
 			ln = lua.LNumber(sys.enableZoomtime)
 		default:

--- a/src/script.go
+++ b/src/script.go
@@ -10365,15 +10365,17 @@ func triggerFunctions(l *lua.LState) {
 		var ln lua.LNumber
 		switch strings.ToLower(strArg(l, 1)) {
 		case "scale":
-			ln = lua.LNumber(sys.drawScale)
+			ln = lua.LNumber(sys.zoom.curScale)
 		case "pos.x":
-			ln = lua.LNumber(sys.zoomPosCur[0])
+			ln = lua.LNumber(sys.zoom.curPos[0])
 		case "pos.y":
-			ln = lua.LNumber(sys.zoomPosCur[1])
+			ln = lua.LNumber(sys.zoom.curPos[1])
 		case "lag":
-			ln = lua.LNumber(sys.zoomLag)
+			ln = lua.LNumber(sys.zoom.lag)
+		case "endlag":
+			ln = lua.LNumber(sys.zoom.endLag)
 		case "time":
-			ln = lua.LNumber(sys.enableZoomtime)
+			ln = lua.LNumber(sys.zoom.time)
 		default:
 			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}

--- a/src/sound.go
+++ b/src/sound.go
@@ -842,8 +842,10 @@ func LoadSndFiltered(filename string, keepItem func([2]int32) bool, max uint32) 
 			return nil, err
 		}
 		if keepItem(num) {
-			_, ok := s.table[num]
-			if !ok {
+			_, exists := s.table[num]
+			if exists {
+				LogMessage("WARNING: Duplicate sound key in %v: %v,%v (index %v ignored)", filename, num[0], num[1], i)
+			} else {
 				tmp, err := readSound(f, subFileLength)
 				if err != nil {
 					LogMessage("Sound %v,%v in %v can't be read: %v", num[0], num[1], filename, err)

--- a/src/stage.go
+++ b/src/stage.go
@@ -984,7 +984,7 @@ func loadStage(def string, maindef bool) (*Stage, error) {
 	s.sff = &Sff{}
 
 	lines, i := SplitAndTrim(str, "\n"), 0
-	s.animTable = ReadAnimationTable(s.sff, &s.sff.palList, lines, &i)
+	s.animTable = ReadAnimationTable(def, s.sff, &s.sff.palList, lines, &i, true)
 	i = 0
 	defmap := make(map[string][]IniSection)
 	for i < len(lines) {

--- a/src/state.go
+++ b/src/state.go
@@ -570,7 +570,9 @@ func NewGameStatePool() GameStatePool {
 		},
 		animationTablePool: sync.Pool{
 			New: func() interface{} {
-				at := make(AnimationTable)
+				at := AnimationTable{
+					anims: make(map[int32]*Animation),
+				}
 				return &at
 			},
 		},

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -627,9 +627,9 @@ func (s *Stage) Clone(a *arena.Arena, gsp *GameStatePool) *Stage {
 
 	// Clone animation table
 	result.animTable = *gsp.Get(s.animTable).(*AnimationTable)
-	maps.Clear(result.animTable)
-	for k, v := range s.animTable {
-		result.animTable[k] = v.Clone(a, gsp)
+	maps.Clear(result.animTable.anims)
+	for k, v := range s.animTable.anims {
+		result.animTable.anims[k] = v.Clone(a, gsp)
 	}
 
 	// Clone backgrounds and rebuild mapping

--- a/src/storyboard.go
+++ b/src/storyboard.go
@@ -297,13 +297,13 @@ func loadStoryboard(def string) (*Storyboard, error) {
 		return nil, err
 	}
 	lines, i := SplitAndTrim(str, "\n"), 0
-	s.AnimTable = ReadAnimationTable(s.Sff, &s.Sff.palList, lines, &i)
+	s.AnimTable = ReadAnimationTable(s.Def, s.Sff, &s.Sff.palList, lines, &i, true)
 	i = 0
 
 	// Storyboard-specific quirk:
 	// enable phantom pixel adjustment on all storyboard animations so that
 	// frames flipped via H or V get an extra pixel of offset.
-	for _, anim := range s.AnimTable {
+	for _, anim := range s.AnimTable.anims {
 		if anim != nil {
 			anim.phantomPixel = true
 		}

--- a/src/system.go
+++ b/src/system.go
@@ -2219,8 +2219,8 @@ func (s *System) resetRoundState() {
 		// Select anim 0
 		firstAnim := int32(0)
 		// Default to first anim in .AIR if 0 was not found
-		if p[0].gi().animTable[0] == nil {
-			for k := range p[0].gi().animTable {
+		if p[0].gi().animTable.anims[0] == nil {
+			for k := range p[0].gi().animTable.anims {
 				firstAnim = k
 				break
 			}
@@ -4508,7 +4508,8 @@ func (s *Select) AddChar(def string) *SelectChar {
 				return err
 			}
 			lines, lnidx := SplitAndTrim(str, "\n"), 0
-			at := ReadAnimationTable(tempSff, &tempSff.palList, lines, &lnidx) // SFF here is temporary
+			// We disable logging here or else preloading will print the errors of all characters in the select screen
+			at := ReadAnimationTable(sc.def, tempSff, &tempSff.palList, lines, &lnidx, false)
 			for v_anim := range s.charAnimPreload {
 				if animation := at.get(v_anim); animation != nil {
 					sc.anims.addAnim(animation, v_anim)
@@ -4768,7 +4769,7 @@ func (s *Select) AddStage(def string) (*SelectStage, error) {
 		sff := newSff()
 		// preload animations
 		atidx := 0
-		at := ReadAnimationTable(sff, &sff.palList, lines, &atidx)
+		at := ReadAnimationTable(finalDefPath, sff, &sff.palList, lines, &atidx, false)
 		for v := range s.stageAnimPreload {
 			if anim := at.get(v); anim != nil {
 				ss.anims.addAnim(anim, v)

--- a/src/system.go
+++ b/src/system.go
@@ -2455,6 +2455,10 @@ func (s *System) action() {
 	// Update: In Mugen, the state change to win pose happens before the character code runs. It's evidence this should be placed before charList.action()
 	s.stepRoundState()
 
+	// In version 0.99 this was moved to before sys.action() for undocumented reasons
+	// Moving it here preserves whatever behavior that implemented while not keeping the stage oddly outside the main loop
+	s.stage.action()
+
 	// Run "tick frame"
 	if s.tickFrame() {
 		// X axis player limits
@@ -3638,8 +3642,6 @@ func (s *System) runMatch() (reload bool) {
 			break
 		}
 
-		// TODO: These probably ought to be in action() as well
-		s.stage.action()
 		// Update game state
 		s.action()
 

--- a/src/system.go
+++ b/src/system.go
@@ -107,14 +107,13 @@ type SystemStateVars struct {
 	reloadCharSlot          [MaxPlayerNo]bool
 	turbo                   float32
 	drawScale               float32
-	zoomlag                 float32
+	zoomLag                 float32
 	zoomScale               float32
-	zoomPosXLag             float32
-	zoomPosYLag             float32
 	enableZoomtime          int32
 	zoomCameraBound         bool
 	zoomStageBound          bool
-	zoomPos                 [2]float32
+	zoomPos                 [2]float32 // Defined parameters
+	zoomPosCur              [2]float32 // Current values with lag
 	finishType              FinishType
 	winwaittime             int32
 	slowtime                int32
@@ -782,49 +781,56 @@ func (s *System) renderFrame() {
 	if !s.frameSkip {
 		x, y, scl := s.cam.Pos[0], s.cam.Pos[1], s.cam.Scale/s.cam.BaseScale()
 		dx, dy, dscl := x, y, scl
+
+		// Apply Zoom sctrl
 		if s.enableZoomtime > 0 {
+			// Apply lag
 			if !s.debugPaused() {
-				s.zoomPosXLag += ((s.zoomPos[0] - s.zoomPosXLag) * (1 - s.zoomlag))
-				s.zoomPosYLag += ((s.zoomPos[1] - s.zoomPosYLag) * (1 - s.zoomlag))
-				s.drawScale = s.drawScale / (s.drawScale + (s.zoomScale*scl-s.drawScale)*s.zoomlag) * s.zoomScale * scl
+				for i := 0; i < 2; i++ {
+					s.zoomPosCur[i] += (s.zoomPos[i] - s.zoomPosCur[i]) * (1 - s.zoomLag)
+				}
+				s.drawScale = s.drawScale / (s.drawScale + (s.zoomScale*scl-s.drawScale)*s.zoomLag) * s.zoomScale * scl
 			}
+			// Apply position limits
 			if s.zoomStageBound {
 				dscl = Max(s.cam.MinScale, s.drawScale/s.cam.BaseScale())
 				if s.zoomCameraBound {
 					zoomedViewWidth := float32(s.gameWidth) / s.drawScale
 					minCamX := x - (s.cam.halfWidth/scl - zoomedViewWidth/2)
 					maxCamX := x + (s.cam.halfWidth/scl - zoomedViewWidth/2)
-					intermediateTargetX := x + s.zoomPosXLag/scl
+					intermediateTargetX := x + s.zoomPosCur[0]/scl
 					dx = Clamp(intermediateTargetX, minCamX, maxCamX)
 				} else {
-					dx = x + s.zoomPosXLag/scl
+					dx = x + s.zoomPosCur[0]/scl
 				}
 				dx = s.cam.XBound(dscl, dx)
 			} else {
 				dscl = s.drawScale / s.cam.BaseScale()
-				dx = x + s.zoomPosXLag/scl
+				dx = x + s.zoomPosCur[0]/scl
 			}
-			dy = y + s.zoomPosYLag/scl
+			dy = y + s.zoomPosCur[1]/scl
 		} else {
-			s.zoomlag = 0
-			s.zoomPosXLag = 0
-			s.zoomPosYLag = 0
+			// Reset zoom
+			s.zoomLag = 0
 			s.zoomScale = 1
 			s.zoomPos = [2]float32{0, 0}
+			s.zoomPosCur = [2]float32{0, 0}
 			s.drawScale = s.cam.Scale
 		}
+
+		// Do the actual drawing
 		s.draw(dx, dy, dscl)
+	}
+
+	// Lua
+	if !s.frameSkip {
+		s.luaFlushDrawQueue()
 	} else {
 		// Keep pause-menu logic responsive even when this render frame is skipped.
 		// Any queued draw ops are discarded below because this frame is not being rendered.
 		if s.motif.me.active {
 			s.motif.me.runLua(&s.motif)
 		}
-	}
-
-	if !s.frameSkip {
-		s.luaFlushDrawQueue()
-	} else {
 		// On skipped frames, discard queued draws to avoid buildup.
 		s.luaDiscardDrawQueue()
 	}

--- a/src/system.go
+++ b/src/system.go
@@ -106,14 +106,7 @@ type SystemStateVars struct {
 	reloadFightScreenFlg    bool
 	reloadCharSlot          [MaxPlayerNo]bool
 	turbo                   float32
-	drawScale               float32
-	zoomLag                 float32
-	zoomScale               float32
-	enableZoomtime          int32
-	zoomCameraBound         bool
-	zoomStageBound          bool
-	zoomPos                 [2]float32 // Defined parameters
-	zoomPosCur              [2]float32 // Current values with lag
+	zoom                    ZoomEffect
 	finishType              FinishType
 	winwaittime             int32
 	slowtime                int32
@@ -780,45 +773,7 @@ func (s *System) await(fps int) bool {
 func (s *System) renderFrame() {
 	if !s.frameSkip {
 		x, y, scl := s.cam.Pos[0], s.cam.Pos[1], s.cam.Scale/s.cam.BaseScale()
-		dx, dy, dscl := x, y, scl
-
-		// Apply Zoom sctrl
-		if s.enableZoomtime > 0 {
-			// Apply lag
-			if !s.debugPaused() {
-				for i := 0; i < 2; i++ {
-					s.zoomPosCur[i] += (s.zoomPos[i] - s.zoomPosCur[i]) * (1 - s.zoomLag)
-				}
-				s.drawScale = s.drawScale / (s.drawScale + (s.zoomScale*scl-s.drawScale)*s.zoomLag) * s.zoomScale * scl
-			}
-			// Apply position limits
-			if s.zoomStageBound {
-				dscl = Max(s.cam.MinScale, s.drawScale/s.cam.BaseScale())
-				if s.zoomCameraBound {
-					zoomedViewWidth := float32(s.gameWidth) / s.drawScale
-					minCamX := x - (s.cam.halfWidth/scl - zoomedViewWidth/2)
-					maxCamX := x + (s.cam.halfWidth/scl - zoomedViewWidth/2)
-					intermediateTargetX := x + s.zoomPosCur[0]/scl
-					dx = Clamp(intermediateTargetX, minCamX, maxCamX)
-				} else {
-					dx = x + s.zoomPosCur[0]/scl
-				}
-				dx = s.cam.XBound(dscl, dx)
-			} else {
-				dscl = s.drawScale / s.cam.BaseScale()
-				dx = x + s.zoomPosCur[0]/scl
-			}
-			dy = y + s.zoomPosCur[1]/scl
-		} else {
-			// Reset zoom
-			s.zoomLag = 0
-			s.zoomScale = 1
-			s.zoomPos = [2]float32{0, 0}
-			s.zoomPosCur = [2]float32{0, 0}
-			s.drawScale = s.cam.Scale
-		}
-
-		// Do the actual drawing
+		dx, dy, dscl := s.zoom.apply(x, y, scl)
 		s.draw(dx, dy, dscl)
 	}
 
@@ -2008,6 +1963,7 @@ func (s *System) resetGblEffect() {
 	s.allPalFX.clear()
 	s.bgPalFX.clear()
 	s.envShake.clear()
+	s.zoom.reset()
 	s.pausetime, s.pausetimebuffer = 0, 0
 	s.supertime, s.supertimebuffer = 0, 0
 	s.envcol_time = 0
@@ -2488,12 +2444,7 @@ func (s *System) action() {
 		if s.envcol_time > 0 {
 			s.envcol_time--
 		}
-		if s.enableZoomtime > 0 {
-			s.enableZoomtime--
-		} else {
-			s.zoomCameraBound = true
-			s.zoomStageBound = true
-		}
+		s.zoom.update()
 		if s.supertime > 0 {
 			s.supertime--
 		} else if s.pausetime > 0 {
@@ -5468,6 +5419,127 @@ func (es *EnvShake) getOffset() [2]float32 {
 			offset * float32(math.Cos(float64(-es.dir)))}
 	}
 	return [2]float32{0, 0}
+}
+
+type ZoomEffect struct {
+	active      bool
+	time        int32
+	lag         float32
+	endLag      float32
+	scale       float32
+	curScale    float32
+	pos         [2]float32 // Defined parameters
+	curPos      [2]float32 // Current values with lag
+	cameraBound bool
+	stageBound  bool
+}
+
+func (z *ZoomEffect) reset() {
+	z.active = false
+	z.time = 0
+	z.pos = [2]float32{0, 0}
+	z.curPos = [2]float32{0, 0}
+	z.scale = 1
+	z.curScale = 1
+	z.lag = 0
+	z.endLag = 0
+	z.cameraBound = true
+	z.stageBound = true
+}
+
+// Step the zoom variables
+func (z *ZoomEffect) update() {
+	if !z.active {
+		return
+	}
+
+	// Active phase target
+	targetPos := z.pos
+	targetScale := z.scale
+	lag := z.lag
+
+	// Release phase target
+	if z.time <= 0 {
+		targetPos = [2]float32{0, 0}
+		targetScale = 1
+		lag = z.endLag
+	}
+
+	// Manage timer
+	if z.time > 0 {
+		z.time--
+	}
+
+	// Threshold for snapping to target
+	const eps = 0.001
+
+	// Apply smoothing
+	if lag == 0 {
+		// Fast path for no lag
+		z.curPos = targetPos
+		z.curScale = targetScale
+	} else if lag < 1 {
+		// Position
+		for i := 0; i < 2; i++ {
+			if Abs(z.curPos[i]-targetPos[i]) < eps {
+				z.curPos[i] = targetPos[i]
+			} else {
+				z.curPos[i] += (targetPos[i] - z.curPos[i]) * (1 - lag)
+			}
+		}
+
+		// Scale
+		if Abs(z.curScale-targetScale) < eps {
+			z.curScale = targetScale
+		} else {
+			z.curScale += (targetScale - z.curScale) * (1 - lag)
+		}
+	}
+	// lag >= 1 freezes current zoom state. Maybe that shouldn't be allowed either?
+
+	// Finish release
+	if z.time <= 0 {
+		if Abs(z.curPos[0]) < eps &&
+			Abs(z.curPos[1]) < eps &&
+			Abs(z.curScale-1) < eps {
+			z.reset()
+		}
+	}
+}
+
+// Apply current zoom to sys.draw() parameters
+func (z *ZoomEffect) apply(x, y, scl float32) (dx, dy, dscl float32) {
+	dx, dy, dscl = x, y, scl
+
+	if !z.active {
+		return
+	}
+
+	finalScale := z.curScale * scl
+
+	// Apply position limits
+	if z.stageBound {
+		dscl = Max(sys.cam.MinScale, finalScale/sys.cam.BaseScale())
+
+		if z.cameraBound {
+			zoomedViewWidth := float32(sys.gameWidth) / finalScale
+			minCamX := x - (sys.cam.halfWidth/scl - zoomedViewWidth/2)
+			maxCamX := x + (sys.cam.halfWidth/scl - zoomedViewWidth/2)
+			intermediateTargetX := x + z.curPos[0]/scl
+			dx = Clamp(intermediateTargetX, minCamX, maxCamX)
+		} else {
+			dx = x + z.curPos[0]/scl
+		}
+
+		dx = sys.cam.XBound(dscl, dx)
+	} else {
+		dscl = finalScale / sys.cam.BaseScale()
+		dx = x + z.curPos[0]/scl
+	}
+
+	dy = y + z.curPos[1]/scl
+
+	return
 }
 
 type CharVarBackup struct {


### PR DESCRIPTION
Features:
- Zoom `endLag` parameter. Adds smoothing when camera returns to normal after Zoom ends
- Added command line warnings for duplicate sprites, sounds and animations
- Fight screen `leaderOnTop` parameter. Enabling it inverts the drawing order of the elements, thus drawing players 1/2 on top of their partners

Fixes:
- Stage stepping moved back inside the global action stepping
- Typo in model environment slice allocation
- Missing parentExist in scripts
- StageBGVar inconsistency in scripts
- ModifyProjectile teamside offset
- Clamped Zoom lag to safe values
- Added validation for zoom scale as well
- Added more default values to Zoom sctrl to prevent parameters from leaking between multiple calls
- Fixed Zoom persisting between rounds or when skipping intros
- Default lifebar drawing order reverted to same as Mugen

Refactor:
- Moved zoom effects to a dedicated struct
- Animation tables now carry information about which file they were loaded from