### PR TITLE
fix: Rectangles' diagonal rendering artifacts (rasterization edge case).

### DIFF
--- a/src/render.go
+++ b/src/render.go
@@ -227,11 +227,17 @@ func (rp *RenderParams) IsValid() bool {
 func drawQuads(modelview mgl.Mat4, x1, y1, x2, y2, x3, y3, x4, y4 float32) {
 	gfx.SetUniformMatrix("modelview", modelview[:])
 	gfx.SetUniformF("x1x2x4x3", x1, x2, x4, x3) // this uniform is optional
+
+	// This effectively side-steps a low-level rectangle rasterization edge case,
+	// that caused visible and frequent artifacts on the diagonal.
+	// See: https://github.com/ikemen-engine/Ikemen-GO/issues/3583
+	uvZero := float32(0.000002)
+
 	gfx.SetVertexData(
 		x2, y2, 1, 1,
-		x3, y3, 1, 0,
-		x1, y1, 0, 1,
-		x4, y4, 0, 0,
+		x3, y3, 1, uvZero,
+		x1, y1, uvZero, 1,
+		x4, y4, uvZero, uvZero,
 	)
 
 	gfx.RenderQuad()


### PR DESCRIPTION
This fix effectively side-steps a low-level rectangle rasterization edge case, that caused visible and frequent artifacts on the diagonal (fix: #3583).


## FAQ


1. **Did you just add a random number in a random place in the code?**

    Short answer: No :stuck_out_tongue_closed_eyes:

    Long answer: @SuperFromND helped me narrow it down to a low-level rasterization edge case, since it turned out that the vertex positions did form a perfect/undistorted rectangle. The usual solutions to such edge cases involve some kind of texture sampling tricks.

    I tried some more complicated and orthodox solutions first but they did not properly fit the current rendering pipeline and I did not want to make deep changes to the pipeline, nor do I think they would be optimal. Ultimately, I reduced the solution to this minimal "one simple trick" that proved effective in wiping out the artifacts in all of my test cases.

---

2. **Won't this cause distortion in the rendered sprites' texture/graphics?**

    Short answer: Effectively no, it should only affect edge cases.

    Long answer: Assuming the worst case scenario of the maximum size of a sprite: 2^15-1, the distortion (in texels) would only be at the level of: (2^15-1) * 0.000002 = 0.0655, so still way below even one actual texel.


---

3. **Won't this cause gap/margin artifacts, like XYTruncate (#2564)?**

    No. The vertex positions are unchanged and nothing is sampled outside of the original texture/sprite area.

    This PR will however also **not** fix any of the previously occuring artifacts of this type.
