### PR TITLE
feat: Add DistOffset sctrl

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -980,6 +980,9 @@ const (
 	OC_ex3_analog_righty
 	OC_ex3_analog_lefttrigger
 	OC_ex3_analog_righttrigger
+	OC_ex3_distoffset_x
+	OC_ex3_distoffset_y
+	OC_ex3_distoffset_z
 	OC_ex3_helpervar_clsnproxy
 	OC_ex3_helpervar_helpertype
 	OC_ex3_helpervar_id
@@ -4195,6 +4198,13 @@ func (be BytecodeExp) run_ex3(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushF(c.analogAxes[4])
 	case OC_ex3_analog_righttrigger:
 		sys.bcStack.PushF(c.analogAxes[5])
+	// DistOffset
+	case OC_ex3_distoffset_x:
+		sys.bcStack.PushF(c.distOffset[0] / oc.localscl) // Already in c.localscl so we only divide by oc.localscl
+	case OC_ex3_distoffset_y:
+		sys.bcStack.PushF(c.distOffset[1] / oc.localscl)
+	case OC_ex3_distoffset_z:
+		sys.bcStack.PushF(c.distOffset[2] / oc.localscl)
 	// HitDefVar
 	case OC_ex3_hitdefvar_guard_dist_width_back:
 		sys.bcStack.PushF(c.hitdef.guard_dist_x[1] * (c.localscl / oc.localscl))
@@ -11325,6 +11335,35 @@ func (sc offset) Run(c *Char, _ []int32) bool {
 			crun.offset[0] = exp[0].evalF(c) * c.localscl
 		case offset_y:
 			crun.offset[1] = exp[0].evalF(c) * c.localscl
+		}
+		return true
+	})
+	return false
+}
+
+type distOffset StateControllerBase
+
+const (
+	distOffset_x byte = iota
+	distOffset_y
+	distOffset_z
+	distOffset_redirectid
+)
+
+func (sc distOffset) Run(c *Char, _ []int32) bool {
+	crun := getRedirectedChar(c, StateControllerBase(sc), distOffset_redirectid, "DistOffset")
+	if crun == nil {
+		return false
+	}
+
+	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
+		switch paramID {
+		case distOffset_x:
+			crun.distOffset[0] = exp[0].evalF(c) * c.localscl
+		case distOffset_y:
+			crun.distOffset[1] = exp[0].evalF(c) * c.localscl
+		case distOffset_z:
+			crun.distOffset[2] = exp[0].evalF(c) * c.localscl
 		}
 		return true
 	})

--- a/src/char.go
+++ b/src/char.go
@@ -3247,6 +3247,7 @@ type Char struct {
 	interPos            [3]float32 // Interpolated position. For the visuals when game and logic speed are different
 	oldPos              [3]float32
 	vel                 [3]float32
+	distOffset          [3]float32
 	facing              float32
 	fbFlip              bool
 	cnsvar              map[int32]int32
@@ -8208,7 +8209,7 @@ func (c *Char) bindToTarget(tar []int32, time int32, x, y, z float32, hmf HMF) {
 				c.setPosZ(t.pos[2]*(t.localscl/c.localscl)+z, true)
 			}
 			c.targetBind(tar[:1], time,
-				c.facing*c.distX(t, c),
+				c.facing*c.distX(t, c, true),
 				(t.pos[1]*(t.localscl/c.localscl))-(c.pos[1]*(c.localscl/t.localscl)),
 				(t.pos[2]*(t.localscl/c.localscl))-(c.pos[2]*(c.localscl/t.localscl)))
 		}
@@ -8740,7 +8741,7 @@ func (c *Char) redLifeEnabled() bool {
 	*/
 }
 
-func (c *Char) distX(opp *Char, oc *Char) float32 {
+func (c *Char) distX(opp *Char, oc *Char, noOffset bool) float32 {
 	cpos := c.pos[0] * c.localscl
 	opos := opp.pos[0] * opp.localscl
 	// Update distance while bound. Mugen chars only
@@ -8756,6 +8757,10 @@ func (c *Char) distX(opp *Char, oc *Char) float32 {
 			}
 		}
 	}
+	if !noOffset {
+		cpos += c.distOffset[0] * c.facing
+		opos += opp.distOffset[0] * opp.facing
+	}
 	dist := (opos - cpos) / oc.localscl
 	if Abs(dist) < 0.0001 {
 		dist = 0
@@ -8763,7 +8768,7 @@ func (c *Char) distX(opp *Char, oc *Char) float32 {
 	return dist
 }
 
-func (c *Char) distY(opp *Char, oc *Char) float32 {
+func (c *Char) distY(opp *Char, oc *Char, noOffset bool) float32 {
 	cpos := c.pos[1] * c.localscl
 	opos := opp.pos[1] * opp.localscl
 	// Update distance while bound. Mugen chars only
@@ -8774,19 +8779,27 @@ func (c *Char) distY(opp *Char, oc *Char) float32 {
 			}
 		}
 	}
+	if !noOffset {
+		cpos += c.distOffset[1]
+		opos += opp.distOffset[1]
+	}
 	return (opos - cpos) / oc.localscl
 }
 
-func (c *Char) distZ(opp *Char, oc *Char) float32 {
+func (c *Char) distZ(opp *Char, oc *Char, noOffset bool) float32 {
 	cpos := c.pos[2] * c.localscl
 	opos := opp.pos[2] * opp.localscl
+	if !noOffset {
+		cpos += c.distOffset[2]
+		opos += opp.distOffset[2]
+	}
 	return (opos - cpos) / oc.localscl
 }
 
 // In Mugen, P2BodyDist X does not account for changes in Width like Ikemen does here
 func (c *Char) bodyDistX(opp *Char, oc *Char) float32 {
 	var cw, oppw float32
-	dist := c.distX(opp, oc)
+	dist := c.distX(opp, oc, true)
 
 	// Get size boxes
 	cbox := c.getAnySizeBox()
@@ -8856,7 +8869,7 @@ func (c *Char) rdDistX(rd *Char, oc *Char) BytecodeValue {
 	if rd == nil {
 		return BytecodeUndefined()
 	}
-	dist := c.facing * c.distX(rd, oc)
+	dist := c.facing * c.distX(rd, oc, false)
 	if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
 		if c.stWgi().mugenver[0] != 1 {
 			// Before Mugen 1.0, rounding down to the nearest whole number was performed.
@@ -8870,7 +8883,7 @@ func (c *Char) rdDistY(rd *Char, oc *Char) BytecodeValue {
 	if rd == nil {
 		return BytecodeUndefined()
 	}
-	dist := c.distY(rd, oc)
+	dist := c.distY(rd, oc, false)
 	if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
 		if c.stWgi().mugenver[0] != 1 {
 			// Before Mugen 1.0, rounding down to the nearest whole number was performed.
@@ -8884,7 +8897,7 @@ func (c *Char) rdDistZ(rd *Char, oc *Char) BytecodeValue {
 	if rd == nil {
 		return BytecodeUndefined()
 	}
-	dist := c.distZ(rd, oc)
+	dist := c.distZ(rd, oc, false)
 	return BytecodeFloat(dist)
 }
 
@@ -11550,6 +11563,8 @@ func (c *Char) actionPrepare() {
 		}
 
 		// The flags below also reset during hitpause, but are new to Ikemen and don't need the exception above
+		c.distOffset = [3]float32{}
+
 		// Reset Clsn modifiers
 		c.clsnScaleMul = [2]float32{1.0, 1.0}
 		c.clsnAngle = 0
@@ -12474,6 +12489,7 @@ func (c *Char) cueDebugDraw() {
 			}
 		}
 		// Add crosshair
+		sys.debugcho.Add([][4]float32{{-1, -1, 1, 1}}, x + (c.distOffset[0] * c.facing), y + c.distOffset[1], 1, 1, 0)
 		sys.debugch.Add([][4]float32{{-1, -1, 1, 1}}, x, y, 1, 1, 0)
 	}
 	// Prepare information for debug text
@@ -13087,9 +13103,9 @@ func (cl *CharList) hitDetectionPlayer(getter *Char) {
 				var inguardx, inguardy, inguardz bool
 
 				// Get distances
-				distX := c.distX(getter, c) * c.facing
-				distY := c.distY(getter, c)
-				distZ := c.distZ(getter, c)
+				distX := c.distX(getter, c, true) * c.facing
+				distY := c.distY(getter, c, true)
+				distZ := c.distZ(getter, c, true)
 
 				// Check X distance
 				inguardx = distX < c.hitdef.guard_dist_x[0] && distX > -c.hitdef.guard_dist_x[1]
@@ -13636,7 +13652,7 @@ func (cl *CharList) pushDetection(getter *Char) {
 			}
 
 			if pushx {
-				tmp := getter.distX(c, getter)
+				tmp := getter.distX(c, getter, false)
 				if tmp == 0 {
 					// Decide direction in which to push each player in case of a tie in position
 					// This also decides who gets to stay in the corner
@@ -13861,7 +13877,7 @@ func (cl *CharList) enemyNear(c *Char, n int32, p2list bool) *Char {
 
 			if valid {
 				// Factor x distance first
-				distX := c.distX(e, c) * c.facing
+				distX := c.distX(e, c, false) * c.facing
 				dist := distX
 				// If an enemy is behind the player, an extra distance buffer is added for the "P2" list
 				if p2list && distX < 0 {
@@ -13869,7 +13885,7 @@ func (cl *CharList) enemyNear(c *Char, n int32, p2list bool) *Char {
 				}
 				// Factor z distance if applicable
 				if sys.zEnabled() {
-					distZ := c.distZ(e, c) * 4.0
+					distZ := c.distZ(e, c, false) * 4.0
 					if p2list {
 						distZ *= 4.0
 					}

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -135,6 +135,7 @@ func newCharCompiler() *CharCompiler {
 		"changemovelist":       c.changeMovelist,
 		"depth":                c.depth,
 		"dialogue":             c.dialogue,
+		"distoffset":           c.distOffset,
 		"dizzypointsadd":       c.dizzyPointsAdd,
 		"dizzypointsset":       c.dizzyPointsSet,
 		"dizzyset":             c.dizzySet,
@@ -5142,6 +5143,18 @@ func (c *CharCompiler) expValue(out *BytecodeExp, in *string,
 			out.append(OC_ex_, OC_ex_offset_y)
 		default:
 			return bvNone(), Error("Invalid Offset trigger argument: " + c.token)
+		}
+	case "distoffset":
+		c.token = c.tokenizer(in)
+		switch c.token {
+		case "x":
+			out.append(OC_ex3_, OC_ex3_distoffset_x)
+		case "y":
+			out.append(OC_ex3_, OC_ex3_distoffset_y)
+		case "z":
+			out.append(OC_ex3_, OC_ex3_distoffset_z)
+		default:
+			return bvNone(), Error("Invalid DistOffset trigger argument: " + c.token)
 		}
 	case "alpha":
 		c.token = c.tokenizer(in)

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -4285,6 +4285,29 @@ func (c *CharCompiler) offset(is IniSection, sc *StateControllerBase) (StateCont
 	return *ret, err
 }
 
+func (c *CharCompiler) distOffset(is IniSection, sc *StateControllerBase) (StateController, error) {
+	ret, err := (*distOffset)(sc), c.stateSec(is, func() error {
+		if err := c.paramValue(is, sc, "redirectid",
+			distOffset_redirectid, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "x",
+			distOffset_x, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "y",
+			distOffset_y, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "z",
+			distOffset_z, VT_Float, 1, false); err != nil {
+			return err
+		}
+		return nil
+	})
+	return *ret, err
+}
+
 func (c *CharCompiler) victoryQuote(is IniSection, sc *StateControllerBase) (StateController, error) {
 	ret, err := (*victoryQuote)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",

--- a/src/script.go
+++ b/src/script.go
@@ -8274,6 +8274,18 @@ func triggerFunctions(l *lua.LState) {
 		l.Push(lua.LString(sys.debugWC.gi().displayname))
 		return 1
 	})
+	luaRegister(l, "distOffsetX", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.distOffset[0]))
+		return 1
+	})
+	luaRegister(l, "distOffsetY", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.distOffset[1]))
+		return 1
+	})
+	luaRegister(l, "distOffsetZ", func(*lua.LState) int {
+		l.Push(lua.LNumber(sys.debugWC.distOffset[2]))
+		return 1
+	})
 	luaRegister(l, "dizzy", func(*lua.LState) int {
 		l.Push(lua.LBool(sys.debugWC.scf(SCF_dizzy)))
 		return 1

--- a/src/system.go
+++ b/src/system.go
@@ -271,6 +271,7 @@ type System struct {
 	debugc2stb          DebugClsn
 	debugcsize          DebugClsn
 	debugch             DebugClsn
+	debugcho            DebugClsn
 	debugAccel          float32
 	clsnSpr             Sprite
 	clsnDisplay         bool
@@ -2503,6 +2504,7 @@ func (s *System) clearSpriteData() {
 	s.debugc2stb.rects = s.debugc2stb.rects[:0]
 	s.debugcsize.rects = s.debugcsize.rects[:0]
 	s.debugch.rects = s.debugch.rects[:0]
+	s.debugcho.rects = s.debugcho.rects[:0]
 	s.debugClsnText = nil
 
 	// Reset afterimage tracker
@@ -3508,6 +3510,7 @@ func (s *System) drawTop() {
 		// Size
 		s.debugcsize.draw(0xff303030, alpha)
 		// Crosshair
+		s.debugcho.draw(0xff7f7f7f, alpha)
 		s.debugch.draw(0xffffffff, alpha)
 	}
 }


### PR DESCRIPTION
I got sick of unwanted side switching mid-combo for various reasons or just when a character moves a large distance in one frame, so I made a simple and easy fix.

DistOffset: Applies an offset to the character's position for determining p2dist, autoturn, and which direction characters push each other.

It must apply to p2dist due to the prevalence of 'p2dist X < 0' being used as a trigger for the Turn sctrl.

Syntax is the same as Offset, with the addition of the Z axis. Comes with a DistOffset X/Y/Z trigger as well.