### PR TITLE
fix: Fix explod ignorehitpause bugs

### DIFF
--- a/src/compiler.go
+++ b/src/compiler.go
@@ -7838,7 +7838,7 @@ func (c *Compiler) stateBlock(line *string, bl *StateBlock, root bool,
 				c.token = "helper"
 			}
 			if ok {
-				scname := c.token
+				//scname := c.token
 				c.scan(line)
 				if err := c.needToken("{"); err != nil {
 					return err
@@ -7859,12 +7859,6 @@ func (c *Compiler) stateBlock(line *string, bl *StateBlock, root bool,
 				}
 				if root {
 					if err := c.statementEnd(line); err != nil {
-						return err
-					}
-				}
-				if scname == "explod" || scname == "modifyexplod" {
-					if err := c.paramValue(is, sc, "ignorehitpause",
-						explod_ignorehitpause, VT_Bool, 1, false); err != nil {
 						return err
 					}
 				}

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -1085,8 +1085,9 @@ func (c *Compiler) explod(is IniSection, sc *StateControllerBase,
 		if err := c.explodInterpolate(is, sc); err != nil {
 			return err
 		}
-		if ihp == 0 {
-			sc.add(explod_ignorehitpause, sc.iToExp(0))
+		if err := c.paramValue(is, sc, "ignorehitpause",
+			explod_ignorehitpause, VT_Bool, 1, false); err != nil {
+			return err
 		}
 		return nil
 	})
@@ -1158,8 +1159,9 @@ func (c *Compiler) modifyExplod(is IniSection, sc *StateControllerBase,
 			explod_interpolation, VT_Bool, 1, false); err != nil {
 			return err
 		}
-		if ihp == 0 {
-			sc.add(explod_ignorehitpause, sc.iToExp(0))
+		if err := c.paramValue(is, sc, "ignorehitpause",
+			explod_ignorehitpause, VT_Bool, 1, false); err != nil {
+			return err
 		}
 		return nil
 	})


### PR DESCRIPTION
Using ignorehitpause as a parameter for Explod and ModifyExplod in ZSS was making multiple other parameters not work.