### PR TITLE
feat: Save/LoadFile filters, Text hidewithbars, noTimeDisplay; refactor SFF loading; fixes

### DIFF
--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -2491,6 +2491,7 @@ function start.f_selectScreen()
 		for side = 1, 2 do
 			local persist = motif.select_info['p' .. side].cursor.persist 
 			local totalSelected = #start.p[side].t_selected
+			local drawnCells = {} -- Track drawn cells to avoid duplicates
 			for k, v in pairs(start.p[side].t_selected) do
 				if v.cursor ~= nil then
 					--get cell coordinates
@@ -2514,7 +2515,11 @@ function start.f_selectScreen()
 							shouldDraw = true
 						end
 						if shouldDraw then
-							start.f_drawCursor(v.pn, x, y, 'done', true)
+							local cellKey = x .. ',' .. y
+							if not drawnCells[cellKey] then
+								start.f_drawCursor(v.pn, x, y, 'done', true)
+								drawnCells[cellKey] = true
+							end
 						end
 					end
 				end
@@ -3112,7 +3117,10 @@ function start.f_palMenu(side, cmd, player, member, selectState)
 	start.p[side].inPalMenu = true
 
 	-- accept selection
-	if #validPals <= 1 or getInput(cmd, motif.select_info['p' .. side].palmenu.done.key) or timerSelect == -1 then
+	local autoConfirm = #validPals <= 1
+	if autoConfirm or getInput(cmd, motif.select_info['p' .. side].palmenu.done.key) or timerSelect == -1 then
+		-- TODO: There's an issue here where when the palette is selected there will be 1 frame without any cursor
+		-- Since the "done" cursor only appears in the next frame
 		pal = (curIdx == maxIdx) and (start.c[player].randPalPreview or start.f_randomPal(charRef, validPals)) or validPals[curIdx]
 		st.pal, st.currentIdx = pal, curIdx
 
@@ -3142,8 +3150,8 @@ function start.f_palMenu(side, cmd, player, member, selectState)
 		end
 		selectState = 3
 		start.f_playWave(start.c[player].selRef, 'cursor', motif.select_info['p' .. side].select.snd[1], motif.select_info['p' .. side].select.snd[2])
-		-- Skip sound for auto-confirmation, since we already played the select character confirmation sound
-		if #validPals > 1 then
+		-- Skip cursor sound for auto-confirmation, since we already played the select character confirmation sound
+		if not autoConfirm then
 			sndPlay(motif.Snd, motif.select_info['p' .. side].palmenu.done.snd[1], motif.select_info['p' .. side].palmenu.done.snd[2])
 		end
 	 -- next palette

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3119,6 +3119,8 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_gethitvar_fall_envshake_freq:
 		sys.bcStack.PushF(c.ghv.fall_envshake_freq)
 	case OC_ex_gethitvar_fall_envshake_ampl:
+		// This one is an int in Mugen but a float in Ikemen, so undefined returns 0 and true undefined respectively
+		// No issues so far, so no need to add a special case for the time being
 		sys.bcStack.PushI(int32(float32(c.ghv.fall_envshake_ampl) * (c.localscl / oc.localscl)))
 	case OC_ex_gethitvar_fall_envshake_phase:
 		sys.bcStack.PushF(c.ghv.fall_envshake_phase)
@@ -13254,6 +13256,7 @@ const (
 	text_scale
 	text_color
 	text_xshear
+	text_hidewithbars
 	text_id
 	text_last = iota + palFX_last + 1 - 1
 	text_redirectid
@@ -13396,6 +13399,8 @@ func (sc text) Run(c *Char, _ []int32) bool {
 			ts.SetColor(r, g, b, a)
 		case text_xshear:
 			ts.xshear = exp[0].evalF(c)
+		case text_hidewithbars:
+			ts.hidewithbars = exp[0].evalB(c)
 		case text_id:
 			ts.id = exp[0].evalI(c)
 		case text_redirectid:
@@ -13670,6 +13675,11 @@ func (sc modifyText) Run(c *Char, _ []int32) bool {
 				xs := exp[0].evalF(c)
 				eachText(func(ts *TextSprite) {
 					ts.xshear = xs
+				})
+			case text_hidewithbars:
+				v := exp[0].evalB(c)
+				eachText(func(ts *TextSprite) {
+					ts.hidewithbars = v
 				})
 			default:
 				if isPalFXParam(paramID) {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -11952,57 +11952,6 @@ func (sc lifebarAction) Run(c *Char, _ []int32) bool {
 	return false
 }
 
-type loadFile StateControllerBase
-
-const (
-	loadFile_path byte = iota
-	loadFile_saveData
-	loadFile_redirectid
-)
-
-func (sc loadFile) Run(c *Char, _ []int32) bool {
-	crun := getRedirectedChar(c, StateControllerBase(sc), loadFile_redirectid, "LoadFile")
-	if crun == nil {
-		return false
-	}
-
-	var path string
-	var data SaveData
-	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
-		switch paramID {
-		case loadFile_path:
-			path = exp[0].evalS()
-		case loadFile_saveData:
-			data = SaveData(exp[0].evalI(c))
-		}
-		return true
-	})
-	if path != "" {
-		decodeFile, err := os.Open(filepath.Dir(c.gi().def) + "/" + path)
-		if err != nil {
-			defer decodeFile.Close()
-			return false
-		}
-		defer decodeFile.Close()
-		decoder := gob.NewDecoder(decodeFile)
-		switch data {
-		case SaveData_map:
-			if err := decoder.Decode(&crun.mapArray); err != nil {
-				panic(err)
-			}
-		case SaveData_var:
-			if err := decoder.Decode(&crun.cnsvar); err != nil {
-				panic(err)
-			}
-		case SaveData_fvar:
-			if err := decoder.Decode(&crun.cnsfvar); err != nil {
-				panic(err)
-			}
-		}
-	}
-	return false
-}
-
 type loadState StateControllerBase
 
 const (
@@ -12339,7 +12288,9 @@ type saveFile StateControllerBase
 
 const (
 	saveFile_path byte = iota
-	saveFile_saveData
+	saveFile_savedata
+	saveFile_maps
+	saveFile_maps_include
 	saveFile_redirectid
 )
 
@@ -12350,37 +12301,190 @@ func (sc saveFile) Run(c *Char, _ []int32) bool {
 	}
 
 	var path string
-	var data SaveData
+	var savedata int32 = -1
+	var mapsList, mapsIncludeList []BytecodeExp
+
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
 		case saveFile_path:
 			path = exp[0].evalS()
-		case saveFile_saveData:
-			data = SaveData(exp[0].evalI(c))
+		case saveFile_savedata:
+			savedata = exp[0].evalI(c)
+		case saveFile_maps:
+			mapsList = exp
+		case saveFile_maps_include:
+			mapsIncludeList = exp
 		}
 		return true
 	})
-	if path != "" {
-		encodeFile, err := os.Create(filepath.Dir(c.gi().def) + "/" + path)
-		if err != nil {
-			panic(err)
+
+	if path == "" || savedata < 0 {
+		return false
+	}
+
+	exactKeys := make([]string, len(mapsList))
+	for i, be := range mapsList {
+		exactKeys[i] = be.evalS()
+	}
+	includeSubstrings := make([]string, len(mapsIncludeList))
+	for i, be := range mapsIncludeList {
+		includeSubstrings[i] = be.evalS()
+	}
+
+	fullPath := filepath.Dir(c.gi().def) + "/" + path
+	f, err := os.Create(fullPath)
+	if err != nil {
+		sys.appendToConsole(crun.warn() + "SaveFile: " + err.Error())
+		return false
+	}
+	defer f.Close()
+	enc := gob.NewEncoder(f)
+
+	// Preface the file with which type of variable we're saving
+	enc.Encode(savedata)
+
+	switch savedata {
+	case 0: // Map
+		if len(exactKeys) > 0 || len(includeSubstrings) > 0 {
+			// Apply filters
+			m := make(map[string]float32)
+			// Try exact match
+			for _, key := range exactKeys {
+				if val, ok := crun.mapArray[key]; ok {
+					m[key] = val
+				}
+			}
+			// Try "include"
+			for _, substr := range includeSubstrings {
+				for existingKey, val := range crun.mapArray {
+					if strings.Contains(existingKey, substr) {
+						m[existingKey] = val
+					}
+				}
+			}
+			enc.Encode(m)
+		} else {
+			// Save all maps
+			enc.Encode(crun.mapArray)
 		}
-		defer encodeFile.Close()
-		encoder := gob.NewEncoder(encodeFile)
-		switch data {
-		case SaveData_map:
-			if err := encoder.Encode(crun.mapArray); err != nil {
-				panic(err)
-			}
-		case SaveData_var:
-			if err := encoder.Encode(crun.cnsvar); err != nil {
-				panic(err)
-			}
-		case SaveData_fvar:
-			if err := encoder.Encode(crun.cnsfvar); err != nil {
-				panic(err)
-			}
+	case 1: // Var
+		enc.Encode(crun.cnsvar)
+	case 2: // Fvar
+		enc.Encode(crun.cnsfvar)
+	}
+	return false
+}
+
+type loadFile StateControllerBase
+
+func (sc loadFile) Run(c *Char, _ []int32) bool {
+	crun := getRedirectedChar(c, StateControllerBase(sc), saveFile_redirectid, "LoadFile")
+	if crun == nil {
+		return false
+	}
+
+	var path string
+	var sctrlSavedata int32 = -1
+	var mapsList, mapsIncludeList []BytecodeExp
+
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
+		case saveFile_path:
+			path = exp[0].evalS()
+		case saveFile_savedata:
+			sctrlSavedata = exp[0].evalI(c)
+		case saveFile_maps:
+			mapsList = exp
+		case saveFile_maps_include:
+			mapsIncludeList = exp
 		}
+		return true
+	})
+
+	if path == "" || sctrlSavedata < 0 {
+		return false
+	}
+
+	exactKeys := make([]string, len(mapsList))
+	for i, be := range mapsList {
+		exactKeys[i] = be.evalS()
+	}
+	includeSubstrings := make([]string, len(mapsIncludeList))
+	for i, be := range mapsIncludeList {
+		includeSubstrings[i] = be.evalS()
+	}
+
+	fullPath := filepath.Dir(c.gi().def) + "/" + path
+	f, err := os.Open(fullPath)
+	if err != nil {
+		sys.appendToConsole(crun.warn() + "LoadFile: " + err.Error())
+		return false
+	}
+	defer f.Close()
+	dec := gob.NewDecoder(f)
+
+	// Decode the type of save
+	var fileSavedata int32
+	if err := dec.Decode(&fileSavedata); err != nil {
+		sys.appendToConsole(crun.warn() + "LoadFile: cannot read savedata type")
+		return false
+	}
+
+	// Check if we're loading maps from a map save, and so on
+	if fileSavedata != sctrlSavedata {
+		sys.appendToConsole(crun.warn() + "LoadFile: savedata type does not match")
+		return false
+	}
+
+	switch fileSavedata {
+	case 0: // Map
+		var loaded map[string]float32
+		if err := dec.Decode(&loaded); err != nil {
+			sys.appendToConsole(crun.warn() + "LoadFile: cannot read map data")
+			return false
+		}
+		if len(exactKeys) > 0 || len(includeSubstrings) > 0 {
+			// Apply filters
+			for key, val := range loaded {
+				matched := false
+				// Try exact match
+				for _, ek := range exactKeys {
+					if key == ek {
+						matched = true
+						break
+					}
+				}
+				// Try "include"
+				if !matched {
+					for _, substr := range includeSubstrings {
+						if strings.Contains(key, substr) {
+							matched = true
+							break
+						}
+					}
+				}
+				if matched {
+					crun.mapArray[key] = val
+				}
+			}
+		} else {
+			// Load all maps
+			crun.mapArray = loaded
+		}
+	case 1: // Var
+		var loaded map[int32]int32
+		if err := dec.Decode(&loaded); err != nil {
+			sys.appendToConsole(crun.warn() + "LoadFile: cannot read var data")
+			return false
+		}
+		crun.cnsvar = loaded
+	case 2: // Fvar
+		var loaded map[int32]float32
+		if err := dec.Decode(&loaded); err != nil {
+			sys.appendToConsole(crun.warn() + "LoadFile: cannot read fvar data")
+			return false
+		}
+		crun.cnsfvar = loaded
 	}
 	return false
 }

--- a/src/char.go
+++ b/src/char.go
@@ -11809,6 +11809,8 @@ func (c *Char) actionRun() {
 					c.receivedHits = 0
 					c.ghv.score = 0
 					c.ghv.down_recovertime = c.gi().data.liedown.time
+					// Mugen specifically resets this one for some reason
+					c.ghv.fall_envshake_time = 0
 					// In Mugen, when returning to idle, characters cannot act until the next frame
 					// To account for this, combos in Mugen linger one frame longer than they normally would in a fighting game
 					// Ikemen's "fake combo" code used to replicate this behavior

--- a/src/char.go
+++ b/src/char.go
@@ -130,6 +130,7 @@ const (
 	GSF_timerfreeze
 	// Ikemen flags
 	GSF_camerafreeze
+	GSF_notimedisplay
 	GSF_roundfreeze
 	GSF_roundnotskip
 	GSF_skipfightdisplay

--- a/src/char.go
+++ b/src/char.go
@@ -166,14 +166,6 @@ const (
 	Projection_Perspective2
 )
 
-type SaveData int32
-
-const (
-	SaveData_map SaveData = iota
-	SaveData_var
-	SaveData_fvar
-)
-
 type DebugClsnText struct {
 	x, y       float32
 	text       string

--- a/src/char.go
+++ b/src/char.go
@@ -1908,7 +1908,7 @@ func (e *Explod) update() {
 		return
 	}
 
-	if e.hidewithbars && (!sys.fightScreen.visible() || sys.gsf(GSF_nobardisplay) || !sys.fightScreen.bars) {
+	if e.hidewithbars && sys.shouldHideWithBars() {
 		return
 	}
 

--- a/src/char.go
+++ b/src/char.go
@@ -8962,11 +8962,13 @@ func (c *Char) setSuperPauseTime(pausetime, movetime int32, unhittable bool, p2d
 		c.superMovetime--
 	}
 
+	// Because the pause will only happen in the next frame, we'll extend this timer by 1
 	if unhittable {
 		c.unhittableTime = pausetime + Btoi(pausetime > 0)
 	}
 
-	c.ignoreDarkenTime = pausetime
+	// Same with this timer
+	c.ignoreDarkenTime = pausetime + Btoi(pausetime > 0)
 	c.propagateIgnoreDarkenTime()
 
 	// Apply superp2defmul to other teams

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -6323,18 +6323,18 @@ func (c *CharCompiler) paramSaveData(is IniSection, sc *StateControllerBase, id 
 		if len(data) <= 1 {
 			return Error("savedata not specified")
 		}
-		var sv SaveData
+		var sv int32
 		switch strings.ToLower(data) {
 		case "map":
-			sv = SaveData_map
+			sv = 0
 		case "var":
-			sv = SaveData_var
+			sv = 1
 		case "fvar":
-			sv = SaveData_fvar
+			sv = 2
 		default:
 			return Error("Invalid savedata type: " + data)
 		}
-		sc.add(id, sc.iToExp(int32(sv)))
+		sc.add(id, sc.iToExp(sv))
 		return nil
 	})
 }
@@ -6471,6 +6471,32 @@ func (c *CharCompiler) paramClsnType(is IniSection, sc *StateControllerBase, par
 			return Error("Invalid Clsn type for " + paramName + ": " + data)
 		}
 		sc.add(id, sc.iToExp(box))
+		return nil
+	})
+}
+
+func (c *CharCompiler) paramStringList(is IniSection, sc *StateControllerBase, paramName string, opcode byte) error {
+	return c.stateParam(is, paramName, false, func(data string) error {
+		parts := strings.Split(data, ",")
+		var allBe []BytecodeExp
+		for _, part := range parts {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			if len(part) < 2 || part[0] != '"' || part[len(part)-1] != '"' {
+				return Error("Value must be enclosed in quotes: " + part)
+			}
+			unquoted, err := strconv.Unquote(part)
+			if err != nil {
+				return Error("Invalid quoted string: " + part)
+			}
+			be := BytecodeExp(unquoted)
+			allBe = append(allBe, be)
+		}
+		if len(allBe) > 0 {
+			sc.add(opcode, allBe)
+		}
 		return nil
 	})
 }

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -4845,6 +4845,8 @@ func (c *CharCompiler) expValue(out *BytecodeExp, in *string,
 			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_camerafreeze))
 		case "globalnoko":
 			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_globalnoko))
+		case "notimedisplay":
+			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_notimedisplay))
 		case "roundfreeze":
 			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_roundfreeze))
 		case "roundnotskip":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -3757,7 +3757,7 @@ func (c *CharCompiler) displayToClipboardSub(is IniSection,
 		return err
 	}
 	if err := c.stateParam(is, "params", false, func(data string) error {
-		bes, err := c.exprs(data, VT_Undefined, 100000)
+		bes, err := c.exprs(data, VT_Undefined, 100) // Arbitrary upper limit
 		if err != nil {
 			return err
 		}
@@ -3769,17 +3769,17 @@ func (c *CharCompiler) displayToClipboardSub(is IniSection,
 	b := false
 	if err := c.stateParam(is, "text", false, func(data string) error {
 		b = true
-		_else := false
+		notEnclosed := false
 		if len(data) >= 2 && data[0] == '"' {
 			if i := strings.Index(data[1:], "\""); i >= 0 {
 				data, _ = strconv.Unquote(data)
 			} else {
-				_else = true
+				notEnclosed = true
 			}
 		} else {
-			_else = true
+			notEnclosed = true
 		}
-		if _else {
+		if notEnclosed {
 			return Error("Text not enclosed in \"")
 		}
 		sc.add(displayToClipboard_text,
@@ -5667,140 +5667,148 @@ func (c *CharCompiler) targetScoreAdd(is IniSection, sc *StateControllerBase) (S
 	return *ret, err
 }
 
+func (c *CharCompiler) textSub(is IniSection, sc *StateControllerBase) error {
+	if err := c.paramValue(is, sc, "id",
+		text_id, VT_Int, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "removetime",
+		text_removetime, VT_Int, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "layerno",
+		text_layerno, VT_Int, 1, false); err != nil {
+		return err
+	}
+	if err := c.stateParam(is, "params",
+		false, func(data string) error {
+		bes, err := c.exprs(data, VT_Undefined, 100)
+		if err != nil {
+			return err
+		}
+		sc.add(text_params, bes)
+		return nil
+	}); err != nil {
+		return err
+	}
+	if err := c.stateParam(is, "text", false, func(data string) error {
+		notEnclosed := false
+		if len(data) >= 2 && data[0] == '"' {
+			if i := strings.Index(data[1:], "\""); i >= 0 {
+				data, _ = strconv.Unquote(data)
+			} else {
+				notEnclosed = true
+			}
+		} else {
+			notEnclosed = true
+		}
+		if notEnclosed {
+			return Error("Text not enclosed in \"")
+		}
+		sc.add(text_text, sc.iToExp(int32(sys.stringPool[c.playerNo].Add(data))))
+		return nil
+	}); err != nil {
+		return err
+	}
+	if err := c.stateParam(is, "font", false, func(data string) error {
+		prefix := c.getDataPrefix(&data, false)
+		// Only "f" (lifebar) or "m" (motif) are meaningful for Text/ModifyText.
+		if prefix != "f" && prefix != "m" {
+			prefix = ""
+		}
+		return c.scAdd(sc, text_font, data, VT_Int, 1,
+			sc.beToExp(BytecodeExp(prefix))...)
+	}); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "localcoord",
+		text_localcoord, VT_Float, 2, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "bank",
+		text_bank, VT_Int, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "align",
+		text_align, VT_Int, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "textspacing",
+		text_textspacing, VT_Float, 2, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "textdelay",
+		text_textdelay, VT_Float, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "pos",
+		text_pos, VT_Float, 2, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "velocity",
+		text_velocity, VT_Float, 2, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "maxdist",
+		text_maxdist, VT_Float, 2, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "friction",
+		text_friction, VT_Float, 2, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "accel",
+		text_accel, VT_Float, 2, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "scale",
+		text_scale, VT_Float, 2, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "angle",
+		text_angle, VT_Float, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "xangle",
+		text_xangle, VT_Float, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "yangle",
+		text_yangle, VT_Float, 1, false); err != nil {
+		return err
+	}
+	if err := c.palFXSub(is, sc, "palfx."); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "color",
+		text_color, VT_Int, 4, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "xshear",
+		text_xshear, VT_Float, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramProjection(is, sc, "projection",
+		text_projection); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "focallength",
+		text_focallength, VT_Float, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "hidewithbars",
+		text_hidewithbars, VT_Bool, 1, false); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (c *CharCompiler) text(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*text)(sc), c.stateSec(is, func() error {
-		if err := c.paramValue(is, sc, "redirectid",
-			text_redirectid, VT_Int, 1, false); err != nil {
+		if err := c.paramValue(is, sc, "redirectid", text_redirectid, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.paramValue(is, sc, "id",
-			text_id, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "removetime",
-			text_removetime, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "layerno",
-			text_layerno, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.stateParam(is, "params", false, func(data string) error {
-			bes, err := c.exprs(data, VT_Undefined, 100000)
-			if err != nil {
-				return err
-			}
-			sc.add(text_params, bes)
-			return nil
-		}); err != nil {
-			return err
-		}
-		if err := c.stateParam(is, "text", false, func(data string) error {
-			_else := false
-			if len(data) >= 2 && data[0] == '"' {
-				if i := strings.Index(data[1:], "\""); i >= 0 {
-					data, _ = strconv.Unquote(data)
-				} else {
-					_else = true
-				}
-			} else {
-				_else = true
-			}
-			if _else {
-				return Error("Text not enclosed in \"")
-			}
-			sc.add(text_text, sc.iToExp(int32(sys.stringPool[c.playerNo].Add(data))))
-			return nil
-		}); err != nil {
-			return err
-		}
-		if err := c.stateParam(is, "font", false, func(data string) error {
-			prefix := c.getDataPrefix(&data, false)
-			// Only "f" (lifebar) or "m" (motif) are meaningful for Text/ModifyText.
-			if prefix != "f" && prefix != "m" {
-				prefix = ""
-			}
-			return c.scAdd(sc, text_font, data, VT_Int, 1,
-				sc.beToExp(BytecodeExp(prefix))...)
-		}); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "localcoord",
-			text_localcoord, VT_Float, 2, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "bank",
-			text_bank, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "align",
-			text_align, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "textspacing",
-			text_textspacing, VT_Float, 2, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "textdelay",
-			text_textdelay, VT_Float, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "pos",
-			text_pos, VT_Float, 2, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "velocity",
-			text_velocity, VT_Float, 2, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "maxdist",
-			text_maxdist, VT_Float, 2, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "friction",
-			text_friction, VT_Float, 2, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "accel",
-			text_accel, VT_Float, 2, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "scale",
-			text_scale, VT_Float, 2, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "angle",
-			text_angle, VT_Float, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "xangle",
-			text_xangle, VT_Float, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "yangle",
-			text_yangle, VT_Float, 1, false); err != nil {
-			return err
-		}
-		if err := c.palFXSub(is, sc, "palfx."); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "color",
-			text_color, VT_Int, 4, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "xshear",
-			text_xshear, VT_Float, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramProjection(is, sc, "projection",
-			text_projection); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "focallength",
-			text_focallength, VT_Float, 1, false); err != nil {
-			return err
-		}
-		return nil
+		return c.textSub(is, sc)
 	})
 	return *ret, err
 }
@@ -5815,134 +5823,7 @@ func (c *CharCompiler) modifyText(is IniSection, sc *StateControllerBase) (State
 			modifytext_index, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.paramValue(is, sc, "id",
-			text_id, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "removetime",
-			text_removetime, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "layerno",
-			text_layerno, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.stateParam(is, "params", false, func(data string) error {
-			bes, err := c.exprs(data, VT_Undefined, 100000)
-			if err != nil {
-				return err
-			}
-			sc.add(text_params, bes)
-			return nil
-		}); err != nil {
-			return err
-		}
-		if err := c.stateParam(is, "text", false, func(data string) error {
-			_else := false
-			if len(data) >= 2 && data[0] == '"' {
-				if i := strings.Index(data[1:], "\""); i >= 0 {
-					data, _ = strconv.Unquote(data)
-				} else {
-					_else = true
-				}
-			} else {
-				_else = true
-			}
-			if _else {
-				return Error("Text not enclosed in \"")
-			}
-			sc.add(text_text, sc.iToExp(int32(sys.stringPool[c.playerNo].Add(data))))
-			return nil
-		}); err != nil {
-			return err
-		}
-		if err := c.stateParam(is, "font", false, func(data string) error {
-			prefix := c.getDataPrefix(&data, false)
-			// Only "f" (lifebar) or "m" (motif) are meaningful for Text/ModifyText.
-			if prefix != "f" && prefix != "m" {
-				prefix = ""
-			}
-			return c.scAdd(sc, text_font, data, VT_Int, 1,
-				sc.beToExp(BytecodeExp(prefix))...)
-		}); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "localcoord",
-			text_localcoord, VT_Float, 2, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "bank",
-			text_bank, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "align",
-			text_align, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "textspacing",
-			text_textspacing, VT_Float, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "textdelay",
-			text_textdelay, VT_Float, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "pos",
-			text_pos, VT_Float, 2, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "velocity",
-			text_velocity, VT_Float, 2, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "maxdist",
-			text_maxdist, VT_Float, 2, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "friction",
-			text_friction, VT_Float, 2, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "accel",
-			text_accel, VT_Float, 2, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "scale",
-			text_scale, VT_Float, 2, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "angle",
-			text_angle, VT_Float, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "xangle",
-			text_xangle, VT_Float, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "yangle",
-			text_yangle, VT_Float, 1, false); err != nil {
-			return err
-		}
-		if err := c.palFXSub(is, sc, "palfx."); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "color",
-			text_color, VT_Int, 4, false); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "xshear",
-			text_xshear, VT_Float, 1, false); err != nil {
-			return err
-		}
-		if err := c.paramProjection(is, sc, "projection",
-			text_projection); err != nil {
-			return err
-		}
-		if err := c.paramValue(is, sc, "focallength",
-			text_focallength, VT_Float, 1, false); err != nil {
-			return err
-		}
-		return nil
+		return c.textSub(is, sc)
 	})
 	return *ret, err
 }

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -283,6 +283,8 @@ func (c *CharCompiler) assertSpecial(is IniSection, sc *StateControllerBase) (St
 			// Ikemen global flags
 			case "camerafreeze":
 				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_camerafreeze)))
+			case "notimedisplay":
+				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_notimedisplay)))
 			case "globalnoko":
 				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_globalnoko)))
 			case "roundnotskip":

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -4710,28 +4710,6 @@ func (c *CharCompiler) lifebarAction(is IniSection, sc *StateControllerBase) (St
 	return *ret, err
 }
 
-func (c *CharCompiler) loadFile(is IniSection, sc *StateControllerBase) (StateController, error) {
-	ret, err := (*loadFile)(sc), c.stateSec(is, func() error {
-		if err := c.paramValue(is, sc, "redirectid",
-			loadFile_redirectid, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.stateParam(is, "path", false, func(data string) error {
-			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
-				return Error("Path not enclosed in \"")
-			}
-			sc.add(loadFile_path, sc.beToExp(BytecodeExp(data[1:len(data)-1])))
-			return nil
-		}); err != nil {
-			return err
-		}
-		if err := c.paramSaveData(is, sc, loadFile_saveData); err != nil {
-			return err
-		}
-		return nil
-	})
-	return *ret, err
-}
 
 func (c *CharCompiler) loadState(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*loadState)(sc), c.stateSec(is, func() error {
@@ -5509,25 +5487,41 @@ func (c *CharCompiler) roundTimeSet(is IniSection, sc *StateControllerBase) (Sta
 	return *ret, err
 }
 
+func (c *CharCompiler) saveLoadFileSub(is IniSection, sc *StateControllerBase) error {
+	if err := c.paramValue(is, sc, "redirectid", saveFile_redirectid, VT_Int, 1, false); err != nil {
+		return err
+	}
+	if err := c.stateParam(is, "path", true, func(data string) error {
+		if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
+			return Error("Path not enclosed in \"")
+		}
+		sc.add(saveFile_path, sc.beToExp(BytecodeExp(data[1:len(data)-1])))
+		return nil
+	}); err != nil {
+		return err
+	}
+	if err := c.paramSaveData(is, sc, saveFile_savedata); err != nil {
+		return err
+	}
+	if err := c.paramStringList(is, sc, "maps", saveFile_maps); err != nil {
+		return err
+	}
+	if err := c.paramStringList(is, sc, "maps.include", saveFile_maps_include); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (c *CharCompiler) saveFile(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*saveFile)(sc), c.stateSec(is, func() error {
-		if err := c.paramValue(is, sc, "redirectid",
-			saveFile_redirectid, VT_Int, 1, false); err != nil {
-			return err
-		}
-		if err := c.stateParam(is, "path", false, func(data string) error {
-			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
-				return Error("Path not enclosed in \"")
-			}
-			sc.add(saveFile_path, sc.beToExp(BytecodeExp(data[1:len(data)-1])))
-			return nil
-		}); err != nil {
-			return err
-		}
-		if err := c.paramSaveData(is, sc, saveFile_saveData); err != nil {
-			return err
-		}
-		return nil
+		return c.saveLoadFileSub(is, sc)
+	})
+	return *ret, err
+}
+
+func (c *CharCompiler) loadFile(is IniSection, sc *StateControllerBase) (StateController, error) {
+	ret, err := (*loadFile)(sc), c.stateSec(is, func() error {
+		return c.saveLoadFileSub(is, sc)
 	})
 	return *ret, err
 }

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -5466,8 +5466,10 @@ func (fs *FightScreen) draw(layerno int16) {
 			}
 
 			// Time
-			fs.time.bgDraw(layerno)
-			fs.time.draw(layerno, fs.fnt)
+			if !sys.gsf(GSF_notimedisplay) {
+				fs.time.bgDraw(layerno)
+				fs.time.draw(layerno, fs.fnt)
+			}
 
 			// WinIcon
 			for i := 0; i < len(fs.winIcons); i++ {

--- a/src/font.go
+++ b/src/font.go
@@ -775,10 +775,11 @@ type TextSprite struct {
 	textSpacing    [2]float32
 	textDelay      float32
 	textWrap       bool
-	friction       [2]float32
-	accel          [2]float32
 	vel            [2]float32
+	accel          [2]float32
+	friction       [2]float32
 	maxDist        [2]float32
+	hidewithbars   bool
 	// initial, unscaled values
 	offsetInit   [2]float32
 	scaleInit    [2]float32
@@ -1357,6 +1358,10 @@ func (ts *TextSprite) Update() {
 
 func (ts *TextSprite) Draw(ln int16) {
 	if sys.frameSkip || ts.layerno != ln || ts.fnt == nil || len(ts.text) == 0 {
+		return
+	}
+
+	if ts.hidewithbars && sys.shouldHideWithBars() {
 		return
 	}
 

--- a/src/image.go
+++ b/src/image.go
@@ -1765,33 +1765,80 @@ func preloadSff(filename string, char bool, preloadSpr map[[2]uint16]bool) (*Sff
 		return nil, nil, err
 	}
 
-	defer func() { chk(f.Close()) }()
+	defer func() {
+		chk(f.Close())
+	}()
 
-	h := &SffHeader{}
+	// Read SFF header
 	var lofs, tofs uint32
-	if err := h.Read(f, &lofs, &tofs); err != nil {
+	if err := sff.header.Read(f, &lofs, &tofs); err != nil {
 		return nil, nil, err
 	}
 
 	sff.filename = filename
-	sff.header.Version[0] = h.Version[0]
-	sff.header.Version[1] = h.Version[1]
-	sff.header.Version[2] = h.Version[2]
-	sff.header.Version[3] = h.Version[3]
-	sff.header.FirstPaletteHeaderOffset = h.FirstPaletteHeaderOffset
-	sff.header.NumberOfPalettes = h.NumberOfPalettes
-
 	read := func(x interface{}) error {
 		return binary.Read(f, binary.LittleEndian, x)
 	}
 
-	var shofs, xofs, size uint32 = h.FirstSpriteHeaderOffset, 0, 0
+	// Load SFFv2 palettes
+	if sff.header.Version[0] != 1 {
+		uniquePals := make(map[[2]uint16]int)
+		for i := 0; i < int(sff.header.NumberOfPalettes); i++ {
+			f.Seek(int64(sff.header.FirstPaletteHeaderOffset)+int64(i*16), 0)
+			var gn_ [3]uint16
+			if err := read(gn_[:]); err != nil {
+				return nil, nil, err
+			}
+			var link uint16
+			if err := read(&link); err != nil {
+				return nil, nil, err
+			}
+			var ofs, plSize uint32
+			if err := read(&ofs); err != nil {
+				return nil, nil, err
+			}
+			if err := read(&plSize); err != nil {
+				return nil, nil, err
+			}
+
+			var pal []uint32
+			var idx int
+			if old, ok := uniquePals[[2]uint16{gn_[0], gn_[1]}]; ok {
+				idx = old
+				pal = sff.palList.Get(old)
+				LogMessage("WARNING: Duplicate palette key in %v: %v,%v (%v/%v)", filename, gn_[0], gn_[1], i+1, sff.header.NumberOfPalettes)
+			} else if plSize == 0 {
+				// Linked palette – use the palette at index 'link'
+				idx = int(link)
+				pal = sff.palList.Get(idx)
+			} else {
+				// Read palette data
+				pal, err = sff.ReadPalette(f, int64(lofs+ofs), plSize)
+				if err != nil {
+					return nil, nil, err
+				}
+				idx = i
+			}
+
+			sff.palList.SetSource(i, pal)
+			sff.palList.PalTable[[2]uint16{gn_[0], gn_[1]}] = idx
+			sff.palList.numcols[[2]uint16{gn_[0], gn_[1]}] = int(gn_[2])
+
+			if i <= sys.cfg.Config.PaletteMax &&
+				sff.palList.PalTable[[2]uint16{1, uint16(i + 1)}] == sff.palList.PalTable[[2]uint16{gn_[0], gn_[1]}] &&
+				(gn_[0] != 1 || gn_[1] != uint16(i+1)) {
+				sff.palList.PalTable[[2]uint16{1, uint16(i + 1)}] = -1
+			}
+		}
+	}
+
+	var shofs, xofs, size uint32 = sff.header.FirstSpriteHeaderOffset, 0, 0
 	var indexOfPrevious uint16
-	var plShofs, plXofs, plSize uint32 = h.FirstPaletteHeaderOffset, 0, 0
+	var plShofs, plXofs, plSize uint32 = sff.header.FirstPaletteHeaderOffset, 0, 0
 	var plIndexOfPrevious uint16
 	pl := &PaletteList{}
 	pl.init()
-	spriteList := make([]*Sprite, int(h.NumberOfSprites))
+	spriteList := make([]*Sprite, int(sff.header.NumberOfSprites))
 	var prev *Sprite
 	preloadSprNum := len(preloadSpr)
 	preloadRef := make(map[int]bool)
@@ -1806,8 +1853,8 @@ func preloadSff(filename string, char bool, preloadSpr map[[2]uint16]bool) (*Sff
 	var initialPalLocation int64
 	coloredPalette := -1
 	if sff.header.Version[0] != 1 {
-		for i := 0; i < int(h.NumberOfPalettes); i++ {
-			f.Seek(int64(h.FirstPaletteHeaderOffset)+int64(i*16), 0)
+		for i := 0; i < int(sff.header.NumberOfPalettes); i++ {
+			f.Seek(int64(sff.header.FirstPaletteHeaderOffset)+int64(i*16), 0)
 			var gn_ [3]int16
 			if err := read(gn_[:]); err != nil {
 				return nil, nil, err
@@ -1821,7 +1868,7 @@ func preloadSff(filename string, char bool, preloadSpr map[[2]uint16]bool) (*Sff
 	for i := 0; i < len(spriteList); i++ {
 		spriteList[i] = newSprite()
 		f.Seek(int64(shofs), 0)
-		switch h.Version[0] {
+		switch sff.header.Version[0] {
 		case 1:
 			if err := spriteList[i].readHeader(f, &xofs, &size, &indexOfPrevious); err != nil {
 				return nil, nil, err
@@ -1889,10 +1936,10 @@ func preloadSff(filename string, char bool, preloadSpr map[[2]uint16]bool) (*Sff
 					bxofs, bsize := headerXofs[base], headerSize[base]
 					if bsize > 0 {
 						var err error
-						switch h.Version[0] {
+						switch sff.header.Version[0] {
 						case 1:
 							err = spriteList[base].read(
-								f, h, headerShofs32[base], bsize, bxofs, prev, pl)
+								f, &sff.header, headerShofs32[base], bsize, bxofs, prev, pl)
 						case 2:
 							err = spriteList[base].readV2(f, int64(bxofs), bsize)
 						}
@@ -1908,9 +1955,9 @@ func preloadSff(filename string, char bool, preloadSpr map[[2]uint16]bool) (*Sff
 					spriteList[i].palidx = 0 // index out of range
 				}
 			} else {
-				switch h.Version[0] {
+				switch sff.header.Version[0] {
 				case 1:
-					if err := spriteList[i].read(f, h, int64(shofs+32), size, xofs, prev, pl); err != nil {
+					if err := spriteList[i].read(f, &sff.header, int64(shofs+32), size, xofs, prev, pl); err != nil {
 						return nil, nil, err
 					}
 				case 2:
@@ -1921,7 +1968,7 @@ func preloadSff(filename string, char bool, preloadSpr map[[2]uint16]bool) (*Sff
 				if ok {
 					// palette
 					plXofs = xofs
-					if h.Version[0] == 1 {
+					if sff.header.Version[0] == 1 {
 						// Try palette from list
 						spriteList[i].Pal = pl.Get(spriteList[i].palidx)
 						if spriteList[i].palidx >= sys.cfg.Config.PaletteMax || spriteList[i].palidx < 0 {
@@ -1953,8 +2000,8 @@ func preloadSff(filename string, char bool, preloadSpr map[[2]uint16]bool) (*Sff
 										spriteList[i].palidx = 0 // shared
 									}
 								}
+								f.Seek(int64(xofs), 0) // reset pointer to sprite data
 							}
-							f.Seek(int64(xofs), 0) // reset pointer to sprite data
 						} else {
 							// Unique palette, keep as is
 							spriteList[i].palidx = 1
@@ -1965,7 +2012,7 @@ func preloadSff(filename string, char bool, preloadSpr map[[2]uint16]bool) (*Sff
 						ip := plIndexOfPrevious + 1
 						for plSize == 0 && ip != plIndexOfPrevious {
 							ip = plIndexOfPrevious
-							plShofs = h.FirstPaletteHeaderOffset + uint32(ip)*16
+							plShofs = sff.header.FirstPaletteHeaderOffset + uint32(ip)*16
 							f.Seek(int64(plShofs)+6, 0)
 							if err := read(&plIndexOfPrevious); err != nil {
 								return nil, nil, err
@@ -1991,7 +2038,6 @@ func preloadSff(filename string, char bool, preloadSpr map[[2]uint16]bool) (*Sff
 						} else {
 							spriteList[i].palidx = 0
 						}
-
 					}
 				}
 				if prev == nil {
@@ -2007,18 +2053,19 @@ func preloadSff(filename string, char bool, preloadSpr map[[2]uint16]bool) (*Sff
 				}
 			}
 		}
-		if h.Version[0] == 1 {
+		if sff.header.Version[0] == 1 {
 			shofs = xofs
 		} else {
 			shofs += 28
 		}
 	}
-	// selectable palettes
+
+	// Build selectable palette list
 	var preSelPal []int32
 	var selPal []int32
-	if h.Version[0] != 1 && char {
-		for i := 0; i < int(h.NumberOfPalettes); i++ {
-			f.Seek(int64(h.FirstPaletteHeaderOffset)+int64(i*16), 0)
+	if sff.header.Version[0] != 1 && char {
+		for i := 0; i < int(sff.header.NumberOfPalettes); i++ {
+			f.Seek(int64(sff.header.FirstPaletteHeaderOffset)+int64(i*16), 0)
 			var gn_ [3]int16
 			if err := read(gn_[:]); err != nil {
 				return nil, nil, err

--- a/src/image.go
+++ b/src/image.go
@@ -471,6 +471,20 @@ func (pl *PaletteList) SwapPalMap(palMap *[]int) bool {
 	return true
 }
 
+// Returns the real index of a selectable palette
+// For instance if palette 3 is requested, it checks palette 1,3's location and returns that index
+func (pl *PaletteList) SelectablePalIndex(palNum int) int {
+	if palNum < 1 || palNum > sys.cfg.Config.PaletteMax {
+		return 0 // Fallback
+	}
+	key := [2]uint16{1, uint16(palNum)}
+	palIdx, ok := pl.PalTable[key]
+	if !ok {
+		return 0
+	}
+	return palIdx
+}
+
 // Convert palette color slice into the format used in textures
 func Pal32ToBytes(pal []uint32) []byte {
 	if len(pal) == 0 {
@@ -1615,25 +1629,6 @@ func preloadSff(filename string, char bool, preloadSpr map[[2]uint16]bool) (*Sff
 		return nil, nil, err
 	}
 
-	// Prepare palette mapping for the select screen
-	// The select screen expects them at "0 to PaletteMax-1"
-	// TODO: Select screen code could use the normal mapping method and thus do without workarounds
-	for i := 1; i <= sys.cfg.Config.PaletteMax; i++ {
-		key := [2]uint16{1, uint16(i)}
-		physIdx, ok := sff.palList.PalTable[key]
-		if !ok || physIdx < 0 {
-			continue
-		}
-		pal := sff.palList.Get(physIdx)
-		if pal == nil {
-			continue
-		}
-		logicalIdx := i - 1
-		sff.palList.SetSource(logicalIdx, pal)
-		sff.palList.PalTable[key] = logicalIdx // point logical key to logical slot
-		sff.palList.numcols[key] = len(pal)
-	}
-
 	// Prepare sprite reading
 	var shofs, xofs, size uint32 = sff.header.FirstSpriteHeaderOffset, 0, 0
 	var indexOfPrevious uint16
@@ -1952,12 +1947,13 @@ func (s *Sff) loadPalettes(f io.ReadSeeker, lofs uint32) error {
 		// We'll use a length check later instead because that's more reliable
 		s.palList.numcols[[2]uint16{gn[0], gn[1]}] = int(gn[2])
 
+		// This no longer seems necessary after merging select screen and ingame palette codes
 		// Clear conflicting selectable palette mapping
-		if i <= sys.cfg.Config.PaletteMax &&
-			s.palList.PalTable[[2]uint16{1, uint16(i+1)}] == s.palList.PalTable[[2]uint16{gn[0], gn[1]}] &&
-			(gn[0] != 1 || gn[1] != uint16(i+1)) {
-			s.palList.PalTable[[2]uint16{1, uint16(i+1)}] = -1
-		}
+		//if i <= sys.cfg.Config.PaletteMax &&
+		//	s.palList.PalTable[[2]uint16{1, uint16(i+1)}] == s.palList.PalTable[[2]uint16{gn[0], gn[1]}] &&
+		//	(gn[0] != 1 || gn[1] != uint16(i+1)) {
+		//	s.palList.PalTable[[2]uint16{1, uint16(i+1)}] = -1
+		//}
 	}
 
 	return nil

--- a/src/image.go
+++ b/src/image.go
@@ -552,126 +552,6 @@ func readActPalette(filename string) ([]uint32, error) {
 	return pal, nil
 }
 
-// Loads a char's selectable palettes for the motif/scripts
-// Used by things like palette selection and Turns faces colors
-func loadCharPalettes(sff *Sff, filename string, ref int) error {
-	f, err := OpenFile(filename)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	h := sff.header
-	read := func(x interface{}) error {
-		return binary.Read(f, binary.LittleEndian, x)
-	}
-	var lofs, tofs uint32
-	if err := h.Read(f, &lofs, &tofs); err != nil {
-		return err
-	}
-	maxPal := int(sys.cfg.Config.PaletteMax)
-	c := sys.sel.charlist[ref]
-
-	// SFF v2
-	uniquePals := make(map[[2]uint16]int)
-	loaded := make(map[int]bool)
-
-	for headerIdx := 0; headerIdx < int(h.NumberOfPalettes); headerIdx++ {
-		f.Seek(int64(h.FirstPaletteHeaderOffset)+int64(headerIdx*16), 0)
-
-		var gn_ [3]uint16
-		if err := read(gn_[:]); err != nil {
-			return err
-		}
-
-		// We only care about group 1
-		if gn_[0] != 1 || gn_[1] <= 0 {
-			continue
-		}
-
-		destIdx := int(gn_[1]) - 1
-		if destIdx < 0 || destIdx >= maxPal {
-			continue
-		}
-
-		var link uint16
-		if err := read(&link); err != nil {
-			return err
-		}
-		var ofs, plSize uint32
-		if err := read(&ofs); err != nil {
-			return err
-		}
-		if err := read(&plSize); err != nil {
-			return err
-		}
-
-		var pal []uint32
-		// Reuse duplicate if already loaded
-		if old, ok := uniquePals[[2]uint16{gn_[0], gn_[1]}]; ok {
-			if old >= 0 && old < maxPal && loaded[old] {
-				pal = sff.palList.Get(old)
-				destIdx = old
-			}
-		} else if plSize == 0 {
-			// Link must point to a previously loaded slot
-			linkIdx := int(link) - 1
-			if linkIdx >= 0 && linkIdx < maxPal && loaded[linkIdx] {
-				pal = sff.palList.Get(linkIdx)
-				destIdx = linkIdx
-			}
-		} else {
-			// Read SFF palette data
-			var err error
-			pal, err = sff.ReadPalette(f, int64(lofs+ofs), plSize)
-			if err != nil {
-				return err
-			}
-		}
-		// Register only if we have data
-		if pal != nil {
-			sff.palList.SetSource(destIdx, pal)
-			loaded[destIdx] = true
-			uniquePals[[2]uint16{gn_[0], gn_[1]}] = destIdx
-			sff.palList.PalTable[[2]uint16{gn_[0], gn_[1]}] = destIdx
-			sff.palList.numcols[[2]uint16{gn_[0], gn_[1]}] = int(gn_[2])
-		}
-	}
-
-	// SFFv1 and Act Overrides
-	// TODO: External .ACTs on SFFv2 without palette slots may cause color bleeding,
-	// on sprites with unique palettes if a SFFv2 with Acts is loaded by sffNew, since is a simplified utility
-	// and lacks the engine's palInfo/cgi logic to properly isolate palette remapping during rendering.
-	searchDirs := []string{c.def, "", "data/"}
-
-	// Read ACT palettes
-	for x := 0; x < len(c.pal_files) && x < len(c.pal); x++ {
-		if c.pal_files[x] == "" {
-			continue
-		}
-
-		palSlot := uint16(c.pal[x])
-		targetIdx := int(palSlot) - 1
-
-		if targetIdx < 0 || targetIdx >= maxPal {
-			continue
-		}
-
-		palPath := SearchFile(c.pal_files[x], searchDirs)
-		pal, err := readActPalette(palPath)
-		if err != nil {
-			fmt.Println("Error reading " + palPath)
-			continue
-		}
-
-		// Update the PalTable mapping
-		sff.palList.SetSource(targetIdx, pal)
-		sff.palList.PalTable[[2]uint16{1, palSlot}] = targetIdx
-		sff.palList.numcols[[2]uint16{1, palSlot}] = 256 // ACT files are always 256 colors
-	}
-
-	return nil
-}
-
 type Sprite struct {
 	Pal      []uint32
 	Tex      Texture
@@ -1620,61 +1500,11 @@ func loadSff(filename string, char bool, isMainThread bool, isActPal bool) (*Sff
 		return nil, err
 	}
 
-	read := func(x interface{}) error {
-		return binary.Read(f, binary.LittleEndian, x)
+	// Load SFFv2 palettes
+	if err := s.loadPalettes(f, lofs); err != nil {
+		return nil, err
 	}
 
-	// Load palettes
-	if s.header.Version[0] != 1 {
-		uniquePals := make(map[[2]uint16]int)
-		for i := 0; i < int(s.header.NumberOfPalettes); i++ {
-			f.Seek(int64(s.header.FirstPaletteHeaderOffset)+int64(i*16), 0)
-			var gn_ [3]uint16
-			if err := read(gn_[:]); err != nil {
-				return nil, err
-			}
-			var link uint16
-			if err := read(&link); err != nil {
-				return nil, err
-			}
-			var ofs, plSize uint32
-			if err := read(&ofs); err != nil {
-				return nil, err
-			}
-			if err := read(&plSize); err != nil {
-				return nil, err
-			}
-			var pal []uint32
-			var idx int
-			if old, ok := uniquePals[[2]uint16{gn_[0], gn_[1]}]; ok {
-				idx = old
-				pal = s.palList.Get(old)
-				LogMessage("WARNING: Duplicate palette key in %v: %v,%v (%v/%v)", filename, gn_[0], gn_[1], i+1, s.header.NumberOfPalettes)
-			} else if plSize == 0 {
-				idx = int(link)
-				pal = s.palList.Get(idx)
-			} else {
-				// Read palette data
-				var err error
-				pal, err = s.ReadPalette(f, int64(lofs+ofs), plSize)
-				if err != nil {
-					return nil, err
-				}
-				idx = i
-			}
-			uniquePals[[2]uint16{gn_[0], gn_[1]}] = idx
-			s.palList.SetSource(i, pal)
-			s.palList.PalTable[[...]uint16{gn_[0], gn_[1]}] = idx
-			// Number of colors as specified in the SFF
-			// We'll use a length check later instead because that's more reliable
-			s.palList.numcols[[...]uint16{gn_[0], gn_[1]}] = int(gn_[2])
-			if i <= sys.cfg.Config.PaletteMax &&
-				s.palList.PalTable[[...]uint16{1, uint16(i + 1)}] == s.palList.PalTable[[...]uint16{gn_[0], gn_[1]}] &&
-				gn_[0] != 1 && gn_[1] != uint16(i+1) {
-				s.palList.PalTable[[...]uint16{1, uint16(i + 1)}] = -1
-			}
-		}
-	}
 	// Load sprites
 	spriteList := make([]*Sprite, int(s.header.NumberOfSprites))
 	var prev *Sprite
@@ -1759,6 +1589,7 @@ func loadSff(filename string, char bool, isMainThread bool, isActPal bool) (*Sff
 // Loads a SFF with only specific sprites
 func preloadSff(filename string, char bool, preloadSpr map[[2]uint16]bool) (*Sff, []int32, error) {
 	sff := newSff()
+	sff.filename = filename
 
 	f, err := OpenFile(filename)
 	if err != nil {
@@ -1775,63 +1606,35 @@ func preloadSff(filename string, char bool, preloadSpr map[[2]uint16]bool) (*Sff
 		return nil, nil, err
 	}
 
-	sff.filename = filename
 	read := func(x interface{}) error {
 		return binary.Read(f, binary.LittleEndian, x)
 	}
 
 	// Load SFFv2 palettes
-	if sff.header.Version[0] != 1 {
-		uniquePals := make(map[[2]uint16]int)
-		for i := 0; i < int(sff.header.NumberOfPalettes); i++ {
-			f.Seek(int64(sff.header.FirstPaletteHeaderOffset)+int64(i*16), 0)
-			var gn_ [3]uint16
-			if err := read(gn_[:]); err != nil {
-				return nil, nil, err
-			}
-			var link uint16
-			if err := read(&link); err != nil {
-				return nil, nil, err
-			}
-			var ofs, plSize uint32
-			if err := read(&ofs); err != nil {
-				return nil, nil, err
-			}
-			if err := read(&plSize); err != nil {
-				return nil, nil, err
-			}
-
-			var pal []uint32
-			var idx int
-			if old, ok := uniquePals[[2]uint16{gn_[0], gn_[1]}]; ok {
-				idx = old
-				pal = sff.palList.Get(old)
-				LogMessage("WARNING: Duplicate palette key in %v: %v,%v (%v/%v)", filename, gn_[0], gn_[1], i+1, sff.header.NumberOfPalettes)
-			} else if plSize == 0 {
-				// Linked palette – use the palette at index 'link'
-				idx = int(link)
-				pal = sff.palList.Get(idx)
-			} else {
-				// Read palette data
-				pal, err = sff.ReadPalette(f, int64(lofs+ofs), plSize)
-				if err != nil {
-					return nil, nil, err
-				}
-				idx = i
-			}
-
-			sff.palList.SetSource(i, pal)
-			sff.palList.PalTable[[2]uint16{gn_[0], gn_[1]}] = idx
-			sff.palList.numcols[[2]uint16{gn_[0], gn_[1]}] = int(gn_[2])
-
-			if i <= sys.cfg.Config.PaletteMax &&
-				sff.palList.PalTable[[2]uint16{1, uint16(i + 1)}] == sff.palList.PalTable[[2]uint16{gn_[0], gn_[1]}] &&
-				(gn_[0] != 1 || gn_[1] != uint16(i+1)) {
-				sff.palList.PalTable[[2]uint16{1, uint16(i + 1)}] = -1
-			}
-		}
+	if err := sff.loadPalettes(f, lofs); err != nil {
+		return nil, nil, err
 	}
 
+	// Prepare palette mapping for the select screen
+	// The select screen expects them at "0 to PaletteMax-1"
+	// TODO: Select screen code could use the normal mapping method and thus do without workarounds
+	for i := 1; i <= sys.cfg.Config.PaletteMax; i++ {
+		key := [2]uint16{1, uint16(i)}
+		physIdx, ok := sff.palList.PalTable[key]
+		if !ok || physIdx < 0 {
+			continue
+		}
+		pal := sff.palList.Get(physIdx)
+		if pal == nil {
+			continue
+		}
+		logicalIdx := i - 1
+		sff.palList.SetSource(logicalIdx, pal)
+		sff.palList.PalTable[key] = logicalIdx // point logical key to logical slot
+		sff.palList.numcols[key] = len(pal)
+	}
+
+	// Prepare sprite reading
 	var shofs, xofs, size uint32 = sff.header.FirstSpriteHeaderOffset, 0, 0
 	var indexOfPrevious uint16
 	var plShofs, plXofs, plSize uint32 = sff.header.FirstPaletteHeaderOffset, 0, 0
@@ -2091,7 +1894,76 @@ func preloadSff(filename string, char bool, preloadSpr map[[2]uint16]bool) (*Sff
 	return sff, selPal, nil
 }
 
-// Read SFFv2 palettes
+// Loads all of a v2 SFF's palettes
+// We also load all of them when preloading to avoid issues
+// https://github.com/ikemen-engine/Ikemen-GO/issues/3460
+func (s *Sff) loadPalettes(f io.ReadSeeker, lofs uint32) error {
+	if s.header.Version[0] == 1 {
+		return nil
+	}
+
+	read := func(x interface{}) error {
+		return binary.Read(f, binary.LittleEndian, x)
+	}
+
+	uniquePals := make(map[[2]uint16]int)
+
+	for i := 0; i < int(s.header.NumberOfPalettes); i++ {
+		f.Seek(int64(s.header.FirstPaletteHeaderOffset)+int64(i*16), 0)
+		var gn [3]uint16
+		if err := read(gn[:]); err != nil {
+			return err
+		}
+		var link uint16
+		if err := read(&link); err != nil {
+			return err
+		}
+		var ofs, plSize uint32
+		if err := read(&ofs); err != nil {
+			return err
+		}
+		if err := read(&plSize); err != nil {
+			return err
+		}
+		var pal []uint32
+		var idx int
+		if old, ok := uniquePals[[2]uint16{gn[0], gn[1]}]; ok {
+			// Duplicate key
+			idx = old
+			pal = s.palList.Get(old)
+			LogMessage("WARNING: Duplicate palette key in %v: %v,%v (%v/%v)", s.filename, gn[0], gn[1], i+1, s.header.NumberOfPalettes)
+		} else if plSize == 0 {
+			// Linked palette
+			idx = int(link)
+			pal = s.palList.Get(idx)
+		} else {
+			// Unique palette
+			var err error
+			pal, err = s.ReadPalette(f, int64(lofs+ofs), plSize)
+			if err != nil {
+				return err
+			}
+			idx = i
+		}
+		uniquePals[[2]uint16{gn[0], gn[1]}] = idx
+		s.palList.SetSource(i, pal)
+		s.palList.PalTable[[2]uint16{gn[0], gn[1]}] = idx
+		// Number of colors as specified in the SFF
+		// We'll use a length check later instead because that's more reliable
+		s.palList.numcols[[2]uint16{gn[0], gn[1]}] = int(gn[2])
+
+		// Clear conflicting selectable palette mapping
+		if i <= sys.cfg.Config.PaletteMax &&
+			s.palList.PalTable[[2]uint16{1, uint16(i+1)}] == s.palList.PalTable[[2]uint16{gn[0], gn[1]}] &&
+			(gn[0] != 1 || gn[1] != uint16(i+1)) {
+			s.palList.PalTable[[2]uint16{1, uint16(i+1)}] = -1
+		}
+	}
+
+	return nil
+}
+
+// Read one SFFv2 palette
 func (s *Sff) ReadPalette(f io.ReadSeeker, offset int64, size uint32) ([]uint32, error) {
 	if _, err := f.Seek(offset, io.SeekStart); err != nil {
 		return nil, err
@@ -2144,6 +2016,49 @@ func (s *Sff) ReadPalette(f io.ReadSeeker, offset int64, size uint32) ([]uint32,
 	}
 
 	return pal, nil
+}
+
+// Loads a char's selectable ACT palettes for the motif/scripts
+// Used by things like palette selection and Turns faces colors
+func (s *Sff) loadActPalettes(ref int) error {
+	// No need to reopen the SFF since the preload already grabbed the palettes
+	//f, err := OpenFile(filename)
+
+	c := sys.sel.charlist[ref]
+	maxPal := int(sys.cfg.Config.PaletteMax)
+
+	// TODO: External .ACTs on SFFv2 without palette slots may cause color bleeding,
+	// on sprites with unique palettes if a SFFv2 with Acts is loaded by sffNew, since is a simplified utility
+	// and lacks the engine's palInfo/cgi logic to properly isolate palette remapping during rendering.
+	searchDirs := []string{c.def, "", "data/"}
+
+	// Read each palette
+	for x := 0; x < len(c.pal_files) && x < len(c.pal); x++ {
+		if c.pal_files[x] == "" {
+			continue
+		}
+
+		palSlot := uint16(c.pal[x])
+		targetIdx := int(palSlot) - 1
+
+		if targetIdx < 0 || targetIdx >= maxPal {
+			continue
+		}
+
+		palPath := SearchFile(c.pal_files[x], searchDirs)
+		pal, err := readActPalette(palPath)
+		if err != nil {
+			LogMessage("Error reading " + palPath)
+			continue
+		}
+
+		// Update the PalTable mapping
+		s.palList.SetSource(targetIdx, pal)
+		s.palList.PalTable[[2]uint16{1, palSlot}] = targetIdx
+		s.palList.numcols[[2]uint16{1, palSlot}] = 256 // ACT files are always 256 colors
+	}
+
+	return nil
 }
 
 func (s *Sff) GetSprite(g, n uint16) *Sprite {

--- a/src/script.go
+++ b/src/script.go
@@ -9231,6 +9231,8 @@ func triggerFunctions(l *lua.LState) {
 		// GlobalSpecialFlag (Ikemen)
 		case "camerafreeze":
 			l.Push(lua.LBool(sys.gsf(GSF_camerafreeze)))
+		case "notimedisplay":
+			l.Push(lua.LBool(sys.gsf(GSF_notimedisplay)))
 		case "roundfreeze":
 			l.Push(lua.LBool(sys.gsf(GSF_roundfreeze)))
 		case "roundnotskip":

--- a/src/script.go
+++ b/src/script.go
@@ -1325,7 +1325,9 @@ func systemScriptInit(l *lua.LState) {
 		if !ok {
 			userDataError(l, 1, a)
 		}
-		pal := a.anim.palettedata.palettes[int(numArg(l, 2))-1]
+		palNum := int(numArg(l, 2))
+		palIdx := a.anim.palettedata.SelectablePalIndex(palNum)
+		pal := a.anim.palettedata.palettes[palIdx]
 		tbl := l.NewTable()
 		for k, v := range pal {
 			col := l.NewTable()
@@ -1350,8 +1352,9 @@ func systemScriptInit(l *lua.LState) {
 		if !ok {
 			userDataError(l, 1, a)
 		}
-		pal := int(numArg(l, 2)) - 1
-		palData := a.anim.palettedata.palettes[pal]
+		palNum := int(numArg(l, 2))
+		palIdx := a.anim.palettedata.SelectablePalIndex(palNum)
+		palData := a.anim.palettedata.palettes[palIdx]
 		tableArg(l, 3).ForEach(func(key, value lua.LValue) {
 			var color uint32
 			switch v := value.(type) {
@@ -1364,8 +1367,8 @@ func systemScriptInit(l *lua.LState) {
 				palData[int(lua.LVAsNumber(key))-1] = color
 			}
 		})
-		a.anim.palettedata.SetSource(pal, palData)
-		a.anim.palettedata.PalTex[pal] = NewTextureFromPalette(palData)
+		a.anim.palettedata.SetSource(palIdx, palData)
+		a.anim.palettedata.PalTex[palIdx] = NewTextureFromPalette(palData)
 		return 0
 	})
 	luaRegister(l, "animPrepare", func(l *lua.LState) int {
@@ -1579,8 +1582,10 @@ func systemScriptInit(l *lua.LState) {
 		@treturn Anim anim The same animation userdata (for chaining).
 		function animSetColorPalette(anim, paletteId) end*/
 		a, _ := toUserData(l, 1).(*Anim)
+		palNum := int(numArg(l, 2))
+		palIdx := a.anim.palettedata.SelectablePalIndex(palNum)
 		if len(a.anim.palettedata.paletteMap) > 0 {
-			a.anim.palettedata.paletteMap[0] = int(numArg(l, 2)) - 1
+			a.anim.palettedata.paletteMap[0] = palIdx
 		}
 		l.Push(newUserData(l, a))
 		return 1

--- a/src/script.go
+++ b/src/script.go
@@ -1252,7 +1252,7 @@ func systemScriptInit(l *lua.LState) {
 		/*Load palettes for an animation's underlying sprite file, if palette usage is enabled.
 		@function animLoadPalettes
 		@tparam Anim anim Animation userdata.
-		@tparam int param Palette parameter passed to `loadCharPalettes` (engine-specific semantics).
+		@tparam int param Palette parameter passed to `loadActPalettes` (engine-specific semantics).
 		function animLoadPalettes(anim, param) end*/
 		a, ok := toUserData(l, 1).(*Anim)
 		if !ok {
@@ -1260,7 +1260,7 @@ func systemScriptInit(l *lua.LState) {
 			return 0
 		}
 		if sys.usePalette == true {
-			loadCharPalettes(a.anim.sff, a.anim.sff.filename, int(numArg(l, 2)))
+			a.anim.sff.loadActPalettes(int(numArg(l, 2)))
 		}
 		return 0
 	})

--- a/src/system.go
+++ b/src/system.go
@@ -5729,3 +5729,7 @@ func (s *System) cleanCustomShaders() {
 		}
 	}
 }
+
+func (s *System) shouldHideWithBars() bool {
+	return !s.fightScreen.visible() || s.gsf(GSF_nobardisplay) || !s.fightScreen.bars
+}

--- a/src/system.go
+++ b/src/system.go
@@ -5241,7 +5241,7 @@ func (l *Loader) prepareTurnsFaces(pn int, fa *FightScreenFace, nm *FightScreenN
 
 			// Only load palettes if necessary
 			if !hasTarget || !has11 {
-				loadCharPalettes(sc.sff, sc.sff.filename, charIdx)
+				sc.sff.loadActPalettes(charIdx)
 			}
 
 			// Check if the sprite uses or shares palette 1, 1


### PR DESCRIPTION
Features:
- Save/LoadFile can now operate on specific maps instead of the entire array
- Text `hidewithbars` parameter. Same as Explod's
- AssertSpecial `noTimeDisplay`. Hides the fight screen's [Time] elements
- Implements #3653

Fixes:
- Fixed "ignore darken" timer being off by 1
- Fixed crash when trying to access linked palettes in the select screen
- Fixes #3460 
- `getHitVar(fall.envshake.time)` now resets outside of movetype H, as in Mugen

Refactor:
- The SFF is no longer reopened to load a char's SFFv2 palettes. Those palettes are loaded during the initial SFF load
- Select screen palette code now uses the same table logic as the ingame palettes, thus unifying the two branches
- When duplicate characters in the same team are all in "done" status, only one "done" cursor will be drawn for them