### PR TITLE
fix: zoom lag, combo shake, empty bytecode crashes, incomplete preload; refactor: dizzy flag, darken

### DIFF
--- a/src/compiler.go
+++ b/src/compiler.go
@@ -1294,6 +1294,9 @@ func (c *CharCompiler) expValue(out *BytecodeExp, in *string,
 			if err != nil {
 				return err
 			}
+			if bv2.IsNone() && len(be2) == 0 {
+				return Error("Missing value after ':=' operator")
+			}
 			be2.appendValue(bv2)
 			if rd {
 				out.appendI32Op(OC_nordrun, int32(len(be2)))
@@ -1416,10 +1419,12 @@ func (c *CharCompiler) expValue(out *BytecodeExp, in *string,
 	var err error
 	switch c.token {
 	case "":
-		if sys.ignoreMostErrors {
-			return bvNone(), nil
-		}
-		return bvNone(), Error("Nothing assigned")
+		// Because empty parameter values are not parsed at all, we don't need to ignore them here
+		// So it's safer to crash in case the value is accidentally empty
+		//if sys.ignoreMostErrors {
+		//	return bvNone(), nil
+		//}
+		return bvNone(), Error("Empty expression")
 	// Redirections without arguments
 	case "root", "parent", "p2", "stateowner":
 		switch c.token {
@@ -1593,8 +1598,7 @@ func (c *CharCompiler) expValue(out *BytecodeExp, in *string,
 		out.append(be2...)
 		return bvNone(), nil
 	case "-":
-		if len(*in) > 0 && (((*in)[0] >= '0' && (*in)[0] <= '9') ||
-			(*in)[0] == '.') {
+		if len(*in) > 0 && (((*in)[0] >= '0' && (*in)[0] <= '9') || (*in)[0] == '.') {
 			c.token += c.tokenizer(in)
 			bv = c.number(c.token)
 			if bv.IsNone() {
@@ -1604,6 +1608,9 @@ func (c *CharCompiler) expValue(out *BytecodeExp, in *string,
 			c.token = c.tokenizer(in)
 			if bv, err = c.expValue(&be1, in, false); err != nil {
 				return bvNone(), err
+			}
+			if bv.IsNone() && len(be1) == 0 {
+				return bvNone(), Error("Missing expression after '-'")
 			}
 			if bv.IsNone() {
 				if rd {
@@ -4901,6 +4908,9 @@ func (c *CharCompiler) expValue(out *BytecodeExp, in *string,
 			bv2, err := c.expEqne(&be2, in)
 			if err != nil {
 				return bvNone(), err
+			}
+			if bv2.IsNone() && len(be2) == 0 {
+				return bvNone(), Error("Missing value after ':=' operator")
 			}
 			be2.appendValue(bv2)
 			if rd {

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -1858,11 +1858,14 @@ func (fa *FightScreenFace) draw(layerno int16, charpn int, refFace *FightScreenF
 			refFace.face.PalTex = refFace.face.CachePalTex(charPal)
 		}
 
+		// Save current brightness
+		//oldBright := sys.brightness
+
 		// Reset system brightness if player initiated SuperPause (cancel "darken" parameter)
-		oldBright := sys.brightness
-		if refChar.ignoreDarkenTime > 0 {
-			sys.brightness = 1.0
-		}
+		// Update: This is an odd thing to do since the rest of the fight screen darkens
+		//if refChar.ignoreDarkenTime > 0 {
+		//	sys.brightness = 1.0
+		//}
 
 		// Draw the actual face sprite
 		fa.face_lay.DrawFaceSprite((float32(fa.pos[0])+sys.fightScreen.offsetX)*sys.fightScreen.scale, float32(fa.pos[1])*sys.fightScreen.scale, layerno,
@@ -1874,7 +1877,7 @@ func (fa *FightScreenFace) draw(layerno int16, charpn int, refFace *FightScreenF
 		}
 
 		// Restore original system brightness
-		sys.brightness = oldBright
+		//sys.brightness = oldBright
 	}
 
 	// Draw top layer
@@ -1891,13 +1894,14 @@ func (fa *FightScreenFace) drawTeammates(layerno int16, charpn int) {
 	//	return
 	//}
 
-	refChar := sys.chars[charpn][0]
+	// Save current brightness
+	oldBright := sys.brightness
 
 	// Reset system brightness if player initiated SuperPause (cancel "darken" parameter)
-	oldBright := sys.brightness
-	if refChar.ignoreDarkenTime > 0 {
-		sys.brightness = 1.0
-	}
+	//refChar := sys.chars[charpn][0]
+	//if refChar.ignoreDarkenTime > 0 {
+	//	sys.brightness = 1.0
+	//}
 
 	teamSize := int32(len(fa.teammate_face))
 

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -2327,8 +2327,8 @@ type FightScreenCombo struct {
 	start_x       float32
 	counter       map[int32]*FSText
 	counter_shake bool
-	counter_time  int32
-	counter_mult  float32
+	counter_time  int32 // Shake effect duration
+	counter_mult  float32 // Shake effect scale correction factor
 	text          map[int32]*FSText
 	bg            AnimLayout
 	top           AnimLayout
@@ -2343,7 +2343,7 @@ type FightScreenCombo struct {
 	shownPct      float32
 	resttime      int32
 	counterX      float32
-	shaketime     int32
+	curShaketime  int32
 	autoalign     bool
 	newCombo      bool
 }
@@ -2439,8 +2439,8 @@ func (co *FightScreenCombo) step(hits, damage int32, percentage float32) {
 		}
 	}
 
-	if co.shaketime > 0 {
-		co.shaketime--
+	if co.curShaketime > 0 {
+		co.curShaketime--
 	}
 
 	// The displayed time only decrements when the counter is in the visible position
@@ -2455,7 +2455,7 @@ func (co *FightScreenCombo) step(hits, damage int32, percentage float32) {
 		// Reset visuals when hits changed
 		if co.newCombo || co.shownHits != co.trueHits {
 			if co.counter_shake {
-				co.shaketime = co.counter_time
+				co.curShaketime = co.counter_time
 			}
 			for i := range co.counter {
 				co.counter[i].resetTxtPfx()
@@ -2504,7 +2504,7 @@ func (co *FightScreenCombo) reset() {
 	co.shownPct = 0
 	co.resttime = 0
 	co.counterX = co.start_x * 2
-	co.shaketime = 0
+	co.curShaketime = 0
 }
 
 func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
@@ -2528,7 +2528,9 @@ func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 		}
 	}
 
+	// Replace operator with current combo value
 	counter := strings.Replace(co.counter[cv].text, "%i", fmt.Sprintf("%v", co.shownHits), 1)
+
 	x := float32(co.pos[0])
 	if side == 0 {
 		if co.start_x <= 0 {
@@ -2545,8 +2547,14 @@ func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 			x -= co.counterX
 		}
 	}
+
+	// BG
 	co.bg.Draw(x+sys.fightScreen.offsetX, float32(co.pos[1]), layerno, sys.fightScreen.scale)
+
+	// Track total string length
 	var length float32
+
+	// Text
 	if co.text[tv].font[0] >= 0 && getFont(f, co.text[tv].font[0]) != nil {
 		text := strings.Replace(co.text[tv].text, "%i", fmt.Sprintf("%v", co.shownHits), 1)
 		text = strings.Replace(text, "%d", fmt.Sprintf("%v", co.shownDmg), 1)
@@ -2583,6 +2591,8 @@ func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 				co.text[tv].palfx, co.text[tv].frgba)
 		}
 	}
+
+	// Counter
 	if co.counter[cv].font[0] >= 0 && getFont(f, co.counter[cv].font[0]) != nil {
 		if side == 0 && co.autoalign {
 			if ff := getFont(f, co.counter[cv].font[0]); ff != nil {
@@ -2590,10 +2600,17 @@ func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 			}
 		}
 
-		z := 1 + float32(co.shaketime)*co.counter_mult*float32(math.Sin(float64(co.shaketime)*(math.Pi/2.5)))
+		// Shake effect
+		// TODO: More customizable parameters
+		// TODO: Maximum scale is currently determined by "time * correction factor". That seems especially odd
+		arg := float64(co.counter_time - co.curShaketime) * math.Pi / 2.5
+		z := 1 + float32(co.curShaketime)*co.counter_mult*float32(math.Cos(arg))
+
 		co.counter[cv].lay.DrawText((x-length+sys.fightScreen.offsetX)/z, float32(co.pos[1])/z, z*sys.fightScreen.scale, layerno,
 			counter, getFont(f, co.counter[cv].font[0]), co.counter[cv].font[1], co.counter[cv].font[2], co.counter[cv].palfx, co.counter[cv].frgba)
 	}
+
+	// Top
 	co.top.Draw(x+sys.fightScreen.offsetX, float32(co.pos[1]), layerno, sys.fightScreen.scale)
 }
 

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -2405,7 +2405,7 @@ func readFightScreenCombo(pre string, is IniSection,
 	return co
 }
 
-func (co *FightScreenCombo) step(hits, damage int32, percentage float32, dizzy bool) {
+func (co *FightScreenCombo) step(hits, damage int32, percentage float32) {
 	co.bg.Action()
 	co.top.Action()
 
@@ -2422,10 +2422,18 @@ func (co *FightScreenCombo) step(hits, damage int32, percentage float32, dizzy b
 	// True hits are only updated by Char(). The live tally is only used for combo display behavior
 	//co.trueHits = hits
 
+	// Handle show/hide speed
 	if co.resttime > 0 {
+		// Slide in
 		co.counterX -= co.counterX / co.showspeed
+		// Snap to visible position
+		if Abs(co.counterX) < 1 {
+			co.counterX = 0
+		}
 	} else if co.trueHits < 2 {
+		// Slide out when combo ends
 		co.counterX -= sys.fightScreen.fnt_scale * co.hidespeed * float32(sys.fightScreen.localcoord[0]) / 320
+		// Snap to starting position
 		if co.counterX < co.start_x*2 {
 			co.counterX = co.start_x * 2
 		}
@@ -2435,9 +2443,10 @@ func (co *FightScreenCombo) step(hits, damage int32, percentage float32, dizzy b
 		co.shaketime--
 	}
 
-	// TODO: Most commercial games don't rely on the dizzy flag
-	// They keep the combo active as long as hits >= 2
-	if Abs(co.counterX) < 1 && !dizzy {
+	// The displayed time only decrements when the counter is in the visible position
+	// Currently, the way the timer decrements while the combo is still ongoing can make it stay visible varying amounts of time past the end of the combo
+	// This makes it not always sync correctly with the "nice combo" actions
+	if co.counterX == 0 {
 		co.resttime--
 	}
 
@@ -5156,7 +5165,7 @@ func (fs *FightScreen) step() {
 	}
 	// Time
 	fs.time.step()
-	cb, cd, cp, dz := [2]int32{}, [2]int32{}, [2]float32{}, [2]bool{}
+	cb, cd, cp := [2]int32{}, [2]int32{}, [2]float32{}
 	targets := [2]int32{}
 	// Combo
 	for _, ch := range sys.chars {
@@ -5169,9 +5178,6 @@ func (fs *FightScreen) step() {
 				// Perhaps helper percentages shouldn't be tracked, but ignoring them creates scenarios where the lifebars show 0% damage which looks wrong
 				cp[side] += float32(c.receivedDmg) / float32(c.lifeMax) * 100
 				targets[side]++
-				if c.scf(SCF_dizzy) {
-					dz[side] = true
-				}
 			}
 		}
 	}
@@ -5181,7 +5187,7 @@ func (fs *FightScreen) step() {
 		}
 	}
 	for i := range fs.combos {
-		fs.combos[i].step(cb[i], cd[i], cp[i], dz[i]) // Combo hits, combo damage, combo damage percentage, dizzy flag
+		fs.combos[i].step(cb[i], cd[i], cp[i]) // Combo hits, combo damage, combo damage percentage
 	}
 	// Action
 	for i := range fs.actions {

--- a/src/system.go
+++ b/src/system.go
@@ -4610,9 +4610,10 @@ func (s *Select) AddChar(def string) *SelectChar {
 		}
 		return nil
 	})
+
 	// preload animations
 	if len(anim_orig) > 0 {
-		LoadFile(&anim_orig, []string{sc.def, "", "data/"}, "", func(filename string) error {
+		err := LoadFile(&anim_orig, []string{sc.def, "", "data/"}, "", func(filename string) error {
 			str, err := LoadText(filename) // LoadText is zip-aware
 			if err != nil {
 				return err
@@ -4633,14 +4634,22 @@ func (s *Select) AddChar(def string) *SelectChar {
 			}
 			return nil
 		})
+		// Crash if we expected an AIR file but didn't find any
+		if err != nil {
+			panic(fmt.Sprintf("Cannot open air file for character %s: %v", def, err))
+		}
 	}
-	// preload portion of sff file
+
+	// Try to use the "_preload.sff" file if available
 	fp := fmt.Sprintf("%v_preload.sff", strings.TrimSuffix(sc.def, filepath.Ext(sc.def)))
 	if fp = FileExist(fp); len(fp) == 0 {
+		// Fall back to normal SFF
 		fp = sprite_orig
 	}
+
+	// preload portion of sff file
 	if len(fp) > 0 {
-		LoadFile(&fp, []string{sc.def, "", "data/"}, "", func(file string) error {
+		err := LoadFile(&fp, []string{sc.def, "", "data/"}, "", func(file string) error {
 			var selPal []int32
 			var err_sff error
 			sc.sff, selPal, err_sff = preloadSff(file, true, listSpr)
@@ -4687,13 +4696,19 @@ func (s *Select) AddChar(def string) *SelectChar {
 			}
 			return nil
 		})
+		// Crash if we expected a SFF file but didn't find any
+		if err != nil {
+			panic(fmt.Sprintf("Cannot open sprite file for character %s: %v", def, err))
+		}
 	} else {
+		// If we deliberately lack a SFF, then make a dummy one
 		sc.sff = newSff()
 		sc.anims.updateSff(sc.sff)
 		for k := range s.charSpritePreload {
 			sc.anims.addSprite(sc.sff, k[0], k[1])
 		}
 	}
+
 	return sc
 }
 

--- a/src/system.go
+++ b/src/system.go
@@ -2554,16 +2554,20 @@ func (s *System) action() {
 		s.zmin = s.stage.topbound * s.stage.localscl
 		s.zmax = s.stage.botbound * s.stage.localscl
 		//s.bgPalFX.step()
+
 		s.envShake.next()
 		if s.envcol_time > 0 {
 			s.envcol_time--
 		}
-		s.zoom.update()
+
+		// Step pause timers
 		if s.supertime > 0 {
 			s.supertime--
 		} else if s.pausetime > 0 {
 			s.pausetime--
 		}
+
+		// Start pause timers
 		if s.supertimebuffer < 0 {
 			s.supertimebuffer = ^s.supertimebuffer
 			s.supertime = s.supertimebuffer
@@ -2572,6 +2576,7 @@ func (s *System) action() {
 			s.pausetimebuffer = ^s.pausetimebuffer
 			s.pausetime = s.pausetimebuffer
 		}
+
 		// In Mugen 1.1, few global AssertSpecial flags persist during pauses. Seemingly only TimerFreeze
 		if s.supertime <= 0 && s.pausetime <= 0 {
 			s.specialFlag = 0
@@ -2580,9 +2585,14 @@ func (s *System) action() {
 			// "NoKOSlow" added to facilitate custom slowdown. In Mugen that flag only needs to be asserted in first frame of KO slowdown
 			s.specialFlag = (s.specialFlag&GSF_nokoslow | s.specialFlag&GSF_timerfreeze)
 		}
+
+		// Run the main character logic
 		s.charList.action()
+
+		// The following must be placed after char action or they will lag behind 1 frame
 		s.allPalFX.step()
 		s.bgPalFX.step()
+		s.zoom.update()
 		s.nomusic = s.gsf(GSF_nomusic) && !sys.postMatchFlg
 	}
 


### PR DESCRIPTION
Fixes:
- Fixed Zoom sctrl taking effect one frame later than supposed to
- Fixed combo counter shake effect starting by making the number smaller
- If char code uses `-`, `var :=` or `map :=` followed by nothing, the crash will now print a known error while compiling instead of a generic one during runtime
- Fixes https://discord.com/channels/233345562261323776/233363722934943744/1511803289052905583
- If a file is expected to exist while preloading but it doesn't, the engine will now crash instead of preloading an incomplete character

Refactor:
- The fight screen doesn't need to track a char's dizzy flag because that is already handled in char code
- The combo counter snaps into place when close to its destination instead of staying infinitely close to it
- The `darken` parameter of SuperPause now also affects the portrait of the player that initiated the pause
- Empty expressions are no longer ignored by CNS