### PR TITLE
feat: add AudioResampleQuality to config.ini

### DIFF
--- a/src/config.go
+++ b/src/config.go
@@ -185,18 +185,19 @@ type Config struct {
 		EnableModelShadow       bool     `ini:"EnableModelShadow"`
 	} `ini:"Video"`
 	Sound struct {
-		SampleRate        int32   `ini:"SampleRate"`
-		SoundFont         string  `ini:"SoundFont"`
-		StereoEffects     bool    `ini:"StereoEffects"`
-		PanningRange      float32 `ini:"PanningRange"`
-		WavChannels       int32   `ini:"WavChannels"`
-		MasterVolume      int     `ini:"MasterVolume"`
-		PauseMasterVolume int     `ini:"PauseMasterVolume"`
-		WavVolume         int     `ini:"WavVolume"`
-		BGMVolume         int     `ini:"BGMVolume"`
-		BGMRAMBuffer      bool    `ini:"BGMRAMBuffer"`
-		MaxBGMVolume      int     `ini:"MaxBGMVolume"`
-		AudioDucking      bool    `ini:"AudioDucking"`
+		SampleRate           int32   `ini:"SampleRate"`
+		SoundFont            string  `ini:"SoundFont"`
+		StereoEffects        bool    `ini:"StereoEffects"`
+		PanningRange         float32 `ini:"PanningRange"`
+		WavChannels          int32   `ini:"WavChannels"`
+		MasterVolume         int     `ini:"MasterVolume"`
+		PauseMasterVolume    int     `ini:"PauseMasterVolume"`
+		WavVolume            int     `ini:"WavVolume"`
+		BGMVolume            int     `ini:"BGMVolume"`
+		BGMRAMBuffer         bool    `ini:"BGMRAMBuffer"`
+		MaxBGMVolume         int     `ini:"MaxBGMVolume"`
+		AudioDucking         bool    `ini:"AudioDucking"`
+		AudioResampleQuality int     `ini:"AudioResampleQuality"`
 	} `ini:"Sound"`
 	Arcade struct {
 		AI struct {
@@ -378,6 +379,7 @@ func (c *Config) normalize() {
 	c.SetValueUpdate("Input.SOCDResolution", int(Clamp(int32(c.Input.SOCDResolution), 0, 4)))
 	c.SetValueUpdate("Input.UiRepeatDelay", int(Max(int32(c.Input.UiRepeatDelay), 0)))
 	c.SetValueUpdate("Input.UiRepeatRate", int(Max(int32(c.Input.UiRepeatRate), 1)))
+	c.SetValueUpdate("Sound.AudioResampleQuality", Clamp(c.Sound.AudioResampleQuality, 1, 16))
 	c.SetValueUpdate("Sound.MaxBGMVolume", int(Clamp(int32(c.Sound.MaxBGMVolume), 100, 250)))
 	c.SetValueUpdate("Sound.PanningRange", Clamp(c.Sound.PanningRange, 0, 100))
 	c.SetValueUpdate("Sound.PauseMasterVolume", int(Clamp(int32(c.Sound.PauseMasterVolume), 0, 100)))

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -295,6 +295,15 @@ AudioDucking      = 0
 ; some formats (namely FLAC). If I.K.E.M.E.N-Go hangs or crashes on your system,
 ; try setting this to 0, at the cost of potential skipping during loop points.
 BGMRAMBuffer      = 1
+; From the beepv2 docs:
+; quality | use case
+; --------|---------
+; 1       | very high performance, on-the-fly resampling, low quality
+; 3-4     | good performance, on-the-fly resampling, good quality
+; 6       | higher CPU usage, usually not suitable for on-the-fly resampling, very good quality
+; >6      | even higher CPU usage, for offline resampling, very good quality
+; Max is 16
+AudioResampleQuality = 1
 
 ; -------------------------------------------------------------------------------
 [Arcade]

--- a/src/sound.go
+++ b/src/sound.go
@@ -21,10 +21,9 @@ import (
 )
 
 const (
-	audioOutLen          = 2048
-	audioFrequency       = 44100
-	audioPrecision       = 4
-	audioResampleQuality = 1
+	audioOutLen    = 2048
+	audioFrequency = 44100
+	audioPrecision = 4
 )
 
 // ------------------------------------------------------------------
@@ -634,7 +633,7 @@ func (bgm *Bgm) OpenFromStreamer(stream beep.Streamer, srcSampleRate beep.Sample
 	bgm.sampleRate = srcSampleRate
 	bgm.volctrl = &effects.Volume{Streamer: stream, Base: 2, Volume: 0, Silent: true}
 	dstFreq := beep.SampleRate(float32(sys.cfg.Sound.SampleRate) / bgm.freqmul)
-	resampler := beep.Resample(audioResampleQuality, bgm.sampleRate, dstFreq, bgm.volctrl)
+	resampler := beep.Resample(Clamp(sys.cfg.Sound.AudioResampleQuality, 1, 16), bgm.sampleRate, dstFreq, bgm.volctrl)
 	bgm.ctrl = &beep.Ctrl{Streamer: resampler}
 	bgm.volRestore = 0
 	bgm.UpdateVolume()
@@ -1002,7 +1001,7 @@ func (s *SoundChannel) Play(sound *Sound, group, number, loop int32, freqmul flo
 	s.sfx = &SoundEffect{streamer: looper, volume: 256, priority: 0, loop: int32(loopCount), freqmul: freqmul, startPos: startPosition}
 	srcRate := s.sound.format.SampleRate
 	dstRate := beep.SampleRate(float32(sys.cfg.Sound.SampleRate) / s.sfx.freqmul)
-	resampler := beep.Resample(audioResampleQuality, srcRate, dstRate, s.sfx)
+	resampler := beep.Resample(Clamp(sys.cfg.Sound.AudioResampleQuality, 1, 16), srcRate, dstRate, s.sfx)
 	s.ctrl = &beep.Ctrl{Streamer: resampler}
 	s.streamer.Seek(startPosition)
 

--- a/src/sound.go
+++ b/src/sound.go
@@ -421,7 +421,7 @@ func (bgm *Bgm) Open(filename string, loop, bgmVolume, bgmLoopStart, bgmLoopEnd,
 	bgm.volctrl = &effects.Volume{Streamer: streamer, Base: 2, Volume: 0, Silent: true}
 	bgm.sampleRate = format.SampleRate
 	dstFreq := beep.SampleRate(float32(sys.cfg.Sound.SampleRate) / bgm.freqmul)
-	resampler := beep.Resample(audioResampleQuality, bgm.sampleRate, dstFreq, bgm.volctrl)
+	resampler := beep.Resample(Clamp(sys.cfg.Sound.AudioResampleQuality, 1, 16), bgm.sampleRate, dstFreq, bgm.volctrl)
 	bgm.ctrl = &beep.Ctrl{Streamer: resampler}
 	bgm.volRestore = 0 // need this to prevent paused BGM volume from overwriting the new BGM volume
 	bgm.UpdateVolume()

--- a/src/video_ffmpeg.go
+++ b/src/video_ffmpeg.go
@@ -183,7 +183,7 @@ func (bgv *bgVideo) Open(filename string, volume int, sm BgVideoScaleMode, sf Bg
 			bgv.videoVol = &effects.Volume{Streamer: rs, Base: 2}
 			// Resample video audio to match engine output sample rate
 			dst := beep.SampleRate(sys.cfg.Sound.SampleRate)
-			resampler := beep.Resample(audioResampleQuality, bgv.audioSampleRate, dst, bgv.videoVol)
+			resampler := beep.Resample(Clamp(sys.cfg.Sound.AudioResampleQuality, 1, 16), bgv.audioSampleRate, dst, bgv.videoVol)
 			bgv.videoCtrl = &beep.Ctrl{Streamer: resampler, Paused: true} // start paused until SetPlaying(true)
 
 			WithSpeakerLock(func() {


### PR DESCRIPTION
Default/min value is 1 (same as before), max is 16

comments directly from beepv2 docs