### PR TITLE
feat(char): set helper maps upon its creation; fixes; refactoring

### DIFF
--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -3112,7 +3112,7 @@ function start.f_palMenu(side, cmd, player, member, selectState)
 	start.p[side].inPalMenu = true
 
 	-- accept selection
-	if getInput(cmd, motif.select_info['p' .. side].palmenu.done.key) or timerSelect == -1 then
+	if #validPals <= 1 or getInput(cmd, motif.select_info['p' .. side].palmenu.done.key) or timerSelect == -1 then
 		pal = (curIdx == maxIdx) and (start.c[player].randPalPreview or start.f_randomPal(charRef, validPals)) or validPals[curIdx]
 		st.pal, st.currentIdx = pal, curIdx
 
@@ -3142,7 +3142,10 @@ function start.f_palMenu(side, cmd, player, member, selectState)
 		end
 		selectState = 3
 		start.f_playWave(start.c[player].selRef, 'cursor', motif.select_info['p' .. side].select.snd[1], motif.select_info['p' .. side].select.snd[2])
-		sndPlay(motif.Snd, motif.select_info['p' .. side].palmenu.done.snd[1], motif.select_info['p' .. side].palmenu.done.snd[2])
+		-- Skip sound for auto-confirmation, since we already played the select character confirmation sound
+		if #validPals > 1 then
+			sndPlay(motif.Snd, motif.select_info['p' .. side].palmenu.done.snd[1], motif.select_info['p' .. side].palmenu.done.snd[2])
+		end
 	 -- next palette
 	elseif getInput(cmd, motif.select_info['p' .. side].palmenu.next.key) then
 		curIdx = (curIdx == maxIdx) and 1 or curIdx + 1

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -4339,7 +4339,12 @@ func (be BytecodeExp) run_ex3(c *Char, i *int, oc *Char) {
 		// Check for valid sprite
 		var spr *Sprite
 		if c.anim != nil {
-			spr = c.anim.spr
+			// TODO: This is a patch to fix a 1-frame delay in SpriteVar
+			// In reality our animation stepping sequence has too many hacks and may need an overhaul
+			// We make a copy to avoid the risk of the update affecting how an animation plays out, just in case
+			acopy := *c.anim
+			acopy.UpdateSprite()
+			spr = acopy.spr
 		}
 		// Handle output
 		if spr != nil {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5552,6 +5552,7 @@ const (
 	helper_standby
 	helper_ownclsnscale
 	helper_ownprojectile
+	helper_map
 	helper_redirectid
 )
 
@@ -5565,8 +5566,8 @@ func (sc helper) Run(c *Char, _ []int32) bool {
 	pt := PT_P1
 	var f, st int32 = 1, 0
 	var extmap bool
-	var x, y, z float32 = 0, 0, 0
-	rp := [...]int32{-1, 0}
+	var pos [3]float32
+	rp := [2]int32{-1, 0}
 
 	h := crun.newHelper()
 	if h == nil {
@@ -5634,11 +5635,11 @@ func (sc helper) Run(c *Char, _ []int32) bool {
 		case helper_id:
 			h.helperId = exp[0].evalI(c)
 		case helper_pos:
-			x = exp[0].evalF(c) * redirscale
+			pos[0] = exp[0].evalF(c) * redirscale
 			if len(exp) > 1 {
-				y = exp[1].evalF(c) * redirscale
+				pos[1] = exp[1].evalF(c) * redirscale
 				if len(exp) > 2 {
-					z = exp[2].evalF(c) * redirscale
+					pos[2] = exp[2].evalF(c) * redirscale
 				}
 			}
 		case helper_facing:
@@ -5654,6 +5655,11 @@ func (sc helper) Run(c *Char, _ []int32) bool {
 			}
 		case helper_extendsmap:
 			extmap = exp[0].evalB(c)
+			if extmap {
+				for key, value := range crun.mapArray {
+					h.mapArray[key] = value
+				}
+			}
 		case helper_inheritjuggle:
 			h.inheritJuggle = exp[0].evalI(c)
 		case helper_inheritchannels:
@@ -5674,6 +5680,9 @@ func (sc helper) Run(c *Char, _ []int32) bool {
 			}
 		case helper_ownprojectile:
 			h.ownProjectile = exp[0].evalB(c)
+		case helper_map:
+			mapKey := exp[0].evalS()
+			h.mapArray[mapKey] = exp[1].evalF(c)
 		}
 		return true
 	})
@@ -5685,7 +5694,7 @@ func (sc helper) Run(c *Char, _ []int32) bool {
 		h.localscl = crun.localscl
 		h.localcoord = crun.localcoord
 	}
-	crun.helperInit(h, st, pt, x, y, z, f, rp, extmap)
+	crun.helperInit(h, st, pt, pos, f, rp)
 	return false
 }
 

--- a/src/camera.go
+++ b/src/camera.go
@@ -58,7 +58,7 @@ type stageCamera struct {
 	prevRightest            float32
 	leftestvel              float32
 	rightestvel             float32
-	roundstart              bool
+	snapToTarget            bool
 	maxRight                float32
 	minLeft                 float32
 	autoZoom                bool
@@ -89,7 +89,6 @@ type Camera struct {
 	stageCamera
 	View                            CameraView
 	ZoomEnable                      bool
-	zoomdelay                       float32
 	Pos, ScreenPos, Offset          [2]float32
 	XMin, XMax                      float32
 	Scale, MinScale                 float32
@@ -185,10 +184,18 @@ func (c *Camera) Reset() {
 func (c *Camera) Init() {
 	c.Reset()
 	c.View = Fighting_View
-	c.roundstart = true
 	c.Scale = c.startzoom
-	c.Pos[0], c.Pos[1], c.ywithoutbound = float32(c.startx)*c.localscl, float32(c.starty)*c.localscl, float32(c.starty)*c.localscl
+	c.Pos[0] = float32(c.startx)*c.localscl
+	c.Pos[1] = float32(c.starty)*c.localscl
+	c.ywithoutbound = c.Pos[1]
 	c.zoomindelaytime = c.zoomindelay
+
+	// We want the camera to just snap to place the first time it moves
+	c.snapToTarget = true
+
+	// Set screen position immediately so that char triggers and postype will be correct in the first frame of the round
+	// https://github.com/ikemen-engine/Ikemen-GO/issues/3600
+	c.setScreenPos(c.Pos[0], c.Pos[1], c.Scale / c.BaseScale())
 }
 
 func (c *Camera) ResetTracking() {
@@ -198,6 +205,16 @@ func (c *Camera) ResetTracking() {
 	c.lowest = -math.MaxFloat32
 	c.leftestvel = 0
 	c.rightestvel = 0
+}
+
+func (c *Camera) setScreenPos(x, y, scl float32) {
+	for i := 0; i < 2; i++ {
+		c.Offset[i] = sys.stage.bga.offset[i] * sys.stage.localscl * scl
+	}
+	c.ScreenPos[0] = x - c.halfWidth/c.Scale - c.Offset[0]
+	c.ScreenPos[1] = y - (c.GroundLevel()-float32(sys.gameHeight-240)*scl)/c.Scale - c.Offset[1]
+	c.Pos[0] = x
+	c.Pos[1] = y
 }
 
 // Use last known good positions if the current ones are invalid
@@ -229,22 +246,12 @@ func (c *Camera) SaveRestoreTracking() {
 }
 
 func (c *Camera) Update(scl, x, y float32) {
-	if sys.gsf(GSF_camerafreeze) {
-		return
-	}
 	c.Scale = c.BaseScale() * scl
 	c.zoff = float32(c.zoffset) * c.localscl
 	if sys.stage.stageCamera.zoomanchor {
 		c.zoomanchorcorrection = c.zoff - (float32(sys.gameHeight) + c.aspectcorrection - (float32(sys.gameHeight)-c.zoff+c.aspectcorrection)*scl)
 	}
-	for i := 0; i < 2; i++ {
-		c.Offset[i] = sys.stage.bga.offset[i] * sys.stage.localscl * scl
-	}
-	c.ScreenPos[0] = x - c.halfWidth/c.Scale - c.Offset[0]
-	c.ScreenPos[1] = y - (c.GroundLevel()-float32(sys.gameHeight-240)*scl)/
-		c.Scale - c.Offset[1]
-	c.Pos[0] = x
-	c.Pos[1] = y
+	c.setScreenPos(x, y, scl)
 }
 
 func (c *Camera) ScaleBound(scl, sclmul float32) float32 {
@@ -273,14 +280,16 @@ func (c *Camera) GroundLevel() float32 {
 	return c.zoff - c.aspectcorrection - c.zoomanchorcorrection
 }
 
-func (c *Camera) ResetZoomdelay() {
-	c.zoomdelay = 0
-}
-
 func (c *Camera) action(x, y, scale float32, pause bool) (newX, newY, newScale float32) {
+	// Default to no change
 	newX = x
 	newY = y
 	newScale = scale
+
+	if sys.gsf(GSF_camerafreeze) {
+		return
+	}
+
 	if !sys.debugPaused() {
 		newY = y / scale
 		switch c.View {
@@ -291,14 +300,17 @@ func (c *Camera) action(x, y, scale float32, pause bool) (newX, newY, newScale f
 			if c.lowestcap {
 				c.lowest = Max(c.lowest, float32(c.boundhigh)*c.localscl-(float32(sys.gameHeight)-c.GroundLevel()-float32(c.tensionlow))/c.zoomout)
 			}
+
 			tension := Max(0, float32(c.tension)*c.localscl)
 			oldLeft, oldRight := x-c.halfWidth/scale, x+c.halfWidth/scale
 			targetLeft, targetRight := oldLeft, oldRight
+
 			if c.autocenter {
 				targetLeft = Min(Max((c.leftest+c.rightest)/2-c.halfWidth/scale, c.minLeft), c.maxRight-2*c.halfWidth/scale)
 				targetRight = targetLeft + 2*c.halfWidth/scale
 			}
 
+			// Adjust target edges when characters exceed tension zones
 			if c.leftest < targetLeft+tension {
 				diff := targetLeft - Max(c.leftest-tension, c.minLeft)
 				targetLeft = Max(c.leftest-tension, c.minLeft)
@@ -308,6 +320,7 @@ func (c *Camera) action(x, y, scale float32, pause bool) (newX, newY, newScale f
 				targetRight = Min(c.rightest+tension, c.maxRight)
 				targetLeft = Min(oldLeft-diff, Max(c.leftest-tension, c.minLeft))
 			}
+
 			if c.halfWidth*2/(targetRight-targetLeft) < c.zoomout {
 				rLeft := Max(targetLeft+tension-c.leftest, 0)
 				rRight := Max(c.rightest-(targetRight-tension), 0)
@@ -338,10 +351,12 @@ func (c *Camera) action(x, y, scale float32, pause bool) (newX, newY, newScale f
 					targetRight += diff
 				}
 			}
+
 			maxScale := c.zoomin
 			if c.ytensionenable {
 				maxScale = Min(Max(float32(sys.gameHeight)/((c.lowest+float32(c.tensionlow)*c.localscl)-(c.highest-float32(c.tensionhigh)*c.localscl)), c.zoomout), maxScale)
 			}
+
 			if c.halfWidth*2/(targetRight-targetLeft) < maxScale {
 				if c.zoomindelaytime > 0 {
 					c.zoomindelaytime -= 1
@@ -379,7 +394,11 @@ func (c *Camera) action(x, y, scale float32, pause bool) (newX, newY, newScale f
 				ywithoutbound := c.ywithoutbound
 				verticalfollow := Max(c.verticalfollow, 0.0) + (targetScale-c.zoomout)*Max(c.verticalfollowzoomdelta, 0.0)
 				targetY := (c.highest + float32(c.floortension)*c.localscl) * verticalfollow
-				if !c.roundstart {
+
+				if c.snapToTarget {
+					ywithoutbound = targetY
+					newY = ywithoutbound
+				} else {
 					for i := 0; i < 3; i++ {
 						ywithoutbound = ywithoutbound*.85 + targetY*.15
 						if Abs(targetY-ywithoutbound)*sys.heightScale < 1 {
@@ -397,9 +416,6 @@ func (c *Camera) action(x, y, scale float32, pause bool) (newX, newY, newScale f
 							}
 						}
 					}
-				} else {
-					ywithoutbound = targetY
-					newY = ywithoutbound
 				}
 				c.ywithoutbound = ywithoutbound
 			} else {
@@ -410,7 +426,10 @@ func (c *Camera) action(x, y, scale float32, pause bool) (newX, newY, newScale f
 
 				newY = c.ywithoutbound
 				targetY := c.GroundLevel()/targetScale + (c.highest - float32(c.tensionhigh)*c.localscl)
-				if !c.roundstart {
+
+				if c.snapToTarget {
+					newY = targetY
+				} else {
 					diff := float32(sys.gameWidth) / 320 * 2.5
 					for i := 0; i < 3; i++ {
 						newY = (newY + targetY) * .5
@@ -423,15 +442,17 @@ func (c *Camera) action(x, y, scale float32, pause bool) (newX, newY, newScale f
 							newY = newY - diff
 						}
 					}
-				} else {
-					newY = targetY
 				}
 				c.ywithoutbound = newY
 			}
 
+			// Apply tension smoothing to X position
 			newLeft, newRight := oldLeft, oldRight
 			logicScale := 60.0 / float32(sys.gameLogicSpeed())
-			if !c.roundstart {
+
+			if c.snapToTarget {
+				newLeft, newRight = targetLeft, targetRight
+			} else {
 				diff := float32(sys.gameWidth) / 3200
 				for i := 0; i < 3; i++ {
 					newLeft = newLeft + (targetLeft-newLeft)*0.05*logicScale*c.tensionvel
@@ -465,9 +486,8 @@ func (c *Camera) action(x, y, scale float32, pause bool) (newX, newY, newScale f
 						newRight = Max(oldRight+c.leftestvel, targetRight)
 					}
 				}
-			} else {
-				newLeft, newRight = targetLeft, targetRight
 			}
+
 			newScale = Min(c.halfWidth*2/(newRight-newLeft), c.zoomin)
 			newLeft, newRight, newScale = c.reduceZoomSpeed(newLeft, newRight, newScale, oldLeft, oldRight, scale)
 			newX = (newLeft + newRight) / 2
@@ -485,7 +505,8 @@ func (c *Camera) action(x, y, scale float32, pause bool) (newX, newY, newScale f
 			newScale = 1
 		}
 	}
-	c.roundstart = false
+
+	c.snapToTarget = false
 	return
 }
 

--- a/src/char.go
+++ b/src/char.go
@@ -6720,8 +6720,8 @@ func (c *Char) newHelper() (h *Char) {
 }
 
 // Init helper after reading the bytecode parameters
-func (c *Char) helperInit(h *Char, st int32, pt PosType, x, y, z float32, facing int32, rp [2]int32, extmap bool) {
-	p := c.helperPos(pt, [3]float32{x, y, z}, facing, &h.facing, h.localscl, false)
+func (c *Char) helperInit(h *Char, st int32, pt PosType, pos [3]float32, facing int32, rp [2]int32) {
+	p := c.helperPos(pt, pos, facing, &h.facing, h.localscl, false)
 	h.setPosX(p[0], true)
 	h.setPosY(p[1], true)
 	h.setPosZ(p[2], true)
@@ -6738,13 +6738,6 @@ func (c *Char) helperInit(h *Char, st int32, pt PosType, x, y, z float32, facing
 		c.forceRemapPal(h.palfx, rp)
 	} else {
 		h.palfx = c.getPalfx()
-	}
-
-	// Copy parent maps
-	if extmap {
-		for key, value := range c.mapArray {
-			h.mapArray[key] = value
-		}
 	}
 
 	// Mugen 1.1 behavior if invertblend param is omitted(Only if char mugenversion = 1.1)

--- a/src/char.go
+++ b/src/char.go
@@ -3062,10 +3062,10 @@ type StateState struct {
 	storeMoveType                bool
 	physics                      StateType
 	ps                           []int32
-	hitPauseExecutionToggleFlags [MaxPlayerNo][]bool // Flags if an sctrl runs during a hit pause on the current tick.
 	no, prevno                   int32
 	time                         int32
 	sb                           StateBytecode
+	//hitPauseExecutionToggleFlags [MaxPlayerNo][]bool // Flags if an sctrl runs during a hit pause on the current tick.
 }
 
 func (ss *StateState) changeStateType(t StateType) {
@@ -3083,6 +3083,8 @@ func (ss *StateState) clear() {
 	ss.changeMoveType(MT_I)
 	ss.physics = ST_N
 	ss.ps = nil
+
+	/*
 	// Iterate over each player's hitPauseExecutionToggleFlags
 	for i, v := range ss.hitPauseExecutionToggleFlags {
 		// Ensure the slice has enough capacity based on hitPauseToggleFlagCount
@@ -3097,11 +3099,14 @@ func (ss *StateState) clear() {
 	}
 	// Further clear the hitPauseExecutionToggleFlags
 	ss.clearHitPauseExecutionToggleFlags()
+	*/
+
 	ss.no, ss.prevno = 0, 0
 	ss.time = 0
 	ss.sb = StateBytecode{}
 }
 
+/*
 // Resets all hitPauseExecutionToggleFlags to false.
 // This ensures that all state controllers are set to execute on the next eligible tick.
 func (ss *StateState) clearHitPauseExecutionToggleFlags() {
@@ -3111,6 +3116,7 @@ func (ss *StateState) clearHitPauseExecutionToggleFlags() {
 		}
 	}
 }
+*/
 
 type HMF int32
 
@@ -12149,9 +12155,9 @@ func (c *Char) tick() {
 		// This flag prevents prevMoveType from being changed twice
 		c.ss.storeMoveType = true
 		c.ss.changeMoveType(MT_H)
-		if c.hitPauseTime > 0 {
-			c.ss.clearHitPauseExecutionToggleFlags()
-		}
+		//if c.hitPauseTime > 0 {
+		//	c.ss.clearHitPauseExecutionToggleFlags()
+		//}
 		c.hitPauseTime = 0
 		//c.targetDrop(-1, false) // GitHub #1148
 		pn := c.playerNo
@@ -12228,7 +12234,7 @@ func (c *Char) tick() {
 		if c.hitPauseTime > 0 {
 			c.hitPauseTime--
 			if c.hitPauseTime == 0 {
-				c.ss.clearHitPauseExecutionToggleFlags()
+				//c.ss.clearHitPauseExecutionToggleFlags()
 				//Having a hitStateChangeIdx means that ChangeState was performed during the hitpause
 				if c.hitStateChangeIdx != -1 {
 					// For Mugen compatibility, the persistent is reset when the hitpause ends during ChangeState

--- a/src/char.go
+++ b/src/char.go
@@ -2499,8 +2499,8 @@ func (p *Projectile) update() {
 		if p.status == ProjActive {
 			if p.removetime == 0 ||
 				p.removetime <= -2 && (p.anim == nil || p.anim.loopend) ||
-				p.pos[0] < (sys.xmin-sys.screenleft)/p.localscl-float32(p.edgebound) ||
-				p.pos[0] > (sys.xmax+sys.screenright)/p.localscl+float32(p.edgebound) ||
+				p.pos[0] < (sys.xmin-sys.screenleft())/p.localscl-float32(p.edgebound) ||
+				p.pos[0] > (sys.xmax+sys.screenright())/p.localscl+float32(p.edgebound) ||
 				p.velocity[0]*p.facing < 0 && p.pos[0] < sys.cam.XMin/p.localscl-float32(p.stagebound) ||
 				p.velocity[0]*p.facing > 0 && p.pos[0] > sys.cam.XMax/p.localscl+float32(p.stagebound) ||
 				p.velocity[1] > 0 && p.pos[1] > float32(p.heightbound[1]) ||
@@ -5977,11 +5977,11 @@ func (c *Char) selfStatenoExist(stateno BytecodeValue) BytecodeValue {
 func (c *Char) stageFrontEdgeDist() float32 {
 	corner := float32(0)
 	if c.facing < 0 {
-		corner = Max(sys.cam.XMin/c.localscl+sys.screenleft/c.localscl,
+		corner = Max(sys.cam.XMin/c.localscl+sys.screenleft()/c.localscl,
 			sys.stage.leftbound*sys.stage.localscl/c.localscl)
 		return c.pos[0] - corner
 	} else {
-		corner = Min(sys.cam.XMax/c.localscl-sys.screenright/c.localscl,
+		corner = Min(sys.cam.XMax/c.localscl-sys.screenright()/c.localscl,
 			sys.stage.rightbound*sys.stage.localscl/c.localscl)
 		return corner - c.pos[0]
 	}
@@ -5990,11 +5990,11 @@ func (c *Char) stageFrontEdgeDist() float32 {
 func (c *Char) stageBackEdgeDist() float32 {
 	corner := float32(0)
 	if c.facing < 0 {
-		corner = Min(sys.cam.XMax/c.localscl-sys.screenright/c.localscl,
+		corner = Min(sys.cam.XMax/c.localscl-sys.screenright()/c.localscl,
 			sys.stage.rightbound*sys.stage.localscl/c.localscl)
 		return corner - c.pos[0]
 	} else {
-		corner = Max(sys.cam.XMin/c.localscl+sys.screenleft/c.localscl,
+		corner = Max(sys.cam.XMin/c.localscl+sys.screenleft()/c.localscl,
 			sys.stage.leftbound*sys.stage.localscl/c.localscl)
 		return c.pos[0] - corner
 	}

--- a/src/char.go
+++ b/src/char.go
@@ -9728,7 +9728,7 @@ func (c *Char) xScreenBound() {
 	x := c.pos[0]
 	before := x
 
-	if !sys.cam.roundstart && c.trackableByCamera() && c.csf(CSF_screenbound) && !c.scf(SCF_standby) {
+	if c.trackableByCamera() && c.csf(CSF_screenbound) && !c.scf(SCF_standby) {
 		min, max := c.edgeWidth[0], -c.edgeWidth[1]
 		if c.facing > 0 {
 			min, max = -max, -min

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -5880,6 +5880,24 @@ func (c *StateCompiler) parseSection(sctrl func(name, data string) error) (IniSe
 
 	for ; c.i < len(c.lines); c.i++ {
 		line := strings.TrimSpace(strings.SplitN(c.lines[c.i], ";", 2)[0])
+
+		// Check for open [State] headers
+		// They end up as an invalid parameter for the previous state controller and cause both blocks to be merged
+		if !strings.Contains(line, "=") {
+			lower := strings.ToLower(line)
+			if strings.Contains(lower, "state") {
+				// We check if at least one bracket exists to avoid false positives like "p2stateno"
+				if strings.Contains(line, "[") != strings.Contains(line, "]") {
+					msg := fmt.Sprintf("State header not closed")
+					if sys.ignoreMostErrors {
+						sys.appendToConsole(c.charWarn() + msg)
+					} else {
+						return nil, Error(msg)
+					}
+				}
+			}
+		}
+
 		if len(line) > 0 && line[0] == '[' {
 			c.i--
 			break

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -14,7 +14,7 @@ type expFunc func(out *BytecodeExp, in *string) (BytecodeValue, error)
 
 type scFunc func(is IniSection, sc *StateControllerBase) (StateController, error)
 
-type StateCompiler struct {
+type CharCompiler struct {
 	cmdl             *CommandList
 	previousOperator string
 	reverseOrder     bool
@@ -32,8 +32,8 @@ type StateCompiler struct {
 	currentFile      string
 }
 
-func newStateCompiler() *StateCompiler {
-	c := &StateCompiler{funcs: make(map[string]BytecodeFunction)}
+func newCharCompiler() *CharCompiler {
+	c := &CharCompiler{funcs: make(map[string]BytecodeFunction)}
 	c.scmap = map[string]scFunc{
 		// Mugen state controllers
 		"afterimage":         c.afterImage,
@@ -482,12 +482,12 @@ var triggerMap = map[string]int{
 	"zoomvar":            1,
 }
 
-func (c *StateCompiler) tokenizer(in *string) string {
+func (c *CharCompiler) tokenizer(in *string) string {
 	return strings.ToLower(c.tokenizerCS(in))
 }
 
 // Same but case-sensitive
-func (*StateCompiler) tokenizerCS(in *string) string {
+func (*CharCompiler) tokenizerCS(in *string) string {
 	*in = strings.TrimSpace(*in)
 	if len(*in) == 0 {
 		return ""
@@ -626,7 +626,7 @@ func (*StateCompiler) tokenizerCS(in *string) string {
 	return token
 }
 
-func (*StateCompiler) isOperator(token string) int {
+func (*CharCompiler) isOperator(token string) int {
 	switch token {
 	case "", ",", ")", "]":
 		return -1
@@ -656,7 +656,7 @@ func (*StateCompiler) isOperator(token string) int {
 	return 0
 }
 
-func (c *StateCompiler) operator(in *string) error {
+func (c *CharCompiler) operator(in *string) error {
 	if len(c.previousOperator) > 0 {
 		if opp := c.isOperator(c.token); opp <= c.isOperator(c.previousOperator) {
 			if opp < 0 || ((!c.reverseOrder || c.token[0] != '(') &&
@@ -673,7 +673,7 @@ func (c *StateCompiler) operator(in *string) error {
 	return nil
 }
 
-func (c *StateCompiler) integer2(in *string) (int32, error) {
+func (c *CharCompiler) integer2(in *string) (int32, error) {
 	istr := c.token
 	c.token = c.tokenizer(in)
 	minus := istr == "-"
@@ -693,7 +693,7 @@ func (c *StateCompiler) integer2(in *string) (int32, error) {
 	return i, nil
 }
 
-func (c *StateCompiler) number(token string) BytecodeValue {
+func (c *CharCompiler) number(token string) BytecodeValue {
 	f, err := strconv.ParseFloat(token, 64)
 	if err != nil && f == 0 {
 		return bvNone()
@@ -715,7 +715,7 @@ func (c *StateCompiler) number(token string) BytecodeValue {
 	return BytecodeValue{VT_Int, f}
 }
 
-func (c *StateCompiler) attr(text string, hitdef bool) (int32, error) {
+func (c *CharCompiler) attr(text string, hitdef bool) (int32, error) {
 	flg := int32(0)
 	att := SplitAndTrim(text, ",")
 	for _, a := range att[0] {
@@ -806,7 +806,7 @@ func (c *StateCompiler) attr(text string, hitdef bool) (int32, error) {
 	return flg, nil
 }
 
-func (c *StateCompiler) trgAttr(in *string) (int32, error) {
+func (c *CharCompiler) trgAttr(in *string) (int32, error) {
 	flg := int32(0)
 	*in = c.token + *in
 	i := strings.IndexAny(*in, specialSymbols)
@@ -881,7 +881,7 @@ func (c *StateCompiler) trgAttr(in *string) (int32, error) {
 	return flg, nil
 }
 
-func (c *StateCompiler) checkOpeningParenthesis(in *string) error {
+func (c *CharCompiler) checkOpeningParenthesis(in *string) error {
 	if c.tokenizer(in) != "(" {
 		return Error("Missing '(' after " + c.token)
 	}
@@ -890,7 +890,7 @@ func (c *StateCompiler) checkOpeningParenthesis(in *string) error {
 }
 
 // Same but case-sensitive
-func (c *StateCompiler) checkOpeningParenthesisCS(in *string) error {
+func (c *CharCompiler) checkOpeningParenthesisCS(in *string) error {
 	if c.tokenizerCS(in) != "(" {
 		return Error("Missing '(' after " + c.token)
 	}
@@ -898,7 +898,7 @@ func (c *StateCompiler) checkOpeningParenthesisCS(in *string) error {
 	return nil
 }
 
-func (c *StateCompiler) checkClosingParenthesis() error {
+func (c *CharCompiler) checkClosingParenthesis() error {
 	c.reverseOrder = true
 	if c.token != ")" {
 		return Error("Missing ')' before " + c.token)
@@ -906,7 +906,7 @@ func (c *StateCompiler) checkClosingParenthesis() error {
 	return nil
 }
 
-func (c *StateCompiler) checkEquality(in *string) (not bool, err error) {
+func (c *CharCompiler) checkEquality(in *string) (not bool, err error) {
 	for {
 		c.token = c.tokenizer(in)
 		if len(c.token) > 0 {
@@ -928,7 +928,7 @@ func (c *StateCompiler) checkEquality(in *string) (not bool, err error) {
 	return
 }
 
-func (c *StateCompiler) intRange(in *string) (minop OpCode, maxop OpCode, min, max int32, err error) {
+func (c *CharCompiler) intRange(in *string) (minop OpCode, maxop OpCode, min, max int32, err error) {
 	switch c.token {
 	case "(":
 		minop = OC_gt
@@ -998,7 +998,7 @@ func (c *StateCompiler) intRange(in *string) (minop OpCode, maxop OpCode, min, m
 	return
 }
 
-func (c *StateCompiler) compareValues(_range bool, in *string) {
+func (c *CharCompiler) compareValues(_range bool, in *string) {
 	if sys.ignoreMostErrors {
 		i := 0
 		for ; i < len(*in); i++ {
@@ -1012,7 +1012,7 @@ func (c *StateCompiler) compareValues(_range bool, in *string) {
 	c.token = c.tokenizer(in)
 }
 
-func (c *StateCompiler) evaluateComparison(out *BytecodeExp, in *string,
+func (c *CharCompiler) evaluateComparison(out *BytecodeExp, in *string,
 	required bool) error {
 	comma := c.token == ","
 	if comma {
@@ -1096,7 +1096,7 @@ func (c *StateCompiler) evaluateComparison(out *BytecodeExp, in *string,
 	return nil
 }
 
-func (c *StateCompiler) oneArg(out *BytecodeExp, in *string,
+func (c *CharCompiler) oneArg(out *BytecodeExp, in *string,
 	rd, appendVal bool, defval ...BytecodeValue) (BytecodeValue, error) {
 	var be BytecodeExp
 	var bv BytecodeValue
@@ -1130,7 +1130,7 @@ func (c *StateCompiler) oneArg(out *BytecodeExp, in *string,
 
 // Read with two optional arguments
 // Currently only for IsHelper
-func (c *StateCompiler) twoOptArg(out *BytecodeExp, in *string,
+func (c *CharCompiler) twoOptArg(out *BytecodeExp, in *string,
 	rd, appendVal bool, defval ...BytecodeValue) (BytecodeValue, BytecodeValue, error) {
 
 	var be BytecodeExp
@@ -1188,7 +1188,7 @@ func (c *StateCompiler) twoOptArg(out *BytecodeExp, in *string,
 	return bv1, bv2, nil
 }
 
-func (c *StateCompiler) mathFunc(out *BytecodeExp, in *string, rd bool,
+func (c *CharCompiler) mathFunc(out *BytecodeExp, in *string, rd bool,
 	oc OpCode, f func(*BytecodeValue)) (bv BytecodeValue, err error) {
 	var be BytecodeExp
 	if bv, err = c.oneArg(&be, in, false, false); err != nil {
@@ -1206,7 +1206,7 @@ func (c *StateCompiler) mathFunc(out *BytecodeExp, in *string, rd bool,
 	return
 }
 
-func (c *StateCompiler) readOldProjectileID(in *string, trname string, baseLen int, out *BytecodeExp) (string, error) {
+func (c *CharCompiler) readOldProjectileID(in *string, trname string, baseLen int, out *BytecodeExp) (string, error) {
 	base := trname[:baseLen]
 	suffix := trname[baseLen:]
 
@@ -1251,7 +1251,7 @@ func (c *StateCompiler) readOldProjectileID(in *string, trname string, baseLen i
 }
 
 // For the first half of "x = y, > z" legacy triggers
-func (c *StateCompiler) parseOldAnimElemStyle(in *string, name string) (int32, error) {
+func (c *CharCompiler) parseOldAnimElemStyle(in *string, name string) (int32, error) {
 	if not, err := c.checkEquality(in); err != nil {
 		return 0, err
 	} else if not && !sys.ignoreMostErrors {
@@ -1269,7 +1269,7 @@ func (c *StateCompiler) parseOldAnimElemStyle(in *string, name string) (int32, e
 }
 
 // rd means Redirect
-func (c *StateCompiler) expValue(out *BytecodeExp, in *string,
+func (c *CharCompiler) expValue(out *BytecodeExp, in *string,
 	rd bool) (BytecodeValue, error) {
 	c.reverseOrder, c.norange = true, false
 	bv := c.number(c.token)
@@ -5279,7 +5279,7 @@ func (c *StateCompiler) expValue(out *BytecodeExp, in *string,
 	return bv, nil
 }
 
-func (c *StateCompiler) contiguousOperator(in *string) error {
+func (c *CharCompiler) contiguousOperator(in *string) error {
 	*in = strings.TrimSpace(*in)
 	if len(*in) > 0 {
 		switch (*in)[0] {
@@ -5295,7 +5295,7 @@ func (c *StateCompiler) contiguousOperator(in *string) error {
 	return nil
 }
 
-func (c *StateCompiler) expPostNot(out *BytecodeExp, in *string) (BytecodeValue, error) {
+func (c *CharCompiler) expPostNot(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	bv, err := c.expValue(out, in, false)
 	if err != nil {
 		return bvNone(), err
@@ -5345,7 +5345,7 @@ func (c *StateCompiler) expPostNot(out *BytecodeExp, in *string) (BytecodeValue,
 	return bv, nil
 }
 
-func (c *StateCompiler) expPow(out *BytecodeExp, in *string) (BytecodeValue, error) {
+func (c *CharCompiler) expPow(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	bv, err := c.expPostNot(out, in)
 	if err != nil {
 		return bvNone(), err
@@ -5377,7 +5377,7 @@ func (c *StateCompiler) expPow(out *BytecodeExp, in *string) (BytecodeValue, err
 	return bv, nil
 }
 
-func (c *StateCompiler) expMldv(out *BytecodeExp, in *string) (BytecodeValue, error) {
+func (c *CharCompiler) expMldv(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	bv, err := c.expPow(out, in)
 	if err != nil {
 		return bvNone(), err
@@ -5405,7 +5405,7 @@ func (c *StateCompiler) expMldv(out *BytecodeExp, in *string) (BytecodeValue, er
 	}
 }
 
-func (c *StateCompiler) expAdsb(out *BytecodeExp, in *string) (BytecodeValue, error) {
+func (c *CharCompiler) expAdsb(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	bv, err := c.expMldv(out, in)
 	if err != nil {
 		return bvNone(), err
@@ -5430,7 +5430,7 @@ func (c *StateCompiler) expAdsb(out *BytecodeExp, in *string) (BytecodeValue, er
 	}
 }
 
-func (c *StateCompiler) expGrls(out *BytecodeExp, in *string) (BytecodeValue, error) {
+func (c *CharCompiler) expGrls(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	bv, err := c.expAdsb(out, in)
 	if err != nil {
 		return bvNone(), err
@@ -5461,7 +5461,7 @@ func (c *StateCompiler) expGrls(out *BytecodeExp, in *string) (BytecodeValue, er
 	}
 }
 
-func (c *StateCompiler) expRange(out *BytecodeExp, in *string,
+func (c *CharCompiler) expRange(out *BytecodeExp, in *string,
 	bv *BytecodeValue, opc OpCode) (bool, error) {
 	open := c.token
 	oldin := *in
@@ -5551,7 +5551,7 @@ func (c *StateCompiler) expRange(out *BytecodeExp, in *string,
 	return true, nil
 }
 
-func (c *StateCompiler) expEqne(out *BytecodeExp, in *string) (BytecodeValue, error) {
+func (c *CharCompiler) expEqne(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	bv, err := c.expGrls(out, in)
 	if err != nil {
 		return bvNone(), err
@@ -5594,7 +5594,7 @@ func (c *StateCompiler) expEqne(out *BytecodeExp, in *string) (BytecodeValue, er
 	}
 }
 
-func (*StateCompiler) expOneOpSub(out *BytecodeExp, in *string, bv *BytecodeValue,
+func (*CharCompiler) expOneOpSub(out *BytecodeExp, in *string, bv *BytecodeValue,
 	ef expFunc, opf func(v1 *BytecodeValue, v2 BytecodeValue),
 	opc OpCode) error {
 	var be BytecodeExp
@@ -5614,7 +5614,7 @@ func (*StateCompiler) expOneOpSub(out *BytecodeExp, in *string, bv *BytecodeValu
 	return nil
 }
 
-func (c *StateCompiler) expOneOp(out *BytecodeExp, in *string, ef expFunc,
+func (c *CharCompiler) expOneOp(out *BytecodeExp, in *string, ef expFunc,
 	opt string, opf func(v1 *BytecodeValue, v2 BytecodeValue),
 	opc OpCode) (BytecodeValue, error) {
 	bv, err := ef(out, in)
@@ -5636,19 +5636,19 @@ func (c *StateCompiler) expOneOp(out *BytecodeExp, in *string, ef expFunc,
 	}
 }
 
-func (c *StateCompiler) expAnd(out *BytecodeExp, in *string) (BytecodeValue, error) {
+func (c *CharCompiler) expAnd(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	return c.expOneOp(out, in, c.expEqne, "&", out.and, OC_and)
 }
 
-func (c *StateCompiler) expXor(out *BytecodeExp, in *string) (BytecodeValue, error) {
+func (c *CharCompiler) expXor(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	return c.expOneOp(out, in, c.expAnd, "^", out.xor, OC_xor)
 }
 
-func (c *StateCompiler) expOr(out *BytecodeExp, in *string) (BytecodeValue, error) {
+func (c *CharCompiler) expOr(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	return c.expOneOp(out, in, c.expXor, "|", out.or, OC_or)
 }
 
-func (c *StateCompiler) expBoolAnd(out *BytecodeExp, in *string) (BytecodeValue, error) {
+func (c *CharCompiler) expBoolAnd(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	if c.block != nil {
 		return c.expOneOp(out, in, c.expOr, "&&", out.bland, OC_bland)
 	}
@@ -5688,11 +5688,11 @@ func (c *StateCompiler) expBoolAnd(out *BytecodeExp, in *string) (BytecodeValue,
 	return bv, nil
 }
 
-func (c *StateCompiler) expBoolXor(out *BytecodeExp, in *string) (BytecodeValue, error) {
+func (c *CharCompiler) expBoolXor(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	return c.expOneOp(out, in, c.expBoolAnd, "^^", out.blxor, OC_blxor)
 }
 
-func (c *StateCompiler) expBoolOr(out *BytecodeExp, in *string) (BytecodeValue, error) {
+func (c *CharCompiler) expBoolOr(out *BytecodeExp, in *string) (BytecodeValue, error) {
 	defer func(omp string) { c.previousOperator = omp }(c.previousOperator)
 	if c.block != nil {
 		return c.expOneOp(out, in, c.expBoolXor, "||", out.blor, OC_blor)
@@ -5733,7 +5733,7 @@ func (c *StateCompiler) expBoolOr(out *BytecodeExp, in *string) (BytecodeValue, 
 	return bv, nil
 }
 
-func (c *StateCompiler) typedExp(ef expFunc, in *string,
+func (c *CharCompiler) typedExp(ef expFunc, in *string,
 	vt ValueType) (BytecodeExp, error) {
 	c.token = c.tokenizer(in)
 	var be BytecodeExp
@@ -5755,7 +5755,7 @@ func (c *StateCompiler) typedExp(ef expFunc, in *string,
 	return be, nil
 }
 
-func (c *StateCompiler) argExpression(in *string, vt ValueType) (BytecodeExp, error) {
+func (c *CharCompiler) argExpression(in *string, vt ValueType) (BytecodeExp, error) {
 	be, err := c.typedExp(c.expBoolOr, in, vt)
 	if err != nil {
 		return nil, err
@@ -5774,7 +5774,7 @@ func (c *StateCompiler) argExpression(in *string, vt ValueType) (BytecodeExp, er
 	return be, nil
 }
 
-func (c *StateCompiler) fullExpression(in *string, vt ValueType) (BytecodeExp, error) {
+func (c *CharCompiler) fullExpression(in *string, vt ValueType) (BytecodeExp, error) {
 	be, err := c.typedExp(c.expBoolOr, in, vt)
 	if err != nil {
 		return nil, err
@@ -5803,7 +5803,7 @@ func parseTriggerNumber(name string) (tn int32, isAll bool, ok bool) {
 	return tn, false, true
 }
 
-func (c *StateCompiler) parseSection(sctrl func(name, data string) error) (IniSection, error) {
+func (c *CharCompiler) parseSection(sctrl func(name, data string) error) (IniSection, error) {
 	is := NewIniSection()
 	var _type, persistent, ignorehitpause bool
 
@@ -6012,7 +6012,7 @@ func (c *StateCompiler) parseSection(sctrl func(name, data string) error) (IniSe
 	return is, nil
 }
 
-func (c *StateCompiler) stateSec(is IniSection, f func() error) error {
+func (c *CharCompiler) stateSec(is IniSection, f func() error) error {
 	if err := f(); err != nil {
 		return err
 	}
@@ -6031,7 +6031,7 @@ func (c *StateCompiler) stateSec(is IniSection, f func() error) error {
 	return nil
 }
 
-func (c *StateCompiler) stateParam(is IniSection, name string, mandatory bool, f func(string) error) error {
+func (c *CharCompiler) stateParam(is IniSection, name string, mandatory bool, f func(string) error) error {
 	data, ok := is[name]
 	if ok {
 		if err := f(data); err != nil {
@@ -6045,7 +6045,7 @@ func (c *StateCompiler) stateParam(is IniSection, name string, mandatory bool, f
 }
 
 // Returns FX prefix from a data string while removing prefix from the data
-func (c *StateCompiler) getDataPrefix(data *string, ffxDefault bool) (prefix string) {
+func (c *CharCompiler) getDataPrefix(data *string, ffxDefault bool) (prefix string) {
 	if len(*data) > 1 {
 		str := strings.ToLower(*data)
 
@@ -6097,7 +6097,7 @@ func (c *StateCompiler) getDataPrefix(data *string, ffxDefault bool) (prefix str
 	return
 }
 
-func (c *StateCompiler) exprs(data string, vt ValueType,
+func (c *CharCompiler) exprs(data string, vt ValueType,
 	numArg int) ([]BytecodeExp, error) {
 	bes := []BytecodeExp{}
 	for n := 1; n <= numArg; n++ {
@@ -6119,7 +6119,7 @@ func (c *StateCompiler) exprs(data string, vt ValueType,
 	return bes, nil
 }
 
-func (c *StateCompiler) scAdd(sc *StateControllerBase, id byte,
+func (c *CharCompiler) scAdd(sc *StateControllerBase, id byte,
 	data string, vt ValueType, numArg int, topbe ...BytecodeExp) error {
 	bes, err := c.exprs(data, vt, numArg)
 	if err != nil {
@@ -6130,7 +6130,7 @@ func (c *StateCompiler) scAdd(sc *StateControllerBase, id byte,
 }
 
 // ParamValue adds the parameter immediately, unlike StateParam which only reads it
-func (c *StateCompiler) paramValue(is IniSection, sc *StateControllerBase,
+func (c *CharCompiler) paramValue(is IniSection, sc *StateControllerBase,
 	paramname string, id byte, vt ValueType, numArg int, mandatory bool) error {
 	found := false
 	if err := c.stateParam(is, paramname, false, func(data string) error {
@@ -6150,7 +6150,7 @@ func (c *StateCompiler) paramValue(is IniSection, sc *StateControllerBase,
 	return nil
 }
 
-func (c *StateCompiler) paramAnimtype(is IniSection, sc *StateControllerBase, paramName string, id byte) error {
+func (c *CharCompiler) paramAnimtype(is IniSection, sc *StateControllerBase, paramName string, id byte) error {
 	return c.stateParam(is, paramName, false, func(data string) error {
 		if len(data) == 0 {
 			return Error(paramName + " not specified")
@@ -6202,7 +6202,7 @@ func (c *StateCompiler) paramAnimtype(is IniSection, sc *StateControllerBase, pa
 	})
 }
 
-func (c *StateCompiler) paramHittype(is IniSection, sc *StateControllerBase, paramName string, id byte) error {
+func (c *CharCompiler) paramHittype(is IniSection, sc *StateControllerBase, paramName string, id byte) error {
 	return c.stateParam(is, paramName, false, func(data string) error {
 		if len(data) == 0 {
 			return Error(paramName + " not specified")
@@ -6244,7 +6244,7 @@ func (c *StateCompiler) paramHittype(is IniSection, sc *StateControllerBase, par
 	})
 }
 
-func (c *StateCompiler) paramPostype(is IniSection, sc *StateControllerBase, id byte) error {
+func (c *CharCompiler) paramPostype(is IniSection, sc *StateControllerBase, id byte) error {
 	return c.stateParam(is, "postype", false, func(data string) error {
 		if len(data) == 0 {
 			return Error("postype not specified")
@@ -6300,7 +6300,7 @@ func (c *StateCompiler) paramPostype(is IniSection, sc *StateControllerBase, id 
 	})
 }
 
-func (c *StateCompiler) paramSpace(is IniSection, sc *StateControllerBase, id byte) error {
+func (c *CharCompiler) paramSpace(is IniSection, sc *StateControllerBase, id byte) error {
 	return c.stateParam(is, "space", false, func(data string) error {
 		if len(data) == 0 {
 			return Error("space not specified")
@@ -6324,7 +6324,7 @@ func (c *StateCompiler) paramSpace(is IniSection, sc *StateControllerBase, id by
 	})
 }
 
-func (c *StateCompiler) paramProjection(is IniSection, sc *StateControllerBase, key string, id byte) error {
+func (c *CharCompiler) paramProjection(is IniSection, sc *StateControllerBase, key string, id byte) error {
 	return c.stateParam(is, key, false, func(data string) error {
 		var proj Projection
 
@@ -6344,7 +6344,7 @@ func (c *StateCompiler) paramProjection(is IniSection, sc *StateControllerBase, 
 	})
 }
 
-func (c *StateCompiler) paramSaveData(is IniSection, sc *StateControllerBase, id byte) error {
+func (c *CharCompiler) paramSaveData(is IniSection, sc *StateControllerBase, id byte) error {
 	return c.stateParam(is, "savedata", false, func(data string) error {
 		if len(data) <= 1 {
 			return Error("savedata not specified")
@@ -6366,7 +6366,7 @@ func (c *StateCompiler) paramSaveData(is IniSection, sc *StateControllerBase, id
 }
 
 // Parse trans and alpha together
-func (c *StateCompiler) paramTrans(is IniSection, sc *StateControllerBase, prefix string, id byte) error {
+func (c *CharCompiler) paramTrans(is IniSection, sc *StateControllerBase, prefix string, id byte) error {
 	// Check if we have both trans and alpha parameters
 	_, alphaExists := is[prefix+"alpha"]
 	_, transExists := is[prefix+"trans"]
@@ -6478,7 +6478,7 @@ func (c *StateCompiler) paramTrans(is IniSection, sc *StateControllerBase, prefi
 	})
 }
 
-func (c *StateCompiler) paramClsnType(is IniSection, sc *StateControllerBase, paramName string, id byte) error {
+func (c *CharCompiler) paramClsnType(is IniSection, sc *StateControllerBase, paramName string, id byte) error {
 	return c.stateParam(is, paramName, false, func(data string) error {
 		if len(data) == 0 {
 			return Error("Clsn type not specified for " + paramName)
@@ -6502,7 +6502,7 @@ func (c *StateCompiler) paramClsnType(is IniSection, sc *StateControllerBase, pa
 }
 
 // Interprets an IniSection of statedef properties and sets them to a StateBytecode
-func (c *StateCompiler) stateDef(is IniSection, sbc *StateBytecode) error {
+func (c *CharCompiler) stateDef(is IniSection, sbc *StateBytecode) error {
 	return c.stateSec(is, func() error {
 		sc := newStateControllerBase()
 		if err := c.stateParam(is, "type", false, func(data string) error {
@@ -6678,7 +6678,7 @@ func cnsStringArray(arg string) ([]string, error) {
 }
 
 // Forwards state compiling to CNS or ZSS branches as appropriate
-func (c *StateCompiler) stateCompile(states map[int32]StateBytecode,
+func (c *CharCompiler) stateCompile(states map[int32]StateBytecode,
 	filename string, dirs []string, negoverride bool, constants map[string]float32) error {
 
 	// Determine type from extension
@@ -6724,7 +6724,7 @@ func (c *StateCompiler) stateCompile(states map[int32]StateBytecode,
 	return c.stateCompileCNS(states, filename, filetext, negoverride, constants)
 }
 
-func (c *StateCompiler) stateCompileCNS(states map[int32]StateBytecode, filename, filetext string, negoverride bool, constants map[string]float32) error {
+func (c *CharCompiler) stateCompileCNS(states map[int32]StateBytecode, filename, filetext string, negoverride bool, constants map[string]float32) error {
 	// Reset ZSS mode
 	c.zssMode = false
 
@@ -7053,14 +7053,14 @@ func (c *StateCompiler) stateCompileCNS(states map[int32]StateBytecode, filename
 	return nil
 }
 
-func (c *StateCompiler) wrongClosureToken() error {
+func (c *CharCompiler) wrongClosureToken() error {
 	if c.token == "" {
 		return Error("Missing closure token")
 	}
 	return Error("Unexpected closure token: " + c.token)
 }
 
-func (c *StateCompiler) nextLine() (string, bool) {
+func (c *CharCompiler) nextLine() (string, bool) {
 	if c.i >= len(c.lines) {
 		return "", false
 	}
@@ -7069,7 +7069,7 @@ func (c *StateCompiler) nextLine() (string, bool) {
 	return line, true
 }
 
-func (c *StateCompiler) scan(line *string) string {
+func (c *CharCompiler) scan(line *string) string {
 	for {
 		c.token = c.tokenizer(line)
 		if len(c.token) > 0 {
@@ -7086,7 +7086,7 @@ func (c *StateCompiler) scan(line *string) string {
 	return c.token
 }
 
-func (c *StateCompiler) needToken(t string) error {
+func (c *CharCompiler) needToken(t string) error {
 	if c.token != t {
 		if c.token == "" {
 			return Error("Missing token: " + t)
@@ -7096,7 +7096,7 @@ func (c *StateCompiler) needToken(t string) error {
 	return nil
 }
 
-func (c *StateCompiler) readString(line *string) (string, error) {
+func (c *CharCompiler) readString(line *string) (string, error) {
 	i := strings.Index(*line, "\"")
 	if i < 0 {
 		return "", Error("String not enclosed in \"")
@@ -7106,7 +7106,7 @@ func (c *StateCompiler) readString(line *string) (string, error) {
 	return s, nil
 }
 
-func (c *StateCompiler) readSentenceLine(line *string) (s string, assign bool,
+func (c *CharCompiler) readSentenceLine(line *string) (s string, assign bool,
 	err error) {
 	c.token = ""
 	offset := 0
@@ -7141,7 +7141,7 @@ func (c *StateCompiler) readSentenceLine(line *string) (s string, assign bool,
 	return
 }
 
-func (c *StateCompiler) readSentence(line *string) (s string, a bool, err error) {
+func (c *CharCompiler) readSentence(line *string) (s string, a bool, err error) {
 	if s, a, err = c.readSentenceLine(line); err != nil {
 		return
 	}
@@ -7161,7 +7161,7 @@ func (c *StateCompiler) readSentence(line *string) (s string, a bool, err error)
 	return strings.TrimSpace(s), a, nil
 }
 
-func (c *StateCompiler) statementEnd(line *string) error {
+func (c *CharCompiler) statementEnd(line *string) error {
 	c.token = c.tokenizer(line)
 	if len(c.token) > 0 && c.token[0] != '#' {
 		return c.wrongClosureToken()
@@ -7170,7 +7170,7 @@ func (c *StateCompiler) statementEnd(line *string) error {
 	return nil
 }
 
-func (c *StateCompiler) readKeyValue(is IniSection, end string, line *string) error {
+func (c *CharCompiler) readKeyValue(is IniSection, end string, line *string) error {
 	// Read the key (parameter name)
 	name := c.scan(line)
 	if name == "" || name == ":" {
@@ -7203,7 +7203,7 @@ func (c *StateCompiler) readKeyValue(is IniSection, end string, line *string) er
 	return nil
 }
 
-func (c *StateCompiler) varNameCheck(nm string) (err error) {
+func (c *CharCompiler) varNameCheck(nm string) (err error) {
 	if (nm[0] < 'a' || nm[0] > 'z') && nm[0] != '_' {
 		return Error("Invalid name: " + nm)
 	}
@@ -7215,7 +7215,7 @@ func (c *StateCompiler) varNameCheck(nm string) (err error) {
 	return nil
 }
 
-func (c *StateCompiler) varNames(end string, line *string) ([]string, error) {
+func (c *CharCompiler) varNames(end string, line *string) ([]string, error) {
 	names, name := []string{}, c.scan(line)
 	if name != end {
 		for {
@@ -7247,7 +7247,7 @@ func (c *StateCompiler) varNames(end string, line *string) ([]string, error) {
 	return names, nil
 }
 
-func (c *StateCompiler) inclNumVars(numVars *int32) error {
+func (c *CharCompiler) inclNumVars(numVars *int32) error {
 	*numVars++
 	if *numVars > 256 {
 		return Error("Exceeded 256 local variable limit")
@@ -7255,7 +7255,7 @@ func (c *StateCompiler) inclNumVars(numVars *int32) error {
 	return nil
 }
 
-func (c *StateCompiler) scanI32(line *string) (int32, error) {
+func (c *CharCompiler) scanI32(line *string) (int32, error) {
 	t := c.scan(line)
 	if t == "" {
 		return 0, c.wrongClosureToken()
@@ -7267,7 +7267,7 @@ func (c *StateCompiler) scanI32(line *string) (int32, error) {
 	return int32(v), err
 }
 
-func (c *StateCompiler) scanStateDef(line *string, constants map[string]float32) (int32, error) {
+func (c *CharCompiler) scanStateDef(line *string, constants map[string]float32) (int32, error) {
 	t := c.scan(line)
 	if t == "" {
 		return 0, c.wrongClosureToken()
@@ -7301,7 +7301,7 @@ func (c *StateCompiler) scanStateDef(line *string, constants map[string]float32)
 }
 
 // Sets attributes to a StateBlock, like IgnoreHitPause, Persistent
-func (c *StateCompiler) blockAttribSet(line *string, bl *StateBlock, sbc *StateBytecode,
+func (c *CharCompiler) blockAttribSet(line *string, bl *StateBlock, sbc *StateBytecode,
 	inheritIhp, nestedInLoop bool) error {
 	// Inherit ignorehitpause/loop attr from parent block
 	if inheritIhp {
@@ -7359,7 +7359,7 @@ func (c *StateCompiler) blockAttribSet(line *string, bl *StateBlock, sbc *StateB
 	return nil
 }
 
-func (c *StateCompiler) subBlock(line *string, root bool,
+func (c *CharCompiler) subBlock(line *string, root bool,
 	sbc *StateBytecode, numVars *int32, inheritIhp, nestedInLoop bool) (*StateBlock, error) {
 	// Inject ignorehitpause property into functions (nil sbc)
 	if sbc == nil {
@@ -7438,7 +7438,7 @@ func (c *StateCompiler) subBlock(line *string, root bool,
 	return bl, nil
 }
 
-func (c *StateCompiler) switchBlock(line *string, bl *StateBlock,
+func (c *CharCompiler) switchBlock(line *string, bl *StateBlock,
 	sbc *StateBytecode, numVars *int32) error {
 	// In this implementation of switch, we convert the statement to an if-elseif-else chain of blocks
 	header, _, err := c.readSentence(line)
@@ -7539,7 +7539,7 @@ func (c *StateCompiler) switchBlock(line *string, bl *StateBlock,
 	return nil
 }
 
-func (c *StateCompiler) loopBlock(line *string, root bool, bl *StateBlock,
+func (c *CharCompiler) loopBlock(line *string, root bool, bl *StateBlock,
 	sbc *StateBytecode, numVars *int32) error {
 	bl.loopBlock = true
 	bl.nestedInLoop = true
@@ -7614,7 +7614,7 @@ func (c *StateCompiler) loopBlock(line *string, root bool, bl *StateBlock,
 	return nil
 }
 
-func (c *StateCompiler) callFunc(line *string, root bool, ctrls *[]StateController, ret []uint8) error {
+func (c *CharCompiler) callFunc(line *string, root bool, ctrls *[]StateController, ret []uint8) error {
 	var cf CallFunction
 
 	// Scan the function name
@@ -7688,7 +7688,7 @@ func (c *StateCompiler) callFunc(line *string, root bool, ctrls *[]StateControll
 	return nil
 }
 
-func (c *StateCompiler) letAssign(line *string, root bool,
+func (c *CharCompiler) letAssign(line *string, root bool,
 	ctrls *[]StateController, numVars *int32, names []string, endLine bool) error {
 	varis := make([]uint8, len(names))
 	for i, n := range names {
@@ -7755,7 +7755,7 @@ func (c *StateCompiler) letAssign(line *string, root bool,
 	return nil
 }
 
-func (c *StateCompiler) stateBlock(line *string, bl *StateBlock, root bool,
+func (c *CharCompiler) stateBlock(line *string, bl *StateBlock, root bool,
 	sbc *StateBytecode, ctrls *[]StateController, numVars *int32) error {
 	c.scan(line)
 	for {
@@ -7904,7 +7904,7 @@ func (c *StateCompiler) stateBlock(line *string, bl *StateBlock, root bool,
 	return c.wrongClosureToken()
 }
 
-func (c *StateCompiler) stateCompileZSS(states map[int32]StateBytecode, filename, filetext string, constants map[string]float32) error {
+func (c *CharCompiler) stateCompileZSS(states map[int32]StateBytecode, filename, filetext string, constants map[string]float32) error {
 	// Enable ZSS mode
 	// TODO: There's some overlap between this flag and sys.ignoreMostErrors
 	c.zssMode = true
@@ -8064,7 +8064,7 @@ func (c *StateCompiler) stateCompileZSS(states map[int32]StateBytecode, filename
 }
 
 // Compile a character definition file
-func (c *StateCompiler) Compile(pn int, def string, constants map[string]float32) (map[int32]StateBytecode, error) {
+func (c *CharCompiler) Compile(pn int, def string, constants map[string]float32) (map[int32]StateBytecode, error) {
 	c.playerNo = pn
 	states := make(map[int32]StateBytecode)
 
@@ -8324,7 +8324,7 @@ func (c *StateCompiler) Compile(pn int, def string, constants map[string]float32
 	return states, nil
 }
 
-func (c *StateCompiler) charWarn() string {
+func (c *CharCompiler) charWarn() string {
 	// Trim path to keep message shorter
 	_, file := SplitPath(c.currentFile)
 	// c.i acts a bit different between CNS and ZSS

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -6789,6 +6789,9 @@ func (c *StateCompiler) stateCompileCNS(states map[int32]StateBytecode, filename
 			// Flag if following triggers can never be true because of triggerall = 0
 			allTerminated := false
 
+			// Missing trigger number only needs to be printed once
+			warnedMissingTrigger := false
+
 			// Parse each line of the sctrl to get triggers and settings
 			is, err := c.parseSection(func(name, data string) error {
 				switch name {
@@ -6829,22 +6832,39 @@ func (c *StateCompiler) stateCompileCNS(states map[int32]StateBytecode, filename
 						// Convert to zero-based index
 						tidx := int(tn - 1)
 
-						// Parse trigger condition into a bytecode expression
-						be, err := c.fullExpression(&data, VT_Bool)
-						if err != nil {
-							// Skip this trigger if an earlier trigger number doesn't exist
-							// e.g. skip trigger3 if trigger2 was not found
-							if sys.ignoreMostErrors && !isAll {
-								broken := false
+						// Check if a previous trigger is missing
+						// e.g. found trigger3 but not trigger2
+						var missingIdx = -1
+						if !isAll && tn > 1 {
+							if tidx > len(trexist) {
+								missingIdx = len(trexist)
+							} else {
 								for i := 0; i < tidx; i++ {
 									if trexist[i] == 0 {
-										broken = true
+										missingIdx = i
 										break
 									}
 								}
-								if broken {
-									break
+							}
+							if missingIdx >= 0 {
+								msg := fmt.Sprintf("trigger%d declared without trigger%d", tn, missingIdx+1)
+								if sys.ignoreMostErrors {
+									if !warnedMissingTrigger {
+										sys.appendToConsole(c.charWarn() + msg)
+										warnedMissingTrigger = true
+									}
+								} else {
+									return Error(msg)
 								}
+							}
+						}
+
+						// Parse trigger conditions into a bytecode expression
+						be, err := c.fullExpression(&data, VT_Bool)
+						if err != nil {
+							// Ignore the error if it happened in a trigger that is being skipped anyway
+							if missingIdx >= 0 && sys.ignoreMostErrors {
+								break
 							}
 							return err
 						}

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -463,7 +463,7 @@ func (c *CharCompiler) changeStateSub(is IniSection,
 		// Assign a unique index to ignorehitpause for this controller
 		c.block.ignorehitpause = sys.cgi[c.playerNo].hitPauseToggleFlagCount
 		// Increment the count of hitPauseExecutionToggleFlags
-		sys.cgi[c.playerNo].hitPauseToggleFlagCount++
+		//sys.cgi[c.playerNo].hitPauseToggleFlagCount++
 	}
 	return nil
 }

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -808,6 +808,28 @@ func (c *StateCompiler) helper(is IniSection, sc *StateControllerBase) (StateCon
 			helper_ownprojectile, VT_Bool, 1, false); err != nil {
 			return err
 		}
+
+		// Handle the "map." parameters
+		// Must be placed after extendsmap or that operation may write over these maps
+		for k, data := range is {
+			lowK := strings.ToLower(k)
+			if strings.HasPrefix(lowK, "map.") {
+				mapKey := k[4:]
+				if mapKey == "" {
+					return Error("Empty map key in helper parameters")
+				}
+				// Compile value expression
+				mapValBes, err := c.exprs(data, VT_Float, 1)
+				if err != nil {
+					return err
+				}
+				// String hack like with most name parameters
+				mapKeyBes := sc.beToExp(BytecodeExp(mapKey))
+				sc.add(helper_map, append(mapKeyBes, mapValBes...))
+				delete(is, k)
+			}
+		}
+
 		return nil
 	})
 	return *ret, err
@@ -4818,6 +4840,23 @@ func (c *StateCompiler) mapSetSub(is IniSection, sc *StateControllerBase) error 
 			}
 		}
 
+		// If map or value are still empty
+		if len(mapName) == 0 {
+			msg := fmt.Sprintf("Map name cannot be empty")
+			if c.zssMode || !sys.ignoreMostErrors {
+				return Error(msg)
+			}
+			sys.appendToConsole(c.charWarn() + msg)
+		}
+		if len(value) == 0 {
+			msg := fmt.Sprintf("Value not specified for map")
+			if c.zssMode || !sys.ignoreMostErrors {
+				return Error(msg)
+			}
+			sys.appendToConsole(c.charWarn() + msg)
+		}
+
+		// Only add the bytecode if both are OK
 		if len(mapName) > 0 && len(value) > 0 {
 			sc.add(mapSet_mapArray, sc.beToExp(BytecodeExp(mapName)))
 			if err := c.scAdd(sc, mapSet_value, value, VT_Float, 1); err != nil {

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -11,7 +11,7 @@ import (
 // State controller definition file.
 // This file contains the parsing code for the function in ZSS and CNS, also called State Controllers.
 
-func (c *StateCompiler) hitBySub(is IniSection, sc *StateControllerBase, sctrlName string) error {
+func (c *CharCompiler) hitBySub(is IniSection, sc *StateControllerBase, sctrlName string) error {
 	attr := int32(-1)
 	var err error
 	var any, new, old bool
@@ -109,7 +109,7 @@ func (c *StateCompiler) hitBySub(is IniSection, sc *StateControllerBase, sctrlNa
 	return nil
 }
 
-func (c *StateCompiler) hitBy(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) hitBy(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*hitBy)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid", hitBy_redirectid, VT_Int, 1, false); err != nil {
 			return err
@@ -119,7 +119,7 @@ func (c *StateCompiler) hitBy(is IniSection, sc *StateControllerBase) (StateCont
 	return *ret, err
 }
 
-func (c *StateCompiler) notHitBy(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) notHitBy(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*notHitBy)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid", hitBy_redirectid, VT_Int, 1, false); err != nil {
 			return err
@@ -129,7 +129,7 @@ func (c *StateCompiler) notHitBy(is IniSection, sc *StateControllerBase) (StateC
 	return *ret, err
 }
 
-func (c *StateCompiler) assertSpecial(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) assertSpecial(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*assertSpecial)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			assertSpecial_redirectid, VT_Int, 1, false); err != nil {
@@ -352,7 +352,7 @@ func (c *StateCompiler) assertSpecial(is IniSection, sc *StateControllerBase) (S
 	return *ret, err
 }
 
-func (c *StateCompiler) playSnd(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) playSnd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*playSnd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			playSnd_redirectid, VT_Int, 1, false); err != nil {
@@ -430,7 +430,7 @@ func (c *StateCompiler) playSnd(is IniSection, sc *StateControllerBase) (StateCo
 	return *ret, err
 }
 
-func (c *StateCompiler) changeStateSub(is IniSection,
+func (c *CharCompiler) changeStateSub(is IniSection,
 	sc *StateControllerBase) error {
 	if err := c.paramValue(is, sc, "redirectid",
 		changeState_redirectid, VT_Int, 1, false); err != nil {
@@ -468,21 +468,21 @@ func (c *StateCompiler) changeStateSub(is IniSection,
 	return nil
 }
 
-func (c *StateCompiler) changeState(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) changeState(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*changeState)(sc), c.stateSec(is, func() error {
 		return c.changeStateSub(is, sc)
 	})
 	return *ret, err
 }
 
-func (c *StateCompiler) selfState(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) selfState(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*selfState)(sc), c.stateSec(is, func() error {
 		return c.changeStateSub(is, sc)
 	})
 	return *ret, err
 }
 
-func (c *StateCompiler) tagIn(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) tagIn(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*tagIn)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			tagIn_redirectid, VT_Int, 1, false); err != nil {
@@ -521,7 +521,7 @@ func (c *StateCompiler) tagIn(is IniSection, sc *StateControllerBase) (StateCont
 	return *ret, err
 }
 
-func (c *StateCompiler) tagOut(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) tagOut(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*tagOut)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			tagOut_redirectid, VT_Int, 1, false); err != nil {
@@ -551,7 +551,7 @@ func (c *StateCompiler) tagOut(is IniSection, sc *StateControllerBase) (StateCon
 	return *ret, err
 }
 
-func (c *StateCompiler) destroySelf(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) destroySelf(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*destroySelf)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			destroySelf_redirectid, VT_Int, 1, false); err != nil {
@@ -574,7 +574,7 @@ func (c *StateCompiler) destroySelf(is IniSection, sc *StateControllerBase) (Sta
 	return *ret, err
 }
 
-func (c *StateCompiler) changeAnimSub(is IniSection,
+func (c *CharCompiler) changeAnimSub(is IniSection,
 	sc *StateControllerBase) error {
 	if err := c.paramValue(is, sc, "redirectid",
 		changeAnim_redirectid, VT_Int, 1, false); err != nil {
@@ -610,21 +610,21 @@ func (c *StateCompiler) changeAnimSub(is IniSection,
 	return nil
 }
 
-func (c *StateCompiler) changeAnim(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) changeAnim(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*changeAnim)(sc), c.stateSec(is, func() error {
 		return c.changeAnimSub(is, sc)
 	})
 	return *ret, err
 }
 
-func (c *StateCompiler) changeAnim2(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) changeAnim2(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*changeAnim2)(sc), c.stateSec(is, func() error {
 		return c.changeAnimSub(is, sc)
 	})
 	return *ret, err
 }
 
-func (c *StateCompiler) helper(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) helper(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*helper)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			helper_redirectid, VT_Int, 1, false); err != nil {
@@ -835,7 +835,7 @@ func (c *StateCompiler) helper(is IniSection, sc *StateControllerBase) (StateCon
 	return *ret, err
 }
 
-func (c *StateCompiler) ctrlSet(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) ctrlSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*ctrlSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			ctrlSet_redirectid, VT_Int, 1, false); err != nil {
@@ -846,7 +846,7 @@ func (c *StateCompiler) ctrlSet(is IniSection, sc *StateControllerBase) (StateCo
 	return *ret, err
 }
 
-func (c *StateCompiler) explodSub(is IniSection, sc *StateControllerBase) error {
+func (c *CharCompiler) explodSub(is IniSection, sc *StateControllerBase) error {
 	if err := c.paramValue(is, sc, "remappal",
 		explod_remappal, VT_Int, 2, false); err != nil {
 		return err
@@ -1056,7 +1056,7 @@ func (c *StateCompiler) explodSub(is IniSection, sc *StateControllerBase) error 
 	return nil
 }
 
-func (c *StateCompiler) explodInterpolate(is IniSection,
+func (c *CharCompiler) explodInterpolate(is IniSection,
 	sc *StateControllerBase) error {
 	if err := c.paramValue(is, sc, "interpolation.time",
 		explod_interpolation_time, VT_Int, 1, false); err != nil {
@@ -1109,7 +1109,7 @@ func (c *StateCompiler) explodInterpolate(is IniSection,
 	return nil
 }
 
-func (c *StateCompiler) explod(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) explod(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*explod)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			explod_redirectid, VT_Int, 1, false); err != nil {
@@ -1123,7 +1123,7 @@ func (c *StateCompiler) explod(is IniSection, sc *StateControllerBase) (StateCon
 	return *ret, err
 }
 
-func (c *StateCompiler) modifyExplod(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) modifyExplod(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*modifyExplod)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			modifyexplod_redirectid, VT_Int, 1, false); err != nil {
@@ -1146,7 +1146,7 @@ func (c *StateCompiler) modifyExplod(is IniSection, sc *StateControllerBase) (St
 	return *ret, err
 }
 
-func (c *StateCompiler) gameMakeAnim(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) gameMakeAnim(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*gameMakeAnim)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			gameMakeAnim_redirectid, VT_Int, 1, false); err != nil {
@@ -1182,7 +1182,7 @@ func (c *StateCompiler) gameMakeAnim(is IniSection, sc *StateControllerBase) (St
 	return *ret, err
 }
 
-func (c *StateCompiler) posSetSub(is IniSection,
+func (c *CharCompiler) posSetSub(is IniSection,
 	sc *StateControllerBase) error {
 	if err := c.paramValue(is, sc, "x",
 		posSet_x, VT_Float, 1, false); err != nil {
@@ -1199,7 +1199,7 @@ func (c *StateCompiler) posSetSub(is IniSection,
 	return nil
 }
 
-func (c *StateCompiler) posSet(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) posSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*posSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			posSet_redirectid, VT_Int, 1, false); err != nil {
@@ -1210,7 +1210,7 @@ func (c *StateCompiler) posSet(is IniSection, sc *StateControllerBase) (StateCon
 	return *ret, err
 }
 
-func (c *StateCompiler) posAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) posAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*posAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			posSet_redirectid, VT_Int, 1, false); err != nil {
@@ -1221,7 +1221,7 @@ func (c *StateCompiler) posAdd(is IniSection, sc *StateControllerBase) (StateCon
 	return *ret, err
 }
 
-func (c *StateCompiler) velSet(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) velSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*velSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			posSet_redirectid, VT_Int, 1, false); err != nil {
@@ -1232,7 +1232,7 @@ func (c *StateCompiler) velSet(is IniSection, sc *StateControllerBase) (StateCon
 	return *ret, err
 }
 
-func (c *StateCompiler) velAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) velAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*velAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			posSet_redirectid, VT_Int, 1, false); err != nil {
@@ -1243,7 +1243,7 @@ func (c *StateCompiler) velAdd(is IniSection, sc *StateControllerBase) (StateCon
 	return *ret, err
 }
 
-func (c *StateCompiler) velMul(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) velMul(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*velMul)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			posSet_redirectid, VT_Int, 1, false); err != nil {
@@ -1254,7 +1254,7 @@ func (c *StateCompiler) velMul(is IniSection, sc *StateControllerBase) (StateCon
 	return *ret, err
 }
 
-func (c *StateCompiler) modifyShadow(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) modifyShadow(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*modifyShadow)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			modifyShadow_redirectid, VT_Int, 1, false); err != nil {
@@ -1336,7 +1336,7 @@ func (c *StateCompiler) modifyShadow(is IniSection, sc *StateControllerBase) (St
 	return *ret, err
 }
 
-func (c *StateCompiler) modifyReflection(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) modifyReflection(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*modifyReflection)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			modifyReflection_redirectid, VT_Int, 1, false); err != nil {
@@ -1418,7 +1418,7 @@ func (c *StateCompiler) modifyReflection(is IniSection, sc *StateControllerBase)
 	return *ret, err
 }
 
-func (c *StateCompiler) palFXSub(is IniSection,
+func (c *CharCompiler) palFXSub(is IniSection,
 	sc *StateControllerBase, prefix string) error {
 	if err := c.paramValue(is, sc, prefix+"time",
 		palFX_time, VT_Int, 1, false); err != nil {
@@ -1521,7 +1521,7 @@ func (c *StateCompiler) palFXSub(is IniSection,
 	return nil
 }
 
-func (c *StateCompiler) palFX(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) palFX(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*palFX)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			palFX_redirectid, VT_Int, 1, false); err != nil {
@@ -1532,14 +1532,14 @@ func (c *StateCompiler) palFX(is IniSection, sc *StateControllerBase) (StateCont
 	return *ret, err
 }
 
-func (c *StateCompiler) allPalFX(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) allPalFX(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*allPalFX)(sc), c.stateSec(is, func() error {
 		return c.palFXSub(is, sc, "")
 	})
 	return *ret, err
 }
 
-func (c *StateCompiler) bgPalFX(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) bgPalFX(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*bgPalFX)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "id",
 			bgPalFX_id, VT_Int, 1, false); err != nil {
@@ -1557,7 +1557,7 @@ func (c *StateCompiler) bgPalFX(is IniSection, sc *StateControllerBase) (StateCo
 	return *ret, err
 }
 
-func (c *StateCompiler) afterImageSub(is IniSection, sc *StateControllerBase, prefix string) error {
+func (c *CharCompiler) afterImageSub(is IniSection, sc *StateControllerBase, prefix string) error {
 	if err := c.paramValue(is, sc, "redirectid",
 		afterImage_redirectid, VT_Int, 1, false); err != nil {
 		return err
@@ -1624,14 +1624,14 @@ func (c *StateCompiler) afterImageSub(is IniSection, sc *StateControllerBase, pr
 	return nil
 }
 
-func (c *StateCompiler) afterImage(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) afterImage(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*afterImage)(sc), c.stateSec(is, func() error {
 		return c.afterImageSub(is, sc, "")
 	})
 	return *ret, err
 }
 
-func (c *StateCompiler) afterImageTime(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) afterImageTime(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*afterImageTime)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			afterImageTime_redirectid, VT_Int, 1, false); err != nil {
@@ -1660,7 +1660,7 @@ func (c *StateCompiler) afterImageTime(is IniSection, sc *StateControllerBase) (
 	return *ret, err
 }
 
-func (c *StateCompiler) parseHitFlag(sc *StateControllerBase, id byte, data string) error {
+func (c *CharCompiler) parseHitFlag(sc *StateControllerBase, id byte, data string) error {
 	var flg int32
 	for _, c := range data {
 		switch c {
@@ -1688,7 +1688,7 @@ func (c *StateCompiler) parseHitFlag(sc *StateControllerBase, id byte, data stri
 	return nil
 }
 
-func (c *StateCompiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
+func (c *CharCompiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 	if err := c.stateParam(is, "attr", false, func(data string) error {
 		attr, err := c.attr(data, true)
 		if err != nil {
@@ -2249,7 +2249,7 @@ func (c *StateCompiler) hitDefSub(is IniSection, sc *StateControllerBase) error 
 	return nil
 }
 
-func (c *StateCompiler) hitDef(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) hitDef(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*hitDef)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			hitDef_redirectid, VT_Int, 1, false); err != nil {
@@ -2260,7 +2260,7 @@ func (c *StateCompiler) hitDef(is IniSection, sc *StateControllerBase) (StateCon
 	return *ret, err
 }
 
-func (c *StateCompiler) modifyHitDef(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) modifyHitDef(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*modifyHitDef)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			modifyHitDef_redirectid, VT_Int, 1, false); err != nil {
@@ -2271,7 +2271,7 @@ func (c *StateCompiler) modifyHitDef(is IniSection, sc *StateControllerBase) (St
 	return *ret, err
 }
 
-func (c *StateCompiler) reversalDef(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) reversalDef(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*reversalDef)(sc), c.stateSec(is, func() error {
 		attr := int32(-1)
 		var err error
@@ -2305,7 +2305,7 @@ func (c *StateCompiler) reversalDef(is IniSection, sc *StateControllerBase) (Sta
 	return *ret, err
 }
 
-func (c *StateCompiler) modifyReversalDef(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) modifyReversalDef(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*modifyReversalDef)(sc), c.stateSec(is, func() error {
 		var err error
 		if err = c.paramValue(is, sc, "redirectid",
@@ -2337,7 +2337,7 @@ func (c *StateCompiler) modifyReversalDef(is IniSection, sc *StateControllerBase
 	return *ret, err
 }
 
-func (c *StateCompiler) projectileSub(is IniSection, sc *StateControllerBase) error {
+func (c *CharCompiler) projectileSub(is IniSection, sc *StateControllerBase) error {
 	if err := c.paramValue(is, sc, "redirectid",
 		projectile_redirectid, VT_Int, 1, false); err != nil {
 		return err
@@ -2515,7 +2515,7 @@ func (c *StateCompiler) projectileSub(is IniSection, sc *StateControllerBase) er
 	return nil
 }
 
-func (c *StateCompiler) projectile(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) projectile(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*projectile)(sc), c.stateSec(is, func() error {
 		if err := c.projectileSub(is, sc); err != nil {
 			return err
@@ -2525,7 +2525,7 @@ func (c *StateCompiler) projectile(is IniSection, sc *StateControllerBase) (Stat
 	return *ret, err
 }
 
-func (c *StateCompiler) modifyProjectile(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) modifyProjectile(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*modifyProjectile)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			modifyProjectile_redirectid, VT_Int, 1, false); err != nil {
@@ -2548,7 +2548,7 @@ func (c *StateCompiler) modifyProjectile(is IniSection, sc *StateControllerBase)
 	return *ret, err
 }
 
-func (c *StateCompiler) width(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) width(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*width)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			width_redirectid, VT_Int, 1, false); err != nil {
@@ -2584,7 +2584,7 @@ func (c *StateCompiler) width(is IniSection, sc *StateControllerBase) (StateCont
 	return *ret, err
 }
 
-func (c *StateCompiler) sprPriority(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) sprPriority(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*sprPriority)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			sprPriority_redirectid, VT_Int, 1, false); err != nil {
@@ -2601,7 +2601,7 @@ func (c *StateCompiler) sprPriority(is IniSection, sc *StateControllerBase) (Sta
 }
 
 // "v = x; value = y" syntax
-func (c *StateCompiler) varSetOlderSub(is IniSection, sc *StateControllerBase, alreadyAssigned func() bool) (bool, error) {
+func (c *CharCompiler) varSetOlderSub(is IniSection, sc *StateControllerBase, alreadyAssigned func() bool) (bool, error) {
 	var value string
 	hasValue := false
 	if err := c.stateParam(is, "value", false, func(data string) error {
@@ -2671,7 +2671,7 @@ func (c *StateCompiler) varSetOlderSub(is IniSection, sc *StateControllerBase, a
 }
 
 // "var(x) = y" syntax. CNS only
-func (c *StateCompiler) varSetNewerSub(name string) (varType int32, index BytecodeExp, ok bool, err error) {
+func (c *CharCompiler) varSetNewerSub(name string) (varType int32, index BytecodeExp, ok bool, err error) {
 	trimmed := strings.TrimSpace(name)
 	lowered := strings.ToLower(trimmed)
 
@@ -2744,7 +2744,7 @@ func (c *StateCompiler) varSetNewerSub(name string) (varType int32, index Byteco
 	return 0, nil, false, nil
 }
 
-func (c *StateCompiler) varSetSub(is IniSection, sc *StateControllerBase, scType int32) error {
+func (c *CharCompiler) varSetSub(is IniSection, sc *StateControllerBase, scType int32) error {
 	alreadyAssigned := func() bool {
 		return sc.hasParam(varSet_index) || sc.hasParam(varSet_varType)
 	}
@@ -2808,7 +2808,7 @@ func (c *StateCompiler) varSetSub(is IniSection, sc *StateControllerBase, scType
 	return Error("Variable or value parameter not specified")
 }
 
-func (c *StateCompiler) varSet(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) varSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*varSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			varSet_redirectid, VT_Int, 1, false); err != nil {
@@ -2819,7 +2819,7 @@ func (c *StateCompiler) varSet(is IniSection, sc *StateControllerBase) (StateCon
 	return *ret, err
 }
 
-func (c *StateCompiler) varAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) varAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*varSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			varSet_redirectid, VT_Int, 1, false); err != nil {
@@ -2830,7 +2830,7 @@ func (c *StateCompiler) varAdd(is IniSection, sc *StateControllerBase) (StateCon
 	return *ret, err
 }
 
-func (c *StateCompiler) parentVarSet(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) parentVarSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*varSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			varSet_redirectid, VT_Int, 1, false); err != nil {
@@ -2841,7 +2841,7 @@ func (c *StateCompiler) parentVarSet(is IniSection, sc *StateControllerBase) (St
 	return *ret, err
 }
 
-func (c *StateCompiler) parentVarAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) parentVarAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*varSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			varSet_redirectid, VT_Int, 1, false); err != nil {
@@ -2852,7 +2852,7 @@ func (c *StateCompiler) parentVarAdd(is IniSection, sc *StateControllerBase) (St
 	return *ret, err
 }
 
-func (c *StateCompiler) rootVarSet(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) rootVarSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*varSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			varSet_redirectid, VT_Int, 1, false); err != nil {
@@ -2863,7 +2863,7 @@ func (c *StateCompiler) rootVarSet(is IniSection, sc *StateControllerBase) (Stat
 	return *ret, err
 }
 
-func (c *StateCompiler) rootVarAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) rootVarAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*varSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			varSet_redirectid, VT_Int, 1, false); err != nil {
@@ -2874,7 +2874,7 @@ func (c *StateCompiler) rootVarAdd(is IniSection, sc *StateControllerBase) (Stat
 	return *ret, err
 }
 
-func (c *StateCompiler) turn(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) turn(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*turn)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			turn_redirectid, VT_Int, 1, false); err != nil {
@@ -2886,7 +2886,7 @@ func (c *StateCompiler) turn(is IniSection, sc *StateControllerBase) (StateContr
 	return *ret, err
 }
 
-func (c *StateCompiler) targetFacing(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) targetFacing(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*targetFacing)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetFacing_redirectid, VT_Int, 1, false); err != nil {
@@ -2909,7 +2909,7 @@ func (c *StateCompiler) targetFacing(is IniSection, sc *StateControllerBase) (St
 	return *ret, err
 }
 
-func (c *StateCompiler) targetBind(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) targetBind(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*targetBind)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetBind_redirectid, VT_Int, 1, false); err != nil {
@@ -2936,7 +2936,7 @@ func (c *StateCompiler) targetBind(is IniSection, sc *StateControllerBase) (Stat
 	return *ret, err
 }
 
-func (c *StateCompiler) bindToTarget(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) bindToTarget(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*bindToTarget)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			bindToTarget_redirectid, VT_Int, 1, false); err != nil {
@@ -2997,7 +2997,7 @@ func (c *StateCompiler) bindToTarget(is IniSection, sc *StateControllerBase) (St
 	return *ret, err
 }
 
-func (c *StateCompiler) targetLifeAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) targetLifeAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*targetLifeAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetLifeAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -3036,7 +3036,7 @@ func (c *StateCompiler) targetLifeAdd(is IniSection, sc *StateControllerBase) (S
 	return *ret, err
 }
 
-func (c *StateCompiler) targetState(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) targetState(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*targetState)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetState_redirectid, VT_Int, 1, false); err != nil {
@@ -3059,7 +3059,7 @@ func (c *StateCompiler) targetState(is IniSection, sc *StateControllerBase) (Sta
 	return *ret, err
 }
 
-func (c *StateCompiler) targetVelSet(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) targetVelSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*targetVelSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetVelSet_redirectid, VT_Int, 1, false); err != nil {
@@ -3090,7 +3090,7 @@ func (c *StateCompiler) targetVelSet(is IniSection, sc *StateControllerBase) (St
 	return *ret, err
 }
 
-func (c *StateCompiler) targetVelAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) targetVelAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*targetVelAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetVelAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -3121,7 +3121,7 @@ func (c *StateCompiler) targetVelAdd(is IniSection, sc *StateControllerBase) (St
 	return *ret, err
 }
 
-func (c *StateCompiler) targetPowerAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) targetPowerAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*targetPowerAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetPowerAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -3144,7 +3144,7 @@ func (c *StateCompiler) targetPowerAdd(is IniSection, sc *StateControllerBase) (
 	return *ret, err
 }
 
-func (c *StateCompiler) targetDrop(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) targetDrop(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*targetDrop)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetDrop_redirectid, VT_Int, 1, false); err != nil {
@@ -3163,7 +3163,7 @@ func (c *StateCompiler) targetDrop(is IniSection, sc *StateControllerBase) (Stat
 	return *ret, err
 }
 
-func (c *StateCompiler) lifeAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) lifeAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*lifeAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			lifeAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -3186,7 +3186,7 @@ func (c *StateCompiler) lifeAdd(is IniSection, sc *StateControllerBase) (StateCo
 	return *ret, err
 }
 
-func (c *StateCompiler) lifeSet(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) lifeSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*lifeSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			lifeSet_redirectid, VT_Int, 1, false); err != nil {
@@ -3197,7 +3197,7 @@ func (c *StateCompiler) lifeSet(is IniSection, sc *StateControllerBase) (StateCo
 	return *ret, err
 }
 
-func (c *StateCompiler) powerAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) powerAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*powerAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			powerAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -3208,7 +3208,7 @@ func (c *StateCompiler) powerAdd(is IniSection, sc *StateControllerBase) (StateC
 	return *ret, err
 }
 
-func (c *StateCompiler) powerSet(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) powerSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*powerSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			powerSet_redirectid, VT_Int, 1, false); err != nil {
@@ -3219,7 +3219,7 @@ func (c *StateCompiler) powerSet(is IniSection, sc *StateControllerBase) (StateC
 	return *ret, err
 }
 
-func (c *StateCompiler) hitVelSet(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) hitVelSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*hitVelSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			hitVelSet_redirectid, VT_Int, 1, false); err != nil {
@@ -3242,7 +3242,7 @@ func (c *StateCompiler) hitVelSet(is IniSection, sc *StateControllerBase) (State
 	return *ret, err
 }
 
-func (c *StateCompiler) screenBound(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) screenBound(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*screenBound)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			screenBound_redirectid, VT_Int, 1, false); err != nil {
@@ -3278,7 +3278,7 @@ func (c *StateCompiler) screenBound(is IniSection, sc *StateControllerBase) (Sta
 	return *ret, err
 }
 
-func (c *StateCompiler) posFreeze(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) posFreeze(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*posFreeze)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			posFreeze_redirectid, VT_Int, 1, false); err != nil {
@@ -3299,7 +3299,7 @@ func (c *StateCompiler) posFreeze(is IniSection, sc *StateControllerBase) (State
 	return *ret, err
 }
 
-func (c *StateCompiler) envShake(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) envShake(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*envShake)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "time",
 			envShake_time, VT_Int, 1, false); err != nil {
@@ -3330,7 +3330,7 @@ func (c *StateCompiler) envShake(is IniSection, sc *StateControllerBase) (StateC
 	return *ret, err
 }
 
-func (c *StateCompiler) hitOverride(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) hitOverride(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*hitOverride)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			hitOverride_redirectid, VT_Int, 1, false); err != nil {
@@ -3385,7 +3385,7 @@ func (c *StateCompiler) hitOverride(is IniSection, sc *StateControllerBase) (Sta
 	return *ret, err
 }
 
-func (c *StateCompiler) pause(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) pause(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*pause)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			pause_redirectid, VT_Int, 1, false); err != nil {
@@ -3412,7 +3412,7 @@ func (c *StateCompiler) pause(is IniSection, sc *StateControllerBase) (StateCont
 	return *ret, err
 }
 
-func (c *StateCompiler) superPause(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) superPause(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*superPause)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			superPause_redirectid, VT_Int, 1, false); err != nil {
@@ -3477,7 +3477,7 @@ func (c *StateCompiler) superPause(is IniSection, sc *StateControllerBase) (Stat
 	return *ret, err
 }
 
-func (c *StateCompiler) trans(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) trans(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*trans)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			trans_redirectid, VT_Int, 1, false); err != nil {
@@ -3491,7 +3491,7 @@ func (c *StateCompiler) trans(is IniSection, sc *StateControllerBase) (StateCont
 	return *ret, err
 }
 
-func (c *StateCompiler) playerPush(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) playerPush(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*playerPush)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			playerPush_redirectid, VT_Int, 1, false); err != nil {
@@ -3539,7 +3539,7 @@ func (c *StateCompiler) playerPush(is IniSection, sc *StateControllerBase) (Stat
 	return *ret, err
 }
 
-func (c *StateCompiler) stateTypeSet(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) stateTypeSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*stateTypeSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			stateTypeSet_redirectid, VT_Int, 1, false); err != nil {
@@ -3626,7 +3626,7 @@ func (c *StateCompiler) stateTypeSet(is IniSection, sc *StateControllerBase) (St
 	return *ret, err
 }
 
-func (c *StateCompiler) angleDraw(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) angleDraw(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*angleDraw)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			angleDraw_redirectid, VT_Int, 1, false); err != nil {
@@ -3653,7 +3653,7 @@ func (c *StateCompiler) angleDraw(is IniSection, sc *StateControllerBase) (State
 	return *ret, err
 }
 
-func (c *StateCompiler) angleSet(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) angleSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*angleSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			angleSet_redirectid, VT_Int, 1, false); err != nil {
@@ -3676,7 +3676,7 @@ func (c *StateCompiler) angleSet(is IniSection, sc *StateControllerBase) (StateC
 	return *ret, err
 }
 
-func (c *StateCompiler) angleAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) angleAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*angleAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			angleAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -3699,7 +3699,7 @@ func (c *StateCompiler) angleAdd(is IniSection, sc *StateControllerBase) (StateC
 	return *ret, err
 }
 
-func (c *StateCompiler) angleMul(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) angleMul(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*angleMul)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			angleMul_redirectid, VT_Int, 1, false); err != nil {
@@ -3722,7 +3722,7 @@ func (c *StateCompiler) angleMul(is IniSection, sc *StateControllerBase) (StateC
 	return *ret, err
 }
 
-func (c *StateCompiler) envColor(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) envColor(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*envColor)(sc), c.stateSec(is, func() error {
 		if err := c.stateParam(is, "value", false, func(data string) error {
 			bes, err := c.exprs(data, VT_Int, 3)
@@ -3750,7 +3750,7 @@ func (c *StateCompiler) envColor(is IniSection, sc *StateControllerBase) (StateC
 	return *ret, err
 }
 
-func (c *StateCompiler) displayToClipboardSub(is IniSection,
+func (c *CharCompiler) displayToClipboardSub(is IniSection,
 	sc *StateControllerBase) error {
 	if err := c.paramValue(is, sc, "redirectid",
 		displayToClipboard_redirectid, VT_Int, 1, false); err != nil {
@@ -3794,21 +3794,21 @@ func (c *StateCompiler) displayToClipboardSub(is IniSection,
 	return nil
 }
 
-func (c *StateCompiler) displayToClipboard(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) displayToClipboard(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*displayToClipboard)(sc), c.stateSec(is, func() error {
 		return c.displayToClipboardSub(is, sc)
 	})
 	return *ret, err
 }
 
-func (c *StateCompiler) appendToClipboard(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) appendToClipboard(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*appendToClipboard)(sc), c.stateSec(is, func() error {
 		return c.displayToClipboardSub(is, sc)
 	})
 	return *ret, err
 }
 
-func (c *StateCompiler) clearClipboard(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) clearClipboard(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*clearClipboard)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			clearClipboard_redirectid, VT_Int, 1, false); err != nil {
@@ -3820,7 +3820,7 @@ func (c *StateCompiler) clearClipboard(is IniSection, sc *StateControllerBase) (
 	return *ret, err
 }
 
-func (c *StateCompiler) makeDust(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) makeDust(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*makeDust)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			makeDust_redirectid, VT_Int, 1, false); err != nil {
@@ -3845,7 +3845,7 @@ func (c *StateCompiler) makeDust(is IniSection, sc *StateControllerBase) (StateC
 	return *ret, err
 }
 
-func (c *StateCompiler) attackDist(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) attackDist(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*attackDist)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			attackDist_redirectid, VT_Int, 1, false); err != nil {
@@ -3872,7 +3872,7 @@ func (c *StateCompiler) attackDist(is IniSection, sc *StateControllerBase) (Stat
 	return *ret, err
 }
 
-func (c *StateCompiler) attackMulSet(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) attackMulSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*attackMulSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			attackMulSet_redirectid, VT_Int, 1, false); err != nil {
@@ -3917,7 +3917,7 @@ func (c *StateCompiler) attackMulSet(is IniSection, sc *StateControllerBase) (St
 	return *ret, err
 }
 
-func (c *StateCompiler) defenceMulSet(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) defenceMulSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*defenceMulSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(
 			is, sc, "redirectid",
@@ -3958,7 +3958,7 @@ func (c *StateCompiler) defenceMulSet(is IniSection, sc *StateControllerBase) (S
 	return *ret, err
 }
 
-func (c *StateCompiler) fallEnvShake(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) fallEnvShake(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*fallEnvShake)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			fallEnvShake_redirectid, VT_Int, 1, false); err != nil {
@@ -3970,7 +3970,7 @@ func (c *StateCompiler) fallEnvShake(is IniSection, sc *StateControllerBase) (St
 	return *ret, err
 }
 
-func (c *StateCompiler) hitFallDamage(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) hitFallDamage(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*hitFallDamage)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			hitFallDamage_redirectid, VT_Int, 1, false); err != nil {
@@ -3982,7 +3982,7 @@ func (c *StateCompiler) hitFallDamage(is IniSection, sc *StateControllerBase) (S
 	return *ret, err
 }
 
-func (c *StateCompiler) hitFallVel(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) hitFallVel(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*hitFallVel)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			hitFallVel_redirectid, VT_Int, 1, false); err != nil {
@@ -3994,7 +3994,7 @@ func (c *StateCompiler) hitFallVel(is IniSection, sc *StateControllerBase) (Stat
 	return *ret, err
 }
 
-func (c *StateCompiler) hitFallSet(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) hitFallSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*hitFallSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			hitFallSet_redirectid, VT_Int, 1, false); err != nil {
@@ -4023,7 +4023,7 @@ func (c *StateCompiler) hitFallSet(is IniSection, sc *StateControllerBase) (Stat
 	return *ret, err
 }
 
-func (c *StateCompiler) varRangeSet(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) varRangeSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*varRangeSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			varRangeSet_redirectid, VT_Int, 1, false); err != nil {
@@ -4060,7 +4060,7 @@ func (c *StateCompiler) varRangeSet(is IniSection, sc *StateControllerBase) (Sta
 	return *ret, err
 }
 
-func (c *StateCompiler) remapPal(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) remapPal(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*remapPal)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			remapPal_redirectid, VT_Int, 1, false); err != nil {
@@ -4079,7 +4079,7 @@ func (c *StateCompiler) remapPal(is IniSection, sc *StateControllerBase) (StateC
 	return *ret, err
 }
 
-func (c *StateCompiler) stopSnd(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) stopSnd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*stopSnd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			stopSnd_redirectid, VT_Int, 1, false); err != nil {
@@ -4094,7 +4094,7 @@ func (c *StateCompiler) stopSnd(is IniSection, sc *StateControllerBase) (StateCo
 	return *ret, err
 }
 
-func (c *StateCompiler) sndPan(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) sndPan(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*sndPan)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			sndPan_redirectid, VT_Int, 1, false); err != nil {
@@ -4117,7 +4117,7 @@ func (c *StateCompiler) sndPan(is IniSection, sc *StateControllerBase) (StateCon
 	return *ret, err
 }
 
-func (c *StateCompiler) varRandom(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) varRandom(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*varRandom)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			varRandom_redirectid, VT_Int, 1, false); err != nil {
@@ -4136,7 +4136,7 @@ func (c *StateCompiler) varRandom(is IniSection, sc *StateControllerBase) (State
 	return *ret, err
 }
 
-func (c *StateCompiler) gravity(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) gravity(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*gravity)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			gravity_redirectid, VT_Int, 1, false); err != nil {
@@ -4148,7 +4148,7 @@ func (c *StateCompiler) gravity(is IniSection, sc *StateControllerBase) (StateCo
 	return *ret, err
 }
 
-func (c *StateCompiler) bindToParentSub(is IniSection,
+func (c *CharCompiler) bindToParentSub(is IniSection,
 	sc *StateControllerBase) error {
 	if err := c.paramValue(is, sc, "redirectid",
 		bindToParent_redirectid, VT_Int, 1, false); err != nil {
@@ -4169,21 +4169,21 @@ func (c *StateCompiler) bindToParentSub(is IniSection,
 	return nil
 }
 
-func (c *StateCompiler) bindToParent(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) bindToParent(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*bindToParent)(sc), c.stateSec(is, func() error {
 		return c.bindToParentSub(is, sc)
 	})
 	return *ret, err
 }
 
-func (c *StateCompiler) bindToRoot(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) bindToRoot(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*bindToRoot)(sc), c.stateSec(is, func() error {
 		return c.bindToParentSub(is, sc)
 	})
 	return *ret, err
 }
 
-func (c *StateCompiler) removeExplod(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) removeExplod(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*removeExplod)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			removeExplod_redirectid, VT_Int, 1, false); err != nil {
@@ -4209,7 +4209,7 @@ func (c *StateCompiler) removeExplod(is IniSection, sc *StateControllerBase) (St
 	return *ret, err
 }
 
-func (c *StateCompiler) explodBindTime(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) explodBindTime(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*explodBindTime)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			explodBindTime_redirectid, VT_Int, 1, false); err != nil {
@@ -4237,7 +4237,7 @@ func (c *StateCompiler) explodBindTime(is IniSection, sc *StateControllerBase) (
 	return *ret, err
 }
 
-func (c *StateCompiler) moveHitReset(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) moveHitReset(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*moveHitReset)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			moveHitReset_redirectid, VT_Int, 1, false); err != nil {
@@ -4249,7 +4249,7 @@ func (c *StateCompiler) moveHitReset(is IniSection, sc *StateControllerBase) (St
 	return *ret, err
 }
 
-func (c *StateCompiler) hitAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) hitAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*hitAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			hitAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -4264,7 +4264,7 @@ func (c *StateCompiler) hitAdd(is IniSection, sc *StateControllerBase) (StateCon
 	return *ret, err
 }
 
-func (c *StateCompiler) offset(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) offset(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*offset)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			offset_redirectid, VT_Int, 1, false); err != nil {
@@ -4283,7 +4283,7 @@ func (c *StateCompiler) offset(is IniSection, sc *StateControllerBase) (StateCon
 	return *ret, err
 }
 
-func (c *StateCompiler) victoryQuote(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) victoryQuote(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*victoryQuote)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			victoryQuote_redirectid, VT_Int, 1, false); err != nil {
@@ -4298,7 +4298,7 @@ func (c *StateCompiler) victoryQuote(is IniSection, sc *StateControllerBase) (St
 	return *ret, err
 }
 
-func (c *StateCompiler) zoom(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) zoom(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*zoom)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "pos",
 			zoom_pos, VT_Float, 2, false); err != nil {
@@ -4333,7 +4333,7 @@ func (c *StateCompiler) zoom(is IniSection, sc *StateControllerBase) (StateContr
 	return *ret, err
 }
 
-func (c *StateCompiler) forceFeedback(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) forceFeedback(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*forceFeedback)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			forceFeedback_redirectid, VT_Int, 1, false); err != nil {
@@ -4393,7 +4393,7 @@ func (c *StateCompiler) forceFeedback(is IniSection, sc *StateControllerBase) (S
 	return *ret, err
 }
 
-func (c *StateCompiler) assertAnalogVector(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) assertAnalogVector(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*assertAnalogVector)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			assertAnalogVector_redirectid, VT_Int, 1, false); err != nil {
@@ -4428,7 +4428,7 @@ func (c *StateCompiler) assertAnalogVector(is IniSection, sc *StateControllerBas
 	return *ret, err
 }
 
-func (c *StateCompiler) assertInput(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) assertInput(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*assertInput)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			assertInput_redirectid, VT_Int, 1, false); err != nil {
@@ -4499,7 +4499,7 @@ func (c *StateCompiler) assertInput(is IniSection, sc *StateControllerBase) (Sta
 	return *ret, err
 }
 
-func (c *StateCompiler) changeMovelist(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) changeMovelist(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*changeMovelist)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			changeMovelist_redirectid, VT_Int, 1, false); err != nil {
@@ -4514,7 +4514,7 @@ func (c *StateCompiler) changeMovelist(is IniSection, sc *StateControllerBase) (
 	return *ret, err
 }
 
-func (c *StateCompiler) dialogue(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) dialogue(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*dialogue)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			dialogue_redirectid, VT_Int, 1, false); err != nil {
@@ -4556,7 +4556,7 @@ func (c *StateCompiler) dialogue(is IniSection, sc *StateControllerBase) (StateC
 	return *ret, err
 }
 
-func (c *StateCompiler) dizzyPointsAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) dizzyPointsAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*dizzyPointsAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			dizzyPointsAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -4575,7 +4575,7 @@ func (c *StateCompiler) dizzyPointsAdd(is IniSection, sc *StateControllerBase) (
 	return *ret, err
 }
 
-func (c *StateCompiler) dizzyPointsSet(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) dizzyPointsSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*dizzyPointsSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			dizzyPointsSet_redirectid, VT_Int, 1, false); err != nil {
@@ -4586,7 +4586,7 @@ func (c *StateCompiler) dizzyPointsSet(is IniSection, sc *StateControllerBase) (
 	return *ret, err
 }
 
-func (c *StateCompiler) dizzySet(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) dizzySet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*dizzySet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			dizzySet_redirectid, VT_Int, 1, false); err != nil {
@@ -4597,7 +4597,7 @@ func (c *StateCompiler) dizzySet(is IniSection, sc *StateControllerBase) (StateC
 	return *ret, err
 }
 
-func (c *StateCompiler) guardBreakSet(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) guardBreakSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*guardBreakSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			guardBreakSet_redirectid, VT_Int, 1, false); err != nil {
@@ -4608,7 +4608,7 @@ func (c *StateCompiler) guardBreakSet(is IniSection, sc *StateControllerBase) (S
 	return *ret, err
 }
 
-func (c *StateCompiler) guardPointsAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) guardPointsAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*guardPointsAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			guardPointsAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -4627,7 +4627,7 @@ func (c *StateCompiler) guardPointsAdd(is IniSection, sc *StateControllerBase) (
 	return *ret, err
 }
 
-func (c *StateCompiler) guardPointsSet(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) guardPointsSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*guardPointsSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			guardPointsSet_redirectid, VT_Int, 1, false); err != nil {
@@ -4638,7 +4638,7 @@ func (c *StateCompiler) guardPointsSet(is IniSection, sc *StateControllerBase) (
 	return *ret, err
 }
 
-func (c *StateCompiler) lifebarAction(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) lifebarAction(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*lifebarAction)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			lifebarAction_redirectid, VT_Int, 1, false); err != nil {
@@ -4710,7 +4710,7 @@ func (c *StateCompiler) lifebarAction(is IniSection, sc *StateControllerBase) (S
 	return *ret, err
 }
 
-func (c *StateCompiler) loadFile(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) loadFile(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*loadFile)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			loadFile_redirectid, VT_Int, 1, false); err != nil {
@@ -4733,7 +4733,7 @@ func (c *StateCompiler) loadFile(is IniSection, sc *StateControllerBase) (StateC
 	return *ret, err
 }
 
-func (c *StateCompiler) loadState(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) loadState(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*loadState)(sc), c.stateSec(is, func() error {
 		sc.add(loadState_, nil)
 		return nil
@@ -4742,7 +4742,7 @@ func (c *StateCompiler) loadState(is IniSection, sc *StateControllerBase) (State
 }
 
 // TODO: Remove boilerplate from the Map's Compiler.
-func (c *StateCompiler) mapSetSub(is IniSection, sc *StateControllerBase) error {
+func (c *CharCompiler) mapSetSub(is IniSection, sc *StateControllerBase) error {
 	err := c.stateSec(is, func() error {
 		assign := false
 		var mapParam, mapName, value string
@@ -4869,7 +4869,7 @@ func (c *StateCompiler) mapSetSub(is IniSection, sc *StateControllerBase) error 
 	return err
 }
 
-func (c *StateCompiler) mapSet(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) mapSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
 			return err
@@ -4881,7 +4881,7 @@ func (c *StateCompiler) mapSet(is IniSection, sc *StateControllerBase) (StateCon
 	return *ret, err
 }
 
-func (c *StateCompiler) mapAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) mapAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
 			return err
@@ -4893,7 +4893,7 @@ func (c *StateCompiler) mapAdd(is IniSection, sc *StateControllerBase) (StateCon
 	return *ret, err
 }
 
-func (c *StateCompiler) parentMapSet(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) parentMapSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
 			return err
@@ -4905,7 +4905,7 @@ func (c *StateCompiler) parentMapSet(is IniSection, sc *StateControllerBase) (St
 	return *ret, err
 }
 
-func (c *StateCompiler) parentMapAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) parentMapAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
 			return err
@@ -4917,7 +4917,7 @@ func (c *StateCompiler) parentMapAdd(is IniSection, sc *StateControllerBase) (St
 	return *ret, err
 }
 
-func (c *StateCompiler) rootMapSet(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) rootMapSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
 			return err
@@ -4929,7 +4929,7 @@ func (c *StateCompiler) rootMapSet(is IniSection, sc *StateControllerBase) (Stat
 	return *ret, err
 }
 
-func (c *StateCompiler) rootMapAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) rootMapAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
 			return err
@@ -4941,7 +4941,7 @@ func (c *StateCompiler) rootMapAdd(is IniSection, sc *StateControllerBase) (Stat
 	return *ret, err
 }
 
-func (c *StateCompiler) teamMapSet(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) teamMapSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
 			return err
@@ -4953,7 +4953,7 @@ func (c *StateCompiler) teamMapSet(is IniSection, sc *StateControllerBase) (Stat
 	return *ret, err
 }
 
-func (c *StateCompiler) teamMapAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) teamMapAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*mapSet)(sc), c.stateSec(is, func() error {
 		if err := c.mapSetSub(is, sc); err != nil {
 			return err
@@ -4965,7 +4965,7 @@ func (c *StateCompiler) teamMapAdd(is IniSection, sc *StateControllerBase) (Stat
 	return *ret, err
 }
 
-func (c *StateCompiler) mapReset(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) mapReset(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*mapReset)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			mapReset_redirectid, VT_Int, 1, false); err != nil {
@@ -5001,7 +5001,7 @@ func (c *StateCompiler) mapReset(is IniSection, sc *StateControllerBase) (StateC
 	return *ret, err
 }
 
-func (c *StateCompiler) matchRestart(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) matchRestart(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*matchRestart)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "reload",
 			matchRestart_reload, VT_Bool, MaxPlayerNo, false); err != nil {
@@ -5141,7 +5141,7 @@ func (c *StateCompiler) matchRestart(is IniSection, sc *StateControllerBase) (St
 	return *ret, err
 }
 
-func (c *StateCompiler) playBgm(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) playBgm(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*playBgm)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			playBgm_redirectid, VT_Int, 1, false); err != nil {
@@ -5226,7 +5226,7 @@ func (c *StateCompiler) playBgm(is IniSection, sc *StateControllerBase) (StateCo
 	return *ret, err
 }
 
-func (c *StateCompiler) modifyBGCtrl(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) modifyBGCtrl(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*modifyBGCtrl)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "id",
 			modifyBGCtrl_id, VT_Int, 1, true); err != nil {
@@ -5301,7 +5301,7 @@ func (c *StateCompiler) modifyBGCtrl(is IniSection, sc *StateControllerBase) (St
 	return *ret, err
 }
 
-func (c *StateCompiler) modifyBGCtrl3d(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) modifyBGCtrl3d(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*modifyBGCtrl3d)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "id",
 			modifyBGCtrl3d_ctrlid, VT_Int, 1, true); err != nil {
@@ -5320,7 +5320,7 @@ func (c *StateCompiler) modifyBGCtrl3d(is IniSection, sc *StateControllerBase) (
 	return *ret, err
 }
 
-func (c *StateCompiler) modifySnd(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) modifySnd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*modifySnd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			modifySnd_redirectid, VT_Int, 1, false); err != nil {
@@ -5387,7 +5387,7 @@ func (c *StateCompiler) modifySnd(is IniSection, sc *StateControllerBase) (State
 	return *ret, err
 }
 
-func (c *StateCompiler) modifyBgm(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) modifyBgm(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*modifyBgm)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "volume",
 			modifyBgm_volume, VT_Int, 1, false); err != nil {
@@ -5414,14 +5414,14 @@ func (c *StateCompiler) modifyBgm(is IniSection, sc *StateControllerBase) (State
 	return *ret, err
 }
 
-func (c *StateCompiler) printToConsole(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) printToConsole(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*printToConsole)(sc), c.stateSec(is, func() error {
 		return c.displayToClipboardSub(is, sc)
 	})
 	return *ret, err
 }
 
-func (c *StateCompiler) redLifeAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) redLifeAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*redLifeAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			redLifeAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -5440,7 +5440,7 @@ func (c *StateCompiler) redLifeAdd(is IniSection, sc *StateControllerBase) (Stat
 	return *ret, err
 }
 
-func (c *StateCompiler) redLifeSet(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) redLifeSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*redLifeSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			redLifeSet_redirectid, VT_Int, 1, false); err != nil {
@@ -5451,7 +5451,7 @@ func (c *StateCompiler) redLifeSet(is IniSection, sc *StateControllerBase) (Stat
 	return *ret, err
 }
 
-func (c *StateCompiler) remapSprite(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) remapSprite(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*remapSprite)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			remapSprite_redirectid, VT_Int, 1, false); err != nil {
@@ -5483,7 +5483,7 @@ func (c *StateCompiler) remapSprite(is IniSection, sc *StateControllerBase) (Sta
 	return *ret, err
 }
 
-func (c *StateCompiler) roundTimeAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) roundTimeAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*roundTimeAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			roundTimeAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -5498,7 +5498,7 @@ func (c *StateCompiler) roundTimeAdd(is IniSection, sc *StateControllerBase) (St
 	return *ret, err
 }
 
-func (c *StateCompiler) roundTimeSet(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) roundTimeSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*roundTimeSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			roundTimeSet_redirectid, VT_Int, 1, false); err != nil {
@@ -5509,7 +5509,7 @@ func (c *StateCompiler) roundTimeSet(is IniSection, sc *StateControllerBase) (St
 	return *ret, err
 }
 
-func (c *StateCompiler) saveFile(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) saveFile(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*saveFile)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			saveFile_redirectid, VT_Int, 1, false); err != nil {
@@ -5532,7 +5532,7 @@ func (c *StateCompiler) saveFile(is IniSection, sc *StateControllerBase) (StateC
 	return *ret, err
 }
 
-func (c *StateCompiler) saveState(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) saveState(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*saveState)(sc), c.stateSec(is, func() error {
 		sc.add(saveState_, nil)
 		return nil
@@ -5540,7 +5540,7 @@ func (c *StateCompiler) saveState(is IniSection, sc *StateControllerBase) (State
 	return *ret, err
 }
 
-func (c *StateCompiler) scoreAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) scoreAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*scoreAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			scoreAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -5554,7 +5554,7 @@ func (c *StateCompiler) scoreAdd(is IniSection, sc *StateControllerBase) (StateC
 	})
 	return *ret, err
 }
-func (c *StateCompiler) shaderSet(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) shaderSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*shaderSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid", shaderSet_redirectid, VT_Int, 1, false); err != nil {
 			return err
@@ -5569,7 +5569,7 @@ func (c *StateCompiler) shaderSet(is IniSection, sc *StateControllerBase) (State
 	})
 	return *ret, err
 }
-func (c *StateCompiler) storyboard(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) storyboard(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*storyboard)(sc), c.stateSec(is, func() error {
 		if err := c.stateParam(is, "path", false, func(data string) error {
 			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
@@ -5585,7 +5585,7 @@ func (c *StateCompiler) storyboard(is IniSection, sc *StateControllerBase) (Stat
 	return *ret, err
 }
 
-func (c *StateCompiler) targetDizzyPointsAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) targetDizzyPointsAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*targetDizzyPointsAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetDizzyPointsAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -5608,7 +5608,7 @@ func (c *StateCompiler) targetDizzyPointsAdd(is IniSection, sc *StateControllerB
 	return *ret, err
 }
 
-func (c *StateCompiler) targetGuardPointsAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) targetGuardPointsAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*targetGuardPointsAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetGuardPointsAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -5631,7 +5631,7 @@ func (c *StateCompiler) targetGuardPointsAdd(is IniSection, sc *StateControllerB
 	return *ret, err
 }
 
-func (c *StateCompiler) targetRedLifeAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) targetRedLifeAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*targetRedLifeAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetRedLifeAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -5654,7 +5654,7 @@ func (c *StateCompiler) targetRedLifeAdd(is IniSection, sc *StateControllerBase)
 	return *ret, err
 }
 
-func (c *StateCompiler) targetScoreAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) targetScoreAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*targetScoreAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetScoreAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -5673,7 +5673,7 @@ func (c *StateCompiler) targetScoreAdd(is IniSection, sc *StateControllerBase) (
 	return *ret, err
 }
 
-func (c *StateCompiler) text(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) text(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*text)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			text_redirectid, VT_Int, 1, false); err != nil {
@@ -5811,7 +5811,7 @@ func (c *StateCompiler) text(is IniSection, sc *StateControllerBase) (StateContr
 	return *ret, err
 }
 
-func (c *StateCompiler) modifyText(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) modifyText(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*modifyText)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			modifytext_redirectid, VT_Int, 1, false); err != nil {
@@ -5953,7 +5953,7 @@ func (c *StateCompiler) modifyText(is IniSection, sc *StateControllerBase) (Stat
 	return *ret, err
 }
 
-func (c *StateCompiler) removeText(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) removeText(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*removeText)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			removetext_redirectid, VT_Int, 1, false); err != nil {
@@ -5980,7 +5980,7 @@ func (c *StateCompiler) removeText(is IniSection, sc *StateControllerBase) (Stat
 }
 
 // Handles "createPlatform" parameters.
-func (c *StateCompiler) createPlatform(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) createPlatform(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*text)(sc), c.stateSec(is, func() error {
 		var err error
 
@@ -6054,7 +6054,7 @@ func (c *StateCompiler) createPlatform(is IniSection, sc *StateControllerBase) (
 	return *ret, err
 }
 
-func (c *StateCompiler) modifyStageVar(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) modifyStageVar(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*modifyStageVar)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "camera.boundleft",
 			modifyStageVar_camera_boundleft, VT_Int, 1, false); err != nil {
@@ -6350,7 +6350,7 @@ func (c *StateCompiler) modifyStageVar(is IniSection, sc *StateControllerBase) (
 	return *ret, err
 }
 
-func (c *StateCompiler) cameraCtrl(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) cameraCtrl(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*cameraCtrl)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "followid",
 			cameraCtrl_followid, VT_Int, 1, false); err != nil {
@@ -6383,7 +6383,7 @@ func (c *StateCompiler) cameraCtrl(is IniSection, sc *StateControllerBase) (Stat
 	return *ret, err
 }
 
-func (c *StateCompiler) height(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) height(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*height)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			height_redirectid, VT_Int, 1, false); err != nil {
@@ -6398,7 +6398,7 @@ func (c *StateCompiler) height(is IniSection, sc *StateControllerBase) (StateCon
 	return *ret, err
 }
 
-func (c *StateCompiler) depth(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) depth(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*depth)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			depth_redirectid, VT_Int, 1, false); err != nil {
@@ -6434,7 +6434,7 @@ func (c *StateCompiler) depth(is IniSection, sc *StateControllerBase) (StateCont
 	return *ret, err
 }
 
-func (c *StateCompiler) modifyPlayer(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) modifyPlayer(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*modifyPlayer)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			modifyPlayer_redirectid, VT_Int, 1, false); err != nil {
@@ -6544,7 +6544,7 @@ func (c *StateCompiler) modifyPlayer(is IniSection, sc *StateControllerBase) (St
 	return *ret, err
 }
 
-func (c *StateCompiler) assertCommand(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) assertCommand(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*assertCommand)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			assertCommand_redirectid, VT_Int, 1, false); err != nil {
@@ -6568,7 +6568,7 @@ func (c *StateCompiler) assertCommand(is IniSection, sc *StateControllerBase) (S
 	return *ret, err
 }
 
-func (c *StateCompiler) getHitVarSet(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) getHitVarSet(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*getHitVarSet)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			getHitVarSet_redirectid, VT_Int, 1, false); err != nil {
@@ -6759,7 +6759,7 @@ func (c *StateCompiler) getHitVarSet(is IniSection, sc *StateControllerBase) (St
 	return *ret, err
 }
 
-func (c *StateCompiler) groundLevelOffset(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) groundLevelOffset(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*groundLevelOffset)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			groundLevelOffset_redirectid, VT_Int, 1, false); err != nil {
@@ -6774,7 +6774,7 @@ func (c *StateCompiler) groundLevelOffset(is IniSection, sc *StateControllerBase
 	return *ret, err
 }
 
-func (c *StateCompiler) targetAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) targetAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*targetAdd)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			targetAdd_redirectid, VT_Int, 1, false); err != nil {
@@ -6789,7 +6789,7 @@ func (c *StateCompiler) targetAdd(is IniSection, sc *StateControllerBase) (State
 	return *ret, err
 }
 
-func (c *StateCompiler) transformClsn(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) transformClsn(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*transformClsn)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			transformClsn_redirectid, VT_Int, 1, false); err != nil {
@@ -6816,7 +6816,7 @@ func (c *StateCompiler) transformClsn(is IniSection, sc *StateControllerBase) (S
 	return *ret, err
 }
 
-func (c *StateCompiler) transformSprite(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) transformSprite(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*transformSprite)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			transformSprite_redirectid, VT_Float, 1, false); err != nil {
@@ -6856,7 +6856,7 @@ func (c *StateCompiler) transformSprite(is IniSection, sc *StateControllerBase) 
 	return *ret, err
 }
 
-func (c *StateCompiler) modifyStageBG(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) modifyStageBG(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*modifyStageBG)(sc), c.stateSec(is, func() error {
 		//if err := c.paramValue(is, sc, "redirectid",
 		//	modifyStageBG_redirectid, VT_Int, 1, false); err != nil {
@@ -6994,7 +6994,7 @@ func (c *StateCompiler) modifyStageBG(is IniSection, sc *StateControllerBase) (S
 	sys.cgi[c.playerNo].canMutateStage = true
 	return *ret, err
 }
-func (c *StateCompiler) shaderSub(is IniSection, sc *StateControllerBase, shaderOpCode, paramOpCode byte) error {
+func (c *CharCompiler) shaderSub(is IniSection, sc *StateControllerBase, shaderOpCode, paramOpCode byte) error {
 	if err := c.stateParam(is, "shader", false, func(data string) error {
 		if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
 			return Error("Shader name not enclosed in \"")
@@ -7044,7 +7044,7 @@ func (c *StateCompiler) shaderSub(is IniSection, sc *StateControllerBase, shader
 	return nil
 }
 
-func (c *StateCompiler) shiftInput(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) shiftInput(is IniSection, sc *StateControllerBase) (StateController, error) {
 	inputIndex := func(name string) (int32, error) {
 		switch name {
 		case "U":
@@ -7121,7 +7121,7 @@ func (c *StateCompiler) shiftInput(is IniSection, sc *StateControllerBase) (Stat
 	return *ret, err
 }
 
-func (c *StateCompiler) overrideClsn(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) overrideClsn(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*overrideClsn)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			overrideClsn_redirectid, VT_Int, 1, false); err != nil {
@@ -7144,6 +7144,6 @@ func (c *StateCompiler) overrideClsn(is IniSection, sc *StateControllerBase) (St
 }
 
 // It's just a Null... Has no effect whatsoever.
-func (c *StateCompiler) null(is IniSection, sc *StateControllerBase) (StateController, error) {
+func (c *CharCompiler) null(is IniSection, sc *StateControllerBase) (StateController, error) {
 	return nullStateController, nil
 }

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -350,8 +350,10 @@ Rollback.FrameDelay            = 2
 Rollback.DisconnectNotifyStart = 1000
 ; Time in milliseconds after a connection stalls before the match is terminated.
 Rollback.DisconnectTimeout     = 3000
-; Rollback debugging parameters (toggles).
+; Set to 1 to save rollback events to the logs folder.
+; May hinder performance, but is helpful for debugging.
 Rollback.LogsEnabled           = 0
+; Other debug toggles.
 Rollback.SaveStageData         = 0
 Rollback.DesyncTest            = 0
 Rollback.DesyncTestFrames      = 0

--- a/src/rollback.go
+++ b/src/rollback.go
@@ -199,8 +199,8 @@ func (rs *RollbackSystem) runFrame(s *System) bool {
 			defer func() {
 				if re := recover(); re != nil {
 					if rs.session.config.DesyncTest {
-						rs.session.log.updateLogs()
-						rs.session.log.saveLogs()
+						rs.session.log.updateStateLogs()
+						rs.session.log.saveStateLogs()
 						panic("RaiseDesyncError")
 					}
 				}
@@ -387,7 +387,7 @@ func (rs *RollbackSystem) anyButton() bool {
 type RollbackLogger struct {
 	filename   string
 	currentLog strings.Builder
-	logs       [(MaxSaveStates + 3) * 3]string
+	logs       [(MaxSaveStates * 2) + 3]string
 }
 
 func NewRollbackLogger(timestamp string) RollbackLogger {
@@ -395,11 +395,18 @@ func NewRollbackLogger(timestamp string) RollbackLogger {
 	return gl
 }
 
-func (g *RollbackLogger) logState(action string, stateID int, state string, checksum int) {
-	fmt.Fprintf(&g.currentLog, "State Logger: \n")
-	fmt.Fprintf(&g.currentLog, "%s state for stateID: %d\n", action, stateID)
-	fmt.Fprintf(&g.currentLog, state+"\n")
-	fmt.Fprintf(&g.currentLog, "Checksum: %d\n", checksum)
+func (g *RollbackLogger) logState(action string, stateIdx int, state *GameState) {
+	//fmt.Fprintf(&g.currentLog, "State Logger: \n")
+	fmt.Fprintf(&g.currentLog, "%s data for the state in slot %d\n", action, stateIdx)
+
+	if state.isSpeculativeFrame {
+		fmt.Fprintf(&g.currentLog, "Frame type: Speculative\n")
+	} else {
+		fmt.Fprintf(&g.currentLog, "Frame type: Confirmed\n")
+	}
+
+	fmt.Fprintf(&g.currentLog, "Checksum: %d\n", state.Checksum()) // Calls String() again. Minor issue
+	fmt.Fprintf(&g.currentLog, "%s\n", state.String())
 }
 
 func (g *RollbackLogger) Write(p []byte) (n int, err error) {
@@ -407,7 +414,8 @@ func (g *RollbackLogger) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
-func (g *RollbackLogger) updateLogs() {
+// Updates state logs using a ring buffer
+func (g *RollbackLogger) updateStateLogs() {
 	tmp := g.logs
 	for i := 0; i < len(g.logs)-1; i++ {
 		g.logs[i] = tmp[i+1]
@@ -416,11 +424,14 @@ func (g *RollbackLogger) updateLogs() {
 	g.currentLog.Reset()
 }
 
-func (g *RollbackLogger) saveLogs() {
-	var fullLog string
-	for i := 0; i < len(g.logs); i++ {
+func (g *RollbackLogger) saveStateLogs() {
+	// Header indicating the number of frames captured
+	fullLog := fmt.Sprintf("Writing save state data from the last %d frames.\n\n", len(g.logs))
+	// Collect all the logs in the buffer
+	 for i := range g.logs {
 		fullLog += g.logs[i]
 	}
+	// Save file
 	err := os.WriteFile(g.filename, []byte(fullLog), 0666)
 	if err != nil {
 		fmt.Println(err)
@@ -610,38 +621,36 @@ func (r *RollbackSession) IsConnected() bool {
 	return r.connected
 }
 
-func (r *RollbackSession) SaveGameState(stateID int) int {
-	sys.savePool.curStateID = stateID
-	sys.rollbackStateID = stateID
-	oldest := stateID + 1%(MaxSaveStates+2)
+func (r *RollbackSession) SaveGameState(stateIdx int) int {
+	sys.savePool.curStateID = stateIdx
+	sys.rollbackStateID = stateIdx
+	oldest := stateIdx + 1%(MaxSaveStates+2)
 	if _, ok := sys.arenaSaveMap[oldest]; ok {
 		sys.arenaSaveMap[oldest].Free()
 		sys.arenaSaveMap[oldest] = nil
 		delete(sys.arenaSaveMap, oldest)
 	}
 	sys.savePool.Free(oldest)
-	if _, ok := sys.arenaSaveMap[stateID]; ok {
-		sys.arenaSaveMap[stateID].Free()
-		sys.arenaSaveMap[stateID] = nil
-		delete(sys.arenaSaveMap, stateID)
+	if _, ok := sys.arenaSaveMap[stateIdx]; ok {
+		sys.arenaSaveMap[stateIdx].Free()
+		sys.arenaSaveMap[stateIdx] = nil
+		delete(sys.arenaSaveMap, stateIdx)
 	}
-	sys.savePool.Free(stateID)
+	sys.savePool.Free(stateIdx)
 
-	r.saveStates[stateID] = sys.statePool.gameStatePool.Get().(*GameState)
-	r.saveStates[stateID].SaveState(stateID)
+	r.saveStates[stateIdx] = sys.statePool.gameStatePool.Get().(*GameState)
+	r.saveStates[stateIdx].SaveState(stateIdx)
 
 	if r.config.DesyncTest {
-		checksum := r.saveStates[stateID].Checksum()
 		if r.config.LogsEnabled {
-			r.log.logState("Saving", stateID, r.saveStates[stateID].String(), checksum)
-			r.log.updateLogs()
+			r.log.logState("Saving", stateIdx, r.saveStates[stateIdx])
+			r.log.updateStateLogs()
 		}
-		return checksum
+		return r.saveStates[stateIdx].Checksum()
 	} else {
 		if r.config.LogsEnabled {
-			checksum := r.saveStates[stateID].Checksum()
-			r.log.logState("Saving", stateID, r.saveStates[stateID].String(), checksum)
-			r.log.updateLogs()
+			r.log.logState("Saving", stateIdx, r.saveStates[stateIdx])
+			r.log.updateStateLogs()
 		}
 		return ggpo.DefaultChecksum
 	}
@@ -649,12 +658,12 @@ func (r *RollbackSession) SaveGameState(stateID int) int {
 
 var lastLoadedFrame int = -1
 
-func (r *RollbackSession) LoadGameState(stateID int) {
-	sys.loadPool.curStateID = stateID
-	if _, ok := sys.arenaLoadMap[stateID]; ok {
-		sys.arenaLoadMap[stateID].Free()
-		sys.arenaLoadMap[stateID] = nil
-		delete(sys.arenaLoadMap, stateID)
+func (r *RollbackSession) LoadGameState(stateIdx int) {
+	sys.loadPool.curStateID = stateIdx
+	if _, ok := sys.arenaLoadMap[stateIdx]; ok {
+		sys.arenaLoadMap[stateIdx].Free()
+		sys.arenaLoadMap[stateIdx] = nil
+		delete(sys.arenaLoadMap, stateIdx)
 	}
 	for sid := range sys.arenaLoadMap {
 		if sid != lastLoadedFrame {
@@ -663,18 +672,17 @@ func (r *RollbackSession) LoadGameState(stateID int) {
 			delete(sys.arenaLoadMap, sid)
 		}
 	}
-	sys.loadPool.Free(stateID)
+	sys.loadPool.Free(stateIdx)
 
-	r.saveStates[stateID].LoadState(stateID)
+	r.saveStates[stateIdx].LoadState(stateIdx)
 
 	if r.config.DesyncTest && r.config.LogsEnabled {
-		checksum := r.saveStates[stateID].Checksum()
-		r.log.logState("Loaded", stateID, r.saveStates[stateID].String(), checksum)
+		r.log.logState("Loading", stateIdx, r.saveStates[stateIdx])
 	}
 
-	sys.statePool.gameStatePool.Put(r.saveStates[stateID])
+	sys.statePool.gameStatePool.Put(r.saveStates[stateIdx])
 
-	lastLoadedFrame = stateID
+	lastLoadedFrame = stateIdx
 }
 
 // Called when the GGPO backend needs the game to simulate a single frame
@@ -705,8 +713,8 @@ func (r *RollbackSession) AdvanceFrame(flags int) {
 		defer func() {
 			if re := recover(); re != nil {
 				if r.config.DesyncTest {
-					r.log.updateLogs()
-					r.log.saveLogs()
+					r.log.updateStateLogs()
+					r.log.saveStateLogs()
 					panic("RaiseDesyncError")
 				}
 			}
@@ -736,7 +744,7 @@ func (r *RollbackSession) OnEvent(info *ggpo.Event) {
 			return
 		}
 		if r.config.LogsEnabled {
-			r.log.saveLogs()
+			r.log.saveStateLogs()
 		}
 		fmt.Println("EventCodeDisconnectedFromPeer")
 		sys.endMatch = true
@@ -749,7 +757,7 @@ func (r *RollbackSession) OnEvent(info *ggpo.Event) {
 		r.loopTimer.OnGGPOTimeSyncEvent(info.FramesAhead)
 	case ggpo.EventCodeDesync:
 		if r.config.LogsEnabled {
-			r.log.saveLogs()
+			r.log.saveStateLogs()
 		}
 		fmt.Println("EventCodeDesync")
 		log.Printf("Rollback desync detected")
@@ -770,7 +778,7 @@ func NewRollbackSession(config RollbackProperties) RollbackSession {
 	r.handles = make([]ggpo.PlayerHandle, 2) // MaxPlayerNo
 	r.config = config
 	r.loopTimer = NewLoopTimer(60, 100)
-	r.timestamp = time.Now().Format("2006-01-02_03-04PM-05s")
+	r.timestamp = time.Now().Format("2006-01-02_15-04-05")
 	r.log = NewRollbackLogger(r.timestamp)
 	r.replayInputs = make([][REPLAY_NUM_INPUTS]InputBits, 0)
 	r.replayAnalogInputs = make([][REPLAY_NUM_INPUTS][6]int8, 0)

--- a/src/state.go
+++ b/src/state.go
@@ -9,90 +9,6 @@ import (
 	"time"
 )
 
-func (cs Char) String() string {
-	str := fmt.Sprintf(`Char %s 
-	RedLife             :%d 
-	Juggle              :%d 
-	Life                :%d 
-	Key                 :%d  
-	Localcoord          :%f 
-	Localscl            :%f 
-	Pos                 :%v 
-	DrawPos             :%v 
-	OldPos              :%v 
-	Vel                 :%v  
-	Facing              :%f
-	Id                  :%d
-	HelperId            :%d
-	HelperIndex         :%d
-	ParentId            :%d
-	PlayerNo            :%d
-	Teamside            :%d
-	AnimPN              :%d
-	AnimNo              :%d
-	LifeMax             :%d
-	PowerMax            :%d
-	DizzyPoints         :%d
-	GuardPoints         :%d
-	FallTime            :%d
-	ClsnScale           :%v
-	HoIdx               :%d
-	Mctime              :%d
-	Targets             :%v
-	HitdefTargets       :%v
-	Atktmp              :%d
-	Hittmp              :%d
-	Acttmp              :%d
-	Minus               :%d
-	GroundAngle          :%f
-	InheritJuggle         :%d
-	Preserve              :%d
-	Cnsvar              :%v
-	Cnsfvar             :%v
-	Offset              :%v`,
-		cs.name, cs.redLife, cs.juggle, cs.life, cs.controller, cs.localcoord,
-		cs.localscl, cs.pos, cs.interPos, cs.oldPos, cs.vel, cs.facing,
-		cs.id, cs.helperId, cs.helperIndex, cs.parentId, cs.playerNo,
-		cs.teamside, cs.animPN, cs.animNo, cs.lifeMax, cs.powerMax, cs.dizzyPoints,
-		cs.guardPoints, cs.fallTime, cs.clsnScale, cs.hoverIdx, cs.mctime, cs.targets, cs.hitdefTargets,
-		cs.atktmp, cs.hittmp, cs.acttmp, cs.minus, cs.groundAngle, cs.inheritJuggle,
-		cs.preserve, cs.cnsvar, cs.cnsfvar, cs.offset)
-	return str
-}
-
-func (gs *GameState) getID() string {
-	return strconv.Itoa(int(gs.id))
-}
-
-func (gs *GameState) Checksum() int {
-	//	buf := bytes.Buffer{}
-	//	enc := gob.NewEncoder(&buf)
-	//	err := enc.Encode(gs)
-	//	if err != nil {
-	//		panic(err)
-	//	}
-	//	gs.bytes = buf.Bytes()
-	gs.bytes = []byte(gs.String())
-	h := fnv.New32a()
-	h.Write(gs.bytes)
-	return int(h.Sum32())
-}
-
-func (gs *GameState) String() (str string) {
-	str = fmt.Sprintf("MatchTime %d CurRoundTime: %d CurPlayTime: %d\n", gs.matchTime, gs.curRoundTime, gs.curPlayTime)
-	str += fmt.Sprintf("bcStack: %v\n", gs.bcStack)
-	str += fmt.Sprintf("bcVarStack: %v\n", gs.bcVarStack)
-	str += fmt.Sprintf("bcVar: %v\n", gs.bcVar)
-	str += fmt.Sprintf("workBe: %v\n", gs.workBe)
-	for i := 0; i < len(gs.charData); i++ {
-		for j := 0; j < len(gs.charData[i]); j++ {
-			str += gs.charData[i][j].String()
-			str += "\n"
-		}
-	}
-	return
-}
-
 const MaxSaveStates = 8
 
 type GameState struct {
@@ -101,6 +17,7 @@ type GameState struct {
 	id    int
 	saved bool
 	frame int32
+	isSpeculativeFrame bool
 
 	SystemStateVars
 
@@ -276,6 +193,7 @@ func (gs *GameState) SaveState(stateID int) {
 	gs.cgi = sys.cgi
 	gs.saved = true
 	gs.frame = sys.frameCounter
+	gs.isSpeculativeFrame = sys.isSpeculativeFrame()
 	gs.SystemStateVars = sys.SystemStateVars
 
 	gs.saveCharData(a, gsp)
@@ -485,6 +403,173 @@ func (gs *GameState) stageCanMutate() bool {
 	return false
 }
 
+func (gs *GameState) getID() string {
+	return strconv.Itoa(int(gs.id))
+}
+
+// Not to be confused with the live checksum. This one's for debugging
+func (gs *GameState) Checksum() int {
+	//	buf := bytes.Buffer{}
+	//	enc := gob.NewEncoder(&buf)
+	//	err := enc.Encode(gs)
+	//	if err != nil {
+	//		panic(err)
+	//	}
+	//	gs.bytes = buf.Bytes()
+	gs.bytes = []byte(gs.String())
+	h := fnv.New32a()
+	h.Write(gs.bytes)
+	return int(h.Sum32())
+}
+
+// Returns some state variables as a string for debugging
+func (gs *GameState) String() (str string) {
+	// Add match data
+	str = fmt.Sprintf("MatchTime %d CurRoundTime: %d\n", gs.matchTime, gs.curRoundTime)
+
+	// Add bytecode data
+	// TODO: Every log seems to have these empty. May not be needed
+	str += fmt.Sprintf("bcStack: %v\n", gs.bcStack)
+	str += fmt.Sprintf("bcVarStack: %v\n", gs.bcVarStack)
+	str += fmt.Sprintf("bcVar: %v\n", gs.bcVar)
+	str += fmt.Sprintf("workBe: %v\n", gs.workBe)
+
+	// Add char data
+	for i := 0; i < len(gs.charData); i++ {
+		for j := 0; j < len(gs.charData[i]); j++ {
+			str += gs.charData[i][j].String()
+			str += "\n"
+		}
+	}
+
+	return
+}
+
+// Returns char status as a string for debugging
+func (cs Char) String() string {
+	// Save button states if char has keyctrl
+	inputBufStr := "none"
+	if cs.keyctrl[0] && len(cs.cmd) > 0 && cs.cmd[0].Buffer != nil {
+		ib := cs.cmd[0].Buffer
+		inputBufStr = fmt.Sprintf(
+			"U:%d D:%d L:%d R:%d B:%d F:%d N:%d a:%d b:%d c:%d x:%d y:%d z:%d s:%d d:%d w:%d m:%d",
+			ib.Ub, ib.Db, ib.Lb, ib.Rb, ib.Bb, ib.Fb, ib.Nb,
+			ib.ab, ib.bb, ib.cb, ib.xb, ib.yb, ib.zb,
+			ib.sb, ib.db, ib.wb, ib.mb,
+		)
+	}
+
+	str := fmt.Sprintf(`Char %s
+	Controller          :%d
+	PlayerNo            :%d
+	HelperIndex         :%d
+	Life                :%d
+	RedLife             :%d
+	DizzyPoints         :%d
+	GuardPoints         :%d
+	Power               :%d
+	Localcoord          :%f
+	Localscl            :%f
+	Pos                 :%v
+	Vel                 :%v
+	Facing              :%f
+	Id                  :%d
+	HelperId            :%d
+	ParentId            :%d
+	StateNo             :%d
+	StateTime           :%d
+	AnimNo              :%d
+	Mctime              :%d
+	Targets             :%v
+	Preserve            :%t
+	MapsActive          :%d
+	CnsVar              :%v
+	CnsFvar             :%v
+	InputBuffer         :%s`,
+		cs.name, cs.controller, cs.playerNo, cs.helperIndex,
+		cs.life, cs.redLife, cs.dizzyPoints, cs.guardPoints, cs.power,
+		cs.localcoord, cs.localscl,
+		cs.pos, cs.vel, cs.facing,
+		cs.id, cs.helperId, cs.parentId, 
+		cs.ss.no, cs.ss.time, cs.animNo, // Move/Statetype would require interpreting the flags so they're not worth it
+		cs.mctime, cs.targets,
+		cs.preserve,
+		len(cs.mapArray), cs.cnsvar, cs.cnsfvar, inputBufStr) // Dumping entire map is too verbose so we'll just log how many are active
+
+	return str
+}
+
+type GameStatePool struct {
+	gameStatePool           sync.Pool
+	stringIntMapPool        sync.Pool
+	hitscaleMapPool         sync.Pool
+	stringFloat32MapPool    sync.Pool
+	animationTablePool      sync.Pool
+	mapArraySlicePool       sync.Pool
+	int32CharPointerMapPool sync.Pool
+	int32int32MapPool       sync.Pool
+	int32float32MapPool     sync.Pool
+
+	animFrameSlicePool sync.Pool
+	poolObjs           map[int][]interface{}
+	curStateID         int
+}
+
+func NewGameStatePool() GameStatePool {
+	return GameStatePool{
+		gameStatePool: sync.Pool{
+			New: func() interface{} {
+				return NewGameState()
+			},
+		},
+		stringIntMapPool: sync.Pool{
+			New: func() interface{} {
+				si := make(map[string]int)
+				return &si
+			},
+		},
+		stringFloat32MapPool: sync.Pool{
+			New: func() interface{} {
+				sf := make(map[string]float32)
+				return &sf
+			},
+		},
+		animationTablePool: sync.Pool{
+			New: func() interface{} {
+				at := AnimationTable{
+					anims: make(map[int32]*Animation),
+				}
+				return &at
+			},
+		},
+		int32CharPointerMapPool: sync.Pool{
+			New: func() interface{} {
+				ic := make(map[int32]*Char)
+				return &ic
+			},
+		},
+		animFrameSlicePool: sync.Pool{
+			New: func() interface{} {
+				af := make([]AnimFrame, 0, 8)
+				return &af
+			},
+		},
+		int32int32MapPool: sync.Pool{
+			New: func() interface{} {
+				ii := make(map[int32]int32)
+				return &ii
+			},
+		},
+		int32float32MapPool: sync.Pool{
+			New: func() interface{} {
+				if3 := make(map[int32]float32)
+				return &if3
+			},
+		},
+		poolObjs: make(map[int][]interface{}),
+	}
+}
+
 func (gsp *GameStatePool) Get(item interface{}) (result interface{}) {
 	objs, ok := gsp.poolObjs[gsp.curStateID]
 	if !ok {
@@ -547,75 +632,4 @@ func (gsp *GameStatePool) Free(stateID int) {
 		}
 	}
 	delete(gsp.poolObjs, stateID)
-}
-
-func NewGameStatePool() GameStatePool {
-	return GameStatePool{
-		gameStatePool: sync.Pool{
-			New: func() interface{} {
-				return NewGameState()
-			},
-		},
-		stringIntMapPool: sync.Pool{
-			New: func() interface{} {
-				si := make(map[string]int)
-				return &si
-			},
-		},
-		stringFloat32MapPool: sync.Pool{
-			New: func() interface{} {
-				sf := make(map[string]float32)
-				return &sf
-			},
-		},
-		animationTablePool: sync.Pool{
-			New: func() interface{} {
-				at := AnimationTable{
-					anims: make(map[int32]*Animation),
-				}
-				return &at
-			},
-		},
-		int32CharPointerMapPool: sync.Pool{
-			New: func() interface{} {
-				ic := make(map[int32]*Char)
-				return &ic
-			},
-		},
-		animFrameSlicePool: sync.Pool{
-			New: func() interface{} {
-				af := make([]AnimFrame, 0, 8)
-				return &af
-			},
-		},
-		int32int32MapPool: sync.Pool{
-			New: func() interface{} {
-				ii := make(map[int32]int32)
-				return &ii
-			},
-		},
-		int32float32MapPool: sync.Pool{
-			New: func() interface{} {
-				if3 := make(map[int32]float32)
-				return &if3
-			},
-		},
-		poolObjs: make(map[int][]interface{}),
-	}
-}
-
-type GameStatePool struct {
-	gameStatePool           sync.Pool
-	stringIntMapPool        sync.Pool
-	hitscaleMapPool         sync.Pool
-	stringFloat32MapPool    sync.Pool
-	animationTablePool      sync.Pool
-	mapArraySlicePool       sync.Pool
-	int32CharPointerMapPool sync.Pool
-	int32int32MapPool       sync.Pool
-	int32float32MapPool     sync.Pool
-
-	animFrameSlicePool sync.Pool
-	poolObjs           map[int][]interface{}
-	curStateID         int
 }

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -254,10 +254,10 @@ func (ss *StateState) Clone(a *arena.Arena) (result StateState) {
 	result = *ss
 	result.ps = arena.MakeSlice[int32](a, len(ss.ps), len(ss.ps))
 	copy(result.ps, ss.ps)
-	for i := 0; i < len(ss.hitPauseExecutionToggleFlags); i++ {
-		result.hitPauseExecutionToggleFlags[i] = arena.MakeSlice[bool](a, len(ss.hitPauseExecutionToggleFlags[i]), len(ss.hitPauseExecutionToggleFlags[i]))
-		copy(result.hitPauseExecutionToggleFlags[i], ss.hitPauseExecutionToggleFlags[i])
-	}
+	//for i := 0; i < len(ss.hitPauseExecutionToggleFlags); i++ {
+	//	result.hitPauseExecutionToggleFlags[i] = arena.MakeSlice[bool](a, len(ss.hitPauseExecutionToggleFlags[i]), len(ss.hitPauseExecutionToggleFlags[i]))
+	//	copy(result.hitPauseExecutionToggleFlags[i], ss.hitPauseExecutionToggleFlags[i])
+	//}
 	result.sb = ss.sb.Clone(a)
 	return result
 }

--- a/src/system.go
+++ b/src/system.go
@@ -5132,7 +5132,7 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 		}
 
 		// Compile character states
-		if sys.cgi[pn].states, l.err = newStateCompiler().Compile(p.playerNo, cdef, p.gi().constants); l.err != nil {
+		if sys.cgi[pn].states, l.err = newCharCompiler().Compile(p.playerNo, cdef, p.gi().constants); l.err != nil {
 			sys.chars[pn] = nil
 			if attached {
 				tstr = fmt.Sprintf("WARNING: Failed to compile new attached char states: %v", cdef)

--- a/src/system.go
+++ b/src/system.go
@@ -95,8 +95,6 @@ type SystemStateVars struct {
 	lastTick                float32
 	nextAddTime             float32
 	oldNextAddTime          float32
-	screenleft              float32
-	screenright             float32
 	xmin, xmax              float32
 	zmin, zmax              float32
 	winskipped              bool
@@ -2283,10 +2281,6 @@ func (s *System) resetRound() {
 	s.cam.stageCamera = s.stage.stageCamera
 	s.cam.Init()
 
-	// TODO: These being saved to system currently makes them unmodifiable by ModifyStageVar
-	s.screenleft = float32(s.stage.screenleft) * s.stage.localscl
-	s.screenright = float32(s.stage.screenright) * s.stage.localscl
-
 	if s.stage.resetbg || stageSwap {
 		s.stage.reset()
 	}
@@ -2517,6 +2511,14 @@ func (s *System) clearSpriteData() {
 	}
 }
 
+func (s *System) screenleft() float32 {
+	return float32(s.stage.screenleft) * s.stage.localscl
+}
+
+func (s *System) screenright() float32 {
+	return float32(s.stage.screenright) * s.stage.localscl
+}
+
 func (s *System) action() {
 	s.clearSpriteData()
 
@@ -2536,8 +2538,8 @@ func (s *System) action() {
 	// Run "tick frame"
 	if s.tickFrame() {
 		// X axis player limits
-		s.xmin = s.cam.ScreenPos[0] + s.cam.Offset[0] + s.screenleft
-		s.xmax = s.cam.ScreenPos[0] + s.cam.Offset[0] + float32(s.gameWidth)/s.cam.Scale - s.screenright
+		s.xmin = s.cam.ScreenPos[0] + s.cam.Offset[0] + s.screenleft()
+		s.xmax = s.cam.ScreenPos[0] + s.cam.Offset[0] + float32(s.gameWidth)/s.cam.Scale - s.screenright()
 		if s.xmin > s.xmax {
 			s.xmin = (s.xmin + s.xmax) / 2
 			s.xmax = s.xmin
@@ -2611,9 +2613,8 @@ func (s *System) action() {
 		x = float32(math.Ceil(float64(x)*4-0.5) / 4)
 	}
 	s.cam.Update(scl, x, y)
-	s.xmin = s.cam.ScreenPos[0] + s.cam.Offset[0] + s.screenleft
-	s.xmax = s.cam.ScreenPos[0] + s.cam.Offset[0] +
-		float32(s.gameWidth)/s.cam.Scale - s.screenright
+	s.xmin = s.cam.ScreenPos[0] + s.cam.Offset[0] + s.screenleft()
+	s.xmax = s.cam.ScreenPos[0] + s.cam.Offset[0] + float32(s.gameWidth)/s.cam.Scale - s.screenright()
 	if s.xmin > s.xmax {
 		s.xmin = (s.xmin + s.xmax) / 2
 		s.xmax = s.xmin

--- a/src/system.go
+++ b/src/system.go
@@ -2238,13 +2238,14 @@ func (s *System) resetRoundState() {
 
 	s.cam.stageCamera = s.stage.stageCamera
 	s.cam.Init()
+
+	// TODO: These being saved to system currently makes them unmodifiable by ModifyStageVar
 	s.screenleft = float32(s.stage.screenleft) * s.stage.localscl
 	s.screenright = float32(s.stage.screenright) * s.stage.localscl
 
 	if s.stage.resetbg || swap {
 		s.stage.reset()
 	}
-	s.cam.ResetZoomdelay()
 	if newMatchMusic {
 		s.stage.music.ClearSelection()
 		s.stage.si().music.ClearSelection()
@@ -2425,6 +2426,8 @@ func (s *System) globalCollision() {
 	s.charList.collisionDetection()
 }
 
+/*
+// This is never called
 func (s *System) posReset() {
 	for _, p := range s.chars {
 		if len(p) > 0 {
@@ -2432,6 +2435,7 @@ func (s *System) posReset() {
 		}
 	}
 }
+*/
 
 // Skip character intros on button press and play the shutter effect
 func (s *System) runIntroSkip() {

--- a/src/system.go
+++ b/src/system.go
@@ -2158,10 +2158,86 @@ func (s *System) clearPlayerAssets(pn int, forceDestroy bool) {
 	s.explodRunOrder = PointerSliceReset(s.explodRunOrder)
 }
 
-func (s *System) resetRoundState() {
-	s.roundBackup.Restore()
+// Select correct stage for current round
+func (s *System) handleStageSwap() bool {
+	var roundRef int32
+	if s.round == 1 {
+		s.stageLoopNo = 0
+	} else {
+		roundRef = s.round
+	}
+
+	if s.stageLoop && !s.roundResetFlg {
+		var keys []int
+		for k := range s.stageList {
+			keys = append(keys, int(k))
+		}
+		sort.Ints(keys)
+		roundRef = int32(keys[s.stageLoopNo])
+		s.stageLoopNo++
+		if s.stageLoopNo >= len(s.stageList) {
+			s.stageLoopNo = 0
+		}
+	}
+
+	swap := false
+	if _, ok := s.stageList[roundRef]; ok {
+		s.stage = s.stageList[roundRef]
+		if s.round > 1 && !s.roundResetFlg {
+			swap = true
+		}
+		if s.stage.model != nil {
+			sys.mainThreadTask <- func() {
+				gfx.SetModelVertexData(0, s.stage.model.vertexBuffer)
+				gfx.SetModelIndexData(0, s.stage.model.elementBuffer...)
+			}
+		}
+	}
+	return swap
+}
+
+func (s *System) updateMusicMaps() {
 	newMatchMusic := s.round == 1 && !s.roundResetFlg
 
+	if newMatchMusic {
+		s.stage.music.ClearSelection()
+		s.stage.si().music.ClearSelection()
+		s.sel.music.ClearSelection()
+	}
+
+	for i, p := range s.chars {
+		if len(p) == 0 {
+			continue
+		}
+		if newMatchMusic {
+			p[0].si().music.ClearSelection()
+		}
+		// Reset music map
+		s.cgi[i].music = make(Music)
+		// Append stage def file music parameters
+		s.cgi[i].music.Append(sys.stage.music)
+		// Append select.def stage music parameters
+		s.cgi[i].music.Append(sys.stage.si().music)
+		// Override with select.def char music parameters
+		useCharMusic := false
+		if sys.sel.gameParams != nil {
+			useCharMusic = sys.sel.gameParams.CharParamMusic
+		}
+		// In Versus modes, round/final/life music shouldn't override stage music; victory.music still can.
+		if useCharMusic {
+			s.cgi[i].music.Override(p[0].si().music)
+		} else if v, ok := p[0].si().music[normalizeMusicPrefix("victory")]; ok {
+			s.cgi[i].music.Override(Music{normalizeMusicPrefix("victory"): v})
+		}
+		// Override with music with launchFight parameters
+		s.cgi[i].music.Override(sys.sel.music)
+		// Debug dump of merged music.
+		s.cgi[i].music.DebugDump(fmt.Sprintf("cgi[%d].music after updateMusicMaps()", i))
+	}
+}
+
+// TODO: This function is still a bit overloaded because it's handling some selections instead of doing a pure reset
+func (s *System) resetRound() {
 	if s.sel.gameParams.PersistRounds && !s.roundResetFlg {
 		s.persistRoundCount++
 	}
@@ -2202,39 +2278,7 @@ func (s *System) resetRoundState() {
 		s.decisiveRound[i] = s.wins[i] >= s.matchWins[i]-1
 	}
 
-	var roundRef int32
-	if s.round == 1 {
-		s.stageLoopNo = 0
-	} else {
-		roundRef = s.round
-	}
-
-	if s.stageLoop && !s.roundResetFlg {
-		var keys []int
-		for k := range s.stageList {
-			keys = append(keys, int(k))
-		}
-		sort.Ints(keys)
-		roundRef = int32(keys[s.stageLoopNo])
-		s.stageLoopNo++
-		if s.stageLoopNo >= len(s.stageList) {
-			s.stageLoopNo = 0
-		}
-	}
-
-	var swap bool
-	if _, ok := s.stageList[roundRef]; ok {
-		s.stage = s.stageList[roundRef]
-		if s.round > 1 && !s.roundResetFlg {
-			swap = true
-		}
-		if s.stage.model != nil {
-			sys.mainThreadTask <- func() {
-				gfx.SetModelVertexData(0, s.stage.model.vertexBuffer)
-				gfx.SetModelIndexData(0, s.stage.model.elementBuffer...)
-			}
-		}
-	}
+	stageSwap := s.handleStageSwap()
 
 	s.cam.stageCamera = s.stage.stageCamera
 	s.cam.Init()
@@ -2243,13 +2287,8 @@ func (s *System) resetRoundState() {
 	s.screenleft = float32(s.stage.screenleft) * s.stage.localscl
 	s.screenright = float32(s.stage.screenright) * s.stage.localscl
 
-	if s.stage.resetbg || swap {
+	if s.stage.resetbg || stageSwap {
 		s.stage.reset()
-	}
-	if newMatchMusic {
-		s.stage.music.ClearSelection()
-		s.stage.si().music.ClearSelection()
-		s.sel.music.ClearSelection()
 	}
 
 	// Reset characters
@@ -2279,31 +2318,6 @@ func (s *System) resetRoundState() {
 					[...]int32{1, 1}, [...]int32{1, s.cgi[i].palno})
 			}
 		}
-
-		if newMatchMusic {
-			p[0].si().music.ClearSelection()
-		}
-		// Reset music map
-		s.cgi[i].music = make(Music)
-		// Append stage def file music parameters
-		s.cgi[i].music.Append(sys.stage.music)
-		// Append select.def stage music parameters
-		s.cgi[i].music.Append(sys.stage.si().music)
-		// Override with select.def char music parameters
-		useCharMusic := false
-		if sys.sel.gameParams != nil {
-			useCharMusic = sys.sel.gameParams.CharParamMusic
-		}
-		// In Versus modes, round/final/life music shouldn't override stage music; victory.music still can.
-		if useCharMusic {
-			s.cgi[i].music.Override(p[0].si().music)
-		} else if v, ok := p[0].si().music[normalizeMusicPrefix("victory")]; ok {
-			s.cgi[i].music.Override(Music{normalizeMusicPrefix("victory"): v})
-		}
-		// Override with music with launchFight parameters
-		s.cgi[i].music.Override(sys.sel.music)
-		// Debug dump of merged music.
-		s.cgi[i].music.DebugDump(fmt.Sprintf("cgi[%d].music after resetRoundState", i))
 	}
 
 	// Place characters in state 5900
@@ -2323,14 +2337,14 @@ func (s *System) resetRoundState() {
 		p[0].selfState(5900, firstAnim, -1, 0, "")
 	}
 
-	// Backup must reflect the post-swap roundXdef stage, or F4 restores the prior round's stage.
-	if s.stage != nil {
-		s.roundBackup.Save()
-	}
-}
+	s.updateMusicMaps()
 
-func (s *System) resetRound() {
-	s.resetRoundState()
+	// Make a new backup reflecting the post-swap roundXdef stage, or F4 will restore the prior round's stage
+	// TODO: The fact that the reset() function needs to make a new backup shows that this function is currently overloaded
+	// Update: Save operations moved outside
+	//s.roundBackup.Save()
+
+	// Ensure main thread catches up
 	s.runMainThreadTask()
 	gfx.Await()
 }
@@ -3647,13 +3661,6 @@ func (s *System) runMatch() (reload bool) {
 	// Setup characters
 	s.SetupCharRoundStart()
 
-	// Make a new backup once everything is initialized
-	s.roundBackup.Save()
-
-	if s.round == 1 {
-		s.matchBackup.Save()
-	}
-
 	// Default debug/scripts to any found char
 	s.debugWC = s.anyChar()
 	debugInput := func() {
@@ -3666,10 +3673,20 @@ func (s *System) runMatch() (reload bool) {
 		}
 	}
 
+	// Reset round state
 	s.resetRound()
 
+	// Make a first backup once everything is initialized
+	s.roundBackup.Save()
+
+	// Save round 1 backup separately
+	if s.round == 1 {
+		s.matchBackup = s.roundBackup
+	}
+
 	// Reset the clock right before entering the loop to ensure we start with a clean timeline
-	s.resetFrameTime()
+	// Handled by resetRound()
+	//s.resetFrameTime()
 
 	// Now switch to rollback if applicable
 	// TODO: More merging so we don't hijack this function at all
@@ -3722,6 +3739,7 @@ func (s *System) runMatch() (reload bool) {
 
 		if s.matchResetFlg {
 			s.matchResetFlg = false
+
 			// If a member has already been changed in Turns mode
 			// the char in memory is different from the char in the backup, so restoration with reload=0 is impossible
 			canReset := true
@@ -3731,6 +3749,7 @@ func (s *System) runMatch() (reload bool) {
 					break
 				}
 			}
+
 			if !canReset {
 				s.appendToConsole("Warning: MatchRestart with resetmatch=1 is disabled in Turns mode after character switch")
 			} else {
@@ -3745,9 +3764,10 @@ func (s *System) runMatch() (reload bool) {
 				s.statsLog.abortMatch()
 				s.statsLog.startMatch()
 
+				// Recover the round 1 backup
 				s.roundBackup = s.matchBackup
+				s.roundBackup.Restore()
 				s.resetRound()
-				s.roundResetFlg = false
 			}
 		}
 
@@ -3758,6 +3778,7 @@ func (s *System) runMatch() (reload bool) {
 					s.saveCharVars(i)
 				}
 			}
+			s.roundBackup.Restore()
 			s.resetRound()
 		}
 
@@ -3950,8 +3971,8 @@ func (s *System) runNextRound() bool {
 					p[0].redLife = p[0].life // TODO: This doesn't truly need to be hardcoded
 				}
 			}
-			s.roundBackup.Save()
 			s.resetRound()
+			s.roundBackup.Save()
 		} else {
 			// End match, or prepare for a new character in turns mode
 			for i, tm := range s.tmode {
@@ -4021,6 +4042,7 @@ func (s *System) IsRollback() bool {
 	return false
 }
 
+// The backup to be used when F4 is pressed
 type RoundStartBackup struct {
 	charBackup    [MaxPlayerNo][]Char
 	cgiBackup     [MaxPlayerNo]CharGlobalInfo

--- a/src/system.go
+++ b/src/system.go
@@ -4036,9 +4036,17 @@ func (s *System) debugModeAllowed() bool {
 	return s.cfg.Debug.AllowDebugMode
 }
 
-func (s *System) IsRollback() bool {
+// Returns true if the current frame is inside a rollback
+func (s *System) inRollback() bool {
 	if s.rollback.session != nil {
 		return s.rollback.session.inRollback
+	}
+	return false
+}
+
+func (s *System) isSpeculativeFrame() bool {
+	if s.rollback.session != nil {
+		return !s.rollback.session.inRollback
 	}
 	return false
 }


### PR DESCRIPTION
Features:
- Maps can now be defined directly in the Helper sctrl. Example: helper{map.apple: 5; map.orange: 10} creates a helper with map(apple) set to 5 and map(orange) set to 10
- Added warning prints for missing triggers. For instance when trigger3 is defined without trigger2
- A warning will now be printed when a [State] header is left open

Fixes:
- Added a patch to fix a 1-frame delay in SpriteVar returns
- Fixed some PosType parameters being incorrect in the first frame of a match
- screenleft and screenright can now be modified by ModifyStageVar
- Fixed MapSet tolerating an empty map name or value
- Fixed the compiler crashing when an error is found in a trigger that will be skipped (e.g. error in trigger3 but trigger2 is missing)
- Fixes #3600
- Fixes #3605

Refactor:
- When a character only has one selectable palette, the palette selection menu will automatically pick it
- Cleaned up round start backup mechanism (for F4 button)
- Rename StateCompiler to CharCompiler. The previous assessment that it specializes on states was incorrect
- Disable the rest of hitPauseExecutionToggleFlags since it's already not used in the current code's state
- Adjusted rollback state logs to provide more useful information