### PR TITLE
fix: arcadepath crashing the engine, multiple attached chars in stage crash, challenger screen explods and sounds

### DIFF
--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -1588,7 +1588,13 @@ function start.f_matchPersistence()
 	-- checked only after at least 1 match
 	if matchNo() >= 2 then
 		local gameStats = getGameStats()
-		local roundStats = gameStats.Matches[matchNo()-1].Rounds
+		local matches = (getGameStats().Matches) or {}
+		local idx = #matches
+		if idx <= (start.matchPersistenceStatsIdx or 0) then
+			return start.p[1].numChars
+		end
+		start.matchPersistenceStatsIdx = idx
+		local roundStats = matches[idx].Rounds
 		-- set 'existed' flag (decides if var/fvar should be persistent between matches)
 		if roundStats then
 			for _, round in ipairs(roundStats) do
@@ -1739,7 +1745,10 @@ function start.f_selectMode()
 			end
 		end
 		--external script execution
+		local oldCustomArcadePath = start.customArcadePath
+		start.customArcadePath = main.charparam.arcadepath and path ~= main.luaPath
 		assert(loadfile(path))()
+		start.customArcadePath = oldCustomArcadePath
 		--infinite matches flag detected
 		if main.makeRoster and start.t_roster[matchNo()] ~= nil and start.t_roster[matchNo()][1] == -1 then
 			table.remove(start.t_roster, matchNo())
@@ -1794,6 +1803,7 @@ function start.f_selectReset(hardReset, preserveProgress)
 	esc(false)
 	if not preserveProgress then
 		resetGameStats()
+		start.matchPersistenceStatsIdx = 0
 		setMatchNo(1)
 		if main.elimination then
 			setWinCount(1, 0)
@@ -1908,6 +1918,7 @@ local function makeChallengerResumeSnapshot(pendingFightData, stageNo)
 		availableChars = main.f_tableCopy(main.t_availableChars),
 		pendingFight = main.f_tableCopy(pendingFightData or {}),
 		matchNo = matchNo(),
+		matchPersistenceStatsIdx = start.matchPersistenceStatsIdx or 0,
 		p1ConsecutiveWins = getConsecutiveWins(1),
 		p2ConsecutiveWins = getConsecutiveWins(2),
 		gameStatsJson = getGameStatsJson(),
@@ -2030,6 +2041,7 @@ function start.f_selectChallenger(resume)
 	main.t_availableChars = main.f_tableCopy(resume.availableChars)
 	setGameStatsJson(resume.gameStatsJson)
 	setMatchNo(resume.matchNo)
+	start.matchPersistenceStatsIdx = resume.matchPersistenceStatsIdx or 0
 	setConsecutiveWins(1, resume.p1ConsecutiveWins)
 	setConsecutiveWins(2, resume.p2ConsecutiveWins)
 	start.reset = false
@@ -2254,8 +2266,10 @@ function launchFight(data)
 		updateCommon(common, true)
 		-- Resolve match-scoped params before VS can start background loading.
 		local winscreen = main.f_arg(t.winscreen, main.motif.winscreen)
-		if winscreen and main.makeRoster and start.t_roster[matchNo() + 1] ~= nil then
-			winscreen = false
+		if winscreen and data.winscreen == nil then
+			if start.customArcadePath or (main.makeRoster and start.t_roster[matchNo() + 1] ~= nil) then
+				winscreen = false
+			end
 		end
 		local loadStartParams = main.f_tableCopy(t)
 		loadStartParams.winscreen = winscreen

--- a/src/char.go
+++ b/src/char.go
@@ -1932,11 +1932,13 @@ func (e *Explod) update() {
 		return
 	}
 
-	paused := false
-	if sys.supertime > 0 {
-		paused = (e.supermovetime >= 0 && e.time >= e.supermovetime) || e.supermovetime < -2
-	} else if sys.pausetime > 0 {
-		paused = (e.pausemovetime >= 0 && e.time >= e.pausemovetime) || e.pausemovetime < -2
+	paused := sys.motif.ch.active && sys.pausetime > 0
+	if !paused {
+		if sys.supertime > 0 {
+			paused = (e.supermovetime >= 0 && e.time >= e.supermovetime) || e.supermovetime < -2
+		} else if sys.pausetime > 0 {
+			paused = (e.pausemovetime >= 0 && e.time >= e.pausemovetime) || e.pausemovetime < -2
+		}
 	}
 
 	act := !paused

--- a/src/motif.go
+++ b/src/motif.go
@@ -3461,6 +3461,7 @@ func (ch *MotifChallenger) step(m *Motif) {
 	sys.setGSF(GSF_timerfreeze)
 	if ch.counter == m.ChallengerInfo.Pause.Time {
 		sys.pausetime = m.ChallengerInfo.Time + m.ChallengerInfo.FadeOut.FadeData.duration()
+		sys.stopAllCharSounds()
 	}
 	if ch.counter == m.ChallengerInfo.Snd.Time {
 		m.Snd.play(m.ChallengerInfo.Snd.Snd, 100, 0, 0, 0, 0)

--- a/src/system.go
+++ b/src/system.go
@@ -2276,7 +2276,8 @@ func (s *System) updateMusicMaps() {
 		if len(p) == 0 {
 			continue
 		}
-		if newMatchMusic {
+		isSelectableChar := i < MaxSimul*2
+		if newMatchMusic && isSelectableChar {
 			p[0].si().music.ClearSelection()
 		}
 		// Reset music map
@@ -2290,11 +2291,13 @@ func (s *System) updateMusicMaps() {
 		if sys.sel.gameParams != nil {
 			useCharMusic = sys.sel.gameParams.CharParamMusic
 		}
-		// In Versus modes, round/final/life music shouldn't override stage music; victory.music still can.
-		if useCharMusic {
-			s.cgi[i].music.Override(p[0].si().music)
-		} else if v, ok := p[0].si().music[normalizeMusicPrefix("victory")]; ok {
-			s.cgi[i].music.Override(Music{normalizeMusicPrefix("victory"): v})
+		if isSelectableChar {
+			// In Versus modes, round/final/life music shouldn't override stage music; victory.music still can.
+			if useCharMusic {
+				s.cgi[i].music.Override(p[0].si().music)
+			} else if v, ok := p[0].si().music[normalizeMusicPrefix("victory")]; ok {
+				s.cgi[i].music.Override(Music{normalizeMusicPrefix("victory"): v})
+			}
 		}
 		// Override with music with launchFight parameters
 		s.cgi[i].music.Override(sys.sel.music)


### PR DESCRIPTION
Fixes #3676
Fixes problem with custom arcadepath logic deciding when to display win/results screen based on maxmatches instead of launchFight winscreen flag.
Fixes #3679
Fixes #3684