### PR TITLE
feat: SubAdd transparency, animation debugging, lifebar action refreshing; refactor; fixes

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -843,8 +843,8 @@ function main.f_preloadTick(limit)
 				if state == 'ready' then
 					--print("Char preload ready ref=" .. tostring(ch.char_ref) .. " row=" .. tostring(row))
 					main.f_syncCharPaletteData(ch.char_ref)
-				elseif state == 'error' then
-					print("Char preload error ref=" .. tostring(ch.char_ref) .. " row=" .. tostring(row) .. ": " .. tostring(err))
+				-- elseif state == 'error' then
+					-- print("Char preload error ref=" .. tostring(ch.char_ref) .. " row=" .. tostring(row) .. ": " .. tostring(err))
 				end
 			end
 			if state == 'ready' then
@@ -864,8 +864,8 @@ function main.f_preloadTick(limit)
 				main.preload.stageState[stageNo] = state
 				if state == 'ready' then
 					--print("Stage preload ready stage=" .. tostring(stageNo))
-				elseif state == 'error' then
-					print("Stage preload error stage=" .. tostring(stageNo) .. ": " .. tostring(err))
+				-- elseif state == 'error' then
+					-- print("Stage preload error stage=" .. tostring(stageNo) .. ": " .. tostring(err))
 				end
 			end
 			if state == 'ready' then

--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -942,6 +942,8 @@ end
 function main.f_commandLine()
 	setGameMode('quickvs')
 	setCredits(-1)
+    -- No need for asynchronous loading when running from command line. Fixes race conditions with Turns teammate faces
+    modifyGameOption('Config.BootLoadingMode', 0)
 	local ref = #main.t_selChars
 	local t_teamMode = {0, 0}
 	local t_numChars = {0, 0}

--- a/external/script/options.lua
+++ b/external/script/options.lua
@@ -1374,7 +1374,7 @@ options.t_itemname = {
 	--Save and Return
 	['savereturn'] = function(t, item, cursorPosY, moveTxt)
 		if getInput(-1, motif.option_info.menu.done.key) then
-			sndPlay(motif.Snd, motif.option_info.cancel.snd[1], motif.option_info.cancel.snd[2])
+			sndPlay(motif.Snd, motif.option_info.cursor.done.snd[1], motif.option_info.cursor.done.snd[2])
 			if options.modified then
 				options.f_saveCfg(options.needReload)
 			end

--- a/src/anim.go
+++ b/src/anim.go
@@ -79,13 +79,16 @@ func ReadAnimFrame(line string) *AnimFrame {
 		parseAlphaNumbers := func(a string, start int, defSrc, defDst byte) (src, dst byte) {
 			src, dst = defSrc, defDst
 			i, alp := start, 0
+			// Parse source alpha
 			for ; i < len(a) && a[i] >= '0' && a[i] <= '9'; i++ {
 				alp = alp*10 + int(a[i]-'0')
 			}
-			alp &= 0x3fff
-			if alp < 255 {
-				src = byte(alp)
+			alp &= 0x3fff // Kind of redundant with the next step, but harmless
+			if alp > 255 {
+				alp = 255
 			}
+			src = byte(alp)
+			// Parse destination alpha
 			if i < len(a) && a[i] == 'd' {
 				i++
 				if i < len(a) && a[i] >= '0' && a[i] <= '9' {
@@ -94,9 +97,10 @@ func ReadAnimFrame(line string) *AnimFrame {
 						alp = alp*10 + int(a[i]-'0')
 					}
 					alp &= 0x3fff
-					if alp < 255 {
-						dst = byte(alp)
+					if alp > 255 {
+						alp = 255
 					}
+					dst = byte(alp)
 				}
 			}
 			return
@@ -115,22 +119,24 @@ func ReadAnimFrame(line string) *AnimFrame {
 
 		case len(a) >= 3 && a[:3] == "sas": // SubAdd
 			af.TransType = TT_subadd
-			af.SrcAlpha, af.DstAlpha = parseAlphaNumbers(a, 3, 255, 255)
+			af.SrcAlpha, af.DstAlpha = parseAlphaNumbers(a, 3, 255, 0)
 
 		case len(a) >= 2 && a[:2] == "as": // Add with alpha
 			af.TransType = TT_add
-			af.SrcAlpha, af.DstAlpha = parseAlphaNumbers(a, 2, 255, 255)
+			af.SrcAlpha, af.DstAlpha = parseAlphaNumbers(a, 2, 255, 0)
 
 		case len(a) >= 2 && a[:2] == "ss": // Sub with alpha
 			af.TransType = TT_sub
-			af.SrcAlpha, af.DstAlpha = parseAlphaNumbers(a, 2, 255, 255)
+			af.SrcAlpha, af.DstAlpha = parseAlphaNumbers(a, 2, 255, 0)
 
+		// The first letter is enough in Mugen
+		// https://github.com/ikemen-engine/Ikemen-GO/issues/3717
 		case len(a) > 0 && a[0] == 'a': // Plain Add
 			af.TransType = TT_add
 			af.SrcAlpha = 255
 			af.DstAlpha = 255
 
-		case len(a) == 1 && a[0] == 's': // Plain sub
+		case len(a) > 0 && a[0] == 's': // Plain sub
 			af.TransType = TT_sub
 			af.SrcAlpha = 255
 			af.DstAlpha = 255

--- a/src/anim.go
+++ b/src/anim.go
@@ -113,18 +113,22 @@ func ReadAnimFrame(line string) *AnimFrame {
 			af.SrcAlpha = 255
 			af.DstAlpha = 128
 
+		case len(a) >= 3 && a[:3] == "sas": // SubAdd
+			af.TransType = TT_subadd
+			af.SrcAlpha, af.DstAlpha = parseAlphaNumbers(a, 3, 255, 255)
+
 		case len(a) >= 2 && a[:2] == "as": // Add with alpha
 			af.TransType = TT_add
+			af.SrcAlpha, af.DstAlpha = parseAlphaNumbers(a, 2, 255, 255)
+
+		case len(a) >= 2 && a[:2] == "ss": // Sub with alpha
+			af.TransType = TT_sub
 			af.SrcAlpha, af.DstAlpha = parseAlphaNumbers(a, 2, 255, 255)
 
 		case len(a) > 0 && a[0] == 'a': // Plain Add
 			af.TransType = TT_add
 			af.SrcAlpha = 255
 			af.DstAlpha = 255
-
-		case len(a) >= 2 && a[:2] == "ss": // Sub with alpha
-			af.TransType = TT_sub
-			af.SrcAlpha, af.DstAlpha = parseAlphaNumbers(a, 2, 255, 255)
 
 		case len(a) == 1 && a[0] == 's': // Plain sub
 			af.TransType = TT_sub

--- a/src/anim.go
+++ b/src/anim.go
@@ -42,14 +42,24 @@ func newAnimFrame() *AnimFrame {
 	}
 }
 
-func ReadAnimFrame(line string) *AnimFrame {
+func ReadAnimFrame(line string) (*AnimFrame, error) {
+	// Valid lines must start with a number or '-'
 	if len(line) == 0 || (line[0] < '0' || '9' < line[0]) && line[0] != '-' {
-		return nil
+		return nil, nil
 	}
-	ary := strings.SplitN(line, ",", 10)
+
+	// Split by commas then trim spaces
+	raw := strings.SplitN(line, ",", 10)
+	ary := make([]string, len(raw))
+	for i, s := range raw {
+		ary[i] = strings.TrimSpace(s)
+	}
+
 	if len(ary) < 5 {
-		return nil
+		return nil, Error("Invalid animation element definition")
 	}
+
+	var err error
 
 	// Read required parameters
 	af := newAnimFrame()
@@ -60,21 +70,23 @@ func ReadAnimFrame(line string) *AnimFrame {
 	af.Time = Atoi(ary[4])
 
 	// Read H and V flags
-	if len(ary) >= 6 {
-		for i := range ary[5] {
-			switch ary[5][i] {
+	if len(ary) >= 6 && ary[5] != "" {
+		for _, ch := range ary[5] {
+			switch ch {
 			case 'H', 'h':
 				af.Hscale = -1
 				af.Xoffset *= -1
 			case 'V', 'v':
 				af.Vscale = -1
 				af.Yoffset *= -1
+			default:
+				err = Error(fmt.Sprintf("Invalid animation element flip flag: %c", ch))
 			}
 		}
 	}
 
 	// Read alpha
-	if len(ary) >= 7 {
+	if len(ary) >= 7 && ary[6] != "" {
 		// Helper to read source and destination
 		parseAlphaNumbers := func(a string, start int, defSrc, defDst byte) (src, dst byte) {
 			src, dst = defSrc, defDst
@@ -110,7 +122,7 @@ func ReadAnimFrame(line string) *AnimFrame {
 		if ia >= 0 {
 			ary[6] = ary[6][ia:]
 		}
-		a := strings.ToLower(SplitAndTrim(ary[6], ",")[0])
+		a := strings.ToLower(ary[6])
 		switch {
 		case a == "a1":
 			af.TransType = TT_add
@@ -129,44 +141,59 @@ func ReadAnimFrame(line string) *AnimFrame {
 			af.TransType = TT_sub
 			af.SrcAlpha, af.DstAlpha = parseAlphaNumbers(a, 2, 255, 0)
 
-		// The first letter is enough in Mugen
-		// https://github.com/ikemen-engine/Ikemen-GO/issues/3717
-		case len(a) > 0 && a[0] == 'a': // Plain Add
+		case len(a) >= 1 && a[0] == 'a': // Plain Add
 			af.TransType = TT_add
 			af.SrcAlpha = 255
 			af.DstAlpha = 255
+			// The first letter is enough in Mugen, but we will warn to encourage proper syntax
+			// https://github.com/ikemen-engine/Ikemen-GO/issues/3717
+			if len(a) > 1 {
+				err = Error(fmt.Sprintf("Invalid animation element transparency: %v", a))
+			}
 
-		case len(a) > 0 && a[0] == 's': // Plain sub
+		case len(a) >= 1 && a[0] == 's': // Plain sub
 			af.TransType = TT_sub
 			af.SrcAlpha = 255
 			af.DstAlpha = 255
+			if len(a) > 1 {
+				err = Error(fmt.Sprintf("Invalid animation element transparency: %v", a))
+			}
+
+		default:
+			err = Error(fmt.Sprintf("Invalid animation element transparency: %v", a))
 		}
 	}
 
 	// Read X scale
 	// In Mugen 1.1 a blank parameter means 0
 	// In Ikemen it means no change, like the other optional parameters
-	if len(ary) >= 8 {
+	if len(ary) >= 8 && ary[7] != "" {
 		if IsNumeric(ary[7]) {
 			af.Xscale = float32(Atof(ary[7]))
+		} else {
+			err = Error(fmt.Sprintf("Invalid animation element x-scale: %v", ary[7]))
 		}
 	}
 
 	// Read Y scale
-	if len(ary) >= 9 {
+	if len(ary) >= 9 && ary[8] != "" {
 		if IsNumeric(ary[8]) {
 			af.Yscale = float32(Atof(ary[8]))
+		} else {
+			err = Error(fmt.Sprintf("Invalid animation element y-scale: %v", ary[8]))
 		}
 	}
 
 	// Read angle
-	if len(ary) >= 10 {
+	if len(ary) >= 10 && ary[9] != "" {
 		if IsNumeric(ary[9]) {
 			af.Angle = float32(Atof(ary[9]))
+		} else {
+			err = Error(fmt.Sprintf("Invalid animation element angle: %v", ary[9]))
 		}
 	}
 
-	return af
+	return af, err
 }
 
 type Animation struct {
@@ -231,13 +258,15 @@ func newAnimation(sff *Sff, pal *PaletteList) *Animation {
 	}
 }
 
-func ReadAnimation(sff *Sff, pal *PaletteList, lines []string, i *int) *Animation {
+func ReadAnimation(sff *Sff, pal *PaletteList, lines []string, i *int) (*Animation, error) {
 	a := newAnimation(sff, pal)
 
 	a.mask = 0
 	ols := int32(0)
+	var err error
 	var clsn1, clsn1d, clsn2, clsn2d [][4]float32
 	def1, def2 := true, true
+
 	for ; *i < len(lines); (*i)++ {
 		if len(lines[*i]) > 0 && lines[*i][0] == '[' {
 			break
@@ -255,10 +284,17 @@ func ReadAnimation(sff *Sff, pal *PaletteList, lines []string, i *int) *Animatio
 			} else {
 				a.copyAction = int32(id)
 			}
-			return a
+			return a, nil
 		}
 
-		af := ReadAnimFrame(line)
+		var af *AnimFrame
+		af, lerr := ReadAnimFrame(line)
+
+		// Use a local error to prevent overwriting the outer one with nil
+		if lerr != nil {
+			err = lerr
+		}
+
 		switch {
 		case af != nil:
 			ols = a.loopstart
@@ -284,16 +320,18 @@ func ReadAnimation(sff *Sff, pal *PaletteList, lines []string, i *int) *Animatio
 		case len(line) >= 17 && line[:17] == "interpolate blend":
 			a.interpolate_blend = append(a.interpolate_blend, int32(len(a.frames)))
 		case len(line) >= 5 && line[:4] == "clsn":
+			// Read Clsn boxes
 			ii := strings.Index(line, ":")
 			if ii < 0 {
 				break
 			}
-			size := Atoi(line[ii+1:])
+			size := Atoi(line[ii+1:]) // Number of expected boxes
 			if size < 0 {
 				break
 			}
 			var clsn [][4]float32
 			if line[4] == '1' {
+				// Clsn1
 				clsn1 = make([][4]float32, size)
 				clsn = clsn1
 				if len(line) >= 12 && line[5:12] == "default" {
@@ -301,6 +339,7 @@ func ReadAnimation(sff *Sff, pal *PaletteList, lines []string, i *int) *Animatio
 				}
 				def1 = false
 			} else if line[4] == '2' {
+				// Clsn2
 				clsn2 = make([][4]float32, size)
 				clsn = clsn2
 				if len(line) >= 12 && line[5:12] == "default" {
@@ -313,17 +352,22 @@ func ReadAnimation(sff *Sff, pal *PaletteList, lines []string, i *int) *Animatio
 			if size == 0 {
 				break
 			}
+			// Move past the "Clsn:" line to the first rectangle line
 			(*i)++
+			// Read exactly 'size' number rectangle lines
+			// TODO: Mugen seems less strict about this
 			for n := int32(0); n < size && *i < len(lines); {
 				line := strings.ToLower(strings.TrimSpace(
 					strings.SplitN(lines[*i], ";", 2)[0]))
 				if len(line) == 0 {
 					(*i)++
-					continue
+					continue // Skip blank lines
 				}
+				// Stop if we encounter a line that doesn't start with "clsn"
 				if len(line) < 4 || line[:4] != "clsn" {
 					break
 				}
+				// Extract the coordinates after "="
 				ii := strings.Index(line, "=")
 				if ii < 0 {
 					break
@@ -333,6 +377,7 @@ func ReadAnimation(sff *Sff, pal *PaletteList, lines []string, i *int) *Animatio
 					break
 				}
 				l, t, r, b := Atoi(ary[0]), Atoi(ary[1]), Atoi(ary[2]), Atoi(ary[3])
+				// Normalize rectangle
 				if l > r {
 					l, r = r, l
 				}
@@ -344,9 +389,11 @@ func ReadAnimation(sff *Sff, pal *PaletteList, lines []string, i *int) *Animatio
 				n++
 				(*i)++
 			}
+			// Back up one step to avoid skipping the line after the last rectangle
 			(*i)--
 		}
 	}
+
 	if int(a.loopstart) >= len(a.frames) {
 		a.loopstart = ols
 	}
@@ -373,10 +420,10 @@ func ReadAnimation(sff *Sff, pal *PaletteList, lines []string, i *int) *Animatio
 			a.prelooptime = 0
 		}
 	}
-	return a
+	return a, err
 }
 
-func ReadAction(sff *Sff, pal *PaletteList, lines []string, i *int) (no int32, a *Animation) {
+func ReadAction(sff *Sff, pal *PaletteList, lines []string, i *int) (no int32, a *Animation, err error) {
 	var name, subname string
 	for ; *i < len(lines); (*i)++ {
 		name, subname = SectionName(lines[*i])
@@ -395,7 +442,11 @@ func ReadAction(sff *Sff, pal *PaletteList, lines []string, i *int) (no int32, a
 		return
 	}
 	(*i)++
-	return Atoi(subname[spi+1:]), ReadAnimation(sff, pal, lines, i)
+
+	no = Atoi(subname[spi+1:])
+	a, err = ReadAnimation(sff, pal, lines, i)
+
+	return
 }
 
 func (a *Animation) Reset() {
@@ -1094,7 +1145,11 @@ func NewAnimationTable() AnimationTable {
 
 func (at AnimationTable) readAction(sff *Sff, pal *PaletteList, lines []string, i *int, log bool) *Animation {
 	for *i < len(lines) {
-		no, a := ReadAction(sff, pal, lines, i)
+		no, a, err := ReadAction(sff, pal, lines, i)
+		// Animation errors do not crash Mugen. But we can log them
+		if log && err != nil {
+			LogMessage("WARNING: Action %v in %v: %v", no, at.filename, err.Error())
+		}
 		if a != nil {
 			// In case of duplicate action numbers, just use the first one
 			// Even if first one is "Copy Action"
@@ -1108,7 +1163,12 @@ func (at AnimationTable) readAction(sff *Sff, pal *PaletteList, lines []string, 
 			at.anims[no] = a
 			// Recursive logic until we find a non-empty animation
 			// If the current action is empty, we attempt to copy the very next action found in the file
+			logged := false
 			for len(a.frames) == 0 && *i < len(lines) && a.copyAction < 0 {
+				if !logged && log {
+					LogMessage("WARNING: Action %v in %v has no valid frames", no, at.filename)
+					logged = true
+				}
 				if a2 := at.readAction(sff, pal, lines, i, log); a2 != nil {
 					*a = *a2
 					break
@@ -1124,13 +1184,18 @@ func (at AnimationTable) readAction(sff *Sff, pal *PaletteList, lines []string, 
 	return nil
 }
 
-func ReadAnimationTable(filename string, sff *Sff, pal *PaletteList,
-	lines []string, i *int, log bool) AnimationTable {
+func ReadAnimationTable(filename string, sff *Sff,
+	pal *PaletteList, lines []string, i *int, log bool) AnimationTable {
+
 	at := NewAnimationTable()
 	at.filename = filename
+
+	// Continue reading actions until none are left
 	for at.readAction(sff, pal, lines, i, log) != nil {
 	}
+
 	at.resolveCopyAction()
+
 	return at
 }
 
@@ -1958,7 +2023,7 @@ func NewAnim(sff *Sff, action string) *Anim {
 	}
 	if action != "" {
 		lines, i := SplitAndTrim(action, "\n"), 0
-		a.anim = ReadAnimation(sff, &sff.palList, lines, &i)
+		a.anim, _ = ReadAnimation(sff, &sff.palList, lines, &i)
 		if len(a.anim.frames) == 0 {
 			return nil
 		}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -11982,6 +11982,7 @@ const (
 	lifebarAction_fontbank
 	lifebarAction_fontalign
 	lifebarAction_fontcolor
+	lifebarAction_refreshtype
 	lifebarAction_redirectid
 )
 
@@ -11991,20 +11992,17 @@ func (sc lifebarAction) Run(c *Char, _ []int32) bool {
 		return false
 	}
 
-	var top bool
-	var timemul float32 = 1
-	var anim int32 = -1
-	s_ffx, a_ffx := "", ""
-	spr := [2]int32{-1, 0}
-	snd := [2]int32{-1, 0}
-
 	// Initialize a text message with defaults
 	msg := newFSMsg(crun.teamside)
+	timemul := float32(1.0)
+
+	// Default to no duplicates and making an identical message reappear
+	refresh := int32(2)
 
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
 		case lifebarAction_top:
-			top = exp[0].evalB(c)
+			msg.top = exp[0].evalB(c)
 		case lifebarAction_timemul:
 			timemul = exp[0].evalF(c)
 		case lifebarAction_time:
@@ -12023,20 +12021,26 @@ func (sc lifebarAction) Run(c *Char, _ []int32) bool {
 			}
 			msg.fontColorSet = true
 		case lifebarAction_anim:
-			a_ffx = exp[0].evalS()
-			anim = exp[1].evalI(c)
+			msg.anim_ffx = exp[0].evalS()
+			msg.animNo = exp[1].evalI(c)
+			msg.spr = [2]int32{-1, -1}
 		case lifebarAction_spr:
-			a_ffx = exp[0].evalS()
-			spr[0] = exp[1].evalI(c)
+			msg.spr[0] = exp[1].evalI(c)
 			if len(exp) > 2 {
-				spr[1] = exp[2].evalI(c)
+				msg.spr[1] = exp[2].evalI(c)
+			} else {
+				msg.spr[1] = 0
 			}
+			msg.animNo = -1
+			msg.anim_ffx = ""
 		case lifebarAction_snd:
-			s_ffx = exp[0].evalS()
-			snd[0] = exp[1].evalI(c)
+			msg.snd_ffx = exp[0].evalS()
+			msg.snd[0] = exp[1].evalI(c)
 			if len(exp) > 2 {
-				snd[1] = exp[2].evalI(c)
+				msg.snd[1] = exp[2].evalI(c)
 			}
+		case lifebarAction_refreshtype:
+			refresh = exp[0].evalI(c)
 		default:
 			if isPalFXParam(paramID) {
 				if msg.palfx == nil {
@@ -12055,7 +12059,7 @@ func (sc lifebarAction) Run(c *Char, _ []int32) bool {
 	}
 	msg.resttime = int32(float32(msg.resttime) * timemul)
 
-	sys.fightScreen.appendAction(crun, msg, s_ffx, a_ffx, snd, spr, anim, top)
+	sys.fightScreen.appendAction(crun, msg, refresh)
 	return false
 }
 

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5077,75 +5077,79 @@ func (sc playSnd) Run(c *Char, _ []int32) bool {
 		return false
 	}
 
-	x := &crun.pos[0]
-	ls := crun.localscl
-	f, lw, lp, stopgh, stopcs, vscaleflg := "", false, false, false, false, false
-	var g, n, ch, vo, pri, lc int32 = -1, 0, -1, 100, 0, 0
-	var loopstart, loopend, startposition = 0, 0, 0
-	var p, fr float32 = 0, 1
+	params := newPlaySndParams()
+	params.localScale = crun.localscl
+	params.xPos = &crun.pos[0]
+	params.log = true
+
+	var vscaleflg bool
+	var lp bool
+	var lc int32
 
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
 		case playSnd_value:
-			f = exp[0].evalS()
-			g = exp[1].evalI(c)
+			params.ffx = exp[0].evalS()
+			params.group = exp[1].evalI(c)
 			if len(exp) > 2 {
-				n = exp[2].evalI(c)
+				params.number = exp[2].evalI(c)
 			}
 		case playSnd_channel:
-			ch = exp[0].evalI(c)
-			if ch == 0 {
-				stopgh = true
+			params.channel = exp[0].evalI(c)
+			if params.channel == 0 {
+				params.stopOnGetHit = true
 			}
 		case playSnd_lowpriority:
-			lw = exp[0].evalB(c)
+			params.lowPriority = exp[0].evalB(c)
 		case playSnd_pan:
-			p = exp[0].evalF(c)
+			params.pan = exp[0].evalF(c)
 		case playSnd_abspan:
-			x = nil
-			ls = 1
-			p = exp[0].evalF(c)
+			params.xPos = nil
+			params.localScale = 1
+			params.pan = exp[0].evalF(c)
 		case playSnd_volume:
-			vo = vo + int32(float64(exp[0].evalI(c))*(25.0/128.0))
+			params.volume = params.volume + int32(float64(exp[0].evalI(c))*(25.0/128.0))
 		case playSnd_volumescale:
-			vo = exp[0].evalI(c)
+			params.volume = exp[0].evalI(c)
 			vscaleflg = true
 		case playSnd_freqmul:
-			fr = Clamp(exp[0].evalF(c), 0.01, 5)
+			params.freqMul = Clamp(exp[0].evalF(c), 0.01, 5)
 		case playSnd_loop:
 			lp = exp[0].evalB(c)
 		case playSnd_priority:
-			pri = exp[0].evalI(c)
+			params.priority = exp[0].evalI(c)
 		case playSnd_loopstart:
-			loopstart = int(exp[0].evalI64(c))
+			params.loopStart = int(exp[0].evalI64(c))
 		case playSnd_loopend:
-			loopend = int(exp[0].evalI64(c))
+			params.loopEnd = int(exp[0].evalI64(c))
 		case playSnd_startposition:
-			startposition = int(exp[0].evalI64(c))
+			params.startPosition = int(exp[0].evalI64(c))
 		case playSnd_loopcount:
 			lc = exp[0].evalI(c)
 		case playSnd_stopongethit:
-			stopgh = exp[0].evalB(c)
+			params.stopOnGetHit = exp[0].evalB(c)
 		case playSnd_stoponchangestate:
-			stopcs = exp[0].evalB(c)
+			params.stopOnChangeState = exp[0].evalB(c)
 		}
 		return true
 	})
-	// Read the loop parameter if loopcount not specified
+
+	// Determine loopCount
 	if lc == 0 {
 		if lp {
-			// WINMUGEN has a bug where the volume parameter is disabled when loop is specified
+			// WINMUGEN bug: volume is disabled when loop is specified (unless volumescale used)
 			if !vscaleflg && c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
-				vo = 100
+				params.volume = 100
 			}
-			crun.playSound(f, lw, -1, g, n, ch, vo, p, fr, ls, x, true, pri, loopstart, loopend, startposition, stopgh, stopcs)
+			params.loopCount = -1
 		} else {
-			crun.playSound(f, lw, 0, g, n, ch, vo, p, fr, ls, x, true, pri, loopstart, loopend, startposition, stopgh, stopcs)
+			params.loopCount = 0
 		}
-		// Use the loopcount directly if it's been specified
 	} else {
-		crun.playSound(f, lw, lc, g, n, ch, vo, p, fr, ls, x, true, pri, loopstart, loopend, startposition, stopgh, stopcs)
+		params.loopCount = lc
 	}
+
+	crun.playSound(params)
 	return false
 }
 
@@ -10308,14 +10312,13 @@ func (sc superPause) Run(c *Char, _ []int32) bool {
 		case superPause_unhittable:
 			uh = exp[0].evalB(c)
 		case superPause_sound:
-			n := int32(0)
+			params := newPlaySndParams()
+			params.ffx = exp[0].evalS()
+			params.group = exp[1].evalI(c)
 			if len(exp) > 2 {
-				n = exp[2].evalI(c)
+				params.number = exp[2].evalI(c)
 			}
-			vo := int32(100)
-			ffx := exp[0].evalS()
-			crun.playSound(ffx, false, 0, exp[1].evalI(c), n, -1,
-				vo, 0, 1, 1, nil, false, 0, 0, 0, 0, false, false)
+			crun.playSound(params)
 		}
 		return true
 	})

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6377,7 +6377,12 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 		case explod_window:
 			e.window = [4]float32{exp[0].evalF(c) * redirscale, exp[1].evalF(c) * redirscale, exp[2].evalF(c) * redirscale, exp[3].evalF(c) * redirscale}
 		case explod_shader:
-			e.shader = exp[0].evalS()
+			shader := exp[0].evalS()
+			if shader == "" || sys.isValidCustomShader(shader) {
+				e.shader = shader
+			} else {
+				sys.appendToConsole(crun.warn() + fmt.Sprintf("invalid explod shader name: %s", shader))
+			}
 		case explod_shaderparam:
 			numParams := int(exp[0].evalI(c))
 			for j := 0; j < numParams; j++ {
@@ -12652,7 +12657,12 @@ func (sc shaderSet) Run(c *Char, _ []int32) bool {
 		case shaderSet_time:
 			st = exp[0].evalI(c)
 		case shaderSet_shader:
-			crun.shader = exp[0].evalS()
+			shader := exp[0].evalS()
+			if shader == "" || sys.isValidCustomShader(shader) {
+				crun.shader = shader
+			} else {
+				sys.appendToConsole(crun.warn() + fmt.Sprintf("invalid shader name: %s", shader))
+			}
 		case shaderSet_shaderparam:
 			numParams := int(exp[0].evalI(c))
 			for j := 0; j < numParams; j++ {

--- a/src/char.go
+++ b/src/char.go
@@ -1900,6 +1900,33 @@ func (e *Explod) setAnimElem() {
 	}
 }
 
+func (e *Explod) canAct() bool {
+	// Challenger screen also pauses the explod
+	// https://github.com/ikemen-engine/Ikemen-GO/issues/3684
+	if sys.motif.ch.active && sys.pausetime > 0 {
+		return false
+	}
+
+	// Determine pause state
+	paused := false
+	if sys.supertime > 0 {
+		paused = (e.supermovetime >= 0 && e.time >= e.supermovetime) || e.supermovetime < -2
+	} else if sys.pausetime > 0 {
+		paused = (e.pausemovetime >= 0 && e.time >= e.pausemovetime) || e.pausemovetime < -2
+	}
+
+	act := !paused
+
+	// Apply ignorehitpause
+	if act && !e.ignorehitpause {
+		if parent := sys.playerID(e.ownerId); parent != nil {
+			act = parent.acttmp%2 >= 0
+		}
+	}
+
+	return act
+}
+
 func (e *Explod) update() {
 	if e.id == IErr || e.anim == nil {
 		e.id = IErr
@@ -1911,10 +1938,6 @@ func (e *Explod) update() {
 	root := sys.chars[e.playerno][0]
 
 	if root.scf(SCF_disabled) {
-		return
-	}
-
-	if e.hidewithbars && sys.shouldHideWithBars() {
 		return
 	}
 
@@ -1931,20 +1954,7 @@ func (e *Explod) update() {
 		return
 	}
 
-	paused := sys.motif.ch.active && sys.pausetime > 0
-	if !paused {
-		if sys.supertime > 0 {
-			paused = (e.supermovetime >= 0 && e.time >= e.supermovetime) || e.supermovetime < -2
-		} else if sys.pausetime > 0 {
-			paused = (e.pausemovetime >= 0 && e.time >= e.pausemovetime) || e.pausemovetime < -2
-		}
-	}
-
-	act := !paused
-
-	if act && !e.ignorehitpause {
-		act = parent == nil || parent.acttmp%2 >= 0
-	}
+	act := e.canAct()
 
 	if sys.tickFrame() {
 		if e.removetime >= 0 && e.time >= e.removetime ||
@@ -1978,6 +1988,8 @@ func (e *Explod) update() {
 			e.pos[i] = e.newPos[i] - (e.newPos[i]-e.oldPos[i])*(1-spd)
 		}
 	}
+
+	// Sync parameters
 	if e.syncId > 0 {
 		if syncChar := sys.playerID(e.syncId); syncChar != nil {
 			syncChar.enableSyncId = true // Enable sync layering for this char
@@ -2035,14 +2047,82 @@ func (e *Explod) update() {
 		}
 	}
 
-	facing := e.trueFacing()
-	//if e.lockSpriteFacing {
-	//	facing = -1
-	//}
-
 	if sys.tickFrame() && act {
 		e.anim.UpdateSprite()
 	}
+
+	// Interpolated position
+	// With z-axis it's important that we don't use localscl here yet
+	e.interPos = [3]float32{
+		e.pos[0] + e.offset[0] + off[0] + e.interpolate_pos[0],
+		e.pos[1] + e.offset[1] + off[1] + e.interpolate_pos[1],
+		e.pos[2] + e.offset[2] + off[2] + e.interpolate_pos[2],
+	}
+
+	if sys.tickNextFrame() {
+
+		//if e.space == Space_screen && e.bindtime == 0 {
+		//	if e.space <= Space_none {
+		//		switch e.postype {
+		//		case PT_Left:
+		//			for i := range e.pos {
+		//				e.pos[i] = sys.cam.ScreenPos[i] + e.offset[i]/sys.cam.Scale
+		//			}
+		//		case PT_Right:
+		//			e.pos[0] = sys.cam.ScreenPos[0] +
+		//				(float32(sys.gameWidth)+e.offset[0])/sys.cam.Scale
+		//			e.pos[1] = sys.cam.ScreenPos[1] + e.offset[1]/sys.cam.Scale
+		//		}
+		//	} else if e.space == Space_screen {
+		//		for i := range e.pos {
+		//			e.pos[i] = sys.cam.ScreenPos[i] + e.offset[i]/sys.cam.Scale
+		//		}
+		//	}
+		//}
+
+		if act {
+			if e.palfx != nil && e.ownpal {
+				e.palfx.step()
+			}
+			e.oldPos = e.pos
+			e.newPos[0] = e.pos[0] + e.velocity[0]*e.facing
+			e.newPos[1] = e.pos[1] + e.velocity[1]
+			e.newPos[2] = e.pos[2] + e.velocity[2]
+			for i := range e.velocity {
+				e.velocity[i] *= e.friction[i]
+				e.velocity[i] += e.accel[i]
+				if math.Abs(float64(e.velocity[i])) < 0.1 && math.Abs(float64(e.friction[i])) < 1 {
+					e.velocity[i] = 0
+				}
+			}
+			eleminterpolate := e.interpolate && e.interpolate_time[1] > 0 && e.interpolate_animelem[1] >= 0
+			if e.animfreeze || eleminterpolate {
+				e.setAnimElem()
+			} else {
+				e.anim.Action()
+			}
+			e.time++
+			if e.bindtime > 0 {
+				e.bindtime--
+			}
+		} else {
+			e.setAllPosX(e.pos[0])
+			e.setAllPosY(e.pos[1])
+			e.setAllPosZ(e.pos[2])
+		}
+	}
+}
+
+func (e *Explod) cueDraw() {
+	if e.hidewithbars && sys.shouldHideWithBars() {
+		return
+	}
+	if e.anim == nil {
+		return
+	}
+
+	parent := sys.playerID(e.ownerId)
+	act := e.canAct()
 
 	var pfx *PalFX
 	if e.palfx != nil && (!e.anim.isCommonFX() || e.ownpal) {
@@ -2058,36 +2138,33 @@ func (e *Explod) update() {
 	fLength := e.fLength
 	scale := e.scale
 	xshear := e.xshear
+
 	if e.interpolate {
 		e.Interpolate(act, &scale, &alp, &anglerot, &fLength, &xshear)
 	}
+
 	if alp[0] < 0 {
 		alp[0] = -1
 	}
+
+	facing := e.trueFacing()
+	//if e.lockSpriteFacing {
+	//	facing = -1
+	//}
 	if (facing < 0) != (e.vfacing < 0) {
 		anglerot[0] *= -1
 		anglerot[2] *= -1
 	}
-	sdwalp := 255 - alp[1]
-	if sdwalp < 0 {
-		sdwalp = 256
-	}
+
 	if fLength <= 0 {
 		fLength = 2048
 	}
 	fLength = fLength * e.localscl
+
 	rot := e.rot
 	rot.angle = anglerot[0]
 	rot.xangle = anglerot[1]
 	rot.yangle = anglerot[2]
-
-	// Interpolated position
-	// With z-axis it's important that we don't use localscl here yet
-	e.interPos = [3]float32{
-		e.pos[0] + e.offset[0] + off[0] + e.interpolate_pos[0],
-		e.pos[1] + e.offset[1] + off[1] + e.interpolate_pos[1],
-		e.pos[2] + e.offset[2] + off[2] + e.interpolate_pos[2],
-	}
 
 	// Set drawing position
 	drawpos := [2]float32{e.interPos[0] * e.localscl, e.interPos[1] * e.localscl}
@@ -2116,7 +2193,7 @@ func (e *Explod) update() {
 	}
 
 	// Calculate window scale
-	var ewin = [4]float32{
+	ewin := [4]float32{
 		e.window[0] * basescale[0],
 		e.window[1] * basescale[1],
 		e.window[2] * basescale[0],
@@ -2185,6 +2262,8 @@ func (e *Explod) update() {
 		// Add shadow to list
 		sys.shadowList.add(ss)
 	}
+
+	// Add reflection
 	if (e.reflection < 0 && sdwclr != 0) || e.reflection > 0 {
 		drawZoff := sys.posZtoYoffset(e.interPos[2], e.localscl)
 
@@ -2196,59 +2275,6 @@ func (e *Explod) update() {
 
 		// Add reflection to list
 		sys.reflectionList.add(rs)
-	}
-
-	if sys.tickNextFrame() {
-
-		//if e.space == Space_screen && e.bindtime == 0 {
-		//	if e.space <= Space_none {
-		//		switch e.postype {
-		//		case PT_Left:
-		//			for i := range e.pos {
-		//				e.pos[i] = sys.cam.ScreenPos[i] + e.offset[i]/sys.cam.Scale
-		//			}
-		//		case PT_Right:
-		//			e.pos[0] = sys.cam.ScreenPos[0] +
-		//				(float32(sys.gameWidth)+e.offset[0])/sys.cam.Scale
-		//			e.pos[1] = sys.cam.ScreenPos[1] + e.offset[1]/sys.cam.Scale
-		//		}
-		//	} else if e.space == Space_screen {
-		//		for i := range e.pos {
-		//			e.pos[i] = sys.cam.ScreenPos[i] + e.offset[i]/sys.cam.Scale
-		//		}
-		//	}
-		//}
-
-		if act {
-			if e.palfx != nil && e.ownpal {
-				e.palfx.step()
-			}
-			e.oldPos = e.pos
-			e.newPos[0] = e.pos[0] + e.velocity[0]*e.facing
-			e.newPos[1] = e.pos[1] + e.velocity[1]
-			e.newPos[2] = e.pos[2] + e.velocity[2]
-			for i := range e.velocity {
-				e.velocity[i] *= e.friction[i]
-				e.velocity[i] += e.accel[i]
-				if math.Abs(float64(e.velocity[i])) < 0.1 && math.Abs(float64(e.friction[i])) < 1 {
-					e.velocity[i] = 0
-				}
-			}
-			eleminterpolate := e.interpolate && e.interpolate_time[1] > 0 && e.interpolate_animelem[1] >= 0
-			if e.animfreeze || eleminterpolate {
-				e.setAnimElem()
-			} else {
-				e.anim.Action()
-			}
-			e.time++
-			if e.bindtime > 0 {
-				e.bindtime--
-			}
-		} else {
-			e.setAllPosX(e.pos[0])
-			e.setAllPosY(e.pos[1])
-			e.setAllPosZ(e.pos[2])
-		}
 	}
 }
 

--- a/src/char.go
+++ b/src/char.go
@@ -749,7 +749,7 @@ func (hd *HitDef) reset(c *Char, proj *Projectile) {
 		zaccel: 0,
 
 		p1sprpriority:       IErr, // 1 in Mugen
-		p2sprpriority:       IErr, // 0 in Mugen
+		p2sprpriority:       0,
 		p1stateno:           -1,
 		p2stateno:           -1,
 		missonoverride:      -1,
@@ -1004,11 +1004,10 @@ func (hd *HitDef) finalizeParams(c *Char, proj *Projectile) {
 		c.juggle = hd.air_juggle
 	}
 
-	// Mugen defaults to changing p1 and p2 sprpriority, but you have to work around that more often than not
-	// The new defaults should be harmless or even beneficial, so we won't lock them behind a version check just yet
+	// Mugen defaults to changing p1sprpriority, but you have to work around that more often than not
+	// The new default should be harmless or even beneficial, so we won't lock it behind a version check just yet
 	//if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
 	//	ifierrset(&hd.p1sprpriority, 1)
-	//	ifierrset(&hd.p2sprpriority, 0)
 	//}
 }
 
@@ -10764,9 +10763,7 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 		if !isProjectile && hd.p1sprpriority != IErr {
 			c.sprPriority = hd.p1sprpriority
 		}
-		if hd.p2sprpriority != IErr {
-			getter.sprPriority = hd.p2sprpriority
-		}
+		getter.sprPriority = hd.p2sprpriority
 	}
 
 	// Attacker facing

--- a/src/char.go
+++ b/src/char.go
@@ -6277,12 +6277,11 @@ func (c *Char) getOwnChannels(chNo int32) (found []*SoundChannel) {
 	return found
 }
 
-func (c *Char) playSound(ffx string, lowpriority bool, loopCount int32, g, n, chNo, vol int32,
-	p, freqmul, ls float32, x *float32, log bool, priority int32, loopstart, loopend, startposition int, stopgh, stopcs bool) {
-	if g < 0 {
+func (c *Char) playSound(params *PlaySndParams) {
+	if params.group < 0 {
 		return
 	}
-	current_ffx := ffx
+	current_ffx := params.ffx
 	if current_ffx == "f" {
 		if c.gi().fightfxPrefix != "" {
 			current_ffx = c.gi().fightfxPrefix
@@ -6293,22 +6292,24 @@ func (c *Char) playSound(ffx string, lowpriority bool, loopCount int32, g, n, ch
 		return
 	}
 
+	// Get sound from self or common sounds
 	var s *Sound
 	if current_ffx == "" || current_ffx == "s" {
 		if c.gi().snd != nil {
-			s = c.gi().snd.Get([...]int32{g, n})
+			s = c.gi().snd.Get([...]int32{params.group, params.number})
 		}
 	} else {
 		if sys.ffx[current_ffx] != nil && sys.ffx[current_ffx].snd != nil {
-			s = sys.ffx[current_ffx].snd.Get([...]int32{g, n})
+			s = sys.ffx[current_ffx].snd.Get([...]int32{params.group, params.number})
 		}
 	}
+
 	if s == nil {
-		if log {
+		if params.log {
 			if current_ffx != "" {
-				sys.appendToConsole(c.warn() + fmt.Sprintf("sound %v %v,%v doesn't exist", strings.ToUpper(current_ffx), g, n))
+				sys.appendToConsole(c.warn() + fmt.Sprintf("sound %v %v,%v doesn't exist", strings.ToUpper(current_ffx), params.group, params.number))
 			} else {
-				sys.appendToConsole(c.warn() + fmt.Sprintf("sound %v,%v doesn't exist", g, n))
+				sys.appendToConsole(c.warn() + fmt.Sprintf("sound %v,%v doesn't exist", params.group, params.number))
 			}
 		}
 		if !sys.ignoreMostErrors {
@@ -6318,7 +6319,7 @@ func (c *Char) playSound(ffx string, lowpriority bool, loopCount int32, g, n, ch
 			} else {
 				str += fmt.Sprintf("P%v:", c.playerNo+1)
 			}
-			LogMessage("%v%v,%v", str, g, n)
+			LogMessage("%v%v,%v", str, params.group, params.number)
 		}
 		return
 	}
@@ -6332,12 +6333,12 @@ func (c *Char) playSound(ffx string, lowpriority bool, loopCount int32, g, n, ch
 	}
 
 	// Request a sound channel
-	ch := sys.charSoundChannels[crun.playerNo].Request(crun.id, chNo, lowpriority, priority)
+	ch := sys.charSoundChannels[crun.playerNo].Request(crun.id, params.channel, params.lowPriority, params.priority)
 
 	// Play the sound in it
 	if ch != nil {
-		ch.Play(s, g, n, loopCount, freqmul, loopstart, loopend, startposition)
-		vol = Clamp(vol, -25600, 25600)
+		ch.Play(s, params.group, params.number, params.loopCount, params.freqMul, params.loopStart, params.loopEnd, params.startPosition)
+		vol := Clamp(params.volume, -25600, 25600)
 
 		//ch.channelNo = chNo // Handled by Request()
 
@@ -6348,9 +6349,9 @@ func (c *Char) playSound(ffx string, lowpriority bool, loopCount int32, g, n, ch
 			ch.SetVolume(float32(c.gi().data.volume * vol / 100))
 		}
 
-		if chNo >= 0 {
-			if priority != 0 {
-				ch.SetPriority(priority) // TODO: We can probably allow priority in channel -1 now
+		if params.channel >= 0 {
+			if params.priority != 0 {
+				ch.SetPriority(params.priority) // TODO: We can probably allow priority in channel -1 now
 			}
 		}
 
@@ -6362,9 +6363,9 @@ func (c *Char) playSound(ffx string, lowpriority bool, loopCount int32, g, n, ch
 		//	}
 		//}
 
-		ch.stopOnGetHit = stopgh
-		ch.stopOnChangeState = stopcs
-		ch.SetPan(p*c.facing, ls, x)
+		ch.stopOnGetHit = params.stopOnGetHit
+		ch.stopOnChangeState = params.stopOnChangeState
+		ch.SetPan(params.pan*c.facing, params.localScale, params.xPos)
 	}
 }
 
@@ -11322,9 +11323,15 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 			hitspark(c, getter, hd.sparkno, hd.sparkno_ffx, hd.sparkangle, hd.sparkscale)
 		}
 		if hd.hitsound[0] >= 0 && hd.hitsound[1] >= 0 {
-			vo := int32(100)
-			c.playSound(hd.hitsound_ffx, false, 0, hd.hitsound[0], hd.hitsound[1],
-				hd.hitsound_channel, vo, 0, 1, getter.localscl, &getter.pos[0], true, 0, 0, 0, 0, false, false)
+			params := newPlaySndParams()
+			params.ffx = hd.hitsound_ffx
+			params.group = hd.hitsound[0]
+			params.number = hd.hitsound[1]
+			params.channel = hd.hitsound_channel
+			params.localScale = getter.localscl
+			params.xPos = &getter.pos[0]
+			params.log = true
+			c.playSound(params)
 		}
 	} else {
 		if hd.reversal_attr > 0 {
@@ -11333,9 +11340,15 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 			hitspark(c, getter, hd.guard_sparkno, hd.guard_sparkno_ffx, hd.guard_sparkangle, hd.guard_sparkscale)
 		}
 		if hd.guardsound[0] >= 0 && hd.guardsound[1] >= 0 {
-			vo := int32(100)
-			c.playSound(hd.guardsound_ffx, false, 0, hd.guardsound[0], hd.guardsound[1],
-				hd.guardsound_channel, vo, 0, 1, getter.localscl, &getter.pos[0], true, 0, 0, 0, 0, false, false)
+			params := newPlaySndParams()
+			params.ffx = hd.guardsound_ffx
+			params.group = hd.guardsound[0]
+			params.number = hd.guardsound[1]
+			params.channel = hd.guardsound_channel
+			params.localScale = getter.localscl
+			params.xPos = &getter.pos[0]
+			params.log = true
+			c.playSound(params)
 		}
 	}
 
@@ -11964,7 +11977,12 @@ func (c *Char) actionFinish() {
 		if c.alive() && c.life <= 0 && !sys.gsf(GSF_globalnoko) && !c.asf(ASF_noko) && (!c.ghv.guarded || !c.asf(ASF_noguardko)) {
 			// KO sound
 			if !sys.gsf(GSF_nokosnd) {
-				c.playSound("", false, 0, 11, 0, -1, 100, 0, 1, c.localscl, &c.pos[0], false, 0, 0, 0, 0, false, false)
+				params := newPlaySndParams()
+				params.group = 11
+				params.localScale = c.localscl
+				params.xPos = &c.pos[0]
+				c.playSound(params)
+				// Start echo timer
 				if c.gi().data.ko.echo != 0 {
 					c.koEchoTimer = 1
 				}
@@ -12168,8 +12186,13 @@ func (c *Char) update() {
 			c.koEchoTimer = 0
 		} else {
 			if c.koEchoTimer == 60 || c.koEchoTimer == 120 {
-				vo := int32(100 * (240 - (c.koEchoTimer + 60)) / 240)
-				c.playSound("", false, 0, 11, 0, -1, vo, 0, 1, c.localscl, &c.pos[0], false, 0, 0, 0, 0, false, false)
+				vol := int32(100 * (240 - (c.koEchoTimer + 60)) / 240)
+				params := newPlaySndParams()
+				params.group = 11
+				params.volume = vol
+				params.localScale = c.localscl
+				params.xPos = &c.pos[0]
+				c.playSound(params)
 			}
 			c.koEchoTimer++
 		}

--- a/src/common.go
+++ b/src/common.go
@@ -1767,7 +1767,10 @@ func SafeGo(f func()) {
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
-				handlePanic(r)
+				// Forward the panic to the main thread, where dialogs and shutdown are safe
+				sys.mainThreadTask <- func() {
+					panic(r)
+				}
 			}
 		}()
 		f()

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -6419,6 +6419,9 @@ func (c *CharCompiler) paramTrans(is IniSection, sc *StateControllerBase, prefix
 		case "sub":
 			tt = TT_sub
 			defsrc, defdst = 255, 255
+		case "subadd":
+			tt = TT_subadd
+			defsrc, defdst = 255, 255
 		default:
 			// In Mugen, CNS ignores invalid parameter names
 			if c.zssMode || !sys.ignoreMostErrors {

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -4518,7 +4518,7 @@ func (c *CharCompiler) expValue(out *BytecodeExp, in *string,
 		default:
 			return bvNone(), Error("Invalid EnvShakeVar argument: " + c.token)
 		}
-		out.append(OC_ex_, opc)
+		out.append(OC_ex2_, opc)
 		c.token = c.tokenizer(in)
 		if err := c.checkClosingParenthesis(); err != nil {
 			return bvNone(), err
@@ -6784,9 +6784,18 @@ func (c *CharCompiler) stateCompileCNS(states map[int32]StateBytecode, filename,
 			return errmes(err)
 		}
 
-		// Skip if this state has already been added
+		// Duplicate StateDef check. CNS tolerates it
 		if existInThisFile[c.stateNo] {
-			continue
+			msg := fmt.Sprintf("State %v already defined in this file. Skipping duplicate", c.stateNo)
+			if c.stateNo == -10 {
+				msg = "State +1 already defined in this file. Skipping duplicate"
+			}
+			if sys.ignoreMostErrors { // Normally true but might be configurable at some point
+				LogMessage(c.charWarn() + msg)
+				continue
+			} else {
+				return Error(msg)
+			}
 		}
 		existInThisFile[c.stateNo] = true
 
@@ -7965,6 +7974,8 @@ func (c *CharCompiler) stateCompileZSS(states map[int32]StateBytecode, filename,
 				return errmes(err)
 			}
 			c.scan(&line)
+
+			// Duplicate StateDef check. ZSS crashes
 			if existInThisFile[c.stateNo] {
 				if c.stateNo == -10 {
 					return errmes(Error(fmt.Sprintf("State +1 already defined in the same file")))
@@ -7973,6 +7984,7 @@ func (c *CharCompiler) stateCompileZSS(states map[int32]StateBytecode, filename,
 				}
 			}
 			existInThisFile[c.stateNo] = true
+
 			is := NewIniSection()
 			for c.token != "]" {
 				switch c.token {

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -4731,6 +4731,10 @@ func (c *CharCompiler) lifebarAction(is IniSection, sc *StateControllerBase) (St
 			lifebarAction_fontcolor, VT_Int, 4, false); err != nil {
 			return err
 		}
+		if err := c.paramValue(is, sc, "refreshtype",
+			lifebarAction_refreshtype, VT_Int, 1, false); err != nil {
+			return err
+		}
 		return nil
 	})
 	return *ret, err

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -2827,6 +2827,12 @@ type FSMsg struct {
 	bg           AnimLayout
 	front        AnimLayout
 	del          bool
+	snd          [2]int32
+	snd_ffx      string
+	spr          [2]int32
+	animNo       int32
+	anim_ffx     string
+	top          bool
 }
 
 func newFSMsg(side int) *FSMsg {
@@ -2837,6 +2843,10 @@ func newFSMsg(side int) *FSMsg {
 		fontBank:  -1,
 		fontAlign: IErr, // Default to the font's
 		fontColor: [4]int32{255, 255, 255, 255},
+		snd:       [2]int32{-1, -1},
+		spr:       [2]int32{-1, -1},
+		animNo:    -1,
+		top:       true,
 	}
 }
 
@@ -2875,6 +2885,36 @@ func insertFSMsg(array []*FSMsg, value *FSMsg, index int) []*FSMsg {
 
 func removeFSMsg(array []*FSMsg, index int) []*FSMsg {
 	return SliceDelete(array, index)
+}
+
+func (m *FSMsg) isEqual(other *FSMsg) bool {
+	if m == other {
+		return true
+	}
+	if m == nil || other == nil {
+		return false
+	}
+	// Compare font settings
+	if m.fontNo != other.fontNo ||
+		m.fontBank != other.fontBank ||
+		m.fontAlign != other.fontAlign ||
+		m.fontColorSet != other.fontColorSet ||
+		m.fontColor != other.fontColor {
+		return false
+	}
+	// Compare animation
+	if m.animNo != other.animNo || m.anim_ffx != other.anim_ffx {
+		return false
+	}
+	// Compare sprite
+	if m.spr != other.spr {
+		return false
+	}
+	// Compare text (slowest last)
+	if m.text != other.text {
+		return false
+	}
+	return true
 }
 
 type FightScreenAction struct {
@@ -5835,7 +5875,7 @@ func (fs *FightScreen) resolvePath() {
 	fs.def = v
 }
 
-func (fs *FightScreen) appendAction(c *Char, msg *FSMsg, s_ffx, a_ffx string, snd, spr [2]int32, anim int32, top bool) {
+func (fs *FightScreen) appendAction(c *Char, msg *FSMsg, refresh int32) {
 	if c.teamside < 0 {
 		return
 	}
@@ -5844,24 +5884,45 @@ func (fs *FightScreen) appendAction(c *Char, msg *FSMsg, s_ffx, a_ffx string, sn
 	}
 
 	// Play sound
-	if snd[0] != -1 && snd[1] != -1 {
-		if s_ffx != "" && s_ffx != "s" && sys.ffx[s_ffx] != nil && sys.ffx[s_ffx].snd != nil {
-			s := sys.ffx[s_ffx].snd.Get(snd) // Common FX
+	if msg.snd[0] != -1 && msg.snd[1] != -1 {
+		if msg.snd_ffx != "" && msg.snd_ffx != "s" && sys.ffx[msg.snd_ffx] != nil && sys.ffx[msg.snd_ffx].snd != nil {
+			s := sys.ffx[msg.snd_ffx].snd.Get(msg.snd)
 			if s != nil {
-				sys.soundChannels.Play(s, snd[0], snd[1], 100, 0, 0, 0, 0)
+				sys.soundChannels.Play(s, msg.snd[0], msg.snd[1], 100, 0, 0, 0, 0)
 			}
 		} else {
-			fs.snd.play(snd, 100, 0, 0, 0, 0)
+			fs.snd.play(msg.snd, 100, 0, 0, 0, 0)
 		}
 	}
 
 	// If sound only, we can stop here
-	if anim == -1 && (spr[0] == -1 || spr[1] == -1) && msg.text == "" {
+	if msg.animNo == -1 && msg.spr[0] == -1 && msg.text == "" {
 		return
 	}
 
 	// Select side of screen
 	teammsg := fs.actions[c.teamside]
+
+	// Duplicate detection
+	if refresh == 1 || refresh == 2 {
+		for _, existing := range teammsg.messages {
+			if existing.del {
+				continue
+			}
+			if existing.isEqual(msg) {
+				// Found an identical message: refresh its timer to keep it alive
+				existing.resttime = msg.resttime
+				existing.agetimer = 0
+				existing.del = false
+				// Also reappear from outside screen
+				if refresh == 2 {
+					existing.counterX = teammsg.start_x * 2
+				}
+				// Don't add another
+				return
+			}
+		}
+	}
 
 	// If adding a new message while exceeding the maximum number allowed, make the oldest message go away faster
 	var count int32
@@ -5872,11 +5933,11 @@ func (fs *FightScreen) appendAction(c *Char, msg *FSMsg, s_ffx, a_ffx string, sn
 	}
 	if count >= teammsg.max {
 		var oldest int
-		var oldesttimer int32
-		for i, msg := range teammsg.messages {
-			if !msg.del && msg.resttime > 0 && msg.agetimer > oldesttimer {
+		var oldestTimer int32
+		for i, m := range teammsg.messages {
+			if !m.del && m.resttime > 0 && m.agetimer > oldestTimer {
 				oldest = i
-				oldesttimer = msg.agetimer
+				oldestTimer = m.agetimer
 			}
 		}
 		if oldest < len(teammsg.messages) {
@@ -5884,9 +5945,9 @@ func (fs *FightScreen) appendAction(c *Char, msg *FSMsg, s_ffx, a_ffx string, sn
 		}
 	}
 
-	// Use index 0 if "top", otherwise find the first free message slot
+	// Use index 0 if "top". Otherwise find the first free message slot
 	index := 0
-	if !top {
+	if !msg.top {
 		for k, v := range teammsg.messages {
 			if v.del {
 				teammsg.messages = removeFSMsg(teammsg.messages, k)
@@ -5902,13 +5963,13 @@ func (fs *FightScreen) appendAction(c *Char, msg *FSMsg, s_ffx, a_ffx string, sn
 	delete(teammsg.is, prefix+"spr")
 
 	// Read animation
-	if anim != -1 {
-		teammsg.is[prefix+"anim"] = fmt.Sprintf("%v", anim)
+	if msg.animNo != -1 {
+		teammsg.is[prefix+"anim"] = fmt.Sprintf("%v", msg.animNo)
 	}
 
 	// Read sprite
-	if spr[0] != -1 && spr[1] != -1 {
-		teammsg.is[prefix+"spr"] = fmt.Sprintf("%v,%v", spr[0], spr[1])
+	if msg.spr[0] != -1 {
+		teammsg.is[prefix+"spr"] = fmt.Sprintf("%v,%v", msg.spr[0], msg.spr[1])
 	}
 
 	// Read background
@@ -5917,21 +5978,21 @@ func (fs *FightScreen) appendAction(c *Char, msg *FSMsg, s_ffx, a_ffx string, sn
 	// Default to fight screen assets
 	sff := fs.sff
 	at := fs.animTable
-	var alscale float32 = 1.0
+	alscale := float32(1.0)
 
 	// Use animation prefixes to change asset source
-	if a_ffx != "" {
-		if a_ffx == "s" {
+	if msg.anim_ffx != "" {
+		if msg.anim_ffx == "s" {
 			// Use the character
 			sff = sys.cgi[c.playerNo].sff
 			at = sys.cgi[c.playerNo].animTable
-			alscale = float32(sys.fightScreen.localcoord[0]) / float32(sys.chars[c.playerNo][0].localcoord)
-		} else if sys.ffx[a_ffx] != nil {
+			alscale = float32(fs.localcoord[0]) / float32(sys.chars[c.playerNo][0].localcoord)
+		} else if sys.ffx[msg.anim_ffx] != nil {
 			// Use common FX
-			fx := sys.ffx[a_ffx]
+			fx := sys.ffx[msg.anim_ffx]
 			sff = fx.sff
 			at = fx.animTable
-			alscale = fx.fx_scale * float32(sys.fightScreen.localcoord[0]) / float32(fx.localcoord[0])
+			alscale = fx.fx_scale * float32(fs.localcoord[0]) / float32(fx.localcoord[0])
 		}
 	}
 
@@ -5943,7 +6004,7 @@ func (fs *FightScreen) appendAction(c *Char, msg *FSMsg, s_ffx, a_ffx string, sn
 		msg.front.anim.start_scale[1] *= alscale
 	}
 
-	// Insert new message
+	// Insert the new message
 	teammsg.messages = insertFSMsg(teammsg.messages, msg, index)
 }
 

--- a/src/image.go
+++ b/src/image.go
@@ -20,6 +20,7 @@ const (
 	TT_none TransType = iota
 	TT_add
 	TT_sub
+	TT_subadd
 	TT_default
 )
 

--- a/src/main.go
+++ b/src/main.go
@@ -387,11 +387,21 @@ func handlePanic(r interface{}) {
 
 	// Show popup message
 	displayErr := errStr
+
+	// Remove stack traces from the popup to keep it concise. The full details already go to the log file
+	// Remove the Lua stack trace
 	if _, ok := r.(*lua.ApiError); ok {
-		parts := strings.SplitN(errStr, "stack traceback:", 2)
-		displayErr = strings.TrimSpace(parts[0]) // Remove the Lua traceback from this one
+		if idx := strings.Index(displayErr, "\nstack traceback:"); idx >= 0 {
+			displayErr = displayErr[:idx]
+		}
+		displayErr = strings.TrimSpace(displayErr)
+	}
+	// Also remove any Go stack trace that may have appeared
+	if idx := strings.Index(displayErr, "\ngoroutine "); idx >= 0 {
+		displayErr = displayErr[:idx]
 	}
 
+	// Limit message to 1000 characters just in case
 	if len(displayErr) > 1000 {
 		displayErr = displayErr[:1000] + "..."
 	}

--- a/src/motif.go
+++ b/src/motif.go
@@ -4620,37 +4620,36 @@ func (di *MotifDialogue) applyToken(m *Motif, line *DialogueParsedLine, token Di
 			if !di.isValidPlayerNo(token.pn) {
 				return true
 			}
-			f, lw, lp, stopgh, stopcs := false, false, false, false, false
-			var g, n, ch, vo, priority, lc int32 = -1, 0, -1, 100, 0, 0
-			var loopstart, loopend, startposition int = 0, 0, 0
-			var p, fr float32 = 0, 1
-			x := &sys.chars[token.pn-1][0].pos[0]
-			ls := sys.chars[token.pn-1][0].localscl
-			prefix := ""
-			if f {
-				prefix = "f"
-			}
+			params := newPlaySndParams()
+			c := sys.chars[token.pn-1][0]
+			params.xPos = &c.pos[0]
+			params.localScale = c.localscl
+			params.log = false
+
 			if v1, ok1 := token.value[0].(float32); ok1 {
-				g = int32(v1)
+				params.group = int32(v1)
 				if v2, ok2 := token.value[1].(float32); ok2 {
-					n = int32(v2)
+					params.number = int32(v2)
 					if len(token.value) >= 3 {
 						if v3, ok3 := token.value[2].(float32); ok3 {
-							vo = int32(v3)
+							params.volume = int32(v3)
 						}
 					}
 				}
 			}
-			if lc == 0 {
-				if lp {
-					sys.chars[token.pn-1][0].playSound(prefix, lw, -1, g, n, ch, vo, p, fr, ls, x, false, priority, loopstart, loopend, startposition, stopgh, stopcs)
-				} else {
-					sys.chars[token.pn-1][0].playSound(prefix, lw, 0, g, n, ch, vo, p, fr, ls, x, false, priority, loopstart, loopend, startposition, stopgh, stopcs)
-				}
-				// Otherwise, read the loopcount parameter directly
-			} else {
-				sys.chars[token.pn-1][0].playSound(prefix, lw, lc, g, n, ch, vo, p, fr, ls, x, false, priority, loopstart, loopend, startposition, stopgh, stopcs)
-			}
+
+			// Loop logic (currently unused since all loop variables remain at defaults)
+			// if lc == 0 {
+				// if lp {
+					// params.loopCount = -1
+				// } else {
+					// params.loopCount = 0
+				// }
+			// } else {
+				// params.loopCount = lc
+			// }
+
+			c.playSound(params)
 		}
 		return true
 	case "anim":

--- a/src/render.go
+++ b/src/render.go
@@ -707,13 +707,13 @@ func renderWithBlending(
 		BlendInv = BlendAdd
 	}
 
-	src := blendAlpha[0]
-	dst := blendAlpha[1]
+	// Convert alpha to the float the renderer uses
+	src := float32(blendAlpha[0]) / 255.0
+	dst := float32(blendAlpha[1]) / 255.0
 
 	// Ensure proper source and destination
-	// TODO: Maybe use byte everywhere
-	src = Clamp(src, 0, 255)
-	dst = Clamp(dst, 0, 255)
+	src = Clamp(src, 0, 1)
+	dst = Clamp(dst, 0, 1)
 
 	// Force None destination to 0 just in case
 	if blendMode == TT_none {
@@ -740,9 +740,9 @@ func renderWithBlending(
 	// Sub
 	case blendMode == TT_sub:
 		switch {
-		case src == 0 && dst == 255:
+		case src == 0 && dst == 1:
 			// Fully transparent. Skip render
-		case src == 255 && dst == 255:
+		case src == 1 && dst == 1:
 			// Fast path for full subtraction
 			if invblend >= 1 {
 				invertAColor()
@@ -753,8 +753,8 @@ func renderWithBlending(
 			render(BlendInv, blendSourceFactor, BlendOne, 1)
 		default:
 			// Full alpha range
-			if dst < 255 {
-				render(BlendAdd, BlendZero, BlendOneMinusSrcAlpha, 1-float32(dst)/255)
+			if dst < 1 {
+				render(BlendAdd, BlendZero, BlendOneMinusSrcAlpha, 1-dst)
 			}
 			if src > 0 {
 				if invblend >= 1 {
@@ -763,14 +763,11 @@ func renderWithBlending(
 				if invblend == 3 {
 					disableNeg()
 				}
-				render(BlendInv, blendSourceFactor, BlendOne, float32(src)/255)
+				render(BlendInv, blendSourceFactor, BlendOne, src)
 			}
 		}
 	// SubAdd
 	case blendMode == TT_subadd:
-		srcf := float32(src) / 255.0
-		dstf := float32(dst) / 255.0
-
 		if neg != nil && *neg {
 			// With invertall we invert the passes. Add then sub
 			// This is kind of like "invblend = 3"
@@ -803,12 +800,12 @@ func renderWithBlending(
 	// Default should normally not reach here, so this is only a fallback
 	default:
 		switch {
-		case src == 0 && dst == 255:
+		case src == 0 && dst == 1:
 			// Fully transparent. Just don't render
-		case src == 255 && dst == 0:
+		case src == 1 && dst == 0:
 			// Fast path for fully opaque
 			render(BlendAdd, blendSourceFactor, BlendOneMinusSrcAlpha, 1)
-		case src == 255 && dst == 255:
+		case src == 1 && dst == 1:
 			// Fast path for full Add
 			if invblend >= 1 {
 				invertAColor()
@@ -819,11 +816,11 @@ func renderWithBlending(
 			render(Blend, blendSourceFactor, BlendOne, 1)
 		default:
 			// AddAlpha (includes Add1)
-			if dst < 255 {
-				render(Blend, BlendZero, BlendOneMinusSrcAlpha, 1-float32(dst)/255)
+			if dst < 1 {
+				render(Blend, BlendZero, BlendOneMinusSrcAlpha, 1-dst)
 			}
 			if src > 0 {
-				if invblend >= 1 && dst >= 255 {
+				if invblend >= 1 && dst == 1 {
 					Blend = BlendReverseSubtract
 					if invblend >= 2 { // Not 1 here. TODO: Explain why in comment
 						invertAColor()
@@ -834,15 +831,15 @@ func renderWithBlending(
 				} else {
 					Blend = BlendAdd
 				}
-				if !isrgba && (invblend <= -1 || invblend >= 2) && acolor != nil && mcolor != nil && src < 255 {
+				if !isrgba && (invblend <= -1 || invblend >= 2) && acolor != nil && mcolor != nil && src < 1 {
 					// Sum of add components
 					gc := Abs(acolor[0]) + Abs(acolor[1]) + Abs(acolor[2])
-					v3, ml, al := Max((gc*255)-float32(dst+src), 512)/128, (float32(src) / 255), (float32(src+dst) / 255)
+					v3, ml, al := Max(255*(gc-(src+dst)), 512)/128, src, src+dst
 					rM, gM, bM := mcolor[0]*ml, mcolor[1]*ml, mcolor[2]*ml
 					(*mcolor)[0], (*mcolor)[1], (*mcolor)[2] = rM, gM, bM
 					render(Blend, blendSourceFactor, BlendOne, al*Pow(v3, 3))
 				} else {
-					render(Blend, blendSourceFactor, BlendOne, float32(src)/255)
+					render(Blend, blendSourceFactor, BlendOne, src)
 				}
 			}
 		}

--- a/src/render.go
+++ b/src/render.go
@@ -684,13 +684,16 @@ func RenderSprite(rp RenderParams) {
 		renderSpriteQuad(modelview, rp)
 	}
 
-	renderWithBlending(renderPass, rp.blendMode, rp.blendAlpha, rp.paltex != nil, invblend, &neg, &padd, &pmul, rp.paltex == nil)
+	renderWithBlending(renderPass, rp.blendMode, rp.blendAlpha,
+		rp.paltex != nil, invblend, &neg, &padd, &pmul, rp.paltex == nil, grayscale)
+
 	gfx.DisableScissor()
 }
 
 func renderWithBlending(
 	render func(eq BlendEquation, src, dst BlendFunc, a float32),
-	blendMode TransType, blendAlpha [2]int32, correctAlpha bool, invblend int32, neg *bool, acolor *[3]float32, mcolor *[3]float32, isrgba bool) {
+	blendMode TransType, blendAlpha [2]int32, correctAlpha bool, invblend int32,
+	neg *bool, acolor *[3]float32, mcolor *[3]float32, isrgba bool, gray float32) {
 
 	blendSourceFactor := BlendSrcAlpha
 	if !correctAlpha {
@@ -718,11 +721,14 @@ func renderWithBlending(
 	}
 
 	// Helpers for invertblend
-	invertColor := func() {
+	// Invert PalFX add
+	invertAColor := func() {
 		if acolor != nil {
 			(*acolor)[0], (*acolor)[1], (*acolor)[2] = -acolor[0], -acolor[1], -acolor[2]
 		}
 	}
+	// Disable the "neg" uniform, which the shader uses to invert colors
+	// We sometimes use this because subtractive transparency already inverts colors on its own, so it'd be a double negation
 	disableNeg := func() {
 		if neg != nil {
 			*neg = false
@@ -739,7 +745,7 @@ func renderWithBlending(
 		case src == 255 && dst == 255:
 			// Fast path for full subtraction
 			if invblend >= 1 {
-				invertColor()
+				invertAColor()
 			}
 			if invblend == 3 {
 				disableNeg()
@@ -752,12 +758,44 @@ func renderWithBlending(
 			}
 			if src > 0 {
 				if invblend >= 1 {
-					invertColor()
+					invertAColor()
 				}
 				if invblend == 3 {
 					disableNeg()
 				}
 				render(BlendInv, blendSourceFactor, BlendOne, float32(src)/255)
+			}
+		}
+	// SubAdd
+	case blendMode == TT_subadd:
+		srcf := float32(src) / 255.0
+		dstf := float32(dst) / 255.0
+
+		if neg != nil && *neg {
+			// With invertall we invert the passes. Add then sub
+			// This is kind of like "invblend = 3"
+			// But adding "invertblend" support here would force people to have to use it to get the expected results
+			disableNeg()
+			//invertAColor()
+			if dst > 0 {
+				gfx.SetUniformF("gray", 1.0)
+				render(BlendAdd, blendSourceFactor, BlendOne, dst)
+			}
+			if src > 0 {
+				gfx.SetUniformF("gray", gray)
+				render(BlendReverseSubtract, blendSourceFactor, BlendOne, src)
+			}
+		} else {
+			// Normal behavior
+			// Pass 1: subtractive, forced grayscale, intensity = dst
+			if dst > 0 {
+				gfx.SetUniformF("gray", 1.0)
+				render(BlendReverseSubtract, blendSourceFactor, BlendOne, dst)
+			}
+			// Pass 2: additive, original grayscale, intensity = src
+			if src > 0 {
+				gfx.SetUniformF("gray", gray)
+				render(BlendAdd, blendSourceFactor, BlendOne, src)
 			}
 		}
 	// Add, None or Default
@@ -773,7 +811,7 @@ func renderWithBlending(
 		case src == 255 && dst == 255:
 			// Fast path for full Add
 			if invblend >= 1 {
-				invertColor()
+				invertAColor()
 			}
 			if invblend == 3 {
 				disableNeg()
@@ -788,7 +826,7 @@ func renderWithBlending(
 				if invblend >= 1 && dst >= 255 {
 					Blend = BlendReverseSubtract
 					if invblend >= 2 { // Not 1 here. TODO: Explain why in comment
-						invertColor()
+						invertAColor()
 					}
 					if invblend == 3 {
 						disableNeg()
@@ -865,7 +903,7 @@ func FillRect(rect [4]int32, color uint32, alpha [2]int32, fx *PalFX) {
 		gfx.RenderQuad()
 	}
 
-	renderWithBlending(renderPass, TT_add, alpha, true, invblend, &neg, &padd, &pmul, true)
+	renderWithBlending(renderPass, TT_add, alpha, true, invblend, &neg, &padd, &pmul, true, grayscale)
 }
 
 type TextureAtlas struct {

--- a/src/script.go
+++ b/src/script.go
@@ -3476,13 +3476,11 @@ func systemScriptInit(l *lua.LState) {
 		/*Query the background preload state of a character slot.
 		@function getCharPreloadStatus
 		@tparam int charRef 0-based character index in the select list.
-		@treturn string state Preload state: `"idle"`, `"queued"`, `"loading"`, `"ready"`, or `"error"`.
-		@treturn string err Error message (empty string if no error).
+		@treturn string state Preload state: `"idle"`, `"queued"`, `"loading"`, or `"ready"`.
 		function getCharPreloadStatus(charRef) end*/
-		state, err := sys.sel.CharPreloadStatus(int(numArg(l, 1)))
+		state := sys.sel.CharPreloadStatus(int(numArg(l, 1)))
 		l.Push(lua.LString(state.String()))
-		l.Push(lua.LString(err))
-		return 2
+		return 1
 	})
 	luaRegister(l, "getCharRandomPalette", func(*lua.LState) int {
 		/*Get a random valid palette number for a character slot.
@@ -4096,13 +4094,11 @@ func systemScriptInit(l *lua.LState) {
 		/*Query the background preload state of a stage slot.
 		@function getStagePreloadStatus
 		@tparam int stageRef Stage index as used by the select system.
-		@treturn string state Preload state: `"idle"`, `"queued"`, `"loading"`, `"ready"`, or `"error"`.
-		@treturn string err Error message (empty string if no error).
+		@treturn string state Preload state: `"idle"`, `"queued"`, `"loading"`, or `"ready"`.
 		function getStagePreloadStatus(stageRef) end*/
-		state, err := sys.sel.StagePreloadStatus(int(numArg(l, 1)))
+		state := sys.sel.StagePreloadStatus(int(numArg(l, 1)))
 		l.Push(lua.LString(state.String()))
-		l.Push(lua.LString(err))
-		return 2
+		return 1
 	})
 	luaRegister(l, "getStageSelectParams", func(*lua.LState) int {
 		/*Get parsed select parameters for a stage entry.

--- a/src/script.go
+++ b/src/script.go
@@ -5459,75 +5459,72 @@ func systemScriptInit(l *lua.LState) {
 		function playSnd(group, sound, volumescale, commonSnd, channel, lowpriority, freqmul,
 		  loop, pan, priority, loopstart, loopend, startposition, loopcount,
 		  stopOnGetHit, stopOnChangeState) end*/
-		f, lw, lp, stopgh, stopcs := false, false, false, false, false
-		var g, n, ch, vo, priority, lc int32 = -1, 0, -1, 100, 0, 0
-		var loopstart, loopend, startposition int = 0, 0, 0
-		var p, fr float32 = 0, 1
-		x := &sys.debugWC.pos[0]
-		ls := sys.debugWC.localscl
-		if !nilArg(l, 1) { // group_no
-			g = int32(numArg(l, 1))
+
+		params := newPlaySndParams()
+		params.xPos = &sys.debugWC.pos[0]
+		params.localScale = sys.debugWC.localscl
+
+		var lp bool
+
+		if !nilArg(l, 1) {
+			params.group = int32(numArg(l, 1))
 		}
-		if !nilArg(l, 2) { // sound_no
-			n = int32(numArg(l, 2))
+		if !nilArg(l, 2) {
+			params.number = int32(numArg(l, 2))
 		}
-		if !nilArg(l, 3) { // volumescale
-			vo = int32(numArg(l, 3))
+		if !nilArg(l, 3) {
+			params.volume = int32(numArg(l, 3))
 		}
-		if !nilArg(l, 4) { // commonSnd
-			f = boolArg(l, 4)
+		if !nilArg(l, 4) {
+			if boolArg(l, 4) {
+				params.ffx = "f"
+			}
 		}
-		if !nilArg(l, 5) { // channel
-			ch = int32(numArg(l, 5))
+		if !nilArg(l, 5) {
+			params.channel = int32(numArg(l, 5))
 		}
-		if !nilArg(l, 6) { // lowpriority
-			lw = boolArg(l, 6)
+		if !nilArg(l, 6) {
+			params.lowPriority = boolArg(l, 6)
 		}
-		if !nilArg(l, 7) { // freqmul
-			fr = float32(numArg(l, 7))
+		if !nilArg(l, 7) {
+			params.freqMul = float32(numArg(l, 7))
 		}
-		if !nilArg(l, 8) { // loop
+		if !nilArg(l, 8) {
 			lp = boolArg(l, 8)
 		}
-		if !nilArg(l, 9) { // pan
-			p = float32(numArg(l, 9))
+		if !nilArg(l, 9) {
+			params.pan = float32(numArg(l, 9))
 		}
-		if !nilArg(l, 10) { // priority
-			priority = int32(numArg(l, 10))
+		if !nilArg(l, 10) {
+			params.priority = int32(numArg(l, 10))
 		}
-		if !nilArg(l, 11) { // loopstart
-			loopstart = int(numArg(l, 11))
+		if !nilArg(l, 11) {
+			params.loopStart = int(numArg(l, 11))
 		}
-		if !nilArg(l, 12) { // loopend
-			loopend = int(numArg(l, 12))
+		if !nilArg(l, 12) {
+			params.loopEnd = int(numArg(l, 12))
 		}
-		if !nilArg(l, 13) { // startposition
-			startposition = int(numArg(l, 13))
+		if !nilArg(l, 13) {
+			params.startPosition = int(numArg(l, 13))
 		}
-		if !nilArg(l, 14) { // loopcount
-			lc = int32(numArg(l, 14))
+		if !nilArg(l, 14) {
+			params.loopCount = int32(numArg(l, 14))
 		}
-		if !nilArg(l, 15) { // StopOnGetHit
-			stopgh = boolArg(l, 15)
+		if !nilArg(l, 15) {
+			params.stopOnGetHit = boolArg(l, 15)
 		}
-		if !nilArg(l, 16) { // StopOnChangeState
-			stopcs = boolArg(l, 16)
+		if !nilArg(l, 16) {
+			params.stopOnChangeState = boolArg(l, 16)
 		}
-		prefix := ""
-		if f {
-			prefix = "f"
-		}
-		// If the loopcount is 0, then read the loop parameter
-		if lc == 0 {
+
+		// If loopcount is 0, use the loop parameter
+		if params.loopCount == 0 {
 			if lp {
-				sys.debugWC.playSound(prefix, lw, -1, g, n, ch, vo, p, fr, ls, x, false, priority, loopstart, loopend, startposition, stopgh, stopcs)
-			} else {
-				sys.debugWC.playSound(prefix, lw, 0, g, n, ch, vo, p, fr, ls, x, false, priority, loopstart, loopend, startposition, stopgh, stopcs)
+				params.loopCount = -1
 			}
-			// Otherwise, read the loopcount parameter directly
-		} else {
-			sys.debugWC.playSound(prefix, lw, lc, g, n, ch, vo, p, fr, ls, x, false, priority, loopstart, loopend, startposition, stopgh, stopcs)
 		}
+
+		sys.debugWC.playSound(params)
 		return 0
 	})
 	luaRegister(l, "postMatch", func(*lua.LState) int {

--- a/src/sound.go
+++ b/src/sound.go
@@ -1336,3 +1336,35 @@ func (s *SoundChannels) Tick() {
 		}
 	}
 }
+
+// Maybe this should be in char.go?
+type PlaySndParams struct {
+	ffx               string
+	group             int32
+	number            int32
+	channel           int32
+	volume            int32
+	pan               float32
+	xPos              *float32
+	localScale        float32
+	freqMul           float32
+	lowPriority       bool
+	priority          int32
+	startPosition     int
+	loopCount         int32
+	loopStart         int
+	loopEnd           int
+	stopOnGetHit      bool
+	stopOnChangeState bool
+	log               bool
+}
+
+func newPlaySndParams() *PlaySndParams {
+	return &PlaySndParams{
+		group:      -1,
+		channel:    -1,
+		volume:     100,
+		freqMul:    1.0,
+		localScale: 1.0,
+	}
+}

--- a/src/stage.go
+++ b/src/stage.go
@@ -365,6 +365,11 @@ func readBackGround(is IniSection, link *backGround,
 			bg.anim.transType = TT_sub
 			bg.anim.srcAlpha = 255
 			bg.anim.dstAlpha = 255
+		case "subadd":
+			bg.anim.mask = 0
+			bg.anim.transType = TT_subadd
+			bg.anim.srcAlpha = 255
+			bg.anim.dstAlpha = 255
 		case "none":
 			// In Mugen this does the same as Default
 			// TODO: Make ikemenversion fix it

--- a/src/system.go
+++ b/src/system.go
@@ -6563,6 +6563,13 @@ func (s *System) restoreCharVars(c *Char) {
 	delete(s.charVarsBackup, c.playerNo)
 }
 
+func (s *System) isValidCustomShader(name string) bool {
+	if _, ok := sys.shaderRefCount[name]; ok {
+		return true
+	}
+	return false
+}
+
 func (s *System) cleanCustomShaders() {
 	activeShaders := make(map[string]bool)
 	for i := 0; i < len(s.cgi); i++ {

--- a/src/system.go
+++ b/src/system.go
@@ -2716,8 +2716,16 @@ func (s *System) action() {
 	}
 
 	s.charList.cueDraw()
+
+	// Note: Explod update must happen after hit detection. Because hit sparks are also explods
 	s.explodUpdate()
 	s.charTextsUpdate()
+
+	for i := range s.explods {
+		for _, e := range s.explods[i] {
+			e.cueDraw()
+		}
+	}
 
 	// Adjust game speed
 	if s.tickNextFrame() {

--- a/src/system.go
+++ b/src/system.go
@@ -4415,7 +4415,7 @@ const (
 	PS_Queued
 	PS_Loading
 	PS_Ready
-	PS_Error
+	//PS_Error // We simply crash when preloading invalid assets
 )
 
 func (ps PreloadState) String() string {
@@ -4428,8 +4428,8 @@ func (ps PreloadState) String() string {
 		return "loading"
 	case PS_Ready:
 		return "ready"
-	case PS_Error:
-		return "error"
+	// case PS_Error:
+		// return "error"
 	}
 	return "idle"
 }
@@ -4443,7 +4443,7 @@ type PreloadEntry struct {
 	State    PreloadState
 	Priority int
 	Order    int64
-	Err      string
+	//Err      string
 }
 
 func newSelect() *Select {
@@ -4525,7 +4525,7 @@ func (s *Select) QueueCharPreload(ref int, priority int) {
 		e.Priority = priority
 		return
 	}
-	if e.State == PS_Idle || e.State == PS_Error {
+	if e.State == PS_Idle {// || e.State == PS_Error {
 		e.State = PS_Queued
 	}
 	if e.Priority == priority {
@@ -4563,7 +4563,7 @@ func (s *Select) QueueStagePreload(ref int, priority int) {
 		e.Priority = priority
 		return
 	}
-	if e.State == PS_Idle || e.State == PS_Error {
+	if e.State == PS_Idle {// || e.State == PS_Error {
 		e.State = PS_Queued
 	}
 	if e.Priority == priority {
@@ -4578,30 +4578,30 @@ func (s *Select) QueueStagePreload(ref int, priority int) {
 	}
 }
 
-func (s *Select) CharPreloadStatus(ref int) (PreloadState, string) {
+func (s *Select) CharPreloadStatus(ref int) (PreloadState) {// (PreloadState, string) {
 	if sys.cfg.Config.BootLoadingMode == 0 {
-		return PS_Ready, ""
+		return PS_Ready//, ""
 	}
 	s.initPreloadSync()
 	s.preloadMu.Lock()
 	defer s.preloadMu.Unlock()
 	if ref < 0 || ref >= len(s.charPreload) {
-		return PS_Idle, ""
+		return PS_Idle//, ""
 	}
-	return s.charPreload[ref].State, s.charPreload[ref].Err
+	return s.charPreload[ref].State //, s.charPreload[ref].Err
 }
 
-func (s *Select) StagePreloadStatus(ref int) (PreloadState, string) {
+func (s *Select) StagePreloadStatus(ref int) (PreloadState) {// (PreloadState, string) {
 	if sys.cfg.Config.BootLoadingMode == 0 {
-		return PS_Ready, ""
+		return PS_Ready//, ""
 	}
 	s.initPreloadSync()
 	s.preloadMu.Lock()
 	defer s.preloadMu.Unlock()
 	if ref <= 0 || ref-1 >= len(s.stagePreload) {
-		return PS_Idle, ""
+		return PS_Idle//, ""
 	}
-	return s.stagePreload[ref-1].State, s.stagePreload[ref-1].Err
+	return s.stagePreload[ref-1].State//, s.stagePreload[ref-1].Err
 }
 
 func (s *Select) AllPreloadsReady() bool {
@@ -4660,10 +4660,10 @@ func (s *Select) preloadWorkerLoop() {
 			if ref >= 0 {
 				if kind == "char" {
 					s.charPreload[ref].State = PS_Loading
-					s.charPreload[ref].Err = ""
+					//s.charPreload[ref].Err = ""
 				} else {
 					s.stagePreload[ref-1].State = PS_Loading
-					s.stagePreload[ref-1].Err = ""
+					//s.stagePreload[ref-1].Err = ""
 				}
 				s.preloadMu.Unlock()
 
@@ -4675,22 +4675,13 @@ func (s *Select) preloadWorkerLoop() {
 				}
 
 				s.preloadMu.Lock()
-				if kind == "char" {
-					if err != nil {
-						s.charPreload[ref].State = PS_Error
-						s.charPreload[ref].Err = err.Error()
-					} else {
-						s.charPreload[ref].State = PS_Ready
-						s.charPreload[ref].Err = ""
-					}
+
+				if err != nil {
+					panic(fmt.Sprintf("Preloading error: %s", err))
+				} else if kind == "char" {
+					s.charPreload[ref].State = PS_Ready
 				} else {
-					if err != nil {
-						s.stagePreload[ref-1].State = PS_Error
-						s.stagePreload[ref-1].Err = err.Error()
-					} else {
-						s.stagePreload[ref-1].State = PS_Ready
-						s.stagePreload[ref-1].Err = ""
-					}
+					s.stagePreload[ref-1].State = PS_Ready
 				}
 				s.preloadCond.Broadcast()
 				break
@@ -4757,7 +4748,9 @@ func (s *Select) preloadCharAssets(ref int) error {
 		for k := range s.charSpritePreload {
 			localAnims.addSprite(localSff, k[0], k[1])
 		}
+		// Determine the character's selectable palettes based on the return from preloadSff()
 		if localSff.header.Version[0] != 1 {
+			// Merge SFF and ACT indexes
 			defPals := make(map[int32]bool)
 			for _, p := range sc.pal {
 				defPals[p] = true
@@ -4787,9 +4780,11 @@ func (s *Select) preloadCharAssets(ref int) error {
 			sc.pal = newPal
 			sc.pal_files = newPalFilesOut
 		} else if len(sc.pal) == 0 {
+			// Just use selPal directly
 			sc.pal = selPal
 		}
 	} else {
+		// Make a dummy SFF
 		localSff = newSff()
 		localAnims.updateSff(localSff)
 		for k := range s.charSpritePreload {


### PR DESCRIPTION
Features:
- `SubAdd` transparency type. Hybrid between sub and add. Draws destination with grayscale sub, then source with full color add. Native implementation of a classic Mugen workaround
- ` lifebarAction` `refreshtype` parameter.  Determines how to handle duplicate messages
- Added warnings when duplicate CNS states are found in the same file
- Expanded error logging for animations

Fixes:
- Calling invalid custom shaders will print a warning instead of crashing the renderer
- `Hitdef` `p2sprpriority` is back to defaulting to 0. Extending p1sprpriority's refactor to it was a mistake
- Force boot loading mode 0 for quick VS. Fixes race conditions when preparing the teammate portraits
- Fixed explod `hidewithbars` skipping most of the explod's logical update
- Sub transparency only requires "S" in animations. It will ignore incorrect letters that come after it like Mugen
- Made default alpha values more like Mugen
- Fixed alpha parsing function not reading value of 256 and above correctly, which only worked because some defaults were 255
- Fixes #3717

Refactor:
- "Save and return" menu option plays confirm sound instead of cancel
- Preloading errors now result in an instant crash instead of deferring it until the character/stage is somehow selected
- Improved error handling for separate goroutines
- Shortened crash message shown in popups
- Added PlaySndParams struct, because "play sound" calls had become unwieldly with 18 arguments