### PR TITLE
feat: add background loading for boot, versus screen, and Turns

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -1542,7 +1542,7 @@ end
 function main.f_storyboard(path)
 	local s = loadStoryboard(path)
 	if s == nil then
-		return
+		return false
 	end
 	if gameOption('Debug.DumpLuaTables') then
 		-- get filename without extension from full path
@@ -1556,6 +1556,7 @@ function main.f_storyboard(path)
 		end
 		refresh()
 	end
+	return storyboardCanceled()
 end
 
 function main.f_hiscore(mode, place)

--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -648,6 +648,293 @@ main.t_stageDef = {['random'] = 0}
 main.t_charDef = {}
 main.t_selChars = {}
 main.t_selStages = {}
+main.preload = {
+	lowQueued = false,
+	charState = {},
+	stageState = {},
+	charHighlight = {},
+}
+
+function main.f_waitForPreloads(force)
+	if not preloading() then
+		return
+	end
+	if gameOption('Config.BootLoadingMode') ~= 1 and not force then
+		return
+	end
+	local path = motif.title_info.loading.storyboard
+	if path ~= '' and loadStoryboard(path) ~= nil then
+		while preloading() do
+			if not runStoryboard() or storyboardCanceled() then
+				break
+			end
+			main.f_preloadTick(2)
+			refresh()
+		end
+	end
+	while preloading() do
+		clearColor(0, 0, 0)
+		main.f_animPosDraw(motif.title_info.loading.wait.AnimData)
+		textImgDraw(motif.title_info.loading.wait.TextSpriteData)
+		main.f_preloadTick(2)
+		refresh()
+	end
+end
+
+function main.f_syncCharPaletteData(ref)
+	if ref == nil then return false end
+	local t_info = getCharInfo(ref)
+	if t_info == nil then return false end
+	local changed = false
+	for row, ch in ipairs(main.t_selChars) do
+		if ch.playable and ch.char_ref == ref then
+			local oldPalCount = ch.pal and #ch.pal or 0
+			local oldDefaultCount = ch.pal_defaults and #ch.pal_defaults or 0
+			ch.pal = t_info.pal
+			ch.pal_defaults = t_info.pal_defaults
+			ch.pal_keymap = t_info.pal_keymap
+			if oldPalCount ~= #ch.pal or oldDefaultCount ~= #ch.pal_defaults then
+				changed = true
+			end
+		end
+	end
+	if changed and start ~= nil and start.p ~= nil then
+		for side = 1, 2 do
+			if start.p[side] ~= nil and start.p[side].t_selTemp ~= nil then
+				for _, st in ipairs(start.p[side].t_selTemp) do
+					if st ~= nil and st.ref == ref then
+						-- Force palette menu to rebuild using the refreshed palette list.
+						st.validPals = nil
+						st.validPalsCharRef = nil
+						st.currentIdx = nil
+					end
+				end
+			end
+		end
+	end
+	return changed
+end
+
+function main.f_preloadSetCharHighlight(player, ref)
+	if gameOption('Config.BootLoadingMode') == 0 then
+		return
+	end
+	if player == nil then return end
+	local old = main.preload.charHighlight[player]
+	if old == ref then
+		return
+	end
+	main.preload.charHighlight[player] = ref
+	if old ~= nil then
+		local stillHighlighted = false
+		for _, v in pairs(main.preload.charHighlight) do
+			if v == old then
+				stillHighlighted = true
+				break
+			end
+		end
+		if not stillHighlighted then
+			queueCharPreload(old, 1)
+		end
+	end
+	if ref ~= nil then
+		queueCharPreload(ref, 2)
+		if getCharPreloadStatus(ref) == 'ready' then
+			main.f_syncCharPaletteData(ref)
+			main.f_materializeCharByRef(ref)
+		end
+	end
+end
+
+function main.f_materializeCharCell(row)
+	local ch = main.t_selChars[row]
+	if ch == nil or ch.playable ~= true or ch.char_ref == nil or ch.cell_data_ready then
+		return ch and ch.cell_data_ready or false
+	end
+	local params = motif.select_info.portrait
+	for _, v in pairs({{params.anim, -1}, params.spr}) do
+		if v[1] ~= -1 then
+			local a = animGetPreloadedCharData(ch.char_ref, v[1], v[2])
+			if a then
+				animSetLocalcoord(a, motif.info.localcoord[1], motif.info.localcoord[2])
+				animSetLayerno(a, params.layerno)
+				animSetPos(a, 0, 0)
+				animSetScale(
+					a,
+					params.scale[1] * ch.portraitscale * motif.info.localcoord[1] / ch.localcoord,
+					params.scale[2] * ch.portraitscale * motif.info.localcoord[1] / ch.localcoord
+				)
+				animSetFacing(a, params.facing)
+				animSetXShear(a, params.xshear)
+				animSetAngle(a, params.angle)
+				animSetXAngle(a, params.xangle)
+				animSetYAngle(a, params.yangle)
+				animSetProjection(a, params.projection)
+				animSetFocalLength(a, params.focallength)
+				animSetWindow(a, params.window[1], params.window[2], params.window[3], params.window[4])
+				animUpdate(a)
+				ch.cell_data = a
+				ch.cell_data_ready = true
+				return true
+			end
+		end
+	end
+	return false
+end
+
+function main.f_materializeStagePortrait(stageNo)
+	local st = main.t_selStages[stageNo]
+	if st == nil or st.anim_data_ready then
+		return st and st.anim_data_ready or false
+	end
+	local function f_makeStageAnim(params, fieldName)
+		for _, v in pairs({{params.anim, -1}, params.spr}) do
+			if #v > 0 and v[1] ~= -1 then
+				local a = animGetPreloadedStageData(stageNo, v[1], v[2])
+				if a then
+					animSetLocalcoord(a, motif.info.localcoord[1], motif.info.localcoord[2])
+					animSetLayerno(a, params.layerno)
+					animSetPos(a, 0, 0)
+					animSetScale(
+						a,
+						params.scale[1] * st.portraitscale * motif.info.localcoord[1] / st.localcoord,
+						params.scale[2] * st.portraitscale * motif.info.localcoord[1] / st.localcoord
+					)
+					animSetFacing(a, params.facing)
+					animSetXShear(a, params.xshear)
+					animSetAngle(a, params.angle)
+					animSetXAngle(a, params.xangle)
+					animSetYAngle(a, params.yangle)
+					animSetProjection(a, params.projection)
+					animSetFocalLength(a, params.focallength)
+					local wnd = params.window
+					if wnd == nil or #wnd < 4 then
+						wnd = {0, 0, motif.info.localcoord[1], motif.info.localcoord[2]}
+					end
+					animSetWindow(a, wnd[1], wnd[2], wnd[3], wnd[4])
+					animUpdate(a)
+					st[fieldName] = a
+					return true
+				end
+			end
+		end
+		return false
+	end
+	local ok1 = f_makeStageAnim(motif.select_info.stage.portrait, "anim_data")
+	local ok2 = f_makeStageAnim(motif.vs_screen.stage.portrait, "vs_anim_data")
+	st.anim_data_ready = ok1 or ok2
+	return st.anim_data_ready
+end
+
+function main.f_preloadTick(limit)
+	if gameOption('Config.BootLoadingMode') == 0 then
+		return
+	end
+	limit = limit or 4
+	local n = 0
+
+	for row, ch in ipairs(main.t_selChars) do
+		if n >= limit then break end
+		if ch.playable and ch.char_ref ~= nil and not ch.cell_data_ready then
+			local state, err = getCharPreloadStatus(ch.char_ref)
+			local prev = main.preload.charState[ch.char_ref]
+			if state ~= prev then
+				main.preload.charState[ch.char_ref] = state
+				if state == 'ready' then
+					--print("Char preload ready ref=" .. tostring(ch.char_ref) .. " row=" .. tostring(row))
+					main.f_syncCharPaletteData(ch.char_ref)
+				elseif state == 'error' then
+					print("Char preload error ref=" .. tostring(ch.char_ref) .. " row=" .. tostring(row) .. ": " .. tostring(err))
+				end
+			end
+			if state == 'ready' then
+				if main.f_materializeCharCell(row) then
+					start.needUpdateDrawList = true
+					n = n + 1
+				end
+			end
+		end
+	end
+	for stageNo, st in ipairs(main.t_selStages) do
+		if n >= limit then break end
+		if not st.anim_data_ready then
+			local state, err = getStagePreloadStatus(stageNo)
+			local prev = main.preload.stageState[stageNo]
+			if state ~= prev then
+				main.preload.stageState[stageNo] = state
+				if state == 'ready' then
+					--print("Stage preload ready stage=" .. tostring(stageNo))
+				elseif state == 'error' then
+					print("Stage preload error stage=" .. tostring(stageNo) .. ": " .. tostring(err))
+				end
+			end
+			if state == 'ready' then
+				if main.f_materializeStagePortrait(stageNo) then
+					start.needUpdateDrawList = true
+					n = n + 1
+				end
+			end
+		end
+	end
+end
+
+function main.f_queueAllPreloadsLow()
+	if gameOption('Config.BootLoadingMode') == 0 then
+		return
+	end
+	if main.preload.lowQueued then
+		return
+	end
+	main.preload.lowQueued = true
+	for _, ch in ipairs(main.t_selChars) do
+		if ch.playable and ch.char_ref ~= nil then
+			queueCharPreload(ch.char_ref, 1)
+		end
+	end
+	for stageNo = 1, #main.t_selStages do
+		queueStagePreload(stageNo, 1)
+	end
+end
+
+function main.f_materializeCharByRef(ref)
+	if ref == nil then return false end
+	local ok = false
+	for row, ch in ipairs(main.t_selChars) do
+		if ch.playable and ch.char_ref == ref and not ch.cell_data_ready then
+			main.f_syncCharPaletteData(ref)
+			if main.f_materializeCharCell(row) then
+				start.needUpdateDrawList = true
+				ok = true
+			end
+		end
+	end
+	return ok
+end
+
+function main.f_preloadBoostChar(ref)
+	if gameOption('Config.BootLoadingMode') == 0 then
+		return
+	end
+	if ref == nil then return end
+	queueCharPreload(ref, 2)
+	if getCharPreloadStatus(ref) == 'ready' then
+		main.f_syncCharPaletteData(ref)
+		main.f_materializeCharByRef(ref)
+	end
+end
+
+function main.f_preloadBoostStage(stageNo)
+	if gameOption('Config.BootLoadingMode') == 0 then
+		return
+	end
+	if stageNo == nil or stageNo <= 0 then return end
+	queueStagePreload(stageNo, 2)
+	if getStagePreloadStatus(stageNo) == 'ready' then
+		if main.f_materializeStagePortrait(stageNo) then
+			start.needUpdateDrawList = true
+		end
+	end
+end
 
 --;===========================================================
 --; COMMAND LINE QUICK VS
@@ -916,6 +1203,8 @@ function main.f_warning(text, sec, background, overlay, titleData, textData, can
 		textImgDraw(textData)
 		--draw layerno = 1 backgrounds
 		bgDraw(background.BGDef, 1)
+		--tick preload
+		main.f_preloadTick(2)
 		--end loop
 		refresh()
 	end
@@ -956,6 +1245,8 @@ function main.f_drawInput(textData, text, sec, background, overlay, defaultInput
 		textImgDraw(textData)
 		--draw layerno = 1 backgrounds
 		bgDraw(background.BGDef, 1)
+		--tick preload
+		main.f_preloadTick(2)
 		--end loop
 		refresh()
 	end
@@ -1101,39 +1392,11 @@ function main.f_addChar(line, playable, loading, slot)
 			main.t_unlockLua.chars[row] = unlock
 		end
 		--cell data
-		local params = motif.select_info.portrait
-		for _, v in pairs({{params.anim, -1}, params.spr}) do
-			if v[1] ~= -1 then
-				local a = animGetPreloadedCharData(main.t_selChars[row].char_ref, v[1], v[2])
-				if a then
-					animSetLocalcoord(a, motif.info.localcoord[1], motif.info.localcoord[2])
-					animSetLayerno(a, params.layerno)
-					--animSetVelocity(a, params.velocity[1], params.velocity[2])
-					--animSetMaxDist(a, params.maxdist[1], params.maxdist[2])
-					--animSetAccel(a, params.accel[1], params.accel[2])
-					--animSetFriction(a, params.friction[1], params.friction[2])
-					animSetPos(a, 0, 0)
-					animSetScale(
-						a,
-						params.scale[1] * main.t_selChars[row].portraitscale * motif.info.localcoord[1] / main.t_selChars[row].localcoord,
-						params.scale[2] * main.t_selChars[row].portraitscale * motif.info.localcoord[1] / main.t_selChars[row].localcoord
-					)
-					animSetFacing(a, params.facing)
-					animSetXShear(a, params.xshear)
-					animSetAngle(a, params.angle)
-					animSetXAngle(a, params.xangle)
-					animSetYAngle(a, params.yangle)
-					animSetProjection(a, params.projection)
-					animSetFocalLength(a, params.focallength)
-					animSetWindow(a, params.window[1], params.window[2], params.window[3], params.window[4])
-					animUpdate(a)
-					main.t_selChars[row].cell_data = a
-					break
-				end
-			end
-		end
-		if main.t_selChars[row].cell_data == nil then
-			main.t_selChars[row].cell_data = animNew(nil, '-1,0, 0,0, -1')
+		main.t_selChars[row].cell_data = animNew(nil, '-1,0, 0,0, -1')
+		main.t_selChars[row].cell_data_ready = false
+		if gameOption('Config.BootLoadingMode') == 0 then
+			main.f_syncCharPaletteData(main.t_selChars[row].char_ref)
+			main.f_materializeCharCell(row)
 		end
 	end
 	--slots
@@ -1194,56 +1457,14 @@ function main.f_addStage(file, hidden, line)
 		end
 	end
 	--anim data
-	local function f_makeStageAnim(stageNo, params, fieldName)
-		for _, v in pairs({{params.anim, -1}, params.spr}) do
-			if #v > 0 and v[1] ~= -1 then
-				local a = animGetPreloadedStageData(stageNo, v[1], v[2])
-				if a then
-					animSetLocalcoord(a, motif.info.localcoord[1], motif.info.localcoord[2])
-					animSetLayerno(a, params.layerno)
-					--animSetVelocity(a, params.velocity[1], params.velocity[2])
-					--animSetMaxDist(a, params.maxdist[1], params.maxdist[2])
-					--animSetAccel(a, params.accel[1], params.accel[2])
-					--animSetFriction(a, params.friction[1], params.friction[2])
-					animSetPos(a, 0, 0)
-					animSetScale(
-						a,
-						params.scale[1] * main.t_selStages[stageNo].portraitscale * motif.info.localcoord[1] / t_info.localcoord,
-						params.scale[2] * main.t_selStages[stageNo].portraitscale * motif.info.localcoord[1] / t_info.localcoord
-					)
-					animSetFacing(a, params.facing)
-					animSetXShear(a, params.xshear)
-					animSetAngle(a, params.angle)
-					animSetXAngle(a, params.xangle)
-					animSetYAngle(a, params.yangle)
-					animSetProjection(a, params.projection)
-					animSetFocalLength(a, params.focallength)
-					if params.window == nil or #params.window < 4 then
-						params.window = {0, 0, motif.info.localcoord[1], motif.info.localcoord[2]}
-					end
-					animSetWindow(
-						a,
-						params.window[1],
-						params.window[2],
-						params.window[3],
-						params.window[4]
-					)
-					animUpdate(a)
-					main.t_selStages[stageNo][fieldName] = a
-					break
-				end
-			end
-		end
-	end
-	--select screen anim data
-	f_makeStageAnim(stageNo, motif.select_info.stage.portrait, "anim_data")
-	--vs screen anim data
-	f_makeStageAnim(stageNo, motif.vs_screen.stage.portrait, "vs_anim_data")
 	if hidden ~= nil and hidden ~= 0 then
 		main.t_selStages[stageNo].hidden = hidden
 	end
-	if main.t_selStages[stageNo].anim_data == nil then
-		main.t_selStages[stageNo].anim_data = animNew(nil, '-1,0, 0,0, -1')
+	main.t_selStages[stageNo].anim_data = animNew(nil, '-1,0, 0,0, -1')
+	main.t_selStages[stageNo].vs_anim_data = animNew(nil, '-1,0, 0,0, -1')
+	main.t_selStages[stageNo].anim_data_ready = false
+	if gameOption('Config.BootLoadingMode') == 0 then
+		main.f_materializeStagePortrait(stageNo)
 	end
 	return stageNo
 end
@@ -1505,6 +1726,9 @@ function main.f_updateSelectableStages()
 	end
 end
 main.f_updateSelectableStages()
+if gameOption('Config.BootLoadingMode') > 0 then
+	main.f_queueAllPreloadsLow()
+end
 
 --add default maxmatches values if config is missing in select.def
 if main.t_selOptions.arcademaxmatches == nil then main.t_selOptions.arcademaxmatches = {6, 1, 1, 0, 0, 0, 0, 0, 0, 0} end
@@ -1554,6 +1778,7 @@ function main.f_storyboard(path)
 		if not runStoryboard() then
 			break
 		end
+		main.f_preloadTick(2)
 		refresh()
 	end
 	return storyboardCanceled()
@@ -1564,6 +1789,7 @@ function main.f_hiscore(mode, place)
 		if not runHiscore(mode, place) then
 			break
 		end
+		main.f_preloadTick(2)
 		refresh()
 	end
 end
@@ -1977,6 +2203,7 @@ main.t_itemname = {
 	end,
 	--SERVER CONNECT
 	['serverconnect'] = function(t, item)
+		main.f_waitForPreloads(true)
 		local doneSnd = motif[main.group].cursor.done.snd.serverconnect or motif[main.group].cursor.done.snd.default
 		sndPlay(motif.Snd, doneSnd[1], doneSnd[2])
 		hook.run("main.t_itemname", t, item)
@@ -1993,6 +2220,7 @@ main.t_itemname = {
 	end,
 	--SERVER HOST
 	['serverhost'] = function(t, item)
+		main.f_waitForPreloads(true)
 		local doneSnd = motif[main.group].cursor.done.snd.serverhost or motif[main.group].cursor.done.snd.default
 		sndPlay(motif.Snd, doneSnd[1], doneSnd[2])
 		hook.run("main.t_itemname", t, item)
@@ -3098,6 +3326,7 @@ function main.f_attractStart()
 		if fadeOutStarted and not fadeActive() then
 			return getCredits() ~= 0
 		end
+		main.f_preloadTick(2)
 		refresh()
 	end
 end
@@ -3444,6 +3673,7 @@ end
 
 --common menu draw
 function main.f_menuCommonDraw(t, item, cursorPosY, moveTxt, sec, bg, skipClear, opts)
+	main.f_preloadTick(2)
 	local m = sec.menu or sec
 	-- opts:
 	--   offx, offy               : per-call offsets

--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -169,6 +169,7 @@ options.t_itemname = {
 			--modifyGameOption('Config.ZoomActive', true)
 			--modifyGameOption('Config.EscOpensMenu', true)
 			modifyGameOption('Config.VsScreenLoading', false)
+			modifyGameOption('Config.TurnsLoading', false)
 			--modifyGameOption('Config.FirstRun', false)
 			--modifyGameOption('Config.WindowTitle', "Ikemen GO")
 			--modifyGameOption('Config.WindowIcon', {"external/icons/IkemenCylia_256.png", "external/icons/IkemenCylia_96.png", "external/icons/IkemenCylia_48.png"})
@@ -1264,6 +1265,20 @@ options.t_itemname = {
 		end
 		return true
 	end,
+	--Turns Preloading
+	['turnsloading'] = function(t, item, cursorPosY, moveTxt)
+		if getInput(-1, motif.option_info.menu.add.key, motif.option_info.menu.subtract.key, motif.option_info.menu.done.key) then
+			sndPlay(motif.Snd, motif.option_info.cursor.move.snd[1], motif.option_info.cursor.move.snd[2])
+			if gameOption('Config.TurnsLoading') then
+				modifyGameOption('Config.TurnsLoading', false)
+			else
+				modifyGameOption('Config.TurnsLoading', true)
+			end
+			t.items[item].vardisplay = options.f_boolDisplay(gameOption('Config.TurnsLoading'), motif.option_info.menu.valuename.enabled, motif.option_info.menu.valuename.disabled)
+			options.modified = true
+		end
+		return true
+	end,
 	--HelperMax
 	['helpermax'] = function(t, item, cursorPosY, moveTxt)
 		if getInput(-1, motif.option_info.menu.add.key) then
@@ -1509,6 +1524,9 @@ options.t_vardisplay = {
 	end,
 	['vsscreenloading'] = function()
 		return options.f_boolDisplay(gameOption('Config.VsScreenLoading'), motif.option_info.menu.valuename.enabled, motif.option_info.menu.valuename.disabled)
+	end,
+	['turnsloading'] = function()
+		return options.f_boolDisplay(gameOption('Config.TurnsLoading'), motif.option_info.menu.valuename.enabled, motif.option_info.menu.valuename.disabled)
 	end,
 	['bgmvolume'] = function()
 		return gameOption('Sound.BGMVolume') .. '%'

--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -170,6 +170,7 @@ options.t_itemname = {
 			--modifyGameOption('Config.EscOpensMenu', true)
 			modifyGameOption('Config.VsScreenLoading', false)
 			modifyGameOption('Config.TurnsLoading', false)
+			--modifyGameOption('Config.BootLoadingMode', 0)
 			--modifyGameOption('Config.FirstRun', false)
 			--modifyGameOption('Config.WindowTitle', "Ikemen GO")
 			--modifyGameOption('Config.WindowIcon', {"external/icons/IkemenCylia_256.png", "external/icons/IkemenCylia_96.png", "external/icons/IkemenCylia_48.png"})

--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -168,7 +168,7 @@ options.t_itemname = {
 			--modifyGameOption('Config.TickInterpolation', true)
 			--modifyGameOption('Config.ZoomActive', true)
 			--modifyGameOption('Config.EscOpensMenu', true)
-			--modifyGameOption('Config.BackgroundLoading', false) --TODO: not implemented
+			modifyGameOption('Config.VsScreenLoading', false)
 			--modifyGameOption('Config.FirstRun', false)
 			--modifyGameOption('Config.WindowTitle', "Ikemen GO")
 			--modifyGameOption('Config.WindowIcon', {"external/icons/IkemenCylia_256.png", "external/icons/IkemenCylia_96.png", "external/icons/IkemenCylia_48.png"})
@@ -1251,19 +1251,19 @@ options.t_itemname = {
 		return true
 	end,
 	--Background Loading
-	--[[['backgroundloading'] = function(t, item, cursorPosY, moveTxt)
+	['vsscreenloading'] = function(t, item, cursorPosY, moveTxt)
 		if getInput(-1, motif.option_info.menu.add.key, motif.option_info.menu.subtract.key, motif.option_info.menu.done.key) then
 			sndPlay(motif.Snd, motif.option_info.cursor.move.snd[1], motif.option_info.cursor.move.snd[2])
-			if gameOption('Config.BackgroundLoading') then
-				modifyGameOption('Config.BackgroundLoading', false)
+			if gameOption('Config.VsScreenLoading') then
+				modifyGameOption('Config.VsScreenLoading', false)
 			else
-				modifyGameOption('Config.BackgroundLoading', true)
+				modifyGameOption('Config.VsScreenLoading', true)
 			end
-			t.items[item].vardisplay = options.f_boolDisplay(gameOption('Config.BackgroundLoading'), motif.option_info.menu.valuename.enabled, motif.option_info.menu.valuename.disabled)
+			t.items[item].vardisplay = options.f_boolDisplay(gameOption('Config.VsScreenLoading'), motif.option_info.menu.valuename.enabled, motif.option_info.menu.valuename.disabled)
 			options.modified = true
 		end
 		return true
-	end,]]
+	end,
 	--HelperMax
 	['helpermax'] = function(t, item, cursorPosY, moveTxt)
 		if getInput(-1, motif.option_info.menu.add.key) then
@@ -1507,9 +1507,9 @@ options.t_vardisplay = {
 	['autoguard'] = function()
 		return options.f_boolDisplay(gameOption('Options.AutoGuard'))
 	end,
-	--['backgroundloading'] = function()
-	--	return options.f_boolDisplay(gameOption('Config.BackgroundLoading'), motif.option_info.menu.valuename.enabled, motif.option_info.menu.valuename.disabled)
-	--end,
+	['vsscreenloading'] = function()
+		return options.f_boolDisplay(gameOption('Config.VsScreenLoading'), motif.option_info.menu.valuename.enabled, motif.option_info.menu.valuename.disabled)
+	end,
 	['bgmvolume'] = function()
 		return gameOption('Sound.BGMVolume') .. '%'
 	end,

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -2096,6 +2096,7 @@ function launchFight(data)
 		t.ai = data.ai or nil
 		t.vsscreen = main.f_arg(data.vsscreen, main.motif.vsscreen)
 		t.victoryscreen = main.f_arg(data.victoryscreen, main.motif.victoryscreen)
+		t.winscreen = main.f_arg(data.winscreen, main.motif.winscreen)
 		--t.frames = data.frames or fightScreenVar("time.framespercount")
 		t.roundtime = data.time or nil
 		t.lua = data.lua or ''
@@ -2219,12 +2220,7 @@ function launchFight(data)
 			return true --continue lua code execution
 		end
 	end
-	--TODO: fix gameOption('Config.BackgroundLoading') setting
-	--if gameOption('Config.BackgroundLoading') then
-	--	selectStart()
-	--else
-		clearSelected()
-	--end
+	clearSelected()
 	local ok = false
 	local loopCount = 0
 	while true do
@@ -2239,11 +2235,6 @@ function launchFight(data)
 			-- Snapshot before game() runs. If a challenger interrupts the fight, this is the last clean arcade state.
 			challengerResume = makeChallengerResumeSnapshot(data, t.stageNo)
 		end
-		if not start.f_selectVersus(t.vsscreen, t.orderselect) then break end
-		local winscreen = main.motif.winscreen
-		if winscreen and main.makeRoster and start.t_roster[matchNo() + 1] ~= nil then
-			winscreen = false
-		end
 		local common = {lua = {}}
 		if t.lua ~= '' then
 			table.insert(common.lua, t.lua)
@@ -2251,12 +2242,21 @@ function launchFight(data)
 		-- Hooks may mutate "common" in place before loading starts.
 		hook.run("launchFight", common, t, data)
 		updateCommon(common, true)
-		start.f_selectLoading{
-			musicParams = t.musicParams,
-			continue = t.continue,
-			victoryscreen = t.victoryscreen,
-			winscreen = winscreen,
-		}
+		-- Resolve match-scoped params before VS can start background loading.
+		local winscreen = main.f_arg(t.winscreen, main.motif.winscreen)
+		if winscreen and main.makeRoster and start.t_roster[matchNo() + 1] ~= nil then
+			winscreen = false
+		end
+		local loadStartParams = main.f_tableCopy(t)
+		loadStartParams.winscreen = winscreen
+
+		if not start.f_selectVersus(t.vsscreen, t.orderselect, loadStartParams) then break end
+		-- If VS started background loading, do not restart the loader here.
+		if gameOption('Config.VsScreenLoading') and start.bgLoadStarted then
+			clearAllSound()
+		elseif not start.f_selectLoading(loadStartParams) then
+			break
+		end
 		start.f_game(common)
 		clearColor(motif.selectbgdef.bgclearcolor[1], motif.selectbgdef.bgclearcolor[2], motif.selectbgdef.bgclearcolor[3])
 		if start.exit or start.characterchange then
@@ -3577,8 +3577,83 @@ end
 --;===========================================================
 --; VERSUS SCREEN / ORDER SELECTION
 --;===========================================================
-function start.f_selectVersus(active, t_orderSelect)
+-- Build params for loadStart()
+function start.f_buildLoadStartParams(arg, doSelectMissing, t_orderRemap)
+	local parts = {}
+	local t = {}
+	local musicParams = arg
+	if type(arg) == "table" then
+		t = arg
+		musicParams = t.musicParams
+	end
+	if musicParams and musicParams ~= "" then
+		parts[#parts + 1] = musicParams
+	end
+	local function addParam(k, v)
+		if v == nil or v == "" then
+			return
+		end
+		parts[#parts + 1] = k .. "=" .. tostring(v)
+	end
+	addParam("continue", t.continue)
+	addParam("quickcontinue", t.quickcontinue)
+	addParam("order", t.order)
+	addParam("stage", t.stage)
+	addParam("ai", t.ai)
+	addParam("time", t.roundtime or t.time)
+	addParam("vsscreen", t.vsscreen)
+	addParam("victoryscreen", t.victoryscreen)
+	addParam("winscreen", t.winscreen)
+	addParam("lua", t.lua)
+	addParam("charparam.ai", main.charparam.ai)
+	addParam("charparam.arcadepath", main.charparam.arcadepath)
+	addParam("charparam.music", main.charparam.music)
+	addParam("charparam.rounds", main.charparam.rounds)
+	addParam("charparam.single", main.charparam.single)
+	addParam("charparam.stage", main.charparam.stage)
+	addParam("charparam.time", main.charparam.time)
+	addParam("p1.turnsoffset", start.p[1].turnsOffset or 0)
+	addParam("p2.turnsoffset", start.p[2].turnsOffset or 0)
+	addParam("persistlife", main.persistLife)
+	addParam("persistmusic", main.persistMusic)
+	addParam("persistrounds", main.persistRounds)
+	addParam("rankingcondition", main.rankingCondition)
+	return table.concat(parts, ", ")
+end
+
+-- Build per-member override params for selectChar().
+function start.f_buildOverrideParams(side, member, v)
+	local parts = {}
+	local function addParam(field, val)
+		if val == nil then return end
+		parts[#parts + 1] = string.format("p%d.%d.%s=%s", side, member, field, tostring(val))
+	end
+	hook.run("start.f_selectLoading.member", v)
+	addParam("life", v.life)
+	addParam("lifemax", v.lifeMax)
+	addParam("power", v.power)
+	addParam("dizzypoints", v.dizzyPoints)
+	addParam("guardpoints", v.guardPoints)
+	addParam("existed", v.existed)
+	if type(v.maps) == "table" then
+		for mapName, mapValue in pairs(v.maps) do
+			if type(mapName) == "string" and mapValue ~= nil then
+				local key = mapName
+				if key:sub(1, 4):lower() == "map." then
+					key = key:sub(5)
+				end
+				if key ~= "" then
+					addParam("map." .. key, mapValue)
+				end
+			end
+		end
+	end
+	return table.concat(parts, ", ")
+end
+
+function start.f_selectVersus(active, t_orderSelect, loadStartArg)
 	start.t_orderRemap = {{}, {}}
+	start.bgLoadStarted = false
 	for side = 1, 2 do
 		-- populate order remap table with default values
 		for i = 1, #start.p[side].t_selected do
@@ -3593,9 +3668,10 @@ function start.f_selectVersus(active, t_orderSelect)
 				t_orderSelect[side] = false
 			end
 		end
-		-- reset loading flags
+		-- reset order-confirm flags and selection flags
 		for _, v in ipairs(start.p[side].t_selected) do
 			v.loading = false
+			v.selected = false
 		end
 	end
 	-- skip versus screen if vs screen is disabled or p2 side char has vsscreen select.def flag set to 0
@@ -3618,22 +3694,59 @@ function start.f_selectVersus(active, t_orderSelect)
 	start.f_resetTempData(motif.vs_screen, '')
 	start.f_playWave(getStageNo(), 'stage', motif.vs_screen.stage.snd[1], motif.vs_screen.stage.snd[2])
 	local counter = 0 - motif.vs_screen.fadein.time
+	local bgLoading = gameOption('Config.VsScreenLoading')
 	local done = (not t_orderSelect[1] and not t_orderSelect[2]) -- both sides having order disabled
-		or (not t_orderSelect[1] and main.cpuSide[2]) -- left side with disabled order, right side controlled by CPU
-		or (not t_orderSelect[2] and main.cpuSide[1]) -- right side with disabled order, left side controlled by CPU
-		or (main.cpuSide[1] and main.cpuSide[2]) -- both sides controlled by CPU
 	local timerActive = not done
 	local timerCount = 0
 	local escFlag = false
 	local doneKeyReady = done
 	local t_order = {{}, {}}
+	local cpuOrderFinalized = {false, false}
 	local t_icon = {false, false}
 	local selStageNo = getStageNo()
+	local loadStarted = false
+	local netReady = false
+	local readyToLeave = not bgLoading
+	local wantSkip = false
+	local wantDone = false
+
+	-- Background loading: start async loader immediately.
+	if bgLoading then
+		local params = start.f_buildLoadStartParams(loadStartArg, false, start.t_orderRemap)
+		if gameOption('Debug.DumpLuaTables') then main.f_printTable(params, "debug/loadStartParams.txt") end
+		resetGameParams()
+		loadStart(params)
+		loadStarted = true
+		start.bgLoadStarted = true
+		-- Sides without order select: select everyone immediately so loading can begin.
+		for side = 1, 2 do
+			if not t_orderSelect[side] then
+				for member, v in ipairs(start.p[side].t_selected) do
+					if not v.selected then
+						selectChar(side, v.ref, v.pal, start.f_buildOverrideParams(side, member, v))
+						v.selected = true
+					end
+					v.loading = true
+					t_order[side][#t_order[side] + 1] = member
+				end
+				t_icon[side] = nil
+			end
+		end
+	end
+
 	local function finishOrderSelection(side)
 		for member, v in ipairs(start.p[side].t_selected) do
 			if not v.loading then
-				table.insert(t_order[side], member)
-				selectChar(side, v.ref, v.pal)
+				t_order[side][#t_order[side] + 1] = member
+				local slot = #t_order[side]
+				if not v.selected then
+					if bgLoading then
+						selectChar(side, v.ref, v.pal, start.f_buildOverrideParams(side, slot, v))
+					else
+						selectChar(side, v.ref, v.pal)
+					end
+					v.selected = true
+				end
 				v.loading = true
 			end
 		end
@@ -3643,6 +3756,26 @@ function start.f_selectVersus(active, t_orderSelect)
 	end
 	while true do
 		local snd = false
+		-- CPU order select: randomize first, then selectChar() using randomized slot order
+		for side = 1, 2 do
+			if main.cpuSide[side] and t_orderSelect[side] and not cpuOrderFinalized[side] then
+				t_order[side] = {}
+				for i = 1, #start.p[side].t_selected do
+					t_order[side][i] = i
+				end
+				main.f_tableShuffle(t_order[side])
+				for slot, idx in ipairs(t_order[side]) do
+					local v = start.p[side].t_selected[idx]
+					if bgLoading and not v.selected then
+						selectChar(side, v.ref, v.pal, start.f_buildOverrideParams(side, slot, v))
+						v.selected = true
+					end
+					v.loading = true
+				end
+				t_icon[side] = nil
+				cpuOrderFinalized[side] = true
+			end
+		end
 		-- for each team side member
 		for side = 1, 2 do
 			if not done and t_orderSelect[side] and not main.cpuSide[side] and getInput(side, motif.vs_screen.skip.key) then
@@ -3657,33 +3790,51 @@ function start.f_selectVersus(active, t_orderSelect)
 				local pCfg = f_getMotifP(motif.vs_screen, pn, side)
 				-- until loading flag is set
 				if not v.loading then
-					-- if not valid for order selection or CPU or doesn't have key for this member assigned, or order timer run out
-					if not t_orderSelect[side] or main.cpuSide[side] or (#pCfg.key == 0 and #t_order[side] == k - 1) or timerCount == -1 then
-						table.insert(t_order[side], k)
-						-- if it's the last unordered team member
-						if #start.p[side].t_selected == #t_order[side] then
-							-- randomize CPU side team order (if valid for order selection)
-							if main.cpuSide[side] and t_orderSelect[side] then
-								main.f_tableShuffle(t_order[side])
-							end
-							-- confirm char selection (starts loading immediately if gameOption('Config.BackgroundLoading') is true)
-							for _, member in ipairs(t_order[side]) do
-								if not start.p[side].t_selected[member].loading then
-									selectChar(side, start.p[side].t_selected[member].ref, start.p[side].t_selected[member].pal)
-									start.p[side].t_selected[member].loading = true
+					-- Timeout: append all remaining members in default order and confirm them.
+					if timerCount == -1 then
+						for kk, vv in ipairs(start.p[side].t_selected) do
+							if not vv.loading then
+								t_order[side][#t_order[side] + 1] = kk
+								local slot = #t_order[side]
+								if not vv.selected then
+									if bgLoading then
+										selectChar(side, vv.ref, vv.pal, start.f_buildOverrideParams(side, slot, vv))
+									else
+										selectChar(side, vv.ref, vv.pal)
+									end
+									vv.selected = true
 								end
-							end
-							t_icon[side] = nil
-							-- play sound if timer run out
-							if not snd and timerCount == -1 then
-								sndPlay(motif.Snd, motif.vs_screen['p' .. side].value.snd[1], motif.vs_screen['p' .. side].value.snd[2])
-								snd = true
+								vv.loading = true
 							end
 						end
+						t_icon[side] = nil
+						if not snd then
+							sndPlay(motif.Snd, motif.vs_screen['p' .. side].value.snd[1], motif.vs_screen['p' .. side].value.snd[2])
+							snd = true
+						end
+					-- CPU / no-key / auto-confirm path
+					elseif not t_orderSelect[side] or main.cpuSide[side] or (#pCfg.key == 0 and #t_order[side] == k - 1) then
+						t_order[side][#t_order[side] + 1] = k
+						local slot = #t_order[side]
+						if bgLoading and not v.selected then
+							selectChar(side, v.ref, v.pal, start.f_buildOverrideParams(side, slot, v))
+							v.selected = true
+						end
+						v.loading = true
+						if #start.p[side].t_selected == #t_order[side] then
+							t_icon[side] = nil
+						end
 					elseif getInput(side, pCfg.key) or (#start.p[side].t_selected == #t_order[side] + 1) then
-						table.insert(t_order[side], k)
-						-- confirm char selection (starts loading immediately if gameOption('Config.BackgroundLoading') is true)
-						selectChar(side, v.ref, v.pal)
+						t_order[side][#t_order[side] + 1] = k
+						local slot = #t_order[side]
+						if bgLoading and not v.selected then
+							selectChar(side, v.ref, v.pal, start.f_buildOverrideParams(side, slot, v))
+							v.selected = true
+						end
+						if not bgLoading and not v.selected then
+							selectChar(side, v.ref, v.pal)
+							v.selected = true
+						end
 						v.loading = true
 						-- if it's the last unordered team member
 						if #start.p[side].t_selected == #t_order[side] then
@@ -3802,6 +3953,22 @@ function start.f_selectVersus(active, t_orderSelect)
 		if not done and motif.vs_screen.timer.count ~= -1 and timerActive and counter >= 0 then
 			timerCount, timerActive = main.f_drawTimer(timerCount, motif.vs_screen.timer)
 		end
+		-- Background loading status
+		readyToLeave = not bgLoading
+		if bgLoading and loadStarted then
+			local localDone = not loading()
+			if localDone and not netReady then
+				netReady = netLoadingReady()
+			end
+			readyToLeave = localDone and netReady
+			if not readyToLeave then
+				main.f_animPosDraw(motif.vs_screen.loading.AnimData)
+				textImgDraw(motif.vs_screen.loading.TextSpriteData)
+			else
+				main.f_animPosDraw(motif.vs_screen.loading.done.AnimData)
+				textImgDraw(motif.vs_screen.loading.done.TextSpriteData)
+			end
+		end
 		--draw layerno = 1 backgrounds
 		bgDraw(motif.versusbgdef.BGDef, 1)
 		-- hook
@@ -3812,19 +3979,33 @@ function start.f_selectVersus(active, t_orderSelect)
 		end
 		--draw fadein / fadeout
 		for side = 1, 2 do
+			-- Latch skip/done while background loading is still in progress.
+			if bgLoading and loadStarted and not readyToLeave then
+				if not main.cpuSide[side] and getInput(side, motif.vs_screen.skip.key) then
+					wantSkip = true
+				end
+				if done and doneKeyReady and getInput(side, motif.vs_screen.done.key) then
+					wantDone = true
+				end
+			end
 			if not fadeOutStarted and (
-				-- Wait for order select to finish before vs_screen.time can end the screen.
-				(counter >= motif.vs_screen.time and (not (t_orderSelect[1] or t_orderSelect[2]) or done))
-				or (done and doneKeyReady and getInput(side, motif.vs_screen.done.key))
-				) then
+				(counter >= motif.vs_screen.time and (not (t_orderSelect[1] or t_orderSelect[2]) or done) and readyToLeave)
+				or (readyToLeave and (not main.cpuSide[side] and (getInput(side, motif.vs_screen.skip.key) or wantSkip)))
+				or (readyToLeave and (done and doneKeyReady and (getInput(side, motif.vs_screen.done.key) or wantDone)))) then
 				fadeOutInit(motif.vs_screen.fadeout.FadeData)
 				fadeOutStarted = true
+				wantSkip = false
+				wantDone = false
 				break
 			end
 		end
 		--frame transition
 		if not escFlag and (esc() or getInput(-1, motif.vs_screen.cancel.key)) then
 			esc(false)
+			if bgLoading and loadStarted then
+				loadCancel()
+				clearSelected()
+			end
 			fadeOutInit(motif.vs_screen.fadeout.FadeData)
 			fadeOutStarted = true
 			escFlag = true
@@ -3842,71 +4023,62 @@ end
 --loading loop called after versus screen is finished
 function start.f_selectLoading(arg)
 	clearAllSound()
-	local parts = {}
 	local t = {}
 	if type(arg) == "table" then
 		t = arg
 	elseif type(arg) == "string" then
 		t.musicParams = arg
 	end
-	if t.musicParams and t.musicParams ~= "" then
-		parts[#parts + 1] = t.musicParams
-	end
-	local function addParam(k, v)
-		if v == nil then return end
-		parts[#parts + 1] = k .. "=" .. tostring(v)
-	end
-	-- Post-match screens are match-scoped.
-	addParam("continue", t.continue)
-	addParam("victoryscreen", t.victoryscreen)
-	addParam("winscreen", t.winscreen)
-	addParam("rankingcondition", main.rankingCondition)
-	addParam("charparam.ai", main.charparam.ai)
-	addParam("charparam.arcadepath", main.charparam.arcadepath)
-	addParam("charparam.music", main.charparam.music)
-	addParam("charparam.rounds", main.charparam.rounds)
-	addParam("charparam.single", main.charparam.single)
-	addParam("charparam.stage", main.charparam.stage)
-	addParam("charparam.time", main.charparam.time)
-	-- Tell the engine how many leading Turns members are already defeated.
-	-- This keeps full roster for lifebar/hiscore while skipping defeated members in gameplay.
-	addParam("p1.turnsoffset", start.p[1].turnsOffset or 0)
-	addParam("p2.turnsoffset", start.p[2].turnsOffset or 0)
-	for side = 1, 2 do
-		for member, v in ipairs(start.p[side].t_selected) do
-			if not v.loading then
-				selectChar(side, v.ref, v.pal)
-				v.loading = true
-			end
-			hook.run("start.f_selectLoading.member", v)
-			local pfx = "p" .. side .. "." .. member .. "."
-			addParam(pfx .. "life", v.life)
-			addParam(pfx .. "lifemax", v.lifeMax)
-			addParam(pfx .. "power", v.power)
-			addParam(pfx .. "dizzypoints", v.dizzyPoints)
-			addParam(pfx .. "guardpoints", v.guardPoints)
-			addParam(pfx .. "existed", v.existed)
-			if type(v.maps) == "table" then
-				for mapName, mapValue in pairs(v.maps) do
-					if type(mapName) == "string" and mapValue ~= nil then
-						local key = mapName
-						if key:sub(1, 4):lower() == "map." then
-							key = key:sub(5)
-						end
-						if key ~= "" then
-							addParam(pfx .. "map." .. key, mapValue)
-						end
-					end
+	local params = start.f_buildLoadStartParams(t, true, start.t_orderRemap)
+	if gameOption('Debug.DumpLuaTables') then main.f_printTable(params, "debug/loadStartParams.txt") end
+	resetGameParams()
+	if not gameOption('Config.VsScreenLoading') then
+		-- If background loading is disabled, first select all chars, then start the loader.
+		for side = 1, 2 do
+			local remap = start.t_orderRemap and start.t_orderRemap[side]
+			for member = 1, #start.p[side].t_selected do
+				local src = remap and remap[member] or member
+				local v = start.p[side].t_selected[src]
+				if not v.selected then
+					selectChar(side, v.ref, v.pal, start.f_buildOverrideParams(side, member, v))
+					v.selected = true
 				end
 			end
 		end
+		loadStart(params)
+	else
+		-- Background loading: start loader first, then feed selections.
+		loadStart(params)
+		for side = 1, 2 do
+			local remap = start.t_orderRemap and start.t_orderRemap[side]
+			for member = 1, #start.p[side].t_selected do
+				local src = remap and remap[member] or member
+				local v = start.p[side].t_selected[src]
+				if not v.selected then
+					selectChar(side, v.ref, v.pal, start.f_buildOverrideParams(side, member, v))
+					v.selected = true
+				end
+			end
+		end
+		if main.f_storyboard(motif.vs_screen.loading.storyboard) then
+			loadCancel()
+			clearSelected()
+			return false
+		end
+		-- VS screen is normally responsible for showing loading progress.
+		-- If it was skipped/disabled, keep a small Lua render loop alive here.
+		local netReady = false
+		while loading() or not netReady do
+			if not loading() then
+				netReady = netLoadingReady()
+			end
+			clearColor(0, 0, 0)
+			main.f_animPosDraw(motif.vs_screen.loading.wait.AnimData)
+			textImgDraw(motif.vs_screen.loading.wait.TextSpriteData)
+			refresh()
+		end
 	end
-	addParam("persistlife", main.persistLife)
-	addParam("persistmusic", main.persistMusic)
-	addParam("persistrounds", main.persistRounds)
-	local params = table.concat(parts, ", ")
-	if gameOption('Debug.DumpLuaTables') then main.f_printTable(params, "debug/loadStartParams.txt") end
-	loadStart(params)
+	return true
 end
 
 return start

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -501,6 +501,7 @@ function start.f_setStage(num, assigned)
 		end
 	end
 	selectStage(num)
+	main.f_preloadBoostStage(num)
 	return num
 end
 
@@ -1699,6 +1700,9 @@ function start.f_selectMode()
 	start.f_selectReset(true)
 	while true do
 		--select screen
+		if gameOption('Config.BootLoadingMode') == 1 then
+			main.f_waitForPreloads()
+		end
 		if not start.f_selectScreen() then
 			sndPlay(motif.Snd, motif.select_info.cancel.snd[1], motif.select_info.cancel.snd[2])
 			bgReset(motif[main.background].BGDef)
@@ -1873,6 +1877,12 @@ function start.f_selectReset(hardReset, preserveProgress)
 	t_reservedChars = {{}, {}}
 	cursorActive = {}
 	cursorDone = {}
+	if main.preload ~= nil and main.preload.charHighlight ~= nil then
+		for _, ref in pairs(main.preload.charHighlight) do
+			queueCharPreload(ref, 1)
+		end
+		main.preload.charHighlight = {}
+	end
 	t_portraitPriority = {1, 1}
 	if start.challenger == 0 and not preserveProgress then
 		start.t_roster = {}
@@ -2332,6 +2342,41 @@ end
 --;===========================================================
 --; SELECT SCREEN
 --;===========================================================
+local function refreshActiveFacePortraits()
+	for side = 1, 2 do
+		for k, v in ipairs(start.p[side].t_selCmd) do
+			local member = main.f_tableLength(start.p[side].t_selected) + k
+			if main.coop and (side == 1 or gameMode('versuscoop')) then
+				member = k
+			end
+			local st = start.p[side].t_selTemp[member]
+			local player = v.player
+			local selRef = start.c[player].selRef
+			if v.selectState == 0 and st ~= nil and selRef ~= nil and st.ref == selRef then
+				local state = getCharPreloadStatus(selRef)
+				if state == 'ready' then
+					local pn = 2 * (member - 1) + side
+					local pCfg = f_getMotifP(motif.select_info, pn, side)
+					local updated = false
+					if st.face_data == nil then
+						st.face_anim = pCfg.face.anim
+						st.face_data = start.f_animGet(selRef, side, member, pCfg.face, nil, true, st.face_data)
+						updated = updated or st.face_data ~= nil
+					end
+					if st.face2_data == nil then
+						st.face2_anim = pCfg.face2.anim
+						st.face2_data = start.f_animGet(selRef, side, member, pCfg.face2, nil, true, st.face2_data)
+						updated = updated or st.face2_data ~= nil
+					end
+					if updated then
+						start.needUpdateDrawList = true
+					end
+				end
+			end
+		end
+	end
+end
+
 function start.updateDrawList()
 	local drawList = {}
 
@@ -2496,6 +2541,8 @@ function start.f_selectScreen()
 	start.needUpdateDrawList = false
 
 	while not selScreenEnd do
+		main.f_preloadTick(4)
+		refreshActiveFacePortraits()
 		counter = counter + 1
 		--draw clearcolor
 		clearColor(motif.selectbgdef.bgclearcolor[1], motif.selectbgdef.bgclearcolor[2], motif.selectbgdef.bgclearcolor[3])
@@ -2688,10 +2735,29 @@ function start.f_selectScreen()
 					)
 				end
 				if not stageEnd then
-					if (getInput(-1, motif.select_info.done.key) and not screenDelayInterrupted) or timerSelect == -1 then
-						sndPlay(motif.Snd, motif.select_info.stage.done.snd[1], motif.select_info.stage.done.snd[2])
-						stageTextData = motif.select_info.stage.done.TextSpriteData
-						stageEnd = true
+					local canConfirmStage = (getInput(-1, motif.select_info.done.key) and not screenDelayInterrupted) or timerSelect == -1
+					if canConfirmStage then
+						local preloadReady = true
+						if stageListNo > 0 then
+							local stageRef = main.t_selectableStages[stageListNo]
+							local state = getStagePreloadStatus(stageRef)
+							preloadReady = state == 'ready'
+							if not preloadReady then
+								main.f_preloadBoostStage(stageRef)
+							else
+								if main.f_materializeStagePortrait(stageRef) then
+									start.needUpdateDrawList = true
+								end
+							end
+						end
+						if not preloadReady and getInput(-1, motif.select_info.done.key) and not screenDelayInterrupted then
+							sndPlay(motif.Snd, motif.select_info.cancel.snd[1], motif.select_info.cancel.snd[2])
+						end
+						if preloadReady then
+							sndPlay(motif.Snd, motif.select_info.stage.done.snd[1], motif.select_info.stage.done.snd[2])
+							stageTextData = motif.select_info.stage.done.TextSpriteData
+							stageEnd = true
+						end
 					elseif stageActiveCount < motif.select_info.stage.active.switchtime then --delay change
 						stageActiveCount = stageActiveCount + 1
 					else
@@ -3281,6 +3347,7 @@ function start.f_selectMenu(side, cmd, player, member, selectState)
 			start.c[player].selX, start.c[player].selY = start.f_cellMovement(start.c[player].selX, start.c[player].selY, cmd, side, start.f_getCursorData(player).cursor.move.snd)
 			start.c[player].cell = start.c[player].selX + motif.select_info.columns * start.c[player].selY
 			start.c[player].selRef = start.f_selGrid(start.c[player].cell + 1).char_ref
+			main.f_preloadSetCharHighlight(player, start.c[player].selRef)
 			-- temp data not existing yet
 			if start.p[side].t_selTemp[member] == nil then
 				t_portraitPriority[side] = member
@@ -3299,6 +3366,9 @@ function start.f_selectMenu(side, cmd, player, member, selectState)
 				local timerExpired = motif.select_info.timer.count ~= -1 and timerSelect == -1
 				needUpdateDrawList = slotChanged
 				local velCopy = false
+				if slotChanged then
+					start.c[player].selRef = start.f_selGrid(start.c[player].cell + 1).char_ref
+				end
 				if timerExpired then
 					if start.c[player].selRef == nil or main.t_selChars[start.c[player].selRef + 1] == nil then
 						start.c[player].selRef = start.f_randomChar(side)
@@ -3354,6 +3424,7 @@ function start.f_selectMenu(side, cmd, player, member, selectState)
 				else
 					start.p[side].t_selTemp[member].inRandom = false
 				end
+				main.f_preloadSetCharHighlight(player, start.c[player].selRef)
 				-- update anim data
 				if updateAnim then
 					local face_data = velCopy and start.p[side].t_selTemp[member].face_data or nil
@@ -3362,7 +3433,26 @@ function start.f_selectMenu(side, cmd, player, member, selectState)
 					start.p[side].t_selTemp[member].face2_data = start.f_animGet(start.c[player].selRef, side, member, pCfg.face2, nil, true, face2_data)
 				end
 				-- cell selected or select screen timer reached 0
-				if (slotSelected and start.f_selGrid(start.c[player].cell + 1).char ~= nil and start.f_selGrid(start.c[player].cell + 1).hidden ~= 2) or timerExpired then
+				local canConfirm = (slotSelected and start.f_selGrid(start.c[player].cell + 1).char ~= nil and start.f_selGrid(start.c[player].cell + 1).hidden ~= 2) or timerExpired
+				if canConfirm then
+					local preloadReady = true
+					if start.c[player].selRef ~= nil then
+						local state = getCharPreloadStatus(start.c[player].selRef)
+						preloadReady = state == 'ready'
+						if not preloadReady then
+							main.f_preloadBoostChar(start.c[player].selRef)
+						else
+							main.f_materializeCharByRef(start.c[player].selRef)
+						end
+					end
+					if not preloadReady then
+						if slotSelected then
+							sndPlay(motif.Snd, motif.select_info.cancel.snd[1], motif.select_info.cancel.snd[2])
+						end
+						canConfirm = false
+					end
+				end
+				if canConfirm then
 					if motif.select_info.paletteselect ~= 0 then
 						timerSelect = motif.select_info.timer.displaytime
 					end
@@ -3476,6 +3566,7 @@ function start.f_selectMenu(side, cmd, player, member, selectState)
 				pn = start.f_getPlayerNo(side, member),
 				cursor = {start.c[player].selX, start.c[player].selY},
 			}
+			main.f_preloadSetCharHighlight(player, nil)
 			hook.run("start.f_selectMenu.selected", side, member, start.p[side].t_selected[member], start.p[side], player)
 			if not gameOption('Options.Team.Duplicates') then
 				t_reservedChars[side][start.c[player].selRef] = true
@@ -3571,6 +3662,9 @@ function start.f_stageMenu()
 	if n ~= stageListNo and stageListNo > 0 then
 		animReset(main.t_selStages[main.t_selectableStages[stageListNo]].anim_data)
 		animUpdate(main.t_selStages[main.t_selectableStages[stageListNo]].anim_data)
+	end
+	if stageListNo > 0 then
+		main.f_preloadBoostStage(main.t_selectableStages[stageListNo])
 	end
 end
 
@@ -3755,6 +3849,7 @@ function start.f_selectVersus(active, t_orderSelect, loadStartArg)
 		end
 	end
 	while true do
+		main.f_preloadTick(4)
 		local snd = false
 		-- CPU order select: randomize first, then selectChar() using randomized slot order
 		for side = 1, 2 do

--- a/src/char.go
+++ b/src/char.go
@@ -3515,7 +3515,7 @@ func (c *Char) prepareNextRound() {
 	//c.updateSizeBox()
 	c.oldPos, c.interPos = c.pos, c.pos
 	if c.helperIndex == 0 {
-		if sys.roundsExisted[c.playerNo&1] > 0 { // TODO: Why do we need this branch?
+		if c.roundsExisted() > 0 && c.palfx != nil { // TODO: Why do we need this branch?
 			c.palfx.clear()
 		} else {
 			c.palfx = newPalFX()
@@ -3569,10 +3569,23 @@ func (c *Char) si() *SelectChar {
 	return &sys.sel.charlist[c.selectNo]
 }
 
+func (c *Char) bgLoadedTurnsRoot() bool {
+	return sys.cfg.Config.TurnsLoading &&
+		c.helperIndex == 0 &&
+		c.playerNo >= 0 &&
+		c.playerNo < MaxSimul*2 &&
+		sys.tmode[c.playerNo&1] == TM_Turns
+}
+
 func (c *Char) ocd() *OverrideCharData {
 	team := c.teamside
 	if c.teamside == -1 {
-		team = 2
+		// BG-loaded Turns roots are hidden from gameplay with teamside -1, but their per-member overrides still belong to their real side.
+		if c.bgLoadedTurnsRoot() {
+			team = c.playerNo & 1
+		} else {
+			team = 2
+		}
 	}
 	if team < 0 || team > 2 || c.memberNo < 0 {
 		return newOverrideCharData()
@@ -5945,6 +5958,13 @@ func (c *Char) rightEdge() float32 {
 
 func (c *Char) roundsExisted() int32 {
 	if c.teamside == -1 {
+		// BG-loaded Turns keeps inactive team members resident as standby players. //They must still initialize like fresh entrants until their turn actually comes.
+		if c.bgLoadedTurnsRoot() && c.memberNo >= 0 {
+			team := c.playerNo & 1
+			if int32(c.memberNo) >= sys.wins[team^1] {
+				return 0
+			}
+		}
 		return sys.round - 1
 	}
 	return sys.roundsExisted[c.playerNo&1]

--- a/src/config.go
+++ b/src/config.go
@@ -114,6 +114,7 @@ type Config struct {
 		ZoomActive        bool     `ini:"ZoomActive" sync:"host"`
 		EscOpensMenu      bool     `ini:"EscOpensMenu" sync:"host"`
 		VsScreenLoading   bool     `ini:"VsScreenLoading" sync:"host"`
+		TurnsLoading      bool     `ini:"TurnsLoading" sync:"host"`
 		FirstRun          bool     `ini:"FirstRun"`
 		WindowTitle       string   `ini:"WindowTitle"`
 		WindowIcon        []string `ini:"WindowIcon"`

--- a/src/config.go
+++ b/src/config.go
@@ -113,6 +113,7 @@ type Config struct {
 		TickInterpolation bool     `ini:"TickInterpolation"`
 		ZoomActive        bool     `ini:"ZoomActive" sync:"host"`
 		EscOpensMenu      bool     `ini:"EscOpensMenu" sync:"host"`
+		VsScreenLoading   bool     `ini:"VsScreenLoading" sync:"host"`
 		FirstRun          bool     `ini:"FirstRun"`
 		WindowTitle       string   `ini:"WindowTitle"`
 		WindowIcon        []string `ini:"WindowIcon"`

--- a/src/config.go
+++ b/src/config.go
@@ -115,6 +115,7 @@ type Config struct {
 		EscOpensMenu      bool     `ini:"EscOpensMenu" sync:"host"`
 		VsScreenLoading   bool     `ini:"VsScreenLoading" sync:"host"`
 		TurnsLoading      bool     `ini:"TurnsLoading" sync:"host"`
+		BootLoadingMode   int32    `ini:"BootLoadingMode" sync:"host"`
 		FirstRun          bool     `ini:"FirstRun"`
 		WindowTitle       string   `ini:"WindowTitle"`
 		WindowIcon        []string `ini:"WindowIcon"`

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -5930,9 +5930,13 @@ func (fs *FightScreen) syncTeamOrder(side int) {
 	order := make([]int, 0, MaxSimul)
 	// Collect all the members of this team
 	for pn := side; pn < MaxSimul*2; pn += 2 {
-		if len(sys.chars[pn]) > 0 {
-			order = append(order, pn)
+		if len(sys.chars[pn]) == 0 || sys.chars[pn][0] == nil {
+			continue
 		}
+		if sys.chars[pn][0].teamside != side {
+			continue
+		}
+		order = append(order, pn)
 	}
 	// Sort them by memberNo
 	sort.Slice(order, func(i, j int) bool {

--- a/src/image.go
+++ b/src/image.go
@@ -1490,8 +1490,16 @@ func findActiveSff(filename string) *Sff {
 	return nil
 }
 
+// Deep loaders should be able to abort quickly when pre-match load is canceled.
+func loadingCanceled() bool {
+	return sys.loader.cancelRequested() || sys.gameEnd || sys.loader.state == LS_Cancel
+}
+
 // Loads the full SFF file
 func loadSff(filename string, char bool, isMainThread bool, isActPal bool) (*Sff, error) {
+	if loadingCanceled() {
+		return nil, ErrLoadingCanceled
+	}
 	// Borrow an existing SFF if possible
 	if s := findActiveSff(filename); s != nil {
 		return s, nil
@@ -1524,6 +1532,9 @@ func loadSff(filename string, char bool, isMainThread bool, isActPal bool) (*Sff
 	var prev *Sprite
 	shofs := int64(s.header.FirstSpriteHeaderOffset)
 	for i := 0; i < len(spriteList); i++ {
+		if loadingCanceled() {
+			return nil, ErrLoadingCanceled
+		}
 		f.Seek(shofs, 0)
 		spriteList[i] = newSprite()
 		var xofs, size uint32
@@ -1543,6 +1554,9 @@ func loadSff(filename string, char bool, isMainThread bool, isActPal bool) (*Sff
 		if size == 0 {
 			if int(indexOfPrevious) < i {
 				dst, src := spriteList[i], spriteList[int(indexOfPrevious)]
+				if loadingCanceled() {
+					return nil, ErrLoadingCanceled
+				}
 				// Moved to shareCopy() itself
 				//sys.mainThreadTask <- func() {
 				dst.shareCopy(src)
@@ -1581,8 +1595,14 @@ func loadSff(filename string, char bool, isMainThread bool, isActPal bool) (*Sff
 			shofs += 28
 		}
 		if isMainThread {
+			if loadingCanceled() {
+				return nil, ErrLoadingCanceled
+			}
 			sys.runMainThreadTask()
 		}
+	}
+	if loadingCanceled() {
+		return nil, ErrLoadingCanceled
 	}
 
 	/*
@@ -1904,6 +1924,9 @@ func (s *Sff) loadPalettes(f io.ReadSeeker, lofs uint32) error {
 	uniquePals := make(map[[2]uint16]int)
 
 	for i := 0; i < int(s.header.NumberOfPalettes); i++ {
+		if loadingCanceled() {
+			return ErrLoadingCanceled
+		}
 		f.Seek(int64(s.header.FirstPaletteHeaderOffset)+int64(i*16), 0)
 		var gn [3]uint16
 		if err := read(gn[:]); err != nil {

--- a/src/motif.go
+++ b/src/motif.go
@@ -72,9 +72,6 @@ type FontProperties struct {
 type FilesProperties struct {
 	Spr     string `ini:"spr" lookup:"def,,data/"`
 	Snd     string `ini:"snd" lookup:"def,,data/"`
-	Loading struct {
-		Storyboard string `ini:"storyboard" lookup:"def,,data/"`
-	} `ini:"loading"`
 	Logo struct {
 		Storyboard string `ini:"storyboard" lookup:"def,,data/"`
 	} `ini:"logo"`
@@ -792,6 +789,12 @@ type VsScreenProperties struct {
 		} `ini:"portrait"`
 		Snd [2]int32 `ini:"snd" default:"-1,0"`
 	} `ini:"stage"`
+	Loading struct {
+		AnimationTextProperties
+		Done       AnimationTextProperties `ini:"done"`
+		Wait       AnimationTextProperties `ini:"wait"`
+		Storyboard string                  `ini:"storyboard" lookup:"def,,data/"`
+	} `ini:"loading"`
 }
 
 type DemoModeProperties struct {
@@ -2216,6 +2219,7 @@ func (m *Motif) overrideParams() {
 		{SrcSec: "Select Info", SrcPrefix: "stage.", DstSec: "Select Info", DstPrefix: "stage.active2."},
 		{SrcSec: "Select Info", SrcPrefix: "stage.", DstSec: "Select Info", DstPrefix: "stage.done."},
 		// [VS Screen]
+		{SrcSec: "Title Info", SrcPrefix: "loading.", DstSec: "VS Screen", DstPrefix: "loading.wait."},
 		{SrcSec: "VS Screen", SrcPrefix: "p1.", DstSec: "VS Screen", DstPrefix: "p1.done."},
 		{SrcSec: "VS Screen", SrcPrefix: "p1.face2.", DstSec: "VS Screen", DstPrefix: "p1.face2.done."},
 		{SrcSec: "VS Screen", SrcPrefix: "p2.", DstSec: "VS Screen", DstPrefix: "p2.done."},

--- a/src/motif.go
+++ b/src/motif.go
@@ -640,7 +640,11 @@ type TitleInfoProperties struct {
 	Cancel struct {
 		Snd [2]int32 `ini:"snd" default:"-1,0"`
 	} `ini:"cancel"`
-	Loading TextProperties `ini:"loading"`
+	Loading struct {
+		TextProperties
+		Wait       AnimationTextProperties `ini:"wait"`
+		Storyboard string `ini:"storyboard" lookup:"def,,data/"`
+	} `ini:"loading"`
 	Footer  struct {
 		Title   TextProperties    `ini:"title"`
 		Info    TextProperties    `ini:"info"`
@@ -2196,6 +2200,8 @@ func (m *Motif) customResultsScreenSections() []string {
 func (m *Motif) overrideParams() {
 	// Define inheritance rules (section/prefix based).
 	specs := []InheritSpec{
+		// [Title Info]
+		{SrcSec: "Title Info", SrcPrefix: "loading.", DstSec: "Title Info", DstPrefix: "loading.wait."},
 		// [Option Info]
 		{SrcSec: "Option Info", SrcPrefix: "menu.", DstSec: "Option Info", DstPrefix: "keymenu."},
 		// [Select Info]

--- a/src/netplay.go
+++ b/src/netplay.go
@@ -174,6 +174,7 @@ type NetConnection struct {
 	closeOnce        sync.Once
 	uiInputDebounced bool
 	headerWritten    bool
+	loadingPhase     uint8 // 0=idle, 1=host sent token
 }
 
 func NewNetConnection() *NetConnection {
@@ -209,6 +210,8 @@ func (nc *NetConnection) Close() {
 	if nc == nil {
 		return
 	}
+	// Reset any pending loading rendezvous.
+	nc.loadingPhase = 0
 	// Ensure connect/accept goroutines stop retrying/handshaking.
 	nc.closeOnce.Do(func() {
 		if nc.closing != nil {
@@ -532,6 +535,8 @@ func (nc *NetConnection) Synchronize() error {
 	if !nc.IsConnected() || nc.st == NS_Error {
 		return Error("Cannot connect to the other player")
 	}
+	// Reset any pending loading rendezvous so it can't interfere with gameplay sync.
+	nc.loadingPhase = 0
 	nc.Stop()
 
 	header, err := sys.synchronizeNetplayConfig(nc)
@@ -686,6 +691,91 @@ func (nc *NetConnection) Synchronize() error {
 	log.Printf("Network synchronized: seed=%d pmTime=%d time=%d host=%v", seed, pmTime, nc.time, nc.host)
 
 	return nil
+}
+
+func (nc *NetConnection) ResetLoadingPhase() {
+	if nc == nil {
+		return
+	}
+	nc.loadingPhase = 0
+}
+
+func (nc *NetConnection) tryReadU8() (byte, bool, error) {
+	if nc == nil || nc.conn == nil {
+		return 0, false, Error("Cannot connect to the other player")
+	}
+	b := [1]byte{}
+	_ = nc.conn.SetReadDeadline(time.Now())
+	n, err := nc.conn.Read(b[:])
+	_ = nc.conn.SetReadDeadline(time.Time{})
+	if err != nil {
+		if ne, ok := err.(net.Error); ok && ne.Timeout() {
+			return 0, false, nil
+		}
+		return 0, false, err
+	}
+	if n <= 0 {
+		return 0, false, nil
+	}
+	return b[0], true, nil
+}
+
+// Handshake for both peers finished loading
+func (nc *NetConnection) LoadingReady() (bool, error) {
+	if nc == nil || !nc.IsConnected() || nc.st == NS_Error {
+		return false, Error("Cannot connect to the other player")
+	}
+	nc.Stop()
+
+	const token byte = 0xC7
+	const tokenI8 int8 = -57
+
+	// Host
+	if nc.host {
+		// Phase 0: send token once.
+		if nc.loadingPhase == 0 {
+			if err := nc.writeI8(tokenI8); err != nil {
+				nc.loadingPhase = 0
+				return false, err
+			}
+			nc.loadingPhase = 1
+			return false, nil
+		}
+		// Phase 1: wait for ack (non-blocking poll).
+		v, ok, err := nc.tryReadU8()
+		if err != nil {
+			nc.loadingPhase = 0
+			return false, err
+		}
+		if !ok {
+			return false, nil
+		}
+		if v != token {
+			nc.loadingPhase = 0
+			return false, Error("Synchronization error")
+		}
+		nc.loadingPhase = 0
+		return true, nil
+	}
+
+	// Guest: wait for token, then immediately ack.
+	v, ok, err := nc.tryReadU8()
+	if err != nil {
+		nc.loadingPhase = 0
+		return false, err
+	}
+	if !ok {
+		return false, nil
+	}
+	if v != token {
+		nc.loadingPhase = 0
+		return false, Error("Synchronization error")
+	}
+	if err := nc.writeI8(tokenI8); err != nil {
+		nc.loadingPhase = 0
+		return false, err
+	}
+	return true, nil
 }
 
 func (nc *NetConnection) Update() bool {

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -123,8 +123,8 @@ TickInterpolation   = 1
 ZoomActive          = 1
 ; Toggles if Esc key should open Pause menu.
 EscOpensMenu        = 1
-; Toggles match info loading during versus screen (currently not functional).
-; BackgroundLoading   = 0
+; Toggles match assets loading during versus screen.
+VsScreenLoading     = 0
 ; This is 1 the first time you run IKEMEN.
 FirstRun            = 1
 ; Title of the application window.

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -125,6 +125,8 @@ ZoomActive          = 1
 EscOpensMenu        = 1
 ; Toggles match assets loading during versus screen.
 VsScreenLoading     = 0
+; Toggles Turns member loading during the match.
+TurnsLoading        = 0
 ; This is 1 the first time you run IKEMEN.
 FirstRun            = 1
 ; Title of the application window.

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -127,6 +127,12 @@ EscOpensMenu        = 1
 VsScreenLoading     = 0
 ; Toggles Turns member loading during the match.
 TurnsLoading        = 0
+; Boot preload behavior for portraits, palettes and stage previews.
+; 0 = Off       : preload everything before entering menus / select. (default)
+; 1 = Wait      : preload in the background, but wait before entering select screen.
+;                 If logo/intro uses waitforloading = 1, that is used instead.
+; 2 = Immediate : enter menus and select screen immediately and load assets in the background.
+BootLoadingMode     = 0
 ; This is 1 the first time you run IKEMEN.
 FirstRun            = 1
 ; Title of the application window.

--- a/src/resources/defaultMotif.ini
+++ b/src/resources/defaultMotif.ini
@@ -3659,6 +3659,7 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	menu.itemname.menuengine.debugkeys = Debug Keys
 	menu.itemname.menuengine.debugmode = Debug Mode
 	menu.itemname.menuengine.vsscreenloading = VS Screen Loading
+	menu.itemname.menuengine.turnsloading = Turns Loading
 	menu.itemname.menuengine.spacer1 = -
 	menu.itemname.menuengine.helpermax = HelperMax
 	menu.itemname.menuengine.projectilemax = ProjectileMax

--- a/src/resources/defaultMotif.ini
+++ b/src/resources/defaultMotif.ini
@@ -2526,6 +2526,63 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	; attachedchar SND file associated with stage)
 	stage.snd = -1, 0
 
+	; Anim/text rendered during background loading
+	loading.anim = -1
+	loading.spr = -1, 0
+	loading.font = -1, 0, -1, 255, 255, 255, 255, -1
+	loading.offset = 0, 0
+	loading.facing = 1
+	loading.scale = 1.0, 1.0
+	loading.xshear = 0
+	loading.angle = 0
+	loading.xangle = 0
+	loading.yangle = 0
+	loading.projection = orthographic
+	loading.focallength = 2048
+	loading.text = LOADING...
+	loading.layerno = 0
+	loading.window = 
+	loading.localcoord = 
+
+	; Anim/text rendered after background loading finishes
+	loading.done.anim = -1
+	loading.done.spr = -1, 0
+	loading.done.font = -1, 0, -1, 255, 255, 255, 255, -1
+	loading.done.offset = 0, 0
+	loading.done.facing = 1
+	loading.done.scale = 1.0, 1.0
+	loading.done.xshear = 0
+	loading.done.angle = 0
+	loading.done.xangle = 0
+	loading.done.yangle = 0
+	loading.done.projection = orthographic
+	loading.done.focallength = 2048
+	loading.done.text = READY!
+	loading.done.layerno = 0
+	loading.done.window = 
+	loading.done.localcoord = 
+
+	; Anim/text rendered during background loading when vs screen is disabled
+	loading.wait.anim = -1
+	loading.wait.spr = -1, 0
+	loading.wait.font = default-3x5.def, 0, -1, 191, 191, 191, 255, -1
+	loading.wait.offset = 0, 0
+	loading.wait.facing = 1
+	loading.wait.scale = 1.0, 1.0
+	loading.wait.xshear = 0
+	loading.wait.angle = 0
+	loading.wait.xangle = 0
+	loading.wait.yangle = 0
+	loading.wait.projection = orthographic
+	loading.wait.focallength = 2048
+	loading.wait.text = LOADING...
+	loading.wait.layerno = 0
+	loading.wait.window = 
+	loading.wait.localcoord = 
+
+	; Optional storyboard used when vs screen is disabled instead of loading.wait
+	loading.storyboard = 
+
 [VersusBgDef]
 	spr = 
 	bgclearcolor = 0, 0, 0
@@ -3601,6 +3658,7 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	menu.itemname.menuengine.players = Players
 	menu.itemname.menuengine.debugkeys = Debug Keys
 	menu.itemname.menuengine.debugmode = Debug Mode
+	menu.itemname.menuengine.vsscreenloading = VS Screen Loading
 	menu.itemname.menuengine.spacer1 = -
 	menu.itemname.menuengine.helpermax = HelperMax
 	menu.itemname.menuengine.projectilemax = ProjectileMax

--- a/src/resources/defaultMotif.ini
+++ b/src/resources/defaultMotif.ini
@@ -460,6 +460,27 @@
 	loading.window = 
 	loading.localcoord = 
 
+	; Boot-loading wait element rendered on black screen when BootLoadingMode = 1
+	loading.wait.anim = -1
+	loading.wait.spr = -1, 0
+	loading.wait.font = default-3x5.def, 0, -1, 191, 191, 191, 255, -1
+	loading.wait.offset = 0, 0
+	loading.wait.facing = 1
+	loading.wait.scale = 1.0, 1.0
+	loading.wait.xshear = 0
+	loading.wait.angle = 0
+	loading.wait.xangle = 0
+	loading.wait.yangle = 0
+	loading.wait.projection = orthographic
+	loading.wait.focallength = 2048
+	loading.wait.text = LOADING...
+	loading.wait.layerno = 0
+	loading.wait.window = 
+	loading.wait.localcoord = 320, 240
+
+	; Optional storyboard used by BootLoadingMode = 1 instead of loading.wait
+	loading.storyboard =
+
 	; Footer parameters control rendering of engine version info. Separated into
 	; 3 elements to allow left/center/right text align at the same time.
 	; Unless overridden, offsets and version text are set when loading the motif.

--- a/src/resources/defaultStoryboard.ini
+++ b/src/resources/defaultStoryboard.ini
@@ -3,3 +3,4 @@ key.skip = s
 key.cancel = a, b, c, x, y, z, m
 stopmusic = 1
 disablecancel = 0
+waitforloading = 0

--- a/src/script.go
+++ b/src/script.go
@@ -1163,7 +1163,14 @@ func systemScriptInit(l *lua.LState) {
 		@treturn Anim|nil anim A new `Anim` userdata wrapping the preloaded animation,
 		  or `nil` if no matching animation exists.
 		function animGetPreloadedCharData(charRef, group, number, keepLoop) end*/
-		if anim := sys.sel.GetChar(int(numArg(l, 1))).anims.get(int32(numArg(l, 2)), int32(numArg(l, 3))); anim != nil {
+		sys.sel.preloadMu.Lock()
+		ch := sys.sel.GetChar(int(numArg(l, 1)))
+		var anim *Animation
+		if ch != nil {
+			anim = ch.anims.get(int32(numArg(l, 2)), int32(numArg(l, 3)))
+		}
+		sys.sel.preloadMu.Unlock()
+		if anim != nil {
 			a := NewAnim(nil, "")
 			a.anim = anim
 			if !nilArg(l, 4) && !boolArg(l, 4) && a.anim.totaltime == a.anim.looptime {
@@ -1188,7 +1195,14 @@ func systemScriptInit(l *lua.LState) {
 		@treturn Anim|nil anim A new `Anim` userdata wrapping the preloaded animation,
 		  or `nil` if no matching animation exists.
 		function animGetPreloadedStageData(stageRef, group, number, keepLoop) end*/
-		if anim := sys.sel.GetStage(int(numArg(l, 1))).anims.get(int32(numArg(l, 2)), int32(numArg(l, 3))); anim != nil {
+		sys.sel.preloadMu.Lock()
+		st := sys.sel.GetStage(int(numArg(l, 1)))
+		var anim *Animation
+		if st != nil {
+			anim = st.anims.get(int32(numArg(l, 2)), int32(numArg(l, 3)))
+		}
+		sys.sel.preloadMu.Unlock()
+		if anim != nil {
 			a := NewAnim(nil, "")
 			a.anim = anim
 			if !nilArg(l, 4) && !boolArg(l, 4) && a.anim.totaltime == a.anim.looptime {
@@ -3397,6 +3411,18 @@ func systemScriptInit(l *lua.LState) {
 		l.Push(lua.LString(c.name))
 		return 1
 	})
+	luaRegister(l, "getCharPreloadStatus", func(l *lua.LState) int {
+		/*Query the background preload state of a character slot.
+		@function getCharPreloadStatus
+		@tparam int charRef 0-based character index in the select list.
+		@treturn string state Preload state: `"idle"`, `"queued"`, `"loading"`, `"ready"`, or `"error"`.
+		@treturn string err Error message (empty string if no error).
+		function getCharPreloadStatus(charRef) end*/
+		state, err := sys.sel.CharPreloadStatus(int(numArg(l, 1)))
+		l.Push(lua.LString(state.String()))
+		l.Push(lua.LString(err))
+		return 2
+	})
 	luaRegister(l, "getCharRandomPalette", func(*lua.LState) int {
 		/*Get a random valid palette number for a character slot.
 		@function getCharRandomPalette
@@ -4004,6 +4030,18 @@ func systemScriptInit(l *lua.LState) {
 		function getStageNo() end*/
 		l.Push(lua.LNumber(sys.sel.selectedStageNo))
 		return 1
+	})
+	luaRegister(l, "getStagePreloadStatus", func(l *lua.LState) int {
+		/*Query the background preload state of a stage slot.
+		@function getStagePreloadStatus
+		@tparam int stageRef Stage index as used by the select system.
+		@treturn string state Preload state: `"idle"`, `"queued"`, `"loading"`, `"ready"`, or `"error"`.
+		@treturn string err Error message (empty string if no error).
+		function getStagePreloadStatus(stageRef) end*/
+		state, err := sys.sel.StagePreloadStatus(int(numArg(l, 1)))
+		l.Push(lua.LString(state.String()))
+		l.Push(lua.LString(err))
+		return 2
 	})
 	luaRegister(l, "getStageSelectParams", func(*lua.LState) int {
 		/*Get parsed select parameters for a stage entry.
@@ -5443,6 +5481,14 @@ func systemScriptInit(l *lua.LState) {
 		l.Push(lua.LBool(sys.postMatchFlg))
 		return 1
 	})
+	luaRegister(l, "preloading", func(l *lua.LState) int {
+		/*Check whether resources are currently being preloaded.
+		@function preloading
+		@treturn boolean `true` if assets are still being preloaded.
+		function preloading() end*/
+		l.Push(lua.LBool(!sys.sel.AllPreloadsReady()))
+		return 1
+	})
 	luaRegister(l, "preloadListChar", func(*lua.LState) int {
 		/*Mark a character sprite or animation for preloading.
 		@function preloadListChar
@@ -5491,6 +5537,34 @@ func systemScriptInit(l *lua.LState) {
 		@tparam string text Text to print.
 		function puts(text) end*/
 		fmt.Println(strArg(l, 1))
+		return 0
+	})
+	luaRegister(l, "queueCharPreload", func(l *lua.LState) int {
+		/*Queue a character for background preloading of portraits and palettes.
+		@function queueCharPreload
+		@tparam int charRef 0-based character index in the select list.
+		@tparam[opt=1] int priority Priority level (`1` = low, `2` = high).
+		function queueCharPreload(charRef, priority) end*/
+		ref := int(numArg(l, 1))
+		priority := PreloadPriorityLow
+		if !nilArg(l, 2) {
+			priority = int(numArg(l, 2))
+		}
+		sys.sel.QueueCharPreload(ref, priority)
+		return 0
+	})
+	luaRegister(l, "queueStagePreload", func(l *lua.LState) int {
+		/*Queue a stage for background preloading of portraits.
+		@function queueStagePreload
+		@tparam int stageRef Stage index as used by the select system.
+		@tparam[opt=1] int priority Priority level (`1` = low, `2` = high).
+		function queueStagePreload(stageRef, priority) end*/
+		ref := int(numArg(l, 1))
+		priority := PreloadPriorityLow
+		if !nilArg(l, 2) {
+			priority = int(numArg(l, 2))
+		}
+		sys.sel.QueueStagePreload(ref, priority)
 		return 0
 	})
 	luaRegister(l, "rectDebug", func(*lua.LState) int {

--- a/src/script.go
+++ b/src/script.go
@@ -2914,6 +2914,13 @@ func systemScriptInit(l *lua.LState) {
 		@treturn int32 winSide Winning side index (`1` or `2`), `0` for draw, `-1` if the game was ended externally.
 		@treturn[opt] int controllerNo 1-based controller index of the challenger player interrupting `arcade` mode.
 		function game() end*/
+		defer func() {
+			if sys.loader.state == LS_Loading {
+				sys.loader.reset()
+			}
+		}()
+		sys.keyString = ""
+		sys.keyInput = KeyUnknown
 		sys.luaDiscardDrawQueue()
 		sys.gameRunning = true
 		sys.motif.fadeIn.reset()
@@ -2970,6 +2977,9 @@ func systemScriptInit(l *lua.LState) {
 				if sys.loader.state == LS_Cancel {
 					return -1, nil
 				}
+
+				// Apply fight/stage aspect only after loading is complete
+				sys.setGameAspect()
 
 				// Assign round start player ID's
 				sys.initPlayerID()
@@ -4780,30 +4790,48 @@ func systemScriptInit(l *lua.LState) {
 		@function loadStart
 		@tparam[opt] string params Optional comma-separated parameter string (from launchFight and quickvs options)
 		function loadStart(params) end*/
-		if sys.gameMode != "randomtest" {
+		if !sys.cfg.Config.VsScreenLoading {
+			sys.selMutex.RLock()
 			for k, v := range sys.sel.selected {
 				if len(v) < int(sys.numSimul[k]) {
+					sys.selMutex.RUnlock()
 					l.RaiseError("\nNot enough P%v side chars to load: expected %v, got %v\n", k+1, sys.numSimul[k], len(v))
 				}
 			}
+			sys.selMutex.RUnlock()
 		}
-		if sys.sel.selectedStageNo == -1 {
+		sys.selMutex.RLock()
+		stageNo := sys.sel.selectedStageNo
+		sys.selMutex.RUnlock()
+		if stageNo == -1 {
 			l.RaiseError("\nStage not selected for load\n")
 		}
 		// Always reset per-launch params; they must not leak across matches/modes.
+		sys.selMutex.Lock()
 		if sys.sel.gameParams == nil {
 			sys.sel.gameParams = newGameParamsFromMotif(&sys.motif)
-		} else {
-			sys.sel.gameParams.ResetFromMotif(&sys.motif)
 		}
 		sys.sel.music = make(Music)
+		sys.selMutex.Unlock()
 		if !nilArg(l, 1) {
 			entries := SplitAndTrim(StripComment(strArg(l, 1)), ",")
+			sys.selMutex.Lock()
 			sys.sel.gameParams.AppendParams(entries)
-			// Feed normalized music params to Music.
 			sys.sel.music.AppendParams(sys.sel.gameParams.MusicEntries())
+			sys.selMutex.Unlock()
 		}
 		sys.loadStart()
+		// Reset the pre-match loading rendezvous each time we start a load.
+		if sys.netConnection != nil {
+			sys.netConnection.ResetLoadingPhase()
+		}
+		return 0
+	})
+	luaRegister(l, "loadCancel", func(*lua.LState) int {
+		/*Cancel an in-progress background load, clean up partially loaded assets, and reset the netplay loading handshake.
+		@function loadCancel
+		function loadCancel() end*/
+		sys.loadCancel()
 		return 0
 	})
 	luaRegister(l, "loadState", func(*lua.LState) int {
@@ -4863,6 +4891,14 @@ func systemScriptInit(l *lua.LState) {
 		}
 		sys.debugWC.mapSet(strArg(l, 1), float32(numArg(l, 2)), scType)
 		return 0
+	})
+	luaRegister(l, "storyboardCanceled", func(l *lua.LState) int {
+		/*Check whether the most recent storyboard was canceled by the player.
+		@function storyboardCanceled
+		@treturn boolean canceled `true` if the storyboard was canceled via Esc or cancel key.
+		function storyboardCanceled() end*/
+		l.Push(lua.LBool(sys.storyboard.canceled))
+		return 1
 	})
 	luaRegister(l, "modelNew", func(l *lua.LState) int {
 		/*Load a 3D model (glTF) as a Model object.
@@ -5010,6 +5046,22 @@ func systemScriptInit(l *lua.LState) {
 		@treturn boolean active `true` if netplay is currently active.
 		function netPlay() end*/
 		l.Push(lua.LBool(sys.netplay()))
+		return 1
+	})
+	luaRegister(l, "netLoadingReady", func(l *lua.LState) int {
+		/*Poll the non-blocking netplay loading handshake. Returns `true` when both peers have finished loading, or immediately if not in netplay.
+		@function netLoadingReady
+		@treturn boolean ready `true` if both sides are ready (or no net connection exists).
+		function netLoadingReady() end*/
+		if sys.netConnection == nil {
+			l.Push(lua.LBool(true))
+			return 1
+		}
+		ready, err := sys.netConnection.LoadingReady()
+		if err != nil {
+			l.RaiseError(err.Error())
+		}
+		l.Push(lua.LBool(ready))
 		return 1
 	})
 	luaRegister(l, "panicError", func(*lua.LState) int {
@@ -5662,6 +5714,17 @@ func systemScriptInit(l *lua.LState) {
 		sys.persistRoundCount = 0
 		return 0
 	})
+	luaRegister(l, "resetGameParams", func(*lua.LState) int {
+		/*Reset per-match game parameters to motif defaults. Called before `loadStart` when background loading feeds params incrementally via `selectChar`.
+		@function resetGameParams
+		function resetGameParams() end*/
+		if sys.sel.gameParams == nil {
+			sys.sel.gameParams = newGameParamsFromMotif(&sys.motif)
+		} else {
+			sys.sel.gameParams.ResetFromMotif(&sys.motif)
+		}
+		return 0
+	})
 	luaRegister(l, "resetKey", func(*lua.LState) int {
 		/*Clear the last captured key and text input.
 		@function resetKey
@@ -5878,17 +5941,18 @@ func systemScriptInit(l *lua.LState) {
 		l.Push(lua.LString(SearchFile(strArg(l, 1), dirs)))
 		return 1
 	})
-	luaRegister(l, "selectChar", func(*lua.LState) int {
+	luaRegister(l, "selectChar", func(l *lua.LState) int {
 		/*Add a character to a team's selection.
 		@function selectChar
 		@tparam int teamSide Team side (`1` or `2`).
 		@tparam int charRef 0-based character index in the select list.
 		@tparam int palette Palette number.
+		@tparam[opt] string overrideParams Optional comma-separated override parameters.
 		@treturn int status Selection status:
 		  - `0` – character not added
 		  - `1` – added, team is not yet full
 		  - `2` – added, team is now full
-		function selectChar(teamSide, charRef, palette) end*/
+		function selectChar(teamSide, charRef, palette, overrideParams) end*/
 		cn := int(numArg(l, 2))
 		if cn < 0 || cn >= len(sys.sel.charlist) {
 			l.RaiseError("\nInvalid char ref: %v\n", cn)
@@ -5903,23 +5967,44 @@ func systemScriptInit(l *lua.LState) {
 		}
 		var ret int
 		if sys.sel.AddSelectedChar(tn-1, cn, pl) {
-			switch sys.tmode[tn-1] {
+			if !nilArg(l, 4) {
+				if s, ok := l.Get(4).(lua.LString); ok {
+					str := strings.TrimSpace(string(s))
+					if str != "" {
+						entries := SplitAndTrim(str, ",")
+						sys.selMutex.Lock()
+						if sys.sel.gameParams == nil {
+							sys.sel.gameParams = newGameParamsFromMotif(&sys.motif)
+						}
+						sys.sel.gameParams.AppendParams(entries)
+						sys.selMutex.Unlock()
+					}
+				}
+			}
+			// Snapshot selection-dependent values under selMutex to avoid races with BG loader.
+			sys.selMutex.RLock()
+			tm := sys.tmode[tn-1]
+			selLen := len(sys.sel.selected[tn-1])
+			nSim := sys.numSimul[tn-1]
+			nTurns := sys.numTurns[tn-1]
+			sys.selMutex.RUnlock()
+			switch tm {
 			case TM_Single:
 				ret = 2
 			case TM_Simul:
-				if len(sys.sel.selected[tn-1]) >= int(sys.numSimul[tn-1]) {
+				if selLen >= int(nSim) {
 					ret = 2
 				} else {
 					ret = 1
 				}
 			case TM_Turns:
-				if len(sys.sel.selected[tn-1]) >= int(sys.numTurns[tn-1]) {
+				if selLen >= int(nTurns) {
 					ret = 2
 				} else {
 					ret = 1
 				}
 			case TM_Tag:
-				if len(sys.sel.selected[tn-1]) >= int(sys.numSimul[tn-1]) {
+				if selLen >= int(nSim) {
 					ret = 2
 				} else {
 					ret = 1
@@ -6506,6 +6591,7 @@ func systemScriptInit(l *lua.LState) {
 		if nt < 1 || (tm != TM_Turns && nt > MaxSimul) {
 			l.RaiseError("\nInvalid team size: %v\n", nt)
 		}
+		sys.selMutex.Lock()
 		sys.sel.selected[tn-1] = nil
 		//sys.sel.ocd[tn-1] = nil
 		sys.tmode[tn-1] = tm
@@ -6518,6 +6604,7 @@ func systemScriptInit(l *lua.LState) {
 		if (tm == TM_Simul || tm == TM_Tag) && nt == 1 {
 			sys.tmode[tn-1] = TM_Single
 		}
+		sys.selMutex.Unlock()
 		return 0
 	})
 	luaRegister(l, "setTime", func(*lua.LState) int {

--- a/src/script.go
+++ b/src/script.go
@@ -2978,6 +2978,31 @@ func systemScriptInit(l *lua.LState) {
 					return -1, nil
 				}
 
+				// Build Turns teammate portraits after loading, when Lua order selection is complete.
+				if sys.round == 1 {
+					for side, tm := range sys.tmode {
+						if tm != TM_Turns {
+							continue
+						}
+						sys.selMutex.RLock()
+						teamSel := make([][2]int, len(sys.sel.selected[side]))
+						copy(teamSel, sys.sel.selected[side])
+						sys.selMutex.RUnlock()
+						if len(teamSel) == 0 ||
+							side >= len(sys.fightScreen.faces[TM_Turns]) ||
+							sys.fightScreen.faces[TM_Turns][side] == nil ||
+							sys.fightScreen.names[TM_Turns][side] == nil {
+							continue
+						}
+						teamChars := make([]int, len(teamSel))
+						for i := range teamSel {
+							teamChars[i] = teamSel[i][0]
+						}
+						sys.loader.prepareTurnsFaces(side, sys.fightScreen.faces[TM_Turns][side],
+							sys.fightScreen.names[TM_Turns][side], teamChars, teamSel)
+					}
+				}
+
 				// Apply fight/stage aspect only after loading is complete
 				sys.setGameAspect()
 
@@ -2986,11 +3011,16 @@ func systemScriptInit(l *lua.LState) {
 
 				for i, c := range sys.chars {
 					if len(c) > 0 {
+						// Skip BG-loaded Turns mode chars so CharList bookkeeping doesn't try to replace nonexistent entries on later rounds.
+						if sys.cfg.Config.TurnsLoading && sys.tmode[i&1] == TM_Turns && c[0].teamside == -1 {
+							continue
+						}
 						// Add or replace in charList
 						if sys.round == 1 {
 							sys.charList.add(c[0])
 						} else if c[0].roundsExisted() == 0 {
-							if !sys.charList.replace(c[0], i, 0) {
+							// BG-loaded Turns switching updates CharList inside activateNextTurnsFighters().
+							if !(sys.cfg.Config.TurnsLoading && sys.tmode[i&1] == TM_Turns) && !sys.charList.replace(c[0], i, 0) {
 								panic(fmt.Errorf("failed to replace player: %v", i))
 							}
 						}
@@ -3116,7 +3146,19 @@ func systemScriptInit(l *lua.LState) {
 					}
 				}
 
-				sys.loader.reset()
+				if sys.cfg.Config.TurnsLoading {
+					// The next Turns member is loaded in the background during the previous round.
+					// If the round ended before that load finished, wait here before promotion.
+					if sys.loader.state != LS_NotYet && sys.loader.state != LS_Complete {
+						if err := load(); err != nil {
+							l.RaiseError(err.Error())
+						}
+					}
+					sys.activateNextTurnsFighters()
+				} else {
+					// Legacy Turns behavior: reload the next fighter between rounds.
+					sys.loader.reset()
+				}
 			}
 
 			// If not restarting match
@@ -4793,9 +4835,13 @@ func systemScriptInit(l *lua.LState) {
 		if !sys.cfg.Config.VsScreenLoading {
 			sys.selMutex.RLock()
 			for k, v := range sys.sel.selected {
-				if len(v) < int(sys.numSimul[k]) {
+				expected := int(sys.numSimul[k])
+				if sys.tmode[k] == TM_Turns && sys.cfg.Config.TurnsLoading {
+					expected = int(sys.numTurns[k])
+				}
+				if len(v) < expected {
 					sys.selMutex.RUnlock()
-					l.RaiseError("\nNot enough P%v side chars to load: expected %v, got %v\n", k+1, sys.numSimul[k], len(v))
+					l.RaiseError("\nNot enough P%v side chars to load: expected %v, got %v\n", k+1, expected, len(v))
 				}
 			}
 			sys.selMutex.RUnlock()

--- a/src/storyboard.go
+++ b/src/storyboard.go
@@ -107,8 +107,9 @@ type Storyboard struct {
 			Skip   []string `ini:"skip"`
 			Cancel []string `ini:"cancel"`
 		} `ini:"key"`
-		StopMusic     bool `ini:"stopmusic"`
-		DisableCancel bool `ini:"disablecancel"`
+		StopMusic      bool `ini:"stopmusic"`
+		DisableCancel  bool `ini:"disablecancel"`
+		WaitForLoading bool `ini:"waitforloading"`
 	} `ini:"scenedef"`
 	Scene         map[string]*SceneProperties `ini:"map:^(?i)scene_?[0-9]+$" lua:"scene"`
 	fntIndexByKey map[string]int
@@ -119,11 +120,13 @@ type Storyboard struct {
 	endTimer          int32
 	sceneKeys         []string
 	currentSceneIndex int
-	cancel            bool
+	canceled          bool
 	musicPlaying      bool
 	fadePolicy        FadeStartPolicy
 	dialogueLayers    []*LayerProperties // ordered text layers (StartTime asc, then layer index)
 	dialoguePos       int                // current layer index into dialogueLayers
+	netReady          bool
+	loadEnding        bool
 }
 
 // loadStoryboard loads and parses the INI file into a struct.
@@ -441,7 +444,9 @@ func (s *Storyboard) reset() {
 	s.initialized = false
 	s.endTimer = -1
 	s.currentSceneIndex = s.SceneDef.StartScene
-	s.cancel = false
+	s.canceled = false
+	s.netReady = false
+	s.loadEnding = false
 	for _, sceneProps := range s.Scene {
 		if sceneProps.Bg.Name != "" {
 			sceneProps.Bg.BGDef.Reset()
@@ -605,11 +610,14 @@ func (s *Storyboard) step() {
 		(!sys.motif.AttractMode.Enabled && sys.uiRawInput(s.SceneDef.Key.Cancel, -1)) ||
 		(!sys.gameRunning && sys.motif.AttractMode.Enabled && sys.credits > 0)) {
 		sys.esc = false
-		s.cancel = true
+		s.canceled = true
 	}
 
 	// Skip handling
 	skipPressed := sys.uiRawInput(s.SceneDef.Key.Skip, -1)
+	if s.SceneDef.WaitForLoading {
+		skipPressed = false
+	}
 
 	// Keep dialogue cursor aligned with time progression.
 	s.syncDialoguePosToTime()
@@ -671,10 +679,42 @@ func (s *Storyboard) step() {
 			startFadeAt = 0
 		}
 	}
-	reachedEndTime := endTime <= 0 || (startFadeAt >= 0 && s.counter >= startFadeAt)
+	// Loading storyboard: when local loading is done, poll net rendezvous (non-blocking) and auto-finish with fadeout.
+	if s.SceneDef.WaitForLoading && !s.canceled && !s.loadEnding && s.endTimer == -1 {
+		if sys.loader.state != LS_Loading {
+			if sys.netConnection == nil {
+				s.netReady = true
+			} else if !s.netReady {
+				ready, err := sys.netConnection.LoadingReady()
+				if err != nil {
+					LogMessage("Loading storyboard: %v", err)
+					s.canceled = true
+				} else {
+					s.netReady = ready
+				}
+			}
+			if s.netReady && !s.canceled {
+				startFadeOut(sceneProps.FadeOut.FadeData, sys.motif.fadeOut, false, s.fadePolicy)
+				s.endTimer = s.counter + sys.motif.fadeOut.timeRemaining
+				s.loadEnding = true
+			}
+		}
+	}
 
-	if s.endTimer == -1 && (reachedEndTime || s.cancel || skipAdvancesScene) {
-		userInterrupt := s.cancel || skipAdvancesScene
+	reachedEndTime := endTime <= 0 || (startFadeAt >= 0 && s.counter >= startFadeAt)
+	// Loading storyboard: don't end when the *final* scene timer finishes; keep the last scene running.
+	if s.SceneDef.WaitForLoading && !s.loadEnding && !s.canceled && reachedEndTime {
+		next := s.currentSceneIndex + 1
+		if sceneProps.Jump != nil && *sceneProps.Jump != s.currentSceneIndex {
+			next = *sceneProps.Jump
+		}
+		if next >= len(s.sceneKeys) {
+			reachedEndTime = false
+		}
+	}
+
+	if s.endTimer == -1 && (reachedEndTime || s.canceled || skipAdvancesScene) {
+		userInterrupt := s.canceled || skipAdvancesScene
 		startFadeOut(sceneProps.FadeOut.FadeData, sys.motif.fadeOut, userInterrupt, s.fadePolicy)
 		s.endTimer = s.counter + sys.motif.fadeOut.timeRemaining
 	}
@@ -741,9 +781,23 @@ func (s *Storyboard) step() {
 		if sys.motif.fadeOut != nil {
 			sys.motif.fadeOut.reset()
 		}
+		// Loading storyboard: once we started the auto-fade, finish immediately after fadeout.
+		if s.loadEnding {
+			if s.musicPlaying && s.SceneDef.StopMusic {
+				sys.bgm.Stop()
+			}
+			for _, cl := range sys.commandLists {
+				if cl != nil {
+					cl.BufReset()
+				}
+			}
+			s.active = false
+			s.loadEnding = false
+			return
+		}
 		s.counter = 0
 		s.endTimer = -1
-		if s.cancel {
+		if s.canceled {
 			s.currentSceneIndex = len(s.sceneKeys)
 		} else {
 			if sceneProps.Jump != nil && *sceneProps.Jump != s.currentSceneIndex {

--- a/src/storyboard.go
+++ b/src/storyboard.go
@@ -679,9 +679,10 @@ func (s *Storyboard) step() {
 			startFadeAt = 0
 		}
 	}
-	// Loading storyboard: when local loading is done, poll net rendezvous (non-blocking) and auto-finish with fadeout.
+	// Loading storyboard: when local loading and boot preloading are done,
+	// poll net rendezvous (non-blocking) and auto-finish with fadeout.
 	if s.SceneDef.WaitForLoading && !s.canceled && !s.loadEnding && s.endTimer == -1 {
-		if sys.loader.state != LS_Loading {
+		if sys.loader.state != LS_Loading && sys.sel.AllPreloadsReady() {
 			if sys.netConnection == nil {
 				s.netReady = true
 			} else if !s.netReady {

--- a/src/system.go
+++ b/src/system.go
@@ -240,6 +240,7 @@ type System struct {
 	chars               [MaxPlayerNo][]*Char
 	charList            CharList
 	cgi                 [MaxPlayerNo]CharGlobalInfo
+	turnsPreloadMember  [2]int // -1 = none; otherwise selected Turns member index to load into side+2
 	selMutex            sync.RWMutex
 	loadMutex           sync.Mutex
 	ignoreMostErrors    bool
@@ -981,6 +982,7 @@ func (s *System) resetRemapInput() {
 
 func (s *System) loaderReset() {
 	s.round, s.wins, s.roundsExisted, s.decisiveRound = 1, [2]int32{}, [2]int32{}, [2]bool{}
+	s.turnsPreloadMember = [2]int{-1, -1}
 	s.loader.reset()
 }
 
@@ -2023,6 +2025,10 @@ func (s *System) initPlayerID() {
 		c := sys.chars[i][0]
 
 		if sys.round == 1 || c.roundsExisted() == 0 {
+			// In BG-loaded Turns, promoted fighters already have a valid ID
+			if sys.cfg.Config.TurnsLoading && sys.tmode[i&1] == TM_Turns && c.id >= 0 {
+				return
+			}
 			c.id = sys.newCharId()
 		}
 	}
@@ -3254,6 +3260,7 @@ func (s *System) roundEndDecision() bool {
 	checkPerfect := func(team int) bool {
 		for i := team; i < MaxSimul*2; i += 2 {
 			if len(s.chars[i]) > 0 &&
+				s.chars[i][0].teamside != -1 &&
 				s.chars[i][0].life < s.chars[i][0].lifeMax {
 				return false
 			}
@@ -3269,7 +3276,7 @@ func (s *System) roundEndDecision() bool {
 		for i := team; i < MaxSimul*2; i += 2 {
 			if len(s.chars[i]) > 0 {
 				char := s.chars[i][0]
-				if float32(char.life) > float32(char.lifeMax)*clutchRatio {
+				if char.teamside != -1 && float32(char.life) > float32(char.lifeMax)*clutchRatio {
 					return false
 				}
 			}
@@ -3309,6 +3316,9 @@ func (s *System) roundEndDecision() bool {
 		for i := 0; i < 2; i++ { // Check life percentage of each team
 			for j := i; j < MaxSimul*2; j += 2 {
 				if len(s.chars[j]) > 0 {
+					if s.chars[j][0].teamside == -1 {
+						continue
+					}
 					if s.tmode[i] == TM_Simul || s.tmode[i] == TM_Tag {
 						l[i] += (float32(s.chars[j][0].life) / float32(s.numSimul[i])) / float32(s.chars[j][0].lifeMax)
 					} else {
@@ -3367,7 +3377,7 @@ func (s *System) roundEndDecision() bool {
 	// Update win triggers if finish type was changed
 	if ft != s.finishType {
 		for i, p := range s.chars {
-			if len(p) > 0 && ko[^i&1] {
+			if len(p) > 0 && p[0].teamside != -1 && ko[^i&1] {
 				for _, h := range p {
 					for _, tid := range h.targets {
 						if t := s.playerID(tid); t != nil {
@@ -3711,7 +3721,8 @@ func (s *System) runMatch() (reload bool) {
 		s.allPalFX.enable = false
 		for i, p := range s.chars {
 			if len(p) > 0 {
-				forceDestroy := s.matchOver() || (s.tmode[i&1] == TM_Turns && p[0].life <= 0)
+				forceDestroy := s.matchOver() ||
+					(s.tmode[i&1] == TM_Turns && p[0].teamside != -1 && p[0].life <= 0)
 				s.clearPlayerAssets(i, forceDestroy)
 			}
 		}
@@ -3756,6 +3767,10 @@ func (s *System) runMatch() (reload bool) {
 	// Save round 1 backup separately
 	if s.round == 1 {
 		s.matchBackup = s.roundBackup
+	}
+
+	if s.cfg.Config.TurnsLoading {
+		s.startNextTurnsPreload()
 	}
 
 	// Reset the clock right before entering the loop to ensure we start with a clean timeline
@@ -4053,6 +4068,9 @@ func (s *System) runNextRound() bool {
 				if s.chars[i][0].win() || (!s.chars[i][0].lose() && tm != TM_Turns) {
 					for j := i; j < len(s.chars); j += 2 {
 						if len(s.chars[j]) > 0 {
+							if tm == TM_Turns && j != i {
+								continue
+							}
 							if !s.chars[j][0].win() {
 								s.chars[j][0].life = Max(1, s.cgi[j].data.life)
 							}
@@ -4204,6 +4222,14 @@ func (bk *RoundStartBackup) Restore() {
 	// Restore characters
 	for i, chars := range sys.chars {
 		if len(chars) == 0 {
+			continue
+		}
+
+		// Staged Turns preload can create standby P3/P4 after roundBackup.Save()
+		if len(bk.charBackup[i]) == 0 {
+			sys.clearPlayerAssets(i, true)
+			sys.removePlayerFromCharList(i)
+			sys.chars[i] = nil
 			continue
 		}
 
@@ -5066,16 +5092,197 @@ func (l *Loader) loadAttachedChar(pn int) int {
 }
 */
 
+func (s *System) turnsPreloadActive() bool {
+	return s.cfg.Config.TurnsLoading && (s.turnsPreloadMember[0] >= 0 || s.turnsPreloadMember[1] >= 0)
+}
+
+func (s *System) startNextTurnsPreload() {
+	if !s.cfg.Config.TurnsLoading || s.loader.state == LS_Loading || s.loader.state == LS_Error {
+		return
+	}
+	next := [2]int{-1, -1}
+	s.selMutex.RLock()
+	for team := 0; team < 2; team++ {
+		if s.tmode[team] != TM_Turns {
+			continue
+		}
+		member := int(s.wins[team^1]) + 1
+		if member <= 0 || member >= int(s.numTurns[team]) || member >= len(s.sel.selected[team]) {
+			continue
+		}
+		pn := team + 2 // one hidden standby slot per Turns side
+		if len(s.chars[pn]) > 0 && s.chars[pn][0] != nil &&
+			s.chars[pn][0].memberNo == member &&
+			s.chars[pn][0].selectNo == s.sel.selected[team][member][0] {
+			continue
+		}
+		next[team] = member
+	}
+	s.selMutex.RUnlock()
+	if next == [2]int{-1, -1} {
+		s.turnsPreloadMember = next
+		return
+	}
+	s.turnsPreloadMember = next
+	if s.loader.state == LS_Complete || s.loader.state == LS_Cancel {
+		select {
+		case <-s.loader.loadExit:
+		default:
+		}
+		s.loader.state = LS_NotYet
+		s.loader.err = nil
+		s.loader.cancelCh = nil
+		s.loader.cancelOnce = sync.Once{}
+	}
+	if s.loader.state == LS_NotYet {
+		s.loader.runTread()
+	}
+}
+
+// Rewrite slot-indexed fields inside chars when a preloaded Turns member is promoted into P1/P2.
+func (s *System) remapCharSlotRefs(chars []*Char, oldSlot, newSlot int) {
+	oldCPU := oldSlot ^ -1
+	newCPU := newSlot ^ -1
+	for _, ch := range chars {
+		if ch == nil {
+			continue
+		}
+		ch.playerNo = newSlot
+		ch.ss.sb.playerNo = newSlot
+		if ch.controller == oldSlot {
+			ch.controller = newSlot
+		} else if ch.controller == oldCPU {
+			ch.controller = newCPU
+		}
+		if ch.animPN == oldSlot {
+			ch.animPN = newSlot
+		}
+		if ch.spritePN == oldSlot {
+			ch.spritePN = newSlot
+		}
+		// Commands are slot-indexed.
+		if oldSlot >= 0 && newSlot >= 0 && oldSlot < len(ch.cmd) && newSlot < len(ch.cmd) {
+			ch.cmd[oldSlot], ch.cmd[newSlot] = ch.cmd[newSlot], ch.cmd[oldSlot]
+		}
+	}
+}
+
+func (s *System) rebindCgiStateOwners(pn int) {
+	if pn < 0 || pn >= len(s.cgi) || s.cgi[pn].states == nil {
+		return
+	}
+	keys := make([]int32, 0, len(s.cgi[pn].states))
+	for k := range s.cgi[pn].states {
+		keys = append(keys, k)
+	}
+	for _, k := range keys {
+		sb := s.cgi[pn].states[k]
+		if sb.playerNo != pn {
+			sb.playerNo = pn
+			s.cgi[pn].states[k] = sb
+		}
+	}
+}
+
+func (s *System) removePlayerFromCharList(pn int) {
+	for {
+		removed := false
+		for _, c := range s.charList.creationOrder {
+			if c != nil && c.playerNo == pn {
+				s.charList.delete(c)
+				removed = true
+				break
+			}
+		}
+		if !removed {
+			return
+		}
+	}
+}
+
+func (s *System) setBGTurnsSlotState(chars []*Char, slot int, active bool) {
+	team := slot & 1
+	for _, ch := range chars {
+		if ch == nil {
+			continue
+		}
+		if active {
+			ch.teamside = team
+			ch.unsetSCF(SCF_disabled)
+			ch.unsetSCF(SCF_standby)
+			if ch.helperIndex == 0 {
+				ch.controller = slot
+				if s.aiLevel[slot] != 0 {
+					ch.controller ^= -1
+				}
+				// Defensive: the real round initialization will run next, but
+				// never let a promoted preloaded fighter enter as already dead.
+				if ch.life <= 0 {
+					ch.life = Max(1, ch.lifeMax)
+					ch.redLife = ch.life
+				}
+			}
+		} else {
+			ch.teamside = -1
+			ch.setSCF(SCF_disabled)
+			ch.setSCF(SCF_standby)
+			ch.setCtrl(false)
+			if ch.helperIndex == 0 {
+				ch.controller = slot
+			}
+		}
+	}
+}
+
+// Promote the next preloaded Turns member into the active P1/P2 slot after a KO.
+func (s *System) activateNextTurnsFighters() {
+	for team := 0; team < 2; team++ {
+		if s.tmode[team] != TM_Turns || !s.effectiveLoss[team] {
+			continue
+		}
+		nextMember := int(s.wins[team^1])
+		if nextMember < 0 || nextMember >= int(s.numTurns[team]) {
+			continue
+		}
+		dst := team
+		src := team + 2
+		if src < 0 || src >= MaxSimul*2 {
+			continue
+		}
+		if len(s.chars[src]) == 0 || s.chars[src][0] == nil ||
+			s.chars[src][0].memberNo != nextMember {
+			continue
+		}
+		s.removePlayerFromCharList(dst)
+		s.removePlayerFromCharList(src)
+		oldDst, oldSrc := dst, src
+		s.chars[dst], s.chars[src] = s.chars[src], s.chars[dst]
+		s.cgi[dst], s.cgi[src] = s.cgi[src], s.cgi[dst]
+		s.stringPool[dst], s.stringPool[src] = s.stringPool[src], s.stringPool[dst]
+		s.remapCharSlotRefs(s.chars[dst], oldSrc, dst)
+		s.remapCharSlotRefs(s.chars[src], oldDst, src)
+		s.rebindCgiStateOwners(dst)
+		s.rebindCgiStateOwners(src)
+		s.workingChar = nil
+		s.workingState = nil
+		s.setBGTurnsSlotState(s.chars[dst], dst, true)
+		s.setBGTurnsSlotState(s.chars[src], src, false)
+		if s.chars[dst][0].id < 0 {
+			s.chars[dst][0].id = s.newCharId()
+		}
+		for _, ch := range s.chars[dst] {
+			if ch != nil {
+				s.charList.add(ch)
+			}
+		}
+		s.charList.enemyNearChanged = true
+	}
+}
+
 func (l *Loader) loadCharacter(pn int, attached bool) int {
 	// Quick abort between expensive steps.
 	if l.cancelRequested() || l.state == LS_Cancel || sys.gameEnd {
 		return 0
-	}
-	if !attached && sys.roundsExisted[pn&1] > 0 {
-		return 1
-	}
-	if attached && sys.round != 1 {
-		return 1
 	}
 
 	sys.selMutex.RLock()
@@ -5089,13 +5296,58 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 	if l.cancelRequested() || l.state == LS_Cancel || sys.gameEnd {
 		return 0
 	}
+	if attached && sys.round != 1 {
+		return 1
+	}
+
 	// Get number of selected characters in team
 	memberNo := pn >> 1
 	nsel := len(teamSel)
 
+	if !attached && tm == TM_Turns && sys.cfg.Config.TurnsLoading {
+		if sys.turnsPreloadActive() {
+			// During the match only the fixed hidden standby slot is eligible.
+			// Active P1/P2 must not be touched by the background loader.
+			if pn < 2 || pn != team+2 {
+				return 1
+			}
+			memberNo = sys.turnsPreloadMember[team]
+			if memberNo < 0 {
+				return 1
+			}
+		} else if pn >= 2 {
+			// Initial pre-match load: only the first Turns member is loaded.
+			// Clear any stale resident char from previous matches/rounds.
+			sys.chars[pn] = nil
+			sys.cgi[pn].states = nil
+			sys.cgi[pn].palettedata = nil
+			sys.cgi[pn].hitPauseToggleFlagCount = 0
+			return 1
+		}
+		if memberNo >= nsel {
+			return 0
+		}
+		if sys.turnsPreloadActive() &&
+			len(sys.chars[pn]) > 0 &&
+			sys.chars[pn][0] != nil &&
+			sys.chars[pn][0].memberNo == memberNo &&
+			sys.chars[pn][0].selectNo == teamSel[memberNo][0] {
+			return 1
+		}
+	} else if !attached && sys.roundsExisted[team] > 0 {
+		return 1
+	}
+
 	// Check if player number is acceptable for selected team mode
 	if !attached {
-		if tm == TM_Simul || tm == TM_Tag {
+		// BG Turns uses a staged standby slot instead of loading the whole team.
+		if tm == TM_Turns && sys.cfg.Config.TurnsLoading {
+			if memberNo >= int(nTurns) || pn >= 4 {
+				sys.cgi[pn].states = nil
+				sys.chars[pn] = nil
+				return 1
+			}
+		} else if tm == TM_Simul || tm == TM_Tag {
 			if memberNo >= int(nSim) {
 				sys.cgi[pn].states = nil
 				sys.chars[pn] = nil
@@ -5105,11 +5357,11 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 			return 0
 		}
 
-		if tm == TM_Turns && nsel < int(nTurns) {
+		if tm == TM_Turns && !sys.cfg.Config.TurnsLoading && nsel < int(nTurns) {
 			return 0
 		}
 
-		if tm == TM_Turns {
+		if tm == TM_Turns && !sys.cfg.Config.TurnsLoading {
 			off := int32(0)
 			if sys.sel.gameParams != nil {
 				off = sys.sel.gameParams.TurnsOffset[pn&1]
@@ -5258,6 +5510,9 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 	// Commit character to system
 	sys.chars[pn] = make([]*Char, 1)
 	sys.chars[pn][0] = p
+	if !attached && tm == TM_Turns && sys.cfg.Config.TurnsLoading {
+		sys.setBGTurnsSlotState(sys.chars[pn], pn, pn < 2 && !sys.turnsPreloadActive())
+	}
 
 	// Load character
 	if !sameChar {
@@ -5309,15 +5564,6 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 	// Apply per-launch map overrides prepared from Lua/loadStart.
 	if !attached {
 		p.applyMapOverrides()
-	}
-
-	// Prepare fight screen portraits and names for Turns mode
-	if !attached {
-		if pn < len(sys.fightScreen.faces[tm]) && tm == TM_Turns && sys.round == 1 {
-			fa := sys.fightScreen.faces[tm][pn]
-			nm := sys.fightScreen.names[tm][pn]
-			l.prepareTurnsFaces(pn, fa, nm, teamChars, teamSel)
-		}
 	}
 
 	// Flag "existed" just in case
@@ -5496,12 +5742,16 @@ func (l *Loader) load() {
 		l.loadExit <- l.state
 	}()
 
+	stagedTurns := sys.turnsPreloadActive()
+
 	// Load any config-driven Common FX not already cached. External modules may
 	// append to Common.Fx before a match; once loaded, non-char FX are kept.
-	if err := loadCommonFightFx(sys.fightScreen.def, false); err != nil {
-		l.err = err
-		l.state = LS_Error
-		return
+	if !stagedTurns {
+		if err := loadCommonFightFx(sys.fightScreen.def, false); err != nil {
+			l.err = err
+			l.state = LS_Error
+			return
+		}
 	}
 
 	/*
@@ -5521,8 +5771,23 @@ func (l *Loader) load() {
 		sys.loadMutex.Unlock()
 	*/
 
-	charDone, stageDone := make([]bool, len(sys.chars)), false
 	playerSlotsEnd := len(sys.chars) - MaxAttachedChar
+	charDone, stageDone := make([]bool, len(sys.chars)), stagedTurns
+
+	if stagedTurns {
+		// In-match Turns preload must not touch active gameplay slots or the other side's normal slots. It only fills one standby slot per Turns side: P3 for side 1, P4 for side 2.
+		for i := range charDone {
+			charDone[i] = true
+		}
+		for team, member := range sys.turnsPreloadMember {
+			if member >= 0 {
+				pn := team + 2
+				if pn >= 0 && pn < playerSlotsEnd {
+					charDone[pn] = false
+				}
+			}
+		}
+	}
 
 	// Check if all chars are loaded
 	allCharDone := func() bool {
@@ -5562,6 +5827,10 @@ func (l *Loader) load() {
 					l.state = LS_Cancel
 					return
 				}
+				if stagedTurns && i >= playerSlotsEnd {
+					charDone[i] = true
+					continue
+				}
 				result := -1
 				// Attached stage chars depend on the loaded stage definition.
 				if i >= playerSlotsEnd {
@@ -5595,7 +5864,8 @@ func (l *Loader) load() {
 			tm := sys.tmode[i]
 			sys.selMutex.RUnlock()
 			if !charDone[i+2] && selLen > 0 &&
-				tm != TM_Simul && tm != TM_Tag {
+				tm != TM_Simul && tm != TM_Tag &&
+				!(tm == TM_Turns && sys.cfg.Config.TurnsLoading) {
 				for j := i + 2; j < playerSlotsEnd; j += 2 {
 					if !charDone[j] {
 						sys.chars[j] = nil
@@ -5636,7 +5906,8 @@ func (l *Loader) reset() {
 	l.cancelCh = nil
 	l.cancelOnce = sync.Once{}
 	for i := range sys.cgi {
-		if sys.roundsExisted[i&1] == 0 {
+		keepPreloadedTurnsPal := sys.cfg.Config.TurnsLoading && sys.round > 1 && sys.tmode[i&1] == TM_Turns
+		if sys.roundsExisted[i&1] == 0 && !keepPreloadedTurnsPal {
 			sys.cgi[i].palno = -1
 		}
 	}

--- a/src/system.go
+++ b/src/system.go
@@ -3,6 +3,7 @@ package main
 import (
 	"arena"
 	"bufio"
+	"errors"
 	"fmt"
 	"image"
 	"io"
@@ -239,6 +240,7 @@ type System struct {
 	chars               [MaxPlayerNo][]*Char
 	charList            CharList
 	cgi                 [MaxPlayerNo]CharGlobalInfo
+	selMutex            sync.RWMutex
 	loadMutex           sync.Mutex
 	ignoreMostErrors    bool
 	stringPool          [MaxPlayerNo]StringPool
@@ -716,6 +718,21 @@ func (s *System) leaveMotifAspect() {
 	s.applyFightAspect()
 }
 
+func (s *System) setGameAspect() {
+	sys.applyFightAspect()
+	if sys.stage != nil {
+		sys.stage.localscl = float32(sys.gameWidth) / float32(sys.stage.stageCamera.localcoord[0])
+		sys.stage.stageCamera.localscl = sys.stage.localscl
+	}
+	for _, p := range sys.chars {
+		if len(p) > 0 {
+			p[0].localcoord = float32(p[0].gi().localcoord[0]) / (float32(sys.gameWidth) / 320)
+			p[0].localscl = 320 / p[0].localcoord
+		}
+	}
+	sys.fightScreen.setScale()
+}
+
 func (s *System) eventUpdate() bool {
 	s.esc = false
 	for _, v := range s.shortcutScripts {
@@ -970,6 +987,52 @@ func (s *System) loaderReset() {
 func (s *System) loadStart() {
 	s.loaderReset()
 	s.loader.runTread()
+}
+
+// Drop everything that might have been partially produced by the pre-match async loader.
+func (s *System) dropCanceledLoadData() {
+	for {
+		select {
+		case <-s.mainThreadTask:
+		default:
+			goto drained
+		}
+	}
+drained:
+	s.loadMutex.Lock()
+	defer s.loadMutex.Unlock()
+
+	for prefix, ffx := range s.ffx {
+		if ffx == nil || !ffx.isCharFX {
+			continue
+		}
+		ffx.sff = nil
+		delete(s.ffx, prefix)
+	}
+
+	for i := range s.cgi {
+		s.cgi[i].sff = nil
+		s.cgi[i].palettedata = nil
+		s.cgi[i].snd = nil
+		s.cgi[i].states = nil
+		s.chars[i] = nil
+		s.cgi[i].palno = -1
+	}
+
+	if s.stage != nil {
+		s.stage.destroy()
+		s.stage = nil
+	}
+	s.stageList = make(map[int32]*Stage)
+	s.stageLoop = false
+}
+
+func (s *System) loadCancel() {
+	s.loader.reset()
+	s.dropCanceledLoadData()
+	if s.netConnection != nil {
+		s.netConnection.ResetLoadingPhase()
+	}
 }
 
 func (s *System) synchronize() error {
@@ -4355,7 +4418,11 @@ func (s *Select) ValidatePalette(charRef, requested int) int {
 	return int(sc.pal[0])
 }
 
-func (s *Select) SelectStage(n int) { s.selectedStageNo = n }
+func (s *Select) SelectStage(n int) {
+	sys.selMutex.Lock()
+	s.selectedStageNo = n
+	sys.selMutex.Unlock()
+}
 
 func (s *Select) GetStage(n int) *SelectStage {
 	if len(s.stagelist) == 0 {
@@ -4924,24 +4991,25 @@ func (s *Select) AddSelectedChar(tn, cn, pl int) bool {
 		n = int(Rand(0, int32(len(s.charlist))-1))
 		pl = int(Rand(1, int32(sys.cfg.Config.PaletteMax)))
 	}
-	sys.loadMutex.Lock()
+	sys.selMutex.Lock()
 	s.selected[tn] = append(s.selected[tn], [...]int{n, pl})
 	if s.gameParams == nil {
 		s.gameParams = newGameParams()
 	}
 	// ensure per-member override slot exists (needed for existed flag / persistence)
-	_ = s.gameParams.ensureOverride(tn, len(s.selected[tn])-1)
-	sys.loadMutex.Unlock()
+	dst := len(s.selected[tn]) - 1
+	_ = s.gameParams.ensureOverride(tn, dst)
+	sys.selMutex.Unlock()
 	return true
 }
 
 func (s *Select) ClearSelected() {
-	sys.loadMutex.Lock()
+	sys.selMutex.Lock()
 	s.selected = [2][][2]int{}
-	sys.loadMutex.Unlock()
 	s.selectedStageNo = -1
 	s.music = make(Music)
 	s.gameParams = newGameParams()
+	sys.selMutex.Unlock()
 }
 
 type LoaderState int32
@@ -4954,14 +5022,38 @@ const (
 	LS_Cancel
 )
 
+// Returned by heavy loaders (notably SFF parsing) to signal cooperative cancellation.
+var ErrLoadingCanceled = errors.New("loading canceled")
+
 type Loader struct {
-	state    LoaderState
-	loadExit chan LoaderState
-	err      error
+	state      LoaderState
+	loadExit   chan LoaderState
+	err        error
+	cancelCh   chan struct{}
+	cancelOnce sync.Once
 }
 
 func newLoader() *Loader {
 	return &Loader{state: LS_NotYet, loadExit: make(chan LoaderState, 1)}
+}
+
+func (l *Loader) requestCancel() {
+	if l.cancelCh == nil {
+		return
+	}
+	l.cancelOnce.Do(func() { close(l.cancelCh) })
+}
+
+func (l *Loader) cancelRequested() bool {
+	if l.cancelCh == nil {
+		return false
+	}
+	select {
+	case <-l.cancelCh:
+		return true
+	default:
+		return false
+	}
 }
 
 /*
@@ -4975,6 +5067,10 @@ func (l *Loader) loadAttachedChar(pn int) int {
 */
 
 func (l *Loader) loadCharacter(pn int, attached bool) int {
+	// Quick abort between expensive steps.
+	if l.cancelRequested() || l.state == LS_Cancel || sys.gameEnd {
+		return 0
+	}
 	if !attached && sys.roundsExisted[pn&1] > 0 {
 		return 1
 	}
@@ -4982,17 +5078,25 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 		return 1
 	}
 
-	sys.loadMutex.Lock()
-	defer sys.loadMutex.Unlock()
-
+	sys.selMutex.RLock()
+	team := pn & 1
+	tm := sys.tmode[team]
+	nSim := sys.numSimul[team]
+	nTurns := sys.numTurns[team]
+	teamSel := make([][2]int, len(sys.sel.selected[team]))
+	copy(teamSel, sys.sel.selected[team])
+	sys.selMutex.RUnlock()
+	if l.cancelRequested() || l.state == LS_Cancel || sys.gameEnd {
+		return 0
+	}
 	// Get number of selected characters in team
 	memberNo := pn >> 1
-	nsel := len(sys.sel.selected[pn&1])
+	nsel := len(teamSel)
 
 	// Check if player number is acceptable for selected team mode
 	if !attached {
-		if sys.tmode[pn&1] == TM_Simul || sys.tmode[pn&1] == TM_Tag {
-			if memberNo >= int(sys.numSimul[pn&1]) {
+		if tm == TM_Simul || tm == TM_Tag {
+			if memberNo >= int(nSim) {
 				sys.cgi[pn].states = nil
 				sys.chars[pn] = nil
 				return 1
@@ -5001,11 +5105,11 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 			return 0
 		}
 
-		if sys.tmode[pn&1] == TM_Turns && nsel < int(sys.numTurns[pn&1]) {
+		if tm == TM_Turns && nsel < int(nTurns) {
 			return 0
 		}
 
-		if sys.tmode[pn&1] == TM_Turns {
+		if tm == TM_Turns {
 			off := int32(0)
 			if sys.sel.gameParams != nil {
 				off = sys.sel.gameParams.TurnsOffset[pn&1]
@@ -5018,11 +5122,11 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 			if int(off) > nsel {
 				off = int32(nsel)
 			}
-			if sys.numTurns[pn&1] < 0 {
-				sys.numTurns[pn&1] = 0
+			if nTurns < 0 {
+				nTurns = 0
 			}
-			if int(off)+int(sys.numTurns[pn&1]) > nsel {
-				sys.numTurns[pn&1] = int32(nsel) - off
+			if int(off)+int(nTurns) > nsel {
+				nTurns = int32(nsel) - off
 			}
 			memberNo = int(off) + int(sys.wins[^pn&1])
 		}
@@ -5034,7 +5138,7 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 
 	teamChars := make([]int, nsel)
 	for i := range teamChars {
-		teamChars[i] = sys.sel.selected[pn&1][i][0]
+		teamChars[i] = teamSel[i][0]
 	}
 
 	// Prepare loading time clipboard message
@@ -5063,13 +5167,16 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 		atcpn := pn - MaxSimul*2
 		cdef = sys.stageList[0].attachedchardef[atcpn]
 	} else {
-		if sys.tmode[pn&1] == TM_Turns {
+		if tm == TM_Turns {
 			cdefOWnumber = memberNo*2 + pn&1
 		} else {
 			cdefOWnumber = pn
 		}
-		if sys.sel.cdefOverwrite[cdefOWnumber] != "" {
-			cdef = sys.sel.cdefOverwrite[cdefOWnumber]
+		sys.selMutex.RLock()
+		cdefOW := sys.sel.cdefOverwrite[cdefOWnumber]
+		sys.selMutex.RUnlock()
+		if cdefOW != "" {
+			cdef = cdefOW
 		} else {
 			cdef = sys.sel.charlist[teamChars[memberNo]].def
 		}
@@ -5144,7 +5251,7 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 		p.controller = pn
 	} else {
 		p.memberNo = memberNo
-		p.selectNo = sys.sel.selected[pn&1][memberNo][0]
+		p.selectNo = teamSel[memberNo][0]
 		p.teamside = p.playerNo & 1
 	}
 
@@ -5154,7 +5261,15 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 
 	// Load character
 	if !sameChar {
+		if l.cancelRequested() || l.state == LS_Cancel || sys.gameEnd {
+			return 0
+		}
 		if l.err = p.load(cdef); l.err != nil {
+			if errors.Is(l.err, ErrLoadingCanceled) {
+				sys.chars[pn] = nil
+				l.state = LS_Cancel
+				return 0
+			}
 			sys.chars[pn] = nil
 			if attached {
 				tstr = fmt.Sprintf("WARNING: Failed to load new attached char: %v", cdef)
@@ -5162,6 +5277,11 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 				tstr = fmt.Sprintf("WARNING: Failed to load new char: %v", cdef)
 			}
 			return -1
+		}
+		if l.cancelRequested() || l.state == LS_Cancel || sys.gameEnd {
+			sys.chars[pn] = nil
+			l.state = LS_Cancel
+			return 0
 		}
 
 		// Compile character states
@@ -5182,7 +5302,7 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 		selectPalno = pal
 	} else if !attached {
 		// Get palette number from select screen choice
-		selectPalno = sys.sel.selected[pn&1][memberNo][1]
+		selectPalno = teamSel[memberNo][1]
 	}
 	sys.cgi[pn].palno = int32(selectPalno)
 
@@ -5193,10 +5313,10 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 
 	// Prepare fight screen portraits and names for Turns mode
 	if !attached {
-		if pn < len(sys.fightScreen.faces[sys.tmode[pn&1]]) && sys.tmode[pn&1] == TM_Turns && sys.round == 1 {
-			fa := sys.fightScreen.faces[sys.tmode[pn&1]][pn]
-			nm := sys.fightScreen.names[sys.tmode[pn&1]][pn]
-			l.prepareTurnsFaces(pn, fa, nm, teamChars)
+		if pn < len(sys.fightScreen.faces[tm]) && tm == TM_Turns && sys.round == 1 {
+			fa := sys.fightScreen.faces[tm][pn]
+			nm := sys.fightScreen.names[tm][pn]
+			l.prepareTurnsFaces(pn, fa, nm, teamChars, teamSel)
 		}
 	}
 
@@ -5207,7 +5327,7 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 	return 1
 }
 
-func (l *Loader) prepareTurnsFaces(pn int, fa *FightScreenFace, nm *FightScreenName, teamChars []int) {
+func (l *Loader) prepareTurnsFaces(pn int, fa *FightScreenFace, nm *FightScreenName, teamChars []int, teamSel [][2]int) {
 	// Reset face and name KO's
 	off := int32(0)
 	if sys.sel.gameParams != nil {
@@ -5260,7 +5380,7 @@ func (l *Loader) prepareTurnsFaces(pn int, fa *FightScreenFace, nm *FightScreenN
 			// Check if palettes are already loaded
 			// They won't be unless the select screen used "applypal" (or if the character was already used before maybe)
 			// https://github.com/ikemen-engine/Ikemen-GO/issues/3300
-			palIdx := sys.sel.selected[pn&1][i][1]
+			palIdx := teamSel[i][1]
 			_, hasTarget := sc.sff.palList.PalTable[[...]uint16{1, uint16(palIdx)}]
 			_, has11 := sc.sff.palList.PalTable[[...]uint16{1, 1}]
 
@@ -5307,6 +5427,10 @@ func (l *Loader) prepareTurnsFaces(pn int, fa *FightScreenFace, nm *FightScreenN
 
 func (l *Loader) loadStage() bool {
 	if sys.round == 1 {
+		if l.cancelRequested() || l.state == LS_Cancel || sys.gameEnd {
+			l.state = LS_Cancel
+			return false
+		}
 		var tstr string
 		tnow := time.Now()
 		defer func() {
@@ -5326,15 +5450,21 @@ func (l *Loader) loadStage() bool {
 				}
 			}
 		}()
+		// Snapshot stage selection quickly (avoid races with Lua).
+		sys.selMutex.RLock()
+		stageNo := sys.sel.selectedStageNo
+		sdefOW := sys.sel.sdefOverwrite
+		sys.selMutex.RUnlock()
+
 		var def string
-		if sys.sel.selectedStageNo == 0 {
+		if stageNo == 0 {
 			randomstageno := Rand(0, int32(len(sys.sel.stagelist))-1)
 			def = sys.sel.stagelist[randomstageno].def
 		} else {
-			def = sys.sel.stagelist[sys.sel.selectedStageNo-1].def
+			def = sys.sel.stagelist[stageNo-1].def
 		}
-		if sys.sel.sdefOverwrite != "" {
-			def = sys.sel.sdefOverwrite
+		if sdefOW != "" {
+			def = sdefOW
 		}
 		if sys.stage != nil && sys.stage.def == def && sys.stage.mainstage && !sys.stage.reload {
 			tstr = fmt.Sprintf("Cached stage loaded: %v", def)
@@ -5366,28 +5496,6 @@ func (l *Loader) load() {
 		l.loadExit <- l.state
 	}()
 
-	// Update aspect ratio
-	sys.applyFightAspect()
-
-	// Update cached stage scaling
-	// In case FightAspect option was changed between matches
-	if sys.stage != nil {
-		sys.stage.localscl = float32(sys.gameWidth) / float32(sys.stage.stageCamera.localcoord[0])
-		sys.stage.stageCamera.localscl = sys.stage.localscl
-	}
-
-	// Update cached character scaling
-	for _, p := range sys.chars {
-		if len(p) > 0 {
-			p[0].localcoord = float32(p[0].gi().localcoord[0]) / (float32(sys.gameWidth) / 320)
-			p[0].localscl = 320 / p[0].localcoord
-		}
-	}
-
-	// Update fight screen scale
-	sys.fightScreen.setScale()
-	//sys.motif.setMotifScale()
-
 	// Load any config-driven Common FX not already cached. External modules may
 	// append to Common.Fx before a match; once loaded, non-char FX are kept.
 	if err := loadCommonFightFx(sys.fightScreen.def, false); err != nil {
@@ -5408,13 +5516,13 @@ func (l *Loader) load() {
 					removeSFFCache(ffx.sff.filename)
 				}
 				delete(sys.ffx, prefix)
-				//LogMessage("Unloaded CommonFX: %s (prefix: %s)", ffx.fileName, prefix)
 			}
 		}
 		sys.loadMutex.Unlock()
 	*/
 
 	charDone, stageDone := make([]bool, len(sys.chars)), false
+	playerSlotsEnd := len(sys.chars) - MaxAttachedChar
 
 	// Check if all chars are loaded
 	allCharDone := func() bool {
@@ -5427,9 +5535,21 @@ func (l *Loader) load() {
 	}
 
 	for !stageDone || !allCharDone() {
+		// Fast exit on cancel without waiting for the whole load to complete.
+		if l.cancelRequested() || l.state == LS_Cancel || sys.gameEnd {
+			l.state = LS_Cancel
+			return
+		}
 		// Load stage
-		if !stageDone && sys.sel.selectedStageNo >= 0 {
+		sys.selMutex.RLock()
+		stageNo := sys.sel.selectedStageNo
+		sys.selMutex.RUnlock()
+		if !stageDone && stageNo >= 0 {
 			if !l.loadStage() {
+				if l.state == LS_Cancel || l.cancelRequested() {
+					l.state = LS_Cancel
+					return
+				}
 				l.state = LS_Error
 				return
 			}
@@ -5438,12 +5558,27 @@ func (l *Loader) load() {
 		// Load characters that aren't already loaded
 		for i, b := range charDone {
 			if !b {
+				if l.cancelRequested() || l.state == LS_Cancel || sys.gameEnd {
+					l.state = LS_Cancel
+					return
+				}
 				result := -1
-				if i < len(sys.chars)-MaxAttachedChar ||
-					len(sys.stageList[0].attachedchardef) <= i-MaxSimul*2 {
-					result = l.loadCharacter(i, false)
-				} else {
+				// Attached stage chars depend on the loaded stage definition.
+				if i >= playerSlotsEnd {
+					if !stageDone || sys.stageList[0] == nil {
+						continue
+					}
+					atcpn := i - MaxSimul*2
+					if atcpn < 0 || atcpn >= len(sys.stageList[0].attachedchardef) || sys.stageList[0].attachedchardef[atcpn] == "" {
+						sys.chars[i] = nil
+						sys.cgi[i].states = nil
+						sys.cgi[i].hitPauseToggleFlagCount = 0
+						charDone[i] = true
+						continue
+					}
 					result = l.loadCharacter(i, true)
+				} else {
+					result = l.loadCharacter(i, false)
 				}
 				if result > 0 {
 					charDone[i] = true
@@ -5454,9 +5589,14 @@ func (l *Loader) load() {
 			}
 		}
 		for i := 0; i < 2; i++ {
-			if !charDone[i+2] && len(sys.sel.selected[i]) > 0 &&
-				sys.tmode[i] != TM_Simul && sys.tmode[i] != TM_Tag {
-				for j := i + 2; j < len(sys.chars); j += 2 {
+			// Snapshot selection + team mode under selMutex.
+			sys.selMutex.RLock()
+			selLen := len(sys.sel.selected[i])
+			tm := sys.tmode[i]
+			sys.selMutex.RUnlock()
+			if !charDone[i+2] && selLen > 0 &&
+				tm != TM_Simul && tm != TM_Tag {
+				for j := i + 2; j < playerSlotsEnd; j += 2 {
 					if !charDone[j] {
 						sys.chars[j] = nil
 						sys.cgi[j].states = nil
@@ -5465,6 +5605,10 @@ func (l *Loader) load() {
 					}
 				}
 			}
+		}
+		if l.cancelRequested() || l.state == LS_Cancel || sys.gameEnd {
+			l.state = LS_Cancel
+			return
 		}
 		time.Sleep(10 * time.Millisecond)
 		if sys.gameEnd {
@@ -5482,11 +5626,15 @@ func (l *Loader) load() {
 
 func (l *Loader) reset() {
 	if l.state != LS_NotYet {
+		// Ensure the loader goroutine gets a cooperative cancel signal.
+		l.requestCancel()
 		l.state = LS_Cancel
 		<-l.loadExit
 		l.state = LS_NotYet
 	}
 	l.err = nil
+	l.cancelCh = nil
+	l.cancelOnce = sync.Once{}
 	for i := range sys.cgi {
 		if sys.roundsExisted[i&1] == 0 {
 			sys.cgi[i].palno = -1
@@ -5498,6 +5646,9 @@ func (l *Loader) runTread() bool {
 	if l.state != LS_NotYet {
 		return false
 	}
+	// Fresh cancel signal for this run.
+	l.cancelCh = make(chan struct{})
+	l.cancelOnce = sync.Once{}
 	l.state = LS_Loading
 	SafeGo(func() {
 		l.load()

--- a/src/system.go
+++ b/src/system.go
@@ -4334,6 +4334,8 @@ type SelectChar struct {
 	sff           *Sff
 	music         Music
 	scp           *SelectCharParams
+	preloadAnim   string
+	preloadSprite string
 }
 
 func newSelectChar() *SelectChar {
@@ -4357,6 +4359,7 @@ type SelectStage struct {
 	sff             *Sff
 	music           Music
 	ssp             *SelectStageParams
+	preloadSprite   string
 }
 
 func newSelectStage() *SelectStage {
@@ -4383,6 +4386,50 @@ type Select struct {
 	sdefOverwrite      string
 	music              Music
 	gameParams         *GameParams
+	preloadMu          sync.Mutex
+	preloadCond        *sync.Cond
+	preloadWorkerRun   bool
+	preloadOrder       int64
+	charPreload        []PreloadEntry
+	stagePreload       []PreloadEntry
+}
+
+type PreloadState int32
+
+const (
+	PS_Idle PreloadState = iota
+	PS_Queued
+	PS_Loading
+	PS_Ready
+	PS_Error
+)
+
+func (ps PreloadState) String() string {
+	switch ps {
+	case PS_Idle:
+		return "idle"
+	case PS_Queued:
+		return "queued"
+	case PS_Loading:
+		return "loading"
+	case PS_Ready:
+		return "ready"
+	case PS_Error:
+		return "error"
+	}
+	return "idle"
+}
+
+const (
+	PreloadPriorityLow  = 1
+	PreloadPriorityHigh = 2
+)
+
+type PreloadEntry struct {
+	State    PreloadState
+	Priority int
+	Order    int64
+	Err      string
 }
 
 func newSelect() *Select {
@@ -4398,6 +4445,420 @@ func newSelect() *Select {
 		music:              make(Music),
 		gameParams:         newGameParams(),
 	}
+}
+
+func (s *Select) initPreloadSync() {
+	s.preloadMu.Lock()
+	defer s.preloadMu.Unlock()
+	if s.preloadCond == nil {
+		s.preloadCond = sync.NewCond(&s.preloadMu)
+	}
+}
+
+func (s *Select) ensurePreloadWorker() {
+	s.initPreloadSync()
+	s.preloadMu.Lock()
+	if s.preloadWorkerRun {
+		s.preloadMu.Unlock()
+		return
+	}
+	s.preloadWorkerRun = true
+	s.preloadMu.Unlock()
+	SafeGo(func() {
+		s.preloadWorkerLoop()
+	})
+}
+
+func (s *Select) ensureCharPreloadSlot(ref int) {
+	if ref < 0 {
+		return
+	}
+	for len(s.charPreload) <= ref {
+		s.charPreload = append(s.charPreload, PreloadEntry{})
+	}
+}
+
+func (s *Select) ensureStagePreloadSlot(ref int) {
+	if ref <= 0 {
+		return
+	}
+	idx := ref - 1
+	for len(s.stagePreload) <= idx {
+		s.stagePreload = append(s.stagePreload, PreloadEntry{})
+	}
+}
+
+func (s *Select) QueueCharPreload(ref int, priority int) {
+	if sys.cfg.Config.BootLoadingMode == 0 {
+		return
+	}
+	if ref < 0 || ref >= len(s.charlist) {
+		return
+	}
+	s.initPreloadSync()
+	s.ensurePreloadWorker()
+	s.preloadMu.Lock()
+	defer func() {
+		s.preloadCond.Broadcast()
+		s.preloadMu.Unlock()
+	}()
+	s.ensureCharPreloadSlot(ref)
+	e := &s.charPreload[ref]
+	if e.State == PS_Ready {
+		return
+	}
+	if e.State == PS_Loading {
+		e.Priority = priority
+		return
+	}
+	if e.State == PS_Idle || e.State == PS_Error {
+		e.State = PS_Queued
+	}
+	if e.Priority == priority {
+		return
+	}
+	e.Priority = priority
+	if priority <= PreloadPriorityLow {
+		e.Order = 0
+	} else {
+		s.preloadOrder++
+		e.Order = s.preloadOrder
+	}
+}
+
+func (s *Select) QueueStagePreload(ref int, priority int) {
+	if sys.cfg.Config.BootLoadingMode == 0 {
+		return
+	}
+	if ref <= 0 || ref > len(s.stagelist) {
+		return
+	}
+	s.initPreloadSync()
+	s.ensurePreloadWorker()
+	s.preloadMu.Lock()
+	defer func() {
+		s.preloadCond.Broadcast()
+		s.preloadMu.Unlock()
+	}()
+	s.ensureStagePreloadSlot(ref)
+	e := &s.stagePreload[ref-1]
+	if e.State == PS_Ready {
+		return
+	}
+	if e.State == PS_Loading {
+		e.Priority = priority
+		return
+	}
+	if e.State == PS_Idle || e.State == PS_Error {
+		e.State = PS_Queued
+	}
+	if e.Priority == priority {
+		return
+	}
+	e.Priority = priority
+	if priority <= PreloadPriorityLow {
+		e.Order = 0
+	} else {
+		s.preloadOrder++
+		e.Order = s.preloadOrder
+	}
+}
+
+func (s *Select) CharPreloadStatus(ref int) (PreloadState, string) {
+	if sys.cfg.Config.BootLoadingMode == 0 {
+		return PS_Ready, ""
+	}
+	s.initPreloadSync()
+	s.preloadMu.Lock()
+	defer s.preloadMu.Unlock()
+	if ref < 0 || ref >= len(s.charPreload) {
+		return PS_Idle, ""
+	}
+	return s.charPreload[ref].State, s.charPreload[ref].Err
+}
+
+func (s *Select) StagePreloadStatus(ref int) (PreloadState, string) {
+	if sys.cfg.Config.BootLoadingMode == 0 {
+		return PS_Ready, ""
+	}
+	s.initPreloadSync()
+	s.preloadMu.Lock()
+	defer s.preloadMu.Unlock()
+	if ref <= 0 || ref-1 >= len(s.stagePreload) {
+		return PS_Idle, ""
+	}
+	return s.stagePreload[ref-1].State, s.stagePreload[ref-1].Err
+}
+
+func (s *Select) AllPreloadsReady() bool {
+	if sys.cfg.Config.BootLoadingMode == 0 {
+		return true
+	}
+	s.initPreloadSync()
+	s.preloadMu.Lock()
+	defer s.preloadMu.Unlock()
+	for _, e := range s.charPreload {
+		switch e.State {
+		case PS_Queued, PS_Loading:
+			return false
+		}
+	}
+	for _, e := range s.stagePreload {
+		switch e.State {
+		case PS_Queued, PS_Loading:
+			return false
+		}
+	}
+	return true
+}
+
+func (s *Select) preloadWorkerLoop() {
+	s.initPreloadSync()
+	for {
+		s.preloadMu.Lock()
+		for {
+			kind := ""
+			ref := -1
+			bestPriority := -1
+			bestOrder := int64(-1)
+			for i, e := range s.charPreload {
+				if e.State != PS_Queued {
+					continue
+				}
+				if e.Priority > bestPriority || (e.Priority == bestPriority && e.Order > bestOrder) {
+					bestPriority = e.Priority
+					bestOrder = e.Order
+					kind = "char"
+					ref = i
+				}
+			}
+			for i, e := range s.stagePreload {
+				if e.State != PS_Queued {
+					continue
+				}
+				if e.Priority > bestPriority || (e.Priority == bestPriority && e.Order > bestOrder) {
+					bestPriority = e.Priority
+					bestOrder = e.Order
+					kind = "stage"
+					ref = i + 1
+				}
+			}
+			if ref >= 0 {
+				if kind == "char" {
+					s.charPreload[ref].State = PS_Loading
+					s.charPreload[ref].Err = ""
+				} else {
+					s.stagePreload[ref-1].State = PS_Loading
+					s.stagePreload[ref-1].Err = ""
+				}
+				s.preloadMu.Unlock()
+
+				var err error
+				if kind == "char" {
+					err = s.preloadCharAssets(ref)
+				} else {
+					err = s.preloadStageAssets(ref)
+				}
+
+				s.preloadMu.Lock()
+				if kind == "char" {
+					if err != nil {
+						s.charPreload[ref].State = PS_Error
+						s.charPreload[ref].Err = err.Error()
+					} else {
+						s.charPreload[ref].State = PS_Ready
+						s.charPreload[ref].Err = ""
+					}
+				} else {
+					if err != nil {
+						s.stagePreload[ref-1].State = PS_Error
+						s.stagePreload[ref-1].Err = err.Error()
+					} else {
+						s.stagePreload[ref-1].State = PS_Ready
+						s.stagePreload[ref-1].Err = ""
+					}
+				}
+				s.preloadCond.Broadcast()
+				break
+			}
+			s.preloadCond.Wait()
+		}
+		s.preloadMu.Unlock()
+	}
+}
+
+func (s *Select) preloadCharAssets(ref int) error {
+	if ref < 0 || ref >= len(s.charlist) {
+		return nil
+	}
+	sc := s.charlist[ref]
+	localAnims := NewPreloadedAnims()
+	listSpr := make(map[[2]uint16]bool)
+	for k := range s.charSpritePreload {
+		listSpr[k] = true
+	}
+	tempSff := newSff()
+
+	if sc.preloadAnim != "" {
+		animPath := sc.preloadAnim
+		if err := LoadFile(&animPath, []string{sc.def}, "", func(filename string) error {
+			str, err := LoadText(filename)
+			if err != nil {
+				return err
+			}
+			lines, lnidx := SplitAndTrim(str, "\n"), 0
+			at := ReadAnimationTable(sc.def, tempSff, &tempSff.palList, lines, &lnidx, false)
+			for vAnim := range s.charAnimPreload {
+				if animation := at.get(vAnim); animation != nil {
+					localAnims.addAnim(animation, vAnim)
+					for _, fr := range animation.frames {
+						if fr.Group < 0 || fr.Number < 0 {
+							continue
+						}
+						listSpr[[2]uint16{uint16(fr.Group), uint16(fr.Number)}] = true
+					}
+				}
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+
+	var localSff *Sff
+	if sc.preloadSprite != "" {
+		spritePath := sc.preloadSprite
+		var selPal []int32
+		if err := LoadFile(&spritePath, []string{sc.def, "", "data/"}, "", func(file string) error {
+			var err error
+			localSff, selPal, err = preloadSff(file, true, listSpr)
+			if err != nil {
+				return err
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+		localAnims.updateSff(localSff)
+		for k := range s.charSpritePreload {
+			localAnims.addSprite(localSff, k[0], k[1])
+		}
+		if localSff.header.Version[0] != 1 {
+			defPals := make(map[int32]bool)
+			for _, p := range sc.pal {
+				defPals[p] = true
+			}
+			maxPalSlots := sys.cfg.Config.PaletteMax
+			newPalFiles := make([]string, maxPalSlots)
+			for i, pIdx := range sc.pal {
+				if pIdx >= 1 && int(pIdx) <= maxPalSlots && i < len(sc.pal_files) {
+					newPalFiles[pIdx-1] = sc.pal_files[i]
+				}
+			}
+			newPal := make([]int32, 0, maxPalSlots)
+			newPalFilesOut := make([]string, 0, maxPalSlots)
+			for i := 1; i <= maxPalSlots; i++ {
+				existsInSff := false
+				for _, sIdx := range selPal {
+					if sIdx == int32(i) {
+						existsInSff = true
+						break
+					}
+				}
+				if defPals[int32(i)] || existsInSff {
+					newPal = append(newPal, int32(i))
+					newPalFilesOut = append(newPalFilesOut, newPalFiles[i-1])
+				}
+			}
+			sc.pal = newPal
+			sc.pal_files = newPalFilesOut
+		} else if len(sc.pal) == 0 {
+			sc.pal = selPal
+		}
+	} else {
+		localSff = newSff()
+		localAnims.updateSff(localSff)
+		for k := range s.charSpritePreload {
+			localAnims.addSprite(localSff, k[0], k[1])
+		}
+	}
+
+	s.preloadMu.Lock()
+	dst := &s.charlist[ref]
+	dst.sff = localSff
+	dst.anims = localAnims
+	dst.pal = sc.pal
+	dst.pal_files = sc.pal_files
+	s.preloadMu.Unlock()
+	return nil
+}
+
+func (s *Select) preloadStageAssets(ref int) error {
+	if ref <= 0 || ref > len(s.stagelist) {
+		return nil
+	}
+	ss := s.stagelist[ref-1]
+	lines := []string{}
+	defPath := ss.def
+	if err := LoadFile(&defPath, nil, "", func(file string) error {
+		str, err := LoadText(file)
+		if err != nil {
+			return err
+		}
+		lines = SplitAndTrim(str, "\n")
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	localAnims := NewPreloadedAnims()
+	listSpr := make(map[[2]uint16]bool)
+	for k := range s.stageSpritePreload {
+		listSpr[k] = true
+	}
+
+	tempSff := newSff()
+	atidx := 0
+	at := ReadAnimationTable(ss.def, tempSff, &tempSff.palList, lines, &atidx, false)
+	for v := range s.stageAnimPreload {
+		if anim := at.get(v); anim != nil {
+			localAnims.addAnim(anim, v)
+			for _, fr := range anim.frames {
+				if fr.Group >= 0 && fr.Number >= 0 {
+					listSpr[[2]uint16{uint16(fr.Group), uint16(fr.Number)}] = true
+				}
+			}
+		}
+	}
+
+	var localSff *Sff
+	if ss.preloadSprite != "" {
+		spritePath := ss.preloadSprite
+		if err := LoadFile(&spritePath, []string{ss.def, "", "data/"}, "", func(file string) error {
+			var err error
+			localSff, _, err = preloadSff(file, false, listSpr)
+			if err != nil {
+				return err
+			}
+			return nil
+		}); err != nil {
+			return err
+		}
+		localAnims.updateSff(localSff)
+		for k := range s.stageSpritePreload {
+			localAnims.addSprite(localSff, k[0], k[1])
+		}
+	} else {
+		localSff = newSff()
+		localAnims.updateSff(localSff)
+	}
+
+	s.preloadMu.Lock()
+	dst := &s.stagelist[ref-1]
+	dst.sff = localSff
+	dst.anims = localAnims
+	s.preloadMu.Unlock()
+	return nil
 }
 
 func (s *Select) GetCharNo(i int) int {
@@ -4676,12 +5137,6 @@ func (s *Select) AddChar(def string) *SelectChar {
 		}
 	}
 
-	listSpr := make(map[[2]uint16]bool)
-	for k := range s.charSpritePreload {
-		listSpr[k] = true
-	}
-
-	tempSff := newSff()
 	LoadFile(&cns_orig, []string{sc.def, "", "data/"}, "", func(filename string) error {
 		str, err := LoadText(filename)
 		if err != nil {
@@ -4706,31 +5161,7 @@ func (s *Select) AddChar(def string) *SelectChar {
 
 	// preload animations
 	if len(anim_orig) > 0 {
-		err := LoadFile(&anim_orig, []string{sc.def, "", "data/"}, "", func(filename string) error {
-			str, err := LoadText(filename) // LoadText is zip-aware
-			if err != nil {
-				return err
-			}
-			lines, lnidx := SplitAndTrim(str, "\n"), 0
-			// We disable logging here or else preloading will print the errors of all characters in the select screen
-			at := ReadAnimationTable(sc.def, tempSff, &tempSff.palList, lines, &lnidx, false)
-			for v_anim := range s.charAnimPreload {
-				if animation := at.get(v_anim); animation != nil {
-					sc.anims.addAnim(animation, v_anim)
-					for _, fr := range animation.frames {
-						if fr.Group < 0 || fr.Number < 0 {
-							continue
-						}
-						listSpr[[2]uint16{uint16(fr.Group), uint16(fr.Number)}] = true
-					}
-				}
-			}
-			return nil
-		})
-		// Crash if we expected an AIR file but didn't find any
-		if err != nil {
-			panic(fmt.Sprintf("Cannot open air file for character %s: %v", def, err))
-		}
+		sc.preloadAnim = anim_orig
 	}
 
 	// Try to use the "_preload.sff" file if available
@@ -4742,63 +5173,17 @@ func (s *Select) AddChar(def string) *SelectChar {
 
 	// preload portion of sff file
 	if len(fp) > 0 {
-		err := LoadFile(&fp, []string{sc.def, "", "data/"}, "", func(file string) error {
-			var selPal []int32
-			var err_sff error
-			sc.sff, selPal, err_sff = preloadSff(file, true, listSpr)
-			if err_sff != nil {
-				return fmt.Errorf("failed to preload SFF %s for %s: %w", file, sc.def, err_sff)
-			}
-			sc.anims.updateSff(sc.sff)
-			for k_spr := range s.charSpritePreload {
-				sc.anims.addSprite(sc.sff, k_spr[0], k_spr[1])
-			}
-			// Synchronize SFFv2 internal palettes with DEF declarations
-			if sc.sff.header.Version[0] != 1 {
-				defPals := make(map[int32]bool)
-				for _, p := range sc.pal {
-					defPals[p] = true
-				}
-				// Map DEF palette files to their intended slots
-				maxPalSlots := sys.cfg.Config.PaletteMax
-				newPalFiles := make([]string, maxPalSlots)
-				for i, pIdx := range sc.pal {
-					if pIdx >= 1 && int(pIdx) <= maxPalSlots {
-						newPalFiles[pIdx-1] = sc.pal_files[i]
-					}
-				}
-				// Rebuild sc.pal and sc.pal_files in sequential order
-				sc.pal = nil
-				sc.pal_files = nil
-				for i := 1; i <= maxPalSlots; i++ {
-					existsInSff := false
-					for _, sIdx := range selPal {
-						if sIdx == int32(i) {
-							existsInSff = true
-							break
-						}
-					}
-					// Include palette if it exists in either the SFFv2 or the DEF
-					if defPals[int32(i)] || existsInSff {
-						sc.pal = append(sc.pal, int32(i))
-						sc.pal_files = append(sc.pal_files, newPalFiles[i-1])
-					}
-				}
-			} else if len(sc.pal) == 0 {
-				sc.pal = selPal
-			}
-			return nil
-		})
-		// Crash if we expected a SFF file but didn't find any
-		if err != nil {
-			panic(fmt.Sprintf("Cannot open sprite file for character %s: %v", def, err))
-		}
-	} else {
-		// If we deliberately lack a SFF, then make a dummy one
+		sc.preloadSprite = fp
+	}
+	if sys.cfg.Config.BootLoadingMode > 0 {
 		sc.sff = newSff()
 		sc.anims.updateSff(sc.sff)
 		for k := range s.charSpritePreload {
 			sc.anims.addSprite(sc.sff, k[0], k[1])
+		}
+	} else {
+		if err := s.preloadCharAssets(len(s.charlist) - 1); err != nil {
+			panic(fmt.Errorf("failed to preload %v: %v", sc.def, err))
 		}
 	}
 
@@ -4968,38 +5353,20 @@ func (s *Select) AddStage(def string) (*SelectStage, error) {
 			}
 		}
 	}
-	if len(s.stageSpritePreload) > 0 || len(s.stageAnimPreload) > 0 {
-		listSpr := make(map[[2]uint16]bool)
+	if spr != "" {
+		ss.preloadSprite = spr
+	}
+	if sys.cfg.Config.BootLoadingMode > 0 {
+		ss.sff = newSff()
+		ss.anims.updateSff(ss.sff)
 		for k := range s.stageSpritePreload {
-			listSpr[[...]uint16{k[0], k[1]}] = true
+			ss.anims.addSprite(ss.sff, k[0], k[1])
 		}
-		sff := newSff()
-		// preload animations
-		atidx := 0
-		at := ReadAnimationTable(finalDefPath, sff, &sff.palList, lines, &atidx, false)
-		for v := range s.stageAnimPreload {
-			if anim := at.get(v); anim != nil {
-				ss.anims.addAnim(anim, v)
-				for _, fr := range anim.frames {
-					if fr.Group >= 0 && fr.Number >= 0 {
-						listSpr[[2]uint16{uint16(fr.Group), uint16(fr.Number)}] = true
-					}
-				}
-			}
+		s.ensureStagePreloadSlot(len(s.stagelist))
+	} else {
+		if err := s.preloadStageAssets(len(s.stagelist)); err != nil {
+			panic(fmt.Errorf("failed to preload %v: %v", def, err))
 		}
-		// preload portion of sff file
-		LoadFile(&spr, []string{finalDefPath, "", "data/"}, "", func(file string) error {
-			var err error
-			ss.sff, _, err = preloadSff(file, false, listSpr)
-			if err != nil {
-				panic(fmt.Errorf("failed to load %v: %v\nerror preloading %v", file, err, def))
-			}
-			ss.anims.updateSff(ss.sff)
-			for k := range s.stageSpritePreload {
-				ss.anims.addSprite(ss.sff, k[0], k[1])
-			}
-			return nil
-		})
 	}
 	return ss, nil
 }


### PR DESCRIPTION
Add asynchronous loading paths for both boot-time select assets and pre-match fight assets, improving boot loading time and removing visible black-screen stalls. The default config keeps the previous behavior: match background loading, Turns preloading, and immediate boot/select background loading are all disabled by default.

Feats:

* Add `Config.VsScreenLoading` to start match asset loading during the versus screen instead of after it.
* Feed characters into the loader as their order slots are confirmed.
* Add versus-screen loading and ready motif elements, plus fallback wait UI/storyboard support when the versus screen is disabled.
* Add `waitforloading` storyboard support so loading storyboards can hold on the final scene until local loading and netplay readiness are complete.
* Add loader cancellation and cleanup for partially loaded match assets.
* Add a netplay loading handshake so both peers leave loading together.
* Add `Config.TurnsLoading` to preload the next Turns member during the match instead of between the matches.
* Add `Config.BootLoadingMode` for boot/select asset preloading:
  * `0`: existing behavior, preload before menus/select.
  * `1`: preload in background but wait before entering select.
  * `2`: enter menus/select immediately and materialize portraits/previews as they become ready.
