### PR TITLE
feat: helper ownProjectile parameter; fixes; compiler cleanup

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -986,6 +986,7 @@ const (
 	OC_ex3_helpervar_keyctrl
 	OC_ex3_helpervar_ownclsnscale
 	OC_ex3_helpervar_ownpal
+	OC_ex3_helpervar_ownprojectile
 	OC_ex3_helpervar_preserve
 	OC_ex3_spritevar_group
 	OC_ex3_spritevar_height
@@ -4306,7 +4307,7 @@ func (be BytecodeExp) run_ex3(c *Char, i *int, oc *Char) {
 	// HelperVar
 	case OC_ex3_helpervar_clsnproxy, OC_ex3_helpervar_id, OC_ex3_helpervar_helpertype,
 		OC_ex3_helpervar_keyctrl, OC_ex3_helpervar_ownclsnscale, OC_ex3_helpervar_ownpal,
-		OC_ex3_helpervar_preserve:
+		OC_ex3_helpervar_ownprojectile, OC_ex3_helpervar_preserve:
 		// If not a helper, return false immediately
 		if c.helperIndex == 0 {
 			sys.bcStack.Push(BytecodeUndefined())
@@ -4327,6 +4328,8 @@ func (be BytecodeExp) run_ex3(c *Char, i *int, oc *Char) {
 			sys.bcStack.PushB(c.ownclsnscale)
 		case OC_ex3_helpervar_ownpal:
 			sys.bcStack.PushB(c.ownpal)
+		case OC_ex3_helpervar_ownprojectile:
+			sys.bcStack.PushB(c.ownProjectile)
 		case OC_ex3_helpervar_preserve:
 			sys.bcStack.PushB(c.preserve)
 		}
@@ -5529,6 +5532,7 @@ const (
 	helper_preserve
 	helper_standby
 	helper_ownclsnscale
+	helper_ownprojectile
 	helper_redirectid
 )
 
@@ -5649,6 +5653,8 @@ func (sc helper) Run(c *Char, _ []int32) bool {
 			} else {
 				h.unsetSCF(SCF_standby)
 			}
+		case helper_ownprojectile:
+			h.ownProjectile = exp[0].evalB(c)
 		}
 		return true
 	})

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -2337,7 +2337,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 		case OC_teamside:
 			sys.bcStack.PushI(int32(c.teamside) + 1)
 		case OC_time:
-			sys.bcStack.PushI(c.time())
+			sys.bcStack.PushI(c.ss.time)
 		case OC_topedge:
 			sys.bcStack.PushF(c.topEdge() * (c.localscl / oc.localscl))
 		case OC_uniqhitcount:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1907,7 +1907,8 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 		case OC_jmp:
 			be.JumpToNext(&i)
 		case OC_player:
-			if c = sys.playerID(c.getPlayerID(int(sys.bcStack.Pop().ToI()))); c != nil {
+			pn := int(sys.bcStack.Pop().ToI())
+			if c = c.playerTrigger(pn, true); c != nil {
 				// Valid: Move past the length header and enter the block
 				i += 4
 				continue

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -4403,14 +4403,14 @@ func (NullStateController) Run(_ *Char, _ []int32) bool {
 
 var nullStateController NullStateController
 
-type bytecodeFunction struct {
+type BytecodeFunction struct {
 	numVars int32
-	numRets int32
 	numArgs int32
+	numRets int32
 	ctrls   []StateController
 }
 
-func (bf bytecodeFunction) run(c *Char, ret []uint8) (changeState bool) {
+func (bf BytecodeFunction) run(c *Char, ret []uint8) (changeState bool) {
 	oldv, oldvslen := sys.bcVar, len(sys.bcVarStack)
 	sys.bcVar = sys.bcVarStack.Alloc(int(bf.numVars))
 
@@ -4449,14 +4449,15 @@ func (bf bytecodeFunction) run(c *Char, ret []uint8) (changeState bool) {
 	return
 }
 
-type callFunction struct {
-	//bytecodeFunction // Moved to CharGlobalInfo
+type CallFunction struct {
+	//BytecodeFunction // Moved to CharGlobalInfo
 	name string
 	arg  BytecodeExp
 	ret  []uint8
+	numArgs int32
 }
 
-func (cf callFunction) Run(c *Char, _ []int32) (changeState bool) {
+func (cf CallFunction) Run(c *Char, _ []int32) (changeState bool) {
 	// Check if the function exists
 	// We use the functions from whatever player owns the current working state
 	bf, ok := sys.cgi[sys.workingState.playerNo].callFuncs[cf.name]
@@ -4464,6 +4465,19 @@ func (cf callFunction) Run(c *Char, _ []int32) (changeState bool) {
 	// If undefined, treat as no-op and log error
 	if !ok {
 		sys.appendToConsole(c.warn() + "called undefined function: " + cf.name)
+		return false
+	}
+
+	// Runtime argument number validation
+	// Validated on runtime because the compiler can't always know in advance what a function will look like
+	if cf.numArgs != bf.numArgs {
+		sys.appendToConsole(c.warn() + fmt.Sprintf("function %s expected %d arguments but got %d", cf.name, bf.numArgs, cf.numArgs))
+		return false
+	}
+
+	// Runtime return number validation
+	if len(cf.ret) > 0 && int32(len(cf.ret)) != bf.numRets {
+		sys.appendToConsole(c.warn() + fmt.Sprintf("function %s expected %d returns but got %d", cf.name, bf.numRets, len(cf.ret)))
 		return false
 	}
 

--- a/src/char.go
+++ b/src/char.go
@@ -4934,6 +4934,15 @@ func (c *Char) playerIndexTrigger(idx int32) *Char {
 	return ch
 }
 
+func (c *Char) playerTrigger(pn int, log bool) *Char {
+	idx := pn - 1
+	root := sys.getCharRoot(idx)
+	if root == nil && log {
+		sys.appendToConsole(c.warn() + fmt.Sprintf("found no player with number: %v", pn))
+	}
+	return root
+}
+
 // Checks if a player should be considered an enemy at all for the "Enemy" and "P2" triggers, before filtering them further
 func (c *Char) isEnemyOf(e *Char) bool {
 	// Disabled players
@@ -5223,12 +5232,14 @@ func (c *Char) gameWidth() float32 {
 	return c.screenWidth() / sys.cam.Scale
 }
 
+/*
 func (c *Char) getPlayerID(pn int) int32 {
 	if pn >= 1 && pn <= len(sys.chars) && len(sys.chars[pn-1]) > 0 {
 		return sys.chars[pn-1][0].id
 	}
 	return 0
 }
+*/
 
 func (c *Char) runOrderTrigger() int32 {
 	for i, ref := range sys.charList.runOrder {

--- a/src/char.go
+++ b/src/char.go
@@ -6096,10 +6096,6 @@ func (c *Char) changeTagLeader(nextLeaderPN int) {
 	c.updateTeamOrder(team)
 }
 
-func (c *Char) time() int32 {
-	return c.ss.time
-}
-
 func (c *Char) topEdge() float32 {
 	return sys.cam.ScreenPos[1] / c.localscl
 }

--- a/src/char.go
+++ b/src/char.go
@@ -2963,6 +2963,27 @@ type CharGlobalInfo struct {
 	customShaders           []string
 }
 
+func newCharGlobalInfo() CharGlobalInfo {
+	gi := CharGlobalInfo{
+		localcoord:    [2]int32{320, 240},
+		constants:     make(map[string]float32),
+		states:        make(map[int32]StateBytecode),
+		callFuncs:     make(map[string]bytecodeFunction),
+		animTable:     NewAnimationTable(),
+		palInfo:       make(map[int]PalInfo, sys.cfg.Config.PaletteMax),
+		fnt:           make(map[int]*Fnt),
+		quotes:        [MaxQuotes]string{},
+		remapPreset:   make(map[string]RemapPreset),
+		portraitscale: 1,
+	}
+
+	for i := 0; i < sys.cfg.Config.PaletteMax; i++ {
+		gi.palInfo[i] = PalInfo{keyMap: int32(i)}
+	}
+
+	return gi
+}
+
 func (cgi *CharGlobalInfo) clearPCTime() {
 	cgi.pctype = PC_Hit
 	cgi.pctime = -1
@@ -3502,27 +3523,17 @@ func (c *Char) resetModifyPlayer() {
 func (c *Char) load(def string) error {
 	gi := &sys.cgi[c.playerNo]
 
+	// We keep the SFF so that loadSff() can reuse it if the same character is selected/reloaded
+	oldSff := gi.sff
+
 	// Reset global info
+	*gi = newCharGlobalInfo()
+
+	// Restore SFF
+	gi.sff = oldSff
+
+	// Register DEF file
 	gi.def = def
-	gi.displayname, gi.lifebarname, gi.author = "", "", ""
-	gi.defaultDisplayname, gi.defaultLifebarname = "", ""
-	gi.palettedata, gi.snd, gi.quotes = nil, nil, [MaxQuotes]string{}
-	gi.animTable = NewAnimationTable()
-	gi.fnt = make(map[int]*Fnt)
-	gi.portraitscale = 1
-	gi.customShaders = nil
-
-	for i := 0; i < sys.cfg.Config.PaletteMax; i++ {
-		pal := gi.palInfo[i]
-		pal.keyMap = int32(i)
-		gi.palInfo[i] = pal
-	}
-
-	// We don't nil the SFF so that loadSff() can reuse it if the same character is selected/reloaded
-	//gi.sff = nil
-
-	// Default localcoord
-	gi.localcoord = [2]int32{320, 240}
 
 	// Reset DEF file maps
 	c.mapDefault = make(map[string]float32)
@@ -7688,10 +7699,7 @@ func (c *Char) initConstants() {
 		gi.movement.down.friction_threshold *= coordRatio
 	}
 
-	// Init custom constants
-	gi.constants = make(map[string]float32)
-
-	// Init default values to ensure we have these maps
+	// Init the required custom constants with default values
 	gi.constants["default.attack.lifetopowermul"] = 0.7
 	gi.constants["super.attack.lifetopowermul"] = 0
 	gi.constants["default.gethit.lifetopowermul"] = 0.6

--- a/src/char.go
+++ b/src/char.go
@@ -751,7 +751,8 @@ func (hd *HitDef) reset(c *Char, proj *Projectile) {
 		yaccel: 0.35 / originLs,
 		zaccel: 0,
 
-		p1sprpriority:       1,
+		p1sprpriority:       IErr, // 1 in Mugen
+		p2sprpriority:       IErr, // 0 in Mugen
 		p1stateno:           -1,
 		p2stateno:           -1,
 		missonoverride:      -1,
@@ -1007,6 +1008,13 @@ func (hd *HitDef) finalizeParams(c *Char, proj *Projectile) {
 	} else if !hd.isprojectile && (c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0) {
 		c.juggle = hd.air_juggle
 	}
+
+	// Mugen defaults to changing p1 and p2 sprpriority, but you have to work around that more often than not
+	// The new defaults should be harmless or even beneficial, so we won't lock them behind a version check just yet
+	//if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
+	//	ifierrset(&hd.p1sprpriority, 1)
+	//	ifierrset(&hd.p2sprpriority, 0)
+	//}		
 }
 
 // When a Hitdef connects, its statetype attribute will be updated to the character's current type
@@ -10597,10 +10605,12 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 		} else {
 			getter.ghv._type = getter.ghv.groundtype
 		}
-		if !isProjectile {
+		if !isProjectile && hd.p1sprpriority != IErr {
 			c.sprPriority = hd.p1sprpriority
 		}
-		getter.sprPriority = hd.p2sprpriority
+		if hd.p2sprpriority != IErr {
+			getter.sprPriority = hd.p2sprpriority
+		}
 	}
 
 	// Attacker facing

--- a/src/char.go
+++ b/src/char.go
@@ -11604,7 +11604,6 @@ func (c *Char) actionRun() {
 					c.changeState(52, -1, -1, "")
 				}
 			}
-			c.groundLevel = 0 // Reset only after position has been updated
 			c.setFacing(c.p1facing)
 			c.p1facing = 0
 			c.ss.time++
@@ -11612,6 +11611,13 @@ func (c *Char) actionRun() {
 				c.mctime++
 			}
 		}
+
+		// Reset groundLevel only after position has been updated
+		// Must reset even during hitpause
+		// https://github.com/ikemen-engine/Ikemen-GO/issues/3587
+		// TODO: Should it also reset during pauses? Test similar scenarios but with pause instead of hitpause
+		c.groundLevel = 0
+
 		// Commit current animation frame to memory
 		// This frame will be used for hit detection and as reference for Lua scripts (including debug info)
 		if !c.hitPause() || c.asf(ASF_animatehitpause) {

--- a/src/char.go
+++ b/src/char.go
@@ -2970,7 +2970,7 @@ type CharGlobalInfo struct {
 	velocity                CharVelocity
 	movement                CharMovement
 	states                  map[int32]StateBytecode
-	callFuncs               map[string]bytecodeFunction
+	callFuncs               map[string]BytecodeFunction
 	hitPauseToggleFlagCount int32
 	quotes                  [MaxQuotes]string
 	portraitscale           float32
@@ -2993,7 +2993,7 @@ func newCharGlobalInfo() CharGlobalInfo {
 		localcoord:    [2]int32{320, 240},
 		constants:     make(map[string]float32),
 		states:        make(map[int32]StateBytecode),
-		callFuncs:     make(map[string]bytecodeFunction),
+		callFuncs:     make(map[string]BytecodeFunction),
 		animTable:     NewAnimationTable(),
 		palInfo:       make(map[int]PalInfo, sys.cfg.Config.PaletteMax),
 		fnt:           make(map[int]*Fnt),

--- a/src/char.go
+++ b/src/char.go
@@ -5990,13 +5990,9 @@ func (c *Char) updateTeamOrder(team []int) {
 		sys.chars[pno][0].memberNo = i
 	}
 
-	// Update lifebar order within its bounds
+	// Update lifebar order
 	side := c.playerNo & 1
-	for i := range sys.fightScreen.teamOrder[side] {
-		if i < len(team) {
-			sys.fightScreen.teamOrder[side][i] = team[i]
-		}
-	}
+	sys.fightScreen.syncTeamOrder(side)
 }
 
 // Perform a direct order swap between the player and another team member

--- a/src/char.go
+++ b/src/char.go
@@ -1600,7 +1600,7 @@ func (ai *AfterImage) recAndCue(sd *SpriteData, playerNo int, rec bool, hitpause
 type Explod struct {
 	id                  int32
 	playerno            int
-	playerId            int32
+	ownerId             int32
 	time                int32
 	postype             PosType
 	space               Space
@@ -1695,7 +1695,7 @@ func (e *Explod) initFromChar(c *Char) *Explod {
 	*e = Explod{
 		id:                -1,
 		playerno:          c.playerNo,
-		playerId:          c.id,
+		ownerId:           c.id,
 		animPN:            c.playerNo,
 		spritePN:          c.playerNo,
 		layerno:           c.layerNo,
@@ -1841,11 +1841,11 @@ func (e *Explod) setPos(c *Char) {
 }
 
 func (e *Explod) matchId(eid, pid int32) bool {
-	return e.id >= 0 && e.playerId == pid && (eid < 0 || e.id == eid)
+	return e.id >= 0 && e.ownerId == pid && (eid < 0 || e.id == eid)
 }
 
 func (e *Explod) setAnim() {
-	c := sys.playerID(e.playerId)
+	c := sys.playerID(e.ownerId)
 	if c == nil {
 		return
 	}
@@ -1909,7 +1909,7 @@ func (e *Explod) update() {
 		return
 	}
 
-	parent := sys.playerID(e.playerId)
+	parent := sys.playerID(e.ownerId)
 	root := sys.chars[e.playerno][0]
 
 	if root.scf(SCF_disabled) || (e.hideonpausemenu && sys.motif.me.active) {
@@ -2325,6 +2325,7 @@ const (
 
 type Projectile struct {
 	playerno        int
+	ownerId         int32
 	id              int32
 	status          ProjStatus
 	hitdef          HitDef
@@ -2449,6 +2450,13 @@ func (p *Projectile) initFromChar(c *Char) *Projectile {
 		p.projection = Projection_Perspective
 	}
 
+	// Determine ownership
+	if c.canOwnProjectiles() {
+		p.ownerId = c.id
+	} else {
+		p.ownerId = sys.chars[c.playerNo][0].id
+	}
+
 	// Initialize projectile Hitdef. Must be placed after its localscl is determined
 	// https://github.com/ikemen-engine/Ikemen-GO/issues/2087
 	p.hitdef.reset(c, p)
@@ -2510,32 +2518,32 @@ func (p *Projectile) update() {
 					if p.hitanim == -1 {
 						// Forcefully clear instead of reaching the fallback where invalid animation does nothing
 						p.anim = nil
-					} else if a := p.owner().getSelfAnimSprite(p.hitanim, p.hitanim_ffx, true); a != nil {
+					} else if a := p.root().getSelfAnimSprite(p.hitanim, p.hitanim_ffx, true); a != nil {
 						p.anim = a
 					} else {
-						sys.appendToConsole(p.owner().warn() + fmt.Sprintf("projectile with ID %v called invalid action %v%v", p.id, strings.ToUpper(p.hitanim_ffx), p.hitanim))
+						sys.appendToConsole(p.warnChar().warn() + fmt.Sprintf("projectile with ID %v called invalid action %v%v", p.id, strings.ToUpper(p.hitanim_ffx), p.hitanim))
 					}
 				}
 			case ProjCancel:
 				if p.cancelanim != p.animNo || p.cancelanim_ffx != p.anim_ffx {
 					if p.cancelanim == -1 {
 						p.anim = nil
-					} else if a := p.owner().getSelfAnimSprite(p.cancelanim, p.cancelanim_ffx, true); a != nil {
+					} else if a := p.root().getSelfAnimSprite(p.cancelanim, p.cancelanim_ffx, true); a != nil {
 						p.anim = a
 					} else {
-						sys.appendToConsole(p.owner().warn() + fmt.Sprintf("projectile with ID %v called invalid action %v%v", p.id, strings.ToUpper(p.cancelanim_ffx), p.cancelanim))
+						sys.appendToConsole(p.warnChar().warn() + fmt.Sprintf("projectile with ID %v called invalid action %v%v", p.id, strings.ToUpper(p.cancelanim_ffx), p.cancelanim))
 					}
 				}
 			case ProjRem:
 				if p.remanim != p.animNo || p.remanim_ffx != p.anim_ffx {
 					if p.remanim == -1 {
 						p.anim = nil
-					} else if a := p.owner().getSelfAnimSprite(p.remanim, p.remanim_ffx, true); a != nil {
+					} else if a := p.root().getSelfAnimSprite(p.remanim, p.remanim_ffx, true); a != nil {
 						p.anim = a
 					} else {
 						// In Mugen, if remanim is invalid the projectile will keep the current one
 						// https://github.com/ikemen-engine/Ikemen-GO/issues/2584
-						sys.appendToConsole(p.owner().warn() + fmt.Sprintf("projectile with ID %v called invalid action %v%v", p.id, strings.ToUpper(p.remanim_ffx), p.remanim))
+						sys.appendToConsole(p.warnChar().warn() + fmt.Sprintf("projectile with ID %v called invalid action %v%v", p.id, strings.ToUpper(p.remanim_ffx), p.remanim))
 					}
 				}
 			}
@@ -2606,12 +2614,11 @@ func (p *Projectile) update() {
 func (p *Projectile) flagProjCancel() {
 	//p.hits = -2
 	p.status = ProjCancel
-	if p.playerno >= 0 && p.playerno < len(sys.cgi) {
-		if rgi := &sys.cgi[p.playerno]; rgi != nil {
-			rgi.pctype = PC_Cancel
-			rgi.pctime = 0
-			rgi.pcid = p.id
-		}
+	owner := p.owner()
+	if owner != nil {
+		owner.pctype = PC_Cancel
+		owner.pctime = 0
+		owner.pcid = p.id
 	}
 }
 
@@ -2899,8 +2906,20 @@ func (p *Projectile) cueDraw() {
 	}
 }
 
+func (p *Projectile) root() *Char {
+	return sys.chars[p.playerno][0]
+}
+
 func (p *Projectile) owner() *Char {
-	return sys.chars[p.playerno][0] // If this is out of bounds we should crash anyway
+	return sys.playerID(p.ownerId)
+}
+
+// Used to print an error message from the owner if possible, or the root otherwise
+func (p *Projectile) warnChar() *Char {
+	if c := p.owner(); c != nil {
+		return c
+	}
+	return p.root()
 }
 
 type MoveContact int32
@@ -2953,8 +2972,6 @@ type CharGlobalInfo struct {
 	states                  map[int32]StateBytecode
 	callFuncs               map[string]bytecodeFunction
 	hitPauseToggleFlagCount int32
-	pctype                  ProjContact
-	pctime, pcid            int32
 	quotes                  [MaxQuotes]string
 	portraitscale           float32
 	constants               map[string]float32
@@ -2990,12 +3007,6 @@ func newCharGlobalInfo() CharGlobalInfo {
 	}
 
 	return gi
-}
-
-func (cgi *CharGlobalInfo) clearPCTime() {
-	cgi.pctype = PC_Hit
-	cgi.pctime = -1
-	cgi.pcid = 0
 }
 
 // StateState contains the state variables like stateNo, prevStateNo, time, stateType, moveType, and physics of the current state.
@@ -3215,6 +3226,7 @@ type Char struct {
 	platformPosY         float32
 	groundAngle          float32
 	ownpal               bool
+	ownProjectile        bool
 	winquote             int32
 	memberNo             int
 	selectNo             int
@@ -3272,6 +3284,8 @@ type Char struct {
 	shader               string
 	shaderParams         [16]float32
 	shaderTime           int32
+	pctype               ProjContact
+	pctime, pcid         int32
 	//soundChannels        SoundChannels // Moved to system
 }
 
@@ -3370,6 +3384,9 @@ func (c *Char) clearState() {
 	}
 	c.mctype = MC_Hit
 	c.mctime = 0
+	c.pctype = PC_Hit
+	c.pctime = -1
+	c.pcid = 0
 	c.counterHit = false
 	c.hitdefContact = false
 	c.fallTime = 0
@@ -5810,16 +5827,21 @@ func (c *Char) pauseTimeTrigger() int32 {
 	return p
 }
 
+func (c *Char) canOwnProjectiles() bool {
+	return c.helperIndex == 0 || c.ownProjectile
+}
+
 func (c *Char) projTimeTrigger(pid BytecodeValue, match func(ProjContact) bool) BytecodeValue {
 	if pid.IsUndefined() {
 		return BytecodeUndefined()
 	}
-	gi := c.gi()
 	id := pid.ToI()
-	if c.helperIndex > 0 || (id > 0 && id != gi.pcid) || !match(gi.pctype) {
+
+	if !c.canOwnProjectiles() || (id > 0 && id != c.pcid) || !match(c.pctype) {
 		return BytecodeInt(-1)
 	}
-	return BytecodeInt(gi.pctime)
+
+	return BytecodeInt(c.pctime)
 }
 
 func (c *Char) projCancelTime(pid BytecodeValue) BytecodeValue {
@@ -6452,8 +6474,9 @@ func (c *Char) stateChange2() bool {
 		c.ss.sb.init(c)
 		// Flag RemoveOnChangeState explods for removal
 		for i := range sys.explods[c.playerNo] {
-			if sys.explods[c.playerNo][i].playerId == c.id && sys.explods[c.playerNo][i].removeonchangestate {
-				sys.explods[c.playerNo][i].statehaschanged = true
+			e := sys.explods[c.playerNo][i]
+			if e.ownerId == c.id && e.removeonchangestate {
+				e.statehaschanged = true
 			}
 		}
 		// Stop flagged sound channels
@@ -6581,6 +6604,10 @@ func (c *Char) destroySelf(recursive, removeexplods, removetexts bool) bool {
 				child.destroySelf(recursive, removeexplods, removetexts)
 			}
 		}
+	}
+
+	if c.canOwnProjectiles() && c.numProj() > 0 {
+		sys.appendToConsole(c.warn() + "Destroyed while projectiles are active")
 	}
 
 	return true
@@ -7340,7 +7367,7 @@ func (c *Char) commitProjectile(p *Projectile, pt PosType, offx, offy, offz floa
 
 	if p.anim == nil && c.anim != nil {
 		// TODO: If Ikemenversion, the invalid animation probably ought to make the projectile disappear
-		sys.appendToConsole(p.owner().warn() + fmt.Sprintf("projectile with ID %v called invalid action %v%v", p.id, strings.ToUpper(p.anim_ffx), p.animNo))
+		sys.appendToConsole(p.warnChar().warn() + fmt.Sprintf("projectile with ID %v called invalid action %v%v", p.id, strings.ToUpper(p.anim_ffx), p.animNo))
 		// The Mugen fallback is to copy the character's current animation
 		p.anim = &Animation{}
 		*p.anim = *c.anim
@@ -7395,8 +7422,8 @@ func (c *Char) projDrawPal(p *Projectile) [2]int32 {
 
 // Get multiple projectiles for ModifyProjectile, etc
 func (c *Char) getMultipleProjs(id int32, idx int, log bool) (projs []*Projectile) {
-	// Helpers cannot own projectiles
-	if c.helperIndex != 0 {
+	// Fast path for helpers that cannot own projectiles
+	if !c.canOwnProjectiles() {
 		return nil
 	}
 
@@ -7405,6 +7432,10 @@ func (c *Char) getMultipleProjs(id int32, idx int, log bool) (projs []*Projectil
 		// Filter projectiles with the specified ID
 		matchCount := 0
 		for _, p := range sys.projs[c.playerNo] {
+			// Filter by owner ID
+			if p.ownerId != c.id {
+				continue
+			}
 			if (id < 0 || p.id == id) && p.isActive() {
 				if idx >= 0 {
 					// Count the matches but only return one
@@ -11721,8 +11752,8 @@ func (c *Char) actionRun() {
 				}
 			}
 		}
-		if c.helperIndex == 0 && c.gi().pctime >= 0 {
-			c.gi().pctime++
+		if c.canOwnProjectiles() && c.pctime >= 0 {
+			c.pctime++
 		}
 		c.makeDustSpacing++
 	}
@@ -13179,7 +13210,6 @@ func (cl *CharList) hitDetectionProjectile(getter *Char) {
 			continue
 		}
 
-		c := sys.chars[i][0]
 		ap_projhit := false
 
 		// Save root's atktmp var so we can temporarily modify it
@@ -13192,6 +13222,14 @@ func (cl *CharList) hitDetectionProjectile(getter *Char) {
 
 			// Skip if projectile can't hit
 			if p.hits <= 0 {
+				continue
+			}
+
+			c := p.owner()
+
+			// Skip if owner has been destroyed
+			// In this case the projectile still travels and interacts with other projectiles, but can't interact with players
+			if c == nil {
 				continue
 			}
 
@@ -13321,14 +13359,14 @@ func (cl *CharList) hitDetectionProjectile(getter *Char) {
 
 						p.contactflag = true
 						if Abs(hitResult) == 1 {
-							sys.cgi[i].pctype = PC_Hit
+							c.pctype = PC_Hit
 							p.hitpause = Max(0, p.hitdef.pausetime[0]-Btoi(c.gi().mugenver[0] == 0)) // Winmugen projectiles are 1 frame short on hitpauses
 						} else {
-							sys.cgi[i].pctype = PC_Guarded
+							c.pctype = PC_Guarded
 							p.hitpause = Max(0, p.hitdef.guard_pausetime[0]-Btoi(c.gi().mugenver[0] == 0))
 						}
-						sys.cgi[i].pctime = 0
-						sys.cgi[i].pcid = p.id
+						c.pctime = 0
+						c.pcid = p.id
 					}
 					// This flag prevents multiple projectiles from the same player from hitting in the same frame
 					// In Mugen, projectiles (sctrl) give 1F of projectile invincibility to the getter instead. This timer persists during (super)pause

--- a/src/common.go
+++ b/src/common.go
@@ -650,6 +650,18 @@ func LoadFile(file *string, dirs []string, defaultDir string, load func(string) 
 	return nil
 }
 
+// Splits a file path into directory and filename
+// Only used for non-critical operations such as error logging
+func SplitPath(p string) (dir, file string) {
+	// Replace backslashes with forward slashes
+	p = strings.ReplaceAll(p, "\\", "/")
+	// Split at last slash
+	if i := strings.LastIndex(p, "/"); i >= 0 {
+		return p[:i+1], p[i+1:]
+	}
+	return "", p
+}
+
 func StripComment(s string) string {
 	if sc := strings.Index(s, ";"); sc >= 0 {
 		s = s[:sc]

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -8382,5 +8382,7 @@ func (c *StateCompiler) Compile(pn int, def string, constants map[string]float32
 }
 
 func (c *StateCompiler) charWarn() string {
-	return fmt.Sprintf("WARNING: %v's state %v in %v: ", sys.cgi[c.playerNo].name, c.stateNo, c.currentFile)
+	// Trim path to keep message shorter
+    _, file := SplitPath(c.currentFile)
+	return fmt.Sprintf("WARNING: %v's state %v in %v: ", sys.cgi[c.playerNo].name, c.stateNo, file)
 }

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -24,15 +24,13 @@ type StateCompiler struct {
 	scmap            map[string]scFunc
 	block            *StateBlock
 	lines            []string
-	i                int
-	linechan         chan *string
+	i                int // Line index
 	vars             map[string]uint8
 	funcs            map[string]bytecodeFunction
 	funcUsed         map[string]bool
 	stateNo          int32
 	zssMode          bool
-    currentFile      string
-    currentLine      int
+	currentFile      string
 }
 
 func newStateCompiler() *StateCompiler {
@@ -5879,7 +5877,6 @@ func (c *StateCompiler) parseSection(sctrl func(name, data string) error) (IniSe
 	}
 
 	for ; c.i < len(c.lines); c.i++ {
-		c.currentLine = c.i + 1
 		line := strings.TrimSpace(strings.SplitN(c.lines[c.i], ";", 2)[0])
 		if len(line) > 0 && line[0] == '[' {
 			c.i--
@@ -6712,11 +6709,11 @@ func (c *StateCompiler) stateCompileCNS(states map[int32]StateBytecode, filename
 	c.zssMode = false
 
 	// Save filename for logging
-    c.currentFile = filename
+	c.currentFile = filename
 
 	c.lines, c.i = SplitAndTrim(filetext, "\n"), 0
 	errmes := func(err error) error {
-		return Error(fmt.Sprintf("%v:%v:\n%v", filename, c.currentLine, err.Error()))
+		return Error(fmt.Sprintf("%v:%v:\n%v", filename, c.i+1, err.Error()))
 	}
 
 	// Keep a map of states that have already been found in this file
@@ -6725,7 +6722,6 @@ func (c *StateCompiler) stateCompileCNS(states map[int32]StateBytecode, filename
 
 	// Loop through state file lines
 	for ; c.i < len(c.lines); c.i++ {
-		c.currentLine = c.i + 1
 		// Find a statedef, skipping over other lines until finding one
 		// Get the current line, without comments
 		line := strings.ToLower(strings.TrimSpace(
@@ -7031,11 +7027,12 @@ func (c *StateCompiler) wrongClosureToken() error {
 }
 
 func (c *StateCompiler) nextLine() (string, bool) {
-	s := <-c.linechan
-	if s == nil {
+	if c.i >= len(c.lines) {
 		return "", false
 	}
-	return *s, true
+	line := strings.TrimSpace(c.lines[c.i])
+	c.i++
+	return line, true
 }
 
 func (c *StateCompiler) scan(line *string) string {
@@ -7930,7 +7927,7 @@ func (c *StateCompiler) stateCompileZSS(states map[int32]StateBytecode, filename
 	c.zssMode = true
 
 	// Save filename for logging
-    c.currentFile = filename
+	c.currentFile = filename
 
 	// ZSS states are compiled with a lower tolerance for mistakes
 	// TODO: Either merge this with our current c.zssMode checks or drop it
@@ -7941,52 +7938,9 @@ func (c *StateCompiler) stateCompileZSS(states map[int32]StateBytecode, filename
 
 	c.block = nil
 	c.lines, c.i = SplitAndTrim(filetext, "\n"), 0
-	c.linechan = make(chan *string)
-	endchan := make(chan bool, 1)
-
-	// TODO: This is usually a little off because it's retroactively trying to guess the line
-	calculateLine := func() int {
-		if c.linechan == nil {
-			return 0
-		}
-		endchan <- true
-		lineOffset := 1
-		for {
-			if sp := <-c.linechan; sp != nil && *sp == "\n" {
-				close(endchan)
-				close(c.linechan)
-				c.linechan = nil
-				return c.i + lineOffset
-			}
-			lineOffset--
-		}
-	}
-	//defer stop()
-
-	SafeGo(func() {
-		i := c.i
-		for {
-			select {
-			case <-endchan:
-				str := "\n"
-				c.linechan <- &str
-				return
-			default:
-			}
-			var sp *string
-			if i < len(c.lines) {
-				str := strings.TrimSpace(c.lines[i])
-				sp = &str
-				c.i = i
-				i++
-			}
-			c.linechan <- sp
-		}
-	})
 
 	errmes := func(err error) error {
-		c.currentLine = calculateLine()
-		return Error(fmt.Sprintf("%v:%v:\n%v", filename, c.currentLine, err.Error()))
+		return Error(fmt.Sprintf("%v:%v:\n%v", filename, c.i, err.Error())) // No c.i+1 offset here
 	}
 
 	existInThisFile := make(map[int32]bool)
@@ -8389,6 +8343,11 @@ func (c *StateCompiler) Compile(pn int, def string, constants map[string]float32
 
 func (c *StateCompiler) charWarn() string {
 	// Trim path to keep message shorter
-    _, file := SplitPath(c.currentFile)
-	return fmt.Sprintf("WARNING: %v's state %v in %v, line %v: ", sys.cgi[c.playerNo].name, c.stateNo, file, c.currentLine)
+	_, file := SplitPath(c.currentFile)
+	// c.i acts a bit different between CNS and ZSS
+	offset := 1
+	if c.zssMode {
+		offset = 0
+	}
+	return fmt.Sprintf("WARNING: %v's state %v in %v, line %v: ", sys.cgi[c.playerNo].name, c.stateNo, file, c.i+offset)
 }

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -12,7 +12,7 @@ const specialSymbols = " !=<>()|&+-*/%,[]^:;{}#\"\t\r\n"
 
 type expFunc func(out *BytecodeExp, in *string) (BytecodeValue, error)
 
-type scFunc func(is IniSection, sc *StateControllerBase, ihp int8) (StateController, error)
+type scFunc func(is IniSection, sc *StateControllerBase) (StateController, error)
 
 type StateCompiler struct {
 	cmdl             *CommandList
@@ -5803,7 +5803,7 @@ func parseTriggerNumber(name string) (tn int32, isAll bool, ok bool) {
 	return tn, false, true
 }
 
-func (c *StateCompiler) parseSection(sctrl func(name, data string) error) (IniSection, bool, error) {
+func (c *StateCompiler) parseSection(sctrl func(name, data string) error) (IniSection, error) {
 	is := NewIniSection()
 	var _type, persistent, ignorehitpause bool
 
@@ -5903,7 +5903,7 @@ func (c *StateCompiler) parseSection(sctrl func(name, data string) error) (IniSe
 					if sys.ignoreMostErrors {
 						continue
 					}
-					return nil, false, Error("Invalid parameter syntax: " + line)
+					return nil, Error("Invalid parameter syntax: " + line)
 				}
 			}
 
@@ -5915,7 +5915,7 @@ func (c *StateCompiler) parseSection(sctrl func(name, data string) error) (IniSe
 						if sys.ignoreMostErrors {
 							continue
 						}
-						return nil, false, Error("Invalid parameter syntax: " + line)
+						return nil, Error("Invalid parameter syntax: " + line)
 					}
 					name = strings.ToLower(lhs)
 				} else {
@@ -5932,7 +5932,7 @@ func (c *StateCompiler) parseSection(sctrl func(name, data string) error) (IniSe
 
 			// Reject empty triggers
 			if isTrigger && len(data) == 0 {
-				return nil, false, Error(name + " cannot be empty")
+				return nil, Error(name + " cannot be empty")
 			}
 
 			// Reject duplicate parameters (normally off)
@@ -5943,7 +5943,7 @@ func (c *StateCompiler) parseSection(sctrl func(name, data string) error) (IniSe
 					LogMessage(c.charWarn() + fmt.Sprintf("Duplicate '%s' parameter", name))
 					continue
 				}
-				return nil, false, Error(name + " is duplicated")
+				return nil, Error(name + " is duplicated")
 			}
 
 			if sctrl != nil {
@@ -5955,7 +5955,7 @@ func (c *StateCompiler) parseSection(sctrl func(name, data string) error) (IniSe
 							LogMessage(c.charWarn() + "Duplicate 'type' parameter")
 							continue
 						}
-						return nil, false, Error("type is duplicated")
+						return nil, Error("type is duplicated")
 					}
 					// Flag as found
 					_type = true
@@ -5965,7 +5965,7 @@ func (c *StateCompiler) parseSection(sctrl func(name, data string) error) (IniSe
 							LogMessage(c.charWarn() + "Duplicate 'persistent' parameter")
 							continue
 						}
-						return nil, false, Error("persistent is duplicated")
+						return nil, Error("persistent is duplicated")
 					}
 					persistent = true
 				case "ignorehitpause":
@@ -5974,7 +5974,7 @@ func (c *StateCompiler) parseSection(sctrl func(name, data string) error) (IniSe
 							LogMessage(c.charWarn() + "Duplicate 'ignorehitpause' parameter")
 							continue
 						}
-						return nil, false, Error("ignorehitpause is duplicated")
+						return nil, Error("ignorehitpause is duplicated")
 					}
 					ignorehitpause = true
 				default:
@@ -5984,14 +5984,14 @@ func (c *StateCompiler) parseSection(sctrl func(name, data string) error) (IniSe
 					}
 				}
 				if err := sctrl(name, data); err != nil {
-					return nil, false, err
+					return nil, err
 				}
 			} else {
 				is[name] = data
 			}
 		}
 	}
-	return is, ignorehitpause, nil
+	return is, nil
 }
 
 func (c *StateCompiler) stateSec(is IniSection, f func() error) error {
@@ -6749,7 +6749,7 @@ func (c *StateCompiler) stateCompileCNS(states map[int32]StateBytecode, filename
 
 		c.i++
 		// Parse the statedef properties
-		is, _, err := c.parseSection(nil)
+		is, err := c.parseSection(nil)
 		if err != nil {
 			return errmes(err)
 		}
@@ -6790,7 +6790,7 @@ func (c *StateCompiler) stateCompileCNS(states map[int32]StateBytecode, filename
 			allTerminated := false
 
 			// Parse each line of the sctrl to get triggers and settings
-			is, ihpFound, err := c.parseSection(func(name, data string) error {
+			is, err := c.parseSection(func(name, data string) error {
 				switch name {
 				case "type":
 					var ok bool
@@ -6967,14 +6967,8 @@ func (c *StateCompiler) stateCompileCNS(states map[int32]StateBytecode, filename
 			}
 			c.block.trigger = texp
 
-			// Ignorehitpause
-			ihp := int8(-1)
-			if ihpFound {
-				ihp = int8(Btoi(c.block.ignorehitpause >= -1))
-			}
-
 			// For this sctrl type, call the function to construct the sctrl
-			sctrl, err := scf(is, sc, ihp)
+			sctrl, err := scf(is, sc)
 			if err != nil {
 				return errmes(err)
 			}
@@ -7882,7 +7876,7 @@ func (c *StateCompiler) stateBlock(line *string, bl *StateBlock, root bool,
 						return err
 					}
 				}
-				if sctrl, err := scf(is, sc, -1); err != nil {
+				if sctrl, err := scf(is, sc); err != nil {
 					return err
 				} else {
 					*ctrls = append(*ctrls, sctrl)

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -14,7 +14,7 @@ type expFunc func(out *BytecodeExp, in *string) (BytecodeValue, error)
 
 type scFunc func(is IniSection, sc *StateControllerBase, ihp int8) (StateController, error)
 
-type Compiler struct {
+type StateCompiler struct {
 	cmdl             *CommandList
 	previousOperator string
 	reverseOrder     bool
@@ -31,10 +31,11 @@ type Compiler struct {
 	funcUsed         map[string]bool
 	stateNo          int32
 	zssMode          bool
+    currentFile      string
 }
 
-func newCompiler() *Compiler {
-	c := &Compiler{funcs: make(map[string]bytecodeFunction)}
+func newStateCompiler() *StateCompiler {
+	c := &StateCompiler{funcs: make(map[string]bytecodeFunction)}
 	c.scmap = map[string]scFunc{
 		// Mugen state controllers
 		"afterimage":         c.afterImage,
@@ -482,12 +483,12 @@ var triggerMap = map[string]int{
 	"zoomvar":            1,
 }
 
-func (c *Compiler) tokenizer(in *string) string {
+func (c *StateCompiler) tokenizer(in *string) string {
 	return strings.ToLower(c.tokenizerCS(in))
 }
 
 // Same but case-sensitive
-func (*Compiler) tokenizerCS(in *string) string {
+func (*StateCompiler) tokenizerCS(in *string) string {
 	*in = strings.TrimSpace(*in)
 	if len(*in) == 0 {
 		return ""
@@ -626,7 +627,7 @@ func (*Compiler) tokenizerCS(in *string) string {
 	return token
 }
 
-func (*Compiler) isOperator(token string) int {
+func (*StateCompiler) isOperator(token string) int {
 	switch token {
 	case "", ",", ")", "]":
 		return -1
@@ -656,7 +657,7 @@ func (*Compiler) isOperator(token string) int {
 	return 0
 }
 
-func (c *Compiler) operator(in *string) error {
+func (c *StateCompiler) operator(in *string) error {
 	if len(c.previousOperator) > 0 {
 		if opp := c.isOperator(c.token); opp <= c.isOperator(c.previousOperator) {
 			if opp < 0 || ((!c.reverseOrder || c.token[0] != '(') &&
@@ -673,7 +674,7 @@ func (c *Compiler) operator(in *string) error {
 	return nil
 }
 
-func (c *Compiler) integer2(in *string) (int32, error) {
+func (c *StateCompiler) integer2(in *string) (int32, error) {
 	istr := c.token
 	c.token = c.tokenizer(in)
 	minus := istr == "-"
@@ -693,7 +694,7 @@ func (c *Compiler) integer2(in *string) (int32, error) {
 	return i, nil
 }
 
-func (c *Compiler) number(token string) BytecodeValue {
+func (c *StateCompiler) number(token string) BytecodeValue {
 	f, err := strconv.ParseFloat(token, 64)
 	if err != nil && f == 0 {
 		return bvNone()
@@ -715,7 +716,7 @@ func (c *Compiler) number(token string) BytecodeValue {
 	return BytecodeValue{VT_Int, f}
 }
 
-func (c *Compiler) attr(text string, hitdef bool) (int32, error) {
+func (c *StateCompiler) attr(text string, hitdef bool) (int32, error) {
 	flg := int32(0)
 	att := SplitAndTrim(text, ",")
 	for _, a := range att[0] {
@@ -806,7 +807,7 @@ func (c *Compiler) attr(text string, hitdef bool) (int32, error) {
 	return flg, nil
 }
 
-func (c *Compiler) trgAttr(in *string) (int32, error) {
+func (c *StateCompiler) trgAttr(in *string) (int32, error) {
 	flg := int32(0)
 	*in = c.token + *in
 	i := strings.IndexAny(*in, specialSymbols)
@@ -881,7 +882,7 @@ func (c *Compiler) trgAttr(in *string) (int32, error) {
 	return flg, nil
 }
 
-func (c *Compiler) checkOpeningParenthesis(in *string) error {
+func (c *StateCompiler) checkOpeningParenthesis(in *string) error {
 	if c.tokenizer(in) != "(" {
 		return Error("Missing '(' after " + c.token)
 	}
@@ -890,7 +891,7 @@ func (c *Compiler) checkOpeningParenthesis(in *string) error {
 }
 
 // Same but case-sensitive
-func (c *Compiler) checkOpeningParenthesisCS(in *string) error {
+func (c *StateCompiler) checkOpeningParenthesisCS(in *string) error {
 	if c.tokenizerCS(in) != "(" {
 		return Error("Missing '(' after " + c.token)
 	}
@@ -898,7 +899,7 @@ func (c *Compiler) checkOpeningParenthesisCS(in *string) error {
 	return nil
 }
 
-func (c *Compiler) checkClosingParenthesis() error {
+func (c *StateCompiler) checkClosingParenthesis() error {
 	c.reverseOrder = true
 	if c.token != ")" {
 		return Error("Missing ')' before " + c.token)
@@ -906,7 +907,7 @@ func (c *Compiler) checkClosingParenthesis() error {
 	return nil
 }
 
-func (c *Compiler) checkEquality(in *string) (not bool, err error) {
+func (c *StateCompiler) checkEquality(in *string) (not bool, err error) {
 	for {
 		c.token = c.tokenizer(in)
 		if len(c.token) > 0 {
@@ -928,7 +929,7 @@ func (c *Compiler) checkEquality(in *string) (not bool, err error) {
 	return
 }
 
-func (c *Compiler) intRange(in *string) (minop OpCode, maxop OpCode, min, max int32, err error) {
+func (c *StateCompiler) intRange(in *string) (minop OpCode, maxop OpCode, min, max int32, err error) {
 	switch c.token {
 	case "(":
 		minop = OC_gt
@@ -998,7 +999,7 @@ func (c *Compiler) intRange(in *string) (minop OpCode, maxop OpCode, min, max in
 	return
 }
 
-func (c *Compiler) compareValues(_range bool, in *string) {
+func (c *StateCompiler) compareValues(_range bool, in *string) {
 	if sys.ignoreMostErrors {
 		i := 0
 		for ; i < len(*in); i++ {
@@ -1012,7 +1013,7 @@ func (c *Compiler) compareValues(_range bool, in *string) {
 	c.token = c.tokenizer(in)
 }
 
-func (c *Compiler) evaluateComparison(out *BytecodeExp, in *string,
+func (c *StateCompiler) evaluateComparison(out *BytecodeExp, in *string,
 	required bool) error {
 	comma := c.token == ","
 	if comma {
@@ -1096,7 +1097,7 @@ func (c *Compiler) evaluateComparison(out *BytecodeExp, in *string,
 	return nil
 }
 
-func (c *Compiler) oneArg(out *BytecodeExp, in *string,
+func (c *StateCompiler) oneArg(out *BytecodeExp, in *string,
 	rd, appendVal bool, defval ...BytecodeValue) (BytecodeValue, error) {
 	var be BytecodeExp
 	var bv BytecodeValue
@@ -1130,7 +1131,7 @@ func (c *Compiler) oneArg(out *BytecodeExp, in *string,
 
 // Read with two optional arguments
 // Currently only for IsHelper
-func (c *Compiler) twoOptArg(out *BytecodeExp, in *string,
+func (c *StateCompiler) twoOptArg(out *BytecodeExp, in *string,
 	rd, appendVal bool, defval ...BytecodeValue) (BytecodeValue, BytecodeValue, error) {
 
 	var be BytecodeExp
@@ -1188,7 +1189,7 @@ func (c *Compiler) twoOptArg(out *BytecodeExp, in *string,
 	return bv1, bv2, nil
 }
 
-func (c *Compiler) mathFunc(out *BytecodeExp, in *string, rd bool,
+func (c *StateCompiler) mathFunc(out *BytecodeExp, in *string, rd bool,
 	oc OpCode, f func(*BytecodeValue)) (bv BytecodeValue, err error) {
 	var be BytecodeExp
 	if bv, err = c.oneArg(&be, in, false, false); err != nil {
@@ -1206,7 +1207,7 @@ func (c *Compiler) mathFunc(out *BytecodeExp, in *string, rd bool,
 	return
 }
 
-func (c *Compiler) readOldProjectileID(in *string, trname string, baseLen int, out *BytecodeExp) (string, error) {
+func (c *StateCompiler) readOldProjectileID(in *string, trname string, baseLen int, out *BytecodeExp) (string, error) {
 	base := trname[:baseLen]
 	suffix := trname[baseLen:]
 
@@ -1251,7 +1252,7 @@ func (c *Compiler) readOldProjectileID(in *string, trname string, baseLen int, o
 }
 
 // For the first half of "x = y, > z" legacy triggers
-func (c *Compiler) parseOldAnimElemStyle(in *string, name string) (int32, error) {
+func (c *StateCompiler) parseOldAnimElemStyle(in *string, name string) (int32, error) {
 	if not, err := c.checkEquality(in); err != nil {
 		return 0, err
 	} else if not && !sys.ignoreMostErrors {
@@ -1269,7 +1270,7 @@ func (c *Compiler) parseOldAnimElemStyle(in *string, name string) (int32, error)
 }
 
 // rd means Redirect
-func (c *Compiler) expValue(out *BytecodeExp, in *string,
+func (c *StateCompiler) expValue(out *BytecodeExp, in *string,
 	rd bool) (BytecodeValue, error) {
 	c.reverseOrder, c.norange = true, false
 	bv := c.number(c.token)
@@ -5277,7 +5278,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 	return bv, nil
 }
 
-func (c *Compiler) contiguousOperator(in *string) error {
+func (c *StateCompiler) contiguousOperator(in *string) error {
 	*in = strings.TrimSpace(*in)
 	if len(*in) > 0 {
 		switch (*in)[0] {
@@ -5293,7 +5294,7 @@ func (c *Compiler) contiguousOperator(in *string) error {
 	return nil
 }
 
-func (c *Compiler) expPostNot(out *BytecodeExp, in *string) (BytecodeValue, error) {
+func (c *StateCompiler) expPostNot(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	bv, err := c.expValue(out, in, false)
 	if err != nil {
 		return bvNone(), err
@@ -5343,7 +5344,7 @@ func (c *Compiler) expPostNot(out *BytecodeExp, in *string) (BytecodeValue, erro
 	return bv, nil
 }
 
-func (c *Compiler) expPow(out *BytecodeExp, in *string) (BytecodeValue, error) {
+func (c *StateCompiler) expPow(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	bv, err := c.expPostNot(out, in)
 	if err != nil {
 		return bvNone(), err
@@ -5375,7 +5376,7 @@ func (c *Compiler) expPow(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	return bv, nil
 }
 
-func (c *Compiler) expMldv(out *BytecodeExp, in *string) (BytecodeValue, error) {
+func (c *StateCompiler) expMldv(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	bv, err := c.expPow(out, in)
 	if err != nil {
 		return bvNone(), err
@@ -5403,7 +5404,7 @@ func (c *Compiler) expMldv(out *BytecodeExp, in *string) (BytecodeValue, error) 
 	}
 }
 
-func (c *Compiler) expAdsb(out *BytecodeExp, in *string) (BytecodeValue, error) {
+func (c *StateCompiler) expAdsb(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	bv, err := c.expMldv(out, in)
 	if err != nil {
 		return bvNone(), err
@@ -5428,7 +5429,7 @@ func (c *Compiler) expAdsb(out *BytecodeExp, in *string) (BytecodeValue, error) 
 	}
 }
 
-func (c *Compiler) expGrls(out *BytecodeExp, in *string) (BytecodeValue, error) {
+func (c *StateCompiler) expGrls(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	bv, err := c.expAdsb(out, in)
 	if err != nil {
 		return bvNone(), err
@@ -5459,7 +5460,7 @@ func (c *Compiler) expGrls(out *BytecodeExp, in *string) (BytecodeValue, error) 
 	}
 }
 
-func (c *Compiler) expRange(out *BytecodeExp, in *string,
+func (c *StateCompiler) expRange(out *BytecodeExp, in *string,
 	bv *BytecodeValue, opc OpCode) (bool, error) {
 	open := c.token
 	oldin := *in
@@ -5549,7 +5550,7 @@ func (c *Compiler) expRange(out *BytecodeExp, in *string,
 	return true, nil
 }
 
-func (c *Compiler) expEqne(out *BytecodeExp, in *string) (BytecodeValue, error) {
+func (c *StateCompiler) expEqne(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	bv, err := c.expGrls(out, in)
 	if err != nil {
 		return bvNone(), err
@@ -5592,7 +5593,7 @@ func (c *Compiler) expEqne(out *BytecodeExp, in *string) (BytecodeValue, error) 
 	}
 }
 
-func (*Compiler) expOneOpSub(out *BytecodeExp, in *string, bv *BytecodeValue,
+func (*StateCompiler) expOneOpSub(out *BytecodeExp, in *string, bv *BytecodeValue,
 	ef expFunc, opf func(v1 *BytecodeValue, v2 BytecodeValue),
 	opc OpCode) error {
 	var be BytecodeExp
@@ -5612,7 +5613,7 @@ func (*Compiler) expOneOpSub(out *BytecodeExp, in *string, bv *BytecodeValue,
 	return nil
 }
 
-func (c *Compiler) expOneOp(out *BytecodeExp, in *string, ef expFunc,
+func (c *StateCompiler) expOneOp(out *BytecodeExp, in *string, ef expFunc,
 	opt string, opf func(v1 *BytecodeValue, v2 BytecodeValue),
 	opc OpCode) (BytecodeValue, error) {
 	bv, err := ef(out, in)
@@ -5634,19 +5635,19 @@ func (c *Compiler) expOneOp(out *BytecodeExp, in *string, ef expFunc,
 	}
 }
 
-func (c *Compiler) expAnd(out *BytecodeExp, in *string) (BytecodeValue, error) {
+func (c *StateCompiler) expAnd(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	return c.expOneOp(out, in, c.expEqne, "&", out.and, OC_and)
 }
 
-func (c *Compiler) expXor(out *BytecodeExp, in *string) (BytecodeValue, error) {
+func (c *StateCompiler) expXor(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	return c.expOneOp(out, in, c.expAnd, "^", out.xor, OC_xor)
 }
 
-func (c *Compiler) expOr(out *BytecodeExp, in *string) (BytecodeValue, error) {
+func (c *StateCompiler) expOr(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	return c.expOneOp(out, in, c.expXor, "|", out.or, OC_or)
 }
 
-func (c *Compiler) expBoolAnd(out *BytecodeExp, in *string) (BytecodeValue, error) {
+func (c *StateCompiler) expBoolAnd(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	if c.block != nil {
 		return c.expOneOp(out, in, c.expOr, "&&", out.bland, OC_bland)
 	}
@@ -5686,11 +5687,11 @@ func (c *Compiler) expBoolAnd(out *BytecodeExp, in *string) (BytecodeValue, erro
 	return bv, nil
 }
 
-func (c *Compiler) expBoolXor(out *BytecodeExp, in *string) (BytecodeValue, error) {
+func (c *StateCompiler) expBoolXor(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	return c.expOneOp(out, in, c.expBoolAnd, "^^", out.blxor, OC_blxor)
 }
 
-func (c *Compiler) expBoolOr(out *BytecodeExp, in *string) (BytecodeValue, error) {
+func (c *StateCompiler) expBoolOr(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	defer func(omp string) { c.previousOperator = omp }(c.previousOperator)
 	if c.block != nil {
 		return c.expOneOp(out, in, c.expBoolXor, "||", out.blor, OC_blor)
@@ -5731,7 +5732,7 @@ func (c *Compiler) expBoolOr(out *BytecodeExp, in *string) (BytecodeValue, error
 	return bv, nil
 }
 
-func (c *Compiler) typedExp(ef expFunc, in *string,
+func (c *StateCompiler) typedExp(ef expFunc, in *string,
 	vt ValueType) (BytecodeExp, error) {
 	c.token = c.tokenizer(in)
 	var be BytecodeExp
@@ -5753,7 +5754,7 @@ func (c *Compiler) typedExp(ef expFunc, in *string,
 	return be, nil
 }
 
-func (c *Compiler) argExpression(in *string, vt ValueType) (BytecodeExp, error) {
+func (c *StateCompiler) argExpression(in *string, vt ValueType) (BytecodeExp, error) {
 	be, err := c.typedExp(c.expBoolOr, in, vt)
 	if err != nil {
 		return nil, err
@@ -5772,7 +5773,7 @@ func (c *Compiler) argExpression(in *string, vt ValueType) (BytecodeExp, error) 
 	return be, nil
 }
 
-func (c *Compiler) fullExpression(in *string, vt ValueType) (BytecodeExp, error) {
+func (c *StateCompiler) fullExpression(in *string, vt ValueType) (BytecodeExp, error) {
 	be, err := c.typedExp(c.expBoolOr, in, vt)
 	if err != nil {
 		return nil, err
@@ -5801,7 +5802,7 @@ func parseTriggerNumber(name string) (tn int32, isAll bool, ok bool) {
 	return tn, false, true
 }
 
-func (c *Compiler) parseSection(sctrl func(name, data string) error) (IniSection, bool, error) {
+func (c *StateCompiler) parseSection(sctrl func(name, data string) error) (IniSection, bool, error) {
 	is := NewIniSection()
 	var _type, persistent, ignorehitpause bool
 
@@ -5992,7 +5993,7 @@ func (c *Compiler) parseSection(sctrl func(name, data string) error) (IniSection
 	return is, ignorehitpause, nil
 }
 
-func (c *Compiler) stateSec(is IniSection, f func() error) error {
+func (c *StateCompiler) stateSec(is IniSection, f func() error) error {
 	if err := f(); err != nil {
 		return err
 	}
@@ -6011,7 +6012,7 @@ func (c *Compiler) stateSec(is IniSection, f func() error) error {
 	return nil
 }
 
-func (c *Compiler) stateParam(is IniSection, name string, mandatory bool, f func(string) error) error {
+func (c *StateCompiler) stateParam(is IniSection, name string, mandatory bool, f func(string) error) error {
 	data, ok := is[name]
 	if ok {
 		if err := f(data); err != nil {
@@ -6025,7 +6026,7 @@ func (c *Compiler) stateParam(is IniSection, name string, mandatory bool, f func
 }
 
 // Returns FX prefix from a data string while removing prefix from the data
-func (c *Compiler) getDataPrefix(data *string, ffxDefault bool) (prefix string) {
+func (c *StateCompiler) getDataPrefix(data *string, ffxDefault bool) (prefix string) {
 	if len(*data) > 1 {
 		str := strings.ToLower(*data)
 
@@ -6077,7 +6078,7 @@ func (c *Compiler) getDataPrefix(data *string, ffxDefault bool) (prefix string) 
 	return
 }
 
-func (c *Compiler) exprs(data string, vt ValueType,
+func (c *StateCompiler) exprs(data string, vt ValueType,
 	numArg int) ([]BytecodeExp, error) {
 	bes := []BytecodeExp{}
 	for n := 1; n <= numArg; n++ {
@@ -6099,7 +6100,7 @@ func (c *Compiler) exprs(data string, vt ValueType,
 	return bes, nil
 }
 
-func (c *Compiler) scAdd(sc *StateControllerBase, id byte,
+func (c *StateCompiler) scAdd(sc *StateControllerBase, id byte,
 	data string, vt ValueType, numArg int, topbe ...BytecodeExp) error {
 	bes, err := c.exprs(data, vt, numArg)
 	if err != nil {
@@ -6110,7 +6111,7 @@ func (c *Compiler) scAdd(sc *StateControllerBase, id byte,
 }
 
 // ParamValue adds the parameter immediately, unlike StateParam which only reads it
-func (c *Compiler) paramValue(is IniSection, sc *StateControllerBase,
+func (c *StateCompiler) paramValue(is IniSection, sc *StateControllerBase,
 	paramname string, id byte, vt ValueType, numArg int, mandatory bool) error {
 	found := false
 	if err := c.stateParam(is, paramname, false, func(data string) error {
@@ -6130,7 +6131,7 @@ func (c *Compiler) paramValue(is IniSection, sc *StateControllerBase,
 	return nil
 }
 
-func (c *Compiler) paramAnimtype(is IniSection, sc *StateControllerBase, paramName string, id byte) error {
+func (c *StateCompiler) paramAnimtype(is IniSection, sc *StateControllerBase, paramName string, id byte) error {
 	return c.stateParam(is, paramName, false, func(data string) error {
 		if len(data) == 0 {
 			return Error(paramName + " not specified")
@@ -6182,7 +6183,7 @@ func (c *Compiler) paramAnimtype(is IniSection, sc *StateControllerBase, paramNa
 	})
 }
 
-func (c *Compiler) paramHittype(is IniSection, sc *StateControllerBase, paramName string, id byte) error {
+func (c *StateCompiler) paramHittype(is IniSection, sc *StateControllerBase, paramName string, id byte) error {
 	return c.stateParam(is, paramName, false, func(data string) error {
 		if len(data) == 0 {
 			return Error(paramName + " not specified")
@@ -6224,7 +6225,7 @@ func (c *Compiler) paramHittype(is IniSection, sc *StateControllerBase, paramNam
 	})
 }
 
-func (c *Compiler) paramPostype(is IniSection, sc *StateControllerBase, id byte) error {
+func (c *StateCompiler) paramPostype(is IniSection, sc *StateControllerBase, id byte) error {
 	return c.stateParam(is, "postype", false, func(data string) error {
 		if len(data) == 0 {
 			return Error("postype not specified")
@@ -6280,7 +6281,7 @@ func (c *Compiler) paramPostype(is IniSection, sc *StateControllerBase, id byte)
 	})
 }
 
-func (c *Compiler) paramSpace(is IniSection, sc *StateControllerBase, id byte) error {
+func (c *StateCompiler) paramSpace(is IniSection, sc *StateControllerBase, id byte) error {
 	return c.stateParam(is, "space", false, func(data string) error {
 		if len(data) == 0 {
 			return Error("space not specified")
@@ -6304,7 +6305,7 @@ func (c *Compiler) paramSpace(is IniSection, sc *StateControllerBase, id byte) e
 	})
 }
 
-func (c *Compiler) paramProjection(is IniSection, sc *StateControllerBase, key string, id byte) error {
+func (c *StateCompiler) paramProjection(is IniSection, sc *StateControllerBase, key string, id byte) error {
 	return c.stateParam(is, key, false, func(data string) error {
 		var proj Projection
 
@@ -6324,7 +6325,7 @@ func (c *Compiler) paramProjection(is IniSection, sc *StateControllerBase, key s
 	})
 }
 
-func (c *Compiler) paramSaveData(is IniSection, sc *StateControllerBase, id byte) error {
+func (c *StateCompiler) paramSaveData(is IniSection, sc *StateControllerBase, id byte) error {
 	return c.stateParam(is, "savedata", false, func(data string) error {
 		if len(data) <= 1 {
 			return Error("savedata not specified")
@@ -6346,7 +6347,7 @@ func (c *Compiler) paramSaveData(is IniSection, sc *StateControllerBase, id byte
 }
 
 // Parse trans and alpha together
-func (c *Compiler) paramTrans(is IniSection, sc *StateControllerBase, prefix string, id byte) error {
+func (c *StateCompiler) paramTrans(is IniSection, sc *StateControllerBase, prefix string, id byte) error {
 	// Check if we have both trans and alpha parameters
 	_, alphaExists := is[prefix+"alpha"]
 	_, transExists := is[prefix+"trans"]
@@ -6458,7 +6459,7 @@ func (c *Compiler) paramTrans(is IniSection, sc *StateControllerBase, prefix str
 	})
 }
 
-func (c *Compiler) paramClsnType(is IniSection, sc *StateControllerBase, paramName string, id byte) error {
+func (c *StateCompiler) paramClsnType(is IniSection, sc *StateControllerBase, paramName string, id byte) error {
 	return c.stateParam(is, paramName, false, func(data string) error {
 		if len(data) == 0 {
 			return Error("Clsn type not specified for " + paramName)
@@ -6482,7 +6483,7 @@ func (c *Compiler) paramClsnType(is IniSection, sc *StateControllerBase, paramNa
 }
 
 // Interprets an IniSection of statedef properties and sets them to a StateBytecode
-func (c *Compiler) stateDef(is IniSection, sbc *StateBytecode) error {
+func (c *StateCompiler) stateDef(is IniSection, sbc *StateBytecode) error {
 	return c.stateSec(is, func() error {
 		sc := newStateControllerBase()
 		if err := c.stateParam(is, "type", false, func(data string) error {
@@ -6658,7 +6659,7 @@ func cnsStringArray(arg string) ([]string, error) {
 }
 
 // Forwards state compiling to CNS or ZSS branches as appropriate
-func (c *Compiler) stateCompile(states map[int32]StateBytecode,
+func (c *StateCompiler) stateCompile(states map[int32]StateBytecode,
 	filename string, dirs []string, negoverride bool, constants map[string]float32) error {
 
 	// Determine type from extension
@@ -6704,9 +6705,12 @@ func (c *Compiler) stateCompile(states map[int32]StateBytecode,
 	return c.stateCompileCNS(states, filename, filetext, negoverride, constants)
 }
 
-func (c *Compiler) stateCompileCNS(states map[int32]StateBytecode, filename, filetext string, negoverride bool, constants map[string]float32) error {
+func (c *StateCompiler) stateCompileCNS(states map[int32]StateBytecode, filename, filetext string, negoverride bool, constants map[string]float32) error {
 	// Reset ZSS mode
 	c.zssMode = false
+
+	// Save filename for logging
+    c.currentFile = filename
 
 	c.lines, c.i = SplitAndTrim(filetext, "\n"), 0
 	errmes := func(err error) error {
@@ -7016,14 +7020,14 @@ func (c *Compiler) stateCompileCNS(states map[int32]StateBytecode, filename, fil
 	return nil
 }
 
-func (c *Compiler) wrongClosureToken() error {
+func (c *StateCompiler) wrongClosureToken() error {
 	if c.token == "" {
 		return Error("Missing closure token")
 	}
 	return Error("Unexpected closure token: " + c.token)
 }
 
-func (c *Compiler) nextLine() (string, bool) {
+func (c *StateCompiler) nextLine() (string, bool) {
 	s := <-c.linechan
 	if s == nil {
 		return "", false
@@ -7031,7 +7035,7 @@ func (c *Compiler) nextLine() (string, bool) {
 	return *s, true
 }
 
-func (c *Compiler) scan(line *string) string {
+func (c *StateCompiler) scan(line *string) string {
 	for {
 		c.token = c.tokenizer(line)
 		if len(c.token) > 0 {
@@ -7048,7 +7052,7 @@ func (c *Compiler) scan(line *string) string {
 	return c.token
 }
 
-func (c *Compiler) needToken(t string) error {
+func (c *StateCompiler) needToken(t string) error {
 	if c.token != t {
 		if c.token == "" {
 			return Error("Missing token: " + t)
@@ -7058,7 +7062,7 @@ func (c *Compiler) needToken(t string) error {
 	return nil
 }
 
-func (c *Compiler) readString(line *string) (string, error) {
+func (c *StateCompiler) readString(line *string) (string, error) {
 	i := strings.Index(*line, "\"")
 	if i < 0 {
 		return "", Error("String not enclosed in \"")
@@ -7068,7 +7072,7 @@ func (c *Compiler) readString(line *string) (string, error) {
 	return s, nil
 }
 
-func (c *Compiler) readSentenceLine(line *string) (s string, assign bool,
+func (c *StateCompiler) readSentenceLine(line *string) (s string, assign bool,
 	err error) {
 	c.token = ""
 	offset := 0
@@ -7103,7 +7107,7 @@ func (c *Compiler) readSentenceLine(line *string) (s string, assign bool,
 	return
 }
 
-func (c *Compiler) readSentence(line *string) (s string, a bool, err error) {
+func (c *StateCompiler) readSentence(line *string) (s string, a bool, err error) {
 	if s, a, err = c.readSentenceLine(line); err != nil {
 		return
 	}
@@ -7123,7 +7127,7 @@ func (c *Compiler) readSentence(line *string) (s string, a bool, err error) {
 	return strings.TrimSpace(s), a, nil
 }
 
-func (c *Compiler) statementEnd(line *string) error {
+func (c *StateCompiler) statementEnd(line *string) error {
 	c.token = c.tokenizer(line)
 	if len(c.token) > 0 && c.token[0] != '#' {
 		return c.wrongClosureToken()
@@ -7132,7 +7136,7 @@ func (c *Compiler) statementEnd(line *string) error {
 	return nil
 }
 
-func (c *Compiler) readKeyValue(is IniSection, end string, line *string) error {
+func (c *StateCompiler) readKeyValue(is IniSection, end string, line *string) error {
 	// Read the key (parameter name)
 	name := c.scan(line)
 	if name == "" || name == ":" {
@@ -7165,7 +7169,7 @@ func (c *Compiler) readKeyValue(is IniSection, end string, line *string) error {
 	return nil
 }
 
-func (c *Compiler) varNameCheck(nm string) (err error) {
+func (c *StateCompiler) varNameCheck(nm string) (err error) {
 	if (nm[0] < 'a' || nm[0] > 'z') && nm[0] != '_' {
 		return Error("Invalid name: " + nm)
 	}
@@ -7177,7 +7181,7 @@ func (c *Compiler) varNameCheck(nm string) (err error) {
 	return nil
 }
 
-func (c *Compiler) varNames(end string, line *string) ([]string, error) {
+func (c *StateCompiler) varNames(end string, line *string) ([]string, error) {
 	names, name := []string{}, c.scan(line)
 	if name != end {
 		for {
@@ -7209,7 +7213,7 @@ func (c *Compiler) varNames(end string, line *string) ([]string, error) {
 	return names, nil
 }
 
-func (c *Compiler) inclNumVars(numVars *int32) error {
+func (c *StateCompiler) inclNumVars(numVars *int32) error {
 	*numVars++
 	if *numVars > 256 {
 		return Error("Exceeded 256 local variable limit")
@@ -7217,7 +7221,7 @@ func (c *Compiler) inclNumVars(numVars *int32) error {
 	return nil
 }
 
-func (c *Compiler) scanI32(line *string) (int32, error) {
+func (c *StateCompiler) scanI32(line *string) (int32, error) {
 	t := c.scan(line)
 	if t == "" {
 		return 0, c.wrongClosureToken()
@@ -7229,7 +7233,7 @@ func (c *Compiler) scanI32(line *string) (int32, error) {
 	return int32(v), err
 }
 
-func (c *Compiler) scanStateDef(line *string, constants map[string]float32) (int32, error) {
+func (c *StateCompiler) scanStateDef(line *string, constants map[string]float32) (int32, error) {
 	t := c.scan(line)
 	if t == "" {
 		return 0, c.wrongClosureToken()
@@ -7263,7 +7267,7 @@ func (c *Compiler) scanStateDef(line *string, constants map[string]float32) (int
 }
 
 // Sets attributes to a StateBlock, like IgnoreHitPause, Persistent
-func (c *Compiler) blockAttribSet(line *string, bl *StateBlock, sbc *StateBytecode,
+func (c *StateCompiler) blockAttribSet(line *string, bl *StateBlock, sbc *StateBytecode,
 	inheritIhp, nestedInLoop bool) error {
 	// Inherit ignorehitpause/loop attr from parent block
 	if inheritIhp {
@@ -7321,7 +7325,7 @@ func (c *Compiler) blockAttribSet(line *string, bl *StateBlock, sbc *StateByteco
 	return nil
 }
 
-func (c *Compiler) subBlock(line *string, root bool,
+func (c *StateCompiler) subBlock(line *string, root bool,
 	sbc *StateBytecode, numVars *int32, inheritIhp, nestedInLoop bool) (*StateBlock, error) {
 	// Inject ignorehitpause property into functions (nil sbc)
 	if sbc == nil {
@@ -7400,7 +7404,7 @@ func (c *Compiler) subBlock(line *string, root bool,
 	return bl, nil
 }
 
-func (c *Compiler) switchBlock(line *string, bl *StateBlock,
+func (c *StateCompiler) switchBlock(line *string, bl *StateBlock,
 	sbc *StateBytecode, numVars *int32) error {
 	// In this implementation of switch, we convert the statement to an if-elseif-else chain of blocks
 	header, _, err := c.readSentence(line)
@@ -7501,7 +7505,7 @@ func (c *Compiler) switchBlock(line *string, bl *StateBlock,
 	return nil
 }
 
-func (c *Compiler) loopBlock(line *string, root bool, bl *StateBlock,
+func (c *StateCompiler) loopBlock(line *string, root bool, bl *StateBlock,
 	sbc *StateBytecode, numVars *int32) error {
 	bl.loopBlock = true
 	bl.nestedInLoop = true
@@ -7576,7 +7580,7 @@ func (c *Compiler) loopBlock(line *string, root bool, bl *StateBlock,
 	return nil
 }
 
-func (c *Compiler) callFunc(line *string, root bool,
+func (c *StateCompiler) callFunc(line *string, root bool,
 	ctrls *[]StateController, ret []uint8) error {
 	var cf callFunction
 	var ok bool
@@ -7701,7 +7705,7 @@ func (c *Compiler) callFunc(line *string, root bool,
 	return nil
 }
 
-func (c *Compiler) letAssign(line *string, root bool,
+func (c *StateCompiler) letAssign(line *string, root bool,
 	ctrls *[]StateController, numVars *int32, names []string, endLine bool) error {
 	varis := make([]uint8, len(names))
 	for i, n := range names {
@@ -7768,7 +7772,7 @@ func (c *Compiler) letAssign(line *string, root bool,
 	return nil
 }
 
-func (c *Compiler) stateBlock(line *string, bl *StateBlock, root bool,
+func (c *StateCompiler) stateBlock(line *string, bl *StateBlock, root bool,
 	sbc *StateBytecode, ctrls *[]StateController, numVars *int32) error {
 	c.scan(line)
 	for {
@@ -7917,10 +7921,13 @@ func (c *Compiler) stateBlock(line *string, bl *StateBlock, root bool,
 	return c.wrongClosureToken()
 }
 
-func (c *Compiler) stateCompileZSS(states map[int32]StateBytecode, filename, filetext string, constants map[string]float32) error {
+func (c *StateCompiler) stateCompileZSS(states map[int32]StateBytecode, filename, filetext string, constants map[string]float32) error {
 	// Enable ZSS mode
 	// TODO: There's some overlap between this flag and sys.ignoreMostErrors
 	c.zssMode = true
+
+	// Save filename for logging
+    c.currentFile = filename
 
 	// ZSS states are compiled with a lower tolerance for mistakes
 	// TODO: Either merge this with our current c.zssMode checks or drop it
@@ -8114,7 +8121,7 @@ func (c *Compiler) stateCompileZSS(states map[int32]StateBytecode, filename, fil
 }
 
 // Compile a character definition file
-func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (map[int32]StateBytecode, error) {
+func (c *StateCompiler) Compile(pn int, def string, constants map[string]float32) (map[int32]StateBytecode, error) {
 	c.playerNo = pn
 	states := make(map[int32]StateBytecode)
 
@@ -8374,6 +8381,6 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 	return states, nil
 }
 
-func (c *Compiler) charWarn() string {
-	return fmt.Sprintf("WARNING: %v state %v: ", sys.cgi[c.playerNo].name, c.stateNo)
+func (c *StateCompiler) charWarn() string {
+	return fmt.Sprintf("WARNING: %v's state %v in %v: ", sys.cgi[c.playerNo].name, c.stateNo, c.currentFile)
 }

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -32,6 +32,7 @@ type StateCompiler struct {
 	stateNo          int32
 	zssMode          bool
     currentFile      string
+    currentLine      int
 }
 
 func newStateCompiler() *StateCompiler {
@@ -5878,6 +5879,7 @@ func (c *StateCompiler) parseSection(sctrl func(name, data string) error) (IniSe
 	}
 
 	for ; c.i < len(c.lines); c.i++ {
+		c.currentLine = c.i + 1
 		line := strings.TrimSpace(strings.SplitN(c.lines[c.i], ";", 2)[0])
 		if len(line) > 0 && line[0] == '[' {
 			c.i--
@@ -6714,7 +6716,7 @@ func (c *StateCompiler) stateCompileCNS(states map[int32]StateBytecode, filename
 
 	c.lines, c.i = SplitAndTrim(filetext, "\n"), 0
 	errmes := func(err error) error {
-		return Error(fmt.Sprintf("%v:%v:\n%v", filename, c.i+1, err.Error()))
+		return Error(fmt.Sprintf("%v:%v:\n%v", filename, c.currentLine, err.Error()))
 	}
 
 	// Keep a map of states that have already been found in this file
@@ -6723,6 +6725,7 @@ func (c *StateCompiler) stateCompileCNS(states map[int32]StateBytecode, filename
 
 	// Loop through state file lines
 	for ; c.i < len(c.lines); c.i++ {
+		c.currentLine = c.i + 1
 		// Find a statedef, skipping over other lines until finding one
 		// Get the current line, without comments
 		line := strings.ToLower(strings.TrimSpace(
@@ -7941,7 +7944,8 @@ func (c *StateCompiler) stateCompileZSS(states map[int32]StateBytecode, filename
 	c.linechan = make(chan *string)
 	endchan := make(chan bool, 1)
 
-	stop := func() int {
+	// TODO: This is usually a little off because it's retroactively trying to guess the line
+	calculateLine := func() int {
 		if c.linechan == nil {
 			return 0
 		}
@@ -7957,7 +7961,7 @@ func (c *StateCompiler) stateCompileZSS(states map[int32]StateBytecode, filename
 			lineOffset--
 		}
 	}
-	defer stop()
+	//defer stop()
 
 	SafeGo(func() {
 		i := c.i
@@ -7981,8 +7985,10 @@ func (c *StateCompiler) stateCompileZSS(states map[int32]StateBytecode, filename
 	})
 
 	errmes := func(err error) error {
-		return Error(fmt.Sprintf("%v:%v:\n%v", filename, stop(), err.Error()))
+		c.currentLine = calculateLine()
+		return Error(fmt.Sprintf("%v:%v:\n%v", filename, c.currentLine, err.Error()))
 	}
+
 	existInThisFile := make(map[int32]bool)
 	funcExistInThisFile := make(map[string]bool)
 	var line string
@@ -8384,5 +8390,5 @@ func (c *StateCompiler) Compile(pn int, def string, constants map[string]float32
 func (c *StateCompiler) charWarn() string {
 	// Trim path to keep message shorter
     _, file := SplitPath(c.currentFile)
-	return fmt.Sprintf("WARNING: %v's state %v in %v: ", sys.cgi[c.playerNo].name, c.stateNo, file)
+	return fmt.Sprintf("WARNING: %v's state %v in %v, line %v: ", sys.cgi[c.playerNo].name, c.stateNo, file, c.currentLine)
 }

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -5803,7 +5803,7 @@ func parseTriggerNumber(name string) (tn int32, isAll bool, ok bool) {
 
 func (c *Compiler) parseSection(sctrl func(name, data string) error) (IniSection, bool, error) {
 	is := NewIniSection()
-	_type, persistent, ignorehitpause := true, true, true
+	var _type, persistent, ignorehitpause bool
 
 	// Placeholder var to toggle all the nonsense Mugen's compiler allowed
 	// Maybe this could be sys.ignoreMostErrors. Or something configurable
@@ -5947,20 +5947,34 @@ func (c *Compiler) parseSection(sctrl func(name, data string) error) (IniSection
 			if sctrl != nil {
 				switch name {
 				case "type":
-					if !_type {
-						continue
+					// Ignore and log if already found
+					if _type {
+						if sys.ignoreMostErrors {
+							LogMessage("WARNING: " + sys.cgi[c.playerNo].name + fmt.Sprintf(": Duplicate 'type' parameter in state %v", c.stateNo))
+							continue
+						}
+						return nil, false, Error("type is duplicated")
 					}
-					_type = false
+					// Flag as found
+					_type = true
 				case "persistent":
-					if !persistent {
-						continue
+					if persistent {
+						if sys.ignoreMostErrors {
+							LogMessage("WARNING: " + sys.cgi[c.playerNo].name + fmt.Sprintf(": Duplicate 'persistent' parameter in state %v", c.stateNo))
+							continue
+						}
+						return nil, false, Error("persistent is duplicated")
 					}
-					persistent = false
+					persistent = true
 				case "ignorehitpause":
-					if !ignorehitpause {
-						continue
+					if ignorehitpause {
+						if sys.ignoreMostErrors {
+							LogMessage("WARNING: " + sys.cgi[c.playerNo].name + fmt.Sprintf(": Duplicate 'ignorehitpause' parameter in state %v", c.stateNo))
+							continue
+						}
+						return nil, false, Error("ignorehitpause is duplicated")
 					}
-					ignorehitpause = false
+					ignorehitpause = true
 				default:
 					if !isTrigger {
 						is[name] = data
@@ -5975,7 +5989,7 @@ func (c *Compiler) parseSection(sctrl func(name, data string) error) (IniSection
 			}
 		}
 	}
-	return is, !ignorehitpause, nil
+	return is, ignorehitpause, nil
 }
 
 func (c *Compiler) stateSec(is IniSection, f func() error) error {
@@ -6771,7 +6785,7 @@ func (c *Compiler) stateCompileCNS(states map[int32]StateBytecode, filename, fil
 			allTerminated := false
 
 			// Parse each line of the sctrl to get triggers and settings
-			is, ihp, err := c.parseSection(func(name, data string) error {
+			is, ihpFound, err := c.parseSection(func(name, data string) error {
 				switch name {
 				case "type":
 					var ok bool
@@ -6949,13 +6963,13 @@ func (c *Compiler) stateCompileCNS(states map[int32]StateBytecode, filename, fil
 			c.block.trigger = texp
 
 			// Ignorehitpause
-			_ihp := int8(-1)
-			if ihp {
-				_ihp = int8(Btoi(c.block.ignorehitpause >= -1))
+			ihp := int8(-1)
+			if ihpFound {
+				ihp = int8(Btoi(c.block.ignorehitpause >= -1))
 			}
 
 			// For this sctrl type, call the function to construct the sctrl
-			sctrl, err := scf(is, sc, _ihp)
+			sctrl, err := scf(is, sc, ihp)
 			if err != nil {
 				return errmes(err)
 			}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2797,6 +2797,8 @@ func (c *StateCompiler) expValue(out *BytecodeExp, in *string,
 			out.append(OC_ex3_, OC_ex3_helpervar_ownclsnscale)
 		case "ownpal":
 			out.append(OC_ex3_, OC_ex3_helpervar_ownpal)
+		case "ownprojectile":
+			out.append(OC_ex3_, OC_ex3_helpervar_ownprojectile)
 		case "preserve":
 			out.append(OC_ex3_, OC_ex3_helpervar_preserve)
 		default:

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -788,7 +788,7 @@ func (c *Compiler) attr(text string, hitdef bool) (int32, error) {
 				//if hitdef {
 				//	flg = hitdefflg
 				//}
-				sys.appendToConsole("WARNING: " + sys.cgi[c.playerNo].name + fmt.Sprintf(": Invalid attr value: "+a+" in state %v ", c.stateNo))
+				sys.appendToConsole(c.charWarn() + "Invalid attr value: " + a)
 				return flg, nil
 			}
 			return 0, Error("Invalid attr value: " + a)
@@ -1214,7 +1214,7 @@ func (c *Compiler) readOldProjectileID(in *string, trname string, baseLen int, o
 	invalid := func(msg string) (string, error) {
 		// Print error but proceed with ID 0
 		if sys.ignoreMostErrors {
-			sys.appendToConsole("WARNING: " + sys.cgi[c.playerNo].name + fmt.Sprintf(": %v in state %v ", msg, c.stateNo))
+			sys.appendToConsole(c.charWarn() + msg)
 			out.appendValue(BytecodeInt(0))
 			return base, nil
 		}
@@ -2832,7 +2832,7 @@ func (c *Compiler) expValue(out *BytecodeExp, in *string,
 			if c.zssMode || !sys.ignoreMostErrors {
 				return bvNone(), err
 			}
-			sys.appendToConsole("WARNING: " + sys.cgi[c.playerNo].name + fmt.Sprintf(": HitDefAttr Missing '=' or '!=' "+" in state %v ", c.stateNo))
+			sys.appendToConsole(c.charWarn() + "HitDefAttr Missing '=' or '!='")
 			out.appendValue(BytecodeBool(false))
 		}
 	case "hitdefvar":
@@ -5938,7 +5938,7 @@ func (c *Compiler) parseSection(sctrl func(name, data string) error) (IniSection
 			if ok && !isTrigger {
 				if sys.ignoreMostErrors {
 					// Because duplicates are harmless and would flood the limited console space, we'll print them to the command line instead
-					LogMessage("WARNING: " + sys.cgi[c.playerNo].name + fmt.Sprintf(": Duplicate '%s' parameter in state %v", name, c.stateNo))
+					LogMessage(c.charWarn() + fmt.Sprintf("Duplicate '%s' parameter", name))
 					continue
 				}
 				return nil, false, Error(name + " is duplicated")
@@ -5950,7 +5950,7 @@ func (c *Compiler) parseSection(sctrl func(name, data string) error) (IniSection
 					// Ignore and log if already found
 					if _type {
 						if sys.ignoreMostErrors {
-							LogMessage("WARNING: " + sys.cgi[c.playerNo].name + fmt.Sprintf(": Duplicate 'type' parameter in state %v", c.stateNo))
+							LogMessage(c.charWarn() + "Duplicate 'type' parameter")
 							continue
 						}
 						return nil, false, Error("type is duplicated")
@@ -5960,7 +5960,7 @@ func (c *Compiler) parseSection(sctrl func(name, data string) error) (IniSection
 				case "persistent":
 					if persistent {
 						if sys.ignoreMostErrors {
-							LogMessage("WARNING: " + sys.cgi[c.playerNo].name + fmt.Sprintf(": Duplicate 'persistent' parameter in state %v", c.stateNo))
+							LogMessage(c.charWarn() + "Duplicate 'persistent' parameter")
 							continue
 						}
 						return nil, false, Error("persistent is duplicated")
@@ -5969,7 +5969,7 @@ func (c *Compiler) parseSection(sctrl func(name, data string) error) (IniSection
 				case "ignorehitpause":
 					if ignorehitpause {
 						if sys.ignoreMostErrors {
-							LogMessage("WARNING: " + sys.cgi[c.playerNo].name + fmt.Sprintf(": Duplicate 'ignorehitpause' parameter in state %v", c.stateNo))
+							LogMessage(c.charWarn() + "Duplicate 'ignorehitpause' parameter")
 							continue
 						}
 						return nil, false, Error("ignorehitpause is duplicated")
@@ -6296,7 +6296,7 @@ func (c *Compiler) paramSpace(is IniSection, sc *StateControllerBase, id byte) e
 			if c.zssMode && !sys.ignoreMostErrors {
 				return Error("Invalid space type: " + data)
 			} else {
-				sys.appendToConsole("WARNING: " + sys.cgi[c.playerNo].name + fmt.Sprintf(": Invalid space type: "+data+" in state %v ", c.stateNo))
+				sys.appendToConsole(c.charWarn() + "Invalid space type: " + data)
 			}
 		}
 		sc.add(id, sc.iToExp(int32(spc)))
@@ -6357,7 +6357,7 @@ func (c *Compiler) paramTrans(is IniSection, sc *StateControllerBase, prefix str
 		if c.zssMode || !sys.ignoreMostErrors {
 			return Error("alpha defined without trans type")
 		} else {
-			sys.appendToConsole("WARNING: " + sys.cgi[c.playerNo].name + fmt.Sprintf(": Alpha defined without trans type in state %v ", c.stateNo))
+			sys.appendToConsole(c.charWarn() + "Alpha defined without trans type")
 			return nil
 		}
 	}
@@ -6371,7 +6371,7 @@ func (c *Compiler) paramTrans(is IniSection, sc *StateControllerBase, prefix str
 			if c.zssMode || !sys.ignoreMostErrors {
 				return Error("trans type not specified")
 			} else {
-				sys.appendToConsole("WARNING: " + sys.cgi[c.playerNo].name + fmt.Sprintf(": Blank trans type in state %v ", c.stateNo))
+				sys.appendToConsole(c.charWarn() + "Blank trans type")
 				return nil
 			}
 		}
@@ -6408,7 +6408,7 @@ func (c *Compiler) paramTrans(is IniSection, sc *StateControllerBase, prefix str
 			if c.zssMode || !sys.ignoreMostErrors {
 				return Error("Invalid trans type: " + data)
 			} else {
-				sys.appendToConsole("WARNING: " + sys.cgi[c.playerNo].name + fmt.Sprintf(": Invalid trans type: "+data+" in state %v ", c.stateNo))
+				sys.appendToConsole(c.charWarn() + "Invalid trans type: " + data)
 				return nil
 			}
 		}
@@ -6424,7 +6424,7 @@ func (c *Compiler) paramTrans(is IniSection, sc *StateControllerBase, prefix str
 				if c.zssMode || !sys.ignoreMostErrors {
 					return Error("alpha not specified")
 				} else {
-					sys.appendToConsole("WARNING: " + sys.cgi[c.playerNo].name + fmt.Sprintf(": Blank trans alpha in state %v ", c.stateNo))
+					sys.appendToConsole(c.charWarn() + "Blank trans alpha")
 					return nil
 				}
 			}
@@ -8372,4 +8372,8 @@ func (c *Compiler) Compile(pn int, def string, constants map[string]float32) (ma
 	// Store functions in Global Info (static data), accessible to all instances
 	sys.cgi[pn].callFuncs = c.funcs
 	return states, nil
+}
+
+func (c *Compiler) charWarn() string {
+	return fmt.Sprintf("WARNING: %v state %v: ", sys.cgi[c.playerNo].name, c.stateNo)
 }

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -26,15 +26,14 @@ type StateCompiler struct {
 	lines            []string
 	i                int // Line index
 	vars             map[string]uint8
-	funcs            map[string]bytecodeFunction
-	funcUsed         map[string]bool
+	funcs            map[string]BytecodeFunction
 	stateNo          int32
 	zssMode          bool
 	currentFile      string
 }
 
 func newStateCompiler() *StateCompiler {
-	c := &StateCompiler{funcs: make(map[string]bytecodeFunction)}
+	c := &StateCompiler{funcs: make(map[string]BytecodeFunction)}
 	c.scmap = map[string]scFunc{
 		// Mugen state controllers
 		"afterimage":         c.afterImage,
@@ -7576,10 +7575,8 @@ func (c *StateCompiler) loopBlock(line *string, root bool, bl *StateBlock,
 	return nil
 }
 
-func (c *StateCompiler) callFunc(line *string, root bool,
-	ctrls *[]StateController, ret []uint8) error {
-	var cf callFunction
-	var ok bool
+func (c *StateCompiler) callFunc(line *string, root bool, ctrls *[]StateController, ret []uint8) error {
+	var cf CallFunction
 
 	// Scan the function name
 	cf.name = c.scan(line)
@@ -7587,8 +7584,7 @@ func (c *StateCompiler) callFunc(line *string, root bool,
 		return c.wrongClosureToken()
 	}
 
-	// Lookup function definition
-	bf, ok := c.funcs[cf.name]
+	// Set the returns
 	cf.ret = ret
 
 	// Consume opening parenthesis
@@ -7604,76 +7600,28 @@ func (c *StateCompiler) callFunc(line *string, root bool,
 	}
 	otk := c.token
 
-	if !ok {
-		// Undefined function path
-		// We parse arguments blindly until we hit ')' to ensure the instruction is valid, even without a definition
-		tmp := expr
-		if c.tokenizer(&tmp) == ")" {
-			c.tokenizer(&expr) // Consume empty ')'
-		} else {
-			for {
-				// Parse arguments
-				be, err := c.typedExp(c.expBoolOr, &expr, VT_Undefined)
-				if err != nil {
-					return err
-				}
-				cf.arg.append(be...)
-
-				// Stop at ')' or expect ','
-				if c.token == ")" {
-					break
-				}
-				if c.token != "," {
-					return Error("Invalid argument list")
-				}
-			}
-		}
+	// Parse arguments blindly until we hit ')'
+	tmp := expr
+	if c.tokenizer(&tmp) == ")" {
+		c.tokenizer(&expr) // Consume empty ')'
 	} else {
-		// Defined function path
-		c.funcUsed[cf.name] = true
-
-		// Validate return values
-		if len(ret) > 0 && len(ret) != int(bf.numRets) {
-			return Error(fmt.Sprintf("Mismatch in number of assignments and return values: %v = %v",
-				len(ret), bf.numRets))
-		}
-
-		// Parse arguments based on known count
-		if bf.numArgs == 0 {
-			c.token = c.tokenizer(&expr)
-			if c.token == "" {
-				c.token = otk
-			}
-			if err := c.needToken(")"); err != nil {
+		for {
+			// Parse arguments
+			be, err := c.typedExp(c.expBoolOr, &expr, VT_Undefined)
+			if err != nil {
 				return err
 			}
-		} else {
-			for i := 0; i < int(bf.numArgs); i++ {
-				var be BytecodeExp
-				if i < int(bf.numArgs)-1 {
-					// Argument followed by ','
-					if be, err = c.argExpression(&expr, VT_Undefined); err != nil {
-						return err
-					}
-					if c.token == "" {
-						c.token = otk
-					}
-					if err := c.needToken(","); err != nil {
-						return err
-					}
-				} else {
-					// Last argument followed by ')'
-					if be, err = c.typedExp(c.expBoolOr, &expr, VT_Undefined); err != nil {
-						return err
-					}
-					if c.token == "" {
-						c.token = otk
-					}
-					if err := c.needToken(")"); err != nil {
-						return err
-					}
-				}
-				cf.arg.append(be...)
+			cf.arg.append(be...)
+
+			// Count arguments for later runtime validation
+			cf.numArgs++
+
+			// Stop at ')' or expect ','
+			if c.token == ")" {
+				break
+			}
+			if c.token != "," {
+				return Error("Invalid argument list")
 			}
 		}
 	}
@@ -7695,7 +7643,7 @@ func (c *StateCompiler) callFunc(line *string, root bool,
 	}
 
 	// Append the instruction
-	// Even if undefined, we append it so it can be resolved at runtime
+	// Even if the function is still undefined, we append the call so it can be resolved at runtime
 	*ctrls = append(*ctrls, cf)
 	c.scan(line)
 	return nil
@@ -8024,7 +7972,7 @@ func (c *StateCompiler) stateCompileZSS(states map[int32]StateBytecode, filename
 			}
 
 			// Start compiling
-			fun := bytecodeFunction{}
+			fun := BytecodeFunction{}
 			c.vars = make(map[string]uint8)
 
 			// Parse arguments
@@ -8299,7 +8247,7 @@ func (c *StateCompiler) Compile(pn int, def string, constants map[string]float32
 	// Compile states
 	sys.stringPool[pn].Clear()
 	sys.cgi[pn].hitPauseToggleFlagCount = 0
-	c.funcUsed = make(map[string]bool)
+
 	// Compile state files
 	for _, s := range st {
 		if len(s) > 0 {

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -824,8 +824,7 @@ func (c *StateCompiler) ctrlSet(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *StateCompiler) explodSub(is IniSection,
-	sc *StateControllerBase, ihp int8) error {
+func (c *StateCompiler) explodSub(is IniSection, sc *StateControllerBase, ihp int8) error {
 	if err := c.paramValue(is, sc, "remappal",
 		explod_remappal, VT_Int, 2, false); err != nil {
 		return err
@@ -857,14 +856,15 @@ func (c *StateCompiler) explodSub(is IniSection,
 		explod_random, VT_Float, 3, false); err != nil {
 		return err
 	}
-	found := false
+	// vel or velocity
+	velFound := false
 	if err := c.stateParam(is, "vel", false, func(data string) error {
-		found = true
+		velFound = true
 		return c.scAdd(sc, explod_velocity, data, VT_Float, 3)
 	}); err != nil {
 		return err
 	}
-	if !found {
+	if !velFound {
 		if err := c.paramValue(is, sc, "velocity",
 			explod_velocity, VT_Float, 3, false); err != nil {
 			return err
@@ -960,6 +960,10 @@ func (c *StateCompiler) explodSub(is IniSection,
 	if err := c.paramTrans(is, sc, "", explod_trans); err != nil {
 		return err
 	}
+	if err := c.paramValue(is, sc, "ownpal",
+		explod_ownpal, VT_Bool, 1, false); err != nil {
+		return err
+	}
 	if err := c.palFXSub(is, sc, "palfx."); err != nil {
 		return err
 	}
@@ -968,6 +972,57 @@ func (c *StateCompiler) explodSub(is IniSection,
 		return err
 	}
 	if err := c.afterImageSub(is, sc, ihp, "afterimage."); err != nil {
+		return err
+	}
+	// animplayerno and spriteplayerno should be placed before anim
+	if err := c.paramValue(is, sc, "animplayerno",
+		explod_animplayerno, VT_Int, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "spriteplayerno",
+		explod_spriteplayerno, VT_Int, 1, false); err != nil {
+		return err
+	}
+	if err := c.stateParam(is, "anim",
+		false, func(data string) error {
+		prefix := c.getDataPrefix(&data, false)
+		return c.scAdd(sc, explod_anim, data, VT_Int, 1, sc.beToExp(BytecodeExp(prefix))...)
+	}); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "animelem",
+		explod_animelem, VT_Int, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "animelemtime",
+		explod_animelemtime, VT_Int, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "animfreeze",
+		explod_animfreeze, VT_Bool, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "angle",
+		explod_angle, VT_Float, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "yangle",
+		explod_yangle, VT_Float, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "xangle",
+		explod_xangle, VT_Float, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "xshear",
+		explod_xshear, VT_Float, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "focallength",
+		explod_focallength, VT_Float, 1, false); err != nil {
+		return err
+	}
+	if err := c.explodInterpolate(is, sc); err != nil {
 		return err
 	}
 	return nil
@@ -1026,72 +1081,13 @@ func (c *StateCompiler) explodInterpolate(is IniSection,
 	return nil
 }
 
-func (c *StateCompiler) explod(is IniSection, sc *StateControllerBase,
-	ihp int8) (StateController, error) {
+func (c *StateCompiler) explod(is IniSection, sc *StateControllerBase, ihp int8) (StateController, error) {
 	ret, err := (*explod)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			explod_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.paramValue(is, sc, "animplayerno",
-			explod_animplayerno, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "spriteplayerno",
-			explod_spriteplayerno, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.stateParam(is, "anim", false, func(data string) error {
-			prefix := c.getDataPrefix(&data, false)
-			return c.scAdd(sc, explod_anim, data, VT_Int, 1,
-				sc.beToExp(BytecodeExp(prefix))...)
-		}); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "ownpal",
-			explod_ownpal, VT_Bool, 1, false); err != nil {
-			return err
-		}
 		if err := c.explodSub(is, sc, ihp); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "animelem",
-			explod_animelem, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "animelemtime",
-			explod_animelemtime, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "animfreeze",
-			explod_animfreeze, VT_Bool, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "angle",
-			explod_angle, VT_Float, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "yangle",
-			explod_yangle, VT_Float, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "xangle",
-			explod_xangle, VT_Float, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "xshear",
-			explod_xshear, VT_Float, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "focallength",
-			explod_focallength, VT_Float, 1, false); err != nil {
-			return err
-		}
-		if err := c.explodInterpolate(is, sc); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "ignorehitpause",
-			explod_ignorehitpause, VT_Bool, 1, false); err != nil {
 			return err
 		}
 		return nil
@@ -1099,8 +1095,7 @@ func (c *StateCompiler) explod(is IniSection, sc *StateControllerBase,
 	return *ret, err
 }
 
-func (c *StateCompiler) modifyExplod(is IniSection, sc *StateControllerBase,
-	ihp int8) (StateController, error) {
+func (c *StateCompiler) modifyExplod(is IniSection, sc *StateControllerBase, ihp int8) (StateController, error) {
 	ret, err := (*modifyExplod)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			modifyexplod_redirectid, VT_Int, 1, false); err != nil {
@@ -1113,59 +1108,9 @@ func (c *StateCompiler) modifyExplod(is IniSection, sc *StateControllerBase,
 		if err := c.explodSub(is, sc, ihp); err != nil {
 			return err
 		}
-		if err := c.paramValue(is, sc, "animplayerno",
-			explod_animplayerno, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "spriteplayerno",
-			explod_spriteplayerno, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.stateParam(is, "anim", false, func(data string) error {
-			prefix := c.getDataPrefix(&data, false)
-			return c.scAdd(sc, explod_anim, data, VT_Int, 1,
-				sc.beToExp(BytecodeExp(prefix))...)
-		}); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "animelem",
-			explod_animelem, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "animelemtime",
-			explod_animelemtime, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "animfreeze",
-			explod_animfreeze, VT_Bool, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "angle",
-			explod_angle, VT_Float, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "yangle",
-			explod_yangle, VT_Float, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "xangle",
-			explod_xangle, VT_Float, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "xshear",
-			explod_xshear, VT_Float, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "focallength",
-			explod_focallength, VT_Float, 1, false); err != nil {
-			return err
-		}
+		// TODO: Undocumented. Possibly a leftover
 		if err := c.paramValue(is, sc, "interpolation",
 			explod_interpolation, VT_Bool, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "ignorehitpause",
-			explod_ignorehitpause, VT_Bool, 1, false); err != nil {
 			return err
 		}
 		return nil
@@ -1584,8 +1529,7 @@ func (c *StateCompiler) bgPalFX(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *StateCompiler) afterImageSub(is IniSection,
-	sc *StateControllerBase, ihp int8, prefix string) error {
+func (c *StateCompiler) afterImageSub(is IniSection, sc *StateControllerBase, ihp int8, prefix string) error {
 	if err := c.paramValue(is, sc, "redirectid",
 		afterImage_redirectid, VT_Int, 1, false); err != nil {
 		return err
@@ -1648,7 +1592,7 @@ func (c *StateCompiler) afterImageSub(is IniSection,
 	if ihp == 0 {
 		sc.add(afterImage_ignorehitpause, sc.iToExp(0))
 	}
-	return nil
+	return nil  
 }
 
 func (c *StateCompiler) afterImage(is IniSection, sc *StateControllerBase,

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -109,7 +109,7 @@ func (c *StateCompiler) hitBySub(is IniSection, sc *StateControllerBase, sctrlNa
 	return nil
 }
 
-func (c *StateCompiler) hitBy(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) hitBy(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*hitBy)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid", hitBy_redirectid, VT_Int, 1, false); err != nil {
 			return err
@@ -119,7 +119,7 @@ func (c *StateCompiler) hitBy(is IniSection, sc *StateControllerBase, _ int8) (S
 	return *ret, err
 }
 
-func (c *StateCompiler) notHitBy(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) notHitBy(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*notHitBy)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid", hitBy_redirectid, VT_Int, 1, false); err != nil {
 			return err
@@ -129,7 +129,7 @@ func (c *StateCompiler) notHitBy(is IniSection, sc *StateControllerBase, _ int8)
 	return *ret, err
 }
 
-func (c *StateCompiler) assertSpecial(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) assertSpecial(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*assertSpecial)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			assertSpecial_redirectid, VT_Int, 1, false); err != nil {
@@ -352,7 +352,7 @@ func (c *StateCompiler) assertSpecial(is IniSection, sc *StateControllerBase, _ 
 	return *ret, err
 }
 
-func (c *StateCompiler) playSnd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) playSnd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*playSnd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			playSnd_redirectid, VT_Int, 1, false); err != nil {
@@ -468,21 +468,21 @@ func (c *StateCompiler) changeStateSub(is IniSection,
 	return nil
 }
 
-func (c *StateCompiler) changeState(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) changeState(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*changeState)(sc), c.stateSec(is, func() error {
 		return c.changeStateSub(is, sc)
 	})
 	return *ret, err
 }
 
-func (c *StateCompiler) selfState(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) selfState(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*selfState)(sc), c.stateSec(is, func() error {
 		return c.changeStateSub(is, sc)
 	})
 	return *ret, err
 }
 
-func (c *StateCompiler) tagIn(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) tagIn(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*tagIn)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			tagIn_redirectid, VT_Int, 1, false); err != nil {
@@ -521,7 +521,7 @@ func (c *StateCompiler) tagIn(is IniSection, sc *StateControllerBase, _ int8) (S
 	return *ret, err
 }
 
-func (c *StateCompiler) tagOut(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) tagOut(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*tagOut)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			tagOut_redirectid, VT_Int, 1, false); err != nil {
@@ -551,7 +551,7 @@ func (c *StateCompiler) tagOut(is IniSection, sc *StateControllerBase, _ int8) (
 	return *ret, err
 }
 
-func (c *StateCompiler) destroySelf(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) destroySelf(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*destroySelf)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			destroySelf_redirectid, VT_Int, 1, false); err != nil {
@@ -610,21 +610,21 @@ func (c *StateCompiler) changeAnimSub(is IniSection,
 	return nil
 }
 
-func (c *StateCompiler) changeAnim(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) changeAnim(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*changeAnim)(sc), c.stateSec(is, func() error {
 		return c.changeAnimSub(is, sc)
 	})
 	return *ret, err
 }
 
-func (c *StateCompiler) changeAnim2(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) changeAnim2(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*changeAnim2)(sc), c.stateSec(is, func() error {
 		return c.changeAnimSub(is, sc)
 	})
 	return *ret, err
 }
 
-func (c *StateCompiler) helper(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) helper(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*helper)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			helper_redirectid, VT_Int, 1, false); err != nil {
@@ -813,7 +813,7 @@ func (c *StateCompiler) helper(is IniSection, sc *StateControllerBase, _ int8) (
 	return *ret, err
 }
 
-func (c *StateCompiler) ctrlSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) ctrlSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*ctrlSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			ctrlSet_redirectid, VT_Int, 1, false); err != nil {
@@ -824,7 +824,7 @@ func (c *StateCompiler) ctrlSet(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *StateCompiler) explodSub(is IniSection, sc *StateControllerBase, ihp int8) error {
+func (c *StateCompiler) explodSub(is IniSection, sc *StateControllerBase) error {
 	if err := c.paramValue(is, sc, "remappal",
 		explod_remappal, VT_Int, 2, false); err != nil {
 		return err
@@ -971,7 +971,7 @@ func (c *StateCompiler) explodSub(is IniSection, sc *StateControllerBase, ihp in
 		explod_window, VT_Float, 4, false); err != nil {
 		return err
 	}
-	if err := c.afterImageSub(is, sc, ihp, "afterimage."); err != nil {
+	if err := c.afterImageSub(is, sc, "afterimage."); err != nil {
 		return err
 	}
 	// animplayerno and spriteplayerno should be placed before anim
@@ -1023,6 +1023,12 @@ func (c *StateCompiler) explodSub(is IniSection, sc *StateControllerBase, ihp in
 		return err
 	}
 	if err := c.explodInterpolate(is, sc); err != nil {
+		return err
+	}
+	// Ikemen used to apply special exceptions to Explod ignorehitpause due to its conflict with the generic ignorehitpause
+	// Turns out that Mugen simply reads it twice, treating it as both an Explod parameter and as the generic sctrl property
+	if err := c.paramValue(is, sc, "ignorehitpause",
+		explod_ignorehitpause, VT_Bool, 1, false); err != nil {
 		return err
 	}
 	return nil
@@ -1081,13 +1087,13 @@ func (c *StateCompiler) explodInterpolate(is IniSection,
 	return nil
 }
 
-func (c *StateCompiler) explod(is IniSection, sc *StateControllerBase, ihp int8) (StateController, error) {
+func (c *StateCompiler) explod(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*explod)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			explod_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.explodSub(is, sc, ihp); err != nil {
+		if err := c.explodSub(is, sc); err != nil {
 			return err
 		}
 		return nil
@@ -1095,7 +1101,7 @@ func (c *StateCompiler) explod(is IniSection, sc *StateControllerBase, ihp int8)
 	return *ret, err
 }
 
-func (c *StateCompiler) modifyExplod(is IniSection, sc *StateControllerBase, ihp int8) (StateController, error) {
+func (c *StateCompiler) modifyExplod(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*modifyExplod)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			modifyexplod_redirectid, VT_Int, 1, false); err != nil {
@@ -1105,7 +1111,7 @@ func (c *StateCompiler) modifyExplod(is IniSection, sc *StateControllerBase, ihp
 			modifyexplod_index, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.explodSub(is, sc, ihp); err != nil {
+		if err := c.explodSub(is, sc); err != nil {
 			return err
 		}
 		// TODO: Undocumented. Possibly a leftover
@@ -1118,7 +1124,7 @@ func (c *StateCompiler) modifyExplod(is IniSection, sc *StateControllerBase, ihp
 	return *ret, err
 }
 
-func (c *StateCompiler) gameMakeAnim(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) gameMakeAnim(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*gameMakeAnim)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			gameMakeAnim_redirectid, VT_Int, 1, false); err != nil {
@@ -1171,7 +1177,7 @@ func (c *StateCompiler) posSetSub(is IniSection,
 	return nil
 }
 
-func (c *StateCompiler) posSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) posSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*posSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			posSet_redirectid, VT_Int, 1, false); err != nil {
@@ -1182,7 +1188,7 @@ func (c *StateCompiler) posSet(is IniSection, sc *StateControllerBase, _ int8) (
 	return *ret, err
 }
 
-func (c *StateCompiler) posAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) posAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*posAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			posSet_redirectid, VT_Int, 1, false); err != nil {
@@ -1193,7 +1199,7 @@ func (c *StateCompiler) posAdd(is IniSection, sc *StateControllerBase, _ int8) (
 	return *ret, err
 }
 
-func (c *StateCompiler) velSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) velSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*velSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			posSet_redirectid, VT_Int, 1, false); err != nil {
@@ -1204,7 +1210,7 @@ func (c *StateCompiler) velSet(is IniSection, sc *StateControllerBase, _ int8) (
 	return *ret, err
 }
 
-func (c *StateCompiler) velAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) velAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*velAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			posSet_redirectid, VT_Int, 1, false); err != nil {
@@ -1215,7 +1221,7 @@ func (c *StateCompiler) velAdd(is IniSection, sc *StateControllerBase, _ int8) (
 	return *ret, err
 }
 
-func (c *StateCompiler) velMul(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) velMul(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*velMul)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			posSet_redirectid, VT_Int, 1, false); err != nil {
@@ -1226,7 +1232,7 @@ func (c *StateCompiler) velMul(is IniSection, sc *StateControllerBase, _ int8) (
 	return *ret, err
 }
 
-func (c *StateCompiler) modifyShadow(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) modifyShadow(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*modifyShadow)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			modifyShadow_redirectid, VT_Int, 1, false); err != nil {
@@ -1308,7 +1314,7 @@ func (c *StateCompiler) modifyShadow(is IniSection, sc *StateControllerBase, _ i
 	return *ret, err
 }
 
-func (c *StateCompiler) modifyReflection(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) modifyReflection(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*modifyReflection)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			modifyReflection_redirectid, VT_Int, 1, false); err != nil {
@@ -1493,7 +1499,7 @@ func (c *StateCompiler) palFXSub(is IniSection,
 	return nil
 }
 
-func (c *StateCompiler) palFX(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) palFX(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*palFX)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			palFX_redirectid, VT_Int, 1, false); err != nil {
@@ -1504,14 +1510,14 @@ func (c *StateCompiler) palFX(is IniSection, sc *StateControllerBase, _ int8) (S
 	return *ret, err
 }
 
-func (c *StateCompiler) allPalFX(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) allPalFX(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*allPalFX)(sc), c.stateSec(is, func() error {
 		return c.palFXSub(is, sc, "")
 	})
 	return *ret, err
 }
 
-func (c *StateCompiler) bgPalFX(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) bgPalFX(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*bgPalFX)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "id",
 			bgPalFX_id, VT_Int, 1, false); err != nil {
@@ -1529,7 +1535,7 @@ func (c *StateCompiler) bgPalFX(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *StateCompiler) afterImageSub(is IniSection, sc *StateControllerBase, ihp int8, prefix string) error {
+func (c *StateCompiler) afterImageSub(is IniSection, sc *StateControllerBase, prefix string) error {
 	if err := c.paramValue(is, sc, "redirectid",
 		afterImage_redirectid, VT_Int, 1, false); err != nil {
 		return err
@@ -1589,21 +1595,21 @@ func (c *StateCompiler) afterImageSub(is IniSection, sc *StateControllerBase, ih
 		afterImage_palmul, VT_Float, 3, false); err != nil {
 		return err
 	}
-	if ihp == 0 {
-		sc.add(afterImage_ignorehitpause, sc.iToExp(0))
+	if err := c.paramValue(is, sc, prefix+"ignorehitpause",
+		afterImage_ignorehitpause, VT_Bool, 1, false); err != nil {
+		return err
 	}
 	return nil  
 }
 
-func (c *StateCompiler) afterImage(is IniSection, sc *StateControllerBase,
-	ihp int8) (StateController, error) {
+func (c *StateCompiler) afterImage(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*afterImage)(sc), c.stateSec(is, func() error {
-		return c.afterImageSub(is, sc, ihp, "")
+		return c.afterImageSub(is, sc, "")
 	})
 	return *ret, err
 }
 
-func (c *StateCompiler) afterImageTime(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) afterImageTime(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*afterImageTime)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			afterImageTime_redirectid, VT_Int, 1, false); err != nil {
@@ -2221,7 +2227,7 @@ func (c *StateCompiler) hitDefSub(is IniSection, sc *StateControllerBase) error 
 	return nil
 }
 
-func (c *StateCompiler) hitDef(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) hitDef(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*hitDef)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			hitDef_redirectid, VT_Int, 1, false); err != nil {
@@ -2232,7 +2238,7 @@ func (c *StateCompiler) hitDef(is IniSection, sc *StateControllerBase, _ int8) (
 	return *ret, err
 }
 
-func (c *StateCompiler) modifyHitDef(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) modifyHitDef(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*modifyHitDef)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			modifyHitDef_redirectid, VT_Int, 1, false); err != nil {
@@ -2243,7 +2249,7 @@ func (c *StateCompiler) modifyHitDef(is IniSection, sc *StateControllerBase, _ i
 	return *ret, err
 }
 
-func (c *StateCompiler) reversalDef(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) reversalDef(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*reversalDef)(sc), c.stateSec(is, func() error {
 		attr := int32(-1)
 		var err error
@@ -2277,7 +2283,7 @@ func (c *StateCompiler) reversalDef(is IniSection, sc *StateControllerBase, _ in
 	return *ret, err
 }
 
-func (c *StateCompiler) modifyReversalDef(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) modifyReversalDef(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*modifyReversalDef)(sc), c.stateSec(is, func() error {
 		var err error
 		if err = c.paramValue(is, sc, "redirectid",
@@ -2309,7 +2315,7 @@ func (c *StateCompiler) modifyReversalDef(is IniSection, sc *StateControllerBase
 	return *ret, err
 }
 
-func (c *StateCompiler) projectileSub(is IniSection, sc *StateControllerBase, ihp int8) error {
+func (c *StateCompiler) projectileSub(is IniSection, sc *StateControllerBase) error {
 	if err := c.paramValue(is, sc, "redirectid",
 		projectile_redirectid, VT_Int, 1, false); err != nil {
 		return err
@@ -2478,7 +2484,7 @@ func (c *StateCompiler) projectileSub(is IniSection, sc *StateControllerBase, ih
 		projectile_remappal, VT_Int, 2, false); err != nil {
 		return err
 	}
-	if err := c.afterImageSub(is, sc, ihp, "afterimage."); err != nil {
+	if err := c.afterImageSub(is, sc, "afterimage."); err != nil {
 		return err
 	}
 	if err := c.shaderSub(is, sc, projectile_shader, projectile_shaderparam); err != nil {
@@ -2487,9 +2493,9 @@ func (c *StateCompiler) projectileSub(is IniSection, sc *StateControllerBase, ih
 	return nil
 }
 
-func (c *StateCompiler) projectile(is IniSection, sc *StateControllerBase, ihp int8) (StateController, error) {
+func (c *StateCompiler) projectile(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*projectile)(sc), c.stateSec(is, func() error {
-		if err := c.projectileSub(is, sc, ihp); err != nil {
+		if err := c.projectileSub(is, sc); err != nil {
 			return err
 		}
 		return nil
@@ -2497,8 +2503,7 @@ func (c *StateCompiler) projectile(is IniSection, sc *StateControllerBase, ihp i
 	return *ret, err
 }
 
-func (c *StateCompiler) modifyProjectile(is IniSection, sc *StateControllerBase,
-	ihp int8) (StateController, error) {
+func (c *StateCompiler) modifyProjectile(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*modifyProjectile)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			modifyProjectile_redirectid, VT_Int, 1, false); err != nil {
@@ -2513,7 +2518,7 @@ func (c *StateCompiler) modifyProjectile(is IniSection, sc *StateControllerBase,
 			return err
 		}
 
-		if err := c.projectileSub(is, sc, ihp); err != nil {
+		if err := c.projectileSub(is, sc); err != nil {
 			return err
 		}
 		return nil
@@ -2521,7 +2526,7 @@ func (c *StateCompiler) modifyProjectile(is IniSection, sc *StateControllerBase,
 	return *ret, err
 }
 
-func (c *StateCompiler) width(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) width(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*width)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			width_redirectid, VT_Int, 1, false); err != nil {
@@ -2557,7 +2562,7 @@ func (c *StateCompiler) width(is IniSection, sc *StateControllerBase, _ int8) (S
 	return *ret, err
 }
 
-func (c *StateCompiler) sprPriority(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) sprPriority(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*sprPriority)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			sprPriority_redirectid, VT_Int, 1, false); err != nil {
@@ -2781,7 +2786,7 @@ func (c *StateCompiler) varSetSub(is IniSection, sc *StateControllerBase, scType
 	return Error("Variable or value parameter not specified")
 }
 
-func (c *StateCompiler) varSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) varSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*varSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			varSet_redirectid, VT_Int, 1, false); err != nil {
@@ -2792,7 +2797,7 @@ func (c *StateCompiler) varSet(is IniSection, sc *StateControllerBase, _ int8) (
 	return *ret, err
 }
 
-func (c *StateCompiler) varAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) varAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*varSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			varSet_redirectid, VT_Int, 1, false); err != nil {
@@ -2803,7 +2808,7 @@ func (c *StateCompiler) varAdd(is IniSection, sc *StateControllerBase, _ int8) (
 	return *ret, err
 }
 
-func (c *StateCompiler) parentVarSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) parentVarSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*varSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			varSet_redirectid, VT_Int, 1, false); err != nil {
@@ -2814,7 +2819,7 @@ func (c *StateCompiler) parentVarSet(is IniSection, sc *StateControllerBase, _ i
 	return *ret, err
 }
 
-func (c *StateCompiler) parentVarAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) parentVarAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*varSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			varSet_redirectid, VT_Int, 1, false); err != nil {
@@ -2825,7 +2830,7 @@ func (c *StateCompiler) parentVarAdd(is IniSection, sc *StateControllerBase, _ i
 	return *ret, err
 }
 
-func (c *StateCompiler) rootVarSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) rootVarSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*varSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			varSet_redirectid, VT_Int, 1, false); err != nil {
@@ -2836,7 +2841,7 @@ func (c *StateCompiler) rootVarSet(is IniSection, sc *StateControllerBase, _ int
 	return *ret, err
 }
 
-func (c *StateCompiler) rootVarAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) rootVarAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*varSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			varSet_redirectid, VT_Int, 1, false); err != nil {
@@ -2847,7 +2852,7 @@ func (c *StateCompiler) rootVarAdd(is IniSection, sc *StateControllerBase, _ int
 	return *ret, err
 }
 
-func (c *StateCompiler) turn(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) turn(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*turn)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			turn_redirectid, VT_Int, 1, false); err != nil {
@@ -2859,7 +2864,7 @@ func (c *StateCompiler) turn(is IniSection, sc *StateControllerBase, _ int8) (St
 	return *ret, err
 }
 
-func (c *StateCompiler) targetFacing(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) targetFacing(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*targetFacing)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetFacing_redirectid, VT_Int, 1, false); err != nil {
@@ -2882,7 +2887,7 @@ func (c *StateCompiler) targetFacing(is IniSection, sc *StateControllerBase, _ i
 	return *ret, err
 }
 
-func (c *StateCompiler) targetBind(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) targetBind(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*targetBind)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetBind_redirectid, VT_Int, 1, false); err != nil {
@@ -2909,7 +2914,7 @@ func (c *StateCompiler) targetBind(is IniSection, sc *StateControllerBase, _ int
 	return *ret, err
 }
 
-func (c *StateCompiler) bindToTarget(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) bindToTarget(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*bindToTarget)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			bindToTarget_redirectid, VT_Int, 1, false); err != nil {
@@ -2970,7 +2975,7 @@ func (c *StateCompiler) bindToTarget(is IniSection, sc *StateControllerBase, _ i
 	return *ret, err
 }
 
-func (c *StateCompiler) targetLifeAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) targetLifeAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*targetLifeAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetLifeAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -3009,7 +3014,7 @@ func (c *StateCompiler) targetLifeAdd(is IniSection, sc *StateControllerBase, _ 
 	return *ret, err
 }
 
-func (c *StateCompiler) targetState(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) targetState(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*targetState)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetState_redirectid, VT_Int, 1, false); err != nil {
@@ -3032,7 +3037,7 @@ func (c *StateCompiler) targetState(is IniSection, sc *StateControllerBase, _ in
 	return *ret, err
 }
 
-func (c *StateCompiler) targetVelSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) targetVelSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*targetVelSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetVelSet_redirectid, VT_Int, 1, false); err != nil {
@@ -3063,7 +3068,7 @@ func (c *StateCompiler) targetVelSet(is IniSection, sc *StateControllerBase, _ i
 	return *ret, err
 }
 
-func (c *StateCompiler) targetVelAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) targetVelAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*targetVelAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetVelAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -3094,7 +3099,7 @@ func (c *StateCompiler) targetVelAdd(is IniSection, sc *StateControllerBase, _ i
 	return *ret, err
 }
 
-func (c *StateCompiler) targetPowerAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) targetPowerAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*targetPowerAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetPowerAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -3117,7 +3122,7 @@ func (c *StateCompiler) targetPowerAdd(is IniSection, sc *StateControllerBase, _
 	return *ret, err
 }
 
-func (c *StateCompiler) targetDrop(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) targetDrop(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*targetDrop)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetDrop_redirectid, VT_Int, 1, false); err != nil {
@@ -3136,7 +3141,7 @@ func (c *StateCompiler) targetDrop(is IniSection, sc *StateControllerBase, _ int
 	return *ret, err
 }
 
-func (c *StateCompiler) lifeAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) lifeAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*lifeAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			lifeAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -3159,7 +3164,7 @@ func (c *StateCompiler) lifeAdd(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *StateCompiler) lifeSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) lifeSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*lifeSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			lifeSet_redirectid, VT_Int, 1, false); err != nil {
@@ -3170,7 +3175,7 @@ func (c *StateCompiler) lifeSet(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *StateCompiler) powerAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) powerAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*powerAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			powerAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -3181,7 +3186,7 @@ func (c *StateCompiler) powerAdd(is IniSection, sc *StateControllerBase, _ int8)
 	return *ret, err
 }
 
-func (c *StateCompiler) powerSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) powerSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*powerSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			powerSet_redirectid, VT_Int, 1, false); err != nil {
@@ -3192,7 +3197,7 @@ func (c *StateCompiler) powerSet(is IniSection, sc *StateControllerBase, _ int8)
 	return *ret, err
 }
 
-func (c *StateCompiler) hitVelSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) hitVelSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*hitVelSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			hitVelSet_redirectid, VT_Int, 1, false); err != nil {
@@ -3215,7 +3220,7 @@ func (c *StateCompiler) hitVelSet(is IniSection, sc *StateControllerBase, _ int8
 	return *ret, err
 }
 
-func (c *StateCompiler) screenBound(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) screenBound(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*screenBound)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			screenBound_redirectid, VT_Int, 1, false); err != nil {
@@ -3251,7 +3256,7 @@ func (c *StateCompiler) screenBound(is IniSection, sc *StateControllerBase, _ in
 	return *ret, err
 }
 
-func (c *StateCompiler) posFreeze(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) posFreeze(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*posFreeze)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			posFreeze_redirectid, VT_Int, 1, false); err != nil {
@@ -3272,7 +3277,7 @@ func (c *StateCompiler) posFreeze(is IniSection, sc *StateControllerBase, _ int8
 	return *ret, err
 }
 
-func (c *StateCompiler) envShake(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) envShake(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*envShake)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "time",
 			envShake_time, VT_Int, 1, false); err != nil {
@@ -3303,7 +3308,7 @@ func (c *StateCompiler) envShake(is IniSection, sc *StateControllerBase, _ int8)
 	return *ret, err
 }
 
-func (c *StateCompiler) hitOverride(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) hitOverride(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*hitOverride)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			hitOverride_redirectid, VT_Int, 1, false); err != nil {
@@ -3358,7 +3363,7 @@ func (c *StateCompiler) hitOverride(is IniSection, sc *StateControllerBase, _ in
 	return *ret, err
 }
 
-func (c *StateCompiler) pause(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) pause(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*pause)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			pause_redirectid, VT_Int, 1, false); err != nil {
@@ -3385,7 +3390,7 @@ func (c *StateCompiler) pause(is IniSection, sc *StateControllerBase, _ int8) (S
 	return *ret, err
 }
 
-func (c *StateCompiler) superPause(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) superPause(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*superPause)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			superPause_redirectid, VT_Int, 1, false); err != nil {
@@ -3450,7 +3455,7 @@ func (c *StateCompiler) superPause(is IniSection, sc *StateControllerBase, _ int
 	return *ret, err
 }
 
-func (c *StateCompiler) trans(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) trans(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*trans)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			trans_redirectid, VT_Int, 1, false); err != nil {
@@ -3464,7 +3469,7 @@ func (c *StateCompiler) trans(is IniSection, sc *StateControllerBase, _ int8) (S
 	return *ret, err
 }
 
-func (c *StateCompiler) playerPush(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) playerPush(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*playerPush)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			playerPush_redirectid, VT_Int, 1, false); err != nil {
@@ -3512,7 +3517,7 @@ func (c *StateCompiler) playerPush(is IniSection, sc *StateControllerBase, _ int
 	return *ret, err
 }
 
-func (c *StateCompiler) stateTypeSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) stateTypeSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*stateTypeSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			stateTypeSet_redirectid, VT_Int, 1, false); err != nil {
@@ -3599,7 +3604,7 @@ func (c *StateCompiler) stateTypeSet(is IniSection, sc *StateControllerBase, _ i
 	return *ret, err
 }
 
-func (c *StateCompiler) angleDraw(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) angleDraw(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*angleDraw)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			angleDraw_redirectid, VT_Int, 1, false); err != nil {
@@ -3626,7 +3631,7 @@ func (c *StateCompiler) angleDraw(is IniSection, sc *StateControllerBase, _ int8
 	return *ret, err
 }
 
-func (c *StateCompiler) angleSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) angleSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*angleSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			angleSet_redirectid, VT_Int, 1, false); err != nil {
@@ -3649,7 +3654,7 @@ func (c *StateCompiler) angleSet(is IniSection, sc *StateControllerBase, _ int8)
 	return *ret, err
 }
 
-func (c *StateCompiler) angleAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) angleAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*angleAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			angleAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -3672,7 +3677,7 @@ func (c *StateCompiler) angleAdd(is IniSection, sc *StateControllerBase, _ int8)
 	return *ret, err
 }
 
-func (c *StateCompiler) angleMul(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) angleMul(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*angleMul)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			angleMul_redirectid, VT_Int, 1, false); err != nil {
@@ -3695,7 +3700,7 @@ func (c *StateCompiler) angleMul(is IniSection, sc *StateControllerBase, _ int8)
 	return *ret, err
 }
 
-func (c *StateCompiler) envColor(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) envColor(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*envColor)(sc), c.stateSec(is, func() error {
 		if err := c.stateParam(is, "value", false, func(data string) error {
 			bes, err := c.exprs(data, VT_Int, 3)
@@ -3767,21 +3772,21 @@ func (c *StateCompiler) displayToClipboardSub(is IniSection,
 	return nil
 }
 
-func (c *StateCompiler) displayToClipboard(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) displayToClipboard(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*displayToClipboard)(sc), c.stateSec(is, func() error {
 		return c.displayToClipboardSub(is, sc)
 	})
 	return *ret, err
 }
 
-func (c *StateCompiler) appendToClipboard(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) appendToClipboard(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*appendToClipboard)(sc), c.stateSec(is, func() error {
 		return c.displayToClipboardSub(is, sc)
 	})
 	return *ret, err
 }
 
-func (c *StateCompiler) clearClipboard(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) clearClipboard(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*clearClipboard)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			clearClipboard_redirectid, VT_Int, 1, false); err != nil {
@@ -3793,7 +3798,7 @@ func (c *StateCompiler) clearClipboard(is IniSection, sc *StateControllerBase, _
 	return *ret, err
 }
 
-func (c *StateCompiler) makeDust(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) makeDust(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*makeDust)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			makeDust_redirectid, VT_Int, 1, false); err != nil {
@@ -3818,7 +3823,7 @@ func (c *StateCompiler) makeDust(is IniSection, sc *StateControllerBase, _ int8)
 	return *ret, err
 }
 
-func (c *StateCompiler) attackDist(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) attackDist(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*attackDist)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			attackDist_redirectid, VT_Int, 1, false); err != nil {
@@ -3845,7 +3850,7 @@ func (c *StateCompiler) attackDist(is IniSection, sc *StateControllerBase, _ int
 	return *ret, err
 }
 
-func (c *StateCompiler) attackMulSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) attackMulSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*attackMulSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			attackMulSet_redirectid, VT_Int, 1, false); err != nil {
@@ -3890,7 +3895,7 @@ func (c *StateCompiler) attackMulSet(is IniSection, sc *StateControllerBase, _ i
 	return *ret, err
 }
 
-func (c *StateCompiler) defenceMulSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) defenceMulSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*defenceMulSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(
 			is, sc, "redirectid",
@@ -3931,7 +3936,7 @@ func (c *StateCompiler) defenceMulSet(is IniSection, sc *StateControllerBase, _ 
 	return *ret, err
 }
 
-func (c *StateCompiler) fallEnvShake(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) fallEnvShake(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*fallEnvShake)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			fallEnvShake_redirectid, VT_Int, 1, false); err != nil {
@@ -3943,7 +3948,7 @@ func (c *StateCompiler) fallEnvShake(is IniSection, sc *StateControllerBase, _ i
 	return *ret, err
 }
 
-func (c *StateCompiler) hitFallDamage(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) hitFallDamage(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*hitFallDamage)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			hitFallDamage_redirectid, VT_Int, 1, false); err != nil {
@@ -3955,7 +3960,7 @@ func (c *StateCompiler) hitFallDamage(is IniSection, sc *StateControllerBase, _ 
 	return *ret, err
 }
 
-func (c *StateCompiler) hitFallVel(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) hitFallVel(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*hitFallVel)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			hitFallVel_redirectid, VT_Int, 1, false); err != nil {
@@ -3967,7 +3972,7 @@ func (c *StateCompiler) hitFallVel(is IniSection, sc *StateControllerBase, _ int
 	return *ret, err
 }
 
-func (c *StateCompiler) hitFallSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) hitFallSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*hitFallSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			hitFallSet_redirectid, VT_Int, 1, false); err != nil {
@@ -3996,7 +4001,7 @@ func (c *StateCompiler) hitFallSet(is IniSection, sc *StateControllerBase, _ int
 	return *ret, err
 }
 
-func (c *StateCompiler) varRangeSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) varRangeSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*varRangeSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			varRangeSet_redirectid, VT_Int, 1, false); err != nil {
@@ -4033,7 +4038,7 @@ func (c *StateCompiler) varRangeSet(is IniSection, sc *StateControllerBase, _ in
 	return *ret, err
 }
 
-func (c *StateCompiler) remapPal(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) remapPal(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*remapPal)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			remapPal_redirectid, VT_Int, 1, false); err != nil {
@@ -4052,7 +4057,7 @@ func (c *StateCompiler) remapPal(is IniSection, sc *StateControllerBase, _ int8)
 	return *ret, err
 }
 
-func (c *StateCompiler) stopSnd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) stopSnd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*stopSnd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			stopSnd_redirectid, VT_Int, 1, false); err != nil {
@@ -4067,7 +4072,7 @@ func (c *StateCompiler) stopSnd(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *StateCompiler) sndPan(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) sndPan(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*sndPan)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			sndPan_redirectid, VT_Int, 1, false); err != nil {
@@ -4090,7 +4095,7 @@ func (c *StateCompiler) sndPan(is IniSection, sc *StateControllerBase, _ int8) (
 	return *ret, err
 }
 
-func (c *StateCompiler) varRandom(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) varRandom(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*varRandom)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			varRandom_redirectid, VT_Int, 1, false); err != nil {
@@ -4109,7 +4114,7 @@ func (c *StateCompiler) varRandom(is IniSection, sc *StateControllerBase, _ int8
 	return *ret, err
 }
 
-func (c *StateCompiler) gravity(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) gravity(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*gravity)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			gravity_redirectid, VT_Int, 1, false); err != nil {
@@ -4142,21 +4147,21 @@ func (c *StateCompiler) bindToParentSub(is IniSection,
 	return nil
 }
 
-func (c *StateCompiler) bindToParent(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) bindToParent(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*bindToParent)(sc), c.stateSec(is, func() error {
 		return c.bindToParentSub(is, sc)
 	})
 	return *ret, err
 }
 
-func (c *StateCompiler) bindToRoot(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) bindToRoot(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*bindToRoot)(sc), c.stateSec(is, func() error {
 		return c.bindToParentSub(is, sc)
 	})
 	return *ret, err
 }
 
-func (c *StateCompiler) removeExplod(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) removeExplod(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*removeExplod)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			removeExplod_redirectid, VT_Int, 1, false); err != nil {
@@ -4182,7 +4187,7 @@ func (c *StateCompiler) removeExplod(is IniSection, sc *StateControllerBase, _ i
 	return *ret, err
 }
 
-func (c *StateCompiler) explodBindTime(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) explodBindTime(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*explodBindTime)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			explodBindTime_redirectid, VT_Int, 1, false); err != nil {
@@ -4210,7 +4215,7 @@ func (c *StateCompiler) explodBindTime(is IniSection, sc *StateControllerBase, _
 	return *ret, err
 }
 
-func (c *StateCompiler) moveHitReset(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) moveHitReset(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*moveHitReset)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			moveHitReset_redirectid, VT_Int, 1, false); err != nil {
@@ -4222,7 +4227,7 @@ func (c *StateCompiler) moveHitReset(is IniSection, sc *StateControllerBase, _ i
 	return *ret, err
 }
 
-func (c *StateCompiler) hitAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) hitAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*hitAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			hitAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -4237,7 +4242,7 @@ func (c *StateCompiler) hitAdd(is IniSection, sc *StateControllerBase, _ int8) (
 	return *ret, err
 }
 
-func (c *StateCompiler) offset(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) offset(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*offset)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			offset_redirectid, VT_Int, 1, false); err != nil {
@@ -4256,7 +4261,7 @@ func (c *StateCompiler) offset(is IniSection, sc *StateControllerBase, _ int8) (
 	return *ret, err
 }
 
-func (c *StateCompiler) victoryQuote(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) victoryQuote(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*victoryQuote)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			victoryQuote_redirectid, VT_Int, 1, false); err != nil {
@@ -4271,7 +4276,7 @@ func (c *StateCompiler) victoryQuote(is IniSection, sc *StateControllerBase, _ i
 	return *ret, err
 }
 
-func (c *StateCompiler) zoom(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) zoom(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*zoom)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "pos",
 			zoom_pos, VT_Float, 2, false); err != nil {
@@ -4306,7 +4311,7 @@ func (c *StateCompiler) zoom(is IniSection, sc *StateControllerBase, _ int8) (St
 	return *ret, err
 }
 
-func (c *StateCompiler) forceFeedback(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) forceFeedback(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*forceFeedback)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			forceFeedback_redirectid, VT_Int, 1, false); err != nil {
@@ -4366,7 +4371,7 @@ func (c *StateCompiler) forceFeedback(is IniSection, sc *StateControllerBase, _ 
 	return *ret, err
 }
 
-func (c *StateCompiler) assertAnalogVector(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) assertAnalogVector(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*assertAnalogVector)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			assertAnalogVector_redirectid, VT_Int, 1, false); err != nil {
@@ -4401,7 +4406,7 @@ func (c *StateCompiler) assertAnalogVector(is IniSection, sc *StateControllerBas
 	return *ret, err
 }
 
-func (c *StateCompiler) assertInput(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) assertInput(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*assertInput)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			assertInput_redirectid, VT_Int, 1, false); err != nil {
@@ -4472,7 +4477,7 @@ func (c *StateCompiler) assertInput(is IniSection, sc *StateControllerBase, _ in
 	return *ret, err
 }
 
-func (c *StateCompiler) dialogue(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) dialogue(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*dialogue)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			dialogue_redirectid, VT_Int, 1, false); err != nil {
@@ -4514,7 +4519,7 @@ func (c *StateCompiler) dialogue(is IniSection, sc *StateControllerBase, _ int8)
 	return *ret, err
 }
 
-func (c *StateCompiler) dizzyPointsAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) dizzyPointsAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*dizzyPointsAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			dizzyPointsAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -4533,7 +4538,7 @@ func (c *StateCompiler) dizzyPointsAdd(is IniSection, sc *StateControllerBase, _
 	return *ret, err
 }
 
-func (c *StateCompiler) dizzyPointsSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) dizzyPointsSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*dizzyPointsSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			dizzyPointsSet_redirectid, VT_Int, 1, false); err != nil {
@@ -4544,7 +4549,7 @@ func (c *StateCompiler) dizzyPointsSet(is IniSection, sc *StateControllerBase, _
 	return *ret, err
 }
 
-func (c *StateCompiler) dizzySet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) dizzySet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*dizzySet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			dizzySet_redirectid, VT_Int, 1, false); err != nil {
@@ -4555,7 +4560,7 @@ func (c *StateCompiler) dizzySet(is IniSection, sc *StateControllerBase, _ int8)
 	return *ret, err
 }
 
-func (c *StateCompiler) guardBreakSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) guardBreakSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*guardBreakSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			guardBreakSet_redirectid, VT_Int, 1, false); err != nil {
@@ -4566,7 +4571,7 @@ func (c *StateCompiler) guardBreakSet(is IniSection, sc *StateControllerBase, _ 
 	return *ret, err
 }
 
-func (c *StateCompiler) guardPointsAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) guardPointsAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*guardPointsAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			guardPointsAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -4585,7 +4590,7 @@ func (c *StateCompiler) guardPointsAdd(is IniSection, sc *StateControllerBase, _
 	return *ret, err
 }
 
-func (c *StateCompiler) guardPointsSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) guardPointsSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*guardPointsSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			guardPointsSet_redirectid, VT_Int, 1, false); err != nil {
@@ -4596,7 +4601,7 @@ func (c *StateCompiler) guardPointsSet(is IniSection, sc *StateControllerBase, _
 	return *ret, err
 }
 
-func (c *StateCompiler) lifebarAction(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) lifebarAction(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*lifebarAction)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			lifebarAction_redirectid, VT_Int, 1, false); err != nil {
@@ -4668,7 +4673,7 @@ func (c *StateCompiler) lifebarAction(is IniSection, sc *StateControllerBase, _ 
 	return *ret, err
 }
 
-func (c *StateCompiler) loadFile(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) loadFile(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*loadFile)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			loadFile_redirectid, VT_Int, 1, false); err != nil {
@@ -4691,7 +4696,7 @@ func (c *StateCompiler) loadFile(is IniSection, sc *StateControllerBase, _ int8)
 	return *ret, err
 }
 
-func (c *StateCompiler) loadState(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) loadState(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*loadState)(sc), c.stateSec(is, func() error {
 		sc.add(loadState_, nil)
 		return nil
@@ -4810,7 +4815,7 @@ func (c *StateCompiler) mapSetSub(is IniSection, sc *StateControllerBase) error 
 	return err
 }
 
-func (c *StateCompiler) mapSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) mapSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
 			return err
@@ -4822,7 +4827,7 @@ func (c *StateCompiler) mapSet(is IniSection, sc *StateControllerBase, _ int8) (
 	return *ret, err
 }
 
-func (c *StateCompiler) mapAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) mapAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
 			return err
@@ -4834,7 +4839,7 @@ func (c *StateCompiler) mapAdd(is IniSection, sc *StateControllerBase, _ int8) (
 	return *ret, err
 }
 
-func (c *StateCompiler) parentMapSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) parentMapSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
 			return err
@@ -4846,7 +4851,7 @@ func (c *StateCompiler) parentMapSet(is IniSection, sc *StateControllerBase, _ i
 	return *ret, err
 }
 
-func (c *StateCompiler) parentMapAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) parentMapAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
 			return err
@@ -4858,7 +4863,7 @@ func (c *StateCompiler) parentMapAdd(is IniSection, sc *StateControllerBase, _ i
 	return *ret, err
 }
 
-func (c *StateCompiler) rootMapSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) rootMapSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
 			return err
@@ -4870,7 +4875,7 @@ func (c *StateCompiler) rootMapSet(is IniSection, sc *StateControllerBase, _ int
 	return *ret, err
 }
 
-func (c *StateCompiler) rootMapAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) rootMapAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
 			return err
@@ -4882,7 +4887,7 @@ func (c *StateCompiler) rootMapAdd(is IniSection, sc *StateControllerBase, _ int
 	return *ret, err
 }
 
-func (c *StateCompiler) teamMapSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) teamMapSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
 			return err
@@ -4894,7 +4899,7 @@ func (c *StateCompiler) teamMapSet(is IniSection, sc *StateControllerBase, _ int
 	return *ret, err
 }
 
-func (c *StateCompiler) teamMapAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) teamMapAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
 			return err
@@ -4906,7 +4911,7 @@ func (c *StateCompiler) teamMapAdd(is IniSection, sc *StateControllerBase, _ int
 	return *ret, err
 }
 
-func (c *StateCompiler) mapReset(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) mapReset(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*mapReset)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			mapReset_redirectid, VT_Int, 1, false); err != nil {
@@ -4942,7 +4947,7 @@ func (c *StateCompiler) mapReset(is IniSection, sc *StateControllerBase, _ int8)
 	return *ret, err
 }
 
-func (c *StateCompiler) matchRestart(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) matchRestart(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*matchRestart)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "reload",
 			matchRestart_reload, VT_Bool, MaxPlayerNo, false); err != nil {
@@ -5082,7 +5087,7 @@ func (c *StateCompiler) matchRestart(is IniSection, sc *StateControllerBase, _ i
 	return *ret, err
 }
 
-func (c *StateCompiler) playBgm(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) playBgm(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*playBgm)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			playBgm_redirectid, VT_Int, 1, false); err != nil {
@@ -5167,7 +5172,7 @@ func (c *StateCompiler) playBgm(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *StateCompiler) modifyBGCtrl(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) modifyBGCtrl(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*modifyBGCtrl)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "id",
 			modifyBGCtrl_id, VT_Int, 1, true); err != nil {
@@ -5242,7 +5247,7 @@ func (c *StateCompiler) modifyBGCtrl(is IniSection, sc *StateControllerBase, _ i
 	return *ret, err
 }
 
-func (c *StateCompiler) modifyBGCtrl3d(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) modifyBGCtrl3d(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*modifyBGCtrl3d)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "id",
 			modifyBGCtrl3d_ctrlid, VT_Int, 1, true); err != nil {
@@ -5261,7 +5266,7 @@ func (c *StateCompiler) modifyBGCtrl3d(is IniSection, sc *StateControllerBase, _
 	return *ret, err
 }
 
-func (c *StateCompiler) modifySnd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) modifySnd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*modifySnd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			modifySnd_redirectid, VT_Int, 1, false); err != nil {
@@ -5328,7 +5333,7 @@ func (c *StateCompiler) modifySnd(is IniSection, sc *StateControllerBase, _ int8
 	return *ret, err
 }
 
-func (c *StateCompiler) modifyBgm(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) modifyBgm(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*modifyBgm)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "volume",
 			modifyBgm_volume, VT_Int, 1, false); err != nil {
@@ -5355,14 +5360,14 @@ func (c *StateCompiler) modifyBgm(is IniSection, sc *StateControllerBase, _ int8
 	return *ret, err
 }
 
-func (c *StateCompiler) printToConsole(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) printToConsole(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*printToConsole)(sc), c.stateSec(is, func() error {
 		return c.displayToClipboardSub(is, sc)
 	})
 	return *ret, err
 }
 
-func (c *StateCompiler) redLifeAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) redLifeAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*redLifeAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			redLifeAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -5381,7 +5386,7 @@ func (c *StateCompiler) redLifeAdd(is IniSection, sc *StateControllerBase, _ int
 	return *ret, err
 }
 
-func (c *StateCompiler) redLifeSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) redLifeSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*redLifeSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			redLifeSet_redirectid, VT_Int, 1, false); err != nil {
@@ -5392,7 +5397,7 @@ func (c *StateCompiler) redLifeSet(is IniSection, sc *StateControllerBase, _ int
 	return *ret, err
 }
 
-func (c *StateCompiler) remapSprite(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) remapSprite(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*remapSprite)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			remapSprite_redirectid, VT_Int, 1, false); err != nil {
@@ -5424,7 +5429,7 @@ func (c *StateCompiler) remapSprite(is IniSection, sc *StateControllerBase, _ in
 	return *ret, err
 }
 
-func (c *StateCompiler) roundTimeAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) roundTimeAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*roundTimeAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			roundTimeAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -5439,7 +5444,7 @@ func (c *StateCompiler) roundTimeAdd(is IniSection, sc *StateControllerBase, _ i
 	return *ret, err
 }
 
-func (c *StateCompiler) roundTimeSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) roundTimeSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*roundTimeSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			roundTimeSet_redirectid, VT_Int, 1, false); err != nil {
@@ -5450,7 +5455,7 @@ func (c *StateCompiler) roundTimeSet(is IniSection, sc *StateControllerBase, _ i
 	return *ret, err
 }
 
-func (c *StateCompiler) saveFile(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) saveFile(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*saveFile)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			saveFile_redirectid, VT_Int, 1, false); err != nil {
@@ -5473,7 +5478,7 @@ func (c *StateCompiler) saveFile(is IniSection, sc *StateControllerBase, _ int8)
 	return *ret, err
 }
 
-func (c *StateCompiler) saveState(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) saveState(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*saveState)(sc), c.stateSec(is, func() error {
 		sc.add(saveState_, nil)
 		return nil
@@ -5481,7 +5486,7 @@ func (c *StateCompiler) saveState(is IniSection, sc *StateControllerBase, _ int8
 	return *ret, err
 }
 
-func (c *StateCompiler) scoreAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) scoreAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*scoreAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			scoreAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -5495,7 +5500,7 @@ func (c *StateCompiler) scoreAdd(is IniSection, sc *StateControllerBase, _ int8)
 	})
 	return *ret, err
 }
-func (c *StateCompiler) shaderSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) shaderSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*shaderSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid", shaderSet_redirectid, VT_Int, 1, false); err != nil {
 			return err
@@ -5510,7 +5515,7 @@ func (c *StateCompiler) shaderSet(is IniSection, sc *StateControllerBase, _ int8
 	})
 	return *ret, err
 }
-func (c *StateCompiler) storyboard(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) storyboard(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*storyboard)(sc), c.stateSec(is, func() error {
 		if err := c.stateParam(is, "path", false, func(data string) error {
 			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
@@ -5526,7 +5531,7 @@ func (c *StateCompiler) storyboard(is IniSection, sc *StateControllerBase, _ int
 	return *ret, err
 }
 
-func (c *StateCompiler) targetDizzyPointsAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) targetDizzyPointsAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*targetDizzyPointsAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetDizzyPointsAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -5549,7 +5554,7 @@ func (c *StateCompiler) targetDizzyPointsAdd(is IniSection, sc *StateControllerB
 	return *ret, err
 }
 
-func (c *StateCompiler) targetGuardPointsAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) targetGuardPointsAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*targetGuardPointsAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetGuardPointsAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -5572,7 +5577,7 @@ func (c *StateCompiler) targetGuardPointsAdd(is IniSection, sc *StateControllerB
 	return *ret, err
 }
 
-func (c *StateCompiler) targetRedLifeAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) targetRedLifeAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*targetRedLifeAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetRedLifeAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -5595,7 +5600,7 @@ func (c *StateCompiler) targetRedLifeAdd(is IniSection, sc *StateControllerBase,
 	return *ret, err
 }
 
-func (c *StateCompiler) targetScoreAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) targetScoreAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*targetScoreAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetScoreAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -5614,7 +5619,7 @@ func (c *StateCompiler) targetScoreAdd(is IniSection, sc *StateControllerBase, _
 	return *ret, err
 }
 
-func (c *StateCompiler) text(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) text(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*text)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			text_redirectid, VT_Int, 1, false); err != nil {
@@ -5752,7 +5757,7 @@ func (c *StateCompiler) text(is IniSection, sc *StateControllerBase, _ int8) (St
 	return *ret, err
 }
 
-func (c *StateCompiler) modifyText(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) modifyText(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*modifyText)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			modifytext_redirectid, VT_Int, 1, false); err != nil {
@@ -5894,7 +5899,7 @@ func (c *StateCompiler) modifyText(is IniSection, sc *StateControllerBase, _ int
 	return *ret, err
 }
 
-func (c *StateCompiler) removeText(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) removeText(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*removeText)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			removetext_redirectid, VT_Int, 1, false); err != nil {
@@ -5921,7 +5926,7 @@ func (c *StateCompiler) removeText(is IniSection, sc *StateControllerBase, _ int
 }
 
 // Handles "createPlatform" parameters.
-func (c *StateCompiler) createPlatform(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) createPlatform(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*text)(sc), c.stateSec(is, func() error {
 		var err error
 
@@ -5995,7 +6000,7 @@ func (c *StateCompiler) createPlatform(is IniSection, sc *StateControllerBase, _
 	return *ret, err
 }
 
-func (c *StateCompiler) modifyStageVar(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) modifyStageVar(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*modifyStageVar)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "camera.boundleft",
 			modifyStageVar_camera_boundleft, VT_Int, 1, false); err != nil {
@@ -6291,7 +6296,7 @@ func (c *StateCompiler) modifyStageVar(is IniSection, sc *StateControllerBase, _
 	return *ret, err
 }
 
-func (c *StateCompiler) cameraCtrl(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) cameraCtrl(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*cameraCtrl)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "followid",
 			cameraCtrl_followid, VT_Int, 1, false); err != nil {
@@ -6324,7 +6329,7 @@ func (c *StateCompiler) cameraCtrl(is IniSection, sc *StateControllerBase, _ int
 	return *ret, err
 }
 
-func (c *StateCompiler) height(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) height(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*height)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			height_redirectid, VT_Int, 1, false); err != nil {
@@ -6339,7 +6344,7 @@ func (c *StateCompiler) height(is IniSection, sc *StateControllerBase, _ int8) (
 	return *ret, err
 }
 
-func (c *StateCompiler) depth(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) depth(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*depth)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			depth_redirectid, VT_Int, 1, false); err != nil {
@@ -6375,7 +6380,7 @@ func (c *StateCompiler) depth(is IniSection, sc *StateControllerBase, _ int8) (S
 	return *ret, err
 }
 
-func (c *StateCompiler) modifyPlayer(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) modifyPlayer(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*modifyPlayer)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			modifyPlayer_redirectid, VT_Int, 1, false); err != nil {
@@ -6485,7 +6490,7 @@ func (c *StateCompiler) modifyPlayer(is IniSection, sc *StateControllerBase, _ i
 	return *ret, err
 }
 
-func (c *StateCompiler) assertCommand(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) assertCommand(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*assertCommand)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			assertCommand_redirectid, VT_Int, 1, false); err != nil {
@@ -6509,7 +6514,7 @@ func (c *StateCompiler) assertCommand(is IniSection, sc *StateControllerBase, _ 
 	return *ret, err
 }
 
-func (c *StateCompiler) getHitVarSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) getHitVarSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*getHitVarSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			getHitVarSet_redirectid, VT_Int, 1, false); err != nil {
@@ -6700,7 +6705,7 @@ func (c *StateCompiler) getHitVarSet(is IniSection, sc *StateControllerBase, _ i
 	return *ret, err
 }
 
-func (c *StateCompiler) groundLevelOffset(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) groundLevelOffset(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*groundLevelOffset)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			groundLevelOffset_redirectid, VT_Int, 1, false); err != nil {
@@ -6715,7 +6720,7 @@ func (c *StateCompiler) groundLevelOffset(is IniSection, sc *StateControllerBase
 	return *ret, err
 }
 
-func (c *StateCompiler) targetAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) targetAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*targetAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -6730,7 +6735,7 @@ func (c *StateCompiler) targetAdd(is IniSection, sc *StateControllerBase, _ int8
 	return *ret, err
 }
 
-func (c *StateCompiler) transformClsn(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) transformClsn(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*transformClsn)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			transformClsn_redirectid, VT_Int, 1, false); err != nil {
@@ -6757,7 +6762,7 @@ func (c *StateCompiler) transformClsn(is IniSection, sc *StateControllerBase, _ 
 	return *ret, err
 }
 
-func (c *StateCompiler) transformSprite(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) transformSprite(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*transformSprite)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			transformSprite_redirectid, VT_Float, 1, false); err != nil {
@@ -6797,7 +6802,7 @@ func (c *StateCompiler) transformSprite(is IniSection, sc *StateControllerBase, 
 	return *ret, err
 }
 
-func (c *StateCompiler) modifyStageBG(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) modifyStageBG(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*modifyStageBG)(sc), c.stateSec(is, func() error {
 		//if err := c.paramValue(is, sc, "redirectid",
 		//	modifyStageBG_redirectid, VT_Int, 1, false); err != nil {
@@ -6985,7 +6990,7 @@ func (c *StateCompiler) shaderSub(is IniSection, sc *StateControllerBase, shader
 	return nil
 }
 
-func (c *StateCompiler) shiftInput(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) shiftInput(is IniSection, sc *StateControllerBase) (StateController, error) {
 	inputIndex := func(name string) (int32, error) {
 		switch name {
 		case "U":
@@ -7062,7 +7067,7 @@ func (c *StateCompiler) shiftInput(is IniSection, sc *StateControllerBase, _ int
 	return *ret, err
 }
 
-func (c *StateCompiler) overrideClsn(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) overrideClsn(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*overrideClsn)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			overrideClsn_redirectid, VT_Int, 1, false); err != nil {
@@ -7085,6 +7090,6 @@ func (c *StateCompiler) overrideClsn(is IniSection, sc *StateControllerBase, _ i
 }
 
 // It's just a Null... Has no effect whatsoever.
-func (c *StateCompiler) null(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) null(is IniSection, sc *StateControllerBase) (StateController, error) {
 	return nullStateController, nil
 }

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -93,10 +93,11 @@ func (c *Compiler) hitBySub(is IniSection, sc *StateControllerBase, sctrlName st
 
 	// Cannot mix old and new syntax
 	if old && new {
+		msg := "Cannot mix old and new syntaxes in " + sctrlName
 		if c.zssMode {
-			return Error("Cannot mix old and new " + sctrlName + " syntaxes")
+			return Error(msg)
 		} else {
-			sys.appendToConsole("WARNING: " + sys.cgi[c.playerNo].name + fmt.Sprintf(": Cannot mix old and new: "+sctrlName+" in state %v ", c.stateNo))
+			sys.appendToConsole(c.charWarn() + msg)
 		}
 	}
 
@@ -662,7 +663,7 @@ func (c *Compiler) helper(is IniSection, sc *StateControllerBase, _ int8) (State
 				if c.zssMode {
 					return Error("Helper name not enclosed in \"")
 				}
-				sys.appendToConsole("WARNING: " + sys.cgi[c.playerNo].name + fmt.Sprintf(": Helper name not enclosed in \" : in state %v ", c.stateNo))
+				sys.appendToConsole(c.charWarn() + "Helper name not enclosed in \"")
 				return nil
 			}
 			sc.add(helper_name, sc.beToExp(BytecodeExp(data[1:len(data)-1])))
@@ -2646,11 +2647,11 @@ func (c *Compiler) varSetOlderSub(is IniSection, sc *StateControllerBase, alread
 	// Helper to select target variable and handle duplicate errors
 	setTargetVar := func(data string, t int32) error {
 		if hasIndex || alreadyAssigned() {
-			msg := fmt.Sprintf("VarSet in state %v can only set one variable at a time", c.stateNo)
+			msg := fmt.Sprintf("VarSet can only set one variable at a time")
 			if c.zssMode || !sys.ignoreMostErrors {
 				return Error(msg)
 			}
-			sys.appendToConsole("WARNING: " + sys.cgi[c.playerNo].name + ": " + msg)
+			sys.appendToConsole(c.charWarn() + msg)
 		}
 		hasIndex = true
 		index = data
@@ -2673,11 +2674,11 @@ func (c *Compiler) varSetOlderSub(is IniSection, sc *StateControllerBase, alread
 	}
 
 	if !hasIndex {
-		msg := fmt.Sprintf("VarSet in state %v does not specify variable number", c.stateNo)
+		msg := fmt.Sprintf("VarSet does not specify variable number")
 		if c.zssMode || !sys.ignoreMostErrors {
 			return false, Error(msg)
 		}
-		sys.appendToConsole("WARNING: " + sys.cgi[c.playerNo].name + ": " + msg)
+		sys.appendToConsole(c.charWarn() + msg)
 		return true, nil
 	}
 
@@ -2791,11 +2792,11 @@ func (c *Compiler) varSetSub(is IniSection, sc *StateControllerBase, scType int3
 
 	for _, name := range targetVars {
 		if handled || alreadyAssigned() {
-			msg := fmt.Sprintf("VarSet in state %v can only set one variable at a time", c.stateNo)
+			msg := fmt.Sprintf("VarSet can only set one variable at a time")
 			if c.zssMode || !sys.ignoreMostErrors {
 				return Error(msg)
 			}
-			sys.appendToConsole("WARNING: " + sys.cgi[c.playerNo].name + ": " + msg)
+			sys.appendToConsole(c.charWarn() + msg)
 			break
 		}
 

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -804,6 +804,10 @@ func (c *StateCompiler) helper(is IniSection, sc *StateControllerBase, _ int8) (
 			helper_ownclsnscale, VT_Bool, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "ownprojectile",
+			helper_ownprojectile, VT_Bool, 1, false); err != nil {
+			return err
+		}
 		return nil
 	})
 	return *ret, err

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -11,7 +11,7 @@ import (
 // State controller definition file.
 // This file contains the parsing code for the function in ZSS and CNS, also called State Controllers.
 
-func (c *Compiler) hitBySub(is IniSection, sc *StateControllerBase, sctrlName string) error {
+func (c *StateCompiler) hitBySub(is IniSection, sc *StateControllerBase, sctrlName string) error {
 	attr := int32(-1)
 	var err error
 	var any, new, old bool
@@ -109,7 +109,7 @@ func (c *Compiler) hitBySub(is IniSection, sc *StateControllerBase, sctrlName st
 	return nil
 }
 
-func (c *Compiler) hitBy(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) hitBy(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*hitBy)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid", hitBy_redirectid, VT_Int, 1, false); err != nil {
 			return err
@@ -119,7 +119,7 @@ func (c *Compiler) hitBy(is IniSection, sc *StateControllerBase, _ int8) (StateC
 	return *ret, err
 }
 
-func (c *Compiler) notHitBy(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) notHitBy(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*notHitBy)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid", hitBy_redirectid, VT_Int, 1, false); err != nil {
 			return err
@@ -129,7 +129,7 @@ func (c *Compiler) notHitBy(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	return *ret, err
 }
 
-func (c *Compiler) assertSpecial(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) assertSpecial(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*assertSpecial)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			assertSpecial_redirectid, VT_Int, 1, false); err != nil {
@@ -352,7 +352,7 @@ func (c *Compiler) assertSpecial(is IniSection, sc *StateControllerBase, _ int8)
 	return *ret, err
 }
 
-func (c *Compiler) playSnd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) playSnd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*playSnd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			playSnd_redirectid, VT_Int, 1, false); err != nil {
@@ -430,7 +430,7 @@ func (c *Compiler) playSnd(is IniSection, sc *StateControllerBase, _ int8) (Stat
 	return *ret, err
 }
 
-func (c *Compiler) changeStateSub(is IniSection,
+func (c *StateCompiler) changeStateSub(is IniSection,
 	sc *StateControllerBase) error {
 	if err := c.paramValue(is, sc, "redirectid",
 		changeState_redirectid, VT_Int, 1, false); err != nil {
@@ -468,21 +468,21 @@ func (c *Compiler) changeStateSub(is IniSection,
 	return nil
 }
 
-func (c *Compiler) changeState(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) changeState(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*changeState)(sc), c.stateSec(is, func() error {
 		return c.changeStateSub(is, sc)
 	})
 	return *ret, err
 }
 
-func (c *Compiler) selfState(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) selfState(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*selfState)(sc), c.stateSec(is, func() error {
 		return c.changeStateSub(is, sc)
 	})
 	return *ret, err
 }
 
-func (c *Compiler) tagIn(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) tagIn(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*tagIn)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			tagIn_redirectid, VT_Int, 1, false); err != nil {
@@ -521,7 +521,7 @@ func (c *Compiler) tagIn(is IniSection, sc *StateControllerBase, _ int8) (StateC
 	return *ret, err
 }
 
-func (c *Compiler) tagOut(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) tagOut(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*tagOut)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			tagOut_redirectid, VT_Int, 1, false); err != nil {
@@ -551,7 +551,7 @@ func (c *Compiler) tagOut(is IniSection, sc *StateControllerBase, _ int8) (State
 	return *ret, err
 }
 
-func (c *Compiler) destroySelf(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) destroySelf(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*destroySelf)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			destroySelf_redirectid, VT_Int, 1, false); err != nil {
@@ -574,7 +574,7 @@ func (c *Compiler) destroySelf(is IniSection, sc *StateControllerBase, _ int8) (
 	return *ret, err
 }
 
-func (c *Compiler) changeAnimSub(is IniSection,
+func (c *StateCompiler) changeAnimSub(is IniSection,
 	sc *StateControllerBase) error {
 	if err := c.paramValue(is, sc, "redirectid",
 		changeAnim_redirectid, VT_Int, 1, false); err != nil {
@@ -610,21 +610,21 @@ func (c *Compiler) changeAnimSub(is IniSection,
 	return nil
 }
 
-func (c *Compiler) changeAnim(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) changeAnim(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*changeAnim)(sc), c.stateSec(is, func() error {
 		return c.changeAnimSub(is, sc)
 	})
 	return *ret, err
 }
 
-func (c *Compiler) changeAnim2(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) changeAnim2(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*changeAnim2)(sc), c.stateSec(is, func() error {
 		return c.changeAnimSub(is, sc)
 	})
 	return *ret, err
 }
 
-func (c *Compiler) helper(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) helper(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*helper)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			helper_redirectid, VT_Int, 1, false); err != nil {
@@ -809,7 +809,7 @@ func (c *Compiler) helper(is IniSection, sc *StateControllerBase, _ int8) (State
 	return *ret, err
 }
 
-func (c *Compiler) ctrlSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) ctrlSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*ctrlSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			ctrlSet_redirectid, VT_Int, 1, false); err != nil {
@@ -820,7 +820,7 @@ func (c *Compiler) ctrlSet(is IniSection, sc *StateControllerBase, _ int8) (Stat
 	return *ret, err
 }
 
-func (c *Compiler) explodSub(is IniSection,
+func (c *StateCompiler) explodSub(is IniSection,
 	sc *StateControllerBase, ihp int8) error {
 	if err := c.paramValue(is, sc, "remappal",
 		explod_remappal, VT_Int, 2, false); err != nil {
@@ -969,7 +969,7 @@ func (c *Compiler) explodSub(is IniSection,
 	return nil
 }
 
-func (c *Compiler) explodInterpolate(is IniSection,
+func (c *StateCompiler) explodInterpolate(is IniSection,
 	sc *StateControllerBase) error {
 	if err := c.paramValue(is, sc, "interpolation.time",
 		explod_interpolation_time, VT_Int, 1, false); err != nil {
@@ -1022,7 +1022,7 @@ func (c *Compiler) explodInterpolate(is IniSection,
 	return nil
 }
 
-func (c *Compiler) explod(is IniSection, sc *StateControllerBase,
+func (c *StateCompiler) explod(is IniSection, sc *StateControllerBase,
 	ihp int8) (StateController, error) {
 	ret, err := (*explod)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -1095,7 +1095,7 @@ func (c *Compiler) explod(is IniSection, sc *StateControllerBase,
 	return *ret, err
 }
 
-func (c *Compiler) modifyExplod(is IniSection, sc *StateControllerBase,
+func (c *StateCompiler) modifyExplod(is IniSection, sc *StateControllerBase,
 	ihp int8) (StateController, error) {
 	ret, err := (*modifyExplod)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -1169,7 +1169,7 @@ func (c *Compiler) modifyExplod(is IniSection, sc *StateControllerBase,
 	return *ret, err
 }
 
-func (c *Compiler) gameMakeAnim(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) gameMakeAnim(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*gameMakeAnim)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			gameMakeAnim_redirectid, VT_Int, 1, false); err != nil {
@@ -1205,7 +1205,7 @@ func (c *Compiler) gameMakeAnim(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *Compiler) posSetSub(is IniSection,
+func (c *StateCompiler) posSetSub(is IniSection,
 	sc *StateControllerBase) error {
 	if err := c.paramValue(is, sc, "x",
 		posSet_x, VT_Float, 1, false); err != nil {
@@ -1222,7 +1222,7 @@ func (c *Compiler) posSetSub(is IniSection,
 	return nil
 }
 
-func (c *Compiler) posSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) posSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*posSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			posSet_redirectid, VT_Int, 1, false); err != nil {
@@ -1233,7 +1233,7 @@ func (c *Compiler) posSet(is IniSection, sc *StateControllerBase, _ int8) (State
 	return *ret, err
 }
 
-func (c *Compiler) posAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) posAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*posAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			posSet_redirectid, VT_Int, 1, false); err != nil {
@@ -1244,7 +1244,7 @@ func (c *Compiler) posAdd(is IniSection, sc *StateControllerBase, _ int8) (State
 	return *ret, err
 }
 
-func (c *Compiler) velSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) velSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*velSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			posSet_redirectid, VT_Int, 1, false); err != nil {
@@ -1255,7 +1255,7 @@ func (c *Compiler) velSet(is IniSection, sc *StateControllerBase, _ int8) (State
 	return *ret, err
 }
 
-func (c *Compiler) velAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) velAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*velAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			posSet_redirectid, VT_Int, 1, false); err != nil {
@@ -1266,7 +1266,7 @@ func (c *Compiler) velAdd(is IniSection, sc *StateControllerBase, _ int8) (State
 	return *ret, err
 }
 
-func (c *Compiler) velMul(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) velMul(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*velMul)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			posSet_redirectid, VT_Int, 1, false); err != nil {
@@ -1277,7 +1277,7 @@ func (c *Compiler) velMul(is IniSection, sc *StateControllerBase, _ int8) (State
 	return *ret, err
 }
 
-func (c *Compiler) modifyShadow(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) modifyShadow(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*modifyShadow)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			modifyShadow_redirectid, VT_Int, 1, false); err != nil {
@@ -1359,7 +1359,7 @@ func (c *Compiler) modifyShadow(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *Compiler) modifyReflection(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) modifyReflection(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*modifyReflection)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			modifyReflection_redirectid, VT_Int, 1, false); err != nil {
@@ -1441,7 +1441,7 @@ func (c *Compiler) modifyReflection(is IniSection, sc *StateControllerBase, _ in
 	return *ret, err
 }
 
-func (c *Compiler) palFXSub(is IniSection,
+func (c *StateCompiler) palFXSub(is IniSection,
 	sc *StateControllerBase, prefix string) error {
 	if err := c.paramValue(is, sc, prefix+"time",
 		palFX_time, VT_Int, 1, false); err != nil {
@@ -1544,7 +1544,7 @@ func (c *Compiler) palFXSub(is IniSection,
 	return nil
 }
 
-func (c *Compiler) palFX(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) palFX(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*palFX)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			palFX_redirectid, VT_Int, 1, false); err != nil {
@@ -1555,14 +1555,14 @@ func (c *Compiler) palFX(is IniSection, sc *StateControllerBase, _ int8) (StateC
 	return *ret, err
 }
 
-func (c *Compiler) allPalFX(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) allPalFX(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*allPalFX)(sc), c.stateSec(is, func() error {
 		return c.palFXSub(is, sc, "")
 	})
 	return *ret, err
 }
 
-func (c *Compiler) bgPalFX(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) bgPalFX(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*bgPalFX)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "id",
 			bgPalFX_id, VT_Int, 1, false); err != nil {
@@ -1580,7 +1580,7 @@ func (c *Compiler) bgPalFX(is IniSection, sc *StateControllerBase, _ int8) (Stat
 	return *ret, err
 }
 
-func (c *Compiler) afterImageSub(is IniSection,
+func (c *StateCompiler) afterImageSub(is IniSection,
 	sc *StateControllerBase, ihp int8, prefix string) error {
 	if err := c.paramValue(is, sc, "redirectid",
 		afterImage_redirectid, VT_Int, 1, false); err != nil {
@@ -1647,7 +1647,7 @@ func (c *Compiler) afterImageSub(is IniSection,
 	return nil
 }
 
-func (c *Compiler) afterImage(is IniSection, sc *StateControllerBase,
+func (c *StateCompiler) afterImage(is IniSection, sc *StateControllerBase,
 	ihp int8) (StateController, error) {
 	ret, err := (*afterImage)(sc), c.stateSec(is, func() error {
 		return c.afterImageSub(is, sc, ihp, "")
@@ -1655,7 +1655,7 @@ func (c *Compiler) afterImage(is IniSection, sc *StateControllerBase,
 	return *ret, err
 }
 
-func (c *Compiler) afterImageTime(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) afterImageTime(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*afterImageTime)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			afterImageTime_redirectid, VT_Int, 1, false); err != nil {
@@ -1684,7 +1684,7 @@ func (c *Compiler) afterImageTime(is IniSection, sc *StateControllerBase, _ int8
 	return *ret, err
 }
 
-func (c *Compiler) parseHitFlag(sc *StateControllerBase, id byte, data string) error {
+func (c *StateCompiler) parseHitFlag(sc *StateControllerBase, id byte, data string) error {
 	var flg int32
 	for _, c := range data {
 		switch c {
@@ -1712,7 +1712,7 @@ func (c *Compiler) parseHitFlag(sc *StateControllerBase, id byte, data string) e
 	return nil
 }
 
-func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
+func (c *StateCompiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 	if err := c.stateParam(is, "attr", false, func(data string) error {
 		attr, err := c.attr(data, true)
 		if err != nil {
@@ -2273,7 +2273,7 @@ func (c *Compiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 	return nil
 }
 
-func (c *Compiler) hitDef(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) hitDef(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*hitDef)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			hitDef_redirectid, VT_Int, 1, false); err != nil {
@@ -2284,7 +2284,7 @@ func (c *Compiler) hitDef(is IniSection, sc *StateControllerBase, _ int8) (State
 	return *ret, err
 }
 
-func (c *Compiler) modifyHitDef(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) modifyHitDef(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*modifyHitDef)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			modifyHitDef_redirectid, VT_Int, 1, false); err != nil {
@@ -2295,7 +2295,7 @@ func (c *Compiler) modifyHitDef(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *Compiler) reversalDef(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) reversalDef(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*reversalDef)(sc), c.stateSec(is, func() error {
 		attr := int32(-1)
 		var err error
@@ -2329,7 +2329,7 @@ func (c *Compiler) reversalDef(is IniSection, sc *StateControllerBase, _ int8) (
 	return *ret, err
 }
 
-func (c *Compiler) modifyReversalDef(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) modifyReversalDef(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*modifyReversalDef)(sc), c.stateSec(is, func() error {
 		var err error
 		if err = c.paramValue(is, sc, "redirectid",
@@ -2361,7 +2361,7 @@ func (c *Compiler) modifyReversalDef(is IniSection, sc *StateControllerBase, _ i
 	return *ret, err
 }
 
-func (c *Compiler) projectileSub(is IniSection, sc *StateControllerBase, ihp int8) error {
+func (c *StateCompiler) projectileSub(is IniSection, sc *StateControllerBase, ihp int8) error {
 	if err := c.paramValue(is, sc, "redirectid",
 		projectile_redirectid, VT_Int, 1, false); err != nil {
 		return err
@@ -2539,7 +2539,7 @@ func (c *Compiler) projectileSub(is IniSection, sc *StateControllerBase, ihp int
 	return nil
 }
 
-func (c *Compiler) projectile(is IniSection, sc *StateControllerBase, ihp int8) (StateController, error) {
+func (c *StateCompiler) projectile(is IniSection, sc *StateControllerBase, ihp int8) (StateController, error) {
 	ret, err := (*projectile)(sc), c.stateSec(is, func() error {
 		if err := c.projectileSub(is, sc, ihp); err != nil {
 			return err
@@ -2549,7 +2549,7 @@ func (c *Compiler) projectile(is IniSection, sc *StateControllerBase, ihp int8) 
 	return *ret, err
 }
 
-func (c *Compiler) modifyProjectile(is IniSection, sc *StateControllerBase,
+func (c *StateCompiler) modifyProjectile(is IniSection, sc *StateControllerBase,
 	ihp int8) (StateController, error) {
 	ret, err := (*modifyProjectile)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
@@ -2573,7 +2573,7 @@ func (c *Compiler) modifyProjectile(is IniSection, sc *StateControllerBase,
 	return *ret, err
 }
 
-func (c *Compiler) width(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) width(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*width)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			width_redirectid, VT_Int, 1, false); err != nil {
@@ -2609,7 +2609,7 @@ func (c *Compiler) width(is IniSection, sc *StateControllerBase, _ int8) (StateC
 	return *ret, err
 }
 
-func (c *Compiler) sprPriority(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) sprPriority(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*sprPriority)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			sprPriority_redirectid, VT_Int, 1, false); err != nil {
@@ -2626,7 +2626,7 @@ func (c *Compiler) sprPriority(is IniSection, sc *StateControllerBase, _ int8) (
 }
 
 // "v = x; value = y" syntax
-func (c *Compiler) varSetOlderSub(is IniSection, sc *StateControllerBase, alreadyAssigned func() bool) (bool, error) {
+func (c *StateCompiler) varSetOlderSub(is IniSection, sc *StateControllerBase, alreadyAssigned func() bool) (bool, error) {
 	var value string
 	hasValue := false
 	if err := c.stateParam(is, "value", false, func(data string) error {
@@ -2696,7 +2696,7 @@ func (c *Compiler) varSetOlderSub(is IniSection, sc *StateControllerBase, alread
 }
 
 // "var(x) = y" syntax. CNS only
-func (c *Compiler) varSetNewerSub(name string) (varType int32, index BytecodeExp, ok bool, err error) {
+func (c *StateCompiler) varSetNewerSub(name string) (varType int32, index BytecodeExp, ok bool, err error) {
 	trimmed := strings.TrimSpace(name)
 	lowered := strings.ToLower(trimmed)
 
@@ -2769,7 +2769,7 @@ func (c *Compiler) varSetNewerSub(name string) (varType int32, index BytecodeExp
 	return 0, nil, false, nil
 }
 
-func (c *Compiler) varSetSub(is IniSection, sc *StateControllerBase, scType int32) error {
+func (c *StateCompiler) varSetSub(is IniSection, sc *StateControllerBase, scType int32) error {
 	alreadyAssigned := func() bool {
 		return sc.hasParam(varSet_index) || sc.hasParam(varSet_varType)
 	}
@@ -2833,7 +2833,7 @@ func (c *Compiler) varSetSub(is IniSection, sc *StateControllerBase, scType int3
 	return Error("Variable or value parameter not specified")
 }
 
-func (c *Compiler) varSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) varSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*varSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			varSet_redirectid, VT_Int, 1, false); err != nil {
@@ -2844,7 +2844,7 @@ func (c *Compiler) varSet(is IniSection, sc *StateControllerBase, _ int8) (State
 	return *ret, err
 }
 
-func (c *Compiler) varAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) varAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*varSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			varSet_redirectid, VT_Int, 1, false); err != nil {
@@ -2855,7 +2855,7 @@ func (c *Compiler) varAdd(is IniSection, sc *StateControllerBase, _ int8) (State
 	return *ret, err
 }
 
-func (c *Compiler) parentVarSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) parentVarSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*varSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			varSet_redirectid, VT_Int, 1, false); err != nil {
@@ -2866,7 +2866,7 @@ func (c *Compiler) parentVarSet(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *Compiler) parentVarAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) parentVarAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*varSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			varSet_redirectid, VT_Int, 1, false); err != nil {
@@ -2877,7 +2877,7 @@ func (c *Compiler) parentVarAdd(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *Compiler) rootVarSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) rootVarSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*varSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			varSet_redirectid, VT_Int, 1, false); err != nil {
@@ -2888,7 +2888,7 @@ func (c *Compiler) rootVarSet(is IniSection, sc *StateControllerBase, _ int8) (S
 	return *ret, err
 }
 
-func (c *Compiler) rootVarAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) rootVarAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*varSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			varSet_redirectid, VT_Int, 1, false); err != nil {
@@ -2899,7 +2899,7 @@ func (c *Compiler) rootVarAdd(is IniSection, sc *StateControllerBase, _ int8) (S
 	return *ret, err
 }
 
-func (c *Compiler) turn(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) turn(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*turn)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			turn_redirectid, VT_Int, 1, false); err != nil {
@@ -2911,7 +2911,7 @@ func (c *Compiler) turn(is IniSection, sc *StateControllerBase, _ int8) (StateCo
 	return *ret, err
 }
 
-func (c *Compiler) targetFacing(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) targetFacing(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*targetFacing)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetFacing_redirectid, VT_Int, 1, false); err != nil {
@@ -2934,7 +2934,7 @@ func (c *Compiler) targetFacing(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *Compiler) targetBind(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) targetBind(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*targetBind)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetBind_redirectid, VT_Int, 1, false); err != nil {
@@ -2961,7 +2961,7 @@ func (c *Compiler) targetBind(is IniSection, sc *StateControllerBase, _ int8) (S
 	return *ret, err
 }
 
-func (c *Compiler) bindToTarget(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) bindToTarget(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*bindToTarget)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			bindToTarget_redirectid, VT_Int, 1, false); err != nil {
@@ -3022,7 +3022,7 @@ func (c *Compiler) bindToTarget(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *Compiler) targetLifeAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) targetLifeAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*targetLifeAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetLifeAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -3061,7 +3061,7 @@ func (c *Compiler) targetLifeAdd(is IniSection, sc *StateControllerBase, _ int8)
 	return *ret, err
 }
 
-func (c *Compiler) targetState(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) targetState(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*targetState)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetState_redirectid, VT_Int, 1, false); err != nil {
@@ -3084,7 +3084,7 @@ func (c *Compiler) targetState(is IniSection, sc *StateControllerBase, _ int8) (
 	return *ret, err
 }
 
-func (c *Compiler) targetVelSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) targetVelSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*targetVelSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetVelSet_redirectid, VT_Int, 1, false); err != nil {
@@ -3115,7 +3115,7 @@ func (c *Compiler) targetVelSet(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *Compiler) targetVelAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) targetVelAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*targetVelAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetVelAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -3146,7 +3146,7 @@ func (c *Compiler) targetVelAdd(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *Compiler) targetPowerAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) targetPowerAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*targetPowerAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetPowerAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -3169,7 +3169,7 @@ func (c *Compiler) targetPowerAdd(is IniSection, sc *StateControllerBase, _ int8
 	return *ret, err
 }
 
-func (c *Compiler) targetDrop(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) targetDrop(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*targetDrop)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetDrop_redirectid, VT_Int, 1, false); err != nil {
@@ -3188,7 +3188,7 @@ func (c *Compiler) targetDrop(is IniSection, sc *StateControllerBase, _ int8) (S
 	return *ret, err
 }
 
-func (c *Compiler) lifeAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) lifeAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*lifeAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			lifeAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -3211,7 +3211,7 @@ func (c *Compiler) lifeAdd(is IniSection, sc *StateControllerBase, _ int8) (Stat
 	return *ret, err
 }
 
-func (c *Compiler) lifeSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) lifeSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*lifeSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			lifeSet_redirectid, VT_Int, 1, false); err != nil {
@@ -3222,7 +3222,7 @@ func (c *Compiler) lifeSet(is IniSection, sc *StateControllerBase, _ int8) (Stat
 	return *ret, err
 }
 
-func (c *Compiler) powerAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) powerAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*powerAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			powerAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -3233,7 +3233,7 @@ func (c *Compiler) powerAdd(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	return *ret, err
 }
 
-func (c *Compiler) powerSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) powerSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*powerSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			powerSet_redirectid, VT_Int, 1, false); err != nil {
@@ -3244,7 +3244,7 @@ func (c *Compiler) powerSet(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	return *ret, err
 }
 
-func (c *Compiler) hitVelSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) hitVelSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*hitVelSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			hitVelSet_redirectid, VT_Int, 1, false); err != nil {
@@ -3267,7 +3267,7 @@ func (c *Compiler) hitVelSet(is IniSection, sc *StateControllerBase, _ int8) (St
 	return *ret, err
 }
 
-func (c *Compiler) screenBound(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) screenBound(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*screenBound)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			screenBound_redirectid, VT_Int, 1, false); err != nil {
@@ -3303,7 +3303,7 @@ func (c *Compiler) screenBound(is IniSection, sc *StateControllerBase, _ int8) (
 	return *ret, err
 }
 
-func (c *Compiler) posFreeze(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) posFreeze(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*posFreeze)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			posFreeze_redirectid, VT_Int, 1, false); err != nil {
@@ -3324,7 +3324,7 @@ func (c *Compiler) posFreeze(is IniSection, sc *StateControllerBase, _ int8) (St
 	return *ret, err
 }
 
-func (c *Compiler) envShake(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) envShake(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*envShake)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "time",
 			envShake_time, VT_Int, 1, false); err != nil {
@@ -3355,7 +3355,7 @@ func (c *Compiler) envShake(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	return *ret, err
 }
 
-func (c *Compiler) hitOverride(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) hitOverride(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*hitOverride)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			hitOverride_redirectid, VT_Int, 1, false); err != nil {
@@ -3410,7 +3410,7 @@ func (c *Compiler) hitOverride(is IniSection, sc *StateControllerBase, _ int8) (
 	return *ret, err
 }
 
-func (c *Compiler) pause(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) pause(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*pause)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			pause_redirectid, VT_Int, 1, false); err != nil {
@@ -3437,7 +3437,7 @@ func (c *Compiler) pause(is IniSection, sc *StateControllerBase, _ int8) (StateC
 	return *ret, err
 }
 
-func (c *Compiler) superPause(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) superPause(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*superPause)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			superPause_redirectid, VT_Int, 1, false); err != nil {
@@ -3502,7 +3502,7 @@ func (c *Compiler) superPause(is IniSection, sc *StateControllerBase, _ int8) (S
 	return *ret, err
 }
 
-func (c *Compiler) trans(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) trans(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*trans)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			trans_redirectid, VT_Int, 1, false); err != nil {
@@ -3516,7 +3516,7 @@ func (c *Compiler) trans(is IniSection, sc *StateControllerBase, _ int8) (StateC
 	return *ret, err
 }
 
-func (c *Compiler) playerPush(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) playerPush(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*playerPush)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			playerPush_redirectid, VT_Int, 1, false); err != nil {
@@ -3564,7 +3564,7 @@ func (c *Compiler) playerPush(is IniSection, sc *StateControllerBase, _ int8) (S
 	return *ret, err
 }
 
-func (c *Compiler) stateTypeSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) stateTypeSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*stateTypeSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			stateTypeSet_redirectid, VT_Int, 1, false); err != nil {
@@ -3651,7 +3651,7 @@ func (c *Compiler) stateTypeSet(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *Compiler) angleDraw(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) angleDraw(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*angleDraw)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			angleDraw_redirectid, VT_Int, 1, false); err != nil {
@@ -3678,7 +3678,7 @@ func (c *Compiler) angleDraw(is IniSection, sc *StateControllerBase, _ int8) (St
 	return *ret, err
 }
 
-func (c *Compiler) angleSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) angleSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*angleSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			angleSet_redirectid, VT_Int, 1, false); err != nil {
@@ -3701,7 +3701,7 @@ func (c *Compiler) angleSet(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	return *ret, err
 }
 
-func (c *Compiler) angleAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) angleAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*angleAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			angleAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -3724,7 +3724,7 @@ func (c *Compiler) angleAdd(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	return *ret, err
 }
 
-func (c *Compiler) angleMul(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) angleMul(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*angleMul)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			angleMul_redirectid, VT_Int, 1, false); err != nil {
@@ -3747,7 +3747,7 @@ func (c *Compiler) angleMul(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	return *ret, err
 }
 
-func (c *Compiler) envColor(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) envColor(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*envColor)(sc), c.stateSec(is, func() error {
 		if err := c.stateParam(is, "value", false, func(data string) error {
 			bes, err := c.exprs(data, VT_Int, 3)
@@ -3775,7 +3775,7 @@ func (c *Compiler) envColor(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	return *ret, err
 }
 
-func (c *Compiler) displayToClipboardSub(is IniSection,
+func (c *StateCompiler) displayToClipboardSub(is IniSection,
 	sc *StateControllerBase) error {
 	if err := c.paramValue(is, sc, "redirectid",
 		displayToClipboard_redirectid, VT_Int, 1, false); err != nil {
@@ -3819,21 +3819,21 @@ func (c *Compiler) displayToClipboardSub(is IniSection,
 	return nil
 }
 
-func (c *Compiler) displayToClipboard(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) displayToClipboard(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*displayToClipboard)(sc), c.stateSec(is, func() error {
 		return c.displayToClipboardSub(is, sc)
 	})
 	return *ret, err
 }
 
-func (c *Compiler) appendToClipboard(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) appendToClipboard(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*appendToClipboard)(sc), c.stateSec(is, func() error {
 		return c.displayToClipboardSub(is, sc)
 	})
 	return *ret, err
 }
 
-func (c *Compiler) clearClipboard(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) clearClipboard(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*clearClipboard)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			clearClipboard_redirectid, VT_Int, 1, false); err != nil {
@@ -3845,7 +3845,7 @@ func (c *Compiler) clearClipboard(is IniSection, sc *StateControllerBase, _ int8
 	return *ret, err
 }
 
-func (c *Compiler) makeDust(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) makeDust(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*makeDust)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			makeDust_redirectid, VT_Int, 1, false); err != nil {
@@ -3870,7 +3870,7 @@ func (c *Compiler) makeDust(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	return *ret, err
 }
 
-func (c *Compiler) attackDist(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) attackDist(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*attackDist)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			attackDist_redirectid, VT_Int, 1, false); err != nil {
@@ -3897,7 +3897,7 @@ func (c *Compiler) attackDist(is IniSection, sc *StateControllerBase, _ int8) (S
 	return *ret, err
 }
 
-func (c *Compiler) attackMulSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) attackMulSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*attackMulSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			attackMulSet_redirectid, VT_Int, 1, false); err != nil {
@@ -3942,7 +3942,7 @@ func (c *Compiler) attackMulSet(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *Compiler) defenceMulSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) defenceMulSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*defenceMulSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(
 			is, sc, "redirectid",
@@ -3983,7 +3983,7 @@ func (c *Compiler) defenceMulSet(is IniSection, sc *StateControllerBase, _ int8)
 	return *ret, err
 }
 
-func (c *Compiler) fallEnvShake(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) fallEnvShake(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*fallEnvShake)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			fallEnvShake_redirectid, VT_Int, 1, false); err != nil {
@@ -3995,7 +3995,7 @@ func (c *Compiler) fallEnvShake(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *Compiler) hitFallDamage(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) hitFallDamage(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*hitFallDamage)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			hitFallDamage_redirectid, VT_Int, 1, false); err != nil {
@@ -4007,7 +4007,7 @@ func (c *Compiler) hitFallDamage(is IniSection, sc *StateControllerBase, _ int8)
 	return *ret, err
 }
 
-func (c *Compiler) hitFallVel(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) hitFallVel(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*hitFallVel)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			hitFallVel_redirectid, VT_Int, 1, false); err != nil {
@@ -4019,7 +4019,7 @@ func (c *Compiler) hitFallVel(is IniSection, sc *StateControllerBase, _ int8) (S
 	return *ret, err
 }
 
-func (c *Compiler) hitFallSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) hitFallSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*hitFallSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			hitFallSet_redirectid, VT_Int, 1, false); err != nil {
@@ -4048,7 +4048,7 @@ func (c *Compiler) hitFallSet(is IniSection, sc *StateControllerBase, _ int8) (S
 	return *ret, err
 }
 
-func (c *Compiler) varRangeSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) varRangeSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*varRangeSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			varRangeSet_redirectid, VT_Int, 1, false); err != nil {
@@ -4085,7 +4085,7 @@ func (c *Compiler) varRangeSet(is IniSection, sc *StateControllerBase, _ int8) (
 	return *ret, err
 }
 
-func (c *Compiler) remapPal(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) remapPal(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*remapPal)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			remapPal_redirectid, VT_Int, 1, false); err != nil {
@@ -4104,7 +4104,7 @@ func (c *Compiler) remapPal(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	return *ret, err
 }
 
-func (c *Compiler) stopSnd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) stopSnd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*stopSnd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			stopSnd_redirectid, VT_Int, 1, false); err != nil {
@@ -4119,7 +4119,7 @@ func (c *Compiler) stopSnd(is IniSection, sc *StateControllerBase, _ int8) (Stat
 	return *ret, err
 }
 
-func (c *Compiler) sndPan(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) sndPan(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*sndPan)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			sndPan_redirectid, VT_Int, 1, false); err != nil {
@@ -4142,7 +4142,7 @@ func (c *Compiler) sndPan(is IniSection, sc *StateControllerBase, _ int8) (State
 	return *ret, err
 }
 
-func (c *Compiler) varRandom(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) varRandom(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*varRandom)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			varRandom_redirectid, VT_Int, 1, false); err != nil {
@@ -4161,7 +4161,7 @@ func (c *Compiler) varRandom(is IniSection, sc *StateControllerBase, _ int8) (St
 	return *ret, err
 }
 
-func (c *Compiler) gravity(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) gravity(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*gravity)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			gravity_redirectid, VT_Int, 1, false); err != nil {
@@ -4173,7 +4173,7 @@ func (c *Compiler) gravity(is IniSection, sc *StateControllerBase, _ int8) (Stat
 	return *ret, err
 }
 
-func (c *Compiler) bindToParentSub(is IniSection,
+func (c *StateCompiler) bindToParentSub(is IniSection,
 	sc *StateControllerBase) error {
 	if err := c.paramValue(is, sc, "redirectid",
 		bindToParent_redirectid, VT_Int, 1, false); err != nil {
@@ -4194,21 +4194,21 @@ func (c *Compiler) bindToParentSub(is IniSection,
 	return nil
 }
 
-func (c *Compiler) bindToParent(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) bindToParent(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*bindToParent)(sc), c.stateSec(is, func() error {
 		return c.bindToParentSub(is, sc)
 	})
 	return *ret, err
 }
 
-func (c *Compiler) bindToRoot(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) bindToRoot(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*bindToRoot)(sc), c.stateSec(is, func() error {
 		return c.bindToParentSub(is, sc)
 	})
 	return *ret, err
 }
 
-func (c *Compiler) removeExplod(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) removeExplod(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*removeExplod)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			removeExplod_redirectid, VT_Int, 1, false); err != nil {
@@ -4234,7 +4234,7 @@ func (c *Compiler) removeExplod(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *Compiler) explodBindTime(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) explodBindTime(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*explodBindTime)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			explodBindTime_redirectid, VT_Int, 1, false); err != nil {
@@ -4262,7 +4262,7 @@ func (c *Compiler) explodBindTime(is IniSection, sc *StateControllerBase, _ int8
 	return *ret, err
 }
 
-func (c *Compiler) moveHitReset(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) moveHitReset(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*moveHitReset)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			moveHitReset_redirectid, VT_Int, 1, false); err != nil {
@@ -4274,7 +4274,7 @@ func (c *Compiler) moveHitReset(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *Compiler) hitAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) hitAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*hitAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			hitAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -4289,7 +4289,7 @@ func (c *Compiler) hitAdd(is IniSection, sc *StateControllerBase, _ int8) (State
 	return *ret, err
 }
 
-func (c *Compiler) offset(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) offset(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*offset)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			offset_redirectid, VT_Int, 1, false); err != nil {
@@ -4308,7 +4308,7 @@ func (c *Compiler) offset(is IniSection, sc *StateControllerBase, _ int8) (State
 	return *ret, err
 }
 
-func (c *Compiler) victoryQuote(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) victoryQuote(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*victoryQuote)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			victoryQuote_redirectid, VT_Int, 1, false); err != nil {
@@ -4323,7 +4323,7 @@ func (c *Compiler) victoryQuote(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *Compiler) zoom(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) zoom(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*zoom)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "pos",
 			zoom_pos, VT_Float, 2, false); err != nil {
@@ -4358,7 +4358,7 @@ func (c *Compiler) zoom(is IniSection, sc *StateControllerBase, _ int8) (StateCo
 	return *ret, err
 }
 
-func (c *Compiler) forceFeedback(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) forceFeedback(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*forceFeedback)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			forceFeedback_redirectid, VT_Int, 1, false); err != nil {
@@ -4418,7 +4418,7 @@ func (c *Compiler) forceFeedback(is IniSection, sc *StateControllerBase, _ int8)
 	return *ret, err
 }
 
-func (c *Compiler) assertAnalogVector(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) assertAnalogVector(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*assertAnalogVector)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			assertAnalogVector_redirectid, VT_Int, 1, false); err != nil {
@@ -4453,7 +4453,7 @@ func (c *Compiler) assertAnalogVector(is IniSection, sc *StateControllerBase, _ 
 	return *ret, err
 }
 
-func (c *Compiler) assertInput(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) assertInput(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*assertInput)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			assertInput_redirectid, VT_Int, 1, false); err != nil {
@@ -4524,7 +4524,7 @@ func (c *Compiler) assertInput(is IniSection, sc *StateControllerBase, _ int8) (
 	return *ret, err
 }
 
-func (c *Compiler) dialogue(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) dialogue(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*dialogue)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			dialogue_redirectid, VT_Int, 1, false); err != nil {
@@ -4566,7 +4566,7 @@ func (c *Compiler) dialogue(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	return *ret, err
 }
 
-func (c *Compiler) dizzyPointsAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) dizzyPointsAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*dizzyPointsAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			dizzyPointsAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -4585,7 +4585,7 @@ func (c *Compiler) dizzyPointsAdd(is IniSection, sc *StateControllerBase, _ int8
 	return *ret, err
 }
 
-func (c *Compiler) dizzyPointsSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) dizzyPointsSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*dizzyPointsSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			dizzyPointsSet_redirectid, VT_Int, 1, false); err != nil {
@@ -4596,7 +4596,7 @@ func (c *Compiler) dizzyPointsSet(is IniSection, sc *StateControllerBase, _ int8
 	return *ret, err
 }
 
-func (c *Compiler) dizzySet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) dizzySet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*dizzySet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			dizzySet_redirectid, VT_Int, 1, false); err != nil {
@@ -4607,7 +4607,7 @@ func (c *Compiler) dizzySet(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	return *ret, err
 }
 
-func (c *Compiler) guardBreakSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) guardBreakSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*guardBreakSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			guardBreakSet_redirectid, VT_Int, 1, false); err != nil {
@@ -4618,7 +4618,7 @@ func (c *Compiler) guardBreakSet(is IniSection, sc *StateControllerBase, _ int8)
 	return *ret, err
 }
 
-func (c *Compiler) guardPointsAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) guardPointsAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*guardPointsAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			guardPointsAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -4637,7 +4637,7 @@ func (c *Compiler) guardPointsAdd(is IniSection, sc *StateControllerBase, _ int8
 	return *ret, err
 }
 
-func (c *Compiler) guardPointsSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) guardPointsSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*guardPointsSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			guardPointsSet_redirectid, VT_Int, 1, false); err != nil {
@@ -4648,7 +4648,7 @@ func (c *Compiler) guardPointsSet(is IniSection, sc *StateControllerBase, _ int8
 	return *ret, err
 }
 
-func (c *Compiler) lifebarAction(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) lifebarAction(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*lifebarAction)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			lifebarAction_redirectid, VT_Int, 1, false); err != nil {
@@ -4720,7 +4720,7 @@ func (c *Compiler) lifebarAction(is IniSection, sc *StateControllerBase, _ int8)
 	return *ret, err
 }
 
-func (c *Compiler) loadFile(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) loadFile(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*loadFile)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			loadFile_redirectid, VT_Int, 1, false); err != nil {
@@ -4743,7 +4743,7 @@ func (c *Compiler) loadFile(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	return *ret, err
 }
 
-func (c *Compiler) loadState(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) loadState(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*loadState)(sc), c.stateSec(is, func() error {
 		sc.add(loadState_, nil)
 		return nil
@@ -4752,7 +4752,7 @@ func (c *Compiler) loadState(is IniSection, sc *StateControllerBase, _ int8) (St
 }
 
 // TODO: Remove boilerplate from the Map's Compiler.
-func (c *Compiler) mapSetSub(is IniSection, sc *StateControllerBase) error {
+func (c *StateCompiler) mapSetSub(is IniSection, sc *StateControllerBase) error {
 	err := c.stateSec(is, func() error {
 		assign := false
 		var mapParam, mapName, value string
@@ -4862,7 +4862,7 @@ func (c *Compiler) mapSetSub(is IniSection, sc *StateControllerBase) error {
 	return err
 }
 
-func (c *Compiler) mapSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) mapSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
 			return err
@@ -4874,7 +4874,7 @@ func (c *Compiler) mapSet(is IniSection, sc *StateControllerBase, _ int8) (State
 	return *ret, err
 }
 
-func (c *Compiler) mapAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) mapAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
 			return err
@@ -4886,7 +4886,7 @@ func (c *Compiler) mapAdd(is IniSection, sc *StateControllerBase, _ int8) (State
 	return *ret, err
 }
 
-func (c *Compiler) parentMapSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) parentMapSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
 			return err
@@ -4898,7 +4898,7 @@ func (c *Compiler) parentMapSet(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *Compiler) parentMapAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) parentMapAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
 			return err
@@ -4910,7 +4910,7 @@ func (c *Compiler) parentMapAdd(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *Compiler) rootMapSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) rootMapSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
 			return err
@@ -4922,7 +4922,7 @@ func (c *Compiler) rootMapSet(is IniSection, sc *StateControllerBase, _ int8) (S
 	return *ret, err
 }
 
-func (c *Compiler) rootMapAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) rootMapAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
 			return err
@@ -4934,7 +4934,7 @@ func (c *Compiler) rootMapAdd(is IniSection, sc *StateControllerBase, _ int8) (S
 	return *ret, err
 }
 
-func (c *Compiler) teamMapSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) teamMapSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
 			return err
@@ -4946,7 +4946,7 @@ func (c *Compiler) teamMapSet(is IniSection, sc *StateControllerBase, _ int8) (S
 	return *ret, err
 }
 
-func (c *Compiler) teamMapAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) teamMapAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
 			return err
@@ -4958,7 +4958,7 @@ func (c *Compiler) teamMapAdd(is IniSection, sc *StateControllerBase, _ int8) (S
 	return *ret, err
 }
 
-func (c *Compiler) mapReset(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) mapReset(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*mapReset)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			mapReset_redirectid, VT_Int, 1, false); err != nil {
@@ -4994,7 +4994,7 @@ func (c *Compiler) mapReset(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	return *ret, err
 }
 
-func (c *Compiler) matchRestart(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) matchRestart(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*matchRestart)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "reload",
 			matchRestart_reload, VT_Bool, MaxPlayerNo, false); err != nil {
@@ -5134,7 +5134,7 @@ func (c *Compiler) matchRestart(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *Compiler) playBgm(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) playBgm(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*playBgm)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			playBgm_redirectid, VT_Int, 1, false); err != nil {
@@ -5219,7 +5219,7 @@ func (c *Compiler) playBgm(is IniSection, sc *StateControllerBase, _ int8) (Stat
 	return *ret, err
 }
 
-func (c *Compiler) modifyBGCtrl(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) modifyBGCtrl(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*modifyBGCtrl)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "id",
 			modifyBGCtrl_id, VT_Int, 1, true); err != nil {
@@ -5294,7 +5294,7 @@ func (c *Compiler) modifyBGCtrl(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *Compiler) modifyBGCtrl3d(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) modifyBGCtrl3d(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*modifyBGCtrl3d)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "id",
 			modifyBGCtrl3d_ctrlid, VT_Int, 1, true); err != nil {
@@ -5313,7 +5313,7 @@ func (c *Compiler) modifyBGCtrl3d(is IniSection, sc *StateControllerBase, _ int8
 	return *ret, err
 }
 
-func (c *Compiler) modifySnd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) modifySnd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*modifySnd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			modifySnd_redirectid, VT_Int, 1, false); err != nil {
@@ -5380,7 +5380,7 @@ func (c *Compiler) modifySnd(is IniSection, sc *StateControllerBase, _ int8) (St
 	return *ret, err
 }
 
-func (c *Compiler) modifyBgm(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) modifyBgm(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*modifyBgm)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "volume",
 			modifyBgm_volume, VT_Int, 1, false); err != nil {
@@ -5407,14 +5407,14 @@ func (c *Compiler) modifyBgm(is IniSection, sc *StateControllerBase, _ int8) (St
 	return *ret, err
 }
 
-func (c *Compiler) printToConsole(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) printToConsole(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*printToConsole)(sc), c.stateSec(is, func() error {
 		return c.displayToClipboardSub(is, sc)
 	})
 	return *ret, err
 }
 
-func (c *Compiler) redLifeAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) redLifeAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*redLifeAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			redLifeAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -5433,7 +5433,7 @@ func (c *Compiler) redLifeAdd(is IniSection, sc *StateControllerBase, _ int8) (S
 	return *ret, err
 }
 
-func (c *Compiler) redLifeSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) redLifeSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*redLifeSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			redLifeSet_redirectid, VT_Int, 1, false); err != nil {
@@ -5444,7 +5444,7 @@ func (c *Compiler) redLifeSet(is IniSection, sc *StateControllerBase, _ int8) (S
 	return *ret, err
 }
 
-func (c *Compiler) remapSprite(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) remapSprite(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*remapSprite)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			remapSprite_redirectid, VT_Int, 1, false); err != nil {
@@ -5476,7 +5476,7 @@ func (c *Compiler) remapSprite(is IniSection, sc *StateControllerBase, _ int8) (
 	return *ret, err
 }
 
-func (c *Compiler) roundTimeAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) roundTimeAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*roundTimeAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			roundTimeAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -5491,7 +5491,7 @@ func (c *Compiler) roundTimeAdd(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *Compiler) roundTimeSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) roundTimeSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*roundTimeSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			roundTimeSet_redirectid, VT_Int, 1, false); err != nil {
@@ -5502,7 +5502,7 @@ func (c *Compiler) roundTimeSet(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *Compiler) saveFile(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) saveFile(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*saveFile)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			saveFile_redirectid, VT_Int, 1, false); err != nil {
@@ -5525,7 +5525,7 @@ func (c *Compiler) saveFile(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	return *ret, err
 }
 
-func (c *Compiler) saveState(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) saveState(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*saveState)(sc), c.stateSec(is, func() error {
 		sc.add(saveState_, nil)
 		return nil
@@ -5533,7 +5533,7 @@ func (c *Compiler) saveState(is IniSection, sc *StateControllerBase, _ int8) (St
 	return *ret, err
 }
 
-func (c *Compiler) scoreAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) scoreAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*scoreAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			scoreAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -5547,7 +5547,7 @@ func (c *Compiler) scoreAdd(is IniSection, sc *StateControllerBase, _ int8) (Sta
 	})
 	return *ret, err
 }
-func (c *Compiler) shaderSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) shaderSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*shaderSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid", shaderSet_redirectid, VT_Int, 1, false); err != nil {
 			return err
@@ -5562,7 +5562,7 @@ func (c *Compiler) shaderSet(is IniSection, sc *StateControllerBase, _ int8) (St
 	})
 	return *ret, err
 }
-func (c *Compiler) storyboard(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) storyboard(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*storyboard)(sc), c.stateSec(is, func() error {
 		if err := c.stateParam(is, "path", false, func(data string) error {
 			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
@@ -5578,7 +5578,7 @@ func (c *Compiler) storyboard(is IniSection, sc *StateControllerBase, _ int8) (S
 	return *ret, err
 }
 
-func (c *Compiler) targetDizzyPointsAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) targetDizzyPointsAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*targetDizzyPointsAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetDizzyPointsAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -5601,7 +5601,7 @@ func (c *Compiler) targetDizzyPointsAdd(is IniSection, sc *StateControllerBase, 
 	return *ret, err
 }
 
-func (c *Compiler) targetGuardPointsAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) targetGuardPointsAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*targetGuardPointsAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetGuardPointsAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -5624,7 +5624,7 @@ func (c *Compiler) targetGuardPointsAdd(is IniSection, sc *StateControllerBase, 
 	return *ret, err
 }
 
-func (c *Compiler) targetRedLifeAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) targetRedLifeAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*targetRedLifeAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetRedLifeAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -5647,7 +5647,7 @@ func (c *Compiler) targetRedLifeAdd(is IniSection, sc *StateControllerBase, _ in
 	return *ret, err
 }
 
-func (c *Compiler) targetScoreAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) targetScoreAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*targetScoreAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetScoreAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -5666,7 +5666,7 @@ func (c *Compiler) targetScoreAdd(is IniSection, sc *StateControllerBase, _ int8
 	return *ret, err
 }
 
-func (c *Compiler) text(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) text(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*text)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			text_redirectid, VT_Int, 1, false); err != nil {
@@ -5804,7 +5804,7 @@ func (c *Compiler) text(is IniSection, sc *StateControllerBase, _ int8) (StateCo
 	return *ret, err
 }
 
-func (c *Compiler) modifyText(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) modifyText(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*modifyText)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			modifytext_redirectid, VT_Int, 1, false); err != nil {
@@ -5946,7 +5946,7 @@ func (c *Compiler) modifyText(is IniSection, sc *StateControllerBase, _ int8) (S
 	return *ret, err
 }
 
-func (c *Compiler) removeText(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) removeText(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*removeText)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			removetext_redirectid, VT_Int, 1, false); err != nil {
@@ -5973,7 +5973,7 @@ func (c *Compiler) removeText(is IniSection, sc *StateControllerBase, _ int8) (S
 }
 
 // Handles "createPlatform" parameters.
-func (c *Compiler) createPlatform(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) createPlatform(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*text)(sc), c.stateSec(is, func() error {
 		var err error
 
@@ -6047,7 +6047,7 @@ func (c *Compiler) createPlatform(is IniSection, sc *StateControllerBase, _ int8
 	return *ret, err
 }
 
-func (c *Compiler) modifyStageVar(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) modifyStageVar(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*modifyStageVar)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "camera.boundleft",
 			modifyStageVar_camera_boundleft, VT_Int, 1, false); err != nil {
@@ -6343,7 +6343,7 @@ func (c *Compiler) modifyStageVar(is IniSection, sc *StateControllerBase, _ int8
 	return *ret, err
 }
 
-func (c *Compiler) cameraCtrl(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) cameraCtrl(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*cameraCtrl)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "followid",
 			cameraCtrl_followid, VT_Int, 1, false); err != nil {
@@ -6376,7 +6376,7 @@ func (c *Compiler) cameraCtrl(is IniSection, sc *StateControllerBase, _ int8) (S
 	return *ret, err
 }
 
-func (c *Compiler) height(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) height(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*height)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			height_redirectid, VT_Int, 1, false); err != nil {
@@ -6391,7 +6391,7 @@ func (c *Compiler) height(is IniSection, sc *StateControllerBase, _ int8) (State
 	return *ret, err
 }
 
-func (c *Compiler) depth(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) depth(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*depth)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			depth_redirectid, VT_Int, 1, false); err != nil {
@@ -6427,7 +6427,7 @@ func (c *Compiler) depth(is IniSection, sc *StateControllerBase, _ int8) (StateC
 	return *ret, err
 }
 
-func (c *Compiler) modifyPlayer(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) modifyPlayer(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*modifyPlayer)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			modifyPlayer_redirectid, VT_Int, 1, false); err != nil {
@@ -6537,7 +6537,7 @@ func (c *Compiler) modifyPlayer(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *Compiler) assertCommand(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) assertCommand(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*assertCommand)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			assertCommand_redirectid, VT_Int, 1, false); err != nil {
@@ -6561,7 +6561,7 @@ func (c *Compiler) assertCommand(is IniSection, sc *StateControllerBase, _ int8)
 	return *ret, err
 }
 
-func (c *Compiler) getHitVarSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) getHitVarSet(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*getHitVarSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			getHitVarSet_redirectid, VT_Int, 1, false); err != nil {
@@ -6752,7 +6752,7 @@ func (c *Compiler) getHitVarSet(is IniSection, sc *StateControllerBase, _ int8) 
 	return *ret, err
 }
 
-func (c *Compiler) groundLevelOffset(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) groundLevelOffset(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*groundLevelOffset)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			groundLevelOffset_redirectid, VT_Int, 1, false); err != nil {
@@ -6767,7 +6767,7 @@ func (c *Compiler) groundLevelOffset(is IniSection, sc *StateControllerBase, _ i
 	return *ret, err
 }
 
-func (c *Compiler) targetAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) targetAdd(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*targetAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -6782,7 +6782,7 @@ func (c *Compiler) targetAdd(is IniSection, sc *StateControllerBase, _ int8) (St
 	return *ret, err
 }
 
-func (c *Compiler) transformClsn(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) transformClsn(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*transformClsn)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			transformClsn_redirectid, VT_Int, 1, false); err != nil {
@@ -6809,7 +6809,7 @@ func (c *Compiler) transformClsn(is IniSection, sc *StateControllerBase, _ int8)
 	return *ret, err
 }
 
-func (c *Compiler) transformSprite(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) transformSprite(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*transformSprite)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			transformSprite_redirectid, VT_Float, 1, false); err != nil {
@@ -6849,7 +6849,7 @@ func (c *Compiler) transformSprite(is IniSection, sc *StateControllerBase, _ int
 	return *ret, err
 }
 
-func (c *Compiler) modifyStageBG(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) modifyStageBG(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*modifyStageBG)(sc), c.stateSec(is, func() error {
 		//if err := c.paramValue(is, sc, "redirectid",
 		//	modifyStageBG_redirectid, VT_Int, 1, false); err != nil {
@@ -6987,7 +6987,7 @@ func (c *Compiler) modifyStageBG(is IniSection, sc *StateControllerBase, _ int8)
 	sys.cgi[c.playerNo].canMutateStage = true
 	return *ret, err
 }
-func (c *Compiler) shaderSub(is IniSection, sc *StateControllerBase, shaderOpCode, paramOpCode byte) error {
+func (c *StateCompiler) shaderSub(is IniSection, sc *StateControllerBase, shaderOpCode, paramOpCode byte) error {
 	if err := c.stateParam(is, "shader", false, func(data string) error {
 		if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
 			return Error("Shader name not enclosed in \"")
@@ -7037,7 +7037,7 @@ func (c *Compiler) shaderSub(is IniSection, sc *StateControllerBase, shaderOpCod
 	return nil
 }
 
-func (c *Compiler) shiftInput(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) shiftInput(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	inputIndex := func(name string) (int32, error) {
 		switch name {
 		case "U":
@@ -7114,7 +7114,7 @@ func (c *Compiler) shiftInput(is IniSection, sc *StateControllerBase, _ int8) (S
 	return *ret, err
 }
 
-func (c *Compiler) overrideClsn(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) overrideClsn(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	ret, err := (*overrideClsn)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			overrideClsn_redirectid, VT_Int, 1, false); err != nil {
@@ -7137,6 +7137,6 @@ func (c *Compiler) overrideClsn(is IniSection, sc *StateControllerBase, _ int8) 
 }
 
 // It's just a Null... Has no effect whatsoever.
-func (c *Compiler) null(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
+func (c *StateCompiler) null(is IniSection, sc *StateControllerBase, _ int8) (StateController, error) {
 	return nullStateController, nil
 }

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -5209,7 +5209,7 @@ func (fs *FightScreen) step() {
 
 // Resets fight screen as well as prepares team mode configuration for each player
 func (fs *FightScreen) reset() {
-	var num [2]int
+	//var num [2]int
 
 	// Update team mode layout for each player
 	for ti, tm := range sys.tmode {
@@ -5236,17 +5236,22 @@ func (fs *FightScreen) reset() {
 			fs.curLayout[ti] = 0 // Single (2)
 		}
 
-		// Set maximum number of lifebars
-		if tm == TM_Simul || tm == TM_Tag {
-			num[ti] = int(math.Min(8, float64(sys.numSimul[ti])*2))
-		} else {
-			num[ti] = len(fs.lifeBars[fs.curLayout[ti]])
-		}
+		// Determine number of players in each team
+		//if tm == TM_Simul || tm == TM_Tag {
+		//	num[ti] = int(math.Min(8, float64(sys.numSimul[ti])*2))
+		//} else {
+		//	num[ti] = len(fs.lifeBars[fs.curLayout[ti]]) // TODO: Why did it check this for single/turns but not simul/tag?
+		//}
+		// Build team order by ascending player number
+		//fs.teamOrder[ti] = []int{}
+		//for i := ti; i < num[ti]; i += 2 {
+		//	fs.teamOrder[ti] = append(fs.teamOrder[ti], i)
+		//}
+	}
 
-		fs.teamOrder[ti] = []int{}
-		for i := ti; i < num[ti]; i += 2 {
-			fs.teamOrder[ti] = append(fs.teamOrder[ti], i)
-		}
+	// Rebuild order of teams
+	for side := range fs.teamOrder {
+		fs.syncTeamOrder(side)
 	}
 
 	// Reset fight screen elements
@@ -5719,4 +5724,21 @@ func (fs *FightScreen) addComboHits(side int, n int32) {
 		return
 	}
 	fs.combos[side].trueHits += n
+}
+
+// Update team order based on the actual character member numbers
+func (fs *FightScreen) syncTeamOrder(side int) {
+	order := make([]int, 0, MaxSimul)
+	// Collect all the members of this team
+	for pn := side; pn < MaxSimul*2; pn += 2 {
+		if len(sys.chars[pn]) > 0 {
+			order = append(order, pn)
+		}
+	}
+	// Sort them by memberNo
+	sort.Slice(order, func(i, j int) bool {
+		return sys.chars[order[i]][0].memberNo < sys.chars[order[j]][0].memberNo
+	})
+	// Save result
+	fs.teamOrder[side] = order
 }

--- a/src/render.go
+++ b/src/render.go
@@ -692,10 +692,10 @@ func renderWithBlending(
 	}
 
 	Blend := BlendAdd
-	BlendI := BlendReverseSubtract
+	BlendInv := BlendReverseSubtract
 	if invblend >= 1 {
 		Blend = BlendReverseSubtract
-		BlendI = BlendAdd
+		BlendInv = BlendAdd
 	}
 
 	src := blendAlpha[0]
@@ -711,73 +711,87 @@ func renderWithBlending(
 		dst = 0
 	}
 
+	// Helpers for invertblend
+	invertColor := func() {
+		if acolor != nil {
+			(*acolor)[0], (*acolor)[1], (*acolor)[2] = -acolor[0], -acolor[1], -acolor[2]
+		}
+	}
+	disableNeg := func() {
+		if neg != nil {
+			*neg = false
+		}
+	}
+
+	// Proceed with the render calls
 	switch {
 	// Sub
 	case blendMode == TT_sub:
-		if src == 0 && dst == 255 {
+		switch {
+		case src == 0 && dst == 255:
 			// Fully transparent. Skip render
-		} else if src == 255 && dst == 255 {
+		case src == 255 && dst == 255:
 			// Fast path for full subtraction
-			if invblend >= 1 && acolor != nil {
-				(*acolor)[0], (*acolor)[1], (*acolor)[2] = -acolor[0], -acolor[1], -acolor[2]
+			if invblend >= 1 {
+				invertColor()
 			}
-			if invblend == 3 && neg != nil {
-				*neg = false
+			if invblend == 3 {
+				disableNeg()
 			}
-			render(BlendI, blendSourceFactor, BlendOne, 1)
-		} else {
+			render(BlendInv, blendSourceFactor, BlendOne, 1)
+		default:
 			// Full alpha range
 			if dst < 255 {
 				render(BlendAdd, BlendZero, BlendOneMinusSrcAlpha, 1-float32(dst)/255)
 			}
 			if src > 0 {
-				if invblend >= 1 && acolor != nil {
-					(*acolor)[0], (*acolor)[1], (*acolor)[2] = -acolor[0], -acolor[1], -acolor[2]
+				if invblend >= 1 {
+					invertColor()
 				}
-				if invblend == 3 && neg != nil {
-					*neg = false
+				if invblend == 3 {
+					disableNeg()
 				}
-				render(BlendI, blendSourceFactor, BlendOne, float32(src)/255)
+				render(BlendInv, blendSourceFactor, BlendOne, float32(src)/255)
 			}
 		}
 	// Add, None or Default
 	// None takes this path because SuperPause darkens sprites through their source alpha
 	// Default should normally not reach here, so this is only a fallback
 	default:
-		if src == 0 && dst == 255 {
+		switch {
+		case src == 0 && dst == 255:
 			// Fully transparent. Just don't render
-		} else if src == 255 && dst == 0 {
+		case src == 255 && dst == 0:
 			// Fast path for fully opaque
 			render(BlendAdd, blendSourceFactor, BlendOneMinusSrcAlpha, 1)
-		} else if src == 255 && dst == 255 {
+		case src == 255 && dst == 255:
 			// Fast path for full Add
-			if invblend >= 1 && acolor != nil {
-				(*acolor)[0], (*acolor)[1], (*acolor)[2] = -acolor[0], -acolor[1], -acolor[2]
+			if invblend >= 1 {
+				invertColor()
 			}
-			if invblend == 3 && neg != nil {
-				*neg = false
+			if invblend == 3 {
+				disableNeg()
 			}
 			render(Blend, blendSourceFactor, BlendOne, 1)
-		} else {
+		default:
 			// AddAlpha (includes Add1)
 			if dst < 255 {
 				render(Blend, BlendZero, BlendOneMinusSrcAlpha, 1-float32(dst)/255)
 			}
 			if src > 0 {
-				if invblend >= 1 && dst >= 255 {
-					if invblend >= 2 {
-						if invblend == 3 && neg != nil {
-							*neg = false
-						}
-						if acolor != nil {
-							(*acolor)[0], (*acolor)[1], (*acolor)[2] = -acolor[0], -acolor[1], -acolor[2]
-						}
-					}
+				// TODO: Wasn't this already done at the start of the function?
+				if invblend >= 1 { // && dst >= 255 {
 					Blend = BlendReverseSubtract
 				} else {
 					Blend = BlendAdd
 				}
-				if !isrgba && (invblend >= 2 || invblend <= -1) && acolor != nil && mcolor != nil && src < 255 {
+				if invblend >= 2 { // Not 1 here. TODO: Explain why in comment
+					invertColor()
+				}
+				if invblend == 3 {
+					disableNeg()
+				}
+				if !isrgba && (invblend <= -1 || invblend >= 2) && acolor != nil && mcolor != nil && src < 255 {
 					// Sum of add components
 					gc := Abs(acolor[0]) + Abs(acolor[1]) + Abs(acolor[2])
 					v3, ml, al := Max((gc*255)-float32(dst+src), 512)/128, (float32(src) / 255), (float32(src+dst) / 255)
@@ -789,7 +803,6 @@ func renderWithBlending(
 				}
 			}
 		}
-
 	}
 }
 

--- a/src/script.go
+++ b/src/script.go
@@ -7584,10 +7584,11 @@ func triggerRedirection(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "player", func(*lua.LState) int {
-		pn := int(numArg(l, 1))
+		idx := int(numArg(l, 1)) - 1
 		ret := false
-		if pn >= 1 && pn <= len(sys.chars) && len(sys.chars[pn-1]) > 0 {
-			sys.debugWC, ret = sys.chars[pn-1][0], true
+		// Uses direct access instead of sys.getCharRoot() because debug mode shows disabled characters
+		if idx >= 0 && idx < len(sys.chars) && len(sys.chars[idx]) > 0 {
+			sys.debugWC, ret = sys.chars[idx][0], true
 		}
 		l.Push(lua.LBool(ret))
 		return 1

--- a/src/script.go
+++ b/src/script.go
@@ -8768,6 +8768,8 @@ func triggerFunctions(l *lua.LState) {
 				lv = lua.LBool(c.ownclsnscale)
 			case "ownpal":
 				lv = lua.LBool(c.ownpal)
+			case "ownprojectile":
+				lv = lua.LBool(c.ownProjectile)
 			case "preserve":
 				lv = lua.LBool(c.preserve)
 			default:

--- a/src/system.go
+++ b/src/system.go
@@ -2278,7 +2278,6 @@ func (s *System) resetRoundState() {
 					[...]int32{1, 1}, [...]int32{1, s.cgi[i].palno})
 			}
 		}
-		s.cgi[i].clearPCTime()
 
 		if newMatchMusic {
 			p[0].si().music.ClearSelection()

--- a/src/system.go
+++ b/src/system.go
@@ -1497,23 +1497,25 @@ func (s *System) playerIndexExist(idx BytecodeValue) BytecodeValue {
 	return BytecodeBool(char != nil)
 }
 
-func (s *System) playerNoExist(no BytecodeValue) BytecodeValue {
-	if no.IsUndefined() {
+// For player number triggers
+func (s *System) getCharRoot(idx int) *Char {
+	if idx < 0 || idx >= len(sys.chars) {
+		return nil
+	}
+	p := sys.chars[idx]
+	if len(p) == 0 || p[0] == nil || p[0].scf(SCF_disabled) {
+		return nil
+	}
+	return p[0]
+}
+
+func (s *System) playerNoExist(pn BytecodeValue) BytecodeValue {
+	if pn.IsUndefined() {
 		return BytecodeUndefined()
 	}
-	number := int(no.ToI() - 1)
-	if number < 0 || number >= len(sys.chars) {
-		return BytecodeBool(false)
-	}
-	ch := sys.chars[number]
-	if len(ch) == 0 {
-		return BytecodeBool(false)
-	}
-	root := ch[0]
-	if root == nil || root.scf(SCF_disabled) {
-		return BytecodeBool(false)
-	}
-	return BytecodeBool(true)
+	idx := int(pn.ToI() - 1) 
+	c := s.getCharRoot(idx)
+	return BytecodeBool(c != nil)
 }
 
 func (s *System) palfxvar(x int32, y int32) int32 {

--- a/src/system.go
+++ b/src/system.go
@@ -1442,26 +1442,26 @@ func (s *System) playerID(id int32) *Char {
 	}
 
 	// Invalid ID
-	ch, ok := s.charList.idMap[id]
+	c, ok := s.charList.idMap[id]
 	if !ok {
 		return nil
 	}
 
-	// Mugen skips DestroySelf helpers here
-	// Note: This will also skip destroyed helpers in the engine's internal ID lookups
-	if ch.csf(CSF_destroy) {
+	// Mugen skips destroyed helpers and disabled players here
+	// Note: This will also make them be skipped in the engine's internal ID lookups
+	if c.csf(CSF_destroy) || c.scf(SCF_disabled) {
 		return nil
 	}
 
-	return ch
+	return c
 }
 
 func (s *System) playerIDExist(id BytecodeValue) BytecodeValue {
 	if id.IsUndefined() {
 		return BytecodeUndefined()
 	}
-	char := s.playerID(id.ToI())
-	return BytecodeBool(char != nil)
+	c := s.playerID(id.ToI())
+	return BytecodeBool(c != nil)
 }
 
 func (s *System) playerIndex(idx int32) *Char {
@@ -1469,12 +1469,12 @@ func (s *System) playerIndex(idx int32) *Char {
 		return nil
 	}
 
-	// We will ignore destroyed helpers here, like Mugen redirections do
+	// We will also ignore destroyed/disabled players here, like Mugen redirections do
 	var searchIdx int32
-	for _, p := range sys.charList.creationOrder {
-		if p != nil && !p.csf(CSF_destroy) {
+	for _, c := range sys.charList.creationOrder {
+		if c != nil && !c.csf(CSF_destroy) && !c.scf(SCF_disabled) {
 			if searchIdx == idx {
-				return p
+				return c
 			}
 			searchIdx++
 		}
@@ -1501,12 +1501,19 @@ func (s *System) playerNoExist(no BytecodeValue) BytecodeValue {
 	if no.IsUndefined() {
 		return BytecodeUndefined()
 	}
-	exist := false
 	number := int(no.ToI() - 1)
-	if number >= 0 && number < len(sys.chars) {
-		exist = len(sys.chars[number]) > 0
+	if number < 0 || number >= len(sys.chars) {
+		return BytecodeBool(false)
 	}
-	return BytecodeBool(exist)
+	ch := sys.chars[number]
+	if len(ch) == 0 {
+		return BytecodeBool(false)
+	}
+	root := ch[0]
+	if root == nil || root.scf(SCF_disabled) {
+		return BytecodeBool(false)
+	}
+	return BytecodeBool(true)
 }
 
 func (s *System) palfxvar(x int32, y int32) int32 {

--- a/src/system.go
+++ b/src/system.go
@@ -5108,7 +5108,7 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 		}
 
 		// Compile character states
-		if sys.cgi[pn].states, l.err = newCompiler().Compile(p.playerNo, cdef, p.gi().constants); l.err != nil {
+		if sys.cgi[pn].states, l.err = newStateCompiler().Compile(p.playerNo, cdef, p.gi().constants); l.err != nil {
 			sys.chars[pn] = nil
 			if attached {
 				tstr = fmt.Sprintf("WARNING: Failed to compile new attached char states: %v", cdef)


### PR DESCRIPTION
Features:
- Duplicate "persistent" and "ignorehitpause" in CNS are now also printed to the command line
- Helper ownProjectile parameter. Enabling it allows the helper to own its own projectiles

Fixes:
- playerIdExist, playerIndexExist and playerNoExist now return false for disabled players
- Fixed the lifebar team order being reset blindly at the start of a new round
- Fixed hitpauses making groundLevel value become stale
- Made same Explod ignorehitpause fix in AfterImage
- Fixes #3587 
- Fixes #3589 

Refactor:
- Add CharGlobalInfo constructor
- HitDef p1 and p2sprpriority now default to no change, as you had to fight the default values more often than not
- Standardize compiler char warnings
- Rename Compiler to StateCompiler
- Added filename and line number to char state compiler warnings
- Remove asynchronous line feeding from the ZSS compiler. Makes the code leaner and line number messages more accurate
- Give "player" redirection its own proper code instead of relying on the removed getPlayerID in a roundabout way
- Moved shared Explod and ModifyExplod parameters to explodSub()
- Because ignorehitpause exceptions are no longer required, the compiler no longer needs to pass it as an argument for every sctrl
- Because the compiler now accepts function calls for functions that may not exist, the validation of number of arguments/returns was moved to runtime