### PR TITLE
feat(lua): fade userdata API

### DIFF
--- a/src/script.go
+++ b/src/script.go
@@ -2636,9 +2636,9 @@ func systemScriptInit(l *lua.LState) {
 		if !ok {
 			userDataError(l, 1, f)
 		}
-		f.col[0] = int32(numArg(l, 2))
-		f.col[1] = int32(numArg(l, 3))
-		f.col[2] = int32(numArg(l, 4))
+		f.col[0] = int32(numArg(l, 2)) & 0xff
+		f.col[1] = int32(numArg(l, 3)) & 0xff
+		f.col[2] = int32(numArg(l, 4)) & 0xff
 		return 0
 	})
 	luaRegister(l, "fadeSetAnim", func(*lua.LState) int {

--- a/src/script.go
+++ b/src/script.go
@@ -2602,6 +2602,87 @@ func systemScriptInit(l *lua.LState) {
 		sys.uiResetTokenGuard()
 		return 0
 	})
+	luaRegister(l, "fadeNew", func(*lua.LState) int {
+		/*Instantiates a Fade userdata for use with fadeInInit and fadeOutInit.
+		@function fadeNew
+		@treturn Fade fade Fade userdata.
+		function fadeNew(fade) end*/
+		f := newFade()
+		l.Push(newUserData(l, f))
+		return 1
+	})
+	luaRegister(l, "fadeSetTime", func(*lua.LState) int {
+		/*Sets the duration of a Fade userdata.
+		@function fadeSetTime
+		@tparam Fade fade The Fade userdata to modify.
+		@tparam int32 ticks The new length of the Fade in ticks.
+		function fadeSetTime(fade, ticks) end*/
+		f, ok := toUserData(l, 1).(*Fade)
+		if !ok {
+			userDataError(l, 1, f)
+		}
+		f.time = int32(numArg(l, 2))
+		return 0
+	})
+	luaRegister(l, "fadeSetColor", func(*lua.LState) int {
+		/*Sets the color of a Fade userdata.
+		@function fadeSetColor
+		@tparam Fade fade The Fade userdata to modify.
+		@tparam int32 r Red component (0–255).
+		@tparam int32 g Green component (0–255).
+		@tparam int32 b Blue component (0–255).
+		function fadeSetColor(fade, r, g, b) end*/
+		f, ok := toUserData(l, 1).(*Fade)
+		if !ok {
+			userDataError(l, 1, f)
+		}
+		f.col[0] = int32(numArg(l, 2))
+		f.col[1] = int32(numArg(l, 3))
+		f.col[2] = int32(numArg(l, 4))
+		return 0
+	})
+	luaRegister(l, "fadeSetAnim", func(*lua.LState) int {
+		/*Sets the Anim associated with a Fade userdata.
+		@function fadeSetAnim
+		@tparam Fade fade The Fade userdata to modify.
+		@tparam[opt] Anim anim The Anim to assign to the fade. If nil or invalid, will remove the anim from the fade.
+		function fadeSetAnim(fade, anim) end*/
+		f, ok := toUserData(l, 1).(*Fade)
+		if !ok {
+			userDataError(l, 1, f)
+		}
+		anim := toUserData(l, 2).(*Anim)
+		f.animData = anim
+		return 0
+	})
+	luaRegister(l, "fadeSetSound", func(*lua.LState) int {
+		/*Sets the sound associated with a Fade userdata.
+		@function fadeSetSound
+		@tparam Fade fade The Fade userdata to modify.
+		@tparam int32 group The group number of the sound, from the motif's SND file.
+		@tparam int32 index The index number of the sound, from the motif's SND file.
+		function fadeSetSound(fade, group, index) end*/
+		f, ok := toUserData(l, 1).(*Fade)
+		if !ok {
+			userDataError(l, 1, f)
+		}
+		f.snd[0] = int32(numArg(l, 2))
+		f.snd[1] = int32(numArg(l, 3))
+		return 0
+	})
+	luaRegister(l, "fadeSetFadeIn", func(*lua.LState) int {
+		/*Sets the flag for fadein for a Fade userdata.
+		@function fadeSetFadeIn
+		@tparam Fade fade The Fade userdata to modify.
+		@tparam boolean fadeIn If `true`, will specify the fade as fadein. Fadeout otherwise.
+		function fadeSetFadeIn(fade, fadeIn) end*/
+		f, ok := toUserData(l, 1).(*Fade)
+		if !ok {
+			userDataError(l, 1, f)
+		}
+		f.isFadeIn = boolArg(l, 2)
+		return 0
+	})
 	luaRegister(l, "fadeActive", func(*lua.LState) int {
 		/*Check whether any global motif fade is active.
 		@function fadeActive

--- a/src/script.go
+++ b/src/script.go
@@ -2658,65 +2658,6 @@ func systemScriptInit(l *lua.LState) {
 		l.Push(newUserData(l, f))
 		return 1
 	})
-	luaRegister(l, "fadeSetTime", func(*lua.LState) int {
-		/*Sets the duration of a Fade userdata.
-		@function fadeSetTime
-		@tparam Fade fade The Fade userdata to modify.
-		@tparam int32 ticks The new length of the Fade in ticks.
-		function fadeSetTime(fade, ticks) end*/
-		f, ok := toUserData(l, 1).(*Fade)
-		if !ok {
-			userDataError(l, 1, f)
-		}
-		f.time = int32(numArg(l, 2))
-		return 0
-	})
-	luaRegister(l, "fadeSetColor", func(*lua.LState) int {
-		/*Sets the color of a Fade userdata.
-		@function fadeSetColor
-		@tparam Fade fade The Fade userdata to modify.
-		@tparam int32 r Red component (0–255).
-		@tparam int32 g Green component (0–255).
-		@tparam int32 b Blue component (0–255).
-		function fadeSetColor(fade, r, g, b) end*/
-		f, ok := toUserData(l, 1).(*Fade)
-		if !ok {
-			userDataError(l, 1, f)
-		}
-		f.col[0] = int32(numArg(l, 2)) & 0xff
-		f.col[1] = int32(numArg(l, 3)) & 0xff
-		f.col[2] = int32(numArg(l, 4)) & 0xff
-		return 0
-	})
-	luaRegister(l, "fadeSetAnim", func(*lua.LState) int {
-		/*Sets the Anim associated with a Fade userdata.
-		@function fadeSetAnim
-		@tparam Fade fade The Fade userdata to modify.
-		@tparam[opt] Anim anim The Anim to assign to the fade. If nil or invalid, will remove the anim from the fade.
-		function fadeSetAnim(fade, anim) end*/
-		f, ok := toUserData(l, 1).(*Fade)
-		if !ok {
-			userDataError(l, 1, f)
-		}
-		anim := toUserData(l, 2).(*Anim)
-		f.animData = anim
-		return 0
-	})
-	luaRegister(l, "fadeSetSound", func(*lua.LState) int {
-		/*Sets the sound associated with a Fade userdata.
-		@function fadeSetSound
-		@tparam Fade fade The Fade userdata to modify.
-		@tparam int32 group The group number of the sound, from the motif's SND file.
-		@tparam int32 index The index number of the sound, from the motif's SND file.
-		function fadeSetSound(fade, group, index) end*/
-		f, ok := toUserData(l, 1).(*Fade)
-		if !ok {
-			userDataError(l, 1, f)
-		}
-		f.snd[0] = int32(numArg(l, 2))
-		f.snd[1] = int32(numArg(l, 3))
-		return 0
-	})
 	luaRegister(l, "fadeActive", func(*lua.LState) int {
 		/*Check whether any global motif fade is active.
 		@function fadeActive

--- a/src/script.go
+++ b/src/script.go
@@ -2605,8 +2605,13 @@ func systemScriptInit(l *lua.LState) {
 	luaRegister(l, "fadeNew", func(*lua.LState) int {
 		/*Instantiates a Fade userdata for use with fadeInInit and fadeOutInit.
 		@function fadeNew
+		@tparam[opt] table params Parameter table (keys are case-insenstive) :
+		  - `time` (int, opt) Duration in ticks
+		  - `color` (int[3], opt) RGB values (0–255)
+		  - `anim` (*Anim, opt) Animation to play in the fade. If nil or invalid, will play no animation
+		  - `sound` (int[2], opt) Sound to play in the fade. Uses motif SND.
 		@treturn Fade fade Fade userdata.
-		function fadeNew(fade) end*/
+		function fadeNew(params) end*/
 		f := newFade()
 
 		// if no table return the Fade as is

--- a/src/script.go
+++ b/src/script.go
@@ -2608,6 +2608,53 @@ func systemScriptInit(l *lua.LState) {
 		@treturn Fade fade Fade userdata.
 		function fadeNew(fade) end*/
 		f := newFade()
+
+		// if no table return the Fade as is
+		if !nilArg(l, 1) {
+			// from here apply parameters by key-value
+			tableArg(l, 1).ForEach(func(key, value lua.LValue){
+				switch k := key.(type) {
+				case lua.LString:
+					switch strings.ToLower(string(k)) {
+					case "time":
+						f.time = int32(lua.LVAsNumber(value))
+					case "color":
+						var s [3]int32
+						switch v := value.(type){
+						case *lua.LTable:
+							v.ForEach(func(key2, value2 lua.LValue){
+								s[int(lua.LVAsNumber(key2))-1] = int32(lua.LVAsNumber(value2))
+							})
+						}
+						f.col[0] = s[0] & 0xff
+						f.col[1] = s[1] & 0xff
+						f.col[2] = s[2] & 0xff
+					case "anim":
+						// if I can't convert to *Anim, that's okay, just leave it nil
+						if ud, ok := value.(*lua.LUserData); ok{
+							if anim, ok := ud.Value.(*Anim); ok{
+								f.animData = anim
+							}
+						}
+					case "sound":
+						var s [2]int32
+						switch v := value.(type){
+						case *lua.LTable:
+							v.ForEach(func(key2, value2 lua.LValue){
+								s[int(lua.LVAsNumber(key2))-1] = int32(lua.LVAsNumber(value2))
+							})
+						}
+						f.snd[0] = s[0]
+						f.snd[1] = s[1]
+					default:
+						l.RaiseError("\nInvalid table key: %v\n", k)
+					}
+				default:
+					l.RaiseError("\nInvalid table key type: %v\n", fmt.Sprintf("%T\n", key))
+				}
+			})
+		}
+
 		l.Push(newUserData(l, f))
 		return 1
 	})
@@ -2668,19 +2715,6 @@ func systemScriptInit(l *lua.LState) {
 		}
 		f.snd[0] = int32(numArg(l, 2))
 		f.snd[1] = int32(numArg(l, 3))
-		return 0
-	})
-	luaRegister(l, "fadeSetFadeIn", func(*lua.LState) int {
-		/*Sets the flag for fadein for a Fade userdata.
-		@function fadeSetFadeIn
-		@tparam Fade fade The Fade userdata to modify.
-		@tparam boolean fadeIn If `true`, will specify the fade as fadein. Fadeout otherwise.
-		function fadeSetFadeIn(fade, fadeIn) end*/
-		f, ok := toUserData(l, 1).(*Fade)
-		if !ok {
-			userDataError(l, 1, f)
-		}
-		f.isFadeIn = boolArg(l, 2)
 		return 0
 	})
 	luaRegister(l, "fadeActive", func(*lua.LState) int {


### PR DESCRIPTION
This PR adds several new Lua functions to create and manage Fade userdata objects which are quite common in motif Lua. These objects are also used in the `fadeInInit`/`fadeOutInit` functions.

For module developers, the new functions are used in the same style as the Anim and TextImg APIs. Following is a list of the added functions:

- `fadeNew()`: Creates a new Fade userdata object with default values, or with a table with the following keys:
  - `time`: Length in ticks
  - `color`: R-G-B values in a Lua table. Range 0-255
  - `anim`: Anim userdata
  - `sound`: Group-index values in a Lua table. Sound from motif.