### PR TITLE
fix: netplay randomseed issues, coop portrait priority with one slot, netplay co-op versus portrait palettes

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -1,10 +1,39 @@
 main = {}
---nClock = os.clock()
---print("Elapsed time: " .. os.clock() - nClock)
 --;===========================================================
 --; INITIALIZE DATA
 --;===========================================================
-math.randomseed(os.time())
+do
+	local RANDOM_IMAX = 2147483647 -- Go IMax / Park-Miller modulus
+	function math.random(min, max)
+		local r = getRandom()
+		-- math.random() -> float in [0, 1)
+		if min == nil then
+			return r / RANDOM_IMAX
+		end
+		-- math.random(max) -> integer in [1, max]
+		if max == nil then
+			max = min
+			min = 1
+		end
+		min = math.floor(min)
+		max = math.floor(max)
+		if max < min then
+			error("bad argument #2 to 'random' (interval is empty)", 2)
+		end
+		local range = max - min + 1
+		if range <= 0 or range > RANDOM_IMAX then
+			error("bad argument to 'random' (interval is too large)", 2)
+		end
+		-- Match Go Rand(min, max):
+		-- return min + Random() / (IMax / range + 1)
+		return min + math.floor(r / (math.floor(RANDOM_IMAX / range) + 1))
+	end
+	-- Keep deterministic engine RNG authoritative.
+	-- math.randomseed(...) is intentionally ignored because math.random uses getRandom().
+	function math.randomseed(_)
+		-- intentionally ignored
+	end
+end
 
 --;===========================================================
 --; COMMON FUNCTIONS
@@ -808,7 +837,6 @@ function main.f_commandLine()
 			os.exit()
 		end
 		main.f_clearShuffleTables()
-		math.randomseed(getRandom())
 		refresh()
 	end
 	local params = table.concat(t_params, ", ")
@@ -978,9 +1006,7 @@ function main.f_addChar(line, playable, loading, slot)
 			end
 			c = c:gsub('\\', '/')
 			c = tostring(c)
-			--nClock = os.clock()
 			addChar(c, line)
-			--print(c .. ": " .. os.clock() - nClock)
 			if c:lower() == 'skipslot' then
 				main.t_selChars[row].skip = 1
 				playable = false
@@ -1535,7 +1561,6 @@ end
 
 local function enterSyncedNetplayMenu()
 	main.f_clearShuffleTables()
-	math.randomseed(getRandom())
 	main.f_menuSnap(motif[main.group])
 	main.f_menuItemBgAnimReset(motif[main.group])
 	fadeInInit(motif[main.group].fadein.FadeData)
@@ -3127,7 +3152,7 @@ function main.f_getUniquePalette(ch, state)
 		end
 	end
 
-	local pal = available[getRandom() % #available + 1]
+	local pal = available[math.random(#available)]
 	used[pal] = true
 	state.last = {ch = ch, pal = pal}
 	return pal

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -17,6 +17,7 @@ local stageRandom = false
 local stageListNo = 0
 local t_aiRamp = {}
 local t_reservedChars = {{}, {}}
+local t_portraitPriority = {1, 1}
 local timerSelect = 0
 local cursorActive = {}
 local cursorDone = {}
@@ -770,9 +771,10 @@ end
 local function drawPortraitLayer(t_portraits, side, t, subname, last, dataField)
 	local lastIdx = #t_portraits
 	-- "next player replaces previous one" case
-	local paramsSide, params = getParams(side, lastIdx, t, subname)
+	local idx = clamp(t_portraitPriority[side] or 1, 1, lastIdx)
+	local paramsSide, params = getParams(side, idx, t, subname)
 	if paramsSide.num == 1 and last then
-		local v = t_portraits[lastIdx]
+		local v = t_portraits[idx]
 		local data = v[dataField]
 		if not v.skipCurrent and data ~= nil then
 			main.f_animPosDraw(
@@ -1840,6 +1842,7 @@ function start.f_selectReset(hardReset, preserveProgress)
 	t_reservedChars = {{}, {}}
 	cursorActive = {}
 	cursorDone = {}
+	t_portraitPriority = {1, 1}
 	if start.challenger == 0 and not preserveProgress then
 		start.t_roster = {}
 		start.reset = true
@@ -3259,6 +3262,9 @@ function start.f_selectMenu(side, cmd, player, member, selectState)
 				end
 				-- cursor changed position or character change within current slot
 				if start.p[side].t_selTemp[member].cell ~= start.c[player].cell or start.p[side].t_selTemp[member].ref ~= start.c[player].selRef then
+					if start.p[side].t_selTemp[member].cell ~= start.c[player].cell then
+						t_portraitPriority[side] = member
+					end
 					--start.p[side].t_selTemp[member].pal = 1
 					start.p[side].t_selTemp[member].ref = start.c[player].selRef
 					start.p[side].t_selTemp[member].cell = start.c[player].cell

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -1358,13 +1358,13 @@ end
 --shuffles a table in-place (using synced RNG)
 function start.f_shuffleTable(t, last)
 	for i = #t, 2, -1 do
-		local j = (getRandom() % i) + 1
+		local j = math.random(i)
 		t[i], t[j] = t[j], t[i]
 	end
 	-- prevent first element from repeating the last of previous cycle
 	if last and #t > 1 and t[#t] == last then
 		-- swap the first element with a random other position
-		local swap = (getRandom() % (#t - 1)) + 1
+		local swap = math.random(#t - 1)
 		t[#t], t[swap] = t[swap], t[#t]
 	end
 end
@@ -1450,7 +1450,7 @@ function start.f_slotSelected(cell, side, cmd, player, x, y)
 								sndPlay(motif.Snd, motif.select_info['p' .. side].swap.snd[1], motif.select_info['p' .. side].swap.snd[2])
 							end
 						else --select
-							main.t_selGrid[cell].slot = v[(getRandom() % #v) + 1]
+							main.t_selGrid[cell].slot = v[math.random(#v)]
 							start.c[player].selRef = start.f_selGrid(cell).char_ref
 						end
 						start.t_grid[y + 1][x + 1].char = start.f_selGrid(cell).char

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -721,8 +721,7 @@ function start.f_animGet(ref, side, member, params, velParams, loop, srcAnim)
 					animApplyVel(a, srcAnim)
 				end
 				-- Apply palette if needed
-				local sel = start.p[side].t_selected[member]
-				if usePal and not gameMode('netplayteamcoop') then
+				if usePal then
 					local sel = start.p[side].t_selected[member]
 					if sel and sel.ref then
 						a = start.loadPalettes(a, ref, sel.pal)


### PR DESCRIPTION
* Fixes portraits using default colors instead of the palettes chosen on the select screen in netplay modes.
* When coop has only one portrait slot, show the portrait of the player who last moved to a different cell instead of always showing the last player slot. This lets any coop player take portrait priority while browsing characters.
* Fixes https://discord.com/channels/233345562261323776/1104677506428182590/1498476832771801209
