### PR TITLE
fix: TTF fonts causing the engine to crash

### DIFF
--- a/src/font.go
+++ b/src/font.go
@@ -100,6 +100,43 @@ func newFnt() *Fnt {
 	}
 }
 
+// workaround for https://github.com/golang/freetype/issues/8
+func stripKernTable(ttf []byte) []byte {
+	if len(ttf) < 12 {
+		return ttf
+	}
+
+	offset := 0
+	if string(ttf[:4]) == "ttcf" {
+		if len(ttf) < 16 {
+			return ttf
+		}
+		offset = int(binary.BigEndian.Uint32(ttf[12:16]))
+		if offset < 0 || len(ttf)-offset < 12 {
+			return ttf
+		}
+	}
+
+	numTables := int(binary.BigEndian.Uint16(ttf[offset+4 : offset+6]))
+	tableDir := offset + 12
+	if len(ttf) < tableDir+16*numTables {
+		return ttf
+	}
+
+	out := append([]byte(nil), ttf...)
+	for i := 0; i < numTables; i++ {
+		p := tableDir + 16*i
+		if string(out[p:p+4]) == "kern" {
+			// Keep the table directory entry, but make the table empty.
+			// golang/freetype will then ignore kerning instead of failing Parse.
+			binary.BigEndian.PutUint32(out[p+12:p+16], 0)
+			break
+		}
+	}
+
+	return out
+}
+
 func loadFnt(filename string, height int32) (*Fnt, error) {
 	if HasExtension(filename, ".fnt") {
 		return loadFntV1(filename)

--- a/src/font_gl33.go
+++ b/src/font_gl33.go
@@ -354,9 +354,18 @@ func (f *Font_GL33) GenerateGlyphs(low, high rune) error {
 	for ch := low; ch <= high; ch++ {
 		char := new(character)
 
+		drawGlyph := true
 		gBnd, gAdv, ok := ttfFace.GlyphBounds(ch)
-		if ok != true {
-			return fmt.Errorf("ttf face glyphBounds error")
+		if !ok {
+			// Some fonts do not provide bounds for every requested rune. This is common for control chars.
+			// Keep loading the font and create an invisible placeholder so future lookups do not retry this glyph forever.
+			drawGlyph = false
+			if adv, advOK := ttfFace.GlyphAdvance(ch); advOK {
+				gAdv = adv
+			} else {
+				gAdv = 0
+			}
+			gBnd = f.ttf.Bounds(fixed.Int26_6(f.scale))
 		}
 
 		gh := int32((gBnd.Max.Y - gBnd.Min.Y) >> 6)
@@ -408,9 +417,22 @@ func (f *Font_GL33) GenerateGlyphs(low, high rune) error {
 		c.SetClip(rgba.Bounds())
 		c.SetDst(rgba)
 		c.SetSrc(fg)
-		_, err := c.DrawString(string(ch), pt)
-		if err != nil {
-			return err
+		if drawGlyph {
+			if _, err := c.DrawString(string(ch), pt); err != nil {
+				// Some fonts have broken hinting bytecode. Keep full hinting for normal fonts.
+				// Retry glyph without hinting instead of failing the whole font load.
+				c2 := freetype.NewContext()
+				c2.SetDPI(72)
+				c2.SetFont(f.ttf)
+				c2.SetFontSize(float64(f.scale))
+				c2.SetHinting(font.HintingNone)
+				c2.SetClip(rgba.Bounds())
+				c2.SetDst(rgba)
+				c2.SetSrc(fg)
+				if _, err := c2.DrawString(string(ch), pt); err != nil {
+					return err
+				}
+			}
 		}
 
 		var uv [4]float32

--- a/src/font_gl33.go
+++ b/src/font_gl33.go
@@ -488,6 +488,9 @@ func (r *FontRenderer_GL33) LoadTrueTypeFont(reader io.Reader, scale int32, low,
 
 	// Read the truetype font.
 	ttf, err := truetype.Parse(data)
+	if err != nil && err.Error() == "freetype: invalid TrueType format: bad kern table length" {
+		ttf, err = truetype.Parse(stripKernTable(data))
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/src/font_gles32.go
+++ b/src/font_gles32.go
@@ -354,9 +354,18 @@ func (f *Font_GLES32) GenerateGlyphs(low, high rune) error {
 	for ch := low; ch <= high; ch++ {
 		char := new(character)
 
+		drawGlyph := true
 		gBnd, gAdv, ok := ttfFace.GlyphBounds(ch)
-		if ok != true {
-			return fmt.Errorf("ttf face glyphBounds error")
+		if !ok {
+			// Some fonts do not provide bounds for every requested rune. This is common for control chars.
+			// Keep loading the font and create an invisible placeholder so future lookups do not retry this glyph forever.
+			drawGlyph = false
+			if adv, advOK := ttfFace.GlyphAdvance(ch); advOK {
+				gAdv = adv
+			} else {
+				gAdv = 0
+			}
+			gBnd = f.ttf.Bounds(fixed.Int26_6(f.scale))
 		}
 
 		gh := int32((gBnd.Max.Y - gBnd.Min.Y) >> 6)
@@ -408,10 +417,23 @@ func (f *Font_GLES32) GenerateGlyphs(low, high rune) error {
 		c.SetClip(rgba.Bounds())
 		c.SetDst(rgba)
 		c.SetSrc(fg)
-		_, err := c.DrawString(string(ch), pt)
-		if err != nil {
-			Logcat(fmt.Sprintf("GLES: ERROR DRAWING STRING: %v", err.Error()))
-			return err
+		if drawGlyph {
+			if _, err := c.DrawString(string(ch), pt); err != nil {
+				// Some fonts have broken hinting bytecode. Keep full hinting for normal fonts.
+				// Retry glyph without hinting instead of failing the whole font load.
+				c2 := freetype.NewContext()
+				c2.SetDPI(72)
+				c2.SetFont(f.ttf)
+				c2.SetFontSize(float64(f.scale))
+				c2.SetHinting(font.HintingNone)
+				c2.SetClip(rgba.Bounds())
+				c2.SetDst(rgba)
+				c2.SetSrc(fg)
+				if _, err := c2.DrawString(string(ch), pt); err != nil {
+					Logcat(fmt.Sprintf("GLES: ERROR DRAWING STRING: %v", err.Error()))
+					return err
+				}
+			}
 		}
 		// Logcat(fmt.Sprintf("Char: %c | Box: %dx%d | Dot: %v | Bounds: %v\n", ch, gw, gh, pt, gBnd))
 

--- a/src/font_gles32.go
+++ b/src/font_gles32.go
@@ -495,6 +495,9 @@ func (r *FontRenderer_GLES32) LoadTrueTypeFont(reader io.Reader, scale int32, lo
 
 	// Read the truetype font.
 	ttf, err := truetype.Parse(data)
+	if err != nil && err.Error() == "freetype: invalid TrueType format: bad kern table length" {
+		ttf, err = truetype.Parse(stripKernTable(data))
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/src/font_vk.go
+++ b/src/font_vk.go
@@ -374,9 +374,18 @@ func (f *Font_VK) GenerateGlyphs(low, high rune) error {
 	for ch := low; ch <= high; ch++ {
 		char := new(character)
 
+		drawGlyph := true
 		gBnd, gAdv, ok := ttfFace.GlyphBounds(ch)
-		if ok != true {
-			return fmt.Errorf("ttf face glyphBounds error")
+		if !ok {
+			// Some fonts do not provide bounds for every requested rune. This is common for control chars.
+			// Keep loading the font and create an invisible placeholder so future lookups do not retry this glyph forever.
+			drawGlyph = false
+			if adv, advOK := ttfFace.GlyphAdvance(ch); advOK {
+				gAdv = adv
+			} else {
+				gAdv = 0
+			}
+			gBnd = f.ttf.Bounds(fixed.Int26_6(f.scale))
 		}
 
 		gh := int32((gBnd.Max.Y - gBnd.Min.Y) >> 6)
@@ -430,9 +439,22 @@ func (f *Font_VK) GenerateGlyphs(low, high rune) error {
 		c.SetClip(rgba.Bounds())
 		c.SetDst(rgba)
 		c.SetSrc(fg)
-		_, err := c.DrawString(string(ch), pt)
-		if err != nil {
-			return err
+		if drawGlyph {
+			if _, err := c.DrawString(string(ch), pt); err != nil {
+				// Some fonts have broken hinting bytecode. Keep full hinting for normal fonts.
+				// Retry glyph without hinting instead of failing the whole font load.
+				c2 := freetype.NewContext()
+				c2.SetDPI(72)
+				c2.SetFont(f.ttf)
+				c2.SetFontSize(float64(f.scale))
+				c2.SetHinting(font.HintingNone)
+				c2.SetClip(rgba.Bounds())
+				c2.SetDst(rgba)
+				c2.SetSrc(fg)
+				if _, err := c2.DrawString(string(ch), pt); err != nil {
+					return err
+				}
+			}
 		}
 
 		// Generate texture

--- a/src/font_vk.go
+++ b/src/font_vk.go
@@ -526,6 +526,9 @@ func (r *FontRenderer_VK) LoadTrueTypeFont(reader io.Reader, scale int32, low, h
 
 	// Read the truetype font.
 	ttf, err := truetype.Parse(data)
+	if err != nil && err.Error() == "freetype: invalid TrueType format: bad kern table length" {
+		ttf, err = truetype.Parse(stripKernTable(data))
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/src/util_desktop.go
+++ b/src/util_desktop.go
@@ -46,7 +46,6 @@ func LoadFntTtf(f *Fnt, fontfile string, filename string, height int32) {
 	}
 	ttf, err := gfxFont.LoadFont(fileDir, height, int(sys.gameWidth), int(sys.gameHeight))
 	if err != nil {
-		panic(err)
 		panic(fmt.Errorf("failed to load ttf font %v: %w", fileDir, err))
 	}
 	f.ttf = ttf.(Font)


### PR DESCRIPTION
2 unrelated crashes.
Fixes #1715
Fixes #3636
Fixes #2359
