### PR TITLE
fix: rollback gameState release

### DIFF
--- a/src/rollback.go
+++ b/src/rollback.go
@@ -624,7 +624,7 @@ func (r *RollbackSession) IsConnected() bool {
 func (r *RollbackSession) SaveGameState(stateIdx int) int {
 	sys.savePool.curStateID = stateIdx
 	sys.rollbackStateID = stateIdx
-	oldest := stateIdx + 1%(MaxSaveStates+2)
+	oldest := (stateIdx + 1) % (MaxSaveStates + 2)
 	if _, ok := sys.arenaSaveMap[oldest]; ok {
 		sys.arenaSaveMap[oldest].Free()
 		sys.arenaSaveMap[oldest] = nil


### PR DESCRIPTION
The old code is equivalent to ```oldest := stateIdx + (1%(MaxSaveStates+2))```. Which is obviously not intended.