### PR TITLE
fix: dialogue name rendered earlier than face/text, text and motif layerno=2 rendered on top of system fade; feat: portrait loading variants inheritance

### DIFF
--- a/src/anim.go
+++ b/src/anim.go
@@ -198,6 +198,7 @@ type Animation struct {
 	isVideo                    bool // Because videos are rendered through Animation.Draw()
 	phantomPixel               bool
 	copyAction                 int32
+	warnMissing                bool
 }
 
 func newAnimation(sff *Sff, pal *PaletteList) *Animation {
@@ -216,6 +217,7 @@ func newAnimation(sff *Sff, pal *PaletteList) *Animation {
 		start_scale:                [...]float32{1, 1},
 		lastActionFrame:            -1,
 		copyAction:                 -1,
+		warnMissing:                true,
 	}
 }
 
@@ -607,15 +609,17 @@ func (a *Animation) UpdateSprite() {
 		if group != -1 && number != -1 {
 			a.spr = a.sff.GetSprite(uint16(group), uint16(number))
 			if a.spr == nil {
-				// Log missing sprites
-				// We will save the history in the SFF itself so that each sprite is only mentioned once
-				key := [2]uint16{uint16(group), uint16(number)}
-				if a.sff.debugMissing == nil {
-					a.sff.debugMissing = make(map[[2]uint16]bool)
-				}
-				if !a.sff.debugMissing[key] {
-					LogMessage("WARNING: Animation missing sprite %v,%v from %v", group, number, a.sff.filename)
-					a.sff.debugMissing[key] = true
+				if a.warnMissing {
+					// Log missing sprites
+					// We will save the history in the SFF itself so that each sprite is only mentioned once
+					key := [2]uint16{uint16(group), uint16(number)}
+					if a.sff.debugMissing == nil {
+						a.sff.debugMissing = make(map[[2]uint16]bool)
+					}
+					if !a.sff.debugMissing[key] {
+						LogMessage("WARNING: Animation missing sprite %v,%v from %v", group, number, a.sff.filename)
+						a.sff.debugMissing[key] = true
+					}
 				}
 			}
 		} else {

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -4079,51 +4079,50 @@ func (ro *FightScreenRound) draw(layerno int16, f map[int]*Fnt) {
 
 	// Restore system brightness
 	sys.brightness = oldBright
+}
 
-	// Screen fading
-	if layerno == 2 {
-		if ro.fadeOut.isActive() {
-			ro.fadeOut.draw()
-		} else if ro.fadeIn.isActive() {
-			ro.fadeIn.draw()
-		} else if sys.clsnDisplay && sys.cfg.Debug.ClsnDarken {
-			ro.fadeIn.drawRect(sys.scrrect, 0, 0)
-		}
+func (ro *FightScreenRound) drawFade() {
+	if ro.fadeOut.isActive() {
+		ro.fadeOut.draw()
+	} else if ro.fadeIn.isActive() {
+		ro.fadeIn.draw()
+	} else if sys.clsnDisplay && sys.cfg.Debug.ClsnDarken {
+		ro.fadeIn.drawRect(sys.scrrect, 0, 0)
+	}
 
-		if ro.shutterTimer > 0 {
-			// shutterTimer is a countdown from (shutter_time*2) to 0:
-			// 2T -> open, T -> fully closed, 0 -> open
-			rect := sys.scrrect
-			half := (sys.scrrect[3] + 1) >> 1
-			var cover int32
-			if ro.shutter_time > 0 {
-				if ro.shutterTimer > ro.shutter_time {
-					// Closing phase
-					t := ro.shutter_time*2 - ro.shutterTimer
-					if t < 0 {
-						t = 0
-					}
-					if t > ro.shutter_time {
-						t = ro.shutter_time
-					}
-					cover = t * half / ro.shutter_time
-				} else {
-					// Opening phase
-					t := ro.shutterTimer
-					if t < 0 {
-						t = 0
-					}
-					if t > ro.shutter_time {
-						t = ro.shutter_time
-					}
-					cover = t * half / ro.shutter_time
+	if ro.shutterTimer > 0 {
+		// shutterTimer is a countdown from (shutter_time*2) to 0:
+		// 2T -> open, T -> fully closed, 0 -> open
+		rect := sys.scrrect
+		half := (sys.scrrect[3] + 1) >> 1
+		var cover int32
+		if ro.shutter_time > 0 {
+			if ro.shutterTimer > ro.shutter_time {
+				// Closing phase
+				t := ro.shutter_time*2 - ro.shutterTimer
+				if t < 0 {
+					t = 0
 				}
+				if t > ro.shutter_time {
+					t = ro.shutter_time
+				}
+				cover = t * half / ro.shutter_time
+			} else {
+				// Opening phase
+				t := ro.shutterTimer
+				if t < 0 {
+					t = 0
+				}
+				if t > ro.shutter_time {
+					t = ro.shutter_time
+				}
+				cover = t * half / ro.shutter_time
 			}
-			rect[3] = cover
-			ro.fadeIn.drawRect(rect, ro.shutter_col, 255)
-			rect[1] = sys.scrrect[3] - rect[3]
-			ro.fadeIn.drawRect(rect, ro.shutter_col, 255)
 		}
+		rect[3] = cover
+		ro.fadeIn.drawRect(rect, ro.shutter_col, 255)
+		rect[1] = sys.scrrect[3] - rect[3]
+		ro.fadeIn.drawRect(rect, ro.shutter_col, 255)
 	}
 }
 
@@ -5751,6 +5750,12 @@ func (fs *FightScreen) draw(layerno int16) {
 	if fs.active && !sys.postMatchFlg {
 		// Round
 		fs.round.draw(layerno, fs.fnt)
+	}
+}
+
+func (fs *FightScreen) drawFade() {
+	if fs.active && !sys.postMatchFlg {
+		fs.round.drawFade()
 	}
 }
 

--- a/src/iniutils.go
+++ b/src/iniutils.go
@@ -1940,7 +1940,7 @@ func getFieldFromHierarchy(primary, parent reflect.Value, name string) (reflect.
 }
 
 // SetAnim sets the Anim field generically for any struct that contains AnimTable and Sff fields.
-func SetAnim(obj interface{}, fVal, structVal, parent reflect.Value, sffOverride *Sff) {
+func SetAnim(obj interface{}, fVal, structVal, parent reflect.Value, sffOverride *Sff, warnMissing bool) {
 	anim := int32(-1)
 	spr := [2]int32{-1, 0}
 	offset := [2]float32{0, 0}
@@ -1969,6 +1969,15 @@ func SetAnim(obj interface{}, fVal, structVal, parent reflect.Value, sffOverride
 		anim = int32(fv.Int())
 	}
 	if fv, ok := get("Spr"); ok && fv.Kind() == reflect.Array && fv.Len() == 2 {
+		if warnMissing {
+			if _, sf, ok := findFieldByINITag(structVal, "spr"); ok &&
+				strings.EqualFold(strings.TrimSpace(sf.Tag.Get("warn")), "false") {
+				warnMissing = false
+			} else if _, sf, ok := findFieldByINITag(parent, "spr"); ok &&
+				strings.EqualFold(strings.TrimSpace(sf.Tag.Get("warn")), "false") {
+				warnMissing = false
+			}
+		}
 		spr[0] = int32(fv.Index(0).Int())
 		spr[1] = int32(fv.Index(1).Int())
 		hasSpr = true
@@ -2085,9 +2094,14 @@ func SetAnim(obj interface{}, fVal, structVal, parent reflect.Value, sffOverride
 	if animData, exists := animMap.anims[anim]; exists {
 		a = NewAnim(nil, "")
 		a.anim = animData
+		if !warnMissing {
+			a.anim = animData.ShallowCopy()
+			a.anim.warnMissing = false
+		}
 	} else if hasSpr {
 		a = NewAnim(sffPtr, fmt.Sprintf("%d,%d, 0,0, -1", spr[0], spr[1]))
 		//a.anim.SetAnimElem(1, 0)
+		a.anim.warnMissing = warnMissing
 		a.anim.UpdateSprite()
 	} else {
 		a = NewAnim(nil, "")
@@ -2598,7 +2612,7 @@ func PopulateDataPointers(obj interface{}, rootLocalcoord [2]int32) {
 	}
 
 	// Thread both localcoord and effective SFF through recursion.
-	var populate func(v reflect.Value, parent reflect.Value, currentLocalCoord [2]int32, currentSff *Sff, skipInit bool)
+	var populate func(v reflect.Value, parent reflect.Value, currentLocalCoord [2]int32, currentSff *Sff, skipInit bool, warnMissing bool)
 
 	// Types we look for
 	animPtrType := reflect.TypeOf((*Anim)(nil))
@@ -2608,7 +2622,7 @@ func PopulateDataPointers(obj interface{}, rootLocalcoord [2]int32) {
 	fadePtrType := reflect.TypeOf((*Fade)(nil))
 
 	// The recursive function
-	populate = func(v reflect.Value, parent reflect.Value, currentLocalCoord [2]int32, currentSff *Sff, skipInit bool) {
+	populate = func(v reflect.Value, parent reflect.Value, currentLocalCoord [2]int32, currentSff *Sff, skipInit bool, warnMissing bool) {
 		if !v.IsValid() {
 			return
 		}
@@ -2616,7 +2630,7 @@ func PopulateDataPointers(obj interface{}, rootLocalcoord [2]int32) {
 			if v.IsNil() {
 				return
 			}
-			populate(v.Elem(), parent, currentLocalCoord, currentSff, skipInit)
+			populate(v.Elem(), parent, currentLocalCoord, currentSff, skipInit, warnMissing)
 			return
 		}
 
@@ -2663,18 +2677,22 @@ func PopulateDataPointers(obj interface{}, rootLocalcoord [2]int32) {
 				if fType.Tag.Get("skipinit") == "true" {
 					childSkipInit = true
 				}
+				childWarnMissing := warnMissing
+				if strings.EqualFold(strings.TrimSpace(fType.Tag.Get("warn")), "false") {
+					childWarnMissing = false
+				}
 
 				kind := fVal.Kind()
 
 				// Recurse for struct or non-nil ptr
 				if kind == reflect.Struct || (kind == reflect.Ptr && !fVal.IsNil()) {
-					populate(fVal, v, localCoordForThisStruct, nextSff, childSkipInit)
+					populate(fVal, v, localCoordForThisStruct, nextSff, childSkipInit, childWarnMissing)
 					continue
 				}
 				// If it's a map, recurse as well
 				if kind == reflect.Map {
 					// Pass along the possibly overridden SFF from this field's tag.
-					populate(fVal, parent, localCoordForThisStruct, nextSff, childSkipInit)
+					populate(fVal, parent, localCoordForThisStruct, nextSff, childSkipInit, childWarnMissing)
 					continue
 				}
 				// If it's *Anim
@@ -2686,7 +2704,7 @@ func PopulateDataPointers(obj interface{}, rootLocalcoord [2]int32) {
 							dummyAnim := NewAnim(nil, "")
 							fVal.Set(reflect.ValueOf(dummyAnim))
 						} else {
-							SetAnim(obj, fVal, v, parent, effectiveSffForThisStruct)
+							SetAnim(obj, fVal, v, parent, effectiveSffForThisStruct, childWarnMissing)
 						}
 					}
 					continue
@@ -2725,12 +2743,12 @@ func PopulateDataPointers(obj interface{}, rootLocalcoord [2]int32) {
 		// If we have a slice or array, recurse into each element
 		case reflect.Slice, reflect.Array:
 			for i := 0; i < v.Len(); i++ {
-				populate(v.Index(i), parent, currentLocalCoord, currentSff, skipInit)
+				populate(v.Index(i), parent, currentLocalCoord, currentSff, skipInit, warnMissing)
 			}
 		case reflect.Map:
 			for _, key := range v.MapKeys() {
 				val := v.MapIndex(key)
-				populate(val, parent, currentLocalCoord, currentSff, skipInit)
+				populate(val, parent, currentLocalCoord, currentSff, skipInit, warnMissing)
 			}
 		default:
 			// basic types: do nothing
@@ -2743,7 +2761,7 @@ func PopulateDataPointers(obj interface{}, rootLocalcoord [2]int32) {
 		return
 	}
 	// Start recursion with the original user-supplied localcoord
-	populate(v.Elem(), v.Elem(), rootLocalcoord, rootSff, false)
+	populate(v.Elem(), v.Elem(), rootLocalcoord, rootSff, false, true)
 }
 
 // Split a [Music] key into (prefix, property) while allowing dots in prefix.

--- a/src/motif.go
+++ b/src/motif.go
@@ -4706,11 +4706,12 @@ func (di *MotifDialogue) step(m *Motif) {
 
 	// Check if we haven't reached StartTime yet
 	if di.counter < m.DialogueInfo.StartTime {
-		// Before dialogue starts, keep both portraits in a neutral pose.
 		di.resetPortraitIdle(m.DialogueInfo.P1.Face.AnimData)
 		di.resetPortraitIdle(m.DialogueInfo.P2.Face.AnimData)
 		di.counter++
-		return
+		if di.counter < m.DialogueInfo.StartTime {
+			return
+		}
 	}
 
 	// Check if we've gone past all lines

--- a/src/motif.go
+++ b/src/motif.go
@@ -416,7 +416,7 @@ type FaceProperties struct {
 		Key                            []string `ini:"key"` // only used by [VS Screen]
 	} `ini:"done"`
 	Random   AnimationProperties `ini:"random"`  // only used by [Select Info]
-	Loading  AnimationProperties `ini:"loading"` // only used by [Select Info] and [VS Screen]
+	Loading  AnimationProperties `ini:"loading" warn:"false"` // only used by [Select Info] and [VS Screen]
 	Velocity [2]float32          `ini:"velocity"`
 	MaxDist  [2]float32          `ini:"maxdist"`
 	Accel    [2]float32          `ini:"accel"`
@@ -736,7 +736,7 @@ type SelectInfoProperties struct {
 			AnimationStagePreloadProperties `skipinit:"true"`
 			Bg                              AnimationProperties `ini:"bg"`
 			Random                          AnimationProperties `ini:"random"`
-			Loading                         AnimationProperties `ini:"loading"`
+			Loading                         AnimationProperties `ini:"loading" warn:"false"`
 		} `ini:"portrait"`
 	} `ini:"stage"`
 	Done struct {
@@ -748,7 +748,7 @@ type SelectInfoProperties struct {
 	} `ini:"cancel"`
 	Portrait struct {
 		AnimationCharPreloadProperties `skipinit:"true"`
-		Loading                        AnimationProperties `ini:"loading"`
+		Loading                        AnimationProperties `ini:"loading" warn:"false"`
 	} `ini:"portrait"`
 	Title    TextMapProperties `ini:"title"`
 	Record   TextMapProperties `ini:"record"`
@@ -795,7 +795,7 @@ type VsScreenProperties struct {
 		Portrait struct {
 			AnimationStagePreloadProperties `skipinit:"true"`
 			Bg                              AnimationProperties `ini:"bg"`
-			Loading                         AnimationProperties `ini:"loading"`
+			Loading                         AnimationProperties `ini:"loading" warn:"false"`
 		} `ini:"portrait"`
 		Snd [2]int32 `ini:"snd" default:"-1,0"`
 	} `ini:"stage"`
@@ -2212,9 +2212,13 @@ func (m *Motif) overrideParams() {
 		{SrcSec: "Option Info", SrcPrefix: "menu.", DstSec: "Option Info", DstPrefix: "keymenu."},
 		// [Select Info]
 		{SrcSec: "Select Info", SrcPrefix: "p1.face.", DstSec: "Select Info", DstPrefix: "p1.face.done."},
+		{SrcSec: "Select Info", SrcPrefix: "p1.face.", DstSec: "Select Info", DstPrefix: "p1.face.loading."},
 		{SrcSec: "Select Info", SrcPrefix: "p1.face2.", DstSec: "Select Info", DstPrefix: "p1.face2.done."},
+		{SrcSec: "Select Info", SrcPrefix: "p1.face2.", DstSec: "Select Info", DstPrefix: "p1.face2.loading."},
 		{SrcSec: "Select Info", SrcPrefix: "p2.face.", DstSec: "Select Info", DstPrefix: "p2.face.done."},
+		{SrcSec: "Select Info", SrcPrefix: "p2.face.", DstSec: "Select Info", DstPrefix: "p2.face.loading."},
 		{SrcSec: "Select Info", SrcPrefix: "p2.face2.", DstSec: "Select Info", DstPrefix: "p2.face2.done."},
+		{SrcSec: "Select Info", SrcPrefix: "p2.face2.", DstSec: "Select Info", DstPrefix: "p2.face2.loading."},
 		{SrcSec: "Select Info", SrcPrefix: "p1.face.", DstSec: "Select Info", DstPrefix: "p1.palmenu.preview."},
 		{SrcSec: "Select Info", SrcPrefix: "p2.face.", DstSec: "Select Info", DstPrefix: "p2.palmenu.preview."},
 		{SrcSec: "Select Info", SrcPrefix: "p1.teammenu.item.", DstSec: "Select Info", DstPrefix: "p1.teammenu.item.active."},
@@ -2227,21 +2231,28 @@ func (m *Motif) overrideParams() {
 		{SrcSec: "Select Info", SrcPrefix: "p2.", DstSec: "Select Info", DstPrefix: "p4."},
 		{SrcSec: "Select Info", SrcPrefix: "p2.", DstSec: "Select Info", DstPrefix: "p6."},
 		{SrcSec: "Select Info", SrcPrefix: "p2.", DstSec: "Select Info", DstPrefix: "p8."},
+		{SrcSec: "Select Info", SrcPrefix: "portrait.", DstSec: "Select Info", DstPrefix: "portrait.loading."},
 		{SrcSec: "Select Info", SrcPrefix: "stage.", DstSec: "Select Info", DstPrefix: "stage.active."},
 		{SrcSec: "Select Info", SrcPrefix: "stage.", DstSec: "Select Info", DstPrefix: "stage.active2."},
 		{SrcSec: "Select Info", SrcPrefix: "stage.", DstSec: "Select Info", DstPrefix: "stage.done."},
+		{SrcSec: "Select Info", SrcPrefix: "stage.portrait.", DstSec: "Select Info", DstPrefix: "stage.portrait.loading."},
 		// [VS Screen]
 		{SrcSec: "Title Info", SrcPrefix: "loading.", DstSec: "VS Screen", DstPrefix: "loading.wait."},
 		{SrcSec: "VS Screen", SrcPrefix: "p1.", DstSec: "VS Screen", DstPrefix: "p1.done."},
+		{SrcSec: "VS Screen", SrcPrefix: "p1.", DstSec: "VS Screen", DstPrefix: "p1.loading."},
 		{SrcSec: "VS Screen", SrcPrefix: "p1.face2.", DstSec: "VS Screen", DstPrefix: "p1.face2.done."},
+		{SrcSec: "VS Screen", SrcPrefix: "p1.face2.", DstSec: "VS Screen", DstPrefix: "p1.face2.loading."},
 		{SrcSec: "VS Screen", SrcPrefix: "p2.", DstSec: "VS Screen", DstPrefix: "p2.done."},
+		{SrcSec: "VS Screen", SrcPrefix: "p2.", DstSec: "VS Screen", DstPrefix: "p2.loading."},
 		{SrcSec: "VS Screen", SrcPrefix: "p2.face2.", DstSec: "VS Screen", DstPrefix: "p2.face2.done."},
+		{SrcSec: "VS Screen", SrcPrefix: "p2.face2.", DstSec: "VS Screen", DstPrefix: "p2.face2.loading."},
 		{SrcSec: "VS Screen", SrcPrefix: "p1.", DstSec: "VS Screen", DstPrefix: "p3."},
 		{SrcSec: "VS Screen", SrcPrefix: "p1.", DstSec: "VS Screen", DstPrefix: "p5."},
 		{SrcSec: "VS Screen", SrcPrefix: "p1.", DstSec: "VS Screen", DstPrefix: "p7."},
 		{SrcSec: "VS Screen", SrcPrefix: "p2.", DstSec: "VS Screen", DstPrefix: "p4."},
 		{SrcSec: "VS Screen", SrcPrefix: "p2.", DstSec: "VS Screen", DstPrefix: "p6."},
 		{SrcSec: "VS Screen", SrcPrefix: "p2.", DstSec: "VS Screen", DstPrefix: "p8."},
+		{SrcSec: "VS Screen", SrcPrefix: "stage.portrait.", DstSec: "VS Screen", DstPrefix: "stage.portrait.loading."},
 		// [Victory Screen]
 		{SrcSec: "Victory Screen", SrcPrefix: "p1.", DstSec: "Victory Screen", DstPrefix: "p3."},
 		{SrcSec: "Victory Screen", SrcPrefix: "p1.", DstSec: "Victory Screen", DstPrefix: "p5."},

--- a/src/system.go
+++ b/src/system.go
@@ -3556,6 +3556,9 @@ func (s *System) draw(x, y, scl float32) {
 	// Draw motif layer 2
 	s.motif.draw(2)
 
+	// Draw system fade/shutter over top-layer texts
+	s.fightScreen.drawFade()
+
 	// Draw motif layer 3
 	s.motif.draw(3)
 }


### PR DESCRIPTION
Implements: https://discord.com/channels/233345562261323776/233363722934943744/1515401506956771501
Fixes: https://discord.com/channels/233345562261323776/233363722934943744/1515863184656044093
Fixes #3706