### PR TITLE
docs: Adding the IKEMEN GO logo in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
-<img width="699" height="257" alt="IKEMEN GO Logo FInal FINAL JP" src="https://github.com/user-attachments/assets/0dcd7ae1-5c9d-44e1-aa32-9ec4b9ed3952" />
 
+<p align="center">
+  <a href="https://ikemen-engine.github.io/">
+    <img src="https://github.com/user-attachments/assets/0dcd7ae1-5c9d-44e1-aa32-9ec4b9ed3952" style="width: 699px; alt="IKEMEN GO Logo"/>
+  </a>
+</p>
 # Ikemen GO
 
 Ikemen GO is an open source fighting game engine that supports resources from the [M.U.G.E.N](https://en.wikipedia.org/wiki/Mugen_(game_engine)) engine, written in Google’s programming language, [Go](https://go.dev/). It is a complete rewrite of a prior engine known simply as Ikemen.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
   </a>
 </p>
 
-# Ikemen GO
-
 Ikemen GO is an open source fighting game engine that supports resources from the [M.U.G.E.N](https://en.wikipedia.org/wiki/Mugen_(game_engine)) engine, written in Google’s programming language, [Go](https://go.dev/). It is a complete rewrite of a prior engine known simply as Ikemen.
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<img width="699" height="257" alt="IKEMEN GO Logo FInal FINAL JP" src="https://github.com/user-attachments/assets/0dcd7ae1-5c9d-44e1-aa32-9ec4b9ed3952" />
+
 # Ikemen GO
 
 Ikemen GO is an open source fighting game engine that supports resources from the [M.U.G.E.N](https://en.wikipedia.org/wiki/Mugen_(game_engine)) engine, written in Google’s programming language, [Go](https://go.dev/). It is a complete rewrite of a prior engine known simply as Ikemen.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
     <img src="https://github.com/user-attachments/assets/0dcd7ae1-5c9d-44e1-aa32-9ec4b9ed3952" style="width: 699px; alt="IKEMEN GO Logo"/>
   </a>
 </p>
+
 # Ikemen GO
 
 Ikemen GO is an open source fighting game engine that supports resources from the [M.U.G.E.N](https://en.wikipedia.org/wiki/Mugen_(game_engine)) engine, written in Google’s programming language, [Go](https://go.dev/). It is a complete rewrite of a prior engine known simply as Ikemen.

--- a/data/dizzy.zss
+++ b/data/dizzy.zss
@@ -21,7 +21,7 @@ if parent,alive = 0 || parent,dizzy = 0 || parent,ctrl || parent,standby {
 
 # Set Explod parameters
 if time = 0 {
-	map(birdType) := randomRange(0, 5); # Bird type. Currently has no effect on gameplay
+	map(birdType) := randomRange(0, 8); # Bird type. Currently has no effect on gameplay
 	map(birdRadius) := parent,const(size.ground.back) + parent,const(size.ground.front); # Circling effect radius
 }
 
@@ -76,8 +76,8 @@ for i = 0; numExplod-1; 1 {
 	let circleHeight = cos($circleTime) * map(birdRadius) * 0.25;
 	let birdScale = (cos($circleTime) + 3) * 0.12 * ifElse($circleHeight < 0, -1, 1);
 	let fadeTime = ifElse(map(birdState) <= 0, 0, ifElse(map(birdState) >= 32, 32, map(birdState))); # Effects are faded out by code rather than animation
-	# Musical notes don't flip
-	if map(birdType) = 5 {
+	# Musical notes, Bells, and Angels don't flip
+	if map(birdType) = 5 || map(birdType) = 6 || map(BirdType) = 8 {
 		let birdScale = abs($birdScale) * facing;
 	}
 	modifyExplod{

--- a/data/dizzy.zss
+++ b/data/dizzy.zss
@@ -76,8 +76,8 @@ for i = 0; numExplod-1; 1 {
 	let circleHeight = cos($circleTime) * map(birdRadius) * 0.25;
 	let birdScale = (cos($circleTime) + 3) * 0.12 * ifElse($circleHeight < 0, -1, 1);
 	let fadeTime = ifElse(map(birdState) <= 0, 0, ifElse(map(birdState) >= 32, 32, map(birdState))); # Effects are faded out by code rather than animation
-	# Musical notes, Bells, and Angels don't flip
-	if map(birdType) = 5 || map(birdType) = 6 || map(BirdType) = 8 {
+	# Musical notes and Bells don't flip
+	if map(birdType) = 5 || map(birdType) = 6 {
 		let birdScale = abs($birdScale) * facing;
 	}
 	modifyExplod{


### PR DESCRIPTION
The IKEMEN Go logo has been added to the repository README, and it links back to the IKEMEN Go website.

<img width="699" height="257" alt="IKEMEN GO Logo FInal FINAL JP" src="https://github.com/user-attachments/assets/3cee2c3c-b825-4cd6-b1be-ac4d111901c9" />
