### PR TITLE
feat: fight screen prefix operators, explodVar(bindID)

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -4532,6 +4532,18 @@ func (b StateBlock) Run(c *Char, ps []int32) (changeState bool) {
 	// But tricking the code like that made bytecode errors print from the wrong characters
 	sys.workingChar = c
 	if b.loopBlock {
+		// Helper to validate loop range
+		forLoopInRange := func() bool {
+			if b.forIncrement > 0 {
+				return b.forBegin <= b.forEnd
+			}
+			if b.forIncrement < 0 {
+				return b.forBegin >= b.forEnd
+			}
+			// Increment of 0 is allowed
+			return true
+		}
+
 		if b.forLoop {
 			if b.forAssign {
 				// Initial assign to control variable
@@ -4540,8 +4552,15 @@ func (b StateBlock) Run(c *Char, ps []int32) (changeState bool) {
 			} else {
 				b.forBegin = b.forExpression[0].evalI(c)
 			}
-			b.forEnd, b.forIncrement = b.forExpression[1].evalI(c), b.forExpression[2].evalI(c)
+			b.forEnd = b.forExpression[1].evalI(c)
+			b.forIncrement = b.forExpression[2].evalI(c)
+			// Validate initial loop range
+			// If the starting value is already outside the valid range, do not run the loop at all
+			if !forLoopInRange() {
+				return false
+			}
 		}
+
 		// Start loop
 		loopCount := 0
 		interrupt := false
@@ -4579,17 +4598,13 @@ func (b StateBlock) Run(c *Char, ps []int32) (changeState bool) {
 			}
 			// Decide if for loop should be stopped
 			if b.forLoop {
-				// Update loop count
+				// Update loop variable
 				if b.forAssign {
 					b.forBegin = sys.bcVar[b.forCtrlVar.vari].ToI() + b.forIncrement
 				} else {
 					b.forBegin += b.forIncrement
 				}
-				if b.forIncrement > 0 {
-					if b.forBegin > b.forEnd {
-						interrupt = true
-					}
-				} else if b.forBegin < b.forEnd {
+				if !forLoopInRange() {
 					interrupt = true
 				}
 				// Update control variable if loop should keep going

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -4448,7 +4448,8 @@ type callFunction struct {
 
 func (cf callFunction) Run(c *Char, _ []int32) (changeState bool) {
 	// Check if the function exists
-	bf, ok := c.gi().callFuncs[cf.name]
+	// We use the functions from whatever player owns the current working state
+	bf, ok := sys.cgi[sys.workingState.playerNo].callFuncs[cf.name]
 
 	// If undefined, treat as no-op and log error
 	if !ok {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -829,6 +829,7 @@ const (
 	OC_ex2_explodvar_animplayerno
 	OC_ex2_explodvar_animtime
 	OC_ex2_explodvar_spriteplayerno
+	OC_ex2_explodvar_bindid
 	OC_ex2_explodvar_bindtime
 	OC_ex2_explodvar_drawpal_group
 	OC_ex2_explodvar_drawpal_index
@@ -3798,6 +3799,8 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	case OC_ex2_explodvar_layerno:
 		fallthrough
 	case OC_ex2_explodvar_id:
+		fallthrough
+	case OC_ex2_explodvar_bindid:
 		fallthrough
 	case OC_ex2_explodvar_bindtime:
 		fallthrough

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -11265,22 +11265,25 @@ func (sc zoom) Run(c *Char, _ []int32) bool {
 				pos[1] = exp[1].evalF(c) * c.localscl
 			}
 		case zoom_scale:
-			scl = exp[0].evalF(c)
-			if scl <= 0 {
-				sys.appendToConsole(c.warn() + fmt.Sprintf("invalid Zoom scale value: %v", scl))
-				scl = 1
+			v := exp[0].evalF(c)
+			if v <= 0 {
+				sys.appendToConsole(c.warn() + fmt.Sprintf("invalid Zoom scale value: %v", v))
+			} else {
+				scl = v
 			}
 		case zoom_lag:
-			lag = exp[0].evalF(c)
-			if lag < 0 || lag > 1 {
-				sys.appendToConsole(c.warn() + fmt.Sprintf("clamped invalid Zoom lag value: %v", lag))
-				lag = Clamp(lag, float32(0), float32(1))
+			v := exp[0].evalF(c)
+			if v < 0 || v > 1 {
+				sys.appendToConsole(c.warn() + fmt.Sprintf("invalid Zoom lag value: %v", v))
+			} else {
+				lag = v
 			}
 		case zoom_endlag:
-			endlag = exp[0].evalF(c)
-			if endlag < 0 || endlag > 1 {
-				sys.appendToConsole(c.warn() + fmt.Sprintf("clamped invalid Zoom endlag value: %v", endlag))
-				endlag = Clamp(endlag, float32(0), float32(1))
+			v := exp[0].evalF(c)
+			if v < 0 || v > 1 {
+				sys.appendToConsole(c.warn() + fmt.Sprintf("invalid Zoom endlag value: %v", v))
+			} else {
+				endlag = v
 			}
 		case zoom_time:
 			t = exp[0].evalI(c)
@@ -11294,6 +11297,7 @@ func (sc zoom) Run(c *Char, _ []int32) bool {
 
 	// This old calculation is both less accurate to Mugen and less intuitive to work with
 	// sys.zoom.pos[0] = sys.zoom.scale * pos[0]
+
 	sys.zoom.pos = pos
 	sys.zoom.scale = scl
 	sys.zoom.lag = lag

--- a/src/char.go
+++ b/src/char.go
@@ -5457,6 +5457,8 @@ func (c *Char) explodVar(eid BytecodeValue, idx BytecodeValue, vtype OpCode) Byt
 			v = BytecodeInt(e.anim.AnimTime())
 		case OC_ex2_explodvar_spriteplayerno:
 			v = BytecodeInt(int32(e.spritePN) + 1)
+		case OC_ex2_explodvar_bindid:
+			v = BytecodeInt(e.bindId)
 		case OC_ex2_explodvar_bindtime:
 			v = BytecodeInt(e.bindtime)
 		case OC_ex2_explodvar_drawpal_group:

--- a/src/char.go
+++ b/src/char.go
@@ -7201,7 +7201,7 @@ func (c *Char) hitAdd(h int32) {
 		for _, tid := range c.targets {
 			if t := sys.playerID(tid); t != nil {
 				t.receivedHits += h
-				c.addComboHits(h)
+				sys.fightScreen.addComboHits(c.teamside, h)
 				break
 			}
 		}
@@ -7212,20 +7212,11 @@ func (c *Char) hitAdd(h int32) {
 				// This is a bit of a workaround for backward compatibility only
 				if p[0].receivedHits != 0 || p[0].ss.moveType == MT_H {
 					p[0].receivedHits += h
-					c.addComboHits(h)
+					sys.fightScreen.addComboHits(c.teamside, h)
 				}
 			}
 		}
 	}
-}
-
-// We track the combo separately from the enemy's received hits
-// So that if partners take turns doing hits to different enemies the combo still adds up
-func (c *Char) addComboHits(n int32) {
-	if c.teamside != 0 && c.teamside != 1 {
-		return
-	}
-	sys.fightScreen.combos[c.teamside].trueHits += n
 }
 
 // Always appends to preserve insertion order
@@ -10997,7 +10988,7 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 		if (ghvset || getter.csf(CSF_gethit)) && getter.hoverIdx < 0 &&
 			!(c.hitdef.air_type == HT_None && getter.ss.stateType == ST_A || getter.ss.stateType != ST_A && c.hitdef.ground_type == HT_None) {
 			getter.receivedHits += hd.numhits
-			c.addComboHits(hd.numhits)
+			sys.fightScreen.addComboHits(hd.teamside, hd.numhits)
 		}
 		if !math.IsNaN(float64(hd.score[0])) && !c.asf(ASF_noscore) {
 			c.scoreAdd(hd.score[0])

--- a/src/common.go
+++ b/src/common.go
@@ -810,6 +810,73 @@ func NewIniSection() IniSection {
 	return IniSection(make(map[string]string))
 }
 
+// Replaces operators like "p1|p2" and "team*" with the appropriate single prefix like "p1"
+func resolveLifebarPrefixOperators(is IniSection, targetPrefix string, prefixBase string) IniSection {
+	// Fast path if no operators are used in the first place
+	hasOperators := false
+	for k := range is {
+		if strings.ContainsRune(k, '*') || strings.ContainsRune(k, '|') {
+			hasOperators = true
+			break
+		}
+	}
+	if !hasOperators {
+		return is
+	}
+
+	// If operators are used, use a temporary INI section so we can mutate it
+	out := NewIniSection()
+
+	// Normalize input strings just in case
+	targetPrefix = strings.ToLower(strings.TrimSpace(targetPrefix))
+	prefixBase = strings.ToLower(strings.TrimSpace(prefixBase))
+	targetPrefixNoDot := strings.TrimSuffix(targetPrefix, ".")
+
+	// Wildcard selector token
+	wildcardToken := prefixBase + "*"
+
+	// Helper to check if a grouped selector applies to the target
+	matchesTarget := func(selector string) bool {
+		selector = strings.ToLower(strings.TrimSpace(selector))
+		for _, token := range strings.Split(selector, "|") {
+			token = strings.TrimSpace(token)
+			if token == targetPrefixNoDot || token == wildcardToken {
+				return true
+			}
+		}
+		return false
+	}
+
+	// Iterate original section once and decide what to do per key
+	for k, v := range is {
+		kl := strings.ToLower(strings.TrimSpace(k))
+
+		// Split at first dot
+		dot := strings.IndexByte(kl, '.')
+		if dot <= 0 {
+			// No dot present at all. Keep as-is
+			out[kl] = v
+			continue
+		}
+
+		selector := strings.ToLower(strings.TrimSpace(kl[:dot]))
+
+		switch {
+		case selector == wildcardToken:
+			// Wildcard selector ("p*" to "p1")
+			out[targetPrefix+kl[dot+1:]] = v
+		case strings.Contains(selector, "|") && matchesTarget(selector):
+			// Grouped selector ("p1|p3|p5" to "p1")
+			out[targetPrefix+kl[dot+1:]] = v
+		default:
+			// Everything else is preserved as-is
+			out[kl] = v
+		}
+	}
+
+	return out
+}
+
 func ReadIniSection(lines []string, i *int) (
 	is IniSection, name string, subname string) {
 	for ; *i < len(lines); (*i)++ {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2420,6 +2420,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			opc = OC_ex2_explodvar_animtime
 		case "spriteplayerno":
 			opc = OC_ex2_explodvar_spriteplayerno
+		case "bindid":
+			opc = OC_ex2_explodvar_bindid
 		case "bindtime":
 			opc = OC_ex2_explodvar_bindtime
 		case "drawpal":

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -490,7 +490,8 @@ func readLifeBar(pre string, is IniSection, sff *Sff, at AnimationTable, f map[i
 		lb.red_value[k] = v
 	}
 
-	// Other fields
+	// TODO: These probably didn't have player prefixes for the sake of making parameters less redundant
+	// With the addition of player operators we could deprecate these forms now and use prefixes as well
 	is.ReadBool("mid.shift", &lb.mid_shift)
 	is.ReadBool("mid.freeze", &lb.mid_freeze)
 	is.ReadI32("mid.delay", &lb.mid_delay)
@@ -4511,6 +4512,18 @@ func loadFightScreen(def string) (*FightScreen, error) {
 
 	for lnidx < len(lines) {
 		is, name, subname := ReadIniSection(lines, &lnidx)
+
+		// Helper to return only the parameters for a given player number
+		resolvedSection := func(prefixBase string, n int) IniSection {
+			// Legacy versions cannot use prefix operators ('*' and '|')
+			// Update: The odds of an operator being found in a legacy fight screen are extremely slim, so we won't limit it for now
+			//if fs.ikemenver[0] == 0 && fs.ikemenver[1] == 0 { // Not "sys.fightScreen" yet
+			//	return is
+			//}
+			targetPrefix := fmt.Sprintf("%s%v.", prefixBase, n)
+			return resolveLifebarPrefixOperators(is, targetPrefix, prefixBase)
+		}
+
 		switch name {
 		case "info":
 			fs.name, _, _ = is.getText("name")
@@ -4657,90 +4670,90 @@ func loadFightScreen(def string) (*FightScreen, error) {
 			is.ReadF32("scale", &ffx.fx_scale)
 		case "lifebar":
 			if fs.lifeBars[0][0] == nil {
-				fs.lifeBars[0][0] = readLifeBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
+				fs.lifeBars[0][0] = readLifeBar("p1.", resolvedSection("p", 1), fs.sff, fs.animTable, fs.fnt)
 			}
 			if fs.lifeBars[0][1] == nil {
-				fs.lifeBars[0][1] = readLifeBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
+				fs.lifeBars[0][1] = readLifeBar("p2.", resolvedSection("p", 2), fs.sff, fs.animTable, fs.fnt)
 			}
 		case "powerbar":
 			if fs.powerBars[0][0] == nil {
-				fs.powerBars[0][0] = readPowerBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
+				fs.powerBars[0][0] = readPowerBar("p1.", resolvedSection("p", 1), fs.sff, fs.animTable, fs.fnt)
 			}
 			if fs.powerBars[0][1] == nil {
-				fs.powerBars[0][1] = readPowerBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
+				fs.powerBars[0][1] = readPowerBar("p2.", resolvedSection("p", 2), fs.sff, fs.animTable, fs.fnt)
 			}
 		case "guardbar":
 			if fs.guardBars[0][0] == nil {
-				fs.guardBars[0][0] = readGuardBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
+				fs.guardBars[0][0] = readGuardBar("p1.", resolvedSection("p", 1), fs.sff, fs.animTable, fs.fnt)
 			}
 			if fs.guardBars[0][1] == nil {
-				fs.guardBars[0][1] = readGuardBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
+				fs.guardBars[0][1] = readGuardBar("p2.", resolvedSection("p", 2), fs.sff, fs.animTable, fs.fnt)
 			}
 		case "stunbar":
 			if fs.stunBars[0][0] == nil {
-				fs.stunBars[0][0] = readStunBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
+				fs.stunBars[0][0] = readStunBar("p1.", resolvedSection("p", 1), fs.sff, fs.animTable, fs.fnt)
 			}
 			if fs.stunBars[0][1] == nil {
-				fs.stunBars[0][1] = readStunBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
+				fs.stunBars[0][1] = readStunBar("p2.", resolvedSection("p", 2), fs.sff, fs.animTable, fs.fnt)
 			}
 		case "face":
 			if fs.faces[0][0] == nil {
-				fs.faces[0][0] = readFightScreenFace("p1.", is, fs.sff, fs.animTable)
+				fs.faces[0][0] = readFightScreenFace("p1.", resolvedSection("p", 1), fs.sff, fs.animTable)
 			}
 			if fs.faces[0][1] == nil {
-				fs.faces[0][1] = readFightScreenFace("p2.", is, fs.sff, fs.animTable)
+				fs.faces[0][1] = readFightScreenFace("p2.", resolvedSection("p", 2), fs.sff, fs.animTable)
 			}
 		case "name":
 			if fs.names[0][0] == nil {
-				fs.names[0][0] = readFightScreenName("p1.", is, fs.sff, fs.animTable, fs.fnt)
+				fs.names[0][0] = readFightScreenName("p1.", resolvedSection("p", 1), fs.sff, fs.animTable, fs.fnt)
 			}
 			if fs.names[0][1] == nil {
-				fs.names[0][1] = readFightScreenName("p2.", is, fs.sff, fs.animTable, fs.fnt)
+				fs.names[0][1] = readFightScreenName("p2.", resolvedSection("p", 2), fs.sff, fs.animTable, fs.fnt)
 			}
 		case "turns ":
 			subname = strings.ToLower(subname)
 			switch {
 			case len(subname) >= 7 && subname[:7] == "lifebar":
 				if fs.lifeBars[2][0] == nil {
-					fs.lifeBars[2][0] = readLifeBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.lifeBars[2][0] = readLifeBar("p1.", resolvedSection("p", 1), fs.sff, fs.animTable, fs.fnt)
 				}
 				if fs.lifeBars[2][1] == nil {
-					fs.lifeBars[2][1] = readLifeBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.lifeBars[2][1] = readLifeBar("p2.", resolvedSection("p", 2), fs.sff, fs.animTable, fs.fnt)
 				}
 			case len(subname) >= 8 && subname[:8] == "powerbar":
 				if fs.powerBars[2][0] == nil {
-					fs.powerBars[2][0] = readPowerBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.powerBars[2][0] = readPowerBar("p1.", resolvedSection("p", 1), fs.sff, fs.animTable, fs.fnt)
 				}
 				if fs.powerBars[2][1] == nil {
-					fs.powerBars[2][1] = readPowerBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.powerBars[2][1] = readPowerBar("p2.", resolvedSection("p", 2), fs.sff, fs.animTable, fs.fnt)
 				}
 			case len(subname) >= 8 && subname[:8] == "guardbar":
 				if fs.guardBars[2][0] == nil {
-					fs.guardBars[2][0] = readGuardBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.guardBars[2][0] = readGuardBar("p1.", resolvedSection("p", 1), fs.sff, fs.animTable, fs.fnt)
 				}
 				if fs.guardBars[2][1] == nil {
-					fs.guardBars[2][1] = readGuardBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.guardBars[2][1] = readGuardBar("p2.", resolvedSection("p", 2), fs.sff, fs.animTable, fs.fnt)
 				}
 			case len(subname) >= 7 && subname[:7] == "stunbar":
 				if fs.stunBars[2][0] == nil {
-					fs.stunBars[2][0] = readStunBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.stunBars[2][0] = readStunBar("p1.", resolvedSection("p", 1), fs.sff, fs.animTable, fs.fnt)
 				}
 				if fs.stunBars[2][1] == nil {
-					fs.stunBars[2][1] = readStunBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.stunBars[2][1] = readStunBar("p2.", resolvedSection("p", 2), fs.sff, fs.animTable, fs.fnt)
 				}
 			case len(subname) >= 4 && subname[:4] == "face":
 				if fs.faces[2][0] == nil {
-					fs.faces[2][0] = readFightScreenFace("p1.", is, fs.sff, fs.animTable)
+					fs.faces[2][0] = readFightScreenFace("p1.", resolvedSection("p", 1), fs.sff, fs.animTable)
 				}
 				if fs.faces[2][1] == nil {
-					fs.faces[2][1] = readFightScreenFace("p2.", is, fs.sff, fs.animTable)
+					fs.faces[2][1] = readFightScreenFace("p2.", resolvedSection("p", 2), fs.sff, fs.animTable)
 				}
 			case len(subname) >= 4 && subname[:4] == "name":
 				if fs.names[2][0] == nil {
-					fs.names[2][0] = readFightScreenName("p1.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.names[2][0] = readFightScreenName("p1.", resolvedSection("p", 1), fs.sff, fs.animTable, fs.fnt)
 				}
 				if fs.names[2][1] == nil {
-					fs.names[2][1] = readFightScreenName("p2.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.names[2][1] = readFightScreenName("p2.", resolvedSection("p", 2), fs.sff, fs.animTable, fs.fnt)
 				}
 			}
 		case "simul ", "simul_3p ", "simul_4p ", "tag ", "tag_3p ", "tag_4p ":
@@ -4761,199 +4774,207 @@ func loadFightScreen(def string) (*FightScreen, error) {
 			switch {
 			case len(subname) >= 7 && subname[:7] == "lifebar":
 				if fs.lifeBars[i][0] == nil {
-					fs.lifeBars[i][0] = readLifeBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.lifeBars[i][0] = readLifeBar("p1.", resolvedSection("p", 1), fs.sff, fs.animTable, fs.fnt)
 				}
 				if fs.lifeBars[i][1] == nil {
-					fs.lifeBars[i][1] = readLifeBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.lifeBars[i][1] = readLifeBar("p2.", resolvedSection("p", 2), fs.sff, fs.animTable, fs.fnt)
 				}
 				if fs.lifeBars[i][2] == nil {
-					fs.lifeBars[i][2] = readLifeBar("p3.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.lifeBars[i][2] = readLifeBar("p3.", resolvedSection("p", 3), fs.sff, fs.animTable, fs.fnt)
 				}
 				if fs.lifeBars[i][3] == nil {
-					fs.lifeBars[i][3] = readLifeBar("p4.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.lifeBars[i][3] = readLifeBar("p4.", resolvedSection("p", 4), fs.sff, fs.animTable, fs.fnt)
 				}
 				if fs.lifeBars[i][4] == nil {
-					fs.lifeBars[i][4] = readLifeBar("p5.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.lifeBars[i][4] = readLifeBar("p5.", resolvedSection("p", 5), fs.sff, fs.animTable, fs.fnt)
 				}
 				if fs.lifeBars[i][5] == nil {
-					fs.lifeBars[i][5] = readLifeBar("p6.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.lifeBars[i][5] = readLifeBar("p6.", resolvedSection("p", 6), fs.sff, fs.animTable, fs.fnt)
 				}
 				if i != 4 && i != 6 {
 					if fs.lifeBars[i][6] == nil {
-						fs.lifeBars[i][6] = readLifeBar("p7.", is, fs.sff, fs.animTable, fs.fnt)
+						fs.lifeBars[i][6] = readLifeBar("p7.", resolvedSection("p", 7), fs.sff, fs.animTable, fs.fnt)
 					}
 					if fs.lifeBars[i][7] == nil {
-						fs.lifeBars[i][7] = readLifeBar("p8.", is, fs.sff, fs.animTable, fs.fnt)
+						fs.lifeBars[i][7] = readLifeBar("p8.", resolvedSection("p", 8), fs.sff, fs.animTable, fs.fnt)
 					}
 				}
 			case len(subname) >= 8 && subname[:8] == "powerbar":
 				if fs.powerBars[i][0] == nil {
-					fs.powerBars[i][0] = readPowerBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.powerBars[i][0] = readPowerBar("p1.", resolvedSection("p", 1), fs.sff, fs.animTable, fs.fnt)
 				}
 				if fs.powerBars[i][1] == nil {
-					fs.powerBars[i][1] = readPowerBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.powerBars[i][1] = readPowerBar("p2.", resolvedSection("p", 2), fs.sff, fs.animTable, fs.fnt)
 				}
 				if fs.powerBars[i][2] == nil {
-					fs.powerBars[i][2] = readPowerBar("p3.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.powerBars[i][2] = readPowerBar("p3.", resolvedSection("p", 3), fs.sff, fs.animTable, fs.fnt)
 				}
 				if fs.powerBars[i][3] == nil {
-					fs.powerBars[i][3] = readPowerBar("p4.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.powerBars[i][3] = readPowerBar("p4.", resolvedSection("p", 4), fs.sff, fs.animTable, fs.fnt)
 				}
 				if fs.powerBars[i][4] == nil {
-					fs.powerBars[i][4] = readPowerBar("p5.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.powerBars[i][4] = readPowerBar("p5.", resolvedSection("p", 5), fs.sff, fs.animTable, fs.fnt)
 				}
 				if fs.powerBars[i][5] == nil {
-					fs.powerBars[i][5] = readPowerBar("p6.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.powerBars[i][5] = readPowerBar("p6.", resolvedSection("p", 6), fs.sff, fs.animTable, fs.fnt)
 				}
 				if i != 4 && i != 6 {
 					if fs.powerBars[i][6] == nil {
-						fs.powerBars[i][6] = readPowerBar("p7.", is, fs.sff, fs.animTable, fs.fnt)
+						fs.powerBars[i][6] = readPowerBar("p7.", resolvedSection("p", 7), fs.sff, fs.animTable, fs.fnt)
 					}
 					if fs.powerBars[i][7] == nil {
-						fs.powerBars[i][7] = readPowerBar("p8.", is, fs.sff, fs.animTable, fs.fnt)
+						fs.powerBars[i][7] = readPowerBar("p8.", resolvedSection("p", 8), fs.sff, fs.animTable, fs.fnt)
 					}
 				}
 			case len(subname) >= 8 && subname[:8] == "guardbar":
 				if fs.guardBars[i][0] == nil {
-					fs.guardBars[i][0] = readGuardBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.guardBars[i][0] = readGuardBar("p1.", resolvedSection("p", 1), fs.sff, fs.animTable, fs.fnt)
 				}
 				if fs.guardBars[i][1] == nil {
-					fs.guardBars[i][1] = readGuardBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.guardBars[i][1] = readGuardBar("p2.", resolvedSection("p", 2), fs.sff, fs.animTable, fs.fnt)
 				}
 				if fs.guardBars[i][2] == nil {
-					fs.guardBars[i][2] = readGuardBar("p3.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.guardBars[i][2] = readGuardBar("p3.", resolvedSection("p", 3), fs.sff, fs.animTable, fs.fnt)
 				}
 				if fs.guardBars[i][3] == nil {
-					fs.guardBars[i][3] = readGuardBar("p4.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.guardBars[i][3] = readGuardBar("p4.", resolvedSection("p", 4), fs.sff, fs.animTable, fs.fnt)
 				}
 				if fs.guardBars[i][4] == nil {
-					fs.guardBars[i][4] = readGuardBar("p5.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.guardBars[i][4] = readGuardBar("p5.", resolvedSection("p", 5), fs.sff, fs.animTable, fs.fnt)
 				}
 				if fs.guardBars[i][5] == nil {
-					fs.guardBars[i][5] = readGuardBar("p6.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.guardBars[i][5] = readGuardBar("p6.", resolvedSection("p", 6), fs.sff, fs.animTable, fs.fnt)
 				}
 				if i != 4 && i != 6 {
 					if fs.guardBars[i][6] == nil {
-						fs.guardBars[i][6] = readGuardBar("p7.", is, fs.sff, fs.animTable, fs.fnt)
+						fs.guardBars[i][6] = readGuardBar("p7.", resolvedSection("p", 7), fs.sff, fs.animTable, fs.fnt)
 					}
 					if fs.guardBars[i][7] == nil {
-						fs.guardBars[i][7] = readGuardBar("p8.", is, fs.sff, fs.animTable, fs.fnt)
+						fs.guardBars[i][7] = readGuardBar("p8.", resolvedSection("p", 8), fs.sff, fs.animTable, fs.fnt)
 					}
 				}
 			case len(subname) >= 7 && subname[:7] == "stunbar":
 				if fs.stunBars[i][0] == nil {
-					fs.stunBars[i][0] = readStunBar("p1.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.stunBars[i][0] = readStunBar("p1.", resolvedSection("p", 1), fs.sff, fs.animTable, fs.fnt)
 				}
 				if fs.stunBars[i][1] == nil {
-					fs.stunBars[i][1] = readStunBar("p2.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.stunBars[i][1] = readStunBar("p2.", resolvedSection("p", 2), fs.sff, fs.animTable, fs.fnt)
 				}
 				if fs.stunBars[i][2] == nil {
-					fs.stunBars[i][2] = readStunBar("p3.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.stunBars[i][2] = readStunBar("p3.", resolvedSection("p", 3), fs.sff, fs.animTable, fs.fnt)
 				}
 				if fs.stunBars[i][3] == nil {
-					fs.stunBars[i][3] = readStunBar("p4.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.stunBars[i][3] = readStunBar("p4.", resolvedSection("p", 4), fs.sff, fs.animTable, fs.fnt)
 				}
 				if fs.stunBars[i][4] == nil {
-					fs.stunBars[i][4] = readStunBar("p5.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.stunBars[i][4] = readStunBar("p5.", resolvedSection("p", 5), fs.sff, fs.animTable, fs.fnt)
 				}
 				if fs.stunBars[i][5] == nil {
-					fs.stunBars[i][5] = readStunBar("p6.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.stunBars[i][5] = readStunBar("p6.", resolvedSection("p", 6), fs.sff, fs.animTable, fs.fnt)
 				}
 				if i != 4 && i != 6 {
 					if fs.stunBars[i][6] == nil {
-						fs.stunBars[i][6] = readStunBar("p7.", is, fs.sff, fs.animTable, fs.fnt)
+						fs.stunBars[i][6] = readStunBar("p7.", resolvedSection("p", 7), fs.sff, fs.animTable, fs.fnt)
 					}
 					if fs.stunBars[i][7] == nil {
-						fs.stunBars[i][7] = readStunBar("p8.", is, fs.sff, fs.animTable, fs.fnt)
+						fs.stunBars[i][7] = readStunBar("p8.", resolvedSection("p", 8), fs.sff, fs.animTable, fs.fnt)
 					}
 				}
 			case len(subname) >= 4 && subname[:4] == "face":
 				if fs.faces[i][0] == nil {
-					fs.faces[i][0] = readFightScreenFace("p1.", is, fs.sff, fs.animTable)
+					fs.faces[i][0] = readFightScreenFace("p1.", resolvedSection("p", 1), fs.sff, fs.animTable)
 				}
 				if fs.faces[i][1] == nil {
-					fs.faces[i][1] = readFightScreenFace("p2.", is, fs.sff, fs.animTable)
+					fs.faces[i][1] = readFightScreenFace("p2.", resolvedSection("p", 2), fs.sff, fs.animTable)
 				}
 				if fs.faces[i][2] == nil {
-					fs.faces[i][2] = readFightScreenFace("p3.", is, fs.sff, fs.animTable)
+					fs.faces[i][2] = readFightScreenFace("p3.", resolvedSection("p", 3), fs.sff, fs.animTable)
 				}
 				if fs.faces[i][3] == nil {
-					fs.faces[i][3] = readFightScreenFace("p4.", is, fs.sff, fs.animTable)
+					fs.faces[i][3] = readFightScreenFace("p4.", resolvedSection("p", 4), fs.sff, fs.animTable)
 				}
 				if fs.faces[i][4] == nil {
-					fs.faces[i][4] = readFightScreenFace("p5.", is, fs.sff, fs.animTable)
+					fs.faces[i][4] = readFightScreenFace("p5.", resolvedSection("p", 5), fs.sff, fs.animTable)
 				}
 				if fs.faces[i][5] == nil {
-					fs.faces[i][5] = readFightScreenFace("p6.", is, fs.sff, fs.animTable)
+					fs.faces[i][5] = readFightScreenFace("p6.", resolvedSection("p", 6), fs.sff, fs.animTable)
 				}
 				if i != 4 && i != 6 {
 					if fs.faces[i][6] == nil {
-						fs.faces[i][6] = readFightScreenFace("p7.", is, fs.sff, fs.animTable)
+						fs.faces[i][6] = readFightScreenFace("p7.", resolvedSection("p", 7), fs.sff, fs.animTable)
 					}
 					if fs.faces[i][7] == nil {
-						fs.faces[i][7] = readFightScreenFace("p8.", is, fs.sff, fs.animTable)
+						fs.faces[i][7] = readFightScreenFace("p8.", resolvedSection("p", 8), fs.sff, fs.animTable)
 					}
 				}
 			case len(subname) >= 4 && subname[:4] == "name":
 				if fs.names[i][0] == nil {
-					fs.names[i][0] = readFightScreenName("p1.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.names[i][0] = readFightScreenName("p1.", resolvedSection("p", 1), fs.sff, fs.animTable, fs.fnt)
 				}
 				if fs.names[i][1] == nil {
-					fs.names[i][1] = readFightScreenName("p2.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.names[i][1] = readFightScreenName("p2.", resolvedSection("p", 2), fs.sff, fs.animTable, fs.fnt)
 				}
 				if fs.names[i][2] == nil {
-					fs.names[i][2] = readFightScreenName("p3.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.names[i][2] = readFightScreenName("p3.", resolvedSection("p", 3), fs.sff, fs.animTable, fs.fnt)
 				}
 				if fs.names[i][3] == nil {
-					fs.names[i][3] = readFightScreenName("p4.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.names[i][3] = readFightScreenName("p4.", resolvedSection("p", 4), fs.sff, fs.animTable, fs.fnt)
 				}
 				if fs.names[i][4] == nil {
-					fs.names[i][4] = readFightScreenName("p5.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.names[i][4] = readFightScreenName("p5.", resolvedSection("p", 5), fs.sff, fs.animTable, fs.fnt)
 				}
 				if fs.names[i][5] == nil {
-					fs.names[i][5] = readFightScreenName("p6.", is, fs.sff, fs.animTable, fs.fnt)
+					fs.names[i][5] = readFightScreenName("p6.", resolvedSection("p", 6), fs.sff, fs.animTable, fs.fnt)
 				}
 				if i != 4 && i != 6 {
 					if fs.names[i][6] == nil {
-						fs.names[i][6] = readFightScreenName("p7.", is, fs.sff, fs.animTable, fs.fnt)
+						fs.names[i][6] = readFightScreenName("p7.", resolvedSection("p", 7), fs.sff, fs.animTable, fs.fnt)
 					}
 					if fs.names[i][7] == nil {
-						fs.names[i][7] = readFightScreenName("p8.", is, fs.sff, fs.animTable, fs.fnt)
+						fs.names[i][7] = readFightScreenName("p8.", resolvedSection("p", 8), fs.sff, fs.animTable, fs.fnt)
 					}
 				}
 			}
 		case "winicon":
 			if fs.winIcons[0] == nil {
-				fs.winIcons[0] = readFightScreenWinIcon("p1.", is, fs.sff, fs.animTable, fs.fnt)
+				fs.winIcons[0] = readFightScreenWinIcon("p1.", resolvedSection("p", 1), fs.sff, fs.animTable, fs.fnt)
 			}
 			if fs.winIcons[1] == nil {
-				fs.winIcons[1] = readFightScreenWinIcon("p2.", is, fs.sff, fs.animTable, fs.fnt)
+				fs.winIcons[1] = readFightScreenWinIcon("p2.", resolvedSection("p", 2), fs.sff, fs.animTable, fs.fnt)
 			}
 		case "time":
 			if fs.time == nil {
 				fs.time = readFightScreenTime(is, fs.sff, fs.animTable, fs.fnt)
 			}
 		case "combo":
-			if fs.combos[0] == nil {
-				if _, ok := is["team1.pos"]; ok {
-					fs.combos[0] = readFightScreenCombo("team1.", is, fs.sff, fs.animTable, fs.fnt, 0)
-				} else {
-					fs.combos[0] = readFightScreenCombo("", is, fs.sff, fs.animTable, fs.fnt, 0)
+			for team := 0; team < 2; team++ {
+				if fs.combos[team] != nil {
+					continue
 				}
-			}
-			if fs.combos[1] == nil {
-				if _, ok := is["team2.pos"]; ok {
-					fs.combos[1] = readFightScreenCombo("team2.", is, fs.sff, fs.animTable, fs.fnt, 1)
+
+				teamNum := team + 1
+				teamPrefix := fmt.Sprintf("team%v.", teamNum)
+
+				if sys.fightScreen.ikemenver[0] == 0 && sys.fightScreen.ikemenver[1] == 0 {
+					// Check if "teamX.pos" exists to determine whether or not to use "teamX" prefixes
+					// Mugen works slightly different and apparently checks whether "pos" or "team1.pos" is found first in order to determine what syntax to use
+					// Such prefixes were only added in Mugen 1.0, hence it running this check
+					if _, ok := is[teamPrefix+"pos"]; ok {
+						fs.combos[team] = readFightScreenCombo(teamPrefix, is, fs.sff, fs.animTable, fs.fnt, team)
+					} else {
+						fs.combos[team] = readFightScreenCombo("", is, fs.sff, fs.animTable, fs.fnt, team)
+					}
 				} else {
-					fs.combos[1] = readFightScreenCombo("", is, fs.sff, fs.animTable, fs.fnt, 1)
+					// In Ikemen version we just read them like other prefixed sections
+					fs.combos[team] = readFightScreenCombo(teamPrefix, resolvedSection("team", teamNum), fs.sff, fs.animTable, fs.fnt, team)
 				}
 			}
 		case "action":
 			if fs.actions[0] == nil {
-				fs.actions[0] = readFightScreenAction("team1.", is, fs.fnt)
+				fs.actions[0] = readFightScreenAction("team1.", resolvedSection("team", 1), fs.fnt)
 			}
 			if fs.actions[1] == nil {
-				fs.actions[1] = readFightScreenAction("team2.", is, fs.fnt)
+				fs.actions[1] = readFightScreenAction("team2.", resolvedSection("team", 2), fs.fnt)
 			}
 		case "round":
 			if fs.round == nil {
@@ -4961,10 +4982,10 @@ func loadFightScreen(def string) (*FightScreen, error) {
 			}
 		case "ratio":
 			if fs.ratios[0] == nil {
-				fs.ratios[0] = readFightScreenRatio("p1.", is, fs.sff, fs.animTable)
+				fs.ratios[0] = readFightScreenRatio("p1.", resolvedSection("p", 1), fs.sff, fs.animTable)
 			}
 			if fs.ratios[1] == nil {
-				fs.ratios[1] = readFightScreenRatio("p2.", is, fs.sff, fs.animTable)
+				fs.ratios[1] = readFightScreenRatio("p2.", resolvedSection("p", 2), fs.sff, fs.animTable)
 			}
 		case "timer":
 			if fs.timer == nil {
@@ -4972,10 +4993,10 @@ func loadFightScreen(def string) (*FightScreen, error) {
 			}
 		case "score":
 			if fs.scores[0] == nil {
-				fs.scores[0] = readFightScreenScore("p1.", is, fs.sff, fs.animTable, fs.fnt)
+				fs.scores[0] = readFightScreenScore("p1.", resolvedSection("p", 1), fs.sff, fs.animTable, fs.fnt)
 			}
 			if fs.scores[1] == nil {
-				fs.scores[1] = readFightScreenScore("p2.", is, fs.sff, fs.animTable, fs.fnt)
+				fs.scores[1] = readFightScreenScore("p2.", resolvedSection("p", 2), fs.sff, fs.animTable, fs.fnt)
 			}
 		case "match":
 			if fs.match == nil {
@@ -4983,17 +5004,17 @@ func loadFightScreen(def string) (*FightScreen, error) {
 			}
 		case "ailevel":
 			if fs.aiLevels[0] == nil {
-				fs.aiLevels[0] = readFightScreenAiLevel("p1.", is, fs.sff, fs.animTable, fs.fnt)
+				fs.aiLevels[0] = readFightScreenAiLevel("p1.", resolvedSection("p", 1), fs.sff, fs.animTable, fs.fnt)
 			}
 			if fs.aiLevels[1] == nil {
-				fs.aiLevels[1] = readFightScreenAiLevel("p2.", is, fs.sff, fs.animTable, fs.fnt)
+				fs.aiLevels[1] = readFightScreenAiLevel("p2.", resolvedSection("p", 2), fs.sff, fs.animTable, fs.fnt)
 			}
 		case "wincount":
 			if fs.winCounts[0] == nil {
-				fs.winCounts[0] = readFightScreenWinCount("p1.", is, fs.sff, fs.animTable, fs.fnt)
+				fs.winCounts[0] = readFightScreenWinCount("p1.", resolvedSection("p", 1), fs.sff, fs.animTable, fs.fnt)
 			}
 			if fs.winCounts[1] == nil {
-				fs.winCounts[1] = readFightScreenWinCount("p2.", is, fs.sff, fs.animTable, fs.fnt)
+				fs.winCounts[1] = readFightScreenWinCount("p2.", resolvedSection("p", 2), fs.sff, fs.animTable, fs.fnt)
 			}
 		case "mode":
 			if fs.modes == nil {

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -5777,3 +5777,14 @@ func (fs *FightScreen) appendAction(c *Char, msg *FSMsg, s_ffx, a_ffx string, sn
 	// Insert new message
 	teammsg.messages = insertFSMsg(teammsg.messages, msg, index)
 }
+
+// We track the combo separately from each player's received hits
+// So that if partners take turns doing hits to different enemies the combo still adds up
+// Only some games do this so we don't strictly need to do it. But it is also harmless. Maybe make it an option
+// TODO: Combo damage should probably also stack like this, either way
+func (fs *FightScreen) addComboHits(side int, n int32) {
+	if side < 0 || side >= len(fs.combos) {
+		return
+	}
+	fs.combos[side].trueHits += n
+}

--- a/src/script.go
+++ b/src/script.go
@@ -8057,6 +8057,8 @@ func triggerFunctions(l *lua.LState) {
 				lv = lua.LNumber(e.anim.AnimTime())
 			case "spriteplayerno":
 				lv = lua.LNumber(e.spritePN + 1)
+			case "bindid":
+				lv = lua.LNumber(e.bindId)
 			case "bindtime":
 				lv = lua.LNumber(e.bindtime)
 			case "drawpal group":


### PR DESCRIPTION
Features:
- Fight screen "pX" and "teamX" parameters can now use `*` and `|` operators. e.g. "p1|p3" applies to p1 and p3
- `explodVar(bindID)`. Returns the ID of the player the explod is bound to

Fixes:
- A reflected projectile will now add combo hits to its current teamside
- When a ZSS loop's ending point is before its starting point, it will no longer execute at all
- Fixed functions potentially trying to run from the wrong player during custom states
- Fixes #3523 

Refactor:
- Invalid Zoom parameter values are now ignored instead of clamped