### PR TITLE
feat(font): add non-uniform scale, projection, shear, rotation to ttf for parity

### DIFF
--- a/src/font.go
+++ b/src/font.go
@@ -21,7 +21,7 @@ type FontRenderer interface {
 type Font interface {
 	SetColor(red float32, green float32, blue float32, alpha float32)
 	UpdateResolution(windowWidth int, windowHeight int)
-	Printf(x, y float32, scale float32, spacingXAdd float32, align int32, blend bool, window [4]int32,
+	Printf(x, y float32, xscl, yscl float32, spacingXAdd float32, align int32, blend bool, window [4]int32,
 		rxadd float32, rot Rotation, projectionMode int32, fLength float32, rcx, rcy float32,
 		fs string, argv ...interface{}) error
 	Width(scale float32, spacingXAdd float32, fs string, argv ...interface{}) float32
@@ -64,7 +64,7 @@ type FntCharImage struct {
 type TtfFont interface {
 	SetColor(red float32, green float32, blue float32, alpha float32)
 	Width(scale float32, spacingXAdd float32, fs string, argv ...interface{}) float32
-	Printf(x, y float32, scale float32, spacingXAdd float32, align int32, blend bool, window [4]int32,
+	Printf(x, y float32, xscl, yscl float32, spacingXAdd float32, align int32, blend bool, window [4]int32,
 		rxadd float32, rot Rotation, projectionMode int32, fLength float32, rcx, rcy float32,
 		fs string, argv ...interface{}) error
 	UpdateResolution(windowWidth int, windowHeight int)
@@ -692,7 +692,7 @@ func (f *Fnt) DrawTtf(txt string, x, y, xscl, yscl, rxadd float32, rot Rotation,
 	//	(*window)[2], (*window)[3]}
 
 	f.ttf.SetColor(frgba[0], frgba[1], frgba[2], frgba[3])
-	f.ttf.Printf(x, y, (xscl+yscl)/2, spacingXAdd, align, blend, *window,
+	f.ttf.Printf(x, y, xscl, yscl, spacingXAdd, align, blend, *window,
 		rxadd, rot, projectionMode, fLength, x, y,
 		"%s", txt) //x, y, scale, spacingXAdd, align, blend, window, transform, string, printf args
 }

--- a/src/font.go
+++ b/src/font.go
@@ -21,7 +21,9 @@ type FontRenderer interface {
 type Font interface {
 	SetColor(red float32, green float32, blue float32, alpha float32)
 	UpdateResolution(windowWidth int, windowHeight int)
-	Printf(x, y float32, scale float32, spacingXAdd float32, align int32, blend bool, window [4]int32, fs string, argv ...interface{}) error
+	Printf(x, y float32, scale float32, spacingXAdd float32, align int32, blend bool, window [4]int32,
+		rxadd float32, rot Rotation, projectionMode int32, fLength float32, rcx, rcy float32,
+		fs string, argv ...interface{}) error
 	Width(scale float32, spacingXAdd float32, fs string, argv ...interface{}) float32
 }
 
@@ -62,7 +64,9 @@ type FntCharImage struct {
 type TtfFont interface {
 	SetColor(red float32, green float32, blue float32, alpha float32)
 	Width(scale float32, spacingXAdd float32, fs string, argv ...interface{}) float32
-	Printf(x, y float32, scale float32, spacingXAdd float32, align int32, blend bool, window [4]int32, fs string, argv ...interface{}) error
+	Printf(x, y float32, scale float32, spacingXAdd float32, align int32, blend bool, window [4]int32,
+		rxadd float32, rot Rotation, projectionMode int32, fLength float32, rcx, rcy float32,
+		fs string, argv ...interface{}) error
 	UpdateResolution(windowWidth int, windowHeight int)
 }
 
@@ -558,7 +562,7 @@ func (f *Fnt) Print(txt string, x, y, xscl, yscl, rxadd float32, rot Rotation, p
 	window *[4]int32, palfx *PalFX, frgba [4]float32) {
 	if !sys.frameSkip {
 		if f.Type == "truetype" {
-			f.DrawTtf(txt, x, y, xscl, yscl, align, true, window, frgba, 0)
+			f.DrawTtf(txt, x, y, xscl, yscl, rxadd, rot, projectionMode, fLength, align, true, window, frgba, 0)
 		} else {
 			f.DrawText(txt, x, y, xscl, yscl, rxadd, rot, projectionMode, fLength, bank, align, window, palfx, frgba[3], 0)
 		}
@@ -668,7 +672,8 @@ func (f *Fnt) DrawText(txt string, x, y, xscl, yscl, rxadd float32,
 	}
 }
 
-func (f *Fnt) DrawTtf(txt string, x, y, xscl, yscl float32, align int32,
+func (f *Fnt) DrawTtf(txt string, x, y, xscl, yscl, rxadd float32, rot Rotation,
+	projectionMode int32, fLength float32, align int32,
 	blend bool, window *[4]int32, frgba [4]float32, spacingXAdd float32) {
 
 	if len(txt) == 0 {
@@ -687,7 +692,9 @@ func (f *Fnt) DrawTtf(txt string, x, y, xscl, yscl float32, align int32,
 	//	(*window)[2], (*window)[3]}
 
 	f.ttf.SetColor(frgba[0], frgba[1], frgba[2], frgba[3])
-	f.ttf.Printf(x, y, (xscl+yscl)/2, spacingXAdd, align, blend, *window, "%s", txt) //x, y, scale, spacingXAdd, align, blend, window, string, printf args
+	f.ttf.Printf(x, y, (xscl+yscl)/2, spacingXAdd, align, blend, *window,
+		rxadd, rot, projectionMode, fLength, x, y,
+		"%s", txt) //x, y, scale, spacingXAdd, align, blend, window, transform, string, printf args
 }
 
 type TextSprite struct {
@@ -1348,7 +1355,8 @@ func (ts *TextSprite) Draw(ln int16) {
 
 		// Draw the visible line
 		if ts.fnt.Type == "truetype" {
-			ts.fnt.DrawTtf(line[:charsToShow], ts.x+ts.vel[0]+phantomX, newY+ts.vel[1], ts.xscl, ts.yscl, ts.align, true, &ts.window, ts.frgba, float32(spacingXAdd))
+			ts.fnt.DrawTtf(line[:charsToShow], ts.x+ts.vel[0]-xsoffset+phantomX, newY+ts.vel[1], ts.xscl, ts.yscl,
+				xshear, ts.rot, ts.projection, ts.fLength, ts.align, true, &ts.window, ts.frgba, float32(spacingXAdd))
 		} else {
 			ts.fnt.DrawText(line[:charsToShow], ts.x+ts.vel[0]-xsoffset+phantomX, newY+ts.vel[1], ts.xscl, ts.yscl,
 				xshear, ts.rot, ts.projection, ts.fLength, ts.bank, ts.align, &ts.window, ts.palfx, ts.frgba[3], spacingXAdd)

--- a/src/font_gl33.go
+++ b/src/font_gl33.go
@@ -116,7 +116,9 @@ func (r *FontRenderer_GL33) SetFontPipeline() {
 
 // Printf draws a string to the screen, takes a list of arguments like printf
 func (f *Font_GL33) Printf(x, y float32, scale float32, spacingXAdd float32,
-	align int32, blend bool, window [4]int32, fs string, argv ...interface{}) error {
+	align int32, blend bool, window [4]int32,
+	rxadd float32, rot Rotation, projectionMode int32, fLength float32, rcx, rcy float32,
+	fs string, argv ...interface{}) error {
 
 	indices := []rune(fmt.Sprintf(fs, argv...))
 	r := gfx.(*Renderer_GL33)
@@ -203,14 +205,24 @@ func (f *Font_GL33) Printf(x, y float32, scale float32, spacingXAdd float32,
 		ypos := y - float32(ch.height-ch.bearingV)*scale
 		w := float32(ch.width) * scale
 		h := float32(ch.height) * scale
-		vertices := []float32{
-			xpos + w, ypos, ch.uv[2], ch.uv[1],
-			xpos, ypos, ch.uv[0], ch.uv[1],
-			xpos, ypos + h, ch.uv[0], ch.uv[3],
 
-			xpos, ypos + h, ch.uv[0], ch.uv[3],
-			xpos + w, ypos + h, ch.uv[2], ch.uv[3],
-			xpos + w, ypos, ch.uv[2], ch.uv[1],
+		x1, y1 := xpos+w, ypos
+		x2, y2 := xpos, ypos
+		x3, y3 := xpos, ypos+h
+		x4, y4 := xpos+w, ypos+h
+		x1, y1, x2, y2, x3, y3, x4, y4 = transformTextQuad(
+			x1, y1, x2, y2, x3, y3, x4, y4,
+			rxadd, rot, projectionMode, fLength, rcx, rcy,
+		)
+
+		vertices := []float32{
+			x1, y1, ch.uv[2], ch.uv[1],
+			x2, y2, ch.uv[0], ch.uv[1],
+			x3, y3, ch.uv[0], ch.uv[3],
+
+			x3, y3, ch.uv[0], ch.uv[3],
+			x4, y4, ch.uv[2], ch.uv[3],
+			x1, y1, ch.uv[2], ch.uv[1],
 		}
 		// Append glyph vertices to the batch buffer
 		batchVertices = append(batchVertices, vertices...)

--- a/src/font_gl33.go
+++ b/src/font_gl33.go
@@ -115,7 +115,7 @@ func (r *FontRenderer_GL33) SetFontPipeline() {
 }
 
 // Printf draws a string to the screen, takes a list of arguments like printf
-func (f *Font_GL33) Printf(x, y float32, scale float32, spacingXAdd float32,
+func (f *Font_GL33) Printf(x, y float32, xscl, yscl float32, spacingXAdd float32,
 	align int32, blend bool, window [4]int32,
 	rxadd float32, rot Rotation, projectionMode int32, fLength float32, rcx, rcy float32,
 	fs string, argv ...interface{}) error {
@@ -159,13 +159,17 @@ func (f *Font_GL33) Printf(x, y float32, scale float32, spacingXAdd float32,
 	//gl.BindVertexArray(gfxFont.(*FontRenderer_GL33).vao)
 
 	//calculate alignment position
+	alignScale := xscl
+	if alignScale == 0 {
+		alignScale = yscl
+	}
 	if align == 0 {
-		x -= f.Width(scale, spacingXAdd, fs, argv...) * 0.5
+		x -= f.Width(alignScale, spacingXAdd, fs, argv...) * 0.5
 	} else if align < 0 {
-		x -= f.Width(scale, spacingXAdd, fs, argv...)
+		x -= f.Width(alignScale, spacingXAdd, fs, argv...)
 	}
 	textureID := int32(-1)
-	spacing := spacingXAdd * scale
+	spacing := spacingXAdd * xscl
 	renderedAny := false
 	// Iterate through all characters in string
 	for i := range indices {
@@ -201,10 +205,10 @@ func (f *Font_GL33) Printf(x, y float32, scale float32, spacingXAdd float32,
 		}
 
 		//calculate position and size for current rune
-		xpos := x + float32(ch.bearingH)*scale
-		ypos := y - float32(ch.height-ch.bearingV)*scale
-		w := float32(ch.width) * scale
-		h := float32(ch.height) * scale
+		xpos := x + float32(ch.bearingH)*xscl
+		ypos := y - float32(ch.height-ch.bearingV)*yscl
+		w := float32(ch.width) * xscl
+		h := float32(ch.height) * yscl
 
 		x1, y1 := xpos+w, ypos
 		x2, y2 := xpos, ypos
@@ -227,7 +231,7 @@ func (f *Font_GL33) Printf(x, y float32, scale float32, spacingXAdd float32,
 		// Append glyph vertices to the batch buffer
 		batchVertices = append(batchVertices, vertices...)
 		// Now advance cursors for next glyph (note that advance is number of 1/64 pixels)
-		x += float32((ch.advance >> 6)) * scale // Bitshift by 6 to get value in pixels (2^6 = 64 (divide amount of 1/64th pixels by 64 to get amount of pixels))
+		x += float32((ch.advance >> 6)) * xscl // Bitshift by 6 to get value in pixels (2^6 = 64 (divide amount of 1/64th pixels by 64 to get amount of pixels))
 		renderedAny = true
 	}
 

--- a/src/font_gles32.go
+++ b/src/font_gles32.go
@@ -113,7 +113,7 @@ func (r *FontRenderer_GLES32) SetFontPipeline() {
 }
 
 // Printf draws a string to the screen, takes a list of arguments like printf
-func (f *Font_GLES32) Printf(x, y float32, scale float32, spacingXAdd float32,
+func (f *Font_GLES32) Printf(x, y float32, xscl, yscl float32, spacingXAdd float32,
 	align int32, blend bool, window [4]int32,
 	rxadd float32, rot Rotation, projectionMode int32, fLength float32, rcx, rcy float32,
 	fs string, argv ...interface{}) error {
@@ -157,13 +157,17 @@ func (f *Font_GLES32) Printf(x, y float32, scale float32, spacingXAdd float32,
 	//gl.BindVertexArray(gfxFont.(*FontRenderer_GLES32).vao)
 
 	//calculate alignment position
+	alignScale := xscl
+	if alignScale == 0 {
+		alignScale = yscl
+	}
 	if align == 0 {
-		x -= f.Width(scale, spacingXAdd, fs, argv...) * 0.5
+		x -= f.Width(alignScale, spacingXAdd, fs, argv...) * 0.5
 	} else if align < 0 {
-		x -= f.Width(scale, spacingXAdd, fs, argv...)
+		x -= f.Width(alignScale, spacingXAdd, fs, argv...)
 	}
 	textureID := int32(-1)
-	spacing := spacingXAdd * scale
+	spacing := spacingXAdd * xscl
 	renderedAny := false
 	// Iterate through all characters in string
 	for i := range indices {
@@ -200,11 +204,11 @@ func (f *Font_GLES32) Printf(x, y float32, scale float32, spacingXAdd float32,
 
 		//calculate position and size for current rune
 		//padding := float32(2)
-		xpos := x + float32(ch.bearingH)*scale
+		xpos := x + float32(ch.bearingH)*xscl
 		//ypos := y - (float32(ch.height-ch.bearingV)-padding)*scale
-		ypos := y - float32(ch.height-ch.bearingV)*scale
-		w := float32(ch.width) * scale
-		h := float32(ch.height) * scale
+		ypos := y - float32(ch.height-ch.bearingV)*yscl
+		w := float32(ch.width) * xscl
+		h := float32(ch.height) * yscl
 
 		x1, y1 := xpos+w, ypos
 		x2, y2 := xpos, ypos
@@ -227,7 +231,7 @@ func (f *Font_GLES32) Printf(x, y float32, scale float32, spacingXAdd float32,
 		// Append glyph vertices to the batch buffer
 		batchVertices = append(batchVertices, vertices...)
 		// Now advance cursors for next glyph (note that advance is number of 1/64 pixels)
-		x += float32((ch.advance >> 6)) * scale // Bitshift by 6 to get value in pixels (2^6 = 64 (divide amount of 1/64th pixels by 64 to get amount of pixels))
+		x += float32((ch.advance >> 6)) * xscl // Bitshift by 6 to get value in pixels (2^6 = 64 (divide amount of 1/64th pixels by 64 to get amount of pixels))
 		renderedAny = true
 	}
 

--- a/src/font_gles32.go
+++ b/src/font_gles32.go
@@ -114,7 +114,9 @@ func (r *FontRenderer_GLES32) SetFontPipeline() {
 
 // Printf draws a string to the screen, takes a list of arguments like printf
 func (f *Font_GLES32) Printf(x, y float32, scale float32, spacingXAdd float32,
-	align int32, blend bool, window [4]int32, fs string, argv ...interface{}) error {
+	align int32, blend bool, window [4]int32,
+	rxadd float32, rot Rotation, projectionMode int32, fLength float32, rcx, rcy float32,
+	fs string, argv ...interface{}) error {
 
 	indices := []rune(fmt.Sprintf(fs, argv...))
 	r := gfx.(*Renderer_GLES32)
@@ -203,14 +205,24 @@ func (f *Font_GLES32) Printf(x, y float32, scale float32, spacingXAdd float32,
 		ypos := y - float32(ch.height-ch.bearingV)*scale
 		w := float32(ch.width) * scale
 		h := float32(ch.height) * scale
-		vertices := []float32{
-			xpos + w, ypos, ch.uv[2], ch.uv[1],
-			xpos, ypos, ch.uv[0], ch.uv[1],
-			xpos, ypos + h, ch.uv[0], ch.uv[3],
 
-			xpos, ypos + h, ch.uv[0], ch.uv[3],
-			xpos + w, ypos + h, ch.uv[2], ch.uv[3],
-			xpos + w, ypos, ch.uv[2], ch.uv[1],
+		x1, y1 := xpos+w, ypos
+		x2, y2 := xpos, ypos
+		x3, y3 := xpos, ypos+h
+		x4, y4 := xpos+w, ypos+h
+		x1, y1, x2, y2, x3, y3, x4, y4 = transformTextQuad(
+			x1, y1, x2, y2, x3, y3, x4, y4,
+			rxadd, rot, projectionMode, fLength, rcx, rcy,
+		)
+
+		vertices := []float32{
+			x1, y1, ch.uv[2], ch.uv[1],
+			x2, y2, ch.uv[0], ch.uv[1],
+			x3, y3, ch.uv[0], ch.uv[3],
+
+			x3, y3, ch.uv[0], ch.uv[3],
+			x4, y4, ch.uv[2], ch.uv[3],
+			x1, y1, ch.uv[2], ch.uv[1],
 		}
 		// Append glyph vertices to the batch buffer
 		batchVertices = append(batchVertices, vertices...)

--- a/src/font_vk.go
+++ b/src/font_vk.go
@@ -550,7 +550,7 @@ func (f *Font_VK) UpdateResolution(windowWidth int, windowHeight int) {
 	f.resolution[1] = float32(windowHeight)
 	return
 }
-func (f *Font_VK) Printf(x, y float32, scale float32, spacingXAdd float32, align int32, blend bool, window [4]int32,
+func (f *Font_VK) Printf(x, y float32, xscl, yscl float32, spacingXAdd float32, align int32, blend bool, window [4]int32,
 	rxadd float32, rot Rotation, projectionMode int32, fLength float32, rcx, rcy float32,
 	fs string, argv ...interface{}) error {
 	r := gfx.(*Renderer_VK)
@@ -608,12 +608,16 @@ func (f *Font_VK) Printf(x, y float32, scale float32, spacingXAdd float32, align
 	resolution := f.resolution
 	vk.CmdPushConstants(r.commandBuffers[0], gfxFont.(*FontRenderer_VK).program.pipelineLayout, vk.ShaderStageFlags(vk.ShaderStageFragmentBit), 0, 4*4, unsafe.Pointer(&color))
 	vk.CmdPushConstants(r.commandBuffers[0], gfxFont.(*FontRenderer_VK).program.pipelineLayout, vk.ShaderStageFlags(vk.ShaderStageVertexBit), 4*4, 4*2, unsafe.Pointer(&resolution[0]))
-	if align == 0 {
-		x -= f.Width(scale, spacingXAdd, fs, argv...) * 0.5
-	} else if align < 0 {
-		x -= f.Width(scale, spacingXAdd, fs, argv...)
+	alignScale := xscl
+	if alignScale == 0 {
+		alignScale = yscl
 	}
-	spacing := spacingXAdd * scale
+	if align == 0 {
+		x -= f.Width(alignScale, spacingXAdd, fs, argv...) * 0.5
+	} else if align < 0 {
+		x -= f.Width(alignScale, spacingXAdd, fs, argv...)
+	}
+	spacing := spacingXAdd * xscl
 	renderedAny := false
 	firstVertex := uint32(r.vertexBufferOffset%r.vertexBuffers[0].size) / 16
 	numVerticesToDraw := uint32(0)
@@ -659,10 +663,10 @@ func (f *Font_VK) Printf(x, y float32, scale float32, spacingXAdd float32, align
 		}
 
 		//calculate position and size for current rune
-		xpos := x + float32(ch.bearingH)*scale
-		ypos := y - float32(ch.height-ch.bearingV)*scale
-		w := float32(ch.width) * scale
-		h := float32(ch.height) * scale
+		xpos := x + float32(ch.bearingH)*xscl
+		ypos := y - float32(ch.height-ch.bearingV)*yscl
+		w := float32(ch.width) * xscl
+		h := float32(ch.height) * yscl
 
 		x1, y1 := xpos+w, ypos
 		x2, y2 := xpos, ypos
@@ -686,7 +690,7 @@ func (f *Font_VK) Printf(x, y float32, scale float32, spacingXAdd float32, align
 		numVerticesToDraw += 6
 
 		// Now advance cursors for next glyph (note that advance is number of 1/64 pixels)
-		x += float32((ch.advance >> 6)) * scale // Bitshift by 6 to get value in pixels (2^6 = 64 (divide amount of 1/64th pixels by 64 to get amount of pixels))
+		x += float32((ch.advance >> 6)) * xscl // Bitshift by 6 to get value in pixels (2^6 = 64 (divide amount of 1/64th pixels by 64 to get amount of pixels))
 		renderedAny = true
 
 		if len(vertexData) >= batchSize {

--- a/src/font_vk.go
+++ b/src/font_vk.go
@@ -550,7 +550,9 @@ func (f *Font_VK) UpdateResolution(windowWidth int, windowHeight int) {
 	f.resolution[1] = float32(windowHeight)
 	return
 }
-func (f *Font_VK) Printf(x, y float32, scale float32, spacingXAdd float32, align int32, blend bool, window [4]int32, fs string, argv ...interface{}) error {
+func (f *Font_VK) Printf(x, y float32, scale float32, spacingXAdd float32, align int32, blend bool, window [4]int32,
+	rxadd float32, rot Rotation, projectionMode int32, fLength float32, rcx, rcy float32,
+	fs string, argv ...interface{}) error {
 	r := gfx.(*Renderer_VK)
 	switchedProgram := r.VKState.currentProgram != gfxFont.(*FontRenderer_VK).program
 	r.VKState.currentProgram = gfxFont.(*FontRenderer_VK).program
@@ -662,14 +664,23 @@ func (f *Font_VK) Printf(x, y float32, scale float32, spacingXAdd float32, align
 		w := float32(ch.width) * scale
 		h := float32(ch.height) * scale
 
-		vertexData = append(vertexData,
-			xpos+w, f.resolution[1]-(ypos), ch.uv[2], ch.uv[1],
-			xpos, f.resolution[1]-(ypos), ch.uv[0], ch.uv[1],
-			xpos, f.resolution[1]-(ypos+h), ch.uv[0], ch.uv[3],
+		x1, y1 := xpos+w, ypos
+		x2, y2 := xpos, ypos
+		x3, y3 := xpos, ypos+h
+		x4, y4 := xpos+w, ypos+h
+		x1, y1, x2, y2, x3, y3, x4, y4 = transformTextQuad(
+			x1, y1, x2, y2, x3, y3, x4, y4,
+			rxadd, rot, projectionMode, fLength, rcx, rcy,
+		)
 
-			xpos, f.resolution[1]-(ypos+h), ch.uv[0], ch.uv[3],
-			xpos+w, f.resolution[1]-(ypos+h), ch.uv[2], ch.uv[3],
-			xpos+w, f.resolution[1]-(ypos), ch.uv[2], ch.uv[1],
+		vertexData = append(vertexData,
+			x1, f.resolution[1]-y1, ch.uv[2], ch.uv[1],
+			x2, f.resolution[1]-y2, ch.uv[0], ch.uv[1],
+			x3, f.resolution[1]-y3, ch.uv[0], ch.uv[3],
+
+			x3, f.resolution[1]-y3, ch.uv[0], ch.uv[3],
+			x4, f.resolution[1]-y4, ch.uv[2], ch.uv[3],
+			x1, f.resolution[1]-y1, ch.uv[2], ch.uv[1],
 		)
 
 		numVerticesToDraw += 6

--- a/src/render.go
+++ b/src/render.go
@@ -289,6 +289,62 @@ func applyProjection(modelview mgl.Mat4, rp RenderParams, n int, botdist, dy flo
 	return modelview
 }
 
+// Applies the same non-tiling transform order used by sprites onto truetype fonts:
+// projection -> shear -> rotation -> pivot translation
+func transformTextQuad(x1, y1, x2, y2, x3, y3, x4, y4, rxadd float32,
+	rot Rotation, projectionMode int32, fLength, rcx, rcy float32) (float32, float32, float32, float32, float32, float32, float32, float32) {
+
+	if rot.IsZero() {
+		return x1, y1, x2, y2, x3, y3, x4, y4
+	}
+
+	rp := RenderParams{
+		rxadd: rxadd,
+		// Font vertices go through an additional Y flip in the font shader...
+		// compensate via angle inversion here so text rotation direction matches the way sprites do it
+		rot:            Rotation{angle: -rot.angle, xangle: -rot.xangle, yangle: -rot.yangle},
+		vs:             1,
+		rcx:            rcx,
+		rcy:            rcy,
+		projectionMode: projectionMode,
+		fLength:        fLength,
+	}
+
+	modelview := applyProjection(mgl.Ident4(), rp, 0, 1, 0)
+
+	// Shear matrix is only part of the rotated path
+	shearMatrix := mgl.Mat4{
+		1, 0, 0, 0,
+		rp.rxadd, 1, 0, 0,
+		0, 0, 1, 0,
+		0, 0, 0, 1,
+	}
+	modelview = modelview.Mul4(shearMatrix)
+
+	// Pretty much the equivalent to rp.rxadd*rp.ys*sizeY in sprites with rp.ys=1 for text quads
+	glyphHeight := y3 - y2
+	modelview = modelview.Mul4(mgl.Translate3D(rp.rxadd*glyphHeight, 0, 0))
+
+	modelview = applyRotation(modelview, rp)
+	modelview = modelview.Mul4(mgl.Translate3D(-rp.rcx, -rp.rcy, 0))
+
+	transformPoint := func(x, y float32) (float32, float32) {
+		v := modelview.Mul4x1(mgl.Vec4{x, y, 0, 1})
+		if v.W() != 0 {
+			invW := 1 / v.W()
+			return v.X() * invW, v.Y() * invW
+		}
+		return v.X(), v.Y()
+	}
+
+	x1, y1 = transformPoint(x1, y1)
+	x2, y2 = transformPoint(x2, y2)
+	x3, y3 = transformPoint(x3, y3)
+	x4, y4 = transformPoint(x4, y4)
+
+	return x1, y1, x2, y2, x3, y3, x4, y4
+}
+
 // Render a quad with optional horizontal tiling
 func renderSpriteHTile(modelview mgl.Mat4, x1, y1, x2, y2, x3, y3, x4, y4, dy, width float32, rp RenderParams) {
 	//            p3

--- a/src/render.go
+++ b/src/render.go
@@ -289,46 +289,40 @@ func applyProjection(modelview mgl.Mat4, rp RenderParams, n int, botdist, dy flo
 	return modelview
 }
 
-// Applies the same non-tiling transform order used by sprites onto truetype fonts:
-// projection -> shear -> rotation -> pivot translation
-func transformTextQuad(x1, y1, x2, y2, x3, y3, x4, y4, rxadd float32,
-	rot Rotation, projectionMode int32, fLength, rcx, rcy float32) (float32, float32, float32, float32, float32, float32, float32, float32) {
-
-	if rot.IsZero() {
-		return x1, y1, x2, y2, x3, y3, x4, y4
+// Applies shear matrix before rotation
+func applyShear(modelview mgl.Mat4, rxadd, width float32) mgl.Mat4 {
+	if rxadd == 0 {
+		return modelview
 	}
-
-	rp := RenderParams{
-		rxadd: rxadd,
-		// Font vertices go through an additional Y flip in the font shader...
-		// compensate via angle inversion here so text rotation direction matches the way sprites do it
-		rot:            Rotation{angle: -rot.angle, xangle: -rot.xangle, yangle: -rot.yangle},
-		vs:             1,
-		rcx:            rcx,
-		rcy:            rcy,
-		projectionMode: projectionMode,
-		fLength:        fLength,
-	}
-
-	modelview := applyProjection(mgl.Ident4(), rp, 0, 1, 0)
-
-	// Shear matrix is only part of the rotated path
 	shearMatrix := mgl.Mat4{
 		1, 0, 0, 0,
-		rp.rxadd, 1, 0, 0,
+		rxadd, 1, 0, 0,
 		0, 0, 1, 0,
 		0, 0, 0, 1,
 	}
 	modelview = modelview.Mul4(shearMatrix)
+	return modelview.Mul4(mgl.Translate3D(rxadd*width, 0, 0))
+}
 
-	// Pretty much the equivalent to rp.rxadd*rp.ys*sizeY in sprites with rp.ys=1 for text quads
-	glyphHeight := y3 - y2
-	modelview = modelview.Mul4(mgl.Translate3D(rp.rxadd*glyphHeight, 0, 0))
+// Applies the sprite rotation path to a truetype glyph quad
+func transformTextQuad(x1, y1, x2, y2, x3, y3, x4, y4, rxadd float32,
+	rot Rotation, projectionMode int32, fLength, rcx, rcy float32) (float32, float32, float32, float32, float32, float32, float32, float32) {
+	sx, sy := sys.widthScale, sys.heightScale
+	if sx == 0 {
+		sx = 1
+	}
+	if sy == 0 {
+		sy = 1
+	}
+	screenH := float32(sys.scrrect[3])
 
-	modelview = applyRotation(modelview, rp)
-	modelview = modelview.Mul4(mgl.Translate3D(-rp.rcx, -rp.rcy, 0))
-
-	transformPoint := func(x, y float32) (float32, float32) {
+	toSpriteSpace := func(x, y float32) (float32, float32) {
+		return x * sx, -y * sy
+	}
+	toTextSpace := func(x, y float32) (float32, float32) {
+		return x / sx, (screenH - y) / sy
+	}
+	transformPoint := func(modelview mgl.Mat4, x, y float32) (float32, float32) {
 		v := modelview.Mul4x1(mgl.Vec4{x, y, 0, 1})
 		if v.W() != 0 {
 			invW := 1 / v.W()
@@ -337,10 +331,57 @@ func transformTextQuad(x1, y1, x2, y2, x3, y3, x4, y4, rxadd float32,
 		return v.X(), v.Y()
 	}
 
-	x1, y1 = transformPoint(x1, y1)
-	x2, y2 = transformPoint(x2, y2)
-	x3, y3 = transformPoint(x3, y3)
-	x4, y4 = transformPoint(x4, y4)
+	// truetype quads use top-left coordinates but sprite transforms expect bottom-left ones
+	blx, bly := toSpriteSpace(x3, y3)
+	brx, bry := toSpriteSpace(x4, y4)
+	trx, try := toSpriteSpace(x1, y1)
+	tlx, tly := toSpriteSpace(x2, y2)
+
+	rp := RenderParams{
+		size:           [2]uint16{1, 1},
+		tile:           notiling,
+		xts:            trx - tlx,
+		xbs:            brx - blx,
+		ys:             try - bry,
+		vs:             1,
+		rxadd:          rxadd,
+		xas:            1,
+		yas:            1,
+		rot:            rot,
+		rcx:            rcx * sx,
+		rcy:            -rcy * sy,
+		projectionMode: projectionMode,
+		fLength:        fLength,
+	}
+
+	if !rp.rot.IsZero() {
+		modelview := mgl.Translate3D(0, screenH, 0)
+		modelview = applyProjection(modelview, rp, 0, 1, 0)
+		modelview = applyShear(modelview, rp.rxadd, rp.ys)
+		modelview = applyRotation(modelview, rp)
+		modelview = modelview.Mul4(mgl.Translate3D(-rp.rcx, -rp.rcy, 0))
+
+		blx, bly = transformPoint(modelview, blx, bly)
+		brx, bry = transformPoint(modelview, brx, bry)
+		trx, try = transformPoint(modelview, trx, try)
+		tlx, tly = transformPoint(modelview, tlx, tly)
+	} else {
+		if rp.rxadd != 0 {
+			// Match the unrotated sprite path by shifting the bottom edge
+			blx += rp.rxadd * rp.ys
+			brx = blx + rp.xbs
+		}
+		// Sprite rendering translates quads into screen space before drawQuads
+		bly += screenH
+		bry += screenH
+		try += screenH
+		tly += screenH
+	}
+
+	x1, y1 = toTextSpace(trx, try)
+	x2, y2 = toTextSpace(tlx, tly)
+	x3, y3 = toTextSpace(blx, bly)
+	x4, y4 = toTextSpace(brx, bry)
 
 	return x1, y1, x2, y2, x3, y3, x4, y4
 }
@@ -423,7 +464,6 @@ func renderSpriteQuad(modelview mgl.Mat4, rp RenderParams) {
 	//	pers = Abs(rp.xbs) / Abs(rp.xts)
 	//}
 	if !rp.rot.IsZero() && rp.tile.xflag == 0 && rp.tile.yflag == 0 {
-
 		if rp.vs != 1 {
 			y1 = rp.rcy + ((rp.y - rp.ys*float32(rp.size[1])) - rp.rcy)
 			y2 = y1
@@ -431,15 +471,7 @@ func renderSpriteQuad(modelview mgl.Mat4, rp RenderParams) {
 			y4 = y3
 		}
 		modelview = applyProjection(modelview, rp, 0, 1, 0)
-		// Apply shear matrix before rotation
-		shearMatrix := mgl.Mat4{
-			1, 0, 0, 0,
-			rp.rxadd, 1, 0, 0,
-			0, 0, 1, 0,
-			0, 0, 0, 1}
-		modelview = modelview.Mul4(shearMatrix)
-		modelview = modelview.Mul4(mgl.Translate3D(rp.rxadd*rp.ys*float32(rp.size[1]), 0, 0))
-
+		modelview = applyShear(modelview, rp.rxadd, rp.ys*float32(rp.size[1]))
 		modelview = applyRotation(modelview, rp)
 		modelview = modelview.Mul4(mgl.Translate3D(-rp.rcx, -rp.rcy, 0))
 


### PR DESCRIPTION
i wish to bring TrueType font rendering up to parity with Sprite rendering because otherwise my plans for my game's screenpack in the far future will absolutely fall apart. as such this pr brings in:

- non-uniform scaling
    - (aka, doesn't average out the x and y scale anymore)
- projection + focal length
- xshear
- rotation (normal, xangle, yangle)

<details><summary>comparision</summary>
<p>

BEFORE:
<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/56517ff6-8bcc-48d0-9395-daa256d8e2b4" />


AFTER:
<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/2868d473-60c2-427a-8a8b-3abd7548092b" />

_note: the following are applied: `title.scale = 1.45, 1.2; title.angle = 5; title.xshear = 0.3; title.yangle = 12; title.yangle = 12; title.focallength = 1024; title.projection = perspective; menu.item.angle = -3`
note: this is exaggerated for demo purpose_

SPRITE VS TRUETYPE (with same settings used on AFTER):
<img width="850" height="294" alt="image" src="https://github.com/user-attachments/assets/7ece09a8-5436-4882-824f-a50c7092f257" />

</p>
</details> 