### PR TITLE
fix: friendly PlayerPush, ontop explods, Camera sctrl pos

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -14245,9 +14245,9 @@ func (sc cameraCtrl) Run(c *Char, _ []int32) bool {
 				sys.cam.FollowChar = c
 			}
 		case cameraCtrl_pos:
-			sys.cam.Pos[0] = exp[0].evalF(c)
+			sys.cam.Pos[0] = exp[0].evalF(c) * c.localscl
 			if len(exp) > 1 {
-				sys.cam.Pos[1] = exp[1].evalF(c)
+				sys.cam.Pos[1] = exp[1].evalF(c) * c.localscl
 			}
 		case cameraCtrl_followid:
 			if cid := sys.playerID(exp[0].evalI(c)); cid != nil {

--- a/src/char.go
+++ b/src/char.go
@@ -13568,19 +13568,23 @@ func (cl *CharList) pushDetection(getter *Char) {
 	}
 
 	for _, c := range cl.runOrder {
-		// Stop current iteration if char won't push
-		interact := false
+		// Stop current iteration if char won't ever push
+		if !c.csf(CSF_playerpush) || c.scf(SCF_standby) || c.scf(SCF_disabled) {
+			continue
+		}
+
+		// AffectTeam check
+		// The logic here needs to be a bit uneven because the default state (pushing enemies only) also is
 		if c.teamside == getter.teamside {
-			if c.pushAffectTeam <= 0 {
-				interact = true
+			// Partners are permissive: skip only if both are in "enemy" mode
+			if c.pushAffectTeam > 0 && getter.pushAffectTeam > 0 {
+				continue
 			}
 		} else {
-			if c.pushAffectTeam >= 0 && getter.pushAffectTeam >= 0 {
-				interact = true
+			// Enemies are strict: skip if either one is in "friendly" mode
+			if c.pushAffectTeam < 0 || getter.pushAffectTeam < 0 {
+				continue
 			}
-		}
-		if !c.csf(CSF_playerpush) || !interact || c.scf(SCF_standby) || c.scf(SCF_disabled) {
-			continue
 		}
 
 		// Get size box

--- a/src/system.go
+++ b/src/system.go
@@ -2878,10 +2878,11 @@ func (s *System) explodCueDraw() {
 		if a.ontop != b.ontop {
 			return a.ontop
 		}
-		// If both are ontop the normal logic is inverted (old index shift trick)
+		// If both are ontop, the age logic is the same as normal, but the index tiebreaker is inverted
+		// https://github.com/ikemen-engine/Ikemen-GO/issues/3737
 		if a.ontop && b.ontop {
 			if a.timestamp != b.timestamp {
-				return a.timestamp >= b.timestamp
+				return a.timestamp < b.timestamp
 			}
 			return a.sortindex >= b.sortindex
 		}


### PR DESCRIPTION
Fixes:
- Fixed the "friendly" PlayerPush case pushing characters unevenly compared to "enemy" case. Now when chars agree to push, they always both push each other
- Fixed explod ontop drawing order when explods of different ages are mixed together. Should be more accurate to Mugen
- Added missing localcoord conversion to Camera sctrl `pos` parameter
- Fixes #3737 