### PR TITLE
refactor: Remove gameWidthFloat/Height, make gameWidth/Height floats

### DIFF
--- a/src/camera.go
+++ b/src/camera.go
@@ -68,7 +68,7 @@ func newStageCamera() *stageCamera {
 	return &stageCamera{verticalfollow: 0.2, tensionvel: 1, tension: 50,
 		cuthigh: 0, cutlow: math.MinInt32,
 		localcoord: [2]int32{320, 240},
-		localscl:   float32(sys.gameWidth / 320),
+		localscl:   sys.gameWidth / 320,
 		topz:       0, botz: 0, ztopscale: 1, zbotscale: 1, depthtoscreen: 1,
 		startzoom: 1, zoomin: 1, zoomout: 1,
 		ytensionenable: false, tensionhigh: 0, tensionlow: 0,
@@ -135,14 +135,14 @@ func (c *Camera) Reset() {
 		c.aspectcorrection = Min(0, (float32(c.localcoord[1])*c.localscl-float32(sys.gameHeight))+Min((float32(sys.gameHeight)-float32(c.localcoord[1])*c.localscl)/2, float32(c.overdrawlow)*c.localscl))
 	} else if float32(c.localcoord[1])*c.localscl-float32(sys.gameHeight) > 0 {
 		if c.cuthigh+c.cutlow <= 0 {
-			c.aspectcorrection = float32(Ceil(float32(c.localcoord[1])*c.localscl) - sys.gameHeight)
+			c.aspectcorrection = float32(Ceil(float32(c.localcoord[1])*c.localscl)) - sys.gameHeight
 		} else {
-			diff := Ceil(float32(c.localcoord[1])*c.localscl) - sys.gameHeight
-			tmp := Ceil(float32(c.cuthigh)*c.localscl) * diff / (Ceil(float32(c.cuthigh)*c.localscl) + Ceil(float32(c.cutlow)*c.localscl))
-			if diff-tmp <= c.cutlow {
+			diff := float32(Ceil(float32(c.localcoord[1])*c.localscl)) - sys.gameHeight
+			tmp := float32(Ceil(float32(c.cuthigh)*c.localscl)) * diff / float32((Ceil(float32(c.cuthigh)*c.localscl) + Ceil(float32(c.cutlow)*c.localscl)))
+			if diff-tmp <= float32(c.cutlow) {
 				c.aspectcorrection = float32(tmp)
 			} else {
-				c.aspectcorrection = float32(diff - Ceil(float32(c.cutlow)*c.localscl))
+				c.aspectcorrection = float32(diff - float32(Ceil(float32(c.cutlow)*c.localscl)))
 			}
 		}
 

--- a/src/config.go
+++ b/src/config.go
@@ -371,15 +371,15 @@ func (c *Config) normalize() {
 func (c *Config) sysSet() {
 	if _, ok := sys.cmdFlags["-width"]; ok {
 		var w, _ = strconv.ParseInt(sys.cmdFlags["-width"], 10, 32)
-		sys.gameWidth = int32(w)
+		sys.gameWidth = float32(int32(w))
 	} else {
-		sys.gameWidth = c.Video.GameWidth
+		sys.gameWidth = float32(c.Video.GameWidth)
 	}
 	if _, ok := sys.cmdFlags["-height"]; ok {
 		var h, _ = strconv.ParseInt(sys.cmdFlags["-height"], 10, 32)
-		sys.gameHeight = int32(h)
+		sys.gameHeight = float32(int32(h))
 	} else {
-		sys.gameHeight = c.Video.GameHeight
+		sys.gameHeight = float32(c.Video.GameHeight)
 	}
 	sys.msaa = c.Video.MSAA
 	stoki := func(key string) int {

--- a/src/main.go
+++ b/src/main.go
@@ -194,7 +194,7 @@ func realMain() {
 
 	// Initialize game and create window
 	// This is where the window is born!
-	sys.luaLState = sys.init(sys.gameWidth, sys.gameHeight)
+	sys.luaLState = sys.init(int32(sys.gameWidth), int32(sys.gameHeight))
 	//defer sys.shutdown()
 
 	// Begin processing game using its lua scripts

--- a/src/stage.go
+++ b/src/stage.go
@@ -639,11 +639,11 @@ func (bg backGround) draw(pos [2]float32, drawscl, bgscl, stglscl float32,
 	rect := bg.startrect
 
 	startrect0 := float32(rect[0]) - (pos[0])/stgscl[0]*bg.windowdelta[0] +
-		(sys.gameWidthFloat/2/sclx - float32(bg.notmaskwindow)*(sys.gameWidthFloat/2)*(1/lscl[0]))
+		(sys.gameWidth/2/sclx - float32(bg.notmaskwindow)*(sys.gameWidth/2)*(1/lscl[0]))
 	startrect0 *= sys.widthScale * wscl[0]
 	if !isStage && wscl[0] == 1 {
 		// Screenpacks X coordinates start from left edge of screen
-		startrect0 += float32(sys.gameWidthFloat-320) / 2 * sys.widthScale
+		startrect0 += float32(sys.gameWidth-320) / 2 * sys.widthScale
 	}
 
 	startrect1 := float32(rect[1]) - pos[1]/drawscl/stgscl[1]*bg.windowdelta[1]
@@ -703,7 +703,7 @@ func (bg backGround) draw(pos [2]float32, drawscl, bgscl, stglscl float32,
 		// Choose render origin: top-left for screenpack/storyboard videos, center for everything else
 		var rcx float32
 		if bg._type != BG_Video || isStage {
-			rcx = sys.gameWidthFloat / 2
+			rcx = sys.gameWidth / 2
 		}
 
 		bg.anim.Draw(&rect, x-xsoffset, y, sclx, scly,
@@ -1112,7 +1112,7 @@ func loadStage(def string, maindef bool) (*Stage, error) {
 	} else if s.hires {
 		s.scale[1] *= 2
 	}
-	s.localscl = sys.gameWidthFloat / float32(s.stageCamera.localcoord[0])
+	s.localscl = sys.gameWidth / float32(s.stageCamera.localcoord[0])
 	s.stageCamera.localscl = s.localscl
 	if s.stageCamera.localcoord[0] != 320 {
 		// Update default values to new localcoord. Like characters do

--- a/src/system.go
+++ b/src/system.go
@@ -64,9 +64,7 @@ type SystemStateVars struct {
 	envcol_time int32
 
 	scrrect                 [4]int32
-	gameWidth, gameHeight   int32
-	gameWidthFloat          float32 // Float forms used for precise screenpack math
-	gameHeightFloat         float32 // TODO: rework gameWidth/gameHeight as floats instead
+	gameWidth, gameHeight   float32
 	widthScale, heightScale float32
 	gameEnd, frameSkip      bool
 	paused, frameStepFlag   bool
@@ -356,7 +354,7 @@ type System struct {
 }
 
 type drawAspectState struct {
-	gameWidth, gameHeight   int32
+	gameWidth, gameHeight   float32
 	widthScale, heightScale float32
 }
 
@@ -619,21 +617,17 @@ func (s *System) setGameSize(w, h int32) {
 
 	if screenAspect > targetAspect {
 		// Screen is wider than 4:3 - scale based on height
-		s.gameWidthFloat = float32(baseHeight) * screenAspect
-		s.gameWidth = int32(s.gameWidthFloat)
-		s.gameHeight = baseHeight
-		s.gameHeightFloat = float32(s.gameHeight)
+		s.gameWidth = float32(baseHeight) * screenAspect
+		s.gameHeight = float32(baseHeight)
 	} else {
 		// Screen is taller than 4:3 - scale based on width
-		s.gameWidth = baseWidth
-		s.gameWidthFloat = float32(baseWidth)
-		s.gameHeightFloat = float32(baseWidth) / screenAspect
-		s.gameHeight = int32(s.gameHeightFloat)
+		s.gameWidth = float32(baseWidth)
+		s.gameHeight = float32(baseWidth) / screenAspect
 	}
 
 	// Update scale
-	s.widthScale = float32(s.scrrect[2]) / s.gameWidthFloat
-	s.heightScale = float32(s.scrrect[3]) / s.gameHeightFloat
+	s.widthScale = float32(s.scrrect[2]) / s.gameWidth
+	s.heightScale = float32(s.scrrect[3]) / s.gameHeight
 }
 
 // Change aspect ratio at match start
@@ -669,8 +663,8 @@ func (s *System) applyFightAspect() {
 
 	// Compute new game dimensions while maintaining the same base height
 	gameWidth := baseHeight * aspectGame
-	s.gameWidth = int32(gameWidth)
-	s.gameHeight = int32(baseHeight)
+	s.gameWidth = gameWidth
+	s.gameHeight = baseHeight
 
 	// Scale to fit current screen size
 	s.widthScale = float32(s.scrrect[2]) / float32(s.gameWidth)


### PR DESCRIPTION
After PoTS informed me of cameras breaking on 4:3 stages (I think it was caused by `applyFightAspect` not using gameWidthFloat), I ended up just making gameWidth/gameHeight into floats and converting down to in32 only in places where it was needed (such as creating a window).

Regarding the janky double-conversion of types in camera.go, I found that not keeping the Ceil( breaks the camera in a different way whenever using "Default" on a 4:3 stage.

Test cases with this change seem OK:
<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/9a1ea08d-7838-4b07-b706-d50f0e3dd48e" />
<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/d007c1c5-dbc7-4fc4-b747-cf1ef22b3c7d" />
<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/990e9f57-1b56-42b2-a1db-40066dbe1e67" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/6b5985f9-c6cc-443a-805f-f01095097a36" />

Fixes #3574 