### PR TITLE
feat: Lua hook entry points, pre-match map injection, externalize Ratio

### DIFF
--- a/data/system.zss
+++ b/data/system.zss
@@ -47,13 +47,8 @@ if !isHelper && roundTime = 0 {
 
 if !isHelper && win && roundState = 4 && map(_iksys_lifeRecoveryFlag) = 0
 	&& (((teamMode = Turns || enemy,teamMode = Turns) && !matchOver) || gameVar(persistlife)) {
-	if ratioLevel > 0 {
-		let bonus = lifeMax * gameOption(options.ratio.recovery.bonus) / 100;
-		let base = lifeMax * gameOption(options.ratio.recovery.base) / 100;
-	} else {
-		let bonus = lifeMax * gameOption(options.turns.recovery.bonus) / 100;
-		let base = lifeMax * gameOption(options.turns.recovery.base) / 100;
-	}
+	let bonus = lifeMax * gameOption(options.turns.recovery.bonus) / 100;
+	let base = lifeMax * gameOption(options.turns.recovery.base) / 100;
 	let timeRatio = float(timeRemaining) / (timeRemaining + timeElapsed);
 	if timeRemaining < 0 {
 		let timeRatio = 1;

--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -228,47 +228,18 @@ end
 -- Allows hooking additional code into existing functions, from within external
 -- modules, without having to worry as much about your code being removed by
 -- engine update.
--- * hook.run(list, ...): Runs all the functions within a certain list.
---   It won't do anything if the list doesn't exist or is empty. ... is any
---   number of arguments, which will be passed to every function in the list.
--- * hook.add(list, name, function): Adds a function to a hook list with a name.
---   It will replace anything in the list with the same name.
--- * hook.stop(list, name): Removes a hook from a list, if it's not needed.
--- Currently there are only few hooks available by default:
--- * loop: global.lua 'loop' function start (called by CommonLua)
--- * loop#[gamemode]: global.lua 'loop' function, limited to the gamemode
--- * main.f_commandLine: main.lua 'f_commandLine' function (before loading)
--- * main.f_default: main.lua 'f_default' function
--- * main.t_itemname: main.lua table entries (modes configuration)
--- * main.menu.loop: main.lua menu loop function (each submenu loop start)
--- * menu.menu.loop: menu.lua menu loop function (each submenu loop start)
--- * options.menu.loop: options.lua menu loop function (each submenu loop start)
--- * launchFight: start.lua 'launchFight' function (right before match starts)
--- * start.f_selectScreen: start.lua 'f_selectScreen' function (pre layerno=1)
--- * start.f_selectVersus: start.lua 'f_selectVersus' function (pre layerno=1)
--- * start.f_selectReset: start.lua 'f_selectReset' function (before returning)
--- * game.result_init: hook executed on the 1st frame of win/results screen
--- * game.result: hook executed from 2nd frame onward on win/results screen
--- * game.victory_init: hook executed on the 1st frame of victory screen
--- * game.victory: hook executed from 2nd frame onward on victory screen
--- * game.continue_init: hook executed on the 1st frame of continue screen
--- * game.continue: hook executed at the 2nd and later frames of continue screen
--- * game.hiscore_init: hook executed on the 1st frame of hiscore screen
--- * game.hiscore: hook executed from 2nd frame onward on hiscore screen
--- * game.challenger_init: hook executed on the 1st frame of challenger screen
--- * game.challenger: hook executed from 2nd frame onward on challenger screen
--- More entry points may be added in future - let us know if your external
--- module needs to hook code in place where it's not allowed yet.
-
+-- https://github.com/ikemen-engine/Ikemen-GO/wiki/lua#hook-system
 hook = {
 	lists = {}
 }
+
 function hook.add(list, name, func)
 	if hook.lists[list] == nil then
 		hook.lists[list] = {}
 	end
 	hook.lists[list][name] = func
 end
+
 function hook.run(list, ...)
 	if hook.lists[list] then
 		for i, k in pairs(hook.lists[list]) do
@@ -276,6 +247,18 @@ function hook.run(list, ...)
 		end
 	end
 end
+
+function hook.runFirst(list, ...)
+	if hook.lists[list] then
+		for _, k in pairs(hook.lists[list]) do
+			local ret = k(...)
+			if ret ~= nil then
+				return ret
+			end
+		end
+	end
+end
+
 function hook.stop(list, name)
 	hook.lists[list][name] = nil
 end
@@ -378,6 +361,136 @@ function main.f_tableMerge(t1, t2, key)
 		end
 	end
 	return t1
+end
+
+-- Appends an itemname entry, or a whole submenu tree, to an already parsed motif menu table.
+-- Existing motif entries win: if the same itemname already exists, nothing is overwritten.
+function main.f_appendItemname(menu, parent, name, src, before)
+	local function itemnameExists(t, name)
+		name = tostring(name or '')
+		if type(t) ~= 'table' or name == 'back' or name:match('^spacer%d*$') then
+			return false
+		end
+		local pat = '_' .. main.f_escapePattern(name) .. '$'
+		local stack = { t }
+		while #stack > 0 do
+			local cur = stack[#stack]
+			stack[#stack] = nil
+
+			for k, v in pairs(cur) do
+				if type(k) == 'string' and not k:match('^__') and (k == name or k:match(pat)) then
+					return true
+				end
+
+				if type(v) == 'table' then
+					stack[#stack + 1] = v
+				end
+			end
+		end
+		return false
+	end
+
+	local function itemnameValue(src)
+		if type(src) == 'table' then
+			return src.__value
+		end
+		return src
+	end
+
+	local function itemnameOrderedKeys(src)
+		local ret, seen = {}, {}
+		if type(src.__order) == 'table' then
+			for _, k in ipairs(src.__order) do
+				if type(k) == 'string' and src[k] ~= nil and not k:match('^__') then
+					table.insert(ret, k)
+					seen[k] = true
+				end
+			end
+		end
+		local rest = {}
+		for k in pairs(src) do
+			if type(k) == 'string' and not k:match('^__') and not seen[k] then
+				table.insert(rest, k)
+			end
+		end
+		table.sort(rest)
+		for _, k in ipairs(rest) do
+			table.insert(ret, k)
+		end
+		return ret
+	end
+
+	local function insertItemnameOrder(order, key, before)
+		if type(order) ~= 'table' then
+			return
+		end
+		for _, v in ipairs(order) do
+			if v == key then
+				return
+			end
+		end
+		local pos = #order + 1
+		if before ~= nil and before ~= '' then
+			local anchor = tostring(before)
+			if not anchor:find('_', 1, true) then
+				local parent = tostring(key):match('^(.*)_')
+				if parent ~= nil and parent ~= '' then
+					anchor = parent .. '_' .. anchor
+				end
+			end
+			for i, v in ipairs(order) do
+				if v == anchor then
+					pos = i
+					break
+				end
+			end
+		end
+		table.insert(order, pos, key)
+	end
+
+	if type(menu) ~= 'table' or type(menu.itemname) ~= 'table' or type(menu.itemname_order) ~= 'table' then
+		return false
+	end
+	parent = parent or ''
+	name = tostring(name or '')
+	if name == '' or src == nil then
+		return false
+	end
+
+	-- Grouped itemname tables, used by select_info.teammenu.itemname.default.
+	if type(menu.itemname[parent]) == 'table' and type(menu.itemname_order[parent]) == 'table' then
+		if menu.itemname[parent][name] ~= nil or itemnameExists(menu.itemname, name) then
+			return false
+		end
+		local value = itemnameValue(src)
+		if value == nil then
+			return false
+		end
+		menu.itemname[parent][name] = value
+		insertItemnameOrder(menu.itemname_order[parent], name, before)
+		return true
+	end
+
+	-- Flat itemname tables, used by normal motif menus.
+	local key = name
+	if parent ~= '' then
+		key = parent .. '_' .. name
+	end
+	if menu.itemname[key] ~= nil or itemnameExists(menu.itemname, name) then
+		return false
+	end
+	local value = itemnameValue(src)
+	if value == nil then
+		return false
+	end
+	menu.itemname[key] = value
+	insertItemnameOrder(menu.itemname_order, key, before)
+	if type(src) == 'table' then
+		for _, child in ipairs(itemnameOrderedKeys(src)) do
+			main.f_appendItemname(menu, key, child, src[child])
+		end
+	end
+	return true
 end
 
 --returns bool if table contains value
@@ -574,12 +687,7 @@ function main.f_commandLine()
 			if flags['-p' .. num .. '.guardPoints'] ~= nil then
 				t[#t].override['guardpoints'] = tonumber(flags['-p' .. num .. '.guardPoints'])
 			end
-			if flags['-p' .. num .. '.lifeRatio'] ~= nil then
-				t[#t].override['liferatio'] = tonumber(flags['-p' .. num .. '.lifeRatio'])
-			end
-			if flags['-p' .. num .. '.attackRatio'] ~= nil then
-				t[#t].override['attackratio'] = tonumber(flags['-p' .. num .. '.attackRatio'])
-			end
+			hook.run("main.f_commandLine.player", t[#t], flags, num, player)
 			refresh()
 		elseif k:match('^-tmode1$') then
 			t_teamMode[1] = tonumber(v)
@@ -681,7 +789,7 @@ function main.f_commandLine()
 			})
 		end
 	end
-	hook.run("main.f_commandLine")
+	hook.run("main.f_commandLine", t, flags, t_teamMode, t_numChars, t_matchWins, t_params)
 	if flags['-ip'] ~= nil then
 		enterNetPlay(flags['-ip'])
 		while not connected() do
@@ -895,11 +1003,12 @@ function main.f_addChar(line, playable, loading, slot)
 			main.t_selChars[row] = main.f_tableMerge(main.t_selChars[row], t_info)
 			main.t_selChars[row].dir = main.t_selChars[row].def:gsub('[^/]+%.def$', '')
 			if playable then
-				for _, v in ipairs({'intro', 'ending', 'arcadepath', 'ratiopath'}) do
+				for _, v in ipairs({'intro', 'ending', 'arcadepath'}) do
 					if main.t_selChars[row][v] ~= '' then
 						main.t_selChars[row][v] = searchFile(main.t_selChars[row][v], {main.t_selChars[row].dir, '', motif.def, 'data/'})
 					end
 				end
+				hook.run("main.f_addChar.files", main.t_selChars[row])
 				main.t_selChars[row].order = 1
 			end
 		else
@@ -1243,26 +1352,8 @@ for line in content:gmatch('[^\r\n]+') do
 			for i, c in ipairs(main.f_strsplit(',', line:gsub('%s*(.-)%s*', '%1'))) do --split using "," delimiter
 				main.t_selOptions[rowName .. 'maxmatches'][i] = tonumber(c)
 			end
-		elseif lineCase:match('%.ratiomatches%s*=') then
-			local rowName, line = lineCase:match('^%s*(.-)%.ratiomatches%s*=%s*(.+)')
-			rowName = rowName:gsub('%.', '_')
-			main.t_selOptions[rowName .. 'ratiomatches'] = {}
-			for i, c in ipairs(main.f_strsplit(',', line:gsub('%s*(.-)%s*', '%1'))) do --split using "," delimiter
-				local rmin, rmax, order = c:match('^%s*([0-9]+)-?([0-9]*)%s*:%s*([0-9]+)%s*$')
-				rmin = tonumber(rmin)
-				rmax = tonumber(rmax) or rmin
-				order = tonumber(order)
-				if rmin == nil or order == nil or rmin < 1 or rmin > 4 or rmax < 1 or rmax > 4 or rmin > rmax then
-					main.f_warning(motif.warning_info.text.text.ratio, motif.title_info, motif.titlebgdef)
-					main.t_selOptions[rowName .. 'ratiomatches'] = nil
-					break
-				end
-				if rmax == '' then
-					rmax = rmin
-				end
-				table.insert(main.t_selOptions[rowName .. 'ratiomatches'], {rmin = rmin, rmax = rmax, order = order})
-			end
 		end
+		hook.run("main.selectDef.options", main.t_selOptions, lineCase)
 	elseif section == 4 then --[StoryMode]
 		local param, value = line:match('^%s*(.-)%s*=%s*(.-)%s*$')
 		if param ~= nil and value ~= nil and param ~= '' and value ~= '' then
@@ -1358,22 +1449,13 @@ function main.f_updateSelectableStages()
 end
 main.f_updateSelectableStages()
 
---add default maxmatches / ratiomatches values if config is missing in select.def
+--add default maxmatches values if config is missing in select.def
 if main.t_selOptions.arcademaxmatches == nil then main.t_selOptions.arcademaxmatches = {6, 1, 1, 0, 0, 0, 0, 0, 0, 0} end
 if main.t_selOptions.teammaxmatches == nil then main.t_selOptions.teammaxmatches = {4, 1, 1, 0, 0, 0, 0, 0, 0, 0} end
 if main.t_selOptions.timeattackmaxmatches == nil then main.t_selOptions.timeattackmaxmatches = {6, 1, 1, 0, 0, 0, 0, 0, 0, 0} end
 if main.t_selOptions.survivalmaxmatches == nil then main.t_selOptions.survivalmaxmatches = {-1, 0, 0, 0, 0, 0, 0, 0, 0, 0} end
-if main.t_selOptions.arcaderatiomatches == nil then
-	main.t_selOptions.arcaderatiomatches = {
-		{rmin = 1, rmax = 3, order = 1},
-		{rmin = 3, rmax = 3, order = 1},
-		{rmin = 2, rmax = 2, order = 1},
-		{rmin = 2, rmax = 2, order = 1},
-		{rmin = 1, rmax = 1, order = 2},
-		{rmin = 3, rmax = 3, order = 1},
-		{rmin = 1, rmax = 2, order = 3},
-	}
-end
+
+hook.run("main.selectDef.defaults", main.t_selOptions)
 
 --uppercase title
 function main.f_itemnameUpper(title, uppercase)
@@ -1532,8 +1614,8 @@ function main.f_default()
 	main.stageOrder = false --if select.def stage order param should be used
 	main.storyboard = {intro = false, ending = false, credits = false, gameover = false} --which storyboards should be active
 	main.teamMenu = {
-		{ratio = false, simul = false, single = false, tag = false, turns = false}, --which team modes should be selectable by P1 side
-		{ratio = false, simul = false, single = false, tag = false, turns = false}, --which team modes should be selectable by P2 side
+		{simul = false, single = false, tag = false, turns = false}, --which team modes should be selectable by P1 side
+		{simul = false, single = false, tag = false, turns = false}, --which team modes should be selectable by P2 side
 	}
 	resetAILevel()
 	resetRemapInput()
@@ -1593,25 +1675,22 @@ main.t_itemname = {
 			textImgSetText(motif.select_info.title.TextSpriteData, motif.select_info.title.text.arcade)
 			main.teamarcade = false
 		else --teamarcade
-			main.teamMenu[1].ratio = true
 			main.teamMenu[1].simul = true
 			main.teamMenu[1].single = true
 			main.teamMenu[1].tag = true
 			main.teamMenu[1].turns = true
-			main.teamMenu[2].ratio = true
 			main.teamMenu[2].simul = true
 			main.teamMenu[2].single = true
 			main.teamMenu[2].tag = true
 			main.teamMenu[2].turns = true
 			textImgSetText(motif.select_info.title.TextSpriteData, motif.select_info.title.text.teamarcade)
 			main.teamarcade = true
-			
 		end
 		main.f_setCredits()
 		remapInput(1, getLastInputController())
 		remapInput(getLastInputController(), 1)
 		setGameMode('arcade')
-		hook.run("main.t_itemname")
+		hook.run("main.t_itemname", t, item)
 		if start.challenger == 0 then
 			return start.f_selectMode
 		end
@@ -1633,15 +1712,16 @@ main.t_itemname = {
 		remapInput(1, getLastInputController())
 		remapInput(getLastInputController(), 1)
 		setGameMode('bonus')
-		hook.run("main.t_itemname")
+		hook.run("main.t_itemname", t, item)
 		return start.f_selectMode
 	end,
 	--DEMO
-	['demo'] = function()
+	['demo'] = function(t, item)
+		hook.run("main.t_itemname", t, item)
 		return main.f_demoStart
 	end,
 	--FREE BATTLE (QUICK VS)
-	['freebattle'] = function()
+	['freebattle'] = function(t, item)
 		--main.fightscreen.p1score = true
 		--main.fightscreen.p2ailevel = true
 		main.motif.vsscreen = true
@@ -1650,12 +1730,10 @@ main.t_itemname = {
 		main.orderSelect[2] = true
 		main.selectMenu[2] = true
 		main.stageMenu = true
-		main.teamMenu[1].ratio = true
 		main.teamMenu[1].simul = true
 		main.teamMenu[1].single = true
 		main.teamMenu[1].tag = true
 		main.teamMenu[1].turns = true
-		main.teamMenu[2].ratio = true
 		main.teamMenu[2].simul = true
 		main.teamMenu[2].single = true
 		main.teamMenu[2].tag = true
@@ -1664,7 +1742,7 @@ main.t_itemname = {
 		remapInput(1, getLastInputController())
 		remapInput(getLastInputController(), 1)
 		setGameMode('freebattle')
-		hook.run("main.t_itemname")
+		hook.run("main.t_itemname", t, item)
 		return start.f_selectMode
 	end,
 	--JOIN (NEW ADDRESS)
@@ -1697,10 +1775,11 @@ main.t_itemname = {
 		else
 			sndPlay(motif.Snd, motif[main.group].cancel.snd[1], motif[main.group].cancel.snd[2])
 		end
+		hook.run("main.t_itemname", t, item)
 		return t
 	end,
 	--NETPLAY SURVIVAL
-	['netplaysurvivalcoop'] = function()
+	['netplaysurvivalcoop'] = function(t, item)
 		main.aiRamp = true
 		main.charparam.ai = true
 		main.charparam.music = true
@@ -1729,18 +1808,17 @@ main.t_itemname = {
 		main.storyboard.gameover = true
 		main.teamMenu[1].simul = true
 		main.teamMenu[1].tag = true
-		main.teamMenu[2].ratio = true
 		main.teamMenu[2].simul = true
 		main.teamMenu[2].single = true
 		main.teamMenu[2].tag = true
 		main.teamMenu[2].turns = true
 		textImgSetText(motif.select_info.title.TextSpriteData, motif.select_info.title.text.netplaysurvivalcoop)
 		setGameMode('netplaysurvivalcoop')
-		hook.run("main.t_itemname")
+		hook.run("main.t_itemname", t, item)
 		return start.f_selectMode
 	end,
 	--NETPLAY CO-OP
-	['netplayteamcoop'] = function()
+	['netplayteamcoop'] = function(t, item)
 		main.aiRamp = true
 		main.charparam.ai = true
 		main.charparam.arcadepath = true
@@ -1769,7 +1847,6 @@ main.t_itemname = {
 		main.storyboard.intro = true
 		main.teamMenu[1].simul = true
 		main.teamMenu[1].tag = true
-		main.teamMenu[2].ratio = true
 		main.teamMenu[2].simul = true
 		main.teamMenu[2].single = true
 		main.teamMenu[2].tag = true
@@ -1777,11 +1854,11 @@ main.t_itemname = {
 		main.f_setCredits()
 		textImgSetText(motif.select_info.title.TextSpriteData, motif.select_info.title.text.netplayteamcoop)
 		setGameMode('netplayteamcoop')
-		hook.run("main.t_itemname")
+		hook.run("main.t_itemname", t, item)
 		return start.f_selectMode
 	end,
 	--NETPLAY VERSUS
-	['netplayversus'] = function()
+	['netplayversus'] = function(t, item)
 		main.cpuSide[2] = false
 		--main.fightscreen.p1wincount = true
 		--main.fightscreen.p2wincount = true
@@ -1791,12 +1868,10 @@ main.t_itemname = {
 		main.orderSelect[2] = true
 		main.selectMenu[2] = true
 		main.stageMenu = true
-		main.teamMenu[1].ratio = true
 		main.teamMenu[1].simul = true
 		main.teamMenu[1].single = true
 		main.teamMenu[1].tag = true
 		main.teamMenu[1].turns = true
-		main.teamMenu[2].ratio = true
 		main.teamMenu[2].simul = true
 		main.teamMenu[2].single = true
 		main.teamMenu[2].tag = true
@@ -1804,28 +1879,30 @@ main.t_itemname = {
 		textImgSetText(motif.select_info.title.TextSpriteData, motif.select_info.title.text.netplayversus)
 		setGameMode('netplayversus')
 		setHomeTeam(1)
-		hook.run("main.t_itemname")
+		hook.run("main.t_itemname", t, item)
 		return start.f_selectMode
 	end,
 	--OPTIONS
-	['options'] = function()
-		hook.run("main.t_itemname")
+	['options'] = function(t, item)
+		hook.run("main.t_itemname", t, item)
 		return options.menu.loop
 	end,
 	--RANDOMTEST
-	['randomtest'] = function()
+	['randomtest'] = function(t, item)
 		setGameMode('randomtest')
-		hook.run("main.t_itemname")
+		hook.run("main.t_itemname", t, item)
 		return main.f_randomtest
 	end,
 	--REPLAY
-	['replay'] = function()
+	['replay'] = function(t, item)
+		hook.run("main.t_itemname", t, item)
 		return main.f_replay
 	end,
 	--SERVER CONNECT
 	['serverconnect'] = function(t, item)
 		local doneSnd = motif[main.group].cursor.done.snd.serverconnect or motif[main.group].cursor.done.snd.default
 		sndPlay(motif.Snd, doneSnd[1], doneSnd[2])
+		hook.run("main.t_itemname", t, item)
 		if main.f_connect(gameOption('Netplay.IP.' .. t[item].displayname), t[item].displayname) then
 			if synchronize() then
 				enterSyncedNetplayMenu()
@@ -1841,6 +1918,7 @@ main.t_itemname = {
 	['serverhost'] = function(t, item)
 		local doneSnd = motif[main.group].cursor.done.snd.serverhost or motif[main.group].cursor.done.snd.default
 		sndPlay(motif.Snd, doneSnd[1], doneSnd[2])
+		hook.run("main.t_itemname", t, item)
 		if main.f_connect("", gameOption('Netplay.ListenPort')) then
 			if synchronize() then
 				enterSyncedNetplayMenu()
@@ -1865,11 +1943,11 @@ main.t_itemname = {
 		remapInput(1, getLastInputController())
 		remapInput(getLastInputController(), 1)
 		setGameMode(t[item].itemname)
-		hook.run("main.t_itemname")
+		hook.run("main.t_itemname", t, item)
 		return start.f_selectMode
 	end,
 	--SURVIVAL
-	['survival'] = function()
+	['survival'] = function(t, item)
 		main.aiRamp = true
 		main.charparam.ai = true
 		main.charparam.music = true
@@ -1898,12 +1976,10 @@ main.t_itemname = {
 		main.stageMenu = true
 		main.storyboard.credits = true
 		main.storyboard.gameover = true
-		main.teamMenu[1].ratio = true
 		main.teamMenu[1].simul = true
 		main.teamMenu[1].single = true
 		main.teamMenu[1].tag = true
 		main.teamMenu[1].turns = true
-		main.teamMenu[2].ratio = true
 		main.teamMenu[2].simul = true
 		main.teamMenu[2].single = true
 		main.teamMenu[2].tag = true
@@ -1912,11 +1988,11 @@ main.t_itemname = {
 		remapInput(1, getLastInputController())
 		remapInput(getLastInputController(), 1)
 		setGameMode('survival')
-		hook.run("main.t_itemname")
+		hook.run("main.t_itemname", t, item)
 		return start.f_selectMode
 	end,
 	--SURVIVAL CO-OP
-	['survivalcoop'] = function()
+	['survivalcoop'] = function(t, item)
 		main.aiRamp = true
 		main.charparam.ai = true
 		main.charparam.music = true
@@ -1946,18 +2022,17 @@ main.t_itemname = {
 		main.storyboard.gameover = true
 		main.teamMenu[1].simul = true
 		main.teamMenu[1].tag = true
-		main.teamMenu[2].ratio = true
 		main.teamMenu[2].simul = true
 		main.teamMenu[2].single = true
 		main.teamMenu[2].tag = true
 		main.teamMenu[2].turns = true
 		textImgSetText(motif.select_info.title.TextSpriteData, motif.select_info.title.text.survivalcoop)
 		setGameMode('survivalcoop')
-		hook.run("main.t_itemname")
+		hook.run("main.t_itemname", t, item)
 		return start.f_selectMode
 	end,
 	--TEAM CO-OP
-	['teamcoop'] = function()
+	['teamcoop'] = function(t, item)
 		main.aiRamp = true
 		main.charparam.ai = true
 		main.charparam.arcadepath = true
@@ -1987,7 +2062,6 @@ main.t_itemname = {
 		main.storyboard.intro = true
 		main.teamMenu[1].simul = true
 		main.teamMenu[1].tag = true
-		main.teamMenu[2].ratio = true
 		main.teamMenu[2].simul = true
 		main.teamMenu[2].single = true
 		main.teamMenu[2].tag = true
@@ -1995,11 +2069,11 @@ main.t_itemname = {
 		main.f_setCredits()
 		textImgSetText(motif.select_info.title.TextSpriteData, motif.select_info.title.text.teamcoop)
 		setGameMode('teamcoop')
-		hook.run("main.t_itemname")
+		hook.run("main.t_itemname", t, item)
 		return start.f_selectMode
 	end,
 	--TIME ATTACK
-	['timeattack'] = function()
+	['timeattack'] = function(t, item)
 		main.aiRamp = true
 		main.charparam.ai = true
 		main.charparam.music = true
@@ -2023,12 +2097,10 @@ main.t_itemname = {
 		main.stageOrder = true
 		main.storyboard.credits = true
 		main.storyboard.gameover = true
-		main.teamMenu[1].ratio = true
 		main.teamMenu[1].simul = true
 		main.teamMenu[1].single = true
 		main.teamMenu[1].tag = true
 		main.teamMenu[1].turns = true
-		main.teamMenu[2].ratio = true
 		main.teamMenu[2].simul = true
 		main.teamMenu[2].single = true
 		main.teamMenu[2].tag = true
@@ -2038,11 +2110,11 @@ main.t_itemname = {
 		remapInput(1, getLastInputController())
 		remapInput(getLastInputController(), 1)
 		setGameMode('timeattack')
-		hook.run("main.t_itemname")
+		hook.run("main.t_itemname", t, item)
 		return start.f_selectMode
 	end,
 	--TRAINING
-	['training'] = function()
+	['training'] = function(t, item)
 		if main.t_charDef[gameOption('Config.TrainingChar'):lower()] ~= nil then
 			main.forceChar[2] = {main.t_charDef[gameOption('Config.TrainingChar'):lower()]}
 		end
@@ -2053,7 +2125,6 @@ main.t_itemname = {
 		if gameOption('Config.TrainingStage') == '' then
 			main.stageMenu = true
 		end
-		main.teamMenu[1].ratio = true
 		main.teamMenu[1].simul = true
 		main.teamMenu[1].single = true
 		main.teamMenu[1].tag = true
@@ -2068,11 +2139,8 @@ main.t_itemname = {
 		remapInput(getLastInputController(), 1)
 		setGameMode('training')
 		setHomeTeam(1)
-		hook.run("main.t_itemname")
+		hook.run("main.t_itemname", t, item)
 		return start.f_selectMode
-	end,
-	--TRIALS
-	['trials'] = function()
 	end,
 	--VS MODE / TEAM VERSUS
 	['versus'] = function(t, item)
@@ -2090,12 +2158,10 @@ main.t_itemname = {
 			main.teamMenu[2].single = true
 			textImgSetText(motif.select_info.title.TextSpriteData, motif.select_info.title.text.versus)
 		else --teamversus
-			main.teamMenu[1].ratio = true
 			main.teamMenu[1].simul = true
 			main.teamMenu[1].single = true
 			main.teamMenu[1].tag = true
 			main.teamMenu[1].turns = true
-			main.teamMenu[2].ratio = true
 			main.teamMenu[2].simul = true
 			main.teamMenu[2].single = true
 			main.teamMenu[2].tag = true
@@ -2108,14 +2174,14 @@ main.t_itemname = {
 			setGameMode('versus')
 		end
 		setHomeTeam(1)
-		hook.run("main.t_itemname")
+		hook.run("main.t_itemname", t, item)
 		if start.challenger == 0 then
 			return start.f_selectMode
 		end
 		return nil
 	end,
 	--VERSUS CO-OP
-	['versuscoop'] = function()
+	['versuscoop'] = function(t, item)
 		main.coop = true
 		main.cpuSide[2] = false
 		--main.fightscreen.p1wincount = true
@@ -2133,11 +2199,11 @@ main.t_itemname = {
 		textImgSetText(motif.select_info.title.TextSpriteData, motif.select_info.title.text.versuscoop)
 		setGameMode('versuscoop')
 		setHomeTeam(1)
-		hook.run("main.t_itemname")
+		hook.run("main.t_itemname", t, item)
 		return start.f_selectMode
 	end,
 	--WATCH
-	['watch'] = function()
+	['watch'] = function(t, item)
 		main.cpuSide[1] = true
 		--main.fightscreen.p1ailevel = true
 		--main.fightscreen.p2ailevel = true
@@ -2145,12 +2211,10 @@ main.t_itemname = {
 		main.motif.victoryscreen = true
 		main.selectMenu[2] = true
 		main.stageMenu = true
-		main.teamMenu[1].ratio = true
 		main.teamMenu[1].simul = true
 		main.teamMenu[1].single = true
 		main.teamMenu[1].tag = true
 		main.teamMenu[1].turns = true
-		main.teamMenu[2].ratio = true
 		main.teamMenu[2].simul = true
 		main.teamMenu[2].single = true
 		main.teamMenu[2].tag = true
@@ -2160,7 +2224,7 @@ main.t_itemname = {
 		remapInput(getLastInputController(), 1)
 		setGameMode('watch')
 		setHomeTeam(1)
-		hook.run("main.t_itemname")
+		hook.run("main.t_itemname", t, item)
 		return start.f_selectMode
 	end,
 }
@@ -3085,7 +3149,7 @@ function main.f_demoStart()
 	if motif.demo_mode.fight.stopbgm then
 		stopBgm()
 	end
-	hook.run("main.t_itemname")
+	hook.run("main.t_itemname", t, item)
 	--clearColor(motif[main.background].bgclearcolor[1], motif[main.background].bgclearcolor[2], motif[main.background].bgclearcolor[3])
 	loadStart()
 	game()

--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -36,6 +36,7 @@ function options.f_saveCfg(reload)
 	end
 	-- Save the current configuration to 'config.ini'
 	saveGameOption(getCommandLineValue("-config"))
+	hook.run("options.save", reload)
 	-- Reload the game if the reload parameter is true
 	if reload then
 		main.f_warning(motif.warning_info.text.text.reload, motif.option_info, motif.optionbgdef)
@@ -50,14 +51,6 @@ end
 --;===========================================================
 --; LOOPS
 --;===========================================================
-function options.f_displayRatio(value)
-	local ret = options.f_precision((value - 1) * 100, '%.01f')
-	if ret >= 0 then
-		return '+' .. ret .. '%'
-	end
-	return ret .. '%'
-end
-
 local function f_switchLanguage(dir)
 	sndPlay(motif.Snd, motif.option_info.cursor.move.snd[1], motif.option_info.cursor.move.snd[2])
 	-- collect available language keys
@@ -163,16 +156,6 @@ options.t_itemname = {
 			modifyGameOption('Options.Turns.Max', 4)
 			modifyGameOption('Options.Turns.Recovery.Base', 12.5)
 			modifyGameOption('Options.Turns.Recovery.Bonus', 27.5)
-			modifyGameOption('Options.Ratio.Recovery.Base', 0)
-			modifyGameOption('Options.Ratio.Recovery.Bonus', 20)
-			modifyGameOption('Options.Ratio.Level1.Attack', 0.82)
-			modifyGameOption('Options.Ratio.Level2.Attack', 1.0)
-			modifyGameOption('Options.Ratio.Level3.Attack', 1.17)
-			modifyGameOption('Options.Ratio.Level4.Attack', 1.30)
-			modifyGameOption('Options.Ratio.Level1.Life', 0.80)
-			modifyGameOption('Options.Ratio.Level2.Life', 1.0)
-			modifyGameOption('Options.Ratio.Level3.Life', 1.17)
-			modifyGameOption('Options.Ratio.Level4.Life', 1.40)
 			--modifyGameOption('Config.Motif', "data/system.def")
 			modifyGameOption('Config.Players', 4)
 			modifyGameOption('Config.Language', "en")
@@ -268,6 +251,7 @@ options.t_itemname = {
 			updateVolume()
 			options.modified = true
 			options.needReload = true
+			hook.run("options.default")
 		end
 		return true
 	end,
@@ -1623,36 +1607,6 @@ options.t_vardisplay = {
 	['quickcontinue'] = function()
 		return options.f_boolDisplay(gameOption('Options.QuickContinue'))
 	end,
-	['ratio1attack'] = function()
-		return options.f_displayRatio(gameOption('Options.Ratio.Level1.Attack'))
-	end,
-	['ratio1life'] = function()
-		return options.f_displayRatio(gameOption('Options.Ratio.Level1.Life'))
-	end,
-	['ratio2attack'] = function()
-		return options.f_displayRatio(gameOption('Options.Ratio.Level2.Attack'))
-	end,
-	['ratio2life'] = function()
-		return options.f_displayRatio(gameOption('Options.Ratio.Level2.Life'))
-	end,
-	['ratio3attack'] = function()
-		return options.f_displayRatio(gameOption('Options.Ratio.Level3.Attack'))
-	end,
-	['ratio3life'] = function()
-		return options.f_displayRatio(gameOption('Options.Ratio.Level3.Life'))
-	end,
-	['ratio4attack'] = function()
-		return options.f_displayRatio(gameOption('Options.Ratio.Level4.Attack'))
-	end,
-	['ratio4life'] = function()
-		return options.f_displayRatio(gameOption('Options.Ratio.Level4.Life'))
-	end,
-	['ratiorecoverybase'] = function()
-		return gameOption('Options.Ratio.Recovery.Base') .. '%'
-	end,
-	['ratiorecoverybonus'] = function()
-		return gameOption('Options.Ratio.Recovery.Bonus') .. '%'
-	end,
 	['redlife'] = function()
 		return options.f_boolDisplay(gameOption('Options.RedLife'))
 	end,
@@ -1832,24 +1786,6 @@ function options.f_start()
 					end
 					return true
 				end
-			end
-		-- ratio
-		elseif v:match('_ratio[1-4]+[al].-$') then
-			local ratioLevel, tmp1, tmp2 = v:match('_ratio([1-4])([al])(.-)$')
-			options.t_itemname['ratio' .. ratioLevel .. tmp1 .. tmp2] = function(t, item, cursorPosY, moveTxt)
-				local ratioKey = 'Options.Ratio.Level' .. tonumber(ratioLevel) .. '.' .. tmp1:upper() .. tmp2
-				if getInput(-1, motif.option_info.menu.add.key) then
-					sndPlay(motif.Snd, motif.option_info.cursor.move.snd[1], motif.option_info.cursor.move.snd[2])
-					modifyGameOption(ratioKey, gameOption(ratioKey) + 0.01)
-					t.items[item].vardisplay = options.f_displayRatio(gameOption(ratioKey))
-					options.modified = true
-				elseif getInput(-1, motif.option_info.menu.subtract.key) and gameOption(ratioKey) > 0.01 then
-					sndPlay(motif.Snd, motif.option_info.cursor.move.snd[1], motif.option_info.cursor.move.snd[2])
-					modifyGameOption(ratioKey, gameOption(ratioKey) - 0.01)
-					t.items[item].vardisplay = options.f_displayRatio(gameOption(ratioKey))
-					options.modified = true
-				end
-				return true
 			end
 		end
 	end

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -25,7 +25,7 @@ local cursorDone = {}
 --; COMMON FUNCTIONS
 --;===========================================================
 --; ROSTER
---converts '.maxmatches' style table (key = order, value = max matches) to the same structure as '.ratiomatches' (key = match number, value = subtable with char num and order data)
+--converts '.maxmatches' style table (key = order, value = max matches) to key = match number, value = subtable with char num and order data
 function start.f_unifySettings(t, t_chars)
 	local ret = {}
 	for i = 1, #t do --for each order number
@@ -64,13 +64,7 @@ end
 -- external module, without conflicting with default scripts.
 start.t_makeRoster = {}
 start.t_makeRoster.arcade = function()
-	if start.p[2].ratio then --Ratio
-		if start.f_getCharData(start.p[1].t_selected[1].ref).ratiomatches ~= nil and main.t_selOptions[start.f_getCharData(start.p[1].t_selected[1].ref).ratiomatches .. '_arcaderatiomatches'] ~= nil then --custom settings exists as char param
-			return main.t_selOptions[start.f_getCharData(start.p[1].t_selected[1].ref).ratiomatches .. '_arcaderatiomatches'], main.t_orderChars
-		else --default settings
-			return main.t_selOptions.arcaderatiomatches, main.t_orderChars
-		end
-	elseif start.p[2].teamMode == 0 then --Single
+	if start.p[2].teamMode == 0 then --Single
 		if start.f_getCharData(start.p[1].t_selected[1].ref).maxmatches ~= nil and main.t_selOptions[start.f_getCharData(start.p[1].t_selected[1].ref).maxmatches .. '_arcademaxmatches'] ~= nil then --custom settings exists as char param
 			return start.f_unifySettings(main.t_selOptions[start.f_getCharData(start.p[1].t_selected[1].ref).maxmatches .. '_arcademaxmatches'], main.t_orderChars), main.t_orderChars
 		else --default settings
@@ -158,8 +152,6 @@ start.t_aiRampData = {}
 start.t_aiRampData.arcade = function()
 	if start.p[2].teamMode == 0 then --Single
 		return gameOption('Arcade.arcade.AIramp.start')[1], gameOption('Arcade.arcade.AIramp.start')[2], gameOption('Arcade.arcade.AIramp.end')[1], gameOption('Arcade.arcade.AIramp.end')[2]
-	elseif start.p[2].ratio then --Ratio
-		return gameOption('Arcade.ratio.AIramp.start')[1], gameOption('Arcade.ratio.AIramp.start')[2], gameOption('Arcade.ratio.AIramp.end')[1], gameOption('Arcade.ratio.AIramp.end')[2]
 	else --Simul / Turns / Tag
 		return gameOption('Arcade.team.AIramp.start')[1], gameOption('Arcade.team.AIramp.start')[2], gameOption('Arcade.team.AIramp.end')[1], gameOption('Arcade.team.AIramp.end')[2]
 	end
@@ -611,41 +603,6 @@ function start.f_selectPal(ref, palno)
 		end
 	end
 	panicError("\n" .. charData.name .. " palette was not selected\n")
-end
-
---returns ratio level
-local t_ratioArray = {
-	{2, 1, 1},
-	{1, 2, 1},
-	{1, 1, 2},
-	{2, 2},
-	{3, 1},
-	{1, 3},
-	{4}
-}
-function start.f_getRatio(player, ratio)
-	if player == 1 then
-		if not start.p[1].ratio and ratio == nil then
-			return nil
-		end
-		return ratio or t_ratioArray[start.p[1].numRatio][#start.p[1].t_selected + 1]
-	end
-	if not start.p[2].ratio and ratio == nil then
-		return nil
-	end
-	if ratio ~= nil then
-		return ratio
-	end
-	if not continued() and not main.selectMenu[2] and #start.p[2].t_selected == 0 then
-		if start.p[2].numChars == 3 then
-			start.p[2].numRatio = math.random(1, 3)
-		elseif start.p[2].numChars == 2 then
-			start.p[2].numRatio = math.random(4, 6)
-		else
-			start.p[2].numRatio = 7
-		end
-	end
-	return t_ratioArray[start.p[2].numRatio][#start.p[2].t_selected + 1]
 end
 
 --returns player number
@@ -1543,14 +1500,55 @@ for i = 1, motif.select_info.rows * motif.select_info.columns do
 end
 if gameOption('Debug.DumpLuaTables') then main.f_printTable(start.t_grid, 'debug/t_grid.txt') end
 
+local function updateCommon(common, add)
+	for k, values in pairs(common) do
+		if values ~= nil and #values > 0 then
+			local optionName = 'Common.' .. k:gsub('^%l', string.upper)
+			local t = gameOption(optionName)
+			if add then
+				local existing = {}
+				local changed = false
+				for _, v in ipairs(t) do
+					existing[v] = true
+				end
+				for _, v in ipairs(values) do
+					if v ~= '' and not existing[v] then
+						table.insert(t, v)
+						existing[v] = true
+						changed = true
+					end
+				end
+				if changed then
+					modifyGameOption(optionName, t)
+				end
+			else
+				local toRemove = {}
+				local changed = false
+				for _, v in ipairs(values) do
+					if v ~= '' then
+						toRemove[v] = true
+					end
+				end
+				for i = #t, 1, -1 do
+					if toRemove[t[i]] then
+						table.remove(t, i)
+						changed = true
+					end
+				end
+				if changed then
+					modifyGameOption(optionName, t)
+				end
+			end
+		end
+	end
+end
+
 -- return amount of life to recover
-local function f_lifeRecovery(lifeMax, ratioLevel)
+local function f_lifeRecovery(lifeMax, fighter)
+	local ret = hook.runFirst("start.f_lifeRecovery", lifeMax, fighter)
+	if ret ~= nil then return ret end
 	local bonus = lifeMax * gameOption('Options.Turns.Recovery.Bonus') / 100
 	local base = lifeMax * gameOption('Options.Turns.Recovery.Base') / 100
-	if ratioLevel > 0 then
-		bonus = lifeMax * gameOption('Options.Ratio.Recovery.Bonus') / 100
-		base = lifeMax * gameOption('Options.Ratio.Recovery.Base') / 100
-	end
 	return base + main.f_round(timeRemaining() / (timeRemaining() + timeElapsed()) * bonus)
 end
 
@@ -1597,7 +1595,7 @@ function start.f_matchPersistence()
 									end
 								-- or resurrect and recover character's life
 								elseif main.persistLife then
-									start.p[1].t_selected[memberIdx].life = math.max(1, f_lifeRecovery(f1.LifeMax or 0, f1.RatioLevel or 0))
+									start.p[1].t_selected[memberIdx].life = math.max(1, f_lifeRecovery(f1.LifeMax or 0, f1))
 								end
 							-- otherwise maintain character's life
 							elseif main.persistLife then
@@ -1625,7 +1623,7 @@ function start.f_matchPersistence()
 								-- if defeated
 								if f.KO and (f.Life or 0) <= 0 then
 									if main.persistLife then
-										start.p[1].t_selected[memberIdx].life = math.max(1, f_lifeRecovery(f.LifeMax or 0, f.RatioLevel or 0))
+										start.p[1].t_selected[memberIdx].life = math.max(1, f_lifeRecovery(f.LifeMax or 0, f))
 									end
 								-- otherwise maintain character's life
 								elseif main.persistLife then
@@ -1642,42 +1640,21 @@ function start.f_matchPersistence()
 end
 
 --start game
-function start.f_game(lua)
+function start.f_game(common)
 	clearColor(0, 0, 0)
-	if gameOption('Debug.DumpLuaTables') and start ~= nil then main.f_printTable(start.p, 'debug/t_p.txt') end
-	if lua ~= '' then
-		local t = gameOption('Common.Lua')
-		local ok = false
-		for _, v in ipairs(t) do
-			if v == lua then
-				ok = true
-				break
-			end
-		end
-		if not ok then
-			table.insert(t, lua)
-		end
-		modifyGameOption('Common.Lua', t)
+	if gameOption('Debug.DumpLuaTables') and start ~= nil then
+		main.f_printTable(start.p, 'debug/t_p.txt')
 	end
 	if gameMode('training') then
 		menu.f_trainingReset()
 	end
 	local winner = -1
 	winner, start.challenger = game()
-
-	if gameOption('Debug.DumpLuaTables') then main.f_printTable(getGameStats(), 'debug/t_gameStats.txt') end
-
-	main.f_restoreInput()
-	if lua ~= '' then
-		local t = gameOption('Common.Lua')
-		for i, v in ipairs(t) do
-			if v == lua then
-				table.remove(t, i)
-				break
-			end
-		end
-		modifyGameOption('Common.Lua', t)
+	if gameOption('Debug.DumpLuaTables') then
+		main.f_printTable(getGameStats(), 'debug/t_gameStats.txt')
 	end
+	main.f_restoreInput()
+	updateCommon(common, false)
 	if shutdown() then
 		clearColor(0, 0, 0)
 		os.exit()
@@ -1717,13 +1694,11 @@ function start.f_selectMode()
 		--lua file with custom arcade path detection
 		local path = main.luaPath
 		if main.charparam.arcadepath then
-			if start.p[2].ratio and start.f_getCharData(start.p[1].t_selected[1].ref).ratiopath ~= '' then
-				path = start.f_getCharData(start.p[1].t_selected[1].ref).ratiopath
-				if not main.f_fileExists(path) then
-					panicError("\n" .. start.f_getCharData(start.p[1].t_selected[1].ref).name .. " ratiopath doesn't exist: " .. path .. "\n")
-				end
-			elseif not start.p[2].ratio and start.f_getCharData(start.p[1].t_selected[1].ref).arcadepath ~= '' then
+			if start.f_getCharData(start.p[1].t_selected[1].ref).arcadepath ~= '' then
 				path = start.f_getCharData(start.p[1].t_selected[1].ref).arcadepath
+			end
+			path = hook.runFirst("start.f_selectMode.luaPath", path) or path
+			if path ~= '' and path ~= main.luaPath then
 				if not main.f_fileExists(path) then
 					panicError("\n" .. start.f_getCharData(start.p[1].t_selected[1].ref).name .. " arcadepath doesn't exist: " .. path .. "\n")
 				end
@@ -1838,7 +1813,6 @@ function start.f_selectReset(hardReset, preserveProgress)
 			start.p[side].numSimul = math.max(2, gameOption('Options.Simul.Min'))
 			start.p[side].numTag = math.max(2, gameOption('Options.Tag.Min'))
 			start.p[side].numTurns = math.max(2, gameOption('Options.Turns.Min'))
-			start.p[side].numRatio = 1
 			start.p[side].teamMenu = 1
 			start.p[side].t_cursor = {}
 			start.p[side].teamMode = 0
@@ -1849,13 +1823,13 @@ function start.f_selectReset(hardReset, preserveProgress)
 		start.p[side].numChars = 1
 		start.p[side].teamEnd = main.cpuSide[side] and (side == 2 or not main.cpuSide[1]) and main.forceChar[side] == nil
 		start.p[side].selEnd = not main.selectMenu[side]
-		start.p[side].ratio = false
 		start.p[side].t_selected = {}
 		start.p[side].t_selTemp = {}
 		start.p[side].t_selCmd = {}
 		-- Tracks how many leading Turns members are already defeated across matches.
 		-- Used by Survival Turns to skip them without removing from roster.
 		start.p[side].turnsOffset = 0
+		hook.run("start.f_selectReset.side", side, hardReset, preserveProgress, start.p[side])
 	end
 	for _, v in ipairs(start.c) do
 		v.cell = -1
@@ -1916,7 +1890,6 @@ local function applyWinnerSelectMemory(resume, winnerSide, challengerState)
 		if srcSide.numSimul ~= nil then resume.p[1].numSimul = srcSide.numSimul end
 		if srcSide.numTag ~= nil then resume.p[1].numTag = srcSide.numTag end
 		if srcSide.numTurns ~= nil then resume.p[1].numTurns = srcSide.numTurns end
-		if srcSide.numRatio ~= nil then resume.p[1].numRatio = srcSide.numRatio end
 	end
 	if challengerState.c ~= nil then
 		-- Promote the winner-side cursor slots onto the new arcade P1 slots:
@@ -1932,6 +1905,7 @@ local function applyWinnerSelectMemory(resume, winnerSide, challengerState)
 			end
 		end
 	end
+	hook.run("start.f_selectChallenger.resume", resume, winnerSide, challengerState)
 end
 
 function start.f_selectChallenger(resume)
@@ -2077,11 +2051,9 @@ function launchFight(data)
 		t.orderselect = {main.f_arg(data.p1orderselect, main.orderSelect[1]), main.f_arg(data.p2orderselect, main.orderSelect[2])}
 		t.p1char = data.p1char or {}
 		t.p1pal = data.p1pal
-		t.p1numratio = data.p1numratio or {}
 		t.p1rounds = data.p1rounds or nil
 		t.p2char = data.p2char or {}
 		t.p2pal = data.p2pal
-		t.p2numratio = data.p2numratio or {}
 		t.p2rounds = data.p2rounds or nil
 		t.exclude = data.exclude or {}
 		t.musicParams = buildMusicParams(data)
@@ -2116,8 +2088,8 @@ function launchFight(data)
 				pal = t.p1pal or start.f_selectPal(ref),
 				pn = start.f_getPlayerNo(1, #start.p[1].t_selected + 1),
 				--cursor = {},
-				ratioLevel = start.f_getRatio(1, t.p1numratio[cnt]),
 			})
+			hook.run("start.launchFight.selected", 1, #start.p[1].t_selected, start.p[1].t_selected[#start.p[1].t_selected], start.p[1], t)
 			main.t_availableChars = start.f_excludeChar(main.t_availableChars, ref)
 		end
 		if #start.p[1].t_selected == 0 then
@@ -2136,8 +2108,8 @@ function launchFight(data)
 				pal = t.p2pal or start.f_selectPal(ref),
 				pn = start.f_getPlayerNo(2, #start.p[2].t_selected + 1),
 				--cursor = {},
-				ratioLevel = start.f_getRatio(2, t.p2numratio[cnt]),
 			})
+			hook.run("start.launchFight.selected", 2, #start.p[2].t_selected, start.p[2].t_selected[#start.p[2].t_selected], start.p[2], t)
 			main.t_availableChars = start.f_excludeChar(main.t_availableChars, ref)
 			if not onlyme then onlyme = start.f_getCharData(ref).single end
 		end
@@ -2185,8 +2157,8 @@ function launchFight(data)
 					pal = start.f_selectPal(v),
 					pn = start.f_getPlayerNo(2, #start.p[2].t_selected + 1),
 					--cursor = {},
-					ratioLevel = start.f_getRatio(2, t.p2numratio[cnt]),
 				})
+				hook.run("start.launchFight.selected", 2, #start.p[2].t_selected, start.p[2].t_selected[#start.p[2].t_selected], start.p[2], t)
 				main.t_availableChars = start.f_excludeChar(main.t_availableChars, v)
 			end
 			-- team conversion if 'single' param is set on randomly added chars
@@ -2237,14 +2209,20 @@ function launchFight(data)
 		if winscreen and main.makeRoster and start.t_roster[matchNo() + 1] ~= nil then
 			winscreen = false
 		end
+		local common = {lua = {}}
+		if t.lua ~= '' then
+			table.insert(common.lua, t.lua)
+		end
+		-- Hooks may mutate "common" in place before loading starts.
+		hook.run("launchFight", common, t, data)
+		updateCommon(common, true)
 		start.f_selectLoading{
 			musicParams = t.musicParams,
 			continue = t.continue,
 			victoryscreen = t.victoryscreen,
 			winscreen = winscreen,
 		}
-		hook.run("launchFight")
-		start.f_game(t.lua)
+		start.f_game(common)
 		clearColor(motif.selectbgdef.bgclearcolor[1], motif.selectbgdef.bgclearcolor[2], motif.selectbgdef.bgclearcolor[3])
 		if start.exit or start.characterchange then
 			start.characterchange = false
@@ -2460,7 +2438,6 @@ function start.f_selectScreen()
 			simul  = 1,
 			turns  = 2,
 			tag    = 3,
-			ratio  = 2,
 		}
 		-- itemname_order lists exactly what to render, in the correct order
 		for _, name in ipairs(itemname_order) do
@@ -2474,6 +2451,7 @@ function start.f_selectScreen()
 				})
 			end
 		end
+		hook.run("start.selectScreen.teamMenu", side, t_teamMenu[side], params, itemname_order)
 	end
 
 	textImgReset(motif.select_info.record.TextSpriteData)
@@ -2780,7 +2758,10 @@ function start.f_teamMenu(side, t)
 				start.p[side].teamMenu = 1
 			end
 		else
-			if t[start.p[side].teamMenu].itemname == 'simul' then
+			local handled = hook.runFirst("start.f_teamMenu.input", side, t, t_cmd)
+			if handled then
+				-- handled by external module
+			elseif t[start.p[side].teamMenu].itemname == 'simul' then
 				if getInput(t_cmd, motif.select_info['p' .. side].teammenu.subtract.key) then
 					if start.p[side].numSimul > main.numSimul[1] then
 						sndPlay(motif.Snd, motif.select_info['p' .. side].teammenu.value.snd[1], motif.select_info['p' .. side].teammenu.value.snd[2])
@@ -2814,22 +2795,6 @@ function start.f_teamMenu(side, t)
 					if start.p[side].numTag < main.numTag[2] then
 						sndPlay(motif.Snd, motif.select_info['p' .. side].teammenu.value.snd[1], motif.select_info['p' .. side].teammenu.value.snd[2])
 						start.p[side].numTag = start.p[side].numTag + 1
-					end
-				end
-			elseif t[start.p[side].teamMenu].itemname == 'ratio' then
-				if getInput(t_cmd, motif.select_info['p' .. side].teammenu.subtract.key) and main.selectMenu[side] then
-					sndPlay(motif.Snd, motif.select_info['p' .. side].teammenu.value.snd[1], motif.select_info['p' .. side].teammenu.value.snd[2])
-					if start.p[side].numRatio > 1 then
-						start.p[side].numRatio = start.p[side].numRatio - 1
-					else
-						start.p[side].numRatio = 7
-					end
-				elseif getInput(t_cmd, motif.select_info['p' .. side].teammenu.add.key) and main.selectMenu[side] then
-					sndPlay(motif.Snd, motif.select_info['p' .. side].teammenu.value.snd[1], motif.select_info['p' .. side].teammenu.value.snd[2])
-					if start.p[side].numRatio < 7 then
-						start.p[side].numRatio = start.p[side].numRatio + 1
-					else
-						start.p[side].numRatio = 1
 					end
 				end
 			end
@@ -2937,8 +2902,8 @@ function start.f_teamMenu(side, t)
 						main.f_animPosDraw(valueCfg.empty.icon.AnimData, vx, vy)
 					end
 				end
-			elseif itemname == 'ratio' and start.p[side].teamMenu == i and main.selectMenu[side] then
-				main.f_animPosDraw(teammenu['ratio' .. start.p[side].numRatio].icon.AnimData, x, y)
+			else
+				hook.runFirst("start.f_teamMenu.drawItemValue", side, t, i, x, y, valueCfg)
 			end
 		end
 		--Confirmed team selection
@@ -2946,7 +2911,17 @@ function start.f_teamMenu(side, t)
 			timerSelect = motif.select_info.timer.displaytime
 			start.p[1].screenDelay, start.p[2].screenDelay = 0, 0
 			sndPlay(motif.Snd, motif.select_info['p' .. side].teammenu.done.snd[1], motif.select_info['p' .. side].teammenu.done.snd[2])
-			if t[start.p[side].teamMenu].itemname == 'single' then
+			local confirmData = hook.runFirst("start.f_teamMenu.confirm", side, t, t_cmd)
+			if confirmData ~= nil then
+				local defaultMode = t[start.p[side].teamMenu].mode
+				local teamMode = confirmData.teamMode or defaultMode
+				local numChars = confirmData.numChars or start.p[side].numChars
+				for k, v in pairs(confirmData) do
+					start.p[side][k] = v
+				end
+				start.p[side].teamMode = teamMode
+				start.p[side].numChars = numChars
+			elseif t[start.p[side].teamMenu].itemname == 'single' then
 				start.p[side].teamMode = t[start.p[side].teamMenu].mode
 				start.p[side].numChars = 1
 			elseif t[start.p[side].teamMenu].itemname == 'simul' then
@@ -2958,16 +2933,6 @@ function start.f_teamMenu(side, t)
 			elseif t[start.p[side].teamMenu].itemname == 'tag' then
 				start.p[side].teamMode = t[start.p[side].teamMenu].mode
 				start.p[side].numChars = start.p[side].numTag
-			elseif t[start.p[side].teamMenu].itemname == 'ratio' then
-				start.p[side].teamMode = t[start.p[side].teamMenu].mode
-				if start.p[side].numRatio <= 3 then
-					start.p[side].numChars = 3
-				elseif start.p[side].numRatio <= 6 then
-					start.p[side].numChars = 2
-				else
-					start.p[side].numChars = 1
-				end
-				start.p[side].ratio = true
 			end
 			start.p[side].teamEnd = true
 		end
@@ -3235,7 +3200,6 @@ function start.f_selectMenu(side, cmd, player, member, selectState)
 				pal = start.f_selectPal(v),
 				--pn = start.f_getPlayerNo(side, #start.p[side].t_selected + 1),
 				--cursor = = {},
-				--ratioLevel = start.f_getRatio(side),
 			})
 		end
 		start.p[side].selEnd = true
@@ -3458,8 +3422,8 @@ function start.f_selectMenu(side, cmd, player, member, selectState)
 				pal = finalPal,
 				pn = start.f_getPlayerNo(side, member),
 				cursor = {start.c[player].selX, start.c[player].selY},
-				ratioLevel = start.f_getRatio(side),
 			}
+			hook.run("start.f_selectMenu.selected", side, member, start.p[side].t_selected[member], start.p[side], player)
 			if not gameOption('Options.Team.Duplicates') then
 				t_reservedChars[side][start.c[player].selRef] = true
 			end
@@ -3860,22 +3824,27 @@ function start.f_selectLoading(arg)
 				selectChar(side, v.ref, v.pal)
 				v.loading = true
 			end
-			-- fold overrideCharData() payload into loadStart() params
-			local lifeRatio, attackRatio
-			if v.ratioLevel then
-				lifeRatio = gameOption("Options.Ratio.Level" .. v.ratioLevel .. ".Life")
-				attackRatio = gameOption("Options.Ratio.Level" .. v.ratioLevel .. ".Attack")
-			end
+			hook.run("start.f_selectLoading.member", v)
 			local pfx = "p" .. side .. "." .. member .. "."
 			addParam(pfx .. "life", v.life)
 			addParam(pfx .. "lifemax", v.lifeMax)
 			addParam(pfx .. "power", v.power)
 			addParam(pfx .. "dizzypoints", v.dizzyPoints)
 			addParam(pfx .. "guardpoints", v.guardPoints)
-			addParam(pfx .. "ratiolevel", v.ratioLevel)
-			addParam(pfx .. "liferatio", v.lifeRatio or lifeRatio)
-			addParam(pfx .. "attackratio", v.attackRatio or attackRatio)
 			addParam(pfx .. "existed", v.existed)
+			if type(v.maps) == "table" then
+				for mapName, mapValue in pairs(v.maps) do
+					if type(mapName) == "string" and mapValue ~= nil then
+						local key = mapName
+						if key:sub(1, 4):lower() == "map." then
+							key = key:sub(5)
+						end
+						if key ~= "" then
+							addParam(pfx .. "map." .. key, mapValue)
+						end
+					end
+				end
+			end
 		end
 	end
 	addParam("persistlife", main.persistLife)

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -702,7 +702,6 @@ const (
 	OC_ex_playerindexexist
 	OC_ex_playernoexist
 	OC_ex_randomrange
-	OC_ex_ratiolevel
 	OC_ex_receiveddamage
 	OC_ex_receivedhits
 	OC_ex_redlife
@@ -940,6 +939,7 @@ const (
 	OC_ex2_gamevar_persistrounds
 	OC_ex2_gamevar_persistlife
 	OC_ex2_gamevar_persistmusic
+	OC_ex2_gamevar_hidebars
 	OC_ex2_topbounddist
 	OC_ex2_topboundbodydist
 	OC_ex2_botbounddist
@@ -3261,8 +3261,7 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_spriteplayerno:
 		sys.bcStack.PushI(int32(c.spritePN) + 1)
 	case OC_ex_attack:
-		base := float32(c.gi().attackBase) * c.ocd().attackRatio / 100
-		sys.bcStack.PushF(base * c.attackMul[0] * 100)
+		sys.bcStack.PushF(float32(c.gi().attackBase) * c.attackMul[0])
 	case OC_ex_clsnoverlap:
 		c2 := sys.bcStack.Pop().ToI()
 		id := sys.bcStack.Pop().ToI()
@@ -3450,8 +3449,6 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_randomrange:
 		v2 := sys.bcStack.Pop()
 		be.random(sys.bcStack.Top(), v2)
-	case OC_ex_ratiolevel:
-		sys.bcStack.PushI(c.ocd().ratioLevel)
 	case OC_ex_receiveddamage:
 		sys.bcStack.PushI(c.receivedDmg)
 	case OC_ex_receivedhits:
@@ -4042,12 +4039,14 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(sys.getSlowtime())
 	case OC_ex2_gamevar_superpausetime:
 		sys.bcStack.PushI(sys.supertime)
-	case OC_ex2_gamevar_persistrounds:
-		sys.bcStack.PushB(sys.sel.gameParams.PersistRounds)
 	case OC_ex2_gamevar_persistlife:
 		sys.bcStack.PushB(sys.sel.gameParams.PersistLife)
 	case OC_ex2_gamevar_persistmusic:
 		sys.bcStack.PushB(sys.sel.gameParams.PersistMusic)
+	case OC_ex2_gamevar_persistrounds:
+		sys.bcStack.PushB(sys.sel.gameParams.PersistRounds)
+	case OC_ex2_gamevar_hidebars:
+		sys.bcStack.PushB(sys.lifebarHide || sys.dialogueBarsFlg)
 	// HitByAttr
 	case OC_ex2_hitbyattr:
 		attr := be.ReadIntAt(i)
@@ -6047,6 +6046,7 @@ const (
 	explod_shadow
 	explod_removeongethit
 	explod_removeonchangestate
+	explod_hideonpausemenu
 	explod_trans
 	explod_animelem
 	explod_animelemtime
@@ -6242,6 +6242,8 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 			e.removeongethit = exp[0].evalB(c)
 		case explod_removeonchangestate:
 			e.removeonchangestate = exp[0].evalB(c)
+		case explod_hideonpausemenu:
+			e.hideonpausemenu = exp[0].evalB(c)
 		case explod_trans:
 			src := Clamp(int32(exp[0].evalI(c)), 0, 255)
 			dst := Clamp(int32(exp[1].evalI(c)), 0, 255)
@@ -6761,6 +6763,11 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				v := exp[0].evalB(c)
 				eachExpl(func(e *Explod) {
 					e.removeonchangestate = v
+				})
+			case explod_hideonpausemenu:
+				v := exp[0].evalB(c)
+				eachExpl(func(e *Explod) {
+					e.hideonpausemenu = v
 				})
 			case explod_trans:
 				src := Clamp(int32(exp[0].evalI(c)), 0, 255)
@@ -10616,23 +10623,22 @@ func (sc attackMulSet) Run(c *Char, _ []int32) bool {
 		return false
 	}
 
-	attackRatio := crun.ocd().attackRatio
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
 		case attackMulSet_value:
 			v := exp[0].evalF(c)
-			crun.attackMul[0] = v * attackRatio
-			crun.attackMul[1] = v * attackRatio
-			crun.attackMul[2] = v * attackRatio
-			crun.attackMul[3] = v * attackRatio
+			crun.attackMul[0] = v
+			crun.attackMul[1] = v
+			crun.attackMul[2] = v
+			crun.attackMul[3] = v
 		case attackMulSet_damage:
-			crun.attackMul[0] = exp[0].evalF(c) * attackRatio
+			crun.attackMul[0] = exp[0].evalF(c)
 		case attackMulSet_redlife:
-			crun.attackMul[1] = exp[0].evalF(c) * attackRatio
+			crun.attackMul[1] = exp[0].evalF(c)
 		case attackMulSet_dizzypoints:
-			crun.attackMul[2] = exp[0].evalF(c) * attackRatio
+			crun.attackMul[2] = exp[0].evalF(c)
 		case attackMulSet_guardpoints:
-			crun.attackMul[3] = exp[0].evalF(c) * attackRatio
+			crun.attackMul[3] = exp[0].evalF(c)
 		}
 		return true
 	})

--- a/src/char.go
+++ b/src/char.go
@@ -1607,6 +1607,7 @@ type Explod struct {
 	scale               [2]float32
 	removeongethit      bool
 	removeonchangestate bool
+	hideonpausemenu     bool
 	statehaschanged     bool
 	removetime          int32
 	velocity            [3]float32
@@ -1900,7 +1901,7 @@ func (e *Explod) update() {
 	parent := sys.playerID(e.playerId)
 	root := sys.chars[e.playerno][0]
 
-	if root.scf(SCF_disabled) {
+	if root.scf(SCF_disabled) || (e.hideonpausemenu && sys.motif.me.active) {
 		return
 	}
 
@@ -2910,10 +2911,12 @@ type CharGlobalInfo struct {
 	def                     string
 	nameLow                 string
 	displayname             string
+	defaultDisplayname      string
 	displaynameLow          string
 	author                  string
 	authorLow               string
 	lifebarname             string
+	defaultLifebarname      string
 	sff                     *Sff
 	palettedata             *Palette
 	snd                     *Snd
@@ -3364,7 +3367,6 @@ func (c *Char) enemyNearP2Clear() {
 func (c *Char) prepareNextRound() {
 	c.sysVarRangeSet(0, math.MaxInt32, 0)
 	c.sysFvarRangeSet(0, math.MaxInt32, 0)
-	atk := c.ocd().attackRatio
 	c.CharSystemVar = CharSystemVar{
 		bindToId:              -1,
 		angleDrawScale:        [2]float32{1, 1},
@@ -3373,7 +3375,7 @@ func (c *Char) prepareNextRound() {
 		sizeWidth:             [2]float32{c.baseWidthFront(), c.baseWidthBack()},
 		sizeHeight:            [2]float32{c.baseHeightTop(), c.baseHeightBottom()},
 		sizeDepth:             [2]float32{c.baseDepthTop(), c.baseDepthBottom()},
-		attackMul:             [4]float32{atk, atk, atk, atk},
+		attackMul:             [4]float32{1, 1, 1, 1},
 		fallDefenseMul:        1,
 		superDefenseMul:       1,
 		superDefenseMulBuffer: 1,
@@ -3448,12 +3450,40 @@ func (c *Char) ocd() *OverrideCharData {
 	return sys.sel.gameParams.ensureOverride(team, c.memberNo)
 }
 
+func (c *Char) applyMapOverrides() {
+	ocd := c.ocd()
+	if ocd == nil || len(ocd.maps) == 0 {
+		return
+	}
+	if c.mapArray == nil {
+		c.mapArray = make(map[string]float32)
+	}
+	for k, v := range ocd.maps {
+		c.mapArray[k] = v
+	}
+}
+
+// Restore defaults for values that ModifyPlayer can mutate and that would
+// otherwise leak when a cached root is reused as a fresh entrant.
+func (c *Char) resetCachedPlayerState() {
+	gi := c.gi()
+	gi.displayname = gi.defaultDisplayname
+	gi.lifebarname = gi.defaultLifebarname
+	gi.attackBase = gi.data.attack
+	gi.defenceBase = gi.data.defence
+	c.lifeMax = gi.data.life
+	c.powerMax = gi.data.power
+	c.dizzyPointsMax = gi.data.dizzypoints
+	c.guardPointsMax = gi.data.guardpoints
+}
+
 func (c *Char) load(def string) error {
 	gi := &sys.cgi[c.playerNo]
 
 	// Reset global info
 	gi.def = def
 	gi.displayname, gi.lifebarname, gi.author = "", "", ""
+	gi.defaultDisplayname, gi.defaultLifebarname = "", ""
 	gi.palettedata, gi.snd, gi.quotes = nil, nil, [MaxQuotes]string{}
 	gi.animTable = NewAnimationTable()
 	gi.fnt = make(map[int]*Fnt)
@@ -3577,6 +3607,8 @@ func (c *Char) load(def string) error {
 				if gi.lifebarname, ok, _ = is.getText("lifebarname"); !ok {
 					gi.lifebarname = gi.displayname
 				}
+				gi.defaultDisplayname = gi.displayname
+				gi.defaultLifebarname = gi.lifebarname
 				gi.author, _, _ = is.getText("author")
 				gi.nameLow = strings.ToLower(c.name)
 				gi.displaynameLow = strings.ToLower(gi.displayname)
@@ -4315,9 +4347,16 @@ func (c *Char) loadFx(def string) error {
 						}
 
 						if found_path != "" {
-							if err := loadFightFx(found_path, false, false); err != nil {
+							alreadyCachedNonChar := false
+							for _, ffx := range sys.ffx {
+								if ffx != nil && !ffx.isCharFX && ffx.fileName == found_path {
+									alreadyCachedNonChar = true
+									break
+								}
+							}
+							if err := loadFightFx(found_path, true, false); err != nil {
 								LogMessage("Could not load CommonFX %s for char %s: %v", found_path, def, err)
-							} else {
+							} else if !alreadyCachedNonChar {
 								gi.fxPath = append(gi.fxPath, found_path)
 							}
 						} else {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -447,7 +447,6 @@ var triggerMap = map[string]int{
 	"projvar":            1,
 	"rad":                1,
 	"randomrange":        1,
-	"ratiolevel":         1,
 	"receiveddamage":     1,
 	"receivedhits":       1,
 	"redlife":            1,
@@ -4619,6 +4618,8 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			opc = OC_ex2_gamevar_persistmusic
 		case "persistrounds":
 			opc = OC_ex2_gamevar_persistrounds
+		case "hidebars":
+			opc = OC_ex2_gamevar_hidebars
 		default:
 			return bvNone(), Error("Invalid GameVar argument: " + svname)
 		}
@@ -5031,8 +5032,6 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			return bvNone(), err
 		}
 		out.append(OC_ex_, OC_ex_playernoexist)
-	case "ratiolevel":
-		out.append(OC_ex_, OC_ex_ratiolevel)
 	case "receiveddamage":
 		out.append(OC_ex_, OC_ex_receiveddamage)
 	case "receivedhits":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -945,6 +945,10 @@ func (c *Compiler) explodSub(is IniSection,
 		explod_removeonchangestate, VT_Bool, 1, false); err != nil {
 		return err
 	}
+	if err := c.paramValue(is, sc, "hideonpausemenu",
+		explod_hideonpausemenu, VT_Bool, 1, false); err != nil {
+		return err
+	}
 	if err := c.paramTrans(is, sc, "", explod_trans, true); err != nil {
 		return err
 	}

--- a/src/config.go
+++ b/src/config.go
@@ -99,28 +99,6 @@ type Config struct {
 				Bonus float32 `ini:"Bonus" sync:"host"`
 			} `ini:"Recovery"`
 		} `ini:"Turns"`
-		Ratio struct {
-			Recovery struct {
-				Base  float32 `ini:"Base" sync:"host"`
-				Bonus float32 `ini:"Bonus" sync:"host"`
-			} `ini:"Recovery"`
-			Level1 struct {
-				Attack float32 `ini:"Attack" sync:"host"`
-				Life   float32 `ini:"Life" sync:"host"`
-			} `ini:"Level1"`
-			Level2 struct {
-				Attack float32 `ini:"Attack" sync:"host"`
-				Life   float32 `ini:"Life" sync:"host"`
-			} `ini:"Level2"`
-			Level3 struct {
-				Attack float32 `ini:"Attack" sync:"host"`
-				Life   float32 `ini:"Life" sync:"host"`
-			} `ini:"Level3"`
-			Level4 struct {
-				Attack float32 `ini:"Attack" sync:"host"`
-				Life   float32 `ini:"Life" sync:"host"`
-			} `ini:"Level4"`
-		} `ini:"Ratio"`
 	} `ini:"Options"`
 	Config struct {
 		Motif             string   `ini:"Motif" sync:"strict"`
@@ -212,9 +190,6 @@ type Config struct {
 		Team struct {
 			AIramp AIrampProperties `ini:"AIramp"`
 		} `ini:"team"`
-		Ratio struct {
-			AIramp AIrampProperties `ini:"AIramp"`
-		} `ini:"ratio"`
 		Survival struct {
 			AIramp AIrampProperties `ini:"AIramp"`
 		} `ini:"survival"`

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -71,7 +71,7 @@ type FightFx struct {
 	fx_scale   float32
 	localcoord [2]int32
 	refCount   int
-	isGlobal   bool
+	isCharFX   bool
 }
 
 func newFightFx() *FightFx {
@@ -82,7 +82,26 @@ func newFightFx() *FightFx {
 	}
 }
 
-func loadFightFx(def string, isGlobal bool, isMainThread bool) error {
+func loadCommonFightFx(def string, isMainThread bool) error {
+	for _, key := range SortedKeys(sys.cfg.Common.Fx) {
+		for _, v := range sys.cfg.Common.Fx[key] {
+			if err := LoadFile(&v, []string{def, sys.motif.Def, "", "data/"},
+				func(filename string) error {
+					for _, ffx := range sys.ffx {
+						if ffx != nil && !ffx.isCharFX && ffx.fileName == filename {
+							return nil
+						}
+					}
+					return loadFightFx(filename, false, isMainThread)
+				}); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func loadFightFx(def string, isCharFX bool, isMainThread bool) error {
 	str, err := LoadText(def)
 	if err != nil {
 		return err
@@ -113,19 +132,23 @@ func loadFightFx(def string, isGlobal bool, isMainThread bool) error {
 				if _, ok := triggerMap[prefix]; ok {
 					return Error(fmt.Sprintf("The %s prefix conflicts with an existing trigger name and cannot be used", strings.ToUpper(prefix)))
 				}
-				// Check if prefix is valid but already in use
-				// TODO: This shouldn't print a warning when just reloading everything
-				for used := range sys.ffx {
-					if prefix == used {
-						sys.appendToConsole(fmt.Sprintf("Duplicate common FX prefix found or reloaded: %s in %s", strings.ToUpper(prefix), def))
-					}
-				}
 				if ffx, ok := sys.ffx[prefix]; ok {
-					// Global FX are always enabled. Character FX increase the count
-					if !isGlobal {
+					// Char FX are the only refcounted FX. Everything else is cached once loaded and kept around.
+					if isCharFX && ffx.isCharFX {
 						if ffx.refCount < 8 {
 							ffx.refCount += 1 + int((sys.numSimul[0]+sys.numSimul[1])/2)
 						}
+					}
+					// If the same file later appears in Common.Fx, promote it to
+					// cached non-char FX instead of letting refcount cleanup remove it.
+					if !isCharFX && ffx.fileName == def {
+						ffx.isCharFX = false
+						ffx.refCount = 99999
+					}
+					if ffx.fileName != def {
+						sys.appendToConsole(fmt.Sprintf(
+							"Duplicate FightFX prefix found: %s already loaded from %s, ignoring %s",
+							strings.ToUpper(prefix), ffx.fileName, def))
 					}
 					return nil
 				}
@@ -181,11 +204,11 @@ func loadFightFx(def string, isGlobal bool, isMainThread bool) error {
 	//	sys.ffxPrefixes = append(sys.ffxPrefixes, prefix)
 	//}
 	ffx.fileName = def
-	ffx.isGlobal = isGlobal
-	if isGlobal {
-		ffx.refCount = 99999
-	} else {
+	ffx.isCharFX = isCharFX
+	if isCharFX {
 		ffx.refCount = 3 + int(sys.numSimul[0]+sys.numSimul[1])
+	} else {
+		ffx.refCount = 99999
 	}
 	sys.ffx[prefix] = ffx
 	return nil
@@ -3879,51 +3902,6 @@ func (ro *FightScreenRound) draw(layerno int16, f map[int]*Fnt) {
 	}
 }
 
-type FightScreenRatio struct {
-	pos  [2]int32
-	icon [4]AnimLayout
-	bg   AnimLayout
-	top  AnimLayout
-}
-
-func newFightScreenRatio() *FightScreenRatio {
-	return &FightScreenRatio{}
-}
-
-func readFightScreenRatio(pre string, is IniSection,
-	sff *Sff, at AnimationTable) *FightScreenRatio {
-	ra := newFightScreenRatio()
-	is.ReadI32(pre+"pos", &ra.pos[0], &ra.pos[1])
-	ra.icon[0] = ReadAnimLayout(pre+"level1.", is, sff, at, 0)
-	ra.icon[1] = ReadAnimLayout(pre+"level2.", is, sff, at, 0)
-	ra.icon[2] = ReadAnimLayout(pre+"level3.", is, sff, at, 0)
-	ra.icon[3] = ReadAnimLayout(pre+"level4.", is, sff, at, 0)
-	ra.bg = ReadAnimLayout(pre+"bg.", is, sff, at, 0)
-	return ra
-}
-
-func (ra *FightScreenRatio) step(num int32) {
-	ra.icon[num].Action()
-	ra.bg.Action()
-}
-
-func (ra *FightScreenRatio) reset() {
-	for i := range ra.icon {
-		ra.icon[i].Reset()
-	}
-	ra.bg.Reset()
-}
-
-func (ra *FightScreenRatio) bgDraw(layerno int16) {
-	ra.bg.Draw(float32(ra.pos[0])+sys.fightScreen.offsetX, float32(ra.pos[1]), layerno, sys.fightScreen.scale)
-}
-
-func (ra *FightScreenRatio) draw(layerno int16, num int32) {
-	ra.icon[num].Draw(float32(ra.pos[0])+sys.fightScreen.offsetX,
-		float32(ra.pos[1]), layerno, sys.fightScreen.scale)
-	ra.top.Draw(float32(ra.pos[0])+sys.fightScreen.offsetX, float32(ra.pos[1]), layerno, sys.fightScreen.scale)
-}
-
 type FightScreenTimer struct {
 	pos     [2]int32
 	text    FSText
@@ -4383,7 +4361,6 @@ type FightScreen struct {
 	combos        [2]*FightScreenCombo
 	actions       [2]*FightScreenAction
 	round         *FightScreenRound
-	ratios        [2]*FightScreenRatio
 	timer         *FightScreenTimer // For Time Attack and such
 	scores        [2]*FightScreenScore
 	match         *FightScreenMatch
@@ -4455,9 +4432,9 @@ func loadFightScreen(def string) (*FightScreen, error) {
 		"[tag_4p stunbar]": 7, "[tag face]": 3, "[simul_3p face]": 4,
 		"[simul_4p face]": 5, "[tag_3p face]": 6, "[tag_4p face]": 7,
 		"[tag name]": 3, "[simul_3p name]": 4, "[simul_4p name]": 5,
-		"[tag_3p name]": 6, "[tag_4p name]": 7, "[action]": -1, "[ratio]": -1,
-		"[timer]": -1, "[score]": -1, "[match]": -1, "[ailevel]": -1,
-		"[wincount]": -1, "[mode]": -1,
+		"[tag_3p name]": 6, "[tag_4p name]": 7, "[action]": -1, "[timer]": -1,
+		"[score]": -1, "[match]": -1, "[ailevel]": -1, "[wincount]": -1,
+		"[mode]": -1,
 	}
 	strc := strings.ToLower(strings.TrimSpace(str))
 	for k := range fs.missing {
@@ -4492,23 +4469,8 @@ func loadFightScreen(def string) (*FightScreen, error) {
 	sys.fightScreen.scale = fs.scale
 	sys.fightScreen.portraitScale = fs.portraitScale
 
-	// Load Common FX first
-	for _, key := range SortedKeys(sys.cfg.Common.Fx) {
-		for _, v := range sys.cfg.Common.Fx[key] {
-			if err := LoadFile(&v, []string{def, sys.motif.Def, "", "data/"}, func(filename string) error {
-				if err := loadFightFx(filename, true, true); err != nil {
-					return err
-				}
-				return nil
-			}); err != nil {
-				return nil, err
-			}
-		}
-	}
-
 	// Prepare fight screen FightFX
 	ffx := newFightFx()
-	ffx.isGlobal = true
 
 	for lnidx < len(lines) {
 		is, name, subname := ReadIniSection(lines, &lnidx)
@@ -4602,7 +4564,7 @@ func loadFightScreen(def string) (*FightScreen, error) {
 				for i := 1; i <= fs.fx_limit; i++ {
 					if err := is.LoadFile(fmt.Sprintf("fx%v", i), []string{def, sys.motif.Def, "", "data/"},
 						func(filename string) error {
-							if err := loadFightFx(filename, true, true); err != nil {
+							if err := loadFightFx(filename, false, true); err != nil {
 								return err
 							}
 							return nil
@@ -4980,13 +4942,6 @@ func loadFightScreen(def string) (*FightScreen, error) {
 			if fs.round == nil {
 				fs.round = readFightScreenRound(is, fs.sff, fs.animTable, fs.snd, fs.fnt)
 			}
-		case "ratio":
-			if fs.ratios[0] == nil {
-				fs.ratios[0] = readFightScreenRatio("p1.", resolvedSection("p", 1), fs.sff, fs.animTable)
-			}
-			if fs.ratios[1] == nil {
-				fs.ratios[1] = readFightScreenRatio("p2.", resolvedSection("p", 2), fs.sff, fs.animTable)
-			}
 		case "timer":
 			if fs.timer == nil {
 				fs.timer = readFightScreenTimer(is, fs.sff, fs.animTable, fs.fnt)
@@ -5230,15 +5185,6 @@ func (fs *FightScreen) step() {
 	for i := range fs.actions {
 		fs.actions[i].step(fs.teamOrder[i][0])
 	}
-	// Ratio
-	for ti, tm := range sys.tmode {
-		if tm == TM_Turns {
-			rl := sys.chars[ti][0].ocd().ratioLevel
-			if rl > 0 {
-				fs.ratios[ti].step(rl - 1)
-			}
-		}
-	}
 	// Timer
 	fs.timer.step()
 	// Score
@@ -5345,9 +5291,6 @@ func (fs *FightScreen) reset() {
 		fs.actions[i].reset(fs.teamOrder[i][0])
 	}
 	fs.round.reset()
-	for i := range fs.ratios {
-		fs.ratios[i].reset()
-	}
 	fs.timer.reset()
 	for i := range fs.scores {
 		fs.scores[i].reset()
@@ -5511,17 +5454,6 @@ func (fs *FightScreen) draw(layerno int16) {
 					}
 					fs.names[layout][barpn].bgDraw(layerno)
 					fs.names[layout][barpn].draw(layerno, charpn, fs.fnt, side)
-				}
-			}
-
-			// Ratio
-			for i := 0; i < len(sys.tmode); i++ {
-				if sys.tmode[i] == TM_Turns {
-					rl := sys.chars[i][0].ocd().ratioLevel
-					if rl > 0 && !sys.chars[i][0].asf(ASF_nofacedisplay) {
-						fs.ratios[i].bgDraw(layerno)
-						fs.ratios[i].draw(layerno, rl-1)
-					}
 				}
 			}
 

--- a/src/motif.go
+++ b/src/motif.go
@@ -492,27 +492,6 @@ type PlayerSelectProperties struct {
 			Key []string `ini:"key"`
 		} `ini:"subtract"`
 		Item   ItemProperties `ini:"item"`
-		Ratio1 struct {
-			Icon AnimationProperties `ini:"icon"`
-		} `ini:"ratio1"`
-		Ratio2 struct {
-			Icon AnimationProperties `ini:"icon"`
-		} `ini:"ratio2"`
-		Ratio3 struct {
-			Icon AnimationProperties `ini:"icon"`
-		} `ini:"ratio3"`
-		Ratio4 struct {
-			Icon AnimationProperties `ini:"icon"`
-		} `ini:"ratio4"`
-		Ratio5 struct {
-			Icon AnimationProperties `ini:"icon"`
-		} `ini:"ratio5"`
-		Ratio6 struct {
-			Icon AnimationProperties `ini:"icon"`
-		} `ini:"ratio6"`
-		Ratio7 struct {
-			Icon AnimationProperties `ini:"icon"`
-		} `ini:"ratio7"`
 	} `ini:"teammenu"`
 	PalMenu struct {
 		Pos  [2]float32 `ini:"pos"`
@@ -552,7 +531,6 @@ type TeamModesProperties struct {
 	Simul  string `ini:"simul"`
 	Turns  string `ini:"turns"`
 	Tag    string `ini:"tag"`
-	Ratio  string `ini:"ratio"`
 }
 
 type ValueIconVsProperties struct {
@@ -1497,7 +1475,7 @@ func reserveUserFontSlots(m *Motif) {
 	}
 }
 
-// returns a stable-sorted list of files named "system.def" located anywhere under the given root (e.g. external/mods), including nested subdirs.
+// returns a stable-sorted list of files named "+system.def" located anywhere under the given root (e.g. external/mods), including nested subdirs.
 func findExternalModSystemDefs(root string) ([]string, error) {
 	st, err := os.Stat(root)
 	if err != nil {
@@ -1519,7 +1497,7 @@ func findExternalModSystemDefs(root string) ([]string, error) {
 			return nil
 		}
 		// Match filename, case-insensitive
-		if strings.EqualFold(d.Name(), "system.def") {
+		if strings.EqualFold(d.Name(), "+system.def") {
 			out = append(out, path)
 		}
 		return nil
@@ -1570,7 +1548,7 @@ func loadMotif(def string) (*Motif, error) {
 	if err := LoadFile(&def, []string{def, "", "data/"}, func(filename string) error {
 		def = filename
 
-		// Inline-append any external/mods/**/system.def files before parsing.
+		// Inline-append any external/mods/**/+system.def files before parsing.
 		modSystemDefs, err := findExternalModSystemDefs(filepath.FromSlash("external/mods"))
 		if err != nil {
 			return fmt.Errorf("Failed to discover external mod system.def files: %w", err)
@@ -2631,13 +2609,6 @@ func (m *Motif) applyPostParsePosAdjustments() {
 			tm.Item.Cursor.AnimData,
 			tm.Value.Icon.AnimData,
 			tm.Value.Empty.Icon.AnimData,
-			tm.Ratio1.Icon.AnimData,
-			tm.Ratio2.Icon.AnimData,
-			tm.Ratio3.Icon.AnimData,
-			tm.Ratio4.Icon.AnimData,
-			tm.Ratio5.Icon.AnimData,
-			tm.Ratio6.Icon.AnimData,
-			tm.Ratio7.Icon.AnimData,
 		)
 		// Palette menu
 		pm := &ps.PalMenu

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -89,19 +89,6 @@ Turns.Max             = 4
 Turns.Recovery.Base   = 0
 ; Percentage of remaining round time life recovery bonus
 Turns.Recovery.Bonus  = 27.5
-; Percentage of max life recovery
-Ratio.Recovery.Base   = 12.5
-; Percentage of remaining round time life recovery bonus
-Ratio.Recovery.Bonus  = 20
-; Ratio levels Attack / Life multipliers
-Ratio.Level1.Attack   = 0.82
-Ratio.Level1.Life     = 0.8
-Ratio.Level2.Attack   = 1
-Ratio.Level2.Life     = 1
-Ratio.Level3.Attack   = 1.17
-Ratio.Level3.Life     = 1.17
-Ratio.Level4.Attack   = 1.3
-Ratio.Level4.Life     = 1.4
 
 ; -------------------------------------------------------------------------------
 [Config]
@@ -337,16 +324,11 @@ AI.Ramping            = 1
 ; 4,4,4,5,6,6
 arcade.AIramp.start   = 2, 0
 arcade.AIramp.end     = 4, 2
-; Arcade / Time Attack team modes AI ramping (sans Ratio)
+; Arcade / Time Attack team modes AI ramping
 ; For 4 matches at level 4 and default values, the difficulty will be:
 ; 4,4,5,6
 team.AIramp.start     = 1, 0
 team.AIramp.end       = 3, 2
-; Arcade / Time Attack Ratio mode AI ramping
-; For 4 matches at level 4 and default values, the difficulty will be:
-; 4,4,5,6
-ratio.AIramp.start    = 1, 0
-ratio.AIramp.end      = 3, 2
 ; Survival Mode AI ramping
 ; For 16 matches at level 4 and default values, the difficulty will be:
 ; 1,1,1,2,2,3,3,4,4,4,5,5,6,6,7,7,8

--- a/src/resources/defaultMotif.ini
+++ b/src/resources/defaultMotif.ini
@@ -1206,114 +1206,6 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	p1.teammenu.item.cursor.window = 
 	p1.teammenu.item.cursor.localcoord = 320, 240
 
-	; Ratio icons offset from ratio item position, which is affected by
-	; teammenu.item.spacing (same way as value.icon/value.empty.icon elements)
-	; Ratio variants: 1: 2-1-1, 2: 1-2-1, 3: 1-1-2, 4: 2-2, 5: 3-1, 6: 1-3, 7: 4
-	p1.teammenu.ratio1.icon.anim = -1
-	p1.teammenu.ratio1.icon.spr = -1, 0
-	p1.teammenu.ratio1.icon.offset = 0, 0
-	p1.teammenu.ratio1.icon.facing = 1
-	p1.teammenu.ratio1.icon.scale = 1.0, 1.0
-	p1.teammenu.ratio1.icon.xshear = 0
-	p1.teammenu.ratio1.icon.angle = 0
-	p1.teammenu.ratio1.icon.xangle = 0
-	p1.teammenu.ratio1.icon.yangle = 0
-	p1.teammenu.ratio1.icon.projection = orthographic
-	p1.teammenu.ratio1.icon.focallength = 2048
-	p1.teammenu.ratio1.icon.layerno = 0
-	p1.teammenu.ratio1.icon.window = 
-	p1.teammenu.ratio1.icon.localcoord = 320, 240
-
-	p1.teammenu.ratio2.icon.anim = -1
-	p1.teammenu.ratio2.icon.spr = -1, 0
-	p1.teammenu.ratio2.icon.offset = 0, 0
-	p1.teammenu.ratio2.icon.facing = 1
-	p1.teammenu.ratio2.icon.scale = 1.0, 1.0
-	p1.teammenu.ratio2.icon.xshear = 0
-	p1.teammenu.ratio2.icon.angle = 0
-	p1.teammenu.ratio2.icon.xangle = 0
-	p1.teammenu.ratio2.icon.yangle = 0
-	p1.teammenu.ratio2.icon.projection = orthographic
-	p1.teammenu.ratio2.icon.focallength = 2048
-	p1.teammenu.ratio2.icon.layerno = 0
-	p1.teammenu.ratio2.icon.window = 
-	p1.teammenu.ratio2.icon.localcoord = 320, 240
-
-	p1.teammenu.ratio3.icon.anim = -1
-	p1.teammenu.ratio3.icon.spr = -1, 0
-	p1.teammenu.ratio3.icon.offset = 0, 0
-	p1.teammenu.ratio3.icon.facing = 1
-	p1.teammenu.ratio3.icon.scale = 1.0, 1.0
-	p1.teammenu.ratio3.icon.xshear = 0
-	p1.teammenu.ratio3.icon.angle = 0
-	p1.teammenu.ratio3.icon.xangle = 0
-	p1.teammenu.ratio3.icon.yangle = 0
-	p1.teammenu.ratio3.icon.projection = orthographic
-	p1.teammenu.ratio3.icon.focallength = 2048
-	p1.teammenu.ratio3.icon.layerno = 0
-	p1.teammenu.ratio3.icon.window = 
-	p1.teammenu.ratio3.icon.localcoord = 320, 240
-
-	p1.teammenu.ratio4.icon.anim = -1
-	p1.teammenu.ratio4.icon.spr = -1, 0
-	p1.teammenu.ratio4.icon.offset = 0, 0
-	p1.teammenu.ratio4.icon.facing = 1
-	p1.teammenu.ratio4.icon.scale = 1.0, 1.0
-	p1.teammenu.ratio4.icon.xshear = 0
-	p1.teammenu.ratio4.icon.angle = 0
-	p1.teammenu.ratio4.icon.xangle = 0
-	p1.teammenu.ratio4.icon.yangle = 0
-	p1.teammenu.ratio4.icon.projection = orthographic
-	p1.teammenu.ratio4.icon.focallength = 2048
-	p1.teammenu.ratio4.icon.layerno = 0
-	p1.teammenu.ratio4.icon.window = 
-	p1.teammenu.ratio4.icon.localcoord = 320, 240
-
-	p1.teammenu.ratio5.icon.anim = -1
-	p1.teammenu.ratio5.icon.spr = -1, 0
-	p1.teammenu.ratio5.icon.offset = 0, 0
-	p1.teammenu.ratio5.icon.facing = 1
-	p1.teammenu.ratio5.icon.scale = 1.0, 1.0
-	p1.teammenu.ratio5.icon.xshear = 0
-	p1.teammenu.ratio5.icon.angle = 0
-	p1.teammenu.ratio5.icon.xangle = 0
-	p1.teammenu.ratio5.icon.yangle = 0
-	p1.teammenu.ratio5.icon.projection = orthographic
-	p1.teammenu.ratio5.icon.focallength = 2048
-	p1.teammenu.ratio5.icon.layerno = 0
-	p1.teammenu.ratio5.icon.window = 
-	p1.teammenu.ratio5.icon.localcoord = 320, 240
-
-	p1.teammenu.ratio6.icon.anim = -1
-	p1.teammenu.ratio6.icon.spr = -1, 0
-	p1.teammenu.ratio6.icon.offset = 0, 0
-	p1.teammenu.ratio6.icon.facing = 1
-	p1.teammenu.ratio6.icon.scale = 1.0, 1.0
-	p1.teammenu.ratio6.icon.xshear = 0
-	p1.teammenu.ratio6.icon.angle = 0
-	p1.teammenu.ratio6.icon.xangle = 0
-	p1.teammenu.ratio6.icon.yangle = 0
-	p1.teammenu.ratio6.icon.projection = orthographic
-	p1.teammenu.ratio6.icon.focallength = 2048
-	p1.teammenu.ratio6.icon.layerno = 0
-	p1.teammenu.ratio6.icon.window = 
-	p1.teammenu.ratio6.icon.localcoord = 320, 240
-
-	p1.teammenu.ratio7.icon.anim = -1
-	p1.teammenu.ratio7.icon.spr = -1, 0
-	p1.teammenu.ratio7.icon.offset = 0, 0
-	p1.teammenu.ratio7.icon.facing = 1
-	p1.teammenu.ratio7.icon.scale = 1.0, 1.0
-	p1.teammenu.ratio7.icon.xshear = 0
-	p1.teammenu.ratio7.icon.angle = 0
-	p1.teammenu.ratio7.icon.xangle = 0
-	p1.teammenu.ratio7.icon.yangle = 0
-	p1.teammenu.ratio7.icon.projection = orthographic
-	p1.teammenu.ratio7.icon.focallength = 2048
-	p1.teammenu.ratio7.icon.layerno = 0
-	p1.teammenu.ratio7.icon.window = 
-	p1.teammenu.ratio7.icon.localcoord = 320, 240
-
 	p1.palmenu.pos = 0, 0
 
 	p1.palmenu.next.key = U, R
@@ -1859,111 +1751,6 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	p2.teammenu.item.cursor.window = 
 	p2.teammenu.item.cursor.localcoord = 320, 240
 
-	p2.teammenu.ratio1.icon.anim = -1
-	p2.teammenu.ratio1.icon.spr = -1, 0
-	p2.teammenu.ratio1.icon.offset = 0, 0
-	p2.teammenu.ratio1.icon.facing = 1
-	p2.teammenu.ratio1.icon.scale = 1.0, 1.0
-	p2.teammenu.ratio1.icon.xshear = 0
-	p2.teammenu.ratio1.icon.angle = 0
-	p2.teammenu.ratio1.icon.xangle = 0
-	p2.teammenu.ratio1.icon.yangle = 0
-	p2.teammenu.ratio1.icon.projection = orthographic
-	p2.teammenu.ratio1.icon.focallength = 2048
-	p2.teammenu.ratio1.icon.layerno = 0
-	p2.teammenu.ratio1.icon.window = 
-	p2.teammenu.ratio1.icon.localcoord = 320, 240
-
-	p2.teammenu.ratio2.icon.anim = -1
-	p2.teammenu.ratio2.icon.spr = -1, 0
-	p2.teammenu.ratio2.icon.offset = 0, 0
-	p2.teammenu.ratio2.icon.facing = 1
-	p2.teammenu.ratio2.icon.scale = 1.0, 1.0
-	p2.teammenu.ratio2.icon.xshear = 0
-	p2.teammenu.ratio2.icon.angle = 0
-	p2.teammenu.ratio2.icon.xangle = 0
-	p2.teammenu.ratio2.icon.yangle = 0
-	p2.teammenu.ratio2.icon.projection = orthographic
-	p2.teammenu.ratio2.icon.focallength = 2048
-	p2.teammenu.ratio2.icon.layerno = 0
-	p2.teammenu.ratio2.icon.window = 
-	p2.teammenu.ratio2.icon.localcoord = 320, 240
-
-	p2.teammenu.ratio3.icon.anim = -1
-	p2.teammenu.ratio3.icon.spr = -1, 0
-	p2.teammenu.ratio3.icon.offset = 0, 0
-	p2.teammenu.ratio3.icon.facing = 1
-	p2.teammenu.ratio3.icon.scale = 1.0, 1.0
-	p2.teammenu.ratio3.icon.xshear = 0
-	p2.teammenu.ratio3.icon.angle = 0
-	p2.teammenu.ratio3.icon.xangle = 0
-	p2.teammenu.ratio3.icon.yangle = 0
-	p2.teammenu.ratio3.icon.projection = orthographic
-	p2.teammenu.ratio3.icon.focallength = 2048
-	p2.teammenu.ratio3.icon.layerno = 0
-	p2.teammenu.ratio3.icon.window = 
-	p2.teammenu.ratio3.icon.localcoord = 320, 240
-
-	p2.teammenu.ratio4.icon.anim = -1
-	p2.teammenu.ratio4.icon.spr = -1, 0
-	p2.teammenu.ratio4.icon.offset = 0, 0
-	p2.teammenu.ratio4.icon.facing = 1
-	p2.teammenu.ratio4.icon.scale = 1.0, 1.0
-	p2.teammenu.ratio4.icon.xshear = 0
-	p2.teammenu.ratio4.icon.angle = 0
-	p2.teammenu.ratio4.icon.xangle = 0
-	p2.teammenu.ratio4.icon.yangle = 0
-	p2.teammenu.ratio4.icon.projection = orthographic
-	p2.teammenu.ratio4.icon.focallength = 2048
-	p2.teammenu.ratio4.icon.layerno = 0
-	p2.teammenu.ratio4.icon.window = 
-	p2.teammenu.ratio4.icon.localcoord = 320, 240
-
-	p2.teammenu.ratio5.icon.anim = -1
-	p2.teammenu.ratio5.icon.spr = -1, 0
-	p2.teammenu.ratio5.icon.offset = 0, 0
-	p2.teammenu.ratio5.icon.facing = 1
-	p2.teammenu.ratio5.icon.scale = 1.0, 1.0
-	p2.teammenu.ratio5.icon.xshear = 0
-	p2.teammenu.ratio5.icon.angle = 0
-	p2.teammenu.ratio5.icon.xangle = 0
-	p2.teammenu.ratio5.icon.yangle = 0
-	p2.teammenu.ratio5.icon.projection = orthographic
-	p2.teammenu.ratio5.icon.focallength = 2048
-	p2.teammenu.ratio5.icon.layerno = 0
-	p2.teammenu.ratio5.icon.window = 
-	p2.teammenu.ratio5.icon.localcoord = 320, 240
-
-	p2.teammenu.ratio6.icon.anim = -1
-	p2.teammenu.ratio6.icon.spr = -1, 0
-	p2.teammenu.ratio6.icon.offset = 0, 0
-	p2.teammenu.ratio6.icon.facing = 1
-	p2.teammenu.ratio6.icon.scale = 1.0, 1.0
-	p2.teammenu.ratio6.icon.xshear = 0
-	p2.teammenu.ratio6.icon.angle = 0
-	p2.teammenu.ratio6.icon.xangle = 0
-	p2.teammenu.ratio6.icon.yangle = 0
-	p2.teammenu.ratio6.icon.projection = orthographic
-	p2.teammenu.ratio6.icon.focallength = 2048
-	p2.teammenu.ratio6.icon.layerno = 0
-	p2.teammenu.ratio6.icon.window = 
-	p2.teammenu.ratio6.icon.localcoord = 320, 240
-
-	p2.teammenu.ratio7.icon.anim = -1
-	p2.teammenu.ratio7.icon.spr = -1, 0
-	p2.teammenu.ratio7.icon.offset = 0, 0
-	p2.teammenu.ratio7.icon.facing = 1
-	p2.teammenu.ratio7.icon.scale = 1.0, 1.0
-	p2.teammenu.ratio7.icon.xshear = 0
-	p2.teammenu.ratio7.icon.angle = 0
-	p2.teammenu.ratio7.icon.xangle = 0
-	p2.teammenu.ratio7.icon.yangle = 0
-	p2.teammenu.ratio7.icon.projection = orthographic
-	p2.teammenu.ratio7.icon.focallength = 2048
-	p2.teammenu.ratio7.icon.layerno = 0
-	p2.teammenu.ratio7.icon.window = 
-	p2.teammenu.ratio7.icon.localcoord = 320, 240
-
 	p2.palmenu.pos = 0, 0
 
 	p2.palmenu.next.key = U, R
@@ -2209,7 +1996,6 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	teammenu.itemname.simul = Simul
 	teammenu.itemname.turns = Turns
 	teammenu.itemname.tag =  ; Tag
-	teammenu.itemname.ratio =  ; Ratio
 
 	; This parameter allows renaming or disabling team mode from selection (via
 	; blank assignment) on per game mode basis.
@@ -2217,7 +2003,6 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	;teammenu.itemname.<gamemode>.simul = 
 	;teammenu.itemname.<gamemode>.turns = 
 	;teammenu.itemname.<gamemode>.tag = 
-	;teammenu.itemname.<gamemode>.ratio = 
 
 	timer.font = -1, 0, 0, 255, 255, 255, 255, -1
 	timer.offset = 0, 0
@@ -3776,20 +3561,6 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	menu.itemname.menugame.menuturns.maxturns = Max Turns Chars
 	menu.itemname.menugame.menuturns.spacer2 = -
 	menu.itemname.menugame.menuturns.back = Back
-	menu.itemname.menugame.menuratio = Ratio Settings
-	menu.itemname.menugame.menuratio.ratiorecoverybase = Ratio Recovery Base
-	menu.itemname.menugame.menuratio.ratiorecoverybonus = Ratio Recovery Bonus
-	menu.itemname.menugame.menuratio.spacer1 = -
-	menu.itemname.menugame.menuratio.ratio1life = Ratio 1 Life
-	menu.itemname.menugame.menuratio.ratio1attack = Ratio 1 Damage
-	menu.itemname.menugame.menuratio.ratio2life = Ratio 2 Life
-	menu.itemname.menugame.menuratio.ratio2attack = Ratio 2 Damage
-	menu.itemname.menugame.menuratio.ratio3life = Ratio 3 Life
-	menu.itemname.menugame.menuratio.ratio3attack = Ratio 3 Damage
-	menu.itemname.menugame.menuratio.ratio4life = Ratio 4 Life
-	menu.itemname.menugame.menuratio.ratio4attack = Ratio 4 Damage
-	menu.itemname.menugame.menuratio.spacer2 = -
-	menu.itemname.menugame.menuratio.back = Back
 	menu.itemname.menugame.back = Back
 
 	menu.itemname.menuvideo = Video Settings
@@ -5791,7 +5562,6 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	text.projection = orthographic
 	text.focallength = 2048
 	;;item.text = 
-	text.ratio.text = Incorrect 'arcade.ratiomatches' settings detected.\nRefer to tutorial available in default select.def.
 	text.reload.text = Some selected options require Ikemen to be restarted.\nPress any key to exit the program.
 	text.noreload.text = Some selected options require Ikemen to be restarted.\nPress any key to continue.
 	text.keys.text = Conflict between button keys detected.\nAll keys should have unique assignment.\n\nPress any key to continue.\nPress ESC to reset.

--- a/src/script.go
+++ b/src/script.go
@@ -430,22 +430,52 @@ func toLValue(l *lua.LState, v interface{}) lua.LValue {
 	}
 }
 
-func setNestedLuaKey(l *lua.LState, tbl *lua.LTable, key string, val lua.LValue) {
+func luaIniAppendOrder(l *lua.LState, tbl *lua.LTable, key string) {
+	if tbl == nil || strings.HasPrefix(key, "__") {
+		return
+	}
+	order, _ := tbl.RawGetString("__order").(*lua.LTable)
+	if order == nil {
+		order = l.NewTable()
+		tbl.RawSetString("__order", order)
+	}
+	for i := 1; i <= order.Len(); i++ {
+		if order.RawGetInt(i).String() == key {
+			return
+		}
+	}
+	order.Append(lua.LString(key))
+}
+
+func setNestedLuaKey(l *lua.LState, tbl *lua.LTable, key string, val lua.LValue, keepMeta bool) {
 	parts := strings.Split(key, ".")
 	cur := tbl
 	for i, part := range parts {
+		if keepMeta {
+			luaIniAppendOrder(l, cur, part)
+		}
 		if i == len(parts)-1 {
-			// last segment: set the value
+			// Last segment: set the value. If this key was already promoted to a
+			// table by a child key, keep the scalar value as table metadata.
+			if keepMeta {
+				if subTbl, ok := cur.RawGetString(part).(*lua.LTable); ok {
+					subTbl.RawSetString("__value", val)
+					return
+				}
+			}
 			cur.RawSetString(part, val)
 			return
 		}
-		// intermediate segment: ensure there's a table here
+		// Intermediate segment: ensure there's a table here. If a previous scalar
+		// value existed for the same key, preserve it as __value.
 		existing := cur.RawGetString(part)
 		if subTbl, ok := existing.(*lua.LTable); ok {
 			cur = subTbl
 		} else {
-			// overwrite non-table or nil with a new table
 			newTbl := l.NewTable()
+			if keepMeta && existing != lua.LNil {
+				newTbl.RawSetString("__value", existing)
+			}
 			cur.RawSetString(part, newTbl)
 			cur = newTbl
 		}
@@ -573,7 +603,7 @@ func parseIniLuaValue(l *lua.LState, raw string) lua.LValue {
 	return lua.LString(s)
 }
 
-func iniToLuaTable(l *lua.LState, f *ini.File) *lua.LTable {
+func iniToLuaTable(l *lua.LState, f *ini.File, normalizeSections bool, keepMeta bool) *lua.LTable {
 	t := l.NewTable()
 	if f == nil {
 		return t
@@ -585,15 +615,214 @@ func iniToLuaTable(l *lua.LState, f *ini.File) *lua.LTable {
 			val := parseIniLuaValue(l, k.Value())
 			if strings.Contains(name, ".") {
 				// use nested tables for dotted keys
-				setNestedLuaKey(l, secTable, name, val)
+				setNestedLuaKey(l, secTable, name, val, keepMeta)
 			} else {
-				// plain key, just set directly
-				secTable.RawSetString(name, val)
+				if keepMeta {
+					luaIniAppendOrder(l, secTable, name)
+					if subTbl, ok := secTable.RawGetString(name).(*lua.LTable); ok {
+						subTbl.RawSetString("__value", val)
+					} else {
+						secTable.RawSetString(name, val)
+					}
+				} else {
+					secTable.RawSetString(name, val)
+				}
 			}
 		}
-		t.RawSetString(normalizeSectionName(sec.Name()), secTable)
+		sectionName := strings.TrimSpace(sec.Name())
+		if normalizeSections {
+			sectionName = normalizeSectionName(sec.Name())
+		}
+		t.RawSetString(sectionName, secTable)
 	}
 	return t
+}
+
+func isLuaArrayTable(t *lua.LTable) bool {
+	if t == nil {
+		return false
+	}
+	n := t.Len()
+	if n == 0 {
+		// Treat empty tables as objects by default. This is safer for INI,
+		// where empty arrays/objects are otherwise ambiguous.
+		return false
+	}
+	isArray := true
+	t.ForEach(func(k, _ lua.LValue) {
+		if !isArray {
+			return
+		}
+		num, ok := k.(lua.LNumber)
+		if !ok {
+			isArray = false
+			return
+		}
+		f := float64(num)
+		if f < 1 || f != math.Trunc(f) || int(f) > n {
+			isArray = false
+		}
+	})
+	return isArray
+}
+
+func needsIniQuotes(s string) bool {
+	if s == "" {
+		return true
+	}
+	trimmed := strings.TrimSpace(s)
+	if trimmed != s {
+		return true
+	}
+	if strings.ContainsAny(s, ",\"'") {
+		return true
+	}
+	switch strings.ToLower(s) {
+	case "true", "false":
+		return true
+	}
+	if _, err := strconv.ParseInt(s, 0, 64); err == nil {
+		return true
+	}
+	if _, err := strconv.ParseFloat(s, 64); err == nil {
+		return true
+	}
+	return false
+}
+
+func encodeIniString(s string) string {
+	if needsIniQuotes(s) {
+		return strconv.Quote(s)
+	}
+	return s
+}
+
+func luaIniScalarString(v lua.LValue) (string, error) {
+	switch x := v.(type) {
+	case *lua.LNilType:
+		return "", nil
+	case lua.LBool:
+		if bool(x) {
+			return "true", nil
+		}
+		return "false", nil
+	case lua.LNumber:
+		f := float64(x)
+		if math.IsNaN(f) || math.IsInf(f, 0) {
+			return "", fmt.Errorf("saveIni: NaN/Inf not permitted in INI numbers")
+		}
+		f = RoundFloat(f, 6)
+		if f == math.Trunc(f) {
+			return strconv.FormatInt(int64(f), 10), nil
+		}
+		return strconv.FormatFloat(f, 'f', -1, 64), nil
+	case lua.LString:
+		return encodeIniString(string(x)), nil
+	default:
+		return "", fmt.Errorf("saveIni: unsupported INI scalar type %T", v)
+	}
+}
+
+func luaIniValueString(v lua.LValue) (string, error) {
+	if tbl, ok := v.(*lua.LTable); ok {
+		if !isLuaArrayTable(tbl) {
+			return "", fmt.Errorf("saveIni: nested non-array table must be flattened as dotted keys")
+		}
+		parts := make([]string, 0, tbl.Len())
+		for i := 1; i <= tbl.Len(); i++ {
+			s, err := luaIniScalarString(tbl.RawGetInt(i))
+			if err != nil {
+				return "", err
+			}
+			parts = append(parts, s)
+		}
+		return strings.Join(parts, ", "), nil
+	}
+	return luaIniScalarString(v)
+}
+
+func flattenLuaIniSection(tbl *lua.LTable, prefix string, out map[string]string) error {
+	if tbl == nil {
+		return nil
+	}
+	var errRet error
+	tbl.ForEach(func(k, v lua.LValue) {
+		if errRet != nil {
+			return
+		}
+		ks, ok := k.(lua.LString)
+		if !ok {
+			errRet = fmt.Errorf("saveIni: INI keys must be strings, got %T", k)
+			return
+		}
+		key := string(ks)
+		fullKey := key
+		if prefix != "" {
+			fullKey = prefix + "." + key
+		}
+		if sub, ok := v.(*lua.LTable); ok && !isLuaArrayTable(sub) {
+			if err := flattenLuaIniSection(sub, fullKey, out); err != nil {
+				errRet = err
+			}
+			return
+		}
+		s, err := luaIniValueString(v)
+		if err != nil {
+			errRet = fmt.Errorf("%v (key %q)", err, fullKey)
+			return
+		}
+		out[fullKey] = s
+	})
+	return errRet
+}
+
+func luaTableToIniFile(root *lua.LTable) (*ini.File, error) {
+	f := ini.Empty()
+	if root == nil {
+		return f, nil
+	}
+	sections := make(map[string]*lua.LTable)
+	sectionNames := make([]string, 0)
+	root.ForEach(func(k, v lua.LValue) {
+		ks, ok := k.(lua.LString)
+		if !ok {
+			return
+		}
+		secTbl, ok := v.(*lua.LTable)
+		if !ok {
+			return
+		}
+		name := strings.TrimSpace(string(ks))
+		sections[name] = secTbl
+		sectionNames = append(sectionNames, name)
+	})
+	sort.Strings(sectionNames)
+	for _, sectionName := range sectionNames {
+		secTbl := sections[sectionName]
+		iniSectionName := sectionName
+		if strings.EqualFold(sectionName, "default") {
+			iniSectionName = ini.DEFAULT_SECTION
+		}
+		sec, err := f.NewSection(iniSectionName)
+		if err != nil {
+			return nil, fmt.Errorf("saveIni: create section %q: %w", sectionName, err)
+		}
+		flat := make(map[string]string)
+		if err := flattenLuaIniSection(secTbl, "", flat); err != nil {
+			return nil, err
+		}
+		keys := make([]string, 0, len(flat))
+		for k := range flat {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			if _, err := sec.NewKey(k, flat[k]); err != nil {
+				return nil, fmt.Errorf("saveIni: create key %q in section %q: %w", k, sectionName, err)
+			}
+		}
+	}
+	return f, nil
 }
 
 func jsonToLuaValue(L *lua.LState, r io.Reader) (lua.LValue, error) {
@@ -3036,7 +3265,6 @@ func systemScriptInit(l *lua.LState) {
 		  - `intro` (string) intro def path
 		  - `ending` (string) ending def path
 		  - `arcadepath` (string) arcade path override
-		  - `ratiopath` (string) ratio path override
 		  - `localcoord` (float32) base localcoord width
 		  - `portraitscale` (float32) scale applied to portraits
 		  - `cns_scale` (float32[]) scale values from the CNS configuration
@@ -3053,7 +3281,6 @@ func systemScriptInit(l *lua.LState) {
 		tbl.RawSetString("intro", lua.LString(c.intro))
 		tbl.RawSetString("ending", lua.LString(c.ending))
 		tbl.RawSetString("arcadepath", lua.LString(c.arcadepath))
-		tbl.RawSetString("ratiopath", lua.LString(c.ratiopath))
 		tbl.RawSetString("localcoord", lua.LNumber(c.localcoord[0]))
 		tbl.RawSetString("portraitscale", lua.LNumber(c.portraitscale))
 		subt := l.NewTable()
@@ -3973,15 +4200,27 @@ func systemScriptInit(l *lua.LState) {
 		/*Load an INI file and convert it to a nested Lua table.
 		@function loadIni
 		@tparam string filename INI file path.
+		@tparam[opt=true] boolean normalizeSections If `true`, section names are normalized:
+		  leading/trailing whitespace removed, letters lowercased, internal whitespace collapsed to `_`.
+		@tparam[opt=false] boolean keepMeta If `true`, each nested table receives an `__order` array
+		  preserving INI key order, and scalar values promoted to parent tables are preserved as `__value`.
 		@treturn table ini Table of sections; each section is a table of keys to strings.
 		  Dotted keys are converted to nested subtables.
-		function loadIni(filename) end*/
+		function loadIni(filename, normalizeSections, keepMeta) end*/
 		def := ""
 		if !nilArg(l, 1) {
 			def = strArg(l, 1)
 		}
 		if def == "" {
 			l.RaiseError("loadIniTable: expected ini filename")
+		}
+		normalizeSections := true
+		if !nilArg(l, 2) {
+			normalizeSections = boolArg(l, 2)
+		}
+		keepMeta := false
+		if !nilArg(l, 3) {
+			keepMeta = boolArg(l, 3)
 		}
 		raw, err := LoadText(def)
 		if err != nil {
@@ -3996,7 +4235,7 @@ func systemScriptInit(l *lua.LState) {
 		if err != nil {
 			l.RaiseError("\nCan't parse ini %v: %v\n", def, err.Error())
 		}
-		l.Push(iniToLuaTable(l, iniFile))
+		l.Push(iniToLuaTable(l, iniFile, normalizeSections, keepMeta))
 		return 1
 	})
 	luaRegister(l, "loadFightScreen", func(l *lua.LState) int {
@@ -4365,7 +4604,7 @@ func systemScriptInit(l *lua.LState) {
 
 			type entry struct {
 				elem     string // "default" or gamemode (e.g. "teamarcade")
-				field    string // single/simul/turns/tag/ratio
+				field    string // single/simul/turns/tag
 				disabled bool
 			}
 			collect := func(file *ini.File, sec string) (out []entry) {
@@ -5552,6 +5791,43 @@ func systemScriptInit(l *lua.LState) {
 		}
 		if err := sys.cfg.Save(path); err != nil {
 			l.RaiseError("\nsaveGameOption: %v\n", err.Error())
+		}
+		return 0
+	})
+	luaRegister(l, "saveIni", func(l *lua.LState) int {
+		/*Save a Lua table to an INI file.
+		@function saveIni
+		@tparam table iniTable Table of sections to save.
+		  Each top-level key is the section name and each value must be a table.
+		  Nested tables inside a section are flattened using dotted keys.
+		  Array-like tables are saved as comma-separated lists.
+		@tparam string filename Output INI file path.
+		function saveIni(iniTable, filename) end*/
+		tbl := tableArg(l, 1)
+		if tbl == nil {
+			l.RaiseError("saveIni: expected table as first argument")
+			return 0
+		}
+
+		def := strArg(l, 2)
+		if def == "" {
+			l.RaiseError("saveIni: expected ini filename")
+			return 0
+		}
+
+		iniFile, err := luaTableToIniFile(tbl)
+		if err != nil {
+			l.RaiseError(err.Error())
+			return 0
+		}
+
+		if dir := filepath.Dir(def); dir != "." && dir != "" {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				l.RaiseError("saveIni: mkdir %s: %v", dir, err)
+			}
+		}
+		if err := iniFile.SaveTo(def); err != nil {
+			l.RaiseError("saveIni: write %s: %v", def, err)
 		}
 		return 0
 	})
@@ -7478,8 +7754,7 @@ func triggerFunctions(l *lua.LState) {
 	})
 	// atan2 (dedicated functionality already exists in Lua)
 	luaRegister(l, "attack", func(*lua.LState) int {
-		base := float32(sys.debugWC.gi().attackBase) * sys.debugWC.ocd().attackRatio / 100
-		l.Push(lua.LNumber(base * sys.debugWC.attackMul[0] * 100))
+		l.Push(lua.LNumber(float32(sys.debugWC.gi().attackBase) * sys.debugWC.attackMul[0]))
 		return 1
 	})
 	luaRegister(l, "attackMul", func(*lua.LState) int {
@@ -8236,12 +8511,14 @@ func triggerFunctions(l *lua.LState) {
 			l.Push(lua.LNumber(sys.getSlowtime()))
 		case "superpausetime":
 			l.Push(lua.LNumber(sys.supertime))
+		case "persistrounds":
+			l.Push(lua.LBool(sys.sel.gameParams.PersistRounds))
 		case "persistlife":
 			l.Push(lua.LBool(sys.sel.gameParams.PersistLife))
 		case "persistmusic":
 			l.Push(lua.LBool(sys.sel.gameParams.PersistMusic))
-		case "persistrounds":
-			l.Push(lua.LBool(sys.sel.gameParams.PersistRounds))
+		case "hidebars":
+			l.Push(lua.LBool(sys.lifebarHide || sys.dialogueBarsFlg))
 		default:
 			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}
@@ -9682,10 +9959,6 @@ func triggerFunctions(l *lua.LState) {
 	// rad (dedicated functionality already exists in Lua)
 	// random (dedicated functionality already exists in Lua)
 	// randomRange (dedicated functionality already exists in Lua)
-	luaRegister(l, "ratioLevel", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.debugWC.ocd().ratioLevel))
-		return 1
-	})
 	luaRegister(l, "receivedDamage", func(*lua.LState) int {
 		l.Push(lua.LNumber(sys.debugWC.receivedDmg))
 		return 1

--- a/src/select_params.go
+++ b/src/select_params.go
@@ -10,12 +10,12 @@ import (
 // -----------------------------------------------------------------------------
 
 // override key format (loadStart params)
-func parseOverrideKey(kl string) (team int, member int, field string, ok bool) {
-	parts := strings.Split(kl, ".")
-	if len(parts) != 3 {
+func parseOverrideKey(key string) (team int, member int, field string, ok bool) {
+	parts := strings.Split(strings.TrimSpace(key), ".")
+	if len(parts) < 3 {
 		return 0, 0, "", false
 	}
-	switch parts[0] {
+	switch strings.ToLower(parts[0]) {
 	case "p1":
 		team = 0
 	case "p2":
@@ -27,7 +27,20 @@ func parseOverrideKey(kl string) (team int, member int, field string, ok bool) {
 	if m <= 0 {
 		return 0, 0, "", false
 	}
-	return team, m - 1, parts[2], true
+	field = strings.TrimSpace(strings.Join(parts[2:], "."))
+	if field == "" {
+		return 0, 0, "", false
+	}
+	return team, m - 1, field, true
+}
+
+func parseMapKey(key string) (name string, ok bool) {
+	key = strings.TrimSpace(key)
+	if len(key) <= 4 || !strings.HasPrefix(strings.ToLower(key), "map.") {
+		return "", false
+	}
+	name = strings.TrimSpace(key[4:])
+	return name, name != ""
 }
 
 func parseKV(s string) (key, value string, ok bool) {
@@ -178,7 +191,6 @@ type SelectCharParams struct {
 	Order         int32    `ini:"order"`
 	OrderSurvival int32    `ini:"ordersurvival"`
 	ArcadePath    string   `ini:"arcadepath"`
-	RatioPath     string   `ini:"ratiopath"`
 	Unlock        string   `ini:"unlock"`
 	SlotSelect    string   `ini:"slotselect"`
 	SlotNext      string   `ini:"slotnext"`
@@ -255,8 +267,6 @@ func (p *SelectCharParams) AppendParams(entries []string) {
 			p.OrderSurvival = Atoi(val)
 		case "arcadepath":
 			p.ArcadePath = val
-		case "ratiopath":
-			p.RatioPath = val
 		case "unlock":
 			p.Unlock = val
 		case "select":
@@ -323,15 +333,12 @@ type OverrideCharData struct {
 	power       int32
 	dizzyPoints int32
 	guardPoints int32
-	ratioLevel  int32
-	lifeRatio   float32
-	attackRatio float32
+	maps        map[string]float32
 	existed     bool
 }
 
 func newOverrideCharData() *OverrideCharData {
-	return &OverrideCharData{life: -1, lifeMax: -1, power: -1, dizzyPoints: -1,
-		guardPoints: -1, ratioLevel: 0, lifeRatio: 1, attackRatio: 1}
+	return &OverrideCharData{life: -1, lifeMax: -1, power: -1, dizzyPoints: -1, guardPoints: -1, maps: make(map[string]float32)}
 }
 
 type GameParams struct {
@@ -429,27 +436,25 @@ func (p *GameParams) AppendParams(entries []string) {
 		}
 
 		// per-character overrides: p1.<member>.<field>=... / p2.<member>.<field>=...
-		if team, member, field, ok := parseOverrideKey(kl); ok {
+		if team, member, field, ok := parseOverrideKey(key); ok {
 			ocd := p.ensureOverride(team, member)
-			switch field {
-			case "life":
+			field = strings.TrimSpace(field)
+			fieldLower := strings.ToLower(field)
+			switch {
+			case fieldLower == "life":
 				ocd.life = int32(Atoi(val))
-			case "lifemax":
+			case fieldLower == "lifemax":
 				ocd.lifeMax = int32(Atoi(val))
-			case "power":
+			case fieldLower == "power":
 				ocd.power = int32(Atoi(val))
-			case "dizzypoints":
+			case fieldLower == "dizzypoints":
 				ocd.dizzyPoints = int32(Atoi(val))
-			case "guardpoints":
+			case fieldLower == "guardpoints":
 				ocd.guardPoints = int32(Atoi(val))
-			case "ratiolevel":
-				ocd.ratioLevel = int32(Atoi(val))
-			case "liferatio":
-				ocd.lifeRatio = float32(Atof(val))
-			case "attackratio":
-				ocd.attackRatio = float32(Atof(val))
-			case "existed":
+			case fieldLower == "existed":
 				ocd.existed, _ = parseBoolLoose(val)
+			case strings.HasPrefix(fieldLower, "map."):
+				if name, ok := parseMapKey(field); ok { ocd.maps[name] = float32(Atof(val)) }
 			}
 			continue
 		}

--- a/src/stats.go
+++ b/src/stats.go
@@ -15,7 +15,6 @@ type StatsFighterState struct {
 	SelectNo   int     `json:"selectNo"`   // select screen index
 	AILevel    float32 `json:"aiLevel"`    // CPU level (0 = human)
 	PalNo      int32   `json:"palNo"`      // pallete number
-	RatioLevel int32   `json:"ratioLevel"` // ratio level
 
 	// Health / quotes
 	Life     int32 `json:"life"`     // life remaining at round end
@@ -192,7 +191,6 @@ func (s *StatsLog) nextRound() {
 				SelectNo:   int(p[0].selectNo),
 				AILevel:    p[0].getAILevel(),
 				PalNo:      p[0].gi().palno,
-				RatioLevel: p[0].ocd().ratioLevel,
 				Life:       p[0].life,
 				LifeMax:    p[0].lifeMax,
 				WinQuote:   p[0].winquote,

--- a/src/system.go
+++ b/src/system.go
@@ -3803,7 +3803,7 @@ func (s *System) SetupCharRoundStart() {
 			}
 
 			// Apply life options
-			lmax *= p[0].ocd().lifeRatio * s.cfg.Options.Life / 100
+			lmax *= s.cfg.Options.Life / 100
 
 			// Adjust life by team mode
 			if p[0].teamside != -1 {
@@ -3823,9 +3823,9 @@ func (s *System) SetupCharRoundStart() {
 							if len(s.chars[j]) > 0 {
 								var charLm float32
 								if s.chars[j][0].ocd().lifeMax > 0 {
-									charLm = float32(s.chars[j][0].ocd().lifeMax) * s.chars[j][0].ocd().lifeRatio * s.cfg.Options.Life / 100
+									charLm = float32(s.chars[j][0].ocd().lifeMax) * s.cfg.Options.Life / 100
 								} else {
-									charLm = float32(s.chars[j][0].gi().data.life) * s.chars[j][0].ocd().lifeRatio * s.cfg.Options.Life / 100
+									charLm = float32(s.chars[j][0].gi().data.life) * s.cfg.Options.Life / 100
 								}
 								totalTeamLife += charLm
 								teamSize++
@@ -4163,7 +4163,6 @@ type SelectChar struct {
 	intro         string
 	ending        string
 	arcadepath    string
-	ratiopath     string
 	movelist      string
 	pal           []int32
 	pal_defaults  []int32
@@ -4542,7 +4541,6 @@ func (s *Select) AddChar(def string) *SelectChar {
 				sc.intro, _, _ = isec.getText("intro.storyboard")
 				sc.ending, _, _ = isec.getText("ending.storyboard")
 				sc.arcadepath, _, _ = isec.getText("arcadepath")
-				sc.ratiopath, _, _ = isec.getText("ratiopath")
 			}
 		}
 	}
@@ -5044,7 +5042,7 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 				break
 			}
 		}
-		if prefixToDecrement && !ffx.isGlobal {
+		if prefixToDecrement && ffx.isCharFX {
 			if ffx.refCount > 0 {
 				ffx.refCount--
 			}
@@ -5059,6 +5057,10 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 
 	if sameChar {
 		p = sys.chars[pn][0]
+
+		// The cached instance is being reused as a fresh entrant.
+		// Restore values that ModifyPlayer may have mutated.
+		p.resetCachedPlayerState()
 
 		// Prepare success message
 		if attached {
@@ -5142,6 +5144,11 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 		selectPalno = sys.sel.selected[pn&1][memberNo][1]
 	}
 	sys.cgi[pn].palno = int32(selectPalno)
+
+	// Apply per-launch map overrides prepared from Lua/loadStart.
+	if !attached {
+		p.applyMapOverrides()
+	}
 
 	// Prepare fight screen portraits and names for Turns mode
 	if !attached {
@@ -5339,11 +5346,19 @@ func (l *Loader) load() {
 	sys.fightScreen.setScale()
 	//sys.motif.setMotifScale()
 
+	// Load any config-driven Common FX not already cached. External modules may
+	// append to Common.Fx before a match; once loaded, non-char FX are kept.
+	if err := loadCommonFightFx(sys.fightScreen.def, false); err != nil {
+		l.err = err
+		l.state = LS_Error
+		return
+	}
+
 	/*
 		// This should now be handled by loadSff()
 		sys.loadMutex.Lock()
 		for prefix, ffx := range sys.ffx {
-			if ffx.isGlobal {
+			if !ffx.isCharFX {
 				continue
 			}
 			if ffx.refCount <= 0 {


### PR DESCRIPTION
Feats:
* 14 new Lua hook entry points
* pre-match map assignment from Lua via hooks (netplay-safe)
* `hook.runFirst(list, ...)`: runs functions in a hook list until one returns non-nil, then returns that value
* `Common.*` lists can now be extended from external modules on a per-match basis
* `gameVar(hidebars)`: returns 1 when fightscreen bars are hidden or dialogue bars are active
* `explod hideonpausemenu` parameter: hides explods while the pause menu is open
* embedded `saveIni` Lua function
* main.f_appendItemname(...): appends itemnames or submenu itemname trees to parsed motif menu tables in a chosen position without overriding screenpack-defined entries

Refactor:
* all Ratio team mode support moved to an external module without losing functionality

Fixes:
* proper reset of cached cloned character `displayname`, `lifebarname`, `attack`, `defence`, `lifeMax`, `powerMax`, `dizzyPointsMax` and `guardPointsMax` after `modifyPlayer` mutations

Breaking:
* removed `ratioLevel` trigger (external modules can expose equivalent data via maps)
* external module screenpack overrides are now auto-appended through `+system.def` instead of `system.def`

Docs:
* hook system [documented on the wiki](https://github.com/ikemen-engine/Ikemen-GO/wiki/Lua#hook-system)