### PR TITLE
feat: expanded combo counter shaking parameters, combo text shaking; extra EnvShake parameters

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -568,6 +568,8 @@ const (
 	OC_ex_gethitvar_fall_envshake_phase
 	OC_ex_gethitvar_fall_envshake_mul
 	OC_ex_gethitvar_fall_envshake_dir
+	OC_ex_gethitvar_fall_envshake_diradd
+	OC_ex_gethitvar_fall_envshake_decay
 	OC_ex_gethitvar_attr
 	OC_ex_gethitvar_dizzypoints
 	OC_ex_gethitvar_guardpoints
@@ -726,10 +728,6 @@ const (
 	OC_ex_prevmovetype
 	OC_ex_prevstatetype
 	OC_ex_reversaldefattr
-	OC_ex_envshakevar_time
-	OC_ex_envshakevar_freq
-	OC_ex_envshakevar_ampl
-	OC_ex_envshakevar_dir
 	OC_ex_angle
 	OC_ex_scale_x
 	OC_ex_scale_y
@@ -741,7 +739,14 @@ const (
 	OC_ex_selfcommand
 )
 const (
-	OC_ex2_index OpCode = iota
+	OC_ex2_envshakevar_time OpCode = iota
+	OC_ex2_envshakevar_freq
+	OC_ex2_envshakevar_phase
+	OC_ex2_envshakevar_ampl
+	OC_ex2_envshakevar_dir
+	OC_ex2_envshakevar_diradd
+	OC_ex2_envshakevar_decay
+	OC_ex2_index
 	OC_ex2_fightscreenvar_info_author
 	OC_ex2_fightscreenvar_info_localcoord_x
 	OC_ex2_fightscreenvar_info_localcoord_y
@@ -3118,16 +3123,20 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(c.ghv.fall_envshake_time)
 	case OC_ex_gethitvar_fall_envshake_freq:
 		sys.bcStack.PushF(c.ghv.fall_envshake_freq)
+	case OC_ex_gethitvar_fall_envshake_phase:
+		sys.bcStack.PushF(c.ghv.fall_envshake_phase)
 	case OC_ex_gethitvar_fall_envshake_ampl:
 		// This one is an int in Mugen but a float in Ikemen, so undefined returns 0 and true undefined respectively
 		// No issues so far, so no need to add a special case for the time being
 		sys.bcStack.PushI(int32(float32(c.ghv.fall_envshake_ampl) * (c.localscl / oc.localscl)))
-	case OC_ex_gethitvar_fall_envshake_phase:
-		sys.bcStack.PushF(c.ghv.fall_envshake_phase)
 	case OC_ex_gethitvar_fall_envshake_mul:
 		sys.bcStack.PushF(c.ghv.fall_envshake_mul)
 	case OC_ex_gethitvar_fall_envshake_dir:
 		sys.bcStack.PushF(c.ghv.fall_envshake_dir)
+	case OC_ex_gethitvar_fall_envshake_diradd:
+		sys.bcStack.PushF(c.ghv.fall_envshake_diradd)
+	case OC_ex_gethitvar_fall_envshake_decay:
+		sys.bcStack.PushF(c.ghv.fall_envshake_decay)
 	case OC_ex_gethitvar_attr:
 		// same as c.hitDefAttr()
 		attr := be.ReadIntAt(i)
@@ -3286,14 +3295,6 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(c.dizzyPoints)
 	case OC_ex_dizzypointsmax:
 		sys.bcStack.PushI(c.dizzyPointsMax)
-	case OC_ex_envshakevar_time:
-		sys.bcStack.PushI(sys.envShake.curTime)
-	case OC_ex_envshakevar_freq:
-		sys.bcStack.PushF(sys.envShake.freq)
-	case OC_ex_envshakevar_ampl:
-		sys.bcStack.PushF(float32(math.Abs(float64(sys.envShake.ampl / oc.localscl))))
-	case OC_ex_envshakevar_dir:
-		sys.bcStack.PushF(sys.envShake.dir)
 	case OC_ex_fighttime:
 		sys.bcStack.PushI(sys.matchTime)
 	case OC_ex_firstattack:
@@ -3556,6 +3557,20 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	camOff := float32(0)
 	camCorrected := false
 	switch opc {
+	case OC_ex2_envshakevar_time:
+		sys.bcStack.PushI(sys.envShake.curTime)
+	case OC_ex2_envshakevar_freq:
+		sys.bcStack.PushF(sys.envShake.freq)
+	case OC_ex2_envshakevar_phase:
+		sys.bcStack.PushF(sys.envShake.phase)
+	case OC_ex2_envshakevar_ampl:
+		sys.bcStack.PushF(float32(math.Abs(float64(sys.envShake.ampl / oc.localscl))))
+	case OC_ex2_envshakevar_dir:
+		sys.bcStack.PushF(sys.envShake.dir)
+	case OC_ex2_envshakevar_diradd:
+		sys.bcStack.PushF(sys.envShake.diradd)
+	case OC_ex2_envshakevar_decay:
+		sys.bcStack.PushF(sys.envShake.decay)
 	case OC_ex2_index:
 		sys.bcStack.PushI(c.indexTrigger())
 	case OC_ex2_fightscreenvar_info_author:
@@ -7373,17 +7388,21 @@ const (
 	hitDef_yaccel
 	hitDef_zaccel
 	hitDef_envshake_time
-	hitDef_envshake_ampl
-	hitDef_envshake_phase
 	hitDef_envshake_freq
+	hitDef_envshake_phase
+	hitDef_envshake_ampl
 	hitDef_envshake_mul
 	hitDef_envshake_dir
+	hitDef_envshake_diradd
+	hitDef_envshake_decay
 	hitDef_fall_envshake_time
-	hitDef_fall_envshake_ampl
-	hitDef_fall_envshake_phase
 	hitDef_fall_envshake_freq
+	hitDef_fall_envshake_phase
+	hitDef_fall_envshake_ampl
 	hitDef_fall_envshake_mul
 	hitDef_fall_envshake_dir
+	hitDef_fall_envshake_diradd
+	hitDef_fall_envshake_decay
 	hitDef_dizzypoints
 	hitDef_guardpoints
 	hitDef_redlife
@@ -7695,28 +7714,36 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, paramID byte, exp []BytecodeExp) {
 		hd.zaccel = exp[0].evalF(c)
 	case hitDef_envshake_time:
 		hd.envshake_time = exp[0].evalI(c)
-	case hitDef_envshake_ampl:
-		hd.envshake_ampl = exp[0].evalI(c)
 	case hitDef_envshake_freq:
 		hd.envshake_freq = Max(0, exp[0].evalF(c))
 	case hitDef_envshake_phase:
 		hd.envshake_phase = exp[0].evalF(c)
+	case hitDef_envshake_ampl:
+		hd.envshake_ampl = exp[0].evalI(c)
 	case hitDef_envshake_mul:
 		hd.envshake_mul = exp[0].evalF(c)
 	case hitDef_envshake_dir:
 		hd.envshake_dir = exp[0].evalF(c)
+	case hitDef_envshake_diradd:
+		hd.envshake_diradd = exp[0].evalF(c)
+	case hitDef_envshake_decay:
+		hd.envshake_decay = exp[0].evalF(c)
 	case hitDef_fall_envshake_time:
 		hd.fall_envshake_time = exp[0].evalI(c)
-	case hitDef_fall_envshake_ampl:
-		hd.fall_envshake_ampl = exp[0].evalI(c)
 	case hitDef_fall_envshake_freq:
 		hd.fall_envshake_freq = Max(0, exp[0].evalF(c))
 	case hitDef_fall_envshake_phase:
 		hd.fall_envshake_phase = exp[0].evalF(c)
+	case hitDef_fall_envshake_ampl:
+		hd.fall_envshake_ampl = exp[0].evalI(c)
 	case hitDef_fall_envshake_mul:
 		hd.fall_envshake_mul = exp[0].evalF(c)
 	case hitDef_fall_envshake_dir:
 		hd.fall_envshake_dir = exp[0].evalF(c)
+	case hitDef_fall_envshake_diradd:
+		hd.fall_envshake_diradd = exp[0].evalF(c)
+	case hitDef_fall_envshake_decay:
+		hd.fall_envshake_decay = exp[0].evalF(c)
 	case hitDef_dizzypoints:
 		hd.dizzypoints = Max(IErr+1, exp[0].evalI(c))
 	case hitDef_guardpoints:
@@ -9090,11 +9117,6 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				eachProj(func(p *Projectile) {
 					p.hitdef.envshake_time = v1
 				})
-			case hitDef_envshake_ampl:
-				v1 := exp[0].evalI(c)
-				eachProj(func(p *Projectile) {
-					p.hitdef.envshake_ampl = v1
-				})
 			case hitDef_envshake_freq:
 				v1 := Max(0, exp[0].evalF(c))
 				eachProj(func(p *Projectile) {
@@ -9104,6 +9126,11 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				v1 := exp[0].evalF(c)
 				eachProj(func(p *Projectile) {
 					p.hitdef.envshake_phase = v1
+				})
+			case hitDef_envshake_ampl:
+				v1 := exp[0].evalI(c)
+				eachProj(func(p *Projectile) {
+					p.hitdef.envshake_ampl = v1
 				})
 			case hitDef_envshake_mul:
 				v1 := exp[0].evalF(c)
@@ -9115,15 +9142,20 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				eachProj(func(p *Projectile) {
 					p.hitdef.envshake_dir = v1
 				})
+			case hitDef_envshake_diradd:
+				v1 := exp[0].evalF(c)
+				eachProj(func(p *Projectile) {
+					p.hitdef.envshake_diradd = v1
+				})
+			case hitDef_envshake_decay:
+				v1 := exp[0].evalF(c)
+				eachProj(func(p *Projectile) {
+					p.hitdef.envshake_decay = v1
+				})
 			case hitDef_fall_envshake_time:
 				v1 := exp[0].evalI(c)
 				eachProj(func(p *Projectile) {
 					p.hitdef.fall_envshake_time = v1
-				})
-			case hitDef_fall_envshake_ampl:
-				v1 := exp[0].evalI(c)
-				eachProj(func(p *Projectile) {
-					p.hitdef.fall_envshake_ampl = v1
 				})
 			case hitDef_fall_envshake_freq:
 				v1 := Max(0, exp[0].evalF(c))
@@ -9135,6 +9167,11 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				eachProj(func(p *Projectile) {
 					p.hitdef.fall_envshake_phase = v1
 				})
+			case hitDef_fall_envshake_ampl:
+				v1 := exp[0].evalI(c)
+				eachProj(func(p *Projectile) {
+					p.hitdef.fall_envshake_ampl = v1
+				})
 			case hitDef_fall_envshake_mul:
 				v1 := exp[0].evalF(c)
 				eachProj(func(p *Projectile) {
@@ -9144,6 +9181,16 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				v1 := exp[0].evalF(c)
 				eachProj(func(p *Projectile) {
 					p.hitdef.fall_envshake_dir = v1
+				})
+			case hitDef_fall_envshake_diradd:
+				v1 := exp[0].evalF(c)
+				eachProj(func(p *Projectile) {
+					p.hitdef.fall_envshake_diradd = v1
+				})
+			case hitDef_fall_envshake_decay:
+				v1 := exp[0].evalF(c)
+				eachProj(func(p *Projectile) {
+					p.hitdef.fall_envshake_decay = v1
 				})
 			case hitDef_dizzypoints:
 				v1 := Max(IErr+1, exp[0].evalI(c))
@@ -10823,7 +10870,8 @@ func (sc fallEnvShake) Run(c *Char, _ []int32) bool {
 					ampl:    float32(crun.ghv.fall_envshake_ampl) * c.localscl,
 					mul:     crun.ghv.fall_envshake_mul,
 					dir:     crun.ghv.fall_envshake_dir,
-					decay:   1.0, // TODO
+					diradd:  crun.ghv.fall_envshake_diradd,
+					decay:   crun.ghv.fall_envshake_decay,
 				}
 				sys.envShake.setDefaultPhase()
 				sys.envShake.restart()
@@ -14392,6 +14440,8 @@ const (
 	getHitVarSet_fall_envshake_phase
 	getHitVarSet_fall_envshake_time
 	getHitVarSet_fall_envshake_dir
+	getHitVarSet_fall_envshake_diradd
+	getHitVarSet_fall_envshake_decay
 	getHitVarSet_fall_kill
 	getHitVarSet_fall_recover
 	getHitVarSet_fall_recovertime
@@ -14459,16 +14509,20 @@ func (sc getHitVarSet) Run(c *Char, _ []int32) bool {
 			crun.ghv.fall_damage = exp[0].evalI(c)
 		case getHitVarSet_fall_envshake_ampl:
 			crun.ghv.fall_envshake_ampl = int32(exp[0].evalF(c) * redirscale)
+		case getHitVarSet_fall_envshake_time:
+			crun.ghv.fall_envshake_time = exp[0].evalI(c)
 		case getHitVarSet_fall_envshake_freq:
 			crun.ghv.fall_envshake_freq = exp[0].evalF(c)
+		case getHitVarSet_fall_envshake_phase:
+			crun.ghv.fall_envshake_phase = exp[0].evalF(c)
 		case getHitVarSet_fall_envshake_mul:
 			crun.ghv.fall_envshake_mul = exp[0].evalF(c)
 		case getHitVarSet_fall_envshake_dir:
 			crun.ghv.fall_envshake_dir = exp[0].evalF(c)
-		case getHitVarSet_fall_envshake_phase:
-			crun.ghv.fall_envshake_phase = exp[0].evalF(c)
-		case getHitVarSet_fall_envshake_time:
-			crun.ghv.fall_envshake_time = exp[0].evalI(c)
+		case getHitVarSet_fall_envshake_diradd:
+			crun.ghv.fall_envshake_diradd = exp[0].evalF(c)
+		case getHitVarSet_fall_envshake_decay:
+			crun.ghv.fall_envshake_decay = exp[0].evalF(c)
 		case getHitVarSet_fall_kill:
 			crun.ghv.fall_kill = exp[0].evalB(c)
 		case getHitVarSet_fall_recover:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3287,13 +3287,13 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_dizzypointsmax:
 		sys.bcStack.PushI(c.dizzyPointsMax)
 	case OC_ex_envshakevar_time:
-		sys.bcStack.PushI(sys.envShake.time)
+		sys.bcStack.PushI(sys.envShake.curTime)
 	case OC_ex_envshakevar_freq:
-		sys.bcStack.PushF(sys.envShake.freq / float32(math.Pi) * 180)
+		sys.bcStack.PushF(sys.envShake.freq)
 	case OC_ex_envshakevar_ampl:
 		sys.bcStack.PushF(float32(math.Abs(float64(sys.envShake.ampl / oc.localscl))))
 	case OC_ex_envshakevar_dir:
-		sys.bcStack.PushF(sys.envShake.dir / float32(math.Pi) * 180)
+		sys.bcStack.PushF(sys.envShake.dir)
 	case OC_ex_fighttime:
 		sys.bcStack.PushI(sys.matchTime)
 	case OC_ex_firstattack:
@@ -9996,10 +9996,13 @@ const (
 	envShake_mul
 	envShake_phase
 	envShake_dir
+	envShake_diradd
+	envShake_decay
 )
 
 func (sc envShake) Run(c *Char, _ []int32) bool {
 	sys.envShake.clear()
+
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
 		case envShake_time:
@@ -10009,17 +10012,24 @@ func (sc envShake) Run(c *Char, _ []int32) bool {
 			// Because of how localscl works, the amplitude will be slightly smaller during widescreen
 			// This also happens in Mugen however
 		case envShake_freq:
-			sys.envShake.freq = Max(0, exp[0].evalF(c)*float32(math.Pi)/180)
+			sys.envShake.freq = Max(0, exp[0].evalF(c))
 		case envShake_phase:
-			sys.envShake.phase = Max(-180*float32(math.Pi)/180, exp[0].evalF(c)*float32(math.Pi)/180)
+			sys.envShake.phase = Clamp(exp[0].evalF(c), -180, 180) // TODO: Why is it clamped here but not in other places
 		case envShake_mul:
 			sys.envShake.mul = exp[0].evalF(c)
 		case envShake_dir:
-			sys.envShake.dir = Max(0, exp[0].evalF(c)*float32(math.Pi)/180)
+			sys.envShake.dir = exp[0].evalF(c)
+		case envShake_diradd:
+			sys.envShake.diradd = exp[0].evalF(c)
+		case envShake_decay:
+			sys.envShake.decay = exp[0].evalF(c)
 		}
 		return true
 	})
+
 	sys.envShake.setDefaultPhase()
+	sys.envShake.restart()
+
 	return false
 }
 
@@ -10806,18 +10816,25 @@ func (sc fallEnvShake) Run(c *Char, _ []int32) bool {
 		switch paramID {
 		case fallEnvShake_:
 			if crun.ghv.fall_envshake_time > 0 {
-				sys.envShake = EnvShake{time: crun.ghv.fall_envshake_time,
-					freq:  crun.ghv.fall_envshake_freq * math.Pi / 180,
-					ampl:  float32(crun.ghv.fall_envshake_ampl) * c.localscl,
-					phase: crun.ghv.fall_envshake_phase,
-					mul:   crun.ghv.fall_envshake_mul,
-					dir:   crun.ghv.fall_envshake_dir * float32(math.Pi) / 180}
+				sys.envShake = EnvShake{
+					time:    crun.ghv.fall_envshake_time,
+					freq:    crun.ghv.fall_envshake_freq,
+					phase:   crun.ghv.fall_envshake_phase,
+					ampl:    float32(crun.ghv.fall_envshake_ampl) * c.localscl,
+					mul:     crun.ghv.fall_envshake_mul,
+					dir:     crun.ghv.fall_envshake_dir,
+					decay:   1.0, // TODO
+				}
 				sys.envShake.setDefaultPhase()
+				sys.envShake.restart()
+				// Consume variable to prevent retriggering
+				// https://github.com/ikemen-engine/Ikemen-GO/issues/583
 				crun.ghv.fall_envshake_time = 0
 			}
 		}
 		return true
 	})
+
 	return false
 }
 

--- a/src/char.go
+++ b/src/char.go
@@ -640,6 +640,8 @@ type HitDef struct {
 	envshake_phase             float32
 	envshake_mul               float32
 	envshake_dir               float32
+	envshake_diradd            float32
+	envshake_decay             float32
 	mindist                    [3]float32
 	maxdist                    [3]float32
 	snap                       [3]float32
@@ -658,6 +660,8 @@ type HitDef struct {
 	fall_envshake_phase        float32
 	fall_envshake_mul          float32
 	fall_envshake_dir          float32
+	fall_envshake_diradd       float32
+	fall_envshake_decay        float32
 	kill                       bool
 	guard_kill                 bool
 	forcenofall                bool
@@ -766,7 +770,6 @@ func (hd *HitDef) reset(c *Char, proj *Projectile) {
 		envshake_ampl:       -4,
 		envshake_phase:      float32(math.NaN()),
 		envshake_mul:        1.0,
-		envshake_dir:        0.0,
 		mindist:             [...]float32{float32(math.NaN()), float32(math.NaN()), float32(math.NaN())},
 		maxdist:             [...]float32{float32(math.NaN()), float32(math.NaN()), float32(math.NaN())},
 		snap:                [...]float32{float32(math.NaN()), float32(math.NaN()), float32(math.NaN())},
@@ -794,7 +797,6 @@ func (hd *HitDef) reset(c *Char, proj *Projectile) {
 		fall_envshake_ampl:  IErr,
 		fall_envshake_phase: float32(math.NaN()),
 		fall_envshake_mul:   1.0,
-		fall_envshake_dir:   0.0,
 		attack_depth:        [2]float32{c.size.attack.depth[0], c.size.attack.depth[1]},
 		unhittabletime:      [2]int32{IErr, IErr},
 		StandFriction:       float32(math.NaN()),
@@ -1072,6 +1074,8 @@ type GetHitVar struct {
 	fall_envshake_phase float32
 	fall_envshake_mul   float32
 	fall_envshake_dir   float32
+	fall_envshake_diradd float32
+	fall_envshake_decay  float32
 	playerid            int32
 	playerno            int
 	projid              int32

--- a/src/char.go
+++ b/src/char.go
@@ -11374,18 +11374,23 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 				c.juggle = 0
 			}
 		}
+		// Apply PalFX to target
 		if hd.palfx.time > 0 && getter.palfx != nil {
 			getter.palfx.clearWithNeg(true)
 			getter.palfx.PalFXDef = hd.palfx
 		}
+		// Apply EnvShake
 		if hd.envshake_time > 0 {
 			sys.envShake.time = hd.envshake_time
-			sys.envShake.freq = hd.envshake_freq * float32(math.Pi) / 180
-			sys.envShake.ampl = float32(int32(float32(hd.envshake_ampl) * c.localscl))
+			sys.envShake.freq = hd.envshake_freq
 			sys.envShake.phase = hd.envshake_phase
+			sys.envShake.ampl = float32(int32(float32(hd.envshake_ampl) * c.localscl)) // Truncated
 			sys.envShake.mul = hd.envshake_mul
-			sys.envShake.dir = hd.envshake_dir * float32(math.Pi) / 180
+			sys.envShake.dir = hd.envshake_dir
+			sys.envShake.diradd = 0
+			sys.envShake.decay = 1.0
 			sys.envShake.setDefaultPhase()
+			sys.envShake.restart()
 		}
 		// Cornerpush on hit
 		// In Mugen it is only set if the enemy is already in the corner before the hit

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -4506,13 +4506,13 @@ func (c *CharCompiler) expValue(out *BytecodeExp, in *string,
 		}
 		switch c.token {
 		case "time":
-			opc = OC_ex_envshakevar_time
+			opc = OC_ex2_envshakevar_time
 		case "freq":
-			opc = OC_ex_envshakevar_freq
+			opc = OC_ex2_envshakevar_freq
 		case "ampl":
-			opc = OC_ex_envshakevar_ampl
+			opc = OC_ex2_envshakevar_ampl
 		case "dir":
-			opc = OC_ex_envshakevar_dir
+			opc = OC_ex2_envshakevar_dir
 		default:
 			return bvNone(), Error("Invalid EnvShakeVar argument: " + c.token)
 		}

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -3327,6 +3327,14 @@ func (c *CharCompiler) envShake(is IniSection, sc *StateControllerBase) (StateCo
 			envShake_dir, VT_Float, 1, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "diradd",
+			envShake_diradd, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "decay",
+			envShake_decay, VT_Float, 1, false); err != nil {
+			return err
+		}
 		return nil
 	})
 	return *ret, err
@@ -6498,28 +6506,36 @@ func (c *CharCompiler) getHitVarSet(is IniSection, sc *StateControllerBase) (Sta
 			getHitVarSet_fall_damage, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.paramValue(is, sc, "fall.envshake.ampl",
-			getHitVarSet_fall_envshake_ampl, VT_Int, 1, false); err != nil {
+		if err := c.paramValue(is, sc, "fall.envshake.time",
+			getHitVarSet_fall_envshake_time, VT_Int, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "fall.envshake.freq",
 			getHitVarSet_fall_envshake_freq, VT_Float, 1, false); err != nil {
 			return err
 		}
-		if err := c.paramValue(is, sc, "fall.envshake.mul",
-			getHitVarSet_fall_envshake_mul, VT_Float, 1, false); err != nil {
-			return err
-		}
 		if err := c.paramValue(is, sc, "fall.envshake.phase",
 			getHitVarSet_fall_envshake_phase, VT_Float, 1, false); err != nil {
 			return err
 		}
-		if err := c.paramValue(is, sc, "fall.envshake.time",
-			getHitVarSet_fall_envshake_time, VT_Int, 1, false); err != nil {
+		if err := c.paramValue(is, sc, "fall.envshake.ampl",
+			getHitVarSet_fall_envshake_ampl, VT_Int, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "fall.envshake.mul",
+			getHitVarSet_fall_envshake_mul, VT_Float, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "fall.envshake.dir",
 			getHitVarSet_fall_envshake_dir, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "fall.envshake.diradd",
+			getHitVarSet_fall_envshake_diradd, VT_Float, 1, false); err != nil {
+			return err
+		}
+		if err := c.paramValue(is, sc, "fall.envshake.decay",
+			getHitVarSet_fall_envshake_decay, VT_Float, 1, false); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "fall.kill",

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -2580,6 +2580,7 @@ func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 	// Replace operator with current combo value
 	counter := strings.Replace(co.counter[cv].text, "%i", fmt.Sprintf("%v", co.shownHits), 1)
 
+	// Compute base x position
 	x := float32(co.pos[0])
 	if side == 0 {
 		if co.start_x <= 0 {
@@ -2601,32 +2602,35 @@ func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 	// BG
 	co.bg.Draw(x+sys.fightScreen.offsetX, float32(co.pos[1]), layerno, sys.fightScreen.scale)
 
-	// Track total string length
-	var length float32
-
-	// Text
-	var maxWidth float32
-	var lineHeight float32
+	// Text block pre-processing
 	var ffText *Fnt
+	var textBlockWidth float32
+	var lineHeight float32
+	var lines []string
 	if co.text[tv].font[0] >= 0 && getFont(f, co.text[tv].font[0]) != nil {
+		// Replace operator with current combo hits
 		text := strings.Replace(co.text[tv].text, "%i", fmt.Sprintf("%v", co.shownHits), 1)
+		// Replace operator with current combo damage
 		text = strings.Replace(text, "%d", fmt.Sprintf("%v", co.shownDmg), 1)
-		// Truncate the percentage to avoid rounding to 100% unless the enemy is defeated
-		truncatedPct := math.Floor(float64(co.shownPct)*math.Pow10(int(co.places))) / math.Pow10(int(co.places))
-		// Split float value
-		s := strings.Split(fmt.Sprintf("%.[2]*[1]f", truncatedPct, co.places), ".")
-		// Decimal separator
-		if co.places > 0 && len(s) > 1 {
-			s[0] = s[0] + co.separator + s[1]
+
+		// Only process combo damage percentage if necessary
+		if strings.Contains(co.text[tv].text, "%p") {
+			// Truncate the percentage to avoid rounding to 100% unless the enemy is defeated
+			truncatedPct := math.Floor(float64(co.shownPct)*math.Pow10(int(co.places))) / math.Pow10(int(co.places))
+			// Split float value
+			s := strings.Split(fmt.Sprintf("%.[2]*[1]f", truncatedPct, co.places), ".")
+			// Decimal separator
+			if co.places > 0 && len(s) > 1 {
+				s[0] = s[0] + co.separator + s[1]
+			}
+			// Replace %p with formatted string
+			text = strings.Replace(text, "%p", s[0], 1)
 		}
-		// Replace %p with formatted string
-		text = strings.Replace(text, "%p", s[0], 1)
 
 		// Split on new line
-		lines := strings.Split(text, "\\n")
+		lines = strings.Split(text, "\\n")
 
-		// Compute line metrics and block dimensions
-		var lineWidths []float32
+		// Compute text block dimensions
 		ffText = getFont(f, co.text[tv].font[0])
 		if ffText != nil {
 			lineHeight = float32(ffText.Size[1])*co.text[tv].lay.scale[1]*sys.fightScreen.fnt_scale +
@@ -2634,20 +2638,22 @@ func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 			for _, line := range lines {
 				w := float32(ffText.TextWidth(line, co.text[tv].font[1], 0)) *
 					co.text[tv].lay.scale[0] * sys.fightScreen.fnt_scale
-				lineWidths = append(lineWidths, w)
-				if w > maxWidth {
-					maxWidth = w
+				if w > textBlockWidth {
+					textBlockWidth = w
 				}
 			}
 		}
+	}
 
-		// Compute block reference position
+	// Draw text
+	if len(lines) > 0 && ffText != nil {
 		blockX := x + sys.fightScreen.offsetX
 		blockY := float32(co.pos[1])
 
-		// Apply shake transformation to the whole block
+		// Apply shake effect
 		scaleShakeText := co.textShake.getScale()
 		xShakeText, yShakeText := co.textShake.getOffset()
+
 		drawBlockX := (blockX + xShakeText) / scaleShakeText
 		drawBlockY := (blockY + yShakeText) / scaleShakeText
 		finalScale := scaleShakeText * sys.fightScreen.scale
@@ -2664,20 +2670,22 @@ func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 	// Counter
 	if co.counter[cv].font[0] >= 0 && getFont(f, co.counter[cv].font[0]) != nil {
 		// Apply autoalign
+		var counterShift float32
 		if side == 0 && co.autoalign {
 			if ff := getFont(f, co.counter[cv].font[0]); ff != nil {
-				length = float32(ff.TextWidth(counter, co.counter[cv].font[1], 0)) * co.counter[cv].lay.scale[0] * sys.fightScreen.fnt_scale
+				counterShift = float32(ff.TextWidth(counter, co.counter[cv].font[1], 0)) *
+					co.counter[cv].lay.scale[0] * sys.fightScreen.fnt_scale
 			}
 		}
 		if side == 1 && co.autoalign {
-			length += maxWidth
+			counterShift = counterShift + textBlockWidth
 		}
 
 		// Apply shake effect
 		scaleShake := co.counterShake.getScale()
 		xShake, yShake := co.counterShake.getOffset()
 
-		drawX := (x - length + sys.fightScreen.offsetX + xShake) / scaleShake
+		drawX := (x - counterShift + sys.fightScreen.offsetX + xShake) / scaleShake
 		drawY := (float32(co.pos[1]) + yShake) / scaleShake
 		finalScale := scaleShake * sys.fightScreen.scale
 

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -2412,6 +2412,7 @@ func readFightScreenCombo(pre string, is IniSection,
 	is.ReadF32(pre+"counter.shake.ampl", &co.counterShake.ampl)
 	is.ReadF32(pre+"counter.shake.scale", &co.counterShake.scale)
 	is.ReadF32(pre+"counter.shake.angle", &co.counterShake.angle)
+	is.ReadF32(pre+"counter.shake.angleadd", &co.counterShake.angleadd)
 
 	co.text[0] = readFSText(pre+"text.", is, "", 2, f, align)
 	for k, v := range readMultipleFSText(pre, "text", is, "", 2, f, align) {
@@ -2650,6 +2651,7 @@ type ComboShake struct {
 	freq     float32
 	phase    float32
 	angle    float32
+	angleadd float32
 }
 
 func (cs *ComboShake) restart() {
@@ -2691,7 +2693,11 @@ func (cs *ComboShake) getOffset() (x, y float32) {
 	curAmp := cs.ampl * t
 	phaseRad := Rad(cs.phase) + Rad(cs.freq)*float32(cs.time-cs.curTime)
 	val := curAmp * float32(math.Cos(float64(phaseRad)))
-	radAng := Rad(cs.angle)
+
+	elapsed := float32(cs.time - cs.curTime)
+	currentAngleDeg := cs.angle + cs.angleadd*elapsed
+	radAng := Rad(currentAngleDeg)
+
 	x = val * float32(math.Cos(float64(radAng)))
 	y = val * float32(math.Sin(float64(radAng)))
 	return

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -2330,9 +2330,9 @@ type FightScreenCombo struct {
 	pos           [2]int32
 	start_x       float32
 	counter       map[int32]*FSText
-	counter_shake bool
-	counter_time  int32   // Shake effect duration
-	counter_mult  float32 // Shake effect scale correction factor
+	//counter_shake bool
+	//counter_time  int32 // Shake effect duration
+	//counter_mult  float32 // Shake effect scale correction factor
 	text          map[int32]*FSText
 	bg            AnimLayout
 	top           AnimLayout
@@ -2347,9 +2347,9 @@ type FightScreenCombo struct {
 	shownPct      float32
 	resttime      int32
 	counterX      float32
-	curShaketime  int32
 	autoalign     bool
 	newCombo      bool
+	counterShake  ComboShake
 }
 
 func newFightScreenCombo() *FightScreenCombo {
@@ -2358,10 +2358,14 @@ func newFightScreenCombo() *FightScreenCombo {
 		showspeed:    8,
 		hidespeed:    4,
 		counter:      make(map[int32]*FSText),
-		counter_time: 7,
-		counter_mult: 1.0 / 20,
+		//counter_time: 7,
+		//counter_mult: 1.0 / 20,
 		text:         make(map[int32]*FSText),
 		autoalign:    true,
+		counterShake: ComboShake{
+			freq:  60, // Same as EnvShake
+			scale: 1.35, // Derived from old Ikemen formula
+		},
 	}
 }
 
@@ -2390,9 +2394,25 @@ func readFightScreenCombo(pre string, is IniSection,
 	for k, v := range readMultipleFSText(pre, "counter", is, "%i", 2, f, align) {
 		co.counter[k] = v
 	}
-	is.ReadBool(pre+"counter.shake", &co.counter_shake)
-	is.ReadI32(pre+"counter.time", &co.counter_time)
-	is.ReadF32(pre+"counter.mult", &co.counter_mult)
+
+	// Counter shake
+	is.ReadBool(pre+"counter.shake", &co.counterShake.enabled)
+
+	// Old shake syntax
+	is.ReadI32(pre+"counter.time", &co.counterShake.time)
+	var mult float32
+	if is.ReadF32(pre+"counter.mult", &mult) {
+		co.counterShake.scale = 1 + float32(co.counterShake.time) * mult
+	}
+
+	// New shake syntax
+	is.ReadI32(pre+"counter.shake.time", &co.counterShake.time)
+	is.ReadF32(pre+"counter.shake.freq", &co.counterShake.freq)
+	is.ReadF32(pre+"counter.shake.phase", &co.counterShake.phase) // Conditional default like in EnvShake seems unnecessary
+	is.ReadF32(pre+"counter.shake.ampl", &co.counterShake.ampl)
+	is.ReadF32(pre+"counter.shake.scale", &co.counterShake.scale)
+	is.ReadF32(pre+"counter.shake.angle", &co.counterShake.angle)
+
 	co.text[0] = readFSText(pre+"text.", is, "", 2, f, align)
 	for k, v := range readMultipleFSText(pre, "text", is, "", 2, f, align) {
 		co.text[k] = v
@@ -2426,6 +2446,9 @@ func (co *FightScreenCombo) step(hits, damage int32, percentage float32) {
 	// True hits are only updated by Char(). The live tally is only used for combo display behavior
 	//co.trueHits = hits
 
+	// Update shake every frame
+	co.counterShake.update()
+
 	// Handle show/hide speed
 	if co.resttime > 0 {
 		// Slide in
@@ -2443,10 +2466,6 @@ func (co *FightScreenCombo) step(hits, damage int32, percentage float32) {
 		}
 	}
 
-	if co.curShaketime > 0 {
-		co.curShaketime--
-	}
-
 	// The displayed time only decrements when the counter is in the visible position
 	// Currently, the way the timer decrements while the combo is still ongoing can make it stay visible varying amounts of time past the end of the combo
 	// This makes it not always sync correctly with the "nice combo" actions
@@ -2458,9 +2477,7 @@ func (co *FightScreenCombo) step(hits, damage int32, percentage float32) {
 	if co.trueHits >= 2 && (co.newCombo || co.shownHits != co.trueHits || co.shownDmg != damage) {
 		// Reset visuals when hits changed
 		if co.newCombo || co.shownHits != co.trueHits {
-			if co.counter_shake {
-				co.curShaketime = co.counter_time
-			}
+			co.counterShake.restart()
 			for i := range co.counter {
 				co.counter[i].resetTxtPfx()
 			}
@@ -2508,7 +2525,10 @@ func (co *FightScreenCombo) reset() {
 	co.shownPct = 0
 	co.resttime = 0
 	co.counterX = co.start_x * 2
-	co.curShaketime = 0
+
+	// Reset combo counter shake
+	co.counterShake.active = false
+	co.counterShake.curTime = 0
 }
 
 func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
@@ -2583,8 +2603,7 @@ func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 					}
 				}
 			}
-			co.text[tv].lay.DrawText(x+sys.fightScreen.offsetX, float32(co.pos[1])+
-				func() float32 {
+			co.text[tv].lay.DrawText(x+sys.fightScreen.offsetX, float32(co.pos[1])+func() float32 {
 					if ff := getFont(f, co.text[tv].font[0]); ff != nil {
 						return float32(ff.Size[1])*co.text[tv].lay.scale[1]*sys.fightScreen.fnt_scale +
 							float32(ff.Spacing[1])*co.text[tv].lay.scale[1]*sys.fightScreen.fnt_scale
@@ -2604,18 +2623,78 @@ func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 			}
 		}
 
-		// Shake effect
-		// TODO: More customizable parameters
-		// TODO: Maximum scale is currently determined by "time * correction factor". That seems especially odd
-		arg := float64(co.counter_time-co.curShaketime) * math.Pi / 2.5
-		z := 1 + float32(co.curShaketime)*co.counter_mult*float32(math.Cos(arg))
+		// Apply shake effect
+		scaleShake := co.counterShake.getScale()
+		xShake, yShake := co.counterShake.getOffset()
 
-		co.counter[cv].lay.DrawText((x-length+sys.fightScreen.offsetX)/z, float32(co.pos[1])/z, z*sys.fightScreen.scale, layerno,
-			counter, getFont(f, co.counter[cv].font[0]), co.counter[cv].font[1], co.counter[cv].font[2], co.counter[cv].palfx, co.counter[cv].frgba)
+		drawX := (x - length + sys.fightScreen.offsetX + xShake) / scaleShake
+		drawY := (float32(co.pos[1]) + yShake) / scaleShake
+		finalScale := scaleShake * sys.fightScreen.scale
+
+		co.counter[cv].lay.DrawText(drawX, drawY, finalScale, layerno,
+			counter, getFont(f, co.counter[cv].font[0]), co.counter[cv].font[1], co.counter[cv].font[2],
+			co.counter[cv].palfx, co.counter[cv].frgba)
 	}
 
 	// Top
 	co.top.Draw(x+sys.fightScreen.offsetX, float32(co.pos[1]), layerno, sys.fightScreen.scale)
+}
+
+type ComboShake struct {
+	enabled  bool // Global toggle
+	active   bool // Currently active
+	time     int32
+	curTime  int32
+	ampl     float32
+	scale    float32
+	freq     float32
+	phase    float32
+	angle    float32
+}
+
+func (cs *ComboShake) restart() {
+	if !cs.enabled || cs.time <= 0 {
+		cs.active = false
+		return
+	}
+	cs.active = true
+	cs.curTime = cs.time
+}
+
+func (cs *ComboShake) update() {
+	if !cs.active {
+		return
+	}
+	if cs.curTime <= 0 {
+		cs.active = false
+		return
+	}
+	cs.curTime--
+}
+
+func (cs *ComboShake) getScale() float32 {
+	if !cs.active || cs.scale == 1 {
+		return 1
+	}
+	t := float32(cs.curTime) / float32(cs.time)
+	phaseRad := Rad(cs.phase) + Rad(cs.freq)*float32(cs.time-cs.curTime)
+	cosVal := float32(math.Cos(float64(phaseRad)))
+	exponent := float32(math.Log(float64(cs.scale))) * t * cosVal
+	return float32(math.Exp(float64(exponent)))
+}
+
+func (cs *ComboShake) getOffset() (x, y float32) {
+	if !cs.active || cs.ampl == 0 {
+		return 0, 0
+	}
+	t := float32(cs.curTime) / float32(cs.time)
+	curAmp := cs.ampl * t
+	phaseRad := Rad(cs.phase) + Rad(cs.freq)*float32(cs.time-cs.curTime)
+	val := curAmp * float32(math.Cos(float64(phaseRad)))
+	radAng := Rad(cs.angle)
+	x = val * float32(math.Cos(float64(radAng)))
+	y = val * float32(math.Sin(float64(radAng)))
+	return
 }
 
 type FSMsg struct {

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -2365,6 +2365,7 @@ func newFightScreenCombo() *FightScreenCombo {
 		counterShake: ComboShake{
 			freq:  60, // Same as EnvShake
 			scale: 1.35, // Derived from old Ikemen formula
+			decay:  1.0, // Linear
 		},
 	}
 }
@@ -2413,6 +2414,7 @@ func readFightScreenCombo(pre string, is IniSection,
 	is.ReadF32(pre+"counter.shake.scale", &co.counterShake.scale)
 	is.ReadF32(pre+"counter.shake.angle", &co.counterShake.angle)
 	is.ReadF32(pre+"counter.shake.angleadd", &co.counterShake.angleadd)
+	is.ReadF32(pre+"counter.shake.decay", &co.counterShake.decay)
 
 	co.text[0] = readFSText(pre+"text.", is, "", 2, f, align)
 	for k, v := range readMultipleFSText(pre, "text", is, "", 2, f, align) {
@@ -2652,6 +2654,7 @@ type ComboShake struct {
 	phase    float32
 	angle    float32
 	angleadd float32
+	decay    float32
 }
 
 func (cs *ComboShake) restart() {
@@ -2674,14 +2677,25 @@ func (cs *ComboShake) update() {
 	cs.curTime--
 }
 
+func (cs *ComboShake) getDecay() float32 {
+	if cs.time <= 0 {
+		return 0
+	}
+	t := float32(cs.curTime) / float32(cs.time)
+	if cs.decay == 0 {
+		return 1
+	}
+	return float32(math.Pow(float64(t), float64(cs.decay)))
+}
+
 func (cs *ComboShake) getScale() float32 {
 	if !cs.active || cs.scale == 1 {
 		return 1
 	}
-	t := float32(cs.curTime) / float32(cs.time)
+	decay := cs.getDecay()
 	phaseRad := Rad(cs.phase) + Rad(cs.freq)*float32(cs.time-cs.curTime)
 	cosVal := float32(math.Cos(float64(phaseRad)))
-	exponent := float32(math.Log(float64(cs.scale))) * t * cosVal
+	exponent := float32(math.Log(float64(cs.scale))) * decay * cosVal
 	return float32(math.Exp(float64(exponent)))
 }
 
@@ -2689,8 +2703,7 @@ func (cs *ComboShake) getOffset() (x, y float32) {
 	if !cs.active || cs.ampl == 0 {
 		return 0, 0
 	}
-	t := float32(cs.curTime) / float32(cs.time)
-	curAmp := cs.ampl * t
+	curAmp := cs.ampl * cs.getDecay()
 	phaseRad := Rad(cs.phase) + Rad(cs.freq)*float32(cs.time-cs.curTime)
 	val := curAmp * float32(math.Cos(float64(phaseRad)))
 

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -2469,10 +2469,6 @@ func (co *FightScreenCombo) step(hits, damage int32, percentage float32) {
 	// True hits are only updated by Char(). The live tally is only used for combo display behavior
 	//co.trueHits = hits
 
-	// Update shake every frame
-	co.counterShake.update()
-	co.textShake.update()
-
 	// Handle show/hide speed
 	if co.resttime > 0 {
 		// Slide in
@@ -2518,6 +2514,10 @@ func (co *FightScreenCombo) step(hits, damage int32, percentage float32) {
 		co.shownPct = percentage
 		co.newCombo = false
 	}
+
+	// Update shaking effects
+	co.counterShake.update()
+	co.textShake.update()
 
 	// Multiple counter fonts
 	var cv int32
@@ -2651,12 +2651,12 @@ func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 		blockY := float32(co.pos[1])
 
 		// Apply shake effect
-		scaleShakeText := co.textShake.getScale()
-		xShakeText, yShakeText := co.textShake.getOffset()
+		textShakeScale := co.textShake.getScale()
+		textShakeOffset := co.textShake.getOffset()
 
-		drawBlockX := (blockX + xShakeText) / scaleShakeText
-		drawBlockY := (blockY + yShakeText) / scaleShakeText
-		finalScale := scaleShakeText * sys.fightScreen.scale
+		drawBlockX := (blockX + textShakeOffset[0]) / textShakeScale
+		drawBlockY := (blockY + textShakeOffset[1]) / textShakeScale
+		finalScale := textShakeScale * sys.fightScreen.scale
 
 		// Draw each line
 		for i, line := range lines {
@@ -2682,12 +2682,12 @@ func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 		}
 
 		// Apply shake effect
-		scaleShake := co.counterShake.getScale()
-		xShake, yShake := co.counterShake.getOffset()
+		shakeScale := co.counterShake.getScale()
+		shakeOffset := co.counterShake.getOffset()
 
-		drawX := (x - counterShift + sys.fightScreen.offsetX + xShake) / scaleShake
-		drawY := (float32(co.pos[1]) + yShake) / scaleShake
-		finalScale := scaleShake * sys.fightScreen.scale
+		drawX := (x - counterShift + sys.fightScreen.offsetX + shakeOffset[0]) / shakeScale
+		drawY := (float32(co.pos[1]) + shakeOffset[1]) / shakeScale
+		finalScale := shakeScale * sys.fightScreen.scale
 
 		co.counter[cv].lay.DrawText(drawX, drawY, finalScale, layerno,
 			counter, getFont(f, co.counter[cv].font[0]), co.counter[cv].font[1], co.counter[cv].font[2],
@@ -2698,20 +2698,31 @@ func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 	co.top.Draw(x+sys.fightScreen.offsetX, float32(co.pos[1]), layerno, sys.fightScreen.scale)
 }
 
+// This is like a miniature EnvShake applied to a single object
 type ComboShake struct {
-	time     int32
-	ampl     float32
-	scale    float32
-	freq     float32
-	phase    float32
-	dir      float32 // It's an angle but this name is consistent with EnvShake
-	diradd   float32
-	decay    float32
-	curTime  int32
+	time      int32
+	ampl      float32
+	scale     float32
+	freq      float32
+	phase     float32
+	dir       float32 // It's an angle but this name is consistent with EnvShake
+	diradd    float32
+	decay     float32
+	curTime   int32
+	curOffset [2]float32
+	curScale  float32
+}
+
+// Uses a reset instead of a clear because we don't want to lose the original parameters
+func (cs *ComboShake) reset() {
+	cs.curTime = 0
+	cs.curOffset = [2]float32{0, 0}
+	cs.curScale = 1
 }
 
 func (cs *ComboShake) restart() {
 	if cs.time <= 0 {
+		cs.reset() // Just in case
 		return
 	}
 	cs.curTime = cs.time
@@ -2719,48 +2730,59 @@ func (cs *ComboShake) restart() {
 
 func (cs *ComboShake) update() {
 	if cs.curTime <= 0 {
+		if cs.time > 0 {
+			cs.reset()
+		}
 		return
 	}
+
+	// Handle decay
+	var decay float32 = 1
+	if cs.decay != 0 && cs.time > 0 {
+		t := float32(cs.curTime) / float32(cs.time)
+		decay = float32(math.Pow(float64(t), float64(cs.decay)))
+	}
+
+	elapsed := float32(cs.time - cs.curTime)
+
+	// Calculate offset and cache it
+	// There's no benefit to caching it yet, but it may be useful for future features and keeps the code similar to EnvShake
+	if cs.ampl == 0 {
+		cs.curOffset = [2]float32{0, 0}
+	} else {
+		curAmp := cs.ampl * decay
+		phaseRad := Rad(cs.phase) + Rad(cs.freq)*elapsed
+		val := curAmp * float32(math.Cos(float64(phaseRad)))
+
+		currentAngleDeg := cs.dir + cs.diradd*elapsed
+		radAng := Rad(currentAngleDeg)
+
+		x := val * float32(math.Cos(float64(radAng)))
+		y := -val * float32(math.Sin(float64(radAng))) // Negated for counter‑clockwise
+
+		cs.curOffset = [2]float32{x, y}
+	}
+
+	// Calculate scale and cache it
+	if cs.scale == 1 {
+		cs.curScale = 1
+	} else {
+		phaseRad := Rad(cs.phase) + Rad(cs.freq)*elapsed
+		cosVal := float32(math.Cos(float64(phaseRad)))
+		exponent := float32(math.Log(float64(cs.scale))) * decay * cosVal
+		cs.curScale = float32(math.Exp(float64(exponent)))
+	}
+
+	// Step timer only after computing offset and scale
 	cs.curTime--
 }
 
-func (cs *ComboShake) getDecay() float32 {
-	if cs.time <= 0 {
-		return 0
-	}
-	t := float32(cs.curTime) / float32(cs.time)
-	if cs.decay == 0 {
-		return 1
-	}
-	return float32(math.Pow(float64(t), float64(cs.decay)))
+func (cs *ComboShake) getOffset() [2]float32 {
+	return cs.curOffset
 }
 
 func (cs *ComboShake) getScale() float32 {
-	if cs.curTime <= 0 || cs.scale == 1 {
-		return 1
-	}
-	decay := cs.getDecay()
-	phaseRad := Rad(cs.phase) + Rad(cs.freq)*float32(cs.time-cs.curTime)
-	cosVal := float32(math.Cos(float64(phaseRad)))
-	exponent := float32(math.Log(float64(cs.scale))) * decay * cosVal
-	return float32(math.Exp(float64(exponent)))
-}
-
-func (cs *ComboShake) getOffset() (x, y float32) {
-	if cs.curTime <= 0 || cs.ampl == 0 {
-		return 0, 0
-	}
-	curAmp := cs.ampl * cs.getDecay()
-	phaseRad := Rad(cs.phase) + Rad(cs.freq)*float32(cs.time-cs.curTime)
-	val := curAmp * float32(math.Cos(float64(phaseRad)))
-
-	elapsed := float32(cs.time - cs.curTime)
-	currentAngleDeg := cs.dir + cs.diradd*elapsed
-	radAng := Rad(currentAngleDeg)
-
-	x = val * float32(math.Cos(float64(radAng)))
-	y = -val * float32(math.Sin(float64(radAng))) // Negated for counter‑clockwise
-	return
+	return cs.curScale
 }
 
 type FSMsg struct {

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -2350,6 +2350,7 @@ type FightScreenCombo struct {
 	autoalign     bool
 	newCombo      bool
 	counterShake  ComboShake
+	textShake     ComboShake
 }
 
 func newFightScreenCombo() *FightScreenCombo {
@@ -2366,6 +2367,10 @@ func newFightScreenCombo() *FightScreenCombo {
 			freq:  60, // Same as EnvShake
 			scale: 1.35, // Derived from old Ikemen formula
 			decay:  1.0, // Linear
+		},
+		textShake: ComboShake{
+			freq:  60,
+			decay:  1.0,
 		},
 	}
 }
@@ -2391,12 +2396,15 @@ func readFightScreenCombo(pre string, is IniSection,
 			align = -1
 		}
 	}
+
+	// Read main counter string then optional multiple values
 	co.counter[0] = readFSText(pre+"counter.", is, "%i", 2, f, align)
 	for k, v := range readMultipleFSText(pre, "counter", is, "%i", 2, f, align) {
 		co.counter[k] = v
 	}
 
 	// Counter shake
+	// TODO: Shouldn't these also have multiple values?
 	is.ReadBool(pre+"counter.shake", &co.counterShake.enabled)
 
 	// Old shake syntax
@@ -2412,14 +2420,27 @@ func readFightScreenCombo(pre string, is IniSection,
 	is.ReadF32(pre+"counter.shake.phase", &co.counterShake.phase) // Conditional default like in EnvShake seems unnecessary
 	is.ReadF32(pre+"counter.shake.ampl", &co.counterShake.ampl)
 	is.ReadF32(pre+"counter.shake.scale", &co.counterShake.scale)
-	is.ReadF32(pre+"counter.shake.angle", &co.counterShake.angle)
-	is.ReadF32(pre+"counter.shake.angleadd", &co.counterShake.angleadd)
+	is.ReadF32(pre+"counter.shake.dir", &co.counterShake.dir)
+	is.ReadF32(pre+"counter.shake.diradd", &co.counterShake.diradd)
 	is.ReadF32(pre+"counter.shake.decay", &co.counterShake.decay)
 
+	// Read main text string then optional multiple values
 	co.text[0] = readFSText(pre+"text.", is, "", 2, f, align)
 	for k, v := range readMultipleFSText(pre, "text", is, "", 2, f, align) {
 		co.text[k] = v
 	}
+
+	// Text shake
+	is.ReadBool(pre+"text.shake", &co.textShake.enabled)
+	is.ReadI32(pre+"text.shake.time", &co.textShake.time)
+	is.ReadF32(pre+"text.shake.freq", &co.textShake.freq)
+	is.ReadF32(pre+"text.shake.phase", &co.textShake.phase)
+	is.ReadF32(pre+"text.shake.ampl", &co.textShake.ampl)
+	is.ReadF32(pre+"text.shake.scale", &co.textShake.scale)
+	is.ReadF32(pre+"text.shake.dir", &co.textShake.dir)
+	is.ReadF32(pre+"text.shake.diradd", &co.textShake.diradd)
+	is.ReadF32(pre+"text.shake.decay", &co.textShake.decay)
+
 	co.bg = ReadAnimLayout(pre+"bg0.", is, sff, at, 2)
 	co.top = ReadAnimLayout(pre+"top.", is, sff, at, 2)
 	is.ReadI32(pre+"displaytime", &co.displaytime)
@@ -2451,6 +2472,7 @@ func (co *FightScreenCombo) step(hits, damage int32, percentage float32) {
 
 	// Update shake every frame
 	co.counterShake.update()
+	co.textShake.update()
 
 	// Handle show/hide speed
 	if co.resttime > 0 {
@@ -2481,6 +2503,7 @@ func (co *FightScreenCombo) step(hits, damage int32, percentage float32) {
 		// Reset visuals when hits changed
 		if co.newCombo || co.shownHits != co.trueHits {
 			co.counterShake.restart()
+			co.textShake.restart()
 			for i := range co.counter {
 				co.counter[i].resetTxtPfx()
 			}
@@ -2532,6 +2555,8 @@ func (co *FightScreenCombo) reset() {
 	// Reset combo counter shake
 	co.counterShake.active = false
 	co.counterShake.curTime = 0
+	co.textShake.active = false
+	co.textShake.curTime = 0
 }
 
 func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
@@ -2563,6 +2588,7 @@ func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 		if co.start_x <= 0 {
 			x += co.counterX
 		}
+		// Apply autoalign
 		if co.counter[cv].font[0] >= 0 && co.autoalign {
 			if ff := getFont(f, co.counter[cv].font[0]); ff != nil {
 				x += float32(ff.TextWidth(counter, co.counter[cv].font[1], 0)) *
@@ -2582,6 +2608,9 @@ func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 	var length float32
 
 	// Text
+	var maxWidth float32
+	var lineHeight float32
+	var ffText *Fnt
 	if co.text[tv].font[0] >= 0 && getFont(f, co.text[tv].font[0]) != nil {
 		text := strings.Replace(co.text[tv].text, "%i", fmt.Sprintf("%v", co.shownHits), 1)
 		text = strings.Replace(text, "%d", fmt.Sprintf("%v", co.shownDmg), 1)
@@ -2590,40 +2619,61 @@ func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 		// Split float value
 		s := strings.Split(fmt.Sprintf("%.[2]*[1]f", truncatedPct, co.places), ".")
 		// Decimal separator
-		if co.places > 0 {
-			if len(s) > 1 {
-				s[0] = s[0] + co.separator + s[1]
-			}
+		if co.places > 0 && len(s) > 1 {
+			s[0] = s[0] + co.separator + s[1]
 		}
 		// Replace %p with formatted string
 		text = strings.Replace(text, "%p", s[0], 1)
+
 		// Split on new line
-		for k, v := range strings.Split(text, "\\n") {
-			if side == 1 && co.autoalign {
-				if ff := getFont(f, co.text[tv].font[0]); ff != nil {
-					if lt := float32(ff.TextWidth(v, co.text[tv].font[1], 0)) * co.text[tv].lay.scale[0] * sys.fightScreen.fnt_scale; lt > length {
-						length = lt
-					}
+		lines := strings.Split(text, "\\n")
+
+		// Compute line metrics and block dimensions
+		var lineWidths []float32
+		ffText = getFont(f, co.text[tv].font[0])
+		if ffText != nil {
+			lineHeight = float32(ffText.Size[1])*co.text[tv].lay.scale[1]*sys.fightScreen.fnt_scale +
+				float32(ffText.Spacing[1])*co.text[tv].lay.scale[1]*sys.fightScreen.fnt_scale
+			for _, line := range lines {
+				w := float32(ffText.TextWidth(line, co.text[tv].font[1], 0)) *
+					co.text[tv].lay.scale[0] * sys.fightScreen.fnt_scale
+				lineWidths = append(lineWidths, w)
+				if w > maxWidth {
+					maxWidth = w
 				}
 			}
-			co.text[tv].lay.DrawText(x+sys.fightScreen.offsetX, float32(co.pos[1])+func() float32 {
-					if ff := getFont(f, co.text[tv].font[0]); ff != nil {
-						return float32(ff.Size[1])*co.text[tv].lay.scale[1]*sys.fightScreen.fnt_scale +
-							float32(ff.Spacing[1])*co.text[tv].lay.scale[1]*sys.fightScreen.fnt_scale
-					}
-					return 0
-				}()*float32(k),
-				sys.fightScreen.scale, layerno, v, getFont(f, co.text[tv].font[0]), co.text[tv].font[1], co.text[tv].font[2],
+		}
+
+		// Compute block reference position
+		blockX := x + sys.fightScreen.offsetX
+		blockY := float32(co.pos[1])
+
+		// Apply shake transformation to the whole block
+		scaleShakeText := co.textShake.getScale()
+		xShakeText, yShakeText := co.textShake.getOffset()
+		drawBlockX := (blockX + xShakeText) / scaleShakeText
+		drawBlockY := (blockY + yShakeText) / scaleShakeText
+		finalScale := scaleShakeText * sys.fightScreen.scale
+
+		// Draw each line
+		for i, line := range lines {
+			y := drawBlockY + float32(i)*lineHeight
+			co.text[tv].lay.DrawText(drawBlockX, y, finalScale, layerno, line,
+				ffText, co.text[tv].font[1], co.text[tv].font[2],
 				co.text[tv].palfx, co.text[tv].frgba)
 		}
 	}
 
 	// Counter
 	if co.counter[cv].font[0] >= 0 && getFont(f, co.counter[cv].font[0]) != nil {
+		// Apply autoalign
 		if side == 0 && co.autoalign {
 			if ff := getFont(f, co.counter[cv].font[0]); ff != nil {
 				length = float32(ff.TextWidth(counter, co.counter[cv].font[1], 0)) * co.counter[cv].lay.scale[0] * sys.fightScreen.fnt_scale
 			}
+		}
+		if side == 1 && co.autoalign {
+			length += maxWidth
 		}
 
 		// Apply shake effect
@@ -2652,8 +2702,8 @@ type ComboShake struct {
 	scale    float32
 	freq     float32
 	phase    float32
-	angle    float32
-	angleadd float32
+	dir      float32 // It's an angle but this name is consistent with EnvShake
+	diradd   float32
 	decay    float32
 }
 
@@ -2708,7 +2758,7 @@ func (cs *ComboShake) getOffset() (x, y float32) {
 	val := curAmp * float32(math.Cos(float64(phaseRad)))
 
 	elapsed := float32(cs.time - cs.curTime)
-	currentAngleDeg := cs.angle + cs.angleadd*elapsed
+	currentAngleDeg := cs.dir + cs.diradd*elapsed
 	radAng := Rad(currentAngleDeg)
 
 	x = val * float32(math.Cos(float64(radAng)))

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -2330,9 +2330,6 @@ type FightScreenCombo struct {
 	pos           [2]int32
 	start_x       float32
 	counter       map[int32]*FSText
-	//counter_shake bool
-	//counter_time  int32 // Shake effect duration
-	//counter_mult  float32 // Shake effect scale correction factor
 	text          map[int32]*FSText
 	bg            AnimLayout
 	top           AnimLayout
@@ -2359,18 +2356,17 @@ func newFightScreenCombo() *FightScreenCombo {
 		showspeed:    8,
 		hidespeed:    4,
 		counter:      make(map[int32]*FSText),
-		//counter_time: 7,
-		//counter_mult: 1.0 / 20,
 		text:         make(map[int32]*FSText),
 		autoalign:    true,
 		counterShake: ComboShake{
 			freq:  60, // Same as EnvShake
-			scale: 1.35, // Derived from old Ikemen formula
 			decay:  1.0, // Linear
+			scale: 1.0, // No change
 		},
 		textShake: ComboShake{
 			freq:  60,
 			decay:  1.0,
+			scale: 1.0,
 		},
 	}
 }
@@ -2381,7 +2377,7 @@ func readFightScreenCombo(pre string, is IniSection,
 	is.ReadI32(pre+"pos", &co.pos[0], &co.pos[1])
 	is.ReadF32(pre+"start.x", &co.start_x)
 	if side == 1 {
-		// mugen 1.0 implementation reuses winmugen code where both sides shared the same values
+		// Mugen 1.0 implementation reuses Winmugen code where both sides shared the same values
 		if pre == "team2." {
 			co.start_x = float32(sys.fightScreen.localcoord[0]) - co.start_x
 		} else {
@@ -2403,18 +2399,22 @@ func readFightScreenCombo(pre string, is IniSection,
 		co.counter[k] = v
 	}
 
-	// Counter shake
-	// TODO: Shouldn't these also have multiple values?
-	is.ReadBool(pre+"counter.shake", &co.counterShake.enabled)
-
-	// Old shake syntax
+	// Old counter shake syntax
+	// TODO: Shouldn't shaking parameters also support "multiple values"?
+	var old bool
+	if is.ReadBool(pre+"counter.shake", &old) {
+		if old {
+			co.counterShake.time = 8 // Mugen value
+			co.counterShake.scale = 1.35 // Derived from old Ikemen formula
+		}
+	}
 	is.ReadI32(pre+"counter.time", &co.counterShake.time)
 	var mult float32
 	if is.ReadF32(pre+"counter.mult", &mult) {
 		co.counterShake.scale = 1 + float32(co.counterShake.time) * mult
 	}
 
-	// New shake syntax
+	// New counter shake syntax
 	is.ReadI32(pre+"counter.shake.time", &co.counterShake.time)
 	is.ReadF32(pre+"counter.shake.freq", &co.counterShake.freq)
 	is.ReadF32(pre+"counter.shake.phase", &co.counterShake.phase) // Conditional default like in EnvShake seems unnecessary
@@ -2431,7 +2431,6 @@ func readFightScreenCombo(pre string, is IniSection,
 	}
 
 	// Text shake
-	is.ReadBool(pre+"text.shake", &co.textShake.enabled)
 	is.ReadI32(pre+"text.shake.time", &co.textShake.time)
 	is.ReadF32(pre+"text.shake.freq", &co.textShake.freq)
 	is.ReadF32(pre+"text.shake.phase", &co.textShake.phase)
@@ -2552,10 +2551,8 @@ func (co *FightScreenCombo) reset() {
 	co.resttime = 0
 	co.counterX = co.start_x * 2
 
-	// Reset combo counter shake
-	co.counterShake.active = false
+	// Reset combo shake
 	co.counterShake.curTime = 0
-	co.textShake.active = false
 	co.textShake.curTime = 0
 }
 
@@ -2694,10 +2691,7 @@ func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 }
 
 type ComboShake struct {
-	enabled  bool // Global toggle
-	active   bool // Currently active
 	time     int32
-	curTime  int32
 	ampl     float32
 	scale    float32
 	freq     float32
@@ -2705,23 +2699,18 @@ type ComboShake struct {
 	dir      float32 // It's an angle but this name is consistent with EnvShake
 	diradd   float32
 	decay    float32
+	curTime  int32
 }
 
 func (cs *ComboShake) restart() {
-	if !cs.enabled || cs.time <= 0 {
-		cs.active = false
+	if cs.time <= 0 {
 		return
 	}
-	cs.active = true
 	cs.curTime = cs.time
 }
 
 func (cs *ComboShake) update() {
-	if !cs.active {
-		return
-	}
 	if cs.curTime <= 0 {
-		cs.active = false
 		return
 	}
 	cs.curTime--
@@ -2739,7 +2728,7 @@ func (cs *ComboShake) getDecay() float32 {
 }
 
 func (cs *ComboShake) getScale() float32 {
-	if !cs.active || cs.scale == 1 {
+	if cs.curTime <= 0 || cs.scale == 1 {
 		return 1
 	}
 	decay := cs.getDecay()
@@ -2750,7 +2739,7 @@ func (cs *ComboShake) getScale() float32 {
 }
 
 func (cs *ComboShake) getOffset() (x, y float32) {
-	if !cs.active || cs.ampl == 0 {
+	if cs.curTime <= 0 || cs.ampl == 0 {
 		return 0, 0
 	}
 	curAmp := cs.ampl * cs.getDecay()
@@ -2762,7 +2751,7 @@ func (cs *ComboShake) getOffset() (x, y float32) {
 	radAng := Rad(currentAngleDeg)
 
 	x = val * float32(math.Cos(float64(radAng)))
-	y = val * float32(math.Sin(float64(radAng)))
+	y = -val * float32(math.Sin(float64(radAng))) // Negated for counter‑clockwise
 	return
 }
 

--- a/src/script.go
+++ b/src/script.go
@@ -8310,10 +8310,16 @@ func triggerFunctions(l *lua.LState) {
 			ln = lua.LNumber(sys.envShake.curTime)
 		case "freq":
 			ln = lua.LNumber(sys.envShake.freq)
+		case "phase":
+			ln = lua.LNumber(sys.envShake.phase)
 		case "ampl":
 			ln = lua.LNumber(sys.envShake.ampl)
 		case "dir":
 			ln = lua.LNumber(sys.envShake.dir)
+		case "diradd":
+			ln = lua.LNumber(sys.envShake.diradd)
+		case "decay":
+			ln = lua.LNumber(sys.envShake.decay)
 		default:
 			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}
@@ -8550,8 +8556,6 @@ func triggerFunctions(l *lua.LState) {
 		c := sys.debugWC
 		var lv lua.LValue
 		switch strings.ToLower(strArg(l, 1)) {
-		case "fall.envshake.dir":
-			lv = lua.LNumber(c.ghv.fall_envshake_dir)
 		case "animtype":
 			lv = lua.LNumber(c.gethitAnimtype())
 		case "air.animtype":
@@ -8654,12 +8658,18 @@ func triggerFunctions(l *lua.LState) {
 			lv = lua.LNumber(c.ghv.fall_envshake_time)
 		case "fall.envshake.freq":
 			lv = lua.LNumber(c.ghv.fall_envshake_freq)
-		case "fall.envshake.ampl":
-			lv = lua.LNumber(c.ghv.fall_envshake_ampl)
 		case "fall.envshake.phase":
 			lv = lua.LNumber(c.ghv.fall_envshake_phase)
+		case "fall.envshake.ampl":
+			lv = lua.LNumber(c.ghv.fall_envshake_ampl)
 		case "fall.envshake.mul":
 			lv = lua.LNumber(c.ghv.fall_envshake_mul)
+		case "fall.envshake.dir":
+			lv = lua.LNumber(c.ghv.fall_envshake_dir)
+		case "fall.envshake.diradd":
+			lv = lua.LNumber(c.ghv.fall_envshake_diradd)
+		case "fall.envshake.decay":
+			lv = lua.LNumber(c.ghv.fall_envshake_decay)
 		case "attr":
 			lv = attrLStr(c.ghv.attr)
 		case "dizzypoints":

--- a/src/script.go
+++ b/src/script.go
@@ -8307,13 +8307,13 @@ func triggerFunctions(l *lua.LState) {
 		var ln lua.LNumber
 		switch strings.ToLower(strArg(l, 1)) {
 		case "time":
-			ln = lua.LNumber(sys.envShake.time)
+			ln = lua.LNumber(sys.envShake.curTime)
 		case "freq":
-			ln = lua.LNumber(sys.envShake.freq / float32(math.Pi) * 180)
+			ln = lua.LNumber(sys.envShake.freq)
 		case "ampl":
 			ln = lua.LNumber(sys.envShake.ampl)
 		case "dir":
-			ln = lua.LNumber(sys.envShake.dir / float32(math.Pi) * 180)
+			ln = lua.LNumber(sys.envShake.dir)
 		default:
 			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}

--- a/src/system.go
+++ b/src/system.go
@@ -2555,7 +2555,6 @@ func (s *System) action() {
 		s.zmax = s.stage.botbound * s.stage.localscl
 		//s.bgPalFX.step()
 
-		s.envShake.next()
 		if s.envcol_time > 0 {
 			s.envcol_time--
 		}
@@ -2592,6 +2591,7 @@ func (s *System) action() {
 		// The following must be placed after char action or they will lag behind 1 frame
 		s.allPalFX.step()
 		s.bgPalFX.step()
+		s.envShake.update()
 		s.zoom.update()
 		s.nomusic = s.gsf(GSF_nomusic) && !sys.postMatchFlg
 	}
@@ -5506,53 +5506,90 @@ func (l *Loader) runTread() bool {
 }
 
 type EnvShake struct {
-	time  int32
-	freq  float32
-	ampl  float32
-	phase float32
-	mul   float32
-	dir   float32 // rad, for ampl=-4:  0: down first, 90: left first, 180: up first, 270: right first
+	time       int32
+	freq       float32
+	ampl       float32
+	phase      float32
+	mul        float32
+	dir        float32
+	diradd     float32
+	decay      float32
+	curTime    int32
+	curOffset  [2]float32
 }
 
 func (es *EnvShake) clear() {
 	*es = EnvShake{
-		freq:  float32(math.Pi / 3),
-		ampl:  -4.0,
+		freq:  60,
 		phase: float32(math.NaN()),
+		ampl:  -4,
 		mul:   1.0,
-		dir:   0.0}
+	}
+}
+
+func (es *EnvShake) restart() {
+	if es.time <= 0 {
+		return
+	}
+	es.curTime = es.time
 }
 
 func (es *EnvShake) setDefaultPhase() {
 	if math.IsNaN(float64(es.phase)) {
-		if es.freq >= math.Pi/2 {
-			es.phase = math.Pi / 2
+		if es.freq >= 90.0 {
+			es.phase = 90.0
 		} else {
 			es.phase = 0
 		}
 	}
 }
 
-func (es *EnvShake) next() {
-	if es.time > 0 {
-		es.time--
-		es.phase += es.freq
-		if es.phase > math.Pi*2 {
-			es.ampl *= es.mul
-			es.phase -= math.Pi * 2
+func (es *EnvShake) update() {
+	if es.curTime <= 0 {
+		// Only run clear() if necessary
+		if es.time > 0 {
+			es.clear()
 		}
-	} else {
-		es.ampl = 0
+		return
 	}
+
+	// Recompute offset once per frame and cache it
+	elapsed := float32(es.time - es.curTime)
+	currentPhase := es.phase + es.freq*elapsed
+	currentDir := es.dir + es.diradd*elapsed
+
+	var factor float64 = 1.0
+
+	// Mul is applied once per cycle
+	if es.mul != 0 && es.mul != 1 {
+		cycles := math.Floor(float64(es.freq*elapsed) / 360.0)
+		factor *= math.Pow(float64(es.mul), cycles)
+	}
+
+	// Apply decay
+	t := float64(es.curTime) / float64(es.time)
+	if es.decay != 0 && t > 0 {
+		factor *= math.Pow(t, float64(es.decay))
+	}
+
+	ampl := float64(es.ampl) * factor
+	if ampl == 0 {
+		es.curOffset = [2]float32{0, 0}
+	} else {
+		phaseRad := float64(currentPhase) * math.Pi / 180.0
+		dirRad := float64(currentDir) * math.Pi / 180.0
+		offset := ampl * math.Sin(phaseRad)
+		x := float32(offset * math.Sin(-dirRad))
+		y := float32(offset * math.Cos(-dirRad))
+		es.curOffset = [2]float32{x, y}
+	}
+
+	// Step timer only after computing the offset
+	es.curTime--
 }
 
 func (es *EnvShake) getOffset() [2]float32 {
-	if es.time > 0 {
-		offset := (es.ampl * float32(math.Sin(float64(es.phase))))
-		return [2]float32{offset * float32(math.Sin(float64(-es.dir))),
-			offset * float32(math.Cos(float64(-es.dir)))}
-	}
-	return [2]float32{0, 0}
+	return es.curOffset
 }
 
 type ZoomEffect struct {

--- a/src/system.go
+++ b/src/system.go
@@ -5529,6 +5529,7 @@ func (es *EnvShake) clear() {
 
 func (es *EnvShake) restart() {
 	if es.time <= 0 {
+		es.clear() // Just in case
 		return
 	}
 	es.curTime = es.time


### PR DESCRIPTION
Features:
- Combo counter shaking now works similarly to EnvShake: added `amplitude`, `scale`, `frequency`, `phase` and `dir` parameters
- Added same parameters to the combo text group
- Added `diradd` to combo shaking as well as EnvShake. Increases `dir` by specified value every frame
- Added `decay` parameter to all as well. Float parameter that fades out the shaking exponentially. Supersedes `mul` parameter but doesn't replace it

Fixes:
- EnvShake effect is now active in the same frame it's called and time is more accurate to the user input. Note: This is not accurate to Mugen, where it does those things incorrectly

Refactor:
- Deprecated `counter.mult` parameter. The new scale parameter takes over its job. If that parameter is used, scale will be automatically computed according to the old Ikemen formula
- Deprecated `counter.shake` boolean. The shaking effect is now determined by its time parameter, like most things. If time is 0 there is no shake. If old bool is present it is interpreted as the old default time and scale
- Refactored EnvShake code to be more like the combo shaking. It now uses only a couple runtime variables instead of mutating all of them every frame
- EnvShake code now uses degress most of the time and conversion to radians is only done at the end. This makes it easier to follow because all user-facing variables already used degrees