### PR TITLE
feat: command parser compatibility mode; fix: explod drawing order, missing plain SubAdd; refactor

### DIFF
--- a/src/anim.go
+++ b/src/anim.go
@@ -118,6 +118,11 @@ func ReadAnimFrame(line string) (*AnimFrame, error) {
 			return
 		}
 
+		// Helper for the repetitive error
+		transErr := func(s string) {
+			err = Error(fmt.Sprintf("Invalid animation element transparency: %v", s))
+		}
+
 		ia := strings.IndexAny(ary[6], "ASas")
 		if ia >= 0 {
 			ary[6] = ary[6][ia:]
@@ -129,17 +134,25 @@ func ReadAnimFrame(line string) (*AnimFrame, error) {
 			af.SrcAlpha = 255
 			af.DstAlpha = 128
 
-		case len(a) >= 3 && a[:3] == "sas": // SubAdd
+		case len(a) >= 3 && a[:3] == "sas": // SubAdd with alpha
 			af.TransType = TT_subadd
-			af.SrcAlpha, af.DstAlpha = parseAlphaNumbers(a, 3, 255, 0)
+			af.SrcAlpha, af.DstAlpha = parseAlphaNumbers(a, 3, 255, 255)
+
+		case len(a) >= 2 && a[:2] == "sa": // Plain SubAdd
+			af.TransType = TT_subadd
+			af.SrcAlpha = 255
+			af.DstAlpha = 255
+			if len(a) > 2 {
+				transErr(a)
+			}
 
 		case len(a) >= 2 && a[:2] == "as": // Add with alpha
 			af.TransType = TT_add
-			af.SrcAlpha, af.DstAlpha = parseAlphaNumbers(a, 2, 255, 0)
+			af.SrcAlpha, af.DstAlpha = parseAlphaNumbers(a, 2, 255, 0) // Mugen defaults to 0 here
 
 		case len(a) >= 2 && a[:2] == "ss": // Sub with alpha
 			af.TransType = TT_sub
-			af.SrcAlpha, af.DstAlpha = parseAlphaNumbers(a, 2, 255, 0)
+			af.SrcAlpha, af.DstAlpha = parseAlphaNumbers(a, 2, 255, 255) // This is new so we can default properly
 
 		case len(a) >= 1 && a[0] == 'a': // Plain Add
 			af.TransType = TT_add
@@ -148,19 +161,19 @@ func ReadAnimFrame(line string) (*AnimFrame, error) {
 			// The first letter is enough in Mugen, but we will warn to encourage proper syntax
 			// https://github.com/ikemen-engine/Ikemen-GO/issues/3717
 			if len(a) > 1 {
-				err = Error(fmt.Sprintf("Invalid animation element transparency: %v", a))
+				transErr(a)
 			}
 
-		case len(a) >= 1 && a[0] == 's': // Plain sub
+		case len(a) >= 1 && a[0] == 's': // Plain Sub
 			af.TransType = TT_sub
 			af.SrcAlpha = 255
 			af.DstAlpha = 255
 			if len(a) > 1 {
-				err = Error(fmt.Sprintf("Invalid animation element transparency: %v", a))
+				transErr(a)
 			}
 
 		default:
-			err = Error(fmt.Sprintf("Invalid animation element transparency: %v", a))
+			transErr(a)
 		}
 	}
 

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -8308,6 +8308,11 @@ func (c *CharCompiler) Compile(pn int, def string, constants map[string]float32)
 			}
 		}
 
+		// Apply backward compatibiliy quirks
+		if sys.cgi[pn].ikemenver[0] == 0 && sys.cgi[pn].ikemenver[1] == 0 {
+			cm.ApplyBackwardCompatibility(pn)
+		}
+
 		c.cmdl.Add(*cm)
 	}
 

--- a/src/font.go
+++ b/src/font.go
@@ -20,7 +20,7 @@ type FontRenderer interface {
 
 type Font interface {
 	SetColor(red float32, green float32, blue float32, alpha float32)
-	SetPalFX(neg bool, gray float32, add, mul [3]float32, hue float32)
+	SetPalFX(pfxstate PalFXState)
 	UpdateResolution(windowWidth int, windowHeight int)
 	Printf(x, y float32, xscl, yscl float32, spacingXAdd float32, align int32, blend bool, window [4]int32,
 		rxadd float32, rot Rotation, projectionMode int32, fLength float32, rcx, rcy float32,
@@ -64,7 +64,7 @@ type FntCharImage struct {
 // TtfFont implements TTF font rendering on supported platforms
 type TtfFont interface {
 	SetColor(red float32, green float32, blue float32, alpha float32)
-	SetPalFX(neg bool, gray float32, add, mul [3]float32, hue float32)
+	SetPalFX(pfxstate PalFXState)
 	Width(scale float32, spacingXAdd float32, fs string, argv ...interface{}) float32
 	Printf(x, y float32, xscl, yscl float32, spacingXAdd float32, align int32, blend bool, window [4]int32,
 		rxadd float32, rot Rotation, projectionMode int32, fLength float32, rcx, rcy float32,
@@ -735,12 +735,16 @@ func (f *Fnt) DrawTtf(txt string, x, y, xscl, yscl, rxadd float32, rot Rotation,
 		blendMode = TT_add
 	}
 	alphaVal := int32(255 * Clamp(frgba[3], float32(0), float32(1)))
+
+	var pfxstate PalFXState
+
 	if palfx != nil {
-		neg, grayscale, add, mul, _, hue := palfx.getFinalPalFx(blendMode, [2]int32{alphaVal, 255 - alphaVal})
-		f.ttf.SetPalFX(neg, grayscale, add, mul, hue)
+		pfxstate = palfx.getFinalPalFx(blendMode, [2]int32{alphaVal, 255 - alphaVal})
 	} else {
-		f.ttf.SetPalFX(false, 0, [3]float32{0, 0, 0}, [3]float32{1, 1, 1}, 0)
+		pfxstate = NewPalFXState()
 	}
+	f.ttf.SetPalFX(pfxstate)
+
 	f.ttf.SetColor(frgba[0], frgba[1], frgba[2], frgba[3])
 	f.ttf.Printf(x, y, xscl, yscl, spacingXAdd, align, blend, *window,
 		rxadd, rot, projectionMode, fLength, x, y,

--- a/src/font.go
+++ b/src/font.go
@@ -20,7 +20,7 @@ type FontRenderer interface {
 
 type Font interface {
 	SetColor(red float32, green float32, blue float32, alpha float32)
-	SetPalFX(pfxstate PalFXState)
+	SetPalFX(spfx ShaderPalFX)
 	UpdateResolution(windowWidth int, windowHeight int)
 	Printf(x, y float32, xscl, yscl float32, spacingXAdd float32, align int32, blend bool, window [4]int32,
 		rxadd float32, rot Rotation, projectionMode int32, fLength float32, rcx, rcy float32,
@@ -64,7 +64,7 @@ type FntCharImage struct {
 // TtfFont implements TTF font rendering on supported platforms
 type TtfFont interface {
 	SetColor(red float32, green float32, blue float32, alpha float32)
-	SetPalFX(pfxstate PalFXState)
+	SetPalFX(spfx ShaderPalFX)
 	Width(scale float32, spacingXAdd float32, fs string, argv ...interface{}) float32
 	Printf(x, y float32, xscl, yscl float32, spacingXAdd float32, align int32, blend bool, window [4]int32,
 		rxadd float32, rot Rotation, projectionMode int32, fLength float32, rcx, rcy float32,
@@ -736,14 +736,14 @@ func (f *Fnt) DrawTtf(txt string, x, y, xscl, yscl, rxadd float32, rot Rotation,
 	}
 	alphaVal := int32(255 * Clamp(frgba[3], float32(0), float32(1)))
 
-	var pfxstate PalFXState
+	var spfx ShaderPalFX
 
 	if palfx != nil {
-		pfxstate = palfx.getFinalPalFx(blendMode, [2]int32{alphaVal, 255 - alphaVal})
+		spfx = palfx.getFinalPalFx(blendMode, [2]int32{alphaVal, 255 - alphaVal})
 	} else {
-		pfxstate = NewPalFXState()
+		spfx = NewShaderPalFX()
 	}
-	f.ttf.SetPalFX(pfxstate)
+	f.ttf.SetPalFX(spfx)
 
 	f.ttf.SetColor(frgba[0], frgba[1], frgba[2], frgba[3])
 	f.ttf.Printf(x, y, xscl, yscl, spacingXAdd, align, blend, *window,

--- a/src/font_gl33.go
+++ b/src/font_gl33.go
@@ -25,11 +25,7 @@ type Font_GL33 struct {
 	windowHeight int
 	textures     []*TextureAtlas
 	color        color
-	palfxAdd     [3]float32
-	palfxMul     [3]float32
-	palfxGray    float32
-	palfxHue     float32
-	palfxNeg     int32
+	palfxState   PalFXState
 }
 
 type FontRenderer_GL33 struct {
@@ -97,12 +93,8 @@ func (f *Font_GL33) SetColor(red float32, green float32, blue float32, alpha flo
 	f.color.a = alpha
 }
 
-func (f *Font_GL33) SetPalFX(neg bool, gray float32, add, mul [3]float32, hue float32) {
-	f.palfxAdd = add
-	f.palfxMul = mul
-	f.palfxGray = gray
-	f.palfxHue = hue
-	f.palfxNeg = int32(Btoi(neg))
+func (f *Font_GL33) SetPalFX(state PalFXState) {
+    f.palfxState = state
 }
 
 func (f *Font_GL33) UpdateResolution(windowWidth int, windowHeight int) {
@@ -165,11 +157,13 @@ func (f *Font_GL33) Printf(x, y float32, xscl, yscl float32, spacingXAdd float32
 
 	//set text color
 	r.SetUniformFSub(program.uniforms["textColor"], f.color.r, f.color.g, f.color.b, f.color.a)
-	r.SetUniformFSub(program.uniforms["palAdd"], f.palfxAdd[0], f.palfxAdd[1], f.palfxAdd[2])
-	r.SetUniformFSub(program.uniforms["palMul"], f.palfxMul[0], f.palfxMul[1], f.palfxMul[2])
-	r.SetUniformFSub(program.uniforms["palGray"], f.palfxGray)
-	r.SetUniformFSub(program.uniforms["palHue"], f.palfxHue)
-	r.SetUniformISub(program.uniforms["palNeg"], f.palfxNeg)
+
+	// Set PalFX uniforms
+	r.SetUniformFSub(program.uniforms["palAdd"], f.palfxState.add[0], f.palfxState.add[1], f.palfxState.add[2])
+	r.SetUniformFSub(program.uniforms["palMul"], f.palfxState.mult[0], f.palfxState.mult[1], f.palfxState.mult[2])
+	r.SetUniformFSub(program.uniforms["palGray"], f.palfxState.gray)
+	r.SetUniformFSub(program.uniforms["palHue"], f.palfxState.hue)
+	r.SetUniformISub(program.uniforms["palNeg"], int32(Btoi(f.palfxState.neg)))
 
 	//set screen resolution
 	r.SetUniformFSub(program.uniforms["resolution"], float32(f.windowWidth), float32(f.windowHeight))
@@ -501,7 +495,7 @@ func (r *FontRenderer_GL33) LoadTrueTypeFont(reader io.Reader, scale int32, low,
 	f.ttf = ttf
 	f.scale = scale
 	f.SetColor(1.0, 1.0, 1.0, 1.0) //set default white
-	f.SetPalFX(false, 0, [3]float32{0, 0, 0}, [3]float32{1, 1, 1}, 0)
+	f.SetPalFX(NewPalFXState())
 	f.textures = append(f.textures, CreateTextureAtlas(256, 256, 32, true))
 
 	err = f.GenerateGlyphs(low, high)

--- a/src/font_gl33.go
+++ b/src/font_gl33.go
@@ -25,7 +25,7 @@ type Font_GL33 struct {
 	windowHeight int
 	textures     []*TextureAtlas
 	color        color
-	palfxState   PalFXState
+	shaderPalFX  ShaderPalFX
 }
 
 type FontRenderer_GL33 struct {
@@ -93,8 +93,8 @@ func (f *Font_GL33) SetColor(red float32, green float32, blue float32, alpha flo
 	f.color.a = alpha
 }
 
-func (f *Font_GL33) SetPalFX(state PalFXState) {
-    f.palfxState = state
+func (f *Font_GL33) SetPalFX(state ShaderPalFX) {
+    f.shaderPalFX = state
 }
 
 func (f *Font_GL33) UpdateResolution(windowWidth int, windowHeight int) {
@@ -159,11 +159,11 @@ func (f *Font_GL33) Printf(x, y float32, xscl, yscl float32, spacingXAdd float32
 	r.SetUniformFSub(program.uniforms["textColor"], f.color.r, f.color.g, f.color.b, f.color.a)
 
 	// Set PalFX uniforms
-	r.SetUniformFSub(program.uniforms["palAdd"], f.palfxState.add[0], f.palfxState.add[1], f.palfxState.add[2])
-	r.SetUniformFSub(program.uniforms["palMul"], f.palfxState.mult[0], f.palfxState.mult[1], f.palfxState.mult[2])
-	r.SetUniformFSub(program.uniforms["palGray"], f.palfxState.gray)
-	r.SetUniformFSub(program.uniforms["palHue"], f.palfxState.hue)
-	r.SetUniformISub(program.uniforms["palNeg"], int32(Btoi(f.palfxState.neg)))
+	r.SetUniformFSub(program.uniforms["palAdd"], f.shaderPalFX.add[0], f.shaderPalFX.add[1], f.shaderPalFX.add[2])
+	r.SetUniformFSub(program.uniforms["palMul"], f.shaderPalFX.mult[0], f.shaderPalFX.mult[1], f.shaderPalFX.mult[2])
+	r.SetUniformFSub(program.uniforms["palGray"], f.shaderPalFX.gray)
+	r.SetUniformFSub(program.uniforms["palHue"], f.shaderPalFX.hue)
+	r.SetUniformISub(program.uniforms["palNeg"], int32(Btoi(f.shaderPalFX.neg)))
 
 	//set screen resolution
 	r.SetUniformFSub(program.uniforms["resolution"], float32(f.windowWidth), float32(f.windowHeight))
@@ -495,7 +495,7 @@ func (r *FontRenderer_GL33) LoadTrueTypeFont(reader io.Reader, scale int32, low,
 	f.ttf = ttf
 	f.scale = scale
 	f.SetColor(1.0, 1.0, 1.0, 1.0) //set default white
-	f.SetPalFX(NewPalFXState())
+	f.SetPalFX(NewShaderPalFX())
 	f.textures = append(f.textures, CreateTextureAtlas(256, 256, 32, true))
 
 	err = f.GenerateGlyphs(low, high)

--- a/src/font_gles32.go
+++ b/src/font_gles32.go
@@ -26,7 +26,7 @@ type Font_GLES32 struct {
 	windowHeight int
 	textures     []*TextureAtlas
 	color        color
-	palfxState   PalFXState
+	shaderPalFX  ShaderPalFX
 }
 
 type FontRenderer_GLES32 struct {
@@ -91,8 +91,8 @@ func (f *Font_GLES32) SetColor(red float32, green float32, blue float32, alpha f
 	f.color.a = alpha
 }
 
-func (f *Font_GLES32) SetPalFX(state PalFXState) {
-    f.palfxState = state
+func (f *Font_GLES32) SetPalFX(state ShaderPalFX) {
+    f.shaderPalFX = state
 }
 
 func (f *Font_GLES32) UpdateResolution(windowWidth int, windowHeight int) {
@@ -157,11 +157,11 @@ func (f *Font_GLES32) Printf(x, y float32, xscl, yscl float32, spacingXAdd float
 	r.SetUniformFSub(program.uniforms["textColor"], f.color.r, f.color.g, f.color.b, f.color.a)
 
 	// Set PalFX uniforms
-	r.SetUniformFSub(program.uniforms["palAdd"], f.palfxState.add[0], f.palfxState.add[1], f.palfxState.add[2])
-	r.SetUniformFSub(program.uniforms["palMul"], f.palfxState.mult[0], f.palfxState.mult[1], f.palfxState.mult[2])
-	r.SetUniformFSub(program.uniforms["palGray"], f.palfxState.gray)
-	r.SetUniformFSub(program.uniforms["palHue"], f.palfxState.hue)
-	r.SetUniformISub(program.uniforms["palNeg"], int32(Btoi(f.palfxState.neg)))
+	r.SetUniformFSub(program.uniforms["palAdd"], f.shaderPalFX.add[0], f.shaderPalFX.add[1], f.shaderPalFX.add[2])
+	r.SetUniformFSub(program.uniforms["palMul"], f.shaderPalFX.mult[0], f.shaderPalFX.mult[1], f.shaderPalFX.mult[2])
+	r.SetUniformFSub(program.uniforms["palGray"], f.shaderPalFX.gray)
+	r.SetUniformFSub(program.uniforms["palHue"], f.shaderPalFX.hue)
+	r.SetUniformISub(program.uniforms["palNeg"], int32(Btoi(f.shaderPalFX.neg)))
 
 	//set screen resolution
 	r.SetUniformFSub(program.uniforms["resolution"], float32(f.windowWidth), float32(f.windowHeight))
@@ -502,7 +502,7 @@ func (r *FontRenderer_GLES32) LoadTrueTypeFont(reader io.Reader, scale int32, lo
 	f.ttf = ttf
 	f.scale = scale
 	f.SetColor(1.0, 1.0, 1.0, 1.0) //set default white
-	f.SetPalFX(NewPalFXState())
+	f.SetPalFX(NewShaderPalFX())
 	f.textures = append(f.textures, CreateTextureAtlas(256, 256, 32, true))
 
 	err = f.GenerateGlyphs(low, high)

--- a/src/font_gles32.go
+++ b/src/font_gles32.go
@@ -26,11 +26,7 @@ type Font_GLES32 struct {
 	windowHeight int
 	textures     []*TextureAtlas
 	color        color
-	palfxAdd     [3]float32
-	palfxMul     [3]float32
-	palfxGray    float32
-	palfxHue     float32
-	palfxNeg     int32
+	palfxState   PalFXState
 }
 
 type FontRenderer_GLES32 struct {
@@ -95,12 +91,8 @@ func (f *Font_GLES32) SetColor(red float32, green float32, blue float32, alpha f
 	f.color.a = alpha
 }
 
-func (f *Font_GLES32) SetPalFX(neg bool, gray float32, add, mul [3]float32, hue float32) {
-	f.palfxAdd = add
-	f.palfxMul = mul
-	f.palfxGray = gray
-	f.palfxHue = hue
-	f.palfxNeg = int32(Btoi(neg))
+func (f *Font_GLES32) SetPalFX(state PalFXState) {
+    f.palfxState = state
 }
 
 func (f *Font_GLES32) UpdateResolution(windowWidth int, windowHeight int) {
@@ -163,11 +155,13 @@ func (f *Font_GLES32) Printf(x, y float32, xscl, yscl float32, spacingXAdd float
 
 	//set text color
 	r.SetUniformFSub(program.uniforms["textColor"], f.color.r, f.color.g, f.color.b, f.color.a)
-	r.SetUniformFSub(program.uniforms["palAdd"], f.palfxAdd[0], f.palfxAdd[1], f.palfxAdd[2])
-	r.SetUniformFSub(program.uniforms["palMul"], f.palfxMul[0], f.palfxMul[1], f.palfxMul[2])
-	r.SetUniformFSub(program.uniforms["palGray"], f.palfxGray)
-	r.SetUniformFSub(program.uniforms["palHue"], f.palfxHue)
-	r.SetUniformISub(program.uniforms["palNeg"], f.palfxNeg)
+
+	// Set PalFX uniforms
+	r.SetUniformFSub(program.uniforms["palAdd"], f.palfxState.add[0], f.palfxState.add[1], f.palfxState.add[2])
+	r.SetUniformFSub(program.uniforms["palMul"], f.palfxState.mult[0], f.palfxState.mult[1], f.palfxState.mult[2])
+	r.SetUniformFSub(program.uniforms["palGray"], f.palfxState.gray)
+	r.SetUniformFSub(program.uniforms["palHue"], f.palfxState.hue)
+	r.SetUniformISub(program.uniforms["palNeg"], int32(Btoi(f.palfxState.neg)))
 
 	//set screen resolution
 	r.SetUniformFSub(program.uniforms["resolution"], float32(f.windowWidth), float32(f.windowHeight))
@@ -508,7 +502,7 @@ func (r *FontRenderer_GLES32) LoadTrueTypeFont(reader io.Reader, scale int32, lo
 	f.ttf = ttf
 	f.scale = scale
 	f.SetColor(1.0, 1.0, 1.0, 1.0) //set default white
-	f.SetPalFX(false, 0, [3]float32{0, 0, 0}, [3]float32{1, 1, 1}, 0)
+	f.SetPalFX(NewPalFXState())
 	f.textures = append(f.textures, CreateTextureAtlas(256, 256, 32, true))
 
 	err = f.GenerateGlyphs(low, high)

--- a/src/font_vk.go
+++ b/src/font_vk.go
@@ -29,15 +29,12 @@ type Font_VK struct {
 	vbo         uint32
 	program     uint32
 	color       color
-	palfxAdd    [3]float32
-	palfxMul    [3]float32
-	palfxGray   float32
-	palfxHue    float32
-	palfxNeg    float32
+	palfxState   PalFXState
 	resolution  [2]float32
 	textures    []*TextureAtlas
 	descriptors []*list.Element
 }
+
 type FontRenderer_VK struct {
 	device          vk.Device
 	program         *VulkanProgramInfo
@@ -539,7 +536,7 @@ func (r *FontRenderer_VK) LoadTrueTypeFont(reader io.Reader, scale int32, low, h
 	f.ttf = ttf
 	f.scale = scale
 	f.SetColor(1.0, 1.0, 1.0, 1.0) //set default white
-	f.SetPalFX(false, 0, [3]float32{0, 0, 0}, [3]float32{1, 1, 1}, 0)
+	f.SetPalFX(NewPalFXState())
 	f.textures = append(f.textures, CreateTextureAtlas(256, 256, 8, true))
 	descriptorSet := r.freeDescriptors.Front()
 	r.freeDescriptors.Remove(descriptorSet)
@@ -577,18 +574,17 @@ func (f *Font_VK) SetColor(red float32, green float32, blue float32, alpha float
 	f.color.a = alpha
 	return
 }
-func (f *Font_VK) SetPalFX(neg bool, gray float32, add, mul [3]float32, hue float32) {
-	f.palfxAdd = add
-	f.palfxMul = mul
-	f.palfxGray = gray
-	f.palfxHue = hue
-	f.palfxNeg = float32(Btoi(neg))
+
+func (f *Font_VK) SetPalFX(state PalFXState) {
+    f.palfxState = state
 }
+
 func (f *Font_VK) UpdateResolution(windowWidth int, windowHeight int) {
 	f.resolution[0] = float32(windowWidth)
 	f.resolution[1] = float32(windowHeight)
 	return
 }
+
 func (f *Font_VK) Printf(x, y float32, xscl, yscl float32, spacingXAdd float32, align int32, blend bool, window [4]int32,
 	rxadd float32, rot Rotation, projectionMode int32, fLength float32, rcx, rcy float32,
 	fs string, argv ...interface{}) error {
@@ -646,9 +642,9 @@ func (f *Font_VK) Printf(x, y float32, xscl, yscl float32, spacingXAdd float32, 
 	vk.CmdSetViewport(r.commandBuffers[0], 0, 1, viewports)
 	vk.CmdSetScissor(r.commandBuffers[0], 0, 1, scissors)
 	color := f.color
-	palAddGray := [4]float32{f.palfxAdd[0], f.palfxAdd[1], f.palfxAdd[2], f.palfxGray}
-	palMulHue := [4]float32{f.palfxMul[0], f.palfxMul[1], f.palfxMul[2], f.palfxHue}
-	palNegPad := [4]float32{f.palfxNeg, 0, 0, 0}
+	palAddGray := [4]float32{f.palfxState.add[0], f.palfxState.add[1], f.palfxState.add[2], f.palfxState.gray}
+	palMulHue := [4]float32{f.palfxState.mult[0], f.palfxState.mult[1], f.palfxState.mult[2], f.palfxState.hue}
+	palNegPad := [4]float32{float32(Btoi(f.palfxState.neg)), 0, 0, 0}
 	resolution := f.resolution
 	vk.CmdPushConstants(r.commandBuffers[0], gfxFont.(*FontRenderer_VK).program.pipelineLayout, vk.ShaderStageFlags(vk.ShaderStageFragmentBit), 0, 4*4, unsafe.Pointer(&color))
 	vk.CmdPushConstants(r.commandBuffers[0], gfxFont.(*FontRenderer_VK).program.pipelineLayout, vk.ShaderStageFlags(vk.ShaderStageFragmentBit), 4*4, 4*4, unsafe.Pointer(&palAddGray[0]))

--- a/src/font_vk.go
+++ b/src/font_vk.go
@@ -29,7 +29,7 @@ type Font_VK struct {
 	vbo         uint32
 	program     uint32
 	color       color
-	palfxState   PalFXState
+	shaderPalFX ShaderPalFX
 	resolution  [2]float32
 	textures    []*TextureAtlas
 	descriptors []*list.Element
@@ -536,7 +536,7 @@ func (r *FontRenderer_VK) LoadTrueTypeFont(reader io.Reader, scale int32, low, h
 	f.ttf = ttf
 	f.scale = scale
 	f.SetColor(1.0, 1.0, 1.0, 1.0) //set default white
-	f.SetPalFX(NewPalFXState())
+	f.SetPalFX(NewShaderPalFX())
 	f.textures = append(f.textures, CreateTextureAtlas(256, 256, 8, true))
 	descriptorSet := r.freeDescriptors.Front()
 	r.freeDescriptors.Remove(descriptorSet)
@@ -575,8 +575,8 @@ func (f *Font_VK) SetColor(red float32, green float32, blue float32, alpha float
 	return
 }
 
-func (f *Font_VK) SetPalFX(state PalFXState) {
-    f.palfxState = state
+func (f *Font_VK) SetPalFX(state ShaderPalFX) {
+    f.shaderPalFX = state
 }
 
 func (f *Font_VK) UpdateResolution(windowWidth int, windowHeight int) {
@@ -642,9 +642,9 @@ func (f *Font_VK) Printf(x, y float32, xscl, yscl float32, spacingXAdd float32, 
 	vk.CmdSetViewport(r.commandBuffers[0], 0, 1, viewports)
 	vk.CmdSetScissor(r.commandBuffers[0], 0, 1, scissors)
 	color := f.color
-	palAddGray := [4]float32{f.palfxState.add[0], f.palfxState.add[1], f.palfxState.add[2], f.palfxState.gray}
-	palMulHue := [4]float32{f.palfxState.mult[0], f.palfxState.mult[1], f.palfxState.mult[2], f.palfxState.hue}
-	palNegPad := [4]float32{float32(Btoi(f.palfxState.neg)), 0, 0, 0}
+	palAddGray := [4]float32{f.shaderPalFX.add[0], f.shaderPalFX.add[1], f.shaderPalFX.add[2], f.shaderPalFX.gray}
+	palMulHue := [4]float32{f.shaderPalFX.mult[0], f.shaderPalFX.mult[1], f.shaderPalFX.mult[2], f.shaderPalFX.hue}
+	palNegPad := [4]float32{float32(Btoi(f.shaderPalFX.neg)), 0, 0, 0}
 	resolution := f.resolution
 	vk.CmdPushConstants(r.commandBuffers[0], gfxFont.(*FontRenderer_VK).program.pipelineLayout, vk.ShaderStageFlags(vk.ShaderStageFragmentBit), 0, 4*4, unsafe.Pointer(&color))
 	vk.CmdPushConstants(r.commandBuffers[0], gfxFont.(*FontRenderer_VK).program.pipelineLayout, vk.ShaderStageFlags(vk.ShaderStageFragmentBit), 4*4, 4*4, unsafe.Pointer(&palAddGray[0]))

--- a/src/image.go
+++ b/src/image.go
@@ -167,7 +167,7 @@ func (pf *PalFX) getFxPal(blendMode TransType, pal []uint32, neg bool) []uint32 
 	return sys.workpal
 }
 
-func (pf *PalFX) getFinalPalFx(blendMode TransType, alpha [2]int32) (state PalFXState) {
+func (pf *PalFX) getFinalPalFx(blendMode TransType, alpha [2]int32) (state ShaderPalFX) {
 	p := pf.getSynFx(blendMode, alpha)
 
 	if !p.enable {

--- a/src/image.go
+++ b/src/image.go
@@ -167,36 +167,33 @@ func (pf *PalFX) getFxPal(blendMode TransType, pal []uint32, neg bool) []uint32 
 	return sys.workpal
 }
 
-func (pf *PalFX) getFinalPalFx(blendMode TransType, alpha [2]int32) (neg bool, grayscale float32,
-	add, mul [3]float32, invblend int32, hue float32) {
-
+func (pf *PalFX) getFinalPalFx(blendMode TransType, alpha [2]int32) (state PalFXState) {
 	p := pf.getSynFx(blendMode, alpha)
+
 	if !p.enable {
-		neg = false
-		grayscale = 0
-		for i := range add {
-			add[i] = 0
-		}
-		for i := range mul {
-			mul[i] = 1
-		}
+		state.neg = false
+		state.gray = 0
+		state.add = [3]float32{0, 0, 0}
+		state.mult = [3]float32{1, 1, 1}
+		state.hue = 0
+		state.invblend = 0
 		return
 	}
-	neg = p.eInvertall
-	grayscale = 1 - p.eColor
-	invblend = p.eInvertblend
-	hue = p.eHue
+
+	state.neg = p.eInvertall
+	state.gray = 1 - p.eColor
+	state.invblend = p.eInvertblend
+	state.hue = p.eHue
 
 	// Determine if we use negative color math based on blendMode
 	useNeg := blendMode == TT_sub && p.eAllowNeg
 
 	for i, v := range p.eAdd {
-		add[i] = float32(v) / 255
+		state.add[i] = float32(v) / 255
 		if useNeg {
-			//add[i] *= -1
-			mul[i] = float32(p.eMul[(i+1)%3]+p.eMul[(i+2)%3]) / 512
+			state.mult[i] = float32(p.eMul[(i+1)%3]+p.eMul[(i+2)%3]) / 512
 		} else {
-			mul[i] = float32(p.eMul[i]) / 256
+			state.mult[i] = float32(p.eMul[i]) / 256
 		}
 	}
 	return

--- a/src/input.go
+++ b/src/input.go
@@ -2355,6 +2355,67 @@ func (c *Command) AutoGreaterExpand() {
 	c.steps = newCmd
 }
 
+// Regress some Ikemen features that may break legacy characters
+// To keep branching to a minimum, we ought to only fix cases that prevent a move from coming out at all
+func (c *Command) ApplyBackwardCompatibility(pn int) {
+	// Helper to log any changes
+	doPrint := func(msg string) {
+		fullMsg := fmt.Sprintf("WARNING: Player %s: command '%s' compatibility: ", sys.cgi[pn].name, c.name) + msg
+		// Print to both places because these characters tend to flood the console with other bugs
+		sys.appendToConsole(fullMsg)
+		LogMessage(fullMsg)
+	}
+
+	// Expand '/' to all elements in the same step ("/x+y" becomes "/x+/y")
+	// https://github.com/ikemen-engine/Ikemen-GO/issues/2922
+	slashModified := false
+	for i := range c.steps {
+		step := &c.steps[i]
+		if step.orLogic {
+			continue // Didn't exist in Mugen
+		}
+		hasSlash := false
+		for _, k := range step.keys {
+			if k.slash {
+				hasSlash = true
+				break
+			}
+		}
+		if hasSlash {
+			for j := range step.keys {
+				if !step.keys[j].slash {
+					step.keys[j].slash = true
+					slashModified = true
+				}
+			}
+		}
+	}
+	if slashModified {
+		doPrint("slash propagated to whole step")
+	}
+
+	// Force buffer time of 1 for "hold-only commands"
+	// https://github.com/ikemen-engine/Ikemen-GO/issues/2235
+	if len(c.steps) > 0 {
+		holdOnly := true
+		for _, step := range c.steps {
+			for _, k := range step.keys {
+				if !k.slash {
+					holdOnly = false
+					break
+				}
+			}
+			if !holdOnly {
+				break
+			}
+		}
+		if holdOnly && c.maxbuftime != 1 {
+			c.maxbuftime = 1
+			doPrint("buffer time forced to 1")
+		}
+	}
+}
+
 func (c *Command) Clear(bufreset bool) {
 	c.curtime = 0
 	c.cursteptime = 0

--- a/src/model.go
+++ b/src/model.go
@@ -1843,36 +1843,36 @@ func drawNode(mdl *Model, scene *Scene, layerNumber int, defaultLayerNumber int,
 		alpha = [2]int32{255, 0}
 	}
 
-	pfxstate := mdl.pfx.getFinalPalFx(blendMode, alpha)
+	spfx := mdl.pfx.getFinalPalFx(blendMode, alpha)
 
 	blendEq := BlendAdd
 	src := BlendOne
 	dst := BlendOneMinusSrcAlpha
 	switch n.trans {
 	case TransAdd:
-		if pfxstate.invblend == 3 {
+		if spfx.invblend == 3 {
 			src = BlendOne
 			dst = BlendOne
 			blendEq = BlendReverseSubtract
-			pfxstate.neg = false
-			if pfxstate.invblend >= 1 {
-				pfxstate.add[0] = -pfxstate.add[0]
-				pfxstate.add[1] = -pfxstate.add[1]
-				pfxstate.add[2] = -pfxstate.add[2]
+			spfx.neg = false
+			if spfx.invblend >= 1 {
+				spfx.add[0] = -spfx.add[0]
+				spfx.add[1] = -spfx.add[1]
+				spfx.add[2] = -spfx.add[2]
 			}
 		} else {
 			src = BlendOne
 			dst = BlendOne
 		}
 	case TransReverseSubtract:
-		if pfxstate.invblend == 3 {
+		if spfx.invblend == 3 {
 			src = BlendOne
 			dst = BlendOne
-			pfxstate.neg = false
-			if pfxstate.invblend >= 1 {
-				pfxstate.add[0] = -pfxstate.add[0]
-				pfxstate.add[1] = -pfxstate.add[1]
-				pfxstate.add[2] = -pfxstate.add[2]
+			spfx.neg = false
+			if spfx.invblend >= 1 {
+				spfx.add[0] = -spfx.add[0]
+				spfx.add[1] = -spfx.add[1]
+				spfx.add[2] = -spfx.add[2]
 			}
 		} else {
 			src = BlendOne
@@ -1880,11 +1880,11 @@ func drawNode(mdl *Model, scene *Scene, layerNumber int, defaultLayerNumber int,
 			blendEq = BlendReverseSubtract
 		}
 	case TransMul:
-		if pfxstate.invblend == 3 {
+		if spfx.invblend == 3 {
 			//Not accurate
 			src = BlendOneMinusDstColor
 			dst = BlendOne
-			pfxstate.neg = false
+			spfx.neg = false
 			blendEq = BlendReverseSubtract
 		} else {
 			src = BlendDstColor
@@ -1946,12 +1946,12 @@ func drawNode(mdl *Model, scene *Scene, layerNumber int, defaultLayerNumber int,
 			mode = 1 // Set mesh render mode to "lines"
 		}
 		gfx.SetModelUniformI("unlit", int(Btoi(unlit || mat.unlit)))
-		// Use pfxstate.add and pfxstate.mult (modified by invblend logic above)
-		gfx.SetModelUniformFv("add", pfxstate.add[:])
-		gfx.SetModelUniformFv("mult", []float32{pfxstate.mult[0] * sys.brightness, pfxstate.mult[1] * sys.brightness, pfxstate.mult[2] * sys.brightness})
-		gfx.SetModelUniformI("neg", int(Btoi(pfxstate.neg)))
-		gfx.SetModelUniformF("hue", pfxstate.hue)
-		gfx.SetModelUniformF("gray", pfxstate.gray)
+		// Use spfx.add and spfx.mult (modified by invblend logic above)
+		gfx.SetModelUniformFv("add", spfx.add[:])
+		gfx.SetModelUniformFv("mult", []float32{spfx.mult[0] * sys.brightness, spfx.mult[1] * sys.brightness, spfx.mult[2] * sys.brightness})
+		gfx.SetModelUniformI("neg", int(Btoi(spfx.neg)))
+		gfx.SetModelUniformF("hue", spfx.hue)
+		gfx.SetModelUniformF("gray", spfx.gray)
 		gfx.SetModelUniformI("enableAlpha", int(Btoi(mat.alphaMode == AlphaModeBlend)))
 		gfx.SetModelUniformF("alphaThreshold", mat.alphaCutoff.getValue().(float32))
 		gfx.SetModelUniformFv("baseColorFactor", color[:])

--- a/src/model.go
+++ b/src/model.go
@@ -1843,36 +1843,36 @@ func drawNode(mdl *Model, scene *Scene, layerNumber int, defaultLayerNumber int,
 		alpha = [2]int32{255, 0}
 	}
 
-	neg, grayscale, padd, pmul, invblend, hue := mdl.pfx.getFinalPalFx(blendMode, alpha)
+	pfxstate := mdl.pfx.getFinalPalFx(blendMode, alpha)
 
 	blendEq := BlendAdd
 	src := BlendOne
 	dst := BlendOneMinusSrcAlpha
 	switch n.trans {
 	case TransAdd:
-		if invblend == 3 {
+		if pfxstate.invblend == 3 {
 			src = BlendOne
 			dst = BlendOne
 			blendEq = BlendReverseSubtract
-			neg = false
-			if invblend >= 1 {
-				padd[0] = -padd[0]
-				padd[1] = -padd[1]
-				padd[2] = -padd[2]
+			pfxstate.neg = false
+			if pfxstate.invblend >= 1 {
+				pfxstate.add[0] = -pfxstate.add[0]
+				pfxstate.add[1] = -pfxstate.add[1]
+				pfxstate.add[2] = -pfxstate.add[2]
 			}
 		} else {
 			src = BlendOne
 			dst = BlendOne
 		}
 	case TransReverseSubtract:
-		if invblend == 3 {
+		if pfxstate.invblend == 3 {
 			src = BlendOne
 			dst = BlendOne
-			neg = false
-			if invblend >= 1 {
-				padd[0] = -padd[0]
-				padd[1] = -padd[1]
-				padd[2] = -padd[2]
+			pfxstate.neg = false
+			if pfxstate.invblend >= 1 {
+				pfxstate.add[0] = -pfxstate.add[0]
+				pfxstate.add[1] = -pfxstate.add[1]
+				pfxstate.add[2] = -pfxstate.add[2]
 			}
 		} else {
 			src = BlendOne
@@ -1880,11 +1880,11 @@ func drawNode(mdl *Model, scene *Scene, layerNumber int, defaultLayerNumber int,
 			blendEq = BlendReverseSubtract
 		}
 	case TransMul:
-		if invblend == 3 {
+		if pfxstate.invblend == 3 {
 			//Not accurate
 			src = BlendOneMinusDstColor
 			dst = BlendOne
-			neg = false
+			pfxstate.neg = false
 			blendEq = BlendReverseSubtract
 		} else {
 			src = BlendDstColor
@@ -1946,11 +1946,12 @@ func drawNode(mdl *Model, scene *Scene, layerNumber int, defaultLayerNumber int,
 			mode = 1 // Set mesh render mode to "lines"
 		}
 		gfx.SetModelUniformI("unlit", int(Btoi(unlit || mat.unlit)))
-		gfx.SetModelUniformFv("add", padd[:])
-		gfx.SetModelUniformFv("mult", []float32{pmul[0] * sys.brightness, pmul[1] * sys.brightness, pmul[2] * sys.brightness})
-		gfx.SetModelUniformI("neg", int(Btoi(neg)))
-		gfx.SetModelUniformF("hue", hue)
-		gfx.SetModelUniformF("gray", grayscale)
+		// Use pfxstate.add and pfxstate.mult (modified by invblend logic above)
+		gfx.SetModelUniformFv("add", pfxstate.add[:])
+		gfx.SetModelUniformFv("mult", []float32{pfxstate.mult[0] * sys.brightness, pfxstate.mult[1] * sys.brightness, pfxstate.mult[2] * sys.brightness})
+		gfx.SetModelUniformI("neg", int(Btoi(pfxstate.neg)))
+		gfx.SetModelUniformF("hue", pfxstate.hue)
+		gfx.SetModelUniformF("gray", pfxstate.gray)
 		gfx.SetModelUniformI("enableAlpha", int(Btoi(mat.alphaMode == AlphaModeBlend)))
 		gfx.SetModelUniformF("alphaThreshold", mat.alphaCutoff.getValue().(float32))
 		gfx.SetModelUniformFv("baseColorFactor", color[:])
@@ -1992,7 +1993,6 @@ func drawNode(mdl *Model, scene *Scene, layerNumber int, defaultLayerNumber int,
 			gfx.SetMeshOutlinePipeline(!reverseCull, meshOutline*outlineConst)
 			gfx.RenderElements(mode, int(p.numIndices), int(p.elementBufferOffset))
 		}
-
 	}
 }
 

--- a/src/render.go
+++ b/src/render.go
@@ -606,9 +606,16 @@ func RenderSprite(rp RenderParams) {
 	initRenderSpriteQuad(&rp)
 
 	// PalFX and color setup
-	neg, grayscale, padd, pmul, invblend, hue := false, float32(0), [3]float32{0, 0, 0}, [3]float32{1, 1, 1}, int32(0), float32(0)
+	pfxstate := PalFXState{
+		neg:      false,
+		add:      [3]float32{0, 0, 0},
+		mult:     [3]float32{1, 1, 1},
+		gray:     0,
+		hue:      0,
+		invblend: 0,
+	}
 	if rp.pfx != nil {
-		neg, grayscale, padd, pmul, invblend, hue = rp.pfx.getFinalPalFx(rp.blendMode, rp.blendAlpha)
+		pfxstate = rp.pfx.getFinalPalFx(rp.blendMode, rp.blendAlpha)
 	}
 
 	tint := [4]float32{
@@ -633,8 +640,8 @@ func RenderSprite(rp RenderParams) {
 	gfx.SetUniformI("mask", int(rp.mask))
 	gfx.SetUniformI("isTrapez", int(Btoi(Abs(Abs(rp.xts)-Abs(rp.xbs)) > 0.001)))
 
-	gfx.SetUniformF("gray", grayscale)
-	gfx.SetUniformF("hue", hue)
+	gfx.SetUniformF("gray", pfxstate.gray)
+	gfx.SetUniformF("hue", pfxstate.hue)
 	gfx.SetUniformFv("tint", tint[:])
 
 	if rp.paltex == nil {
@@ -676,24 +683,23 @@ func RenderSprite(rp RenderParams) {
 
 		// Dynamic uniforms
 		// We must include the parameters that renderWithBlending() may have changed
-		gfx.SetUniformI("neg", int(Btoi(neg)))
-		gfx.SetUniformFv("add", padd[:])
-		gfx.SetUniformFv("mult", pmul[:])
+		gfx.SetUniformI("neg", int(Btoi(pfxstate.neg)))
+		gfx.SetUniformFv("add", pfxstate.add[:])
+		gfx.SetUniformFv("mult", pfxstate.mult[:])
 		gfx.SetUniformF("alpha", a)
 
 		renderSpriteQuad(modelview, rp)
 	}
 
-	renderWithBlending(renderPass, rp.blendMode, rp.blendAlpha,
-		rp.paltex != nil, invblend, &neg, &padd, &pmul, rp.paltex == nil, grayscale)
+	renderWithBlending(renderPass, rp.blendMode, rp.blendAlpha, rp.paltex != nil, &pfxstate, rp.paltex == nil)
 
 	gfx.DisableScissor()
 }
 
 func renderWithBlending(
 	render func(eq BlendEquation, src, dst BlendFunc, a float32),
-	blendMode TransType, blendAlpha [2]int32, correctAlpha bool, invblend int32,
-	neg *bool, acolor *[3]float32, mcolor *[3]float32, isrgba bool, gray float32) {
+	blendMode TransType, blendAlpha [2]int32, correctAlpha bool,
+	pfxstate *PalFXState, isrgba bool) {
 
 	blendSourceFactor := BlendSrcAlpha
 	if !correctAlpha {
@@ -702,7 +708,7 @@ func renderWithBlending(
 
 	Blend := BlendAdd
 	BlendInv := BlendReverseSubtract
-	if invblend >= 1 {
+	if pfxstate.invblend >= 1 {
 		Blend = BlendReverseSubtract
 		BlendInv = BlendAdd
 	}
@@ -723,16 +729,12 @@ func renderWithBlending(
 	// Helpers for invertblend
 	// Invert PalFX add
 	invertAColor := func() {
-		if acolor != nil {
-			(*acolor)[0], (*acolor)[1], (*acolor)[2] = -acolor[0], -acolor[1], -acolor[2]
-		}
+		pfxstate.add[0], pfxstate.add[1], pfxstate.add[2] = -pfxstate.add[0], -pfxstate.add[1], -pfxstate.add[2]
 	}
 	// Disable the "neg" uniform, which the shader uses to invert colors
 	// We sometimes use this because subtractive transparency already inverts colors on its own, so it'd be a double negation
 	disableNeg := func() {
-		if neg != nil {
-			*neg = false
-		}
+		pfxstate.neg = false
 	}
 
 	// Proceed with the render calls
@@ -744,10 +746,10 @@ func renderWithBlending(
 			// Fully transparent. Skip render
 		case src == 1 && dst == 1:
 			// Fast path for full subtraction
-			if invblend >= 1 {
+			if pfxstate.invblend >= 1 {
 				invertAColor()
 			}
-			if invblend == 3 {
+			if pfxstate.invblend == 3 {
 				disableNeg()
 			}
 			render(BlendInv, blendSourceFactor, BlendOne, 1)
@@ -757,10 +759,10 @@ func renderWithBlending(
 				render(BlendAdd, BlendZero, BlendOneMinusSrcAlpha, 1-dst)
 			}
 			if src > 0 {
-				if invblend >= 1 {
+				if pfxstate.invblend >= 1 {
 					invertAColor()
 				}
-				if invblend == 3 {
+				if pfxstate.invblend == 3 {
 					disableNeg()
 				}
 				render(BlendInv, blendSourceFactor, BlendOne, src)
@@ -768,7 +770,7 @@ func renderWithBlending(
 		}
 	// SubAdd
 	case blendMode == TT_subadd:
-		if neg != nil && *neg {
+		if pfxstate.neg {
 			// With invertall we invert the passes. Add then sub
 			// This is kind of like "invblend = 3"
 			// But adding "invertblend" support here would force people to have to use it to get the expected results
@@ -779,7 +781,7 @@ func renderWithBlending(
 				render(BlendAdd, blendSourceFactor, BlendOne, dst)
 			}
 			if src > 0 {
-				gfx.SetUniformF("gray", gray)
+				gfx.SetUniformF("gray", pfxstate.gray)
 				render(BlendReverseSubtract, blendSourceFactor, BlendOne, src)
 			}
 		} else {
@@ -791,7 +793,7 @@ func renderWithBlending(
 			}
 			// Pass 2: additive, original grayscale, intensity = src
 			if src > 0 {
-				gfx.SetUniformF("gray", gray)
+				gfx.SetUniformF("gray", pfxstate.gray)
 				render(BlendAdd, blendSourceFactor, BlendOne, src)
 			}
 		}
@@ -807,10 +809,10 @@ func renderWithBlending(
 			render(BlendAdd, blendSourceFactor, BlendOneMinusSrcAlpha, 1)
 		case src == 1 && dst == 1:
 			// Fast path for full Add
-			if invblend >= 1 {
+			if pfxstate.invblend >= 1 {
 				invertAColor()
 			}
-			if invblend == 3 {
+			if pfxstate.invblend == 3 {
 				disableNeg()
 			}
 			render(Blend, blendSourceFactor, BlendOne, 1)
@@ -820,23 +822,23 @@ func renderWithBlending(
 				render(Blend, BlendZero, BlendOneMinusSrcAlpha, 1-dst)
 			}
 			if src > 0 {
-				if invblend >= 1 && dst == 1 {
+				if pfxstate.invblend >= 1 && dst == 1 {
 					Blend = BlendReverseSubtract
-					if invblend >= 2 { // Not 1 here. TODO: Explain why in comment
+					if pfxstate.invblend >= 2 { // Not 1 here. TODO: Explain why in comment
 						invertAColor()
 					}
-					if invblend == 3 {
+					if pfxstate.invblend == 3 {
 						disableNeg()
 					}
 				} else {
 					Blend = BlendAdd
 				}
-				if !isrgba && (invblend <= -1 || invblend >= 2) && acolor != nil && mcolor != nil && src < 1 {
+				if !isrgba && (pfxstate.invblend <= -1 || pfxstate.invblend >= 2) && src < 1 {
 					// Sum of add components
-					gc := Abs(acolor[0]) + Abs(acolor[1]) + Abs(acolor[2])
+					gc := Abs(pfxstate.add[0]) + Abs(pfxstate.add[1]) + Abs(pfxstate.add[2])
 					v3, ml, al := Max(255*(gc-(src+dst)), 512)/128, src, src+dst
-					rM, gM, bM := mcolor[0]*ml, mcolor[1]*ml, mcolor[2]*ml
-					(*mcolor)[0], (*mcolor)[1], (*mcolor)[2] = rM, gM, bM
+					rM, gM, bM := pfxstate.mult[0]*ml, pfxstate.mult[1]*ml, pfxstate.mult[2]*ml
+					pfxstate.mult[0], pfxstate.mult[1], pfxstate.mult[2] = rM, gM, bM
 					render(Blend, blendSourceFactor, BlendOne, al*Pow(v3, 3))
 				} else {
 					render(Blend, blendSourceFactor, BlendOne, src)
@@ -852,10 +854,17 @@ func FillRect(rect [4]int32, color uint32, alpha [2]int32, fx *PalFX) {
 	b := float32(color&0xff) / 255
 
 	// PalFX setup
-	neg, grayscale, padd, pmul, invblend, hue := false, float32(0), [3]float32{0, 0, 0}, [3]float32{1, 1, 1}, int32(0), float32(0)
+	pfxstate := PalFXState{
+		neg:      false,
+		add:      [3]float32{0, 0, 0},
+		mult:     [3]float32{1, 1, 1},
+		gray:     0,
+		hue:      0,
+		invblend: 0,
+	}
 
 	// This call is safe even if fx is nil. Defaults to just AllPalFX
-	neg, grayscale, padd, pmul, invblend, hue = fx.getFinalPalFx(TT_add, alpha)
+	pfxstate = fx.getFinalPalFx(TT_add, alpha)
 
 	modelview := mgl.Translate3D(0, float32(sys.scrrect[3]), 0)
 	proj := gfx.OrthographicProjectionMatrix(0, float32(sys.scrrect[2]), 0, float32(sys.scrrect[3]), -65535, 65535)
@@ -881,8 +890,8 @@ func FillRect(rect [4]int32, color uint32, alpha [2]int32, fx *PalFX) {
 	gfx.SetUniformI("isTrapez", 0)
 	gfx.SetUniformI("mask", 0)
 	gfx.SetUniformI("isRgba", 1)
-	gfx.SetUniformF("gray", grayscale)
-	gfx.SetUniformF("hue", hue)
+	gfx.SetUniformF("gray", pfxstate.gray)
+	gfx.SetUniformF("hue", pfxstate.hue)
 
 	// Alpha is determined by tint, so we reset it here
 	// TODO: Maybe the shader shouldn't have a duplicate alpha component inside "tint"
@@ -893,14 +902,14 @@ func FillRect(rect [4]int32, color uint32, alpha [2]int32, fx *PalFX) {
 		// Update only the dynamic state
 		gfx.EnableBlending(eq, src, dst)
 		gfx.SetUniformF("tint", r, g, b, a)
-		gfx.SetUniformI("neg", int(Btoi(neg)))
-		gfx.SetUniformFv("add", padd[:])
-		gfx.SetUniformFv("mult", pmul[:])
+		gfx.SetUniformI("neg", int(Btoi(pfxstate.neg)))
+		gfx.SetUniformFv("add", pfxstate.add[:])
+		gfx.SetUniformFv("mult", pfxstate.mult[:])
 
 		gfx.RenderQuad()
 	}
 
-	renderWithBlending(renderPass, TT_add, alpha, true, invblend, &neg, &padd, &pmul, true, grayscale)
+	renderWithBlending(renderPass, TT_add, alpha, true, &pfxstate, true)
 }
 
 type TextureAtlas struct {
@@ -1110,4 +1119,25 @@ func (ta *TextureAtlas) Resize(width, height int32) {
 	ta.height = height
 	ta.texture = t
 	return
+}
+
+// The PalFX parameters sent to the shaders
+type PalFXState struct {
+	neg      bool
+	add      [3]float32
+	mult     [3]float32
+	gray     float32
+	hue      float32
+	invblend int32
+}
+
+func NewPalFXState() PalFXState {
+	return PalFXState{
+		neg:      false,
+		add:      [3]float32{0, 0, 0},
+		mult:     [3]float32{1, 1, 1},
+		gray:     0,
+		hue:      0,
+		invblend: 0,
+	}
 }

--- a/src/render.go
+++ b/src/render.go
@@ -606,7 +606,7 @@ func RenderSprite(rp RenderParams) {
 	initRenderSpriteQuad(&rp)
 
 	// PalFX and color setup
-	pfxstate := PalFXState{
+	spfx := ShaderPalFX{
 		neg:      false,
 		add:      [3]float32{0, 0, 0},
 		mult:     [3]float32{1, 1, 1},
@@ -615,7 +615,7 @@ func RenderSprite(rp RenderParams) {
 		invblend: 0,
 	}
 	if rp.pfx != nil {
-		pfxstate = rp.pfx.getFinalPalFx(rp.blendMode, rp.blendAlpha)
+		spfx = rp.pfx.getFinalPalFx(rp.blendMode, rp.blendAlpha)
 	}
 
 	tint := [4]float32{
@@ -640,8 +640,8 @@ func RenderSprite(rp RenderParams) {
 	gfx.SetUniformI("mask", int(rp.mask))
 	gfx.SetUniformI("isTrapez", int(Btoi(Abs(Abs(rp.xts)-Abs(rp.xbs)) > 0.001)))
 
-	gfx.SetUniformF("gray", pfxstate.gray)
-	gfx.SetUniformF("hue", pfxstate.hue)
+	gfx.SetUniformF("gray", spfx.gray)
+	gfx.SetUniformF("hue", spfx.hue)
 	gfx.SetUniformFv("tint", tint[:])
 
 	if rp.paltex == nil {
@@ -683,15 +683,15 @@ func RenderSprite(rp RenderParams) {
 
 		// Dynamic uniforms
 		// We must include the parameters that renderWithBlending() may have changed
-		gfx.SetUniformI("neg", int(Btoi(pfxstate.neg)))
-		gfx.SetUniformFv("add", pfxstate.add[:])
-		gfx.SetUniformFv("mult", pfxstate.mult[:])
+		gfx.SetUniformI("neg", int(Btoi(spfx.neg)))
+		gfx.SetUniformFv("add", spfx.add[:])
+		gfx.SetUniformFv("mult", spfx.mult[:])
 		gfx.SetUniformF("alpha", a)
 
 		renderSpriteQuad(modelview, rp)
 	}
 
-	renderWithBlending(renderPass, rp.blendMode, rp.blendAlpha, rp.paltex != nil, &pfxstate, rp.paltex == nil)
+	renderWithBlending(renderPass, rp.blendMode, rp.blendAlpha, rp.paltex != nil, &spfx, rp.paltex == nil)
 
 	gfx.DisableScissor()
 }
@@ -699,7 +699,7 @@ func RenderSprite(rp RenderParams) {
 func renderWithBlending(
 	render func(eq BlendEquation, src, dst BlendFunc, a float32),
 	blendMode TransType, blendAlpha [2]int32, correctAlpha bool,
-	pfxstate *PalFXState, isrgba bool) {
+	spfx *ShaderPalFX, isrgba bool) {
 
 	blendSourceFactor := BlendSrcAlpha
 	if !correctAlpha {
@@ -708,7 +708,7 @@ func renderWithBlending(
 
 	Blend := BlendAdd
 	BlendInv := BlendReverseSubtract
-	if pfxstate.invblend >= 1 {
+	if spfx.invblend >= 1 {
 		Blend = BlendReverseSubtract
 		BlendInv = BlendAdd
 	}
@@ -729,12 +729,12 @@ func renderWithBlending(
 	// Helpers for invertblend
 	// Invert PalFX add
 	invertAColor := func() {
-		pfxstate.add[0], pfxstate.add[1], pfxstate.add[2] = -pfxstate.add[0], -pfxstate.add[1], -pfxstate.add[2]
+		spfx.add[0], spfx.add[1], spfx.add[2] = -spfx.add[0], -spfx.add[1], -spfx.add[2]
 	}
 	// Disable the "neg" uniform, which the shader uses to invert colors
 	// We sometimes use this because subtractive transparency already inverts colors on its own, so it'd be a double negation
 	disableNeg := func() {
-		pfxstate.neg = false
+		spfx.neg = false
 	}
 
 	// Proceed with the render calls
@@ -746,10 +746,10 @@ func renderWithBlending(
 			// Fully transparent. Skip render
 		case src == 1 && dst == 1:
 			// Fast path for full subtraction
-			if pfxstate.invblend >= 1 {
+			if spfx.invblend >= 1 {
 				invertAColor()
 			}
-			if pfxstate.invblend == 3 {
+			if spfx.invblend == 3 {
 				disableNeg()
 			}
 			render(BlendInv, blendSourceFactor, BlendOne, 1)
@@ -759,10 +759,10 @@ func renderWithBlending(
 				render(BlendAdd, BlendZero, BlendOneMinusSrcAlpha, 1-dst)
 			}
 			if src > 0 {
-				if pfxstate.invblend >= 1 {
+				if spfx.invblend >= 1 {
 					invertAColor()
 				}
-				if pfxstate.invblend == 3 {
+				if spfx.invblend == 3 {
 					disableNeg()
 				}
 				render(BlendInv, blendSourceFactor, BlendOne, src)
@@ -771,21 +771,21 @@ func renderWithBlending(
 	// SubAdd
 	case blendMode == TT_subadd:
 		// Save original state for later restoration
-		origState := *pfxstate
+		origState := *spfx
 
 		// Helper to set PalFX parameters to grayscale for the first pass
 		makeFxGrayscale := func() {
 			avgAdd := (origState.add[0] + origState.add[1] + origState.add[2]) / 3
-			pfxstate.add = [3]float32{avgAdd, avgAdd, avgAdd}
+			spfx.add = [3]float32{avgAdd, avgAdd, avgAdd}
 			avgMult := (origState.mult[0] + origState.mult[1] + origState.mult[2]) / 3
-			pfxstate.mult = [3]float32{avgMult, avgMult, avgMult}
+			spfx.mult = [3]float32{avgMult, avgMult, avgMult}
 		}
-		if pfxstate.neg {
+		if spfx.neg {
 			// With invertall we invert the passes. Add then sub
 			// This is kind of like "invblend = 3"
 			// But adding "invertblend" support here would force people to have to use it to get the expected results
 			// We avoid "neg" entirely because it turns black edges into white auras. But maybe allowing that would be more consistent?
-			disableNeg() // pfxstate.neg = false
+			disableNeg() // spfx.neg = false
 			//invertAColor()
 
 			// Pass 1: additive with gray PalFX
@@ -797,9 +797,9 @@ func renderWithBlending(
 			}
 			// Pass 2: subtractive with original PalFX
 			if src > 0 {
-				*pfxstate = origState
+				*spfx = origState
 				disableNeg() // Disable neg again because of the restore
-				gfx.SetUniformF("gray", pfxstate.gray)
+				gfx.SetUniformF("gray", spfx.gray)
 				render(BlendReverseSubtract, blendSourceFactor, BlendOne, src)
 			}
 		} else {
@@ -812,8 +812,8 @@ func renderWithBlending(
 			}
 			// Pass 2: additive with original PalFX
 			if src > 0 {
-				*pfxstate = origState
-				gfx.SetUniformF("gray", pfxstate.gray)
+				*spfx = origState
+				gfx.SetUniformF("gray", spfx.gray)
 				render(BlendAdd, blendSourceFactor, BlendOne, src)
 			}
 		}
@@ -829,10 +829,10 @@ func renderWithBlending(
 			render(BlendAdd, blendSourceFactor, BlendOneMinusSrcAlpha, 1)
 		case src == 1 && dst == 1:
 			// Fast path for full Add
-			if pfxstate.invblend >= 1 {
+			if spfx.invblend >= 1 {
 				invertAColor()
 			}
-			if pfxstate.invblend == 3 {
+			if spfx.invblend == 3 {
 				disableNeg()
 			}
 			render(Blend, blendSourceFactor, BlendOne, 1)
@@ -842,23 +842,23 @@ func renderWithBlending(
 				render(Blend, BlendZero, BlendOneMinusSrcAlpha, 1-dst)
 			}
 			if src > 0 {
-				if pfxstate.invblend >= 1 && dst == 1 {
+				if spfx.invblend >= 1 && dst == 1 {
 					Blend = BlendReverseSubtract
-					if pfxstate.invblend >= 2 { // Not 1 here. TODO: Explain why in comment
+					if spfx.invblend >= 2 { // Not 1 here. TODO: Explain why in comment
 						invertAColor()
 					}
-					if pfxstate.invblend == 3 {
+					if spfx.invblend == 3 {
 						disableNeg()
 					}
 				} else {
 					Blend = BlendAdd
 				}
-				if !isrgba && (pfxstate.invblend <= -1 || pfxstate.invblend >= 2) && src < 1 {
+				if !isrgba && (spfx.invblend <= -1 || spfx.invblend >= 2) && src < 1 {
 					// Sum of add components
-					gc := Abs(pfxstate.add[0]) + Abs(pfxstate.add[1]) + Abs(pfxstate.add[2])
+					gc := Abs(spfx.add[0]) + Abs(spfx.add[1]) + Abs(spfx.add[2])
 					v3, ml, al := Max(255*(gc-(src+dst)), 512)/128, src, src+dst
-					rM, gM, bM := pfxstate.mult[0]*ml, pfxstate.mult[1]*ml, pfxstate.mult[2]*ml
-					pfxstate.mult[0], pfxstate.mult[1], pfxstate.mult[2] = rM, gM, bM
+					rM, gM, bM := spfx.mult[0]*ml, spfx.mult[1]*ml, spfx.mult[2]*ml
+					spfx.mult[0], spfx.mult[1], spfx.mult[2] = rM, gM, bM
 					render(Blend, blendSourceFactor, BlendOne, al*Pow(v3, 3))
 				} else {
 					render(Blend, blendSourceFactor, BlendOne, src)
@@ -874,7 +874,7 @@ func FillRect(rect [4]int32, color uint32, alpha [2]int32, fx *PalFX) {
 	b := float32(color&0xff) / 255
 
 	// PalFX setup
-	pfxstate := PalFXState{
+	spfx := ShaderPalFX{
 		neg:      false,
 		add:      [3]float32{0, 0, 0},
 		mult:     [3]float32{1, 1, 1},
@@ -884,7 +884,7 @@ func FillRect(rect [4]int32, color uint32, alpha [2]int32, fx *PalFX) {
 	}
 
 	// This call is safe even if fx is nil. Defaults to just AllPalFX
-	pfxstate = fx.getFinalPalFx(TT_add, alpha)
+	spfx = fx.getFinalPalFx(TT_add, alpha)
 
 	modelview := mgl.Translate3D(0, float32(sys.scrrect[3]), 0)
 	proj := gfx.OrthographicProjectionMatrix(0, float32(sys.scrrect[2]), 0, float32(sys.scrrect[3]), -65535, 65535)
@@ -910,8 +910,8 @@ func FillRect(rect [4]int32, color uint32, alpha [2]int32, fx *PalFX) {
 	gfx.SetUniformI("isTrapez", 0)
 	gfx.SetUniformI("mask", 0)
 	gfx.SetUniformI("isRgba", 1)
-	gfx.SetUniformF("gray", pfxstate.gray)
-	gfx.SetUniformF("hue", pfxstate.hue)
+	gfx.SetUniformF("gray", spfx.gray)
+	gfx.SetUniformF("hue", spfx.hue)
 
 	// Alpha is determined by tint, so we reset it here
 	// TODO: Maybe the shader shouldn't have a duplicate alpha component inside "tint"
@@ -922,14 +922,14 @@ func FillRect(rect [4]int32, color uint32, alpha [2]int32, fx *PalFX) {
 		// Update only the dynamic state
 		gfx.EnableBlending(eq, src, dst)
 		gfx.SetUniformF("tint", r, g, b, a)
-		gfx.SetUniformI("neg", int(Btoi(pfxstate.neg)))
-		gfx.SetUniformFv("add", pfxstate.add[:])
-		gfx.SetUniformFv("mult", pfxstate.mult[:])
+		gfx.SetUniformI("neg", int(Btoi(spfx.neg)))
+		gfx.SetUniformFv("add", spfx.add[:])
+		gfx.SetUniformFv("mult", spfx.mult[:])
 
 		gfx.RenderQuad()
 	}
 
-	renderWithBlending(renderPass, TT_add, alpha, true, &pfxstate, true)
+	renderWithBlending(renderPass, TT_add, alpha, true, &spfx, true)
 }
 
 type TextureAtlas struct {
@@ -1141,8 +1141,8 @@ func (ta *TextureAtlas) Resize(width, height int32) {
 	return
 }
 
-// The PalFX parameters sent to the shaders
-type PalFXState struct {
+// The PalFX parameters sent to the shader uniforms
+type ShaderPalFX struct {
 	neg      bool
 	add      [3]float32
 	mult     [3]float32
@@ -1151,8 +1151,8 @@ type PalFXState struct {
 	invblend int32
 }
 
-func NewPalFXState() PalFXState {
-	return PalFXState{
+func NewShaderPalFX() ShaderPalFX {
+	return ShaderPalFX{
 		neg:      false,
 		add:      [3]float32{0, 0, 0},
 		mult:     [3]float32{1, 1, 1},

--- a/src/render.go
+++ b/src/render.go
@@ -770,29 +770,49 @@ func renderWithBlending(
 		}
 	// SubAdd
 	case blendMode == TT_subadd:
+		// Save original state for later restoration
+		origState := *pfxstate
+
+		// Helper to set PalFX parameters to grayscale for the first pass
+		makeFxGrayscale := func() {
+			avgAdd := (origState.add[0] + origState.add[1] + origState.add[2]) / 3
+			pfxstate.add = [3]float32{avgAdd, avgAdd, avgAdd}
+			avgMult := (origState.mult[0] + origState.mult[1] + origState.mult[2]) / 3
+			pfxstate.mult = [3]float32{avgMult, avgMult, avgMult}
+		}
 		if pfxstate.neg {
 			// With invertall we invert the passes. Add then sub
 			// This is kind of like "invblend = 3"
 			// But adding "invertblend" support here would force people to have to use it to get the expected results
-			disableNeg()
+			// We avoid "neg" entirely because it turns black edges into white auras. But maybe allowing that would be more consistent?
+			disableNeg() // pfxstate.neg = false
 			//invertAColor()
+
+			// Pass 1: additive with gray PalFX
 			if dst > 0 {
+				makeFxGrayscale()
+				// Set gray uniform manually because render() doesn't set it (and doesn't need to most of the time)
 				gfx.SetUniformF("gray", 1.0)
 				render(BlendAdd, blendSourceFactor, BlendOne, dst)
 			}
+			// Pass 2: subtractive with original PalFX
 			if src > 0 {
+				*pfxstate = origState
+				disableNeg() // Disable neg again because of the restore
 				gfx.SetUniformF("gray", pfxstate.gray)
 				render(BlendReverseSubtract, blendSourceFactor, BlendOne, src)
 			}
 		} else {
 			// Normal behavior
-			// Pass 1: subtractive, forced grayscale, intensity = dst
+			// Pass 1: subtractive with gray PalFX
 			if dst > 0 {
+				makeFxGrayscale()
 				gfx.SetUniformF("gray", 1.0)
 				render(BlendReverseSubtract, blendSourceFactor, BlendOne, dst)
 			}
-			// Pass 2: additive, original grayscale, intensity = src
+			// Pass 2: additive with original PalFX
 			if src > 0 {
+				*pfxstate = origState
 				gfx.SetUniformF("gray", pfxstate.gray)
 				render(BlendAdd, blendSourceFactor, BlendOne, src)
 			}

--- a/src/system.go
+++ b/src/system.go
@@ -258,7 +258,7 @@ type System struct {
 	debugWC             *Char
 	projs               [MaxPlayerNo][]*Projectile
 	explods             [MaxPlayerNo][]*Explod
-	explodRunOrder      []*Explod
+	explodDrawOrder     []*Explod
 	chartexts           [MaxPlayerNo][]*TextSprite // From Text sctrl
 	spriteList          DrawList
 	shadowList          ShadowList
@@ -2221,8 +2221,8 @@ func (s *System) clearPlayerAssets(pn int, forceDestroy bool) {
 	s.explods[pn] = PointerSliceReset(s.explods[pn])
 	s.chartexts[pn] = PointerSliceReset(s.chartexts[pn])
 
-	// Clear explod run order so that no reference is left to this char
-	s.explodRunOrder = PointerSliceReset(s.explodRunOrder)
+	// Clear explod draw order so that no reference is left to this char
+	s.explodDrawOrder = PointerSliceReset(s.explodDrawOrder)
 }
 
 // Select correct stage for current round
@@ -2720,12 +2720,7 @@ func (s *System) action() {
 	// Note: Explod update must happen after hit detection. Because hit sparks are also explods
 	s.explodUpdate()
 	s.charTextsUpdate()
-
-	for i := range s.explods {
-		for _, e := range s.explods[i] {
-			e.cueDraw()
-		}
-	}
+	s.explodCueDraw()
 
 	// Adjust game speed
 	if s.tickNextFrame() {
@@ -2841,8 +2836,23 @@ func (s *System) projectilePrune(pn int) {
 
 // Update all explods for all players
 func (s *System) explodUpdate() {
+	// Update each explod in storage order
+	for i := range s.explods {
+		for _, e := range s.explods[i] {
+			e.update()
+		}
+	}
+
+	// Cleanup
+	for i := range s.explods {
+		s.explodPrune(i)
+	}
+}
+
+// Sort explods by age, ontop, etc before queuing them for drawing
+func (s *System) explodCueDraw() {
 	// Reset sorting list
-	s.explodRunOrder = s.explodRunOrder[:0]
+	s.explodDrawOrder = s.explodDrawOrder[:0]
 
 	// Flatten all explods into the sorting list
 	// Using this list makes the drawing order fairer instead of prioritizing player 1
@@ -2853,7 +2863,7 @@ func (s *System) explodUpdate() {
 		for j := range s.explods[i] {
 			e := s.explods[i][j]
 			e.sortindex = count // Unique reference for this frame
-			s.explodRunOrder = append(s.explodRunOrder, e)
+			s.explodDrawOrder = append(s.explodDrawOrder, e)
 			count++
 		}
 	}
@@ -2861,8 +2871,8 @@ func (s *System) explodUpdate() {
 	// Sort explods by age
 	// For the sake of backward compatibility we must also open exceptions for the ontop parameter
 	// The sortindex variable saves us from needing the more expensive SliceStable
-	sort.Slice(s.explodRunOrder, func(i, j int) bool {
-		a, b := s.explodRunOrder[i], s.explodRunOrder[j]
+	sort.Slice(s.explodDrawOrder, func(i, j int) bool {
+		a, b := s.explodDrawOrder[i], s.explodDrawOrder[j]
 
 		// All ontop explods come before the rest
 		if a.ontop != b.ontop {
@@ -2883,14 +2893,9 @@ func (s *System) explodUpdate() {
 		return a.sortindex < b.sortindex
 	})
 
-	// Update logic
-	for _, e := range s.explodRunOrder {
-		e.update()
-	}
-
-	// Cleanup
-	for i := range s.explods {
-		s.explodPrune(i)
+	// Queue in the sorted order
+	for _, e := range s.explodDrawOrder {
+		e.cueDraw()
 	}
 }
 


### PR DESCRIPTION
Features:
- For cases where Ikemen's expanded command syntax could make a Mugen character's command stop working, we will now adapt the command and print a warning
- Fixes #2235 
- Fixes #2922

Fixes:
- Added missing "SA" transparency support (without alpha numbers) to animations
- Fixed explods being drawn in their slice order instead of the sorted order
- Mul, add, etc are also flattened to grayscale during the first pass of SubAdd

Refactor:
- Moved explod sorting to the drawing function instead of update function, since it only affects drawing
- Added ShaderPalFX struct. Simplifies some render function signatures