### PR TITLE
fix: hidewithbars (replacing hideonpausemenu), win counter in survival mode, hidewithbars explods wrong coords on pause menu exit, motif chars disabling not affecting helpers

### DIFF
--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -1763,6 +1763,8 @@ function start.f_selectReset(hardReset, preserveProgress)
 	if not preserveProgress then
 		resetGameStats()
 		setMatchNo(1)
+		setWinCount(1, 0)
+		setWinCount(2, 0)
 		setConsecutiveWins(1, 0)
 		setConsecutiveWins(2, 0)
 	end

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6071,7 +6071,7 @@ const (
 	explod_shadow
 	explod_removeongethit
 	explod_removeonchangestate
-	explod_hideonpausemenu
+	explod_hidewithbars
 	explod_trans
 	explod_animelem
 	explod_animelemtime
@@ -6269,8 +6269,8 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 			e.removeongethit = exp[0].evalB(c)
 		case explod_removeonchangestate:
 			e.removeonchangestate = exp[0].evalB(c)
-		case explod_hideonpausemenu:
-			e.hideonpausemenu = exp[0].evalB(c)
+		case explod_hidewithbars:
+			e.hidewithbars = exp[0].evalB(c)
 		case explod_trans:
 			src := Clamp(int32(exp[0].evalI(c)), 0, 255)
 			dst := Clamp(int32(exp[1].evalI(c)), 0, 255)
@@ -6800,10 +6800,10 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 				eachExpl(func(e *Explod) {
 					e.removeonchangestate = v
 				})
-			case explod_hideonpausemenu:
+			case explod_hidewithbars:
 				v := exp[0].evalB(c)
 				eachExpl(func(e *Explod) {
-					e.hideonpausemenu = v
+					e.hidewithbars = v
 				})
 			case explod_trans:
 				src := Clamp(int32(exp[0].evalI(c)), 0, 255)

--- a/src/char.go
+++ b/src/char.go
@@ -1615,7 +1615,7 @@ type Explod struct {
 	scale               [2]float32
 	removeongethit      bool
 	removeonchangestate bool
-	hideonpausemenu     bool
+	hidewithbars        bool
 	statehaschanged     bool
 	removetime          int32
 	velocity            [3]float32
@@ -1912,7 +1912,11 @@ func (e *Explod) update() {
 	parent := sys.playerID(e.ownerId)
 	root := sys.chars[e.playerno][0]
 
-	if root.scf(SCF_disabled) || (e.hideonpausemenu && sys.motif.me.active) {
+	if root.scf(SCF_disabled) {
+		return
+	}
+
+	if e.hidewithbars && (!sys.fightScreen.visible() || sys.gsf(GSF_nobardisplay) || !sys.fightScreen.bars) {
 		return
 	}
 

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -953,8 +953,8 @@ func (c *StateCompiler) explodSub(is IniSection, sc *StateControllerBase) error 
 		explod_removeonchangestate, VT_Bool, 1, false); err != nil {
 		return err
 	}
-	if err := c.paramValue(is, sc, "hideonpausemenu",
-		explod_hideonpausemenu, VT_Bool, 1, false); err != nil {
+	if err := c.paramValue(is, sc, "hidewithbars",
+		explod_hidewithbars, VT_Bool, 1, false); err != nil {
 		return err
 	}
 	if err := c.paramTrans(is, sc, "", explod_trans); err != nil {

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -5317,7 +5317,8 @@ func (fs *FightScreen) visible() bool {
 		!sys.postMatchFlg &&
 		!sys.lifebarHide &&
 		!sys.dialogueBarsFlg &&
-		!(sys.motif.me.active && sys.motif.PauseMenu["pause_menu"].HideBars)
+		!(sys.motif.me.active && sys.motif.PauseMenu["pause_menu"].HideBars &&
+			(!sys.motif.me.closeRequested || sys.paused))
 }
 
 func (fs *FightScreen) draw(layerno int16) {

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -5312,24 +5312,24 @@ func (fs *FightScreen) reset() {
 	}
 }
 
+func (fs *FightScreen) visible() bool {
+	return fs.active &&
+		!sys.postMatchFlg &&
+		!sys.lifebarHide &&
+		!sys.dialogueBarsFlg &&
+		!(sys.motif.me.active && sys.motif.PauseMenu["pause_menu"].HideBars)
+}
+
 func (fs *FightScreen) draw(layerno int16) {
-	// Do not draw anything during victory and such screens
-	if sys.postMatchFlg {
-		return
-	}
-
-	pauseHide := sys.motif.me.active && sys.motif.PauseMenu["pause_menu"].HideBars
-
-	if !sys.lifebarHide && fs.active && !sys.dialogueBarsFlg && !pauseHide {
-		// Helper to determine whether to iterate elements forward or backward (drawing order)
-		iterationOrder := func(leaderontop bool) (int, int, int) {
-			if leaderontop {
-				return MaxSimul - 1, -1, -1
-			}
-			return 0, MaxSimul, 1
-		}
-
+	if fs.visible() {
 		if !sys.gsf(GSF_nobardisplay) && fs.bars {
+			// Helper to determine whether to iterate elements forward or backward (drawing order)
+			iterationOrder := func(leaderontop bool) (int, int, int) {
+				if leaderontop {
+					return MaxSimul - 1, -1, -1
+				}
+				return 0, MaxSimul, 1
+			}
 			// LifeBar
 			for side := 0; side < len(sys.tmode); side++ {
 				layout := fs.curLayout[side]
@@ -5521,7 +5521,7 @@ func (fs *FightScreen) draw(layerno int16) {
 		}
 	}
 
-	if fs.active {
+	if fs.active && !sys.postMatchFlg {
 		// Round
 		fs.round.draw(layerno, fs.fnt)
 	}

--- a/src/motif.go
+++ b/src/motif.go
@@ -2793,7 +2793,11 @@ func (m *Motif) Save(file string) error {
 
 func (mo *Motif) processStateChange(c *Char, states []int32) bool {
 	if len(states) == 0 {
-		c.setSCF(SCF_disabled)
+		for _, ch := range sys.chars[c.playerNo] {
+			if ch != nil {
+				ch.setSCF(SCF_disabled)
+			}
+		}
 		return true
 	}
 	for _, stateNo := range states {
@@ -2802,8 +2806,12 @@ func (mo *Motif) processStateChange(c *Char, states []int32) bool {
 			return true
 		}
 		if c.selfStatenoExist(BytecodeInt(stateNo)) == BytecodeBool(true) {
-			// If the character was previously disabled, re-enable it when a valid state transition is requested.
-			c.unsetSCF(SCF_disabled)
+			// If the player slot was previously disabled, re-enable its loaded chars.
+			for _, ch := range sys.chars[c.playerNo] {
+				if ch != nil && ch.scf(SCF_disabled) {
+					ch.unsetSCF(SCF_disabled)
+				}
+			}
 			c.changeState(stateNo, -1, -1, "")
 			return true
 		}

--- a/src/motif.go
+++ b/src/motif.go
@@ -3239,9 +3239,6 @@ func (me *MotifMenu) reset(m *Motif) {
 	me.initialized = false
 	me.endTimer = -1
 	me.closeRequested = false
-	if !m.di.active {
-		sys.leaveMotifAspect()
-	}
 	if err := sys.luaLState.DoString("menuReset()"); err != nil {
 		sys.luaLState.RaiseError("Error executing Lua code: %v\n", err.Error())
 	}
@@ -3284,6 +3281,9 @@ func (me *MotifMenu) requestClose(m *Motif) {
 		return
 	}
 	me.closeRequested = true
+	if !m.di.active {
+		sys.leaveMotifAspect()
+	}
 	if pm := me.pauseMenuBase(m); pm != nil {
 		startFadeOut(pm.FadeOut.FadeData, m.fadeOut, false, m.fadePolicy)
 	}


### PR DESCRIPTION
Fixes #3602
Fixes https://discord.com/channels/233345562261323776/233363722934943744/1503836459050864824
Fixes limitation mentioned here: https://discord.com/channels/233345562261323776/233363722934943744/1503099544618008697