### PR TITLE
fix: delay netplay sync error during Turns swaps

### DIFF
--- a/src/system.go
+++ b/src/system.go
@@ -3623,7 +3623,13 @@ func (s *System) runMatch() (reload bool) {
 		s.esc = true
 	}
 	if s.netConnection != nil {
-		defer s.netConnection.Stop()
+		defer func() {
+			// Keep delay-netplay alive across Turns character swaps;
+			// stopping here can desync nc.time before the next Synchronize().
+			if s.matchOver() || s.esc || s.endMatch || s.gameEnd || s.fightLoopEnd {
+				s.netConnection.Stop()
+			}
+		}()
 	}
 
 	// Setup characters


### PR DESCRIPTION
Do not stop delay netplay while switching to the next Turns character. One player can reach this point a little earlier, and stopping the stream there can make both sides have different nc.time values at the next Synchronize().