### PR TITLE
fix: Explod ignorehitpause regression, compiler warnings, darken; refactor CNS compiler

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6934,12 +6934,10 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 					e.window = [4]float32{exp[0].evalF(c) * redirscale, exp[1].evalF(c) * redirscale, exp[2].evalF(c) * redirscale, exp[3].evalF(c) * redirscale}
 				})
 			case explod_ignorehitpause:
-				if c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 { // You could not modify this one in Mugen
-					ihp := exp[0].evalB(c)
-					eachExpl(func(e *Explod) {
-						e.ignorehitpause = ihp
-					})
-				}
+				ihp := exp[0].evalB(c)
+				eachExpl(func(e *Explod) {
+					e.ignorehitpause = ihp
+				})
 			case explod_bindid:
 				bId := exp[0].evalI(c)
 				if bId == -1 {

--- a/src/char.go
+++ b/src/char.go
@@ -6744,6 +6744,7 @@ func (c *Char) helperInit(h *Char, st int32, pt PosType, pos [3]float32, facing 
 		c.forceRemapPal(h.palfx, rp)
 	} else {
 		h.palfx = c.getPalfx()
+		h.ignoreDarkenTime = c.ignoreDarkenTime
 	}
 
 	// Mugen 1.1 behavior if invertblend param is omitted(Only if char mugenversion = 1.1)
@@ -8926,7 +8927,7 @@ func (c *Char) p2BodyDistZ(oc *Char) BytecodeValue {
 
 func (c *Char) setPauseTime(pausetime, movetime int32) {
 	// Buffer a new Pause only if its timer is higher than the current one or the same player is overriding their own pause
-	// This method is more complex but also fairer than Mugen, where only the last pause triggered matters
+	// This method is more complex but also fairer than Mugen, where only the last triggered pause matters
 	if ^pausetime < sys.pausetimebuffer || sys.pauseplayerno == c.playerNo || c.playerNo != c.ss.sb.playerNo {
 		sys.pausetimebuffer = ^pausetime
 		sys.pauseplayerno = c.playerNo
@@ -8966,6 +8967,7 @@ func (c *Char) setSuperPauseTime(pausetime, movetime int32, unhittable bool, p2d
 	}
 
 	c.ignoreDarkenTime = pausetime
+	c.propagateIgnoreDarkenTime()
 
 	// Apply superp2defmul to other teams
 	// Having this here makes it stack when partners initiate a double pause. Mugen does the same
@@ -8977,6 +8979,46 @@ func (c *Char) setSuperPauseTime(pausetime, movetime int32, unhittable bool, p2d
 					e.superDefenseMulBuffer *= p2defmul
 				}
 			}
+		}
+	}
+}
+
+// In Mugen, the darkening effect depends on the ownpal parameter, making its mechanism fairly different from ours
+// We will emulate that by passing the timer along the "ownpal family tree"
+func (c *Char) propagateIgnoreDarkenTime() {
+	value := c.ignoreDarkenTime
+	top := c
+
+	// Find the top of the tree
+	// Mugen doesn't do this. If the current helper has no ownpal, both it and its parent will darken
+	if !c.ownpal {
+		for {
+			parent := top.parent(false)
+			if parent == nil {
+				break
+			}
+			top = parent
+			if top.ownpal {
+				break
+			}
+		}
+	}
+
+	top.ignoreDarkenTime = value
+
+	// Propagate down the tree
+	stack := []*Char{top}
+	for len(stack) > 0 {
+		node := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+
+		for _, childID := range node.children {
+			child := sys.playerID(childID)
+			if child == nil || child.ownpal {
+				continue
+			}
+			child.ignoreDarkenTime = value
+			stack = append(stack, child)
 		}
 	}
 }
@@ -11490,9 +11532,6 @@ func (c *Char) actionPrepare() {
 			} else if sys.pausetime > 0 && c.pauseMovetime > 0 {
 				c.pauseMovetime--
 			}
-			if c.ignoreDarkenTime > 0 {
-				c.ignoreDarkenTime--
-			}
 		}
 
 		// Reset input modifiers
@@ -11555,6 +11594,11 @@ func (c *Char) actionPrepare() {
 		c.fLength = 2048
 		c.projection = Projection_Orthographic
 	}
+
+	if c.ignoreDarkenTime > 0 {
+		c.ignoreDarkenTime--
+	}
+
 	// Decrease unhittable timer
 	// This used to be in tick(), but Mugen Clsn display suggests it happens sooner than that
 	// This also used to be CharGlobalInfo, but that made root and helpers share the same timer

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -5995,7 +5995,10 @@ func (c *CharCompiler) parseSection(sctrl func(name, data string) error) (IniSec
 						return nil, Error("ignorehitpause is duplicated")
 					}
 					ignorehitpause = true
+					// Also save this one because some state controllers need it for their own "ignorehitpause" parameters
+					is[name] = data
 				default:
+					// Save remaining parameters that aren't triggers
 					if !isTrigger {
 						is[name] = data
 						continue
@@ -7336,9 +7339,6 @@ func (c *CharCompiler) blockAttribSet(line *string, bl *StateBlock, sbc *StateBy
 			c.scan(line)
 			if err := c.needToken(")"); err != nil {
 				return err
-			}
-			if bl.persistent == 1 {
-				return Error("Persistent(1) is meaningless") // TODO: Do we really need to crash here?
 			}
 			if bl.persistent <= 0 {
 				bl.persistent = math.MaxInt32

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -5805,7 +5805,6 @@ func parseTriggerNumber(name string) (tn int32, isAll bool, ok bool) {
 
 func (c *CharCompiler) parseSection(sctrl func(name, data string) error) (IniSection, error) {
 	is := NewIniSection()
-	var _type, persistent, ignorehitpause bool
 
 	// Placeholder var to toggle all the nonsense Mugen's compiler allowed
 	// Maybe this could be sys.ignoreMostErrors. Or something configurable
@@ -5844,6 +5843,7 @@ func (c *CharCompiler) parseSection(sctrl func(name, data string) error) (IniSec
 		if !strict {
 			fn = strings.TrimSpace(fn) // Mugen tolerates "var ("
 		}
+
 		switch strings.ToLower(fn) {
 		case "var", "fvar", "sysvar", "sysfvar", "map":
 		default:
@@ -5860,7 +5860,7 @@ func (c *CharCompiler) parseSection(sctrl func(name, data string) error) (IniSec
 				uneven--
 				if uneven == 0 {
 					end = j
-					j = len(lhs)
+					j = len(lhs) // End loop
 				}
 			}
 		}
@@ -5885,15 +5885,13 @@ func (c *CharCompiler) parseSection(sctrl func(name, data string) error) (IniSec
 		// They end up as an invalid parameter for the previous state controller and cause both blocks to be merged
 		if !strings.Contains(line, "=") {
 			lower := strings.ToLower(line)
-			if strings.Contains(lower, "state") {
-				// We check if at least one bracket exists to avoid false positives like "p2stateno"
-				if strings.Contains(line, "[") != strings.Contains(line, "]") {
-					msg := fmt.Sprintf("State header not closed")
-					if sys.ignoreMostErrors {
-						sys.appendToConsole(c.charWarn() + msg)
-					} else {
-						return nil, Error(msg)
-					}
+			// We check if at least one bracket exists to avoid false positives like "p2stateno"
+			if strings.Contains(lower, "state") && strings.Contains(line, "[") != strings.Contains(line, "]") {
+				msg := "State header not closed"
+				if sys.ignoreMostErrors {
+					sys.appendToConsole(c.charWarn() + msg)
+				} else {
+					return nil, Error(msg)
 				}
 			}
 		}
@@ -5945,70 +5943,43 @@ func (c *CharCompiler) parseSection(sctrl func(name, data string) error) (IniSec
 			}
 		}
 
-		if len(name) > 0 {
-			_, _, isTrigger := parseTriggerNumber(name)
+		// Nothing to parse here
+		if len(name) == 0 {
+			continue
+		}
 
-			// Reject empty triggers
-			if isTrigger && len(data) == 0 {
-				return nil, Error(name + " cannot be empty")
+		// Check if this line is a trigger
+		_, _, isTrigger := parseTriggerNumber(name)
+
+		// Reject empty triggers
+		if isTrigger && len(data) == 0 {
+			return nil, Error(name + " cannot be empty")
+		}
+
+		// Check for duplicate parameters
+		// This includes "type", "persistent" and "ignorehitpause"
+		if _, ok := is[name]; ok && !isTrigger {
+			msg := fmt.Sprintf("Duplicate '%s' parameter", name)
+			if sys.ignoreMostErrors {
+				// Because duplicates are harmless and would flood the limited console space, we'll print them to the command line instead
+				LogMessage(c.charWarn() + msg)
+				continue
 			}
-
 			// Reject duplicate parameters (normally off)
-			_, ok := is[name]
-			if ok && !isTrigger {
-				if sys.ignoreMostErrors {
-					// Because duplicates are harmless and would flood the limited console space, we'll print them to the command line instead
-					LogMessage(c.charWarn() + fmt.Sprintf("Duplicate '%s' parameter", name))
-					continue
-				}
-				return nil, Error(name + " is duplicated")
-			}
+			return nil, Error(msg)
+		}
 
-			if sctrl != nil {
-				switch name {
-				case "type":
-					// Ignore and log if already found
-					if _type {
-						if sys.ignoreMostErrors {
-							LogMessage(c.charWarn() + "Duplicate 'type' parameter")
-							continue
-						}
-						return nil, Error("type is duplicated")
-					}
-					// Flag as found
-					_type = true
-				case "persistent":
-					if persistent {
-						if sys.ignoreMostErrors {
-							LogMessage(c.charWarn() + "Duplicate 'persistent' parameter")
-							continue
-						}
-						return nil, Error("persistent is duplicated")
-					}
-					persistent = true
-				case "ignorehitpause":
-					if ignorehitpause {
-						if sys.ignoreMostErrors {
-							LogMessage(c.charWarn() + "Duplicate 'ignorehitpause' parameter")
-							continue
-						}
-						return nil, Error("ignorehitpause is duplicated")
-					}
-					ignorehitpause = true
-					// Also save this one because some state controllers need it for their own "ignorehitpause" parameters
-					is[name] = data
-				default:
-					// Save remaining parameters that aren't triggers
-					if !isTrigger {
-						is[name] = data
-						continue
-					}
-				}
-				if err := sctrl(name, data); err != nil {
-					return nil, err
-				}
-			} else {
-				is[name] = data
+		// Store every non‑trigger key in the section map
+		// Previously, we only stored the specific sctrl parameters
+		// However, since some sctrl's like Explod also need "ignorehitpause" saved, we might as well just save everything
+		if !isTrigger {
+			is[name] = data
+		}
+
+		// Run this sctrl's specific compiler function
+		if sctrl != nil {
+			if err := sctrl(name, data); err != nil {
+				return nil, err
 			}
 		}
 	}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -6805,6 +6805,7 @@ func (c *CharCompiler) stateCompileCNS(states map[int32]StateBytecode, filename,
 			var trexist []int8
 
 			// Flag if following triggers can never be true because of triggerall = 0
+			// In which case the following triggers will still be parsed but not stored
 			allTerminated := false
 
 			// Missing trigger number only needs to be printed once
@@ -6853,7 +6854,7 @@ func (c *CharCompiler) stateCompileCNS(states map[int32]StateBytecode, filename,
 						// Check if a previous trigger is missing
 						// e.g. found trigger3 but not trigger2
 						var missingIdx = -1
-						if !isAll && tn > 1 {
+						if !isAll && !allTerminated && tn > 1 {
 							if tidx > len(trexist) {
 								missingIdx = len(trexist)
 							} else {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -6806,7 +6806,9 @@ func (c *CharCompiler) stateCompileCNS(states map[int32]StateBytecode, filename,
 
 			// Flag if following triggers can never be true because of triggerall = 0
 			// In which case the following triggers will still be parsed but not stored
-			allTerminated := false
+			// Update: This was excessive optimization. It complicated the code and created false positives in error logging
+			// Just let them be compiled as no-ops
+			//allTerminated := false
 
 			// Missing trigger number only needs to be printed once
 			warnedMissingTrigger := false
@@ -6854,7 +6856,7 @@ func (c *CharCompiler) stateCompileCNS(states map[int32]StateBytecode, filename,
 						// Check if a previous trigger is missing
 						// e.g. found trigger3 but not trigger2
 						var missingIdx = -1
-						if !isAll && !allTerminated && tn > 1 {
+						if !isAll && tn > 1 {
 							if tidx > len(trexist) {
 								missingIdx = len(trexist)
 							} else {
@@ -6890,14 +6892,7 @@ func (c *CharCompiler) stateCompileCNS(states map[int32]StateBytecode, filename,
 
 						// Handle triggerall
 						if isAll {
-							// If triggerall = 0 is encountered, flag it
-							if len(be) == 2 && be[0] == OC_int8 {
-								if be[1] == 0 {
-									allTerminated = true
-								}
-							} else if !allTerminated {
-								triggerall = append(triggerall, be)
-							}
+							triggerall = append(triggerall, be)
 							break
 						}
 
@@ -6918,7 +6913,7 @@ func (c *CharCompiler) stateCompileCNS(states map[int32]StateBytecode, filename,
 							} else if trexist[tidx] == 0 {
 								trexist[tidx] = 1
 							}
-						} else if !allTerminated && trexist[tidx] >= 0 {
+						} else if trexist[tidx] >= 0 {
 							trigger[tidx] = append(trigger[tidx], be)
 							trexist[tidx] = 1
 						}
@@ -6929,6 +6924,7 @@ func (c *CharCompiler) stateCompileCNS(states map[int32]StateBytecode, filename,
 			if err != nil {
 				return errmes(err)
 			}
+
 			c.block.persistentIndex = int32(sctrl_index_counter)
 			sctrl_index_counter++
 
@@ -6939,11 +6935,14 @@ func (c *CharCompiler) stateCompileCNS(states map[int32]StateBytecode, filename,
 				sbc.ctrlsps = make([]int32, newSize)
 				copy(sbc.ctrlsps, oldCtrlsps)
 			}
+
 			// Check that the sctrl has a valid type parameter
 			if scf == nil {
 				return errmes(Error("State controller type not specified"))
 			}
-			if len(trexist) == 0 || (!allTerminated && trexist[0] == 0) {
+
+			// trigger1 is mandatory
+			if len(trexist) == 0 || trexist[0] == 0 {
 				return errmes(Error("Missing trigger1"))
 			}
 
@@ -6954,53 +6953,49 @@ func (c *CharCompiler) stateCompileCNS(states map[int32]StateBytecode, filename,
 				texp.append(OC_jz8, 0)
 				texp.append(OC_pop)
 			}
-			if allTerminated {
-				if len(texp) > 0 {
-					texp.appendValue(BytecodeBool(false))
+
+			// Loop over triggers
+			for i, tr := range trigger {
+				if trexist[i] == 0 {
+					break
 				}
-			} else {
-				for i, tr := range trigger {
-					if trexist[i] == 0 {
+				var te BytecodeExp
+				if trexist[i] < 0 {
+					te.append(OC_pop)
+					te.appendValue(BytecodeBool(false))
+				}
+				oldlen := len(te)
+				for j := len(tr) - 1; j >= 0; j-- {
+					tmp := tr[j]
+					if j < len(tr)-1 {
+						if len(te) > int(math.MaxUint8-1) {
+							tmp.appendI32Op(OC_jz, int32(len(te)+1))
+						} else {
+							tmp.append(OC_jz8, OpCode(len(te)+1))
+						}
+						tmp.append(OC_pop)
+					}
+					te = append(tmp, te...)
+				}
+				if len(te) == oldlen {
+					te = nil
+				}
+				if len(te) == 0 {
+					if trexist[i] > 0 {
+						if len(texp) > 0 {
+							texp.appendValue(BytecodeBool(true))
+							texp.append(OC_jmp8, 0)
+						}
 						break
 					}
-					var te BytecodeExp
-					if trexist[i] < 0 {
-						te.append(OC_pop)
-						te.appendValue(BytecodeBool(false))
+					if len(texp) > 0 && (i == len(trigger)-1 || trexist[i+1] == 0) {
+						texp.appendValue(BytecodeBool(false))
 					}
-					oldlen := len(te)
-					for j := len(tr) - 1; j >= 0; j-- {
-						tmp := tr[j]
-						if j < len(tr)-1 {
-							if len(te) > int(math.MaxUint8-1) {
-								tmp.appendI32Op(OC_jz, int32(len(te)+1))
-							} else {
-								tmp.append(OC_jz8, OpCode(len(te)+1))
-							}
-							tmp.append(OC_pop)
-						}
-						te = append(tmp, te...)
-					}
-					if len(te) == oldlen {
-						te = nil
-					}
-					if len(te) == 0 {
-						if trexist[i] > 0 {
-							if len(texp) > 0 {
-								texp.appendValue(BytecodeBool(true))
-								texp.append(OC_jmp8, 0)
-							}
-							break
-						}
-						if len(texp) > 0 && (i == len(trigger)-1 || trexist[i+1] == 0) {
-							texp.appendValue(BytecodeBool(false))
-						}
-					} else {
-						texp.append(te...)
-						if i < len(trigger)-1 && trexist[i+1] != 0 {
-							texp.append(OC_jnz8, 0)
-							texp.append(OC_pop)
-						}
+				} else {
+					texp.append(te...)
+					if i < len(trigger)-1 && trexist[i+1] != 0 {
+						texp.append(OC_jnz8, 0)
+						texp.append(OC_pop)
 					}
 				}
 			}
@@ -7016,14 +7011,12 @@ func (c *CharCompiler) stateCompileCNS(states map[int32]StateBytecode, filename,
 			appending := true
 			if len(c.block.trigger) == 0 {
 				appending = false
-				if !allTerminated {
-					for _, te := range trexist {
-						if te >= 0 {
-							if te > 0 {
-								appending = true
-							}
-							break
+				for _, te := range trexist {
+					if te >= 0 {
+						if te > 0 {
+							appending = true
 						}
+						break
 					}
 				}
 			}


### PR DESCRIPTION
Fixes:
- SuperPause darkening effect is now determined by the ownpal parameter, similarly to Mugen
- `triggerall = 0` now makes the compiler ignore missing trigger numbers
- Fixed the ignorehitpause parameter being lost in the process of parsing Explod
- Fixes #3623 
- Fixes https://discord.com/channels/233345562261323776/233363722934943744/1505024234924277802
- Fixes https://discord.com/channels/233345562261323776/233363722934943744/1505193213579886754

Refactor:
- The compiler no longer has special treatment for triggers following "triggerall = 0". They're now simply compiled as no-ops. This simplifies the code a bit and makes error logging more accurate
- CNS sctrl parameters, type, persistent and ignorehitpause are now all handled the same way. They are all stored in the temporay INI section map instead of being cherry-picked