### PR TITLE
feat(lifebar): face.darkenshare parameter; fixes

### DIFF
--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -1734,7 +1734,6 @@ function start.f_selectMode()
 			main.f_waitForPreloads()
 		end
 		if not start.f_selectScreen() then
-			sndPlay(motif.Snd, motif.select_info.cancel.snd[1], motif.select_info.cancel.snd[2])
 			bgReset(motif[main.background].BGDef)
 			fadeInInit(motif[main.group].fadein.FadeData)
 			playBgm({source = "motif.title", interrupt = true})
@@ -2720,6 +2719,7 @@ function start.f_selectScreen()
 			--exit select screen
 			for _, v in ipairs(start.p[side].t_selCmd) do
 				if not start.escFlag and (esc() or (getInput(v.cmd, motif.select_info.cancel.key) and not start.p[side].inPalMenu)) then
+					sndPlay(motif.Snd, motif.select_info.cancel.snd[1], motif.select_info.cancel.snd[2])
 					fadeOutInit(motif.select_info.fadeout.FadeData)
 					fadeOutStarted = true
 					start.escFlag = true
@@ -2978,6 +2978,7 @@ function start.f_teamMenu(side, t)
 		--Exit during team menu
 		if not start.escFlag and (esc() or getInput(-1, motif.select_info.cancel.key)) then
 			esc(false)
+			sndPlay(motif.Snd, motif.select_info.cancel.snd[1], motif.select_info.cancel.snd[2])
 			fadeOutInit(motif.select_info.fadeout.FadeData)
 			fadeOutStarted = true
 			start.escFlag = true

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -4069,7 +4069,7 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 	case OC_ex2_gamevar_persistrounds:
 		sys.bcStack.PushB(sys.sel.gameParams.PersistRounds)
 	case OC_ex2_gamevar_hidebars:
-		sys.bcStack.PushB(sys.lifebarHide || sys.dialogueBarsFlg)
+		sys.bcStack.PushB(sys.lifebarHide || sys.dialogueHideBars)
 	// HitByAttr
 	case OC_ex2_hitbyattr:
 		attr := be.ReadIntAt(i)
@@ -11802,7 +11802,7 @@ func (sc dialogue) Run(c *Char, _ []int32) bool {
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
 		case dialogue_hidebars:
-			sys.dialogueBarsFlg = sys.motif.DialogueInfo.Enabled && exp[0].evalB(c)
+			sys.dialogueHideBars = sys.motif.DialogueInfo.Enabled && exp[0].evalB(c)
 		case dialogue_force:
 			force = exp[0].evalB(c)
 		case dialogue_text:

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -5820,10 +5820,6 @@ func parseTriggerNumber(name string) (tn int32, isAll bool, ok bool) {
 func (c *CharCompiler) parseSection(sctrl func(name, data string) error) (IniSection, error) {
 	is := NewIniSection()
 
-	// Placeholder var to toggle all the nonsense Mugen's compiler allowed
-	// Maybe this could be sys.ignoreMostErrors. Or something configurable
-	strict := false
-
 	// Helper to find '=' only outside parentheses
 	findTopLevelEqual := func(s string) int {
 		uneven := 0
@@ -5854,7 +5850,7 @@ func (c *CharCompiler) parseSection(sctrl func(name, data string) error) (IniSec
 		}
 
 		fn := lhs[:i]
-		if !strict {
+		if sys.ignoreMostErrors {
 			fn = strings.TrimSpace(fn) // Mugen tolerates "var ("
 		}
 
@@ -5882,8 +5878,9 @@ func (c *CharCompiler) parseSection(sctrl func(name, data string) error) (IniSec
 			return "", false
 		}
 
-		if strict {
-			// When strict, only "var(...)" is valid. No "var (...)" and no trailing garbage
+		// When strict, only "var(...)" is valid. No "var (...)" and no trailing garbage
+		// Note: CNS normally has "sys.ignoreMostErrors" set to false, but that could be configurable in the future
+		if !sys.ignoreMostErrors {
 			if lhs[:i] != strings.TrimSpace(lhs[:i]) || end != len(lhs)-1 {
 				return "", false
 			}
@@ -5929,17 +5926,18 @@ func (c *CharCompiler) parseSection(sctrl func(name, data string) error) (IniSec
 				name = parsed
 			} else if strings.Index(lhs, "(") >= 0 {
 				// Looks like a special parameter, but wasn't valid
-				if strict {
-					if sys.ignoreMostErrors {
-						continue
-					}
-					return nil, Error("Invalid parameter syntax: " + line)
+				msg := "Invalid parameter syntax: " + line
+				if sys.ignoreMostErrors {
+					LogMessage(c.charWarn() + msg)
+					continue
+				} else {
+					return nil, Error(msg)
 				}
 			}
 
 			// Normal parameters
 			if name == "" {
-				if strict {
+				if !sys.ignoreMostErrors {
 					// If strict, only a single token is valid on the LHS
 					if strings.IndexAny(lhs, " \t") >= 0 {
 						if sys.ignoreMostErrors {
@@ -6004,16 +6002,26 @@ func (c *CharCompiler) stateSec(is IniSection, f func() error) error {
 	if err := f(); err != nil {
 		return err
 	}
-	if !sys.ignoreMostErrors {
-		var str string
-		for k := range is {
-			if len(str) > 0 {
-				str += ", "
+	// Check for leftover (unknown) parameters
+	var str string
+	for k := range is {
+		// Ignore CNS keywords
+		if !c.zssMode {
+			if k == "type" || k == "persistent" || k == "ignorehitpause" {
+				continue
 			}
-			str += k
 		}
 		if len(str) > 0 {
-			return Error("Invalid key name: " + str)
+			str += ", "
+		}
+		str += k
+	}
+	if len(str) > 0 {
+		msg := "Unknown state controller parameter(s): " + str
+		if sys.ignoreMostErrors {
+			LogMessage(c.charWarn() + msg)
+		} else {
+			return Error(msg)
 		}
 	}
 	return nil
@@ -7956,9 +7964,9 @@ func (c *CharCompiler) stateCompileZSS(states map[int32]StateBytecode, filename,
 			c.scan(&line)
 			if existInThisFile[c.stateNo] {
 				if c.stateNo == -10 {
-					return errmes(Error(fmt.Sprintf("State +1 overloaded")))
+					return errmes(Error(fmt.Sprintf("State +1 already defined in the same file")))
 				} else {
-					return errmes(Error(fmt.Sprintf("State %v overloaded", c.stateNo)))
+					return errmes(Error(fmt.Sprintf("State %v already defined in the same file", c.stateNo)))
 				}
 			}
 			existInThisFile[c.stateNo] = true

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -2169,6 +2169,14 @@ func (c *CharCompiler) hitDefSub(is IniSection, sc *StateControllerBase) error {
 		hitDef_envshake_dir, VT_Float, 1, false); err != nil {
 		return err
 	}
+	if err := c.paramValue(is, sc, "envshake.diradd",
+		hitDef_envshake_diradd, VT_Float, 1, false); err != nil {
+		return err
+	}
+	if err := c.paramValue(is, sc, "envshake.decay",
+		hitDef_envshake_decay, VT_Float, 1, false); err != nil {
+		return err
+	}
 	if err := c.paramValue(is, sc, "fall.envshake.time",
 		hitDef_fall_envshake_time, VT_Int, 1, false); err != nil {
 		return err

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -1697,6 +1697,7 @@ type FightScreenFace struct {
 	face_lay               Layout
 	face_palshare          bool
 	face_palfxshare        bool
+	face_darkenshare       bool
 	teammate_pos           [2]int32
 	teammate_spacing       [2]int32
 	teammate_bg            AnimLayout
@@ -1728,6 +1729,11 @@ func newFightScreenFace() *FightScreenFace {
 		teammate_face_palshare: true,
 		teammate_face_pfx:      nil, // Allocated later
 	}
+	// Before Mugen 1.1, portraits used to share the character's palette in every way
+	// The equivalent of enabling face_palshare, face_palfxshare and face_darkenshare
+	// Mugen 1.1 has some bugs that broke all off that
+	// However, we will default face_palfxshare to disabled because it's no longer a common fighting game feature
+	// face_darkenshare has the same default as face_palfxshare because the two are related
 }
 
 func readFightScreenFace(pre string, is IniSection, sff *Sff, at AnimationTable) *FightScreenFace {
@@ -1745,6 +1751,7 @@ func readFightScreenFace(pre string, is IniSection, sff *Sff, at AnimationTable)
 	fa.face_lay = *ReadLayout(pre+"face.", is, 0)
 	is.ReadBool(pre+"face.palshare", &fa.face_palshare)
 	is.ReadBool(pre+"face.palfxshare", &fa.face_palfxshare)
+	is.ReadBool(pre+"face.darkenshare", &fa.face_darkenshare)
 	is.ReadBool("leaderontop", &fa.leaderontop)
 
 	// Teammates
@@ -1859,13 +1866,12 @@ func (fa *FightScreenFace) draw(layerno int16, charpn int, refFace *FightScreenF
 		}
 
 		// Save current brightness
-		//oldBright := sys.brightness
+		oldBright := sys.brightness
 
 		// Reset system brightness if player initiated SuperPause (cancel "darken" parameter)
-		// Update: This is an odd thing to do since the rest of the fight screen darkens
-		//if refChar.ignoreDarkenTime > 0 {
-		//	sys.brightness = 1.0
-		//}
+		if fa.face_darkenshare && refChar.ignoreDarkenTime > 0 {
+			sys.brightness = 1.0
+		}
 
 		// Draw the actual face sprite
 		fa.face_lay.DrawFaceSprite((float32(fa.pos[0])+sys.fightScreen.offsetX)*sys.fightScreen.scale, float32(fa.pos[1])*sys.fightScreen.scale, layerno,
@@ -1877,14 +1883,14 @@ func (fa *FightScreenFace) draw(layerno int16, charpn int, refFace *FightScreenF
 		}
 
 		// Restore original system brightness
-		//sys.brightness = oldBright
+		sys.brightness = oldBright
 	}
 
 	// Draw top layer
 	fa.top.Draw(float32(fa.pos[0])+sys.fightScreen.offsetX, float32(fa.pos[1]), layerno, sys.fightScreen.scale)
 }
 
-func (fa *FightScreenFace) drawTeammates(layerno int16, charpn int) {
+func (fa *FightScreenFace) drawTeammates(layerno int16) {
 	if len(fa.teammate_face) == 0 {
 		return
 	}
@@ -1898,6 +1904,7 @@ func (fa *FightScreenFace) drawTeammates(layerno int16, charpn int) {
 	oldBright := sys.brightness
 
 	// Reset system brightness if player initiated SuperPause (cancel "darken" parameter)
+	// Update: Mugen doesn't do this and it doesn't make much sense to begin with
 	//refChar := sys.chars[charpn][0]
 	//if refChar.ignoreDarkenTime > 0 {
 	//	sys.brightness = 1.0
@@ -2026,7 +2033,7 @@ func (nm *FightScreenName) draw(layerno int16, charpn int, f map[int]*Fnt, side 
 	nm.top.Draw(float32(nm.pos[0])+sys.fightScreen.offsetX, float32(nm.pos[1]), layerno, sys.fightScreen.scale)
 }
 
-func (nm *FightScreenName) drawTeammates(layerno int16, charpn int, f map[int]*Fnt, side int) {
+func (nm *FightScreenName) drawTeammates(layerno int16, f map[int]*Fnt, side int) {
 	if len(nm.teammate_name_strings) == 0 {
 		return
 	}
@@ -5643,7 +5650,7 @@ func (fs *FightScreen) draw(layerno int16) {
 					}
 					// Draw Turns teammates from the first bar only
 					if slot == 0 {
-						fs.faces[layout][side].drawTeammates(layerno, charpn)
+						fs.faces[layout][side].drawTeammates(layerno)
 					}
 					fs.faces[layout][barpn].bgDraw(layerno)
 					fs.faces[layout][barpn].draw(layerno, charpn, fs.faces[layout][charpn])
@@ -5667,7 +5674,7 @@ func (fs *FightScreen) draw(layerno int16) {
 					}
 					// Draw Turns teammates from the first bar only
 					if slot == 0 {
-						fs.names[layout][side].drawTeammates(layerno, charpn, fs.fnt, side)
+						fs.names[layout][side].drawTeammates(layerno, fs.fnt, side)
 					}
 					fs.names[layout][barpn].bgDraw(layerno)
 					fs.names[layout][barpn].draw(layerno, charpn, fs.fnt, side)

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -5534,7 +5534,7 @@ func (fs *FightScreen) visible() bool {
 	return fs.active &&
 		!sys.postMatchFlg &&
 		!sys.lifebarHide &&
-		!sys.dialogueBarsFlg &&
+		!(sys.dialogueHideBars || sys.motif.di.active) &&
 		!(sys.motif.me.active && sys.motif.PauseMenu["pause_menu"].HideBars &&
 			(!sys.motif.me.closeRequested || sys.paused))
 }

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -1005,17 +1005,23 @@ func (pb *PowerBar) step(charpn int, pbr *PowerBar, snd *Snd) {
 		pbr.midpower = pbr.midpowerMin
 	}
 
+	// Initialize "previous power" in the first frame of the round
+	// This prevents level sounds and similar actions from happening in that frame
+	if sys.matchTime == 0 {
+		pbr.prevLevel = level
+		pbr.prevPower = pbval
+	}
+
 	// Level sounds
 	// Skipped if the bar is invisible
-	canPlaySnd := !sys.gsf(GSF_nobardisplay) && !refChar.powerOwner().asf(ASF_nopowerbardisplay)
-	if pbval >= refChar.powerMax && pbr.prevPower < refChar.powerMax && pb.levelmax_snd[0] != -1 {
-		if canPlaySnd {
+	if !sys.gsf(GSF_nobardisplay) && !refChar.powerOwner().asf(ASF_nopowerbardisplay) {
+		if pbval >= refChar.powerMax && pbr.prevPower < refChar.powerMax && pb.levelmax_snd[0] != -1 {
 			snd.play(pb.levelmax_snd, 100, 0, 0, 0, 0)
-		}
-	} else if level > pbr.prevLevel && canPlaySnd {
-		i := int(level - 1)
-		if i >= 0 && i < len(pb.level_snd) {
-			snd.play(pb.level_snd[i], 100, 0, 0, 0, 0)
+		} else if level > pbr.prevLevel {
+			i := int(level - 1)
+			if i >= 0 && i < len(pb.level_snd) {
+				snd.play(pb.level_snd[i], 100, 0, 0, 0, 0)
+			}
 		}
 	}
 

--- a/src/motif.go
+++ b/src/motif.go
@@ -4203,7 +4203,7 @@ func (di *MotifDialogue) clear(m *Motif) {
 	}
 	di.initialized = false
 	sys.dialogueForce = 0
-	sys.dialogueBarsFlg = false
+	sys.dialogueHideBars = false
 	m.DialogueInfo.P1.Face.AnimData.anim = nil
 	m.DialogueInfo.P2.Face.AnimData.anim = nil
 	if m.DialogueInfo.P1.Face.Active.AnimData != nil {

--- a/src/render.go
+++ b/src/render.go
@@ -785,17 +785,16 @@ func renderWithBlending(
 				render(Blend, BlendZero, BlendOneMinusSrcAlpha, 1-float32(dst)/255)
 			}
 			if src > 0 {
-				// TODO: Wasn't this already done at the start of the function?
-				if invblend >= 1 { // && dst >= 255 {
+				if invblend >= 1 && dst >= 255 {
 					Blend = BlendReverseSubtract
+					if invblend >= 2 { // Not 1 here. TODO: Explain why in comment
+						invertColor()
+					}
+					if invblend == 3 {
+						disableNeg()
+					}
 				} else {
 					Blend = BlendAdd
-				}
-				if invblend >= 2 { // Not 1 here. TODO: Explain why in comment
-					invertColor()
-				}
-				if invblend == 3 {
-					disableNeg()
 				}
 				if !isrgba && (invblend <= -1 || invblend >= 2) && acolor != nil && mcolor != nil && src < 255 {
 					// Sum of add components

--- a/src/script.go
+++ b/src/script.go
@@ -3206,7 +3206,7 @@ func systemScriptInit(l *lua.LState) {
 				sys.bgPalFX = newPalFX()
 				sys.resetGblEffect()
 				sys.dialogueForce = 0
-				sys.dialogueBarsFlg = false
+				sys.dialogueHideBars = false
 				sys.noSoundFlg = false
 				sys.postMatchFlg = false
 				sys.preMatchTime += sys.matchTime
@@ -8749,7 +8749,7 @@ func triggerFunctions(l *lua.LState) {
 		case "persistmusic":
 			l.Push(lua.LBool(sys.sel.gameParams.PersistMusic))
 		case "hidebars":
-			l.Push(lua.LBool(sys.lifebarHide || sys.dialogueBarsFlg))
+			l.Push(lua.LBool(sys.lifebarHide || sys.dialogueHideBars || sys.motif.di.active))
 		default:
 			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}

--- a/src/system.go
+++ b/src/system.go
@@ -123,7 +123,7 @@ type SystemStateVars struct {
 	firstAttack     [3]int
 	home            int
 	stageLoop       bool
-	dialogueBarsFlg bool
+	dialogueHideBars bool
 	dialogueForce   int
 	playBgmFlg      bool
 

--- a/src/system.go
+++ b/src/system.go
@@ -5972,6 +5972,9 @@ func (l *Loader) prepareTurnsFaces(pn int, fa *FightScreenFace, nm *FightScreenN
 	fa.teammate_scale = make([]float32, nsel)
 	fa.teammate_face_pfx = make([]*PalFX, nsel)
 
+	// Wait for texture uploads before we clone the portraits. Fixes quick VS
+	sys.runMainThreadTask()
+
 	// Iterate all selected characters
 	for i, charIdx := range teamChars {
 		sc := &sys.sel.charlist[charIdx]


### PR DESCRIPTION
Features:
- `face.darkenshare` parameter. If enabled, SuperPause darken parameter will make the portrait darken/not darken like the character. If disabled, it always darkens. Unhardcodes that behavior
- If a CNS sctrl has unknown parameters, they will now be printed to the terminal

Fixes:
- Dialogue `hidebars` works as documented. If true, the bars are hidden immediately when dialogue is called. If false, the bars are only hidden while the dialogue is active
- Inverted blend regression in BGPalFX
- Fixes #3672 
- Select screen cancel sound is now played when escape/back is pressed, instead of after the fadeout effect
- Fixed quick VS not loading teammate portraits

Refactor:
- Powerbar level sounds disabled in first frame of round