### PR TITLE
fix: update portrait priority for new team members

### DIFF
--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -3239,6 +3239,7 @@ function start.f_selectMenu(side, cmd, player, member, selectState)
 			start.c[player].selRef = start.f_selGrid(start.c[player].cell + 1).char_ref
 			-- temp data not existing yet
 			if start.p[side].t_selTemp[member] == nil then
+				t_portraitPriority[side] = member
 				table.insert(start.p[side].t_selTemp, {
 					ref = start.c[player].selRef,
 					cell = start.c[player].cell,


### PR DESCRIPTION
Fixes #3591.

Updates `t_portraitPriority` when a new Turns/team member is added, so single-portrait layouts don’t keep showing the previous member.

Tested Turns selection before and after returning from a match, plus normal portrait updates.

Happy to adjust anything if needed!