### PR TITLE
fix: Use float versions of gameWidth/gameHeight for w/hScale & render origin

### DIFF
--- a/src/stage.go
+++ b/src/stage.go
@@ -703,7 +703,7 @@ func (bg backGround) draw(pos [2]float32, drawscl, bgscl, stglscl float32,
 		// Choose render origin: top-left for screenpack/storyboard videos, center for everything else
 		var rcx float32
 		if bg._type != BG_Video || isStage {
-			rcx = float32(sys.gameWidth) / 2
+			rcx = sys.gameWidthFloat / 2
 		}
 
 		bg.anim.Draw(&rect, x-xsoffset, y, sclx, scly,

--- a/src/system.go
+++ b/src/system.go
@@ -65,6 +65,8 @@ type SystemStateVars struct {
 
 	scrrect                 [4]int32
 	gameWidth, gameHeight   int32
+	gameWidthFloat          float32 // Float forms used for precise screenpack math
+	gameHeightFloat         float32 // TODO: rework gameWidth/gameHeight as floats instead
 	widthScale, heightScale float32
 	gameEnd, frameSkip      bool
 	paused, frameStepFlag   bool
@@ -617,17 +619,21 @@ func (s *System) setGameSize(w, h int32) {
 
 	if screenAspect > targetAspect {
 		// Screen is wider than 4:3 - scale based on height
-		s.gameWidth = int32(float32(baseHeight) * screenAspect)
+		s.gameWidthFloat = float32(baseHeight) * screenAspect
+		s.gameWidth = int32(s.gameWidthFloat)
 		s.gameHeight = baseHeight
+		s.gameHeightFloat = float32(s.gameHeight)
 	} else {
 		// Screen is taller than 4:3 - scale based on width
 		s.gameWidth = baseWidth
-		s.gameHeight = int32(float32(baseWidth) / screenAspect)
+		s.gameWidthFloat = float32(baseWidth)
+		s.gameHeightFloat = float32(baseWidth) / screenAspect
+		s.gameHeight = int32(s.gameHeightFloat)
 	}
 
 	// Update scale
-	s.widthScale = float32(s.scrrect[2]) / float32(s.gameWidth)
-	s.heightScale = float32(s.scrrect[3]) / float32(s.gameHeight)
+	s.widthScale = float32(s.scrrect[2]) / s.gameWidthFloat
+	s.heightScale = float32(s.scrrect[3]) / s.gameHeightFloat
 }
 
 // Change aspect ratio at match start


### PR DESCRIPTION
Floating-point imprecision was causing gameWidth values to be incorrect for screenpacks with certain aspect ratios like 16:9 that attempt to draw pixel-perfect backgrounds, resulting in slight visual stretching.
<img width="1230" height="682" alt="Image" src="https://github.com/user-attachments/assets/238242b1-3ec9-42f9-a554-d9669b11c21e" />

This commit adds two new `float32`s to System, gameWidthFloat and gameHeightFloat, and modifies the function that sets gameWidth/gameHeight to store these more precise versions. I figured this was easier than making them floats and refactoring a bunch of other code.

The reason this is stored in `System` is because of one single calculation in `stage.go` that also requires the more precise, floating-point version of `gameWidth`, lest the result be off by one pixel.

It's worth noting a good chunk of calls to gameWidth/Height in the current source code convert it to float32 anyways, so it might be worth switching them out for these new ones and seeing if that fixes any other similar issues. This is an exercise I'll leave to the reader.

For more detailed information on this change, I strongly recommend reading the relevant issue ticket.

Fixes #1615