### PR TITLE
refactor: gradual life recovery; minor fixes and refactoring

### DIFF
--- a/data/system.zss
+++ b/data/system.zss
@@ -42,18 +42,34 @@ mapSet{map: "_iksys_dustposz"; value: pos z}
 
 # Round start maps reset
 if !isHelper && roundTime = 0 {
+	map(_iksys_lifeRecoveryValue) := 0;
 	map(_iksys_lifeRecoveryFlag) := 0;
 }
 
-if !isHelper && win && roundState = 4 && map(_iksys_lifeRecoveryFlag) = 0
+# Turns/Survival life recovery
+# TODO: There's a bug here where the enemy also recovers life when you lose in Survival
+if !isHelper && win && roundState = 4 {
+	# Determine how much to recover
+	if map(_iksys_lifeRecoveryFlag) = 0
 	&& (((teamMode = Turns || enemy,teamMode = Turns) && !matchOver) || gameVar(persistlife)) {
-	let bonus = lifeMax * gameOption(options.turns.recovery.bonus) / 100;
-	let base = lifeMax * gameOption(options.turns.recovery.base) / 100;
-	let timeRatio = float(timeRemaining) / (timeRemaining + timeElapsed);
-	if timeRemaining < 0 {
-		let timeRatio = 1;
+		let base = lifeMax * gameOption(options.turns.recovery.base) / 100;
+		let bonus = lifeMax * gameOption(options.turns.recovery.bonus) / 100;
+		let timeRatio = float(timeRemaining) / (timeRemaining + timeElapsed);
+		if timeRemaining < 0 {
+			let timeRatio = 1;
+		}
+		map(_iksys_lifeRecoveryValue) := round($base + $bonus * $timeRatio, 0);
+		map(_iksys_lifeRecoveryFlag) := 1;
 	}
-	let lifeRecovery = round($base + $timeRatio * $bonus, 0);
-	lifeSet{value: min(life + $lifeRecovery, lifeMax)}
-	map(_iksys_lifeRecoveryFlag) := 1;
+	# Recover gradually
+	if map(_iksys_lifeRecoveryValue) > 0 {
+		assertSpecial{flag: roundNotOver; flag2: roundNotSkip}
+		let lifeStep = Min(3, map(_iksys_lifeRecoveryValue));
+		lifeAdd{value: $lifeStep}
+		mapAdd{map: "_iksys_lifeRecoveryValue"; value: -$lifeStep}
+	}
+	# No need to delay round further if life is full
+	if life >= lifeMax {
+		map(_iksys_lifeRecoveryValue) := 0;
+	}
 }

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -842,6 +842,7 @@ const (
 	OC_ex2_explodvar_friction_y
 	OC_ex2_explodvar_friction_z
 	OC_ex2_explodvar_id
+	OC_ex2_explodvar_ignorehitpause
 	OC_ex2_explodvar_layerno
 	OC_ex2_explodvar_pausemovetime
 	OC_ex2_explodvar_pos_x
@@ -3816,6 +3817,8 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	case OC_ex2_explodvar_layerno:
 		fallthrough
 	case OC_ex2_explodvar_id:
+		fallthrough
+	case OC_ex2_explodvar_ignorehitpause:
 		fallthrough
 	case OC_ex2_explodvar_bindid:
 		fallthrough

--- a/src/char.go
+++ b/src/char.go
@@ -5646,6 +5646,8 @@ func (c *Char) explodVar(eid BytecodeValue, idx BytecodeValue, vtype OpCode) Byt
 			v = BytecodeFloat(e.friction[2])
 		case OC_ex2_explodvar_id:
 			v = BytecodeInt(e.id)
+		case OC_ex2_explodvar_ignorehitpause:
+			v = BytecodeBool(e.ignorehitpause)
 		case OC_ex2_explodvar_layerno:
 			v = BytecodeInt(e.layerno)
 		case OC_ex2_explodvar_pausemovetime:

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2459,6 +2459,8 @@ func (c *CharCompiler) expValue(out *BytecodeExp, in *string,
 			}
 		case "id":
 			opc = OC_ex2_explodvar_id
+		case "ignorehitpause":
+			opc = OC_ex2_explodvar_ignorehitpause
 		case "layerno":
 			opc = OC_ex2_explodvar_layerno
 		case "pausemovetime":

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -2405,6 +2405,7 @@ func readFightScreenCombo(pre string, is IniSection,
 	if is.ReadBool(pre+"counter.shake", &old) {
 		if old {
 			co.counterShake.time = 8     // Mugen value
+			co.counterShake.phase = 90   // Like old Ikemen default
 			co.counterShake.scale = 1.35 // Derived from old Ikemen formula
 		}
 	}
@@ -2416,8 +2417,10 @@ func readFightScreenCombo(pre string, is IniSection,
 
 	// New counter shake syntax
 	is.ReadI32(pre+"counter.shake.time", &co.counterShake.time)
-	is.ReadF32(pre+"counter.shake.freq", &co.counterShake.freq)
-	is.ReadF32(pre+"counter.shake.phase", &co.counterShake.phase) // Conditional default like in EnvShake seems unnecessary
+	if is.ReadF32(pre+"counter.shake.freq", &co.counterShake.freq) {
+		co.counterShake.setDefaultPhase()
+	}
+	is.ReadF32(pre+"counter.shake.phase", &co.counterShake.phase)
 	is.ReadF32(pre+"counter.shake.ampl", &co.counterShake.ampl)
 	is.ReadF32(pre+"counter.shake.scale", &co.counterShake.scale)
 	is.ReadF32(pre+"counter.shake.dir", &co.counterShake.dir)
@@ -2432,7 +2435,9 @@ func readFightScreenCombo(pre string, is IniSection,
 
 	// Text shake
 	is.ReadI32(pre+"text.shake.time", &co.textShake.time)
-	is.ReadF32(pre+"text.shake.freq", &co.textShake.freq)
+	if is.ReadF32(pre+"text.shake.freq", &co.textShake.freq) {
+		co.textShake.setDefaultPhase()
+	}
 	is.ReadF32(pre+"text.shake.phase", &co.textShake.phase)
 	is.ReadF32(pre+"text.shake.ampl", &co.textShake.ampl)
 	is.ReadF32(pre+"text.shake.scale", &co.textShake.scale)
@@ -2449,6 +2454,7 @@ func readFightScreenCombo(pre string, is IniSection,
 	co.separator, _, _ = is.getText("format.decimal.separator")
 	is.ReadI32("format.decimal.places", &co.places)
 	is.ReadBool(pre+"autoalign", &co.autoalign)
+
 	return co
 }
 
@@ -2728,6 +2734,15 @@ func (cs *ComboShake) restart() {
 	cs.curTime = cs.time
 }
 
+func (cs *ComboShake) setDefaultPhase() {
+	// No need for NaN
+	if cs.freq >= 90.0 {
+		cs.phase = 90.0
+	} else {
+		cs.phase = 0
+	}
+}
+
 func (cs *ComboShake) update() {
 	if cs.curTime <= 0 {
 		if cs.time > 0 {
@@ -2752,7 +2767,7 @@ func (cs *ComboShake) update() {
 	} else {
 		curAmp := cs.ampl * decay
 		phaseRad := Rad(cs.phase) + Rad(cs.freq)*elapsed
-		val := curAmp * float32(math.Cos(float64(phaseRad)))
+		val := curAmp * float32(math.Sin(float64(phaseRad)))
 
 		currentAngleDeg := cs.dir + cs.diradd*elapsed
 		radAng := Rad(currentAngleDeg)
@@ -2768,8 +2783,8 @@ func (cs *ComboShake) update() {
 		cs.curScale = 1
 	} else {
 		phaseRad := Rad(cs.phase) + Rad(cs.freq)*elapsed
-		cosVal := float32(math.Cos(float64(phaseRad)))
-		exponent := float32(math.Log(float64(cs.scale))) * decay * cosVal
+		sinVal := float32(math.Sin(float64(phaseRad)))
+		exponent := float32(math.Log(float64(cs.scale))) * decay * sinVal
 		cs.curScale = float32(math.Exp(float64(exponent)))
 	}
 

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -5114,7 +5114,7 @@ func loadFightScreen(def string) (*FightScreen, error) {
 				teamNum := team + 1
 				teamPrefix := fmt.Sprintf("team%v.", teamNum)
 
-				if sys.fightScreen.ikemenver[0] == 0 && sys.fightScreen.ikemenver[1] == 0 {
+				if fs.ikemenver[0] == 0 && fs.ikemenver[1] == 0 { // Not sys.fightScreen yet
 					// Check if "teamX.pos" exists to determine whether or not to use "teamX" prefixes
 					// Mugen works slightly different and apparently checks whether "pos" or "team1.pos" is found first in order to determine what syntax to use
 					// Such prefixes were only added in Mugen 1.0, hence it running this check

--- a/src/iniutils.go
+++ b/src/iniutils.go
@@ -2598,7 +2598,7 @@ func PopulateDataPointers(obj interface{}, rootLocalcoord [2]int32) {
 	}
 
 	// Thread both localcoord and effective SFF through recursion.
-	var populate func(v reflect.Value, parent reflect.Value, currentLocalCoord [2]int32, currentSff *Sff)
+	var populate func(v reflect.Value, parent reflect.Value, currentLocalCoord [2]int32, currentSff *Sff, skipInit bool)
 
 	// Types we look for
 	animPtrType := reflect.TypeOf((*Anim)(nil))
@@ -2608,7 +2608,7 @@ func PopulateDataPointers(obj interface{}, rootLocalcoord [2]int32) {
 	fadePtrType := reflect.TypeOf((*Fade)(nil))
 
 	// The recursive function
-	populate = func(v reflect.Value, parent reflect.Value, currentLocalCoord [2]int32, currentSff *Sff) {
+	populate = func(v reflect.Value, parent reflect.Value, currentLocalCoord [2]int32, currentSff *Sff, skipInit bool) {
 		if !v.IsValid() {
 			return
 		}
@@ -2616,7 +2616,7 @@ func PopulateDataPointers(obj interface{}, rootLocalcoord [2]int32) {
 			if v.IsNil() {
 				return
 			}
-			populate(v.Elem(), parent, currentLocalCoord, currentSff)
+			populate(v.Elem(), parent, currentLocalCoord, currentSff, skipInit)
 			return
 		}
 
@@ -2658,27 +2658,34 @@ func PopulateDataPointers(obj interface{}, rootLocalcoord [2]int32) {
 					}
 				}
 
+				// Check for skipInit tag on this field
+				childSkipInit := skipInit
+				if fType.Tag.Get("skipinit") == "true" {
+					childSkipInit = true
+				}
+
 				kind := fVal.Kind()
 
 				// Recurse for struct or non-nil ptr
 				if kind == reflect.Struct || (kind == reflect.Ptr && !fVal.IsNil()) {
-					populate(fVal, v, localCoordForThisStruct, nextSff)
+					populate(fVal, v, localCoordForThisStruct, nextSff, childSkipInit)
 					continue
 				}
 				// If it's a map, recurse as well
 				if kind == reflect.Map {
 					// Pass along the possibly overridden SFF from this field's tag.
-					populate(fVal, parent, localCoordForThisStruct, nextSff)
+					populate(fVal, parent, localCoordForThisStruct, nextSff, childSkipInit)
 					continue
 				}
 				// If it's *Anim
 				if kind == reflect.Ptr && fVal.Type().AssignableTo(animPtrType) {
 					if fVal.IsNil() && fVal.CanSet() {
-						curType := v.Type()
-						animCharPreloadType := reflect.TypeOf(AnimationCharPreloadProperties{})
-						animStagePreloadType := reflect.TypeOf(AnimationStagePreloadProperties{})
-						// Skip these or we'll end up trying to draw them from the motif SFF
-						if curType != animCharPreloadType && curType != animStagePreloadType {
+						if childSkipInit {
+							// Use a dummy anim
+							// Prevents populating pointers to character and stage sprites from the motif's SFF
+							dummyAnim := NewAnim(nil, "")
+							fVal.Set(reflect.ValueOf(dummyAnim))
+						} else {
 							SetAnim(obj, fVal, v, parent, effectiveSffForThisStruct)
 						}
 					}
@@ -2718,13 +2725,12 @@ func PopulateDataPointers(obj interface{}, rootLocalcoord [2]int32) {
 		// If we have a slice or array, recurse into each element
 		case reflect.Slice, reflect.Array:
 			for i := 0; i < v.Len(); i++ {
-				populate(v.Index(i), parent, currentLocalCoord, currentSff)
+				populate(v.Index(i), parent, currentLocalCoord, currentSff, skipInit)
 			}
-		// If we have a map, recurse into each key-value pair
 		case reflect.Map:
 			for _, key := range v.MapKeys() {
 				val := v.MapIndex(key)
-				populate(val, parent, currentLocalCoord, currentSff)
+				populate(val, parent, currentLocalCoord, currentSff, skipInit)
 			}
 		default:
 			// basic types: do nothing
@@ -2737,7 +2743,7 @@ func PopulateDataPointers(obj interface{}, rootLocalcoord [2]int32) {
 		return
 	}
 	// Start recursion with the original user-supplied localcoord
-	populate(v.Elem(), v.Elem(), rootLocalcoord, rootSff)
+	populate(v.Elem(), v.Elem(), rootLocalcoord, rootSff, false)
 }
 
 // Split a [Music] key into (prefix, property) while allowing dots in prefix.

--- a/src/motif.go
+++ b/src/motif.go
@@ -410,9 +410,9 @@ type ItemProperties struct {
 }
 
 type FaceProperties struct {
-	AnimationCharPreloadProperties
+	AnimationCharPreloadProperties `skipinit:"true"`
 	Done struct { // not used by [Victory Screen]
-		AnimationCharPreloadProperties
+		AnimationCharPreloadProperties `skipinit:"true"`
 		Key []string `ini:"key"` // only used by [VS Screen]
 	} `ini:"done"`
 	Random   AnimationProperties `ini:"random"` // only used by [Select Info]
@@ -514,7 +514,7 @@ type PlayerSelectProperties struct {
 			Snd [2]int32 `ini:"snd" default:"-1,0"`
 		} `ini:"value"`
 		Preview struct {
-			AnimationCharPreloadProperties
+			AnimationCharPreloadProperties `skipinit:"true"`
 			Snd [2]int32 `ini:"snd" default:"-1,0"`
 		} `ini:"preview"`
 		Number TextProperties      `ini:"number"`
@@ -596,7 +596,7 @@ type PlayerDialogueProperties struct {
 	Face struct {
 		AnimationProperties
 		Active AnimationProperties `ini:"active"`
-	} `ini:"face"`
+	} `ini:"face" skipinit:"true"`
 	Name TextProperties `ini:"name"`
 	Text struct {
 		TextProperties
@@ -732,7 +732,7 @@ type SelectInfoProperties struct {
 			Snd [2]int32 `ini:"snd" default:"-1,0"`
 		} `ini:"move"`
 		Portrait struct {
-			AnimationStagePreloadProperties
+			AnimationStagePreloadProperties `skipinit:"true"`
 			Bg     AnimationProperties `ini:"bg"`
 			Random AnimationProperties `ini:"random"`
 		} `ini:"portrait"`
@@ -744,7 +744,7 @@ type SelectInfoProperties struct {
 		Key []string `ini:"key"`
 		Snd [2]int32 `ini:"snd" default:"-1,0"`
 	} `ini:"cancel"`
-	Portrait AnimationCharPreloadProperties `ini:"portrait"`
+	Portrait AnimationCharPreloadProperties `ini:"portrait" skipinit:"true"`
 	Title    TextMapProperties              `ini:"title"`
 	Record   TextMapProperties              `ini:"record"`
 	TeamMenu struct {
@@ -788,7 +788,7 @@ type VsScreenProperties struct {
 		Pos [2]float32 `ini:"pos"`
 		TextProperties
 		Portrait struct {
-			AnimationStagePreloadProperties
+			AnimationStagePreloadProperties `skipinit:"true"`
 			Bg AnimationProperties `ini:"bg"`
 		} `ini:"portrait"`
 		Snd [2]int32 `ini:"snd" default:"-1,0"`
@@ -1237,7 +1237,7 @@ type HiscoreInfoProperties struct {
 		Result  ItemProperties `ini:"result"`
 		Name    ItemProperties `ini:"name"`
 		Face    struct {
-			AnimationCharPreloadProperties
+			AnimationCharPreloadProperties `skipinit:"true"`
 			Num     int32               `ini:"num"`
 			Spacing [2]float32          `ini:"spacing"`
 			Bg      AnimationProperties `ini:"bg"`


### PR DESCRIPTION
Refactor:
- Turns/Survival life recovery is now gradual instead of instant

Fixes:
- Fixed `team*` and `|` operators not working in [Combo]
- Fixed combo shaking "phase 0" resulting in starting with the full effect. Old syntax now defaults to phase 90
- Fixed "missing sprite 9000,3" false warnings on boot

Features:
- Added missing `explodVar(ignorehitpause)`