### PR TITLE
fix: shadows, playerpush, ontop, sound panning, attack/defence triggers

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3276,7 +3276,7 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_spriteplayerno:
 		sys.bcStack.PushI(int32(c.spritePN) + 1)
 	case OC_ex_attack:
-		sys.bcStack.PushF(float32(c.gi().attackBase) * c.attackMul[0])
+		sys.bcStack.PushF(c.attackTrigger())
 	case OC_ex_clsnoverlap:
 		c2 := sys.bcStack.Pop().ToI()
 		id := sys.bcStack.Pop().ToI()
@@ -3289,7 +3289,7 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_decisiveround:
 		sys.bcStack.PushB(sys.decisiveRound[c.playerNo&1])
 	case OC_ex_defence:
-		sys.bcStack.PushF(float32(c.finalDefense * 100))
+		sys.bcStack.PushF(c.defenceTrigger())
 	case OC_ex_dizzy:
 		sys.bcStack.PushB(c.scf(SCF_dizzy))
 	case OC_ex_dizzypoints:

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -5068,10 +5068,6 @@ const (
 )
 
 func (sc playSnd) Run(c *Char, _ []int32) bool {
-	if sys.noSoundFlg {
-		return false
-	}
-
 	crun := getRedirectedChar(c, StateControllerBase(sc), playSnd_redirectid, "PlaySnd")
 	if crun == nil {
 		return false
@@ -12971,10 +12967,6 @@ const (
 )
 
 func (sc modifySnd) Run(c *Char, _ []int32) bool {
-	if sys.noSoundFlg {
-		return false
-	}
-
 	crun := getRedirectedChar(c, StateControllerBase(sc), modifySnd_redirectid, "ModifySnd")
 	if crun == nil {
 		return false

--- a/src/char.go
+++ b/src/char.go
@@ -8492,6 +8492,29 @@ func (c *Char) targetDrop(excludeid int32, excludechar int32, keepone bool) {
 	}
 }
 
+// We do the extra steps to prevent the internal multiplication by 100 from exposing garbage float digits
+// https://github.com/ikemen-engine/Ikemen-GO/issues/1386
+func (c *Char) attackTrigger() float32 {
+	// Do the multiplication in float64
+	base := float64(c.gi().attackBase)
+	mul := float64(c.attackMul[0])
+	result := base * mul
+
+	// Snap to a 3-decimal grid to kill the garbage (e.g. 120.000008 -> 120.0)
+	// 3 because default attack/defence values have 3 significant digits
+	cleaned := math.Round(result*1e3) / 1e3
+
+	return float32(cleaned)
+}
+
+// See attackTrigger()
+func (c *Char) defenceTrigger() float32 {
+	def := float64(c.finalDefense)
+	result := def * 100
+	clean := math.Round(result*1e3) / 1e3
+	return float32(clean)
+}
+
 // Process raw damage into the value that will actually be used
 // Calculations are done in float64 for the sake of precision
 func (c *Char) computeDamage(damage float64, kill, absolute bool, atkmul float32, attacker *Char, bounds bool) int32 {

--- a/src/char.go
+++ b/src/char.go
@@ -6278,7 +6278,7 @@ func (c *Char) getOwnChannels(chNo int32) (found []*SoundChannel) {
 }
 
 func (c *Char) playSound(params *PlaySndParams) {
-	if params.group < 0 {
+	if params.group < 0 || sys.noCharSoundFlg {
 		return
 	}
 	current_ffx := params.ffx

--- a/src/char.go
+++ b/src/char.go
@@ -11565,7 +11565,7 @@ func (c *Char) actionPrepare() {
 				if c.alive() || c.ss.no != 5150 || c.numPartner() == 0 {
 					c.setCSF(CSF_screenbound | CSF_movecamera_x | CSF_movecamera_y)
 				}
-				if sys.roundState() > 0 && (c.alive() || c.numPartner() == 0) {
+				if sys.roundState() > 0 && sys.roundState() < 4 && (c.alive() || c.numPartner() == 0) {
 					c.setCSF(CSF_playerpush)
 				}
 			}

--- a/src/motif.go
+++ b/src/motif.go
@@ -3653,7 +3653,7 @@ func (co *MotifContinue) init(m *Motif) {
 
 	if !m.ContinueScreen.Sounds.Enabled {
 		sys.clearAllSound()
-		sys.noSoundFlg = true
+		sys.noCharSoundFlg = true
 	}
 
 	m.Music.Play("continue", sys.motif.Def)
@@ -3811,7 +3811,7 @@ func (co *MotifContinue) step(m *Motif) {
 		}
 		co.active = false
 		if !m.ContinueScreen.Sounds.Enabled {
-			sys.noSoundFlg = false
+			sys.noCharSoundFlg = false
 		}
 		return
 	}
@@ -6183,7 +6183,7 @@ func (vi *MotifVictory) init(m *Motif) {
 
 	if !m.VictoryScreen.Sounds.Enabled {
 		sys.clearAllSound()
-		sys.noSoundFlg = true
+		sys.noCharSoundFlg = true
 	}
 
 	// If match/stage/select.def defines victory.music, it should keep playing
@@ -6311,7 +6311,7 @@ func (vi *MotifVictory) step(m *Motif) {
 		}
 		vi.active = false
 		if !m.VictoryScreen.Sounds.Enabled {
-			sys.noSoundFlg = false
+			sys.noCharSoundFlg = false
 		}
 		return
 	}
@@ -6628,7 +6628,7 @@ func (wi *MotifWin) init(m *Motif) {
 
 	if !wi.soundsEnabled {
 		sys.clearAllSound()
-		sys.noSoundFlg = true
+		sys.noCharSoundFlg = true
 	}
 
 	m.Music.Play("results", sys.motif.Def)
@@ -6811,7 +6811,7 @@ func (wi *MotifWin) step(m *Motif) {
 		}
 		wi.active = false
 		if !wi.soundsEnabled {
-			sys.noSoundFlg = false
+			sys.noCharSoundFlg = false
 		}
 		return
 	}

--- a/src/render.go
+++ b/src/render.go
@@ -483,12 +483,13 @@ func renderSpriteQuad(modelview mgl.Mat4, rp RenderParams) {
 	//	pers = Abs(rp.xbs) / Abs(rp.xts)
 	//}
 	if !rp.rot.IsZero() && rp.tile.xflag == 0 && rp.tile.yflag == 0 {
-		if rp.vs != 1 {
-			y1 = rp.rcy + ((rp.y - rp.ys*float32(rp.size[1])) - rp.rcy)
-			y2 = y1
-			y3 = rp.y
-			y4 = y3
-		}
+		// This block makes shadows ignore their own yscale when in perspective
+		//if rp.vs != 1 {
+		//	y1 = rp.rcy + ((rp.y - rp.ys*float32(rp.size[1])) - rp.rcy)
+		//	y2 = y1
+		//	y3 = rp.y
+		//	y4 = y3
+		//}
 		modelview = applyProjection(modelview, rp, 0, 1, 0)
 		modelview = applyShear(modelview, rp.rxadd, rp.ys*float32(rp.size[1]))
 		modelview = applyRotation(modelview, rp)

--- a/src/script.go
+++ b/src/script.go
@@ -3268,7 +3268,7 @@ func systemScriptInit(l *lua.LState) {
 				sys.resetGblEffect()
 				sys.dialogueForce = 0
 				sys.dialogueHideBars = false
-				sys.noSoundFlg = false
+				sys.noCharSoundFlg = false
 				sys.postMatchFlg = false
 				sys.preMatchTime += sys.matchTime
 				sys.matchTime = 0
@@ -7666,9 +7666,9 @@ func systemScriptInit(l *lua.LState) {
 		@tparam[opt] boolean state If provided, sets mute on/off; otherwise toggles it.
 		function toggleNoSound(state) end*/
 		if !nilArg(l, 1) {
-			sys.noSoundFlg = boolArg(l, 1)
+			sys.noCharSoundFlg = boolArg(l, 1)
 		} else {
-			sys.noSoundFlg = !sys.noSoundFlg
+			sys.noCharSoundFlg = !sys.noCharSoundFlg
 		}
 		return 0
 	})

--- a/src/sound.go
+++ b/src/sound.go
@@ -931,11 +931,19 @@ func (s *SoundEffect) Stream(samples [][2]float64) (n int, ok bool) {
 	// TODO: Test mugen panning in relation to PanningWidth and zoom settings
 	lv, rv := s.volume, s.volume
 	if sys.cfg.Sound.StereoEffects && (s.x != nil || s.pan != 0) {
+		screen := sys.xmax - sys.xmin
+		// Enforce a minimum playable area
+		// Prevents a division by 0 from corrupting the sound engine
+		// TODO: Panning shouldn't depend on playable area but rather screen area
+		// https://github.com/ikemen-engine/Ikemen-GO/issues/3743
+		if screen < 1 {
+			screen = 1
+		}
 		var r float32
 		if s.x != nil { // pan
-			r = ((sys.xmax - s.localscl**s.x) - s.pan) / (sys.xmax - sys.xmin)
+			r = ((sys.xmax - s.localscl**s.x) - s.pan) / screen
 		} else { // abspan
-			r = ((sys.xmax-sys.xmin)/2 - s.pan) / (sys.xmax - sys.xmin)
+			r = ((sys.xmax-sys.xmin)/2 - s.pan) / screen
 		}
 		sc := sys.cfg.Sound.PanningRange / 100
 		of := (100 - sys.cfg.Sound.PanningRange) / 200

--- a/src/sound.go
+++ b/src/sound.go
@@ -931,20 +931,24 @@ func (s *SoundEffect) Stream(samples [][2]float64) (n int, ok bool) {
 	// TODO: Test mugen panning in relation to PanningWidth and zoom settings
 	lv, rv := s.volume, s.volume
 	if sys.cfg.Sound.StereoEffects && (s.x != nil || s.pan != 0) {
-		screen := sys.xmax - sys.xmin
-		// Enforce a minimum playable area
-		// Prevents a division by 0 from corrupting the sound engine
-		// TODO: Panning shouldn't depend on playable area but rather screen area
-		// https://github.com/ikemen-engine/Ikemen-GO/issues/3743
-		if screen < 1 {
-			screen = 1
-		}
+		// Use the camera viewport for panning, not the playable area
+		//screen := sys.xmax - sys.xmin
+		leftEdge := sys.cam.ScreenPos[0] + sys.cam.Offset[0]
+		screenWidth := float32(sys.gameWidth) / sys.cam.Scale
+		rightEdge := leftEdge + screenWidth
+
+		// Position ratio, where 0 is all the way right and 1 is all the way left
 		var r float32
-		if s.x != nil { // pan
-			r = ((sys.xmax - s.localscl**s.x) - s.pan) / screen
-		} else { // abspan
-			r = ((sys.xmax-sys.xmin)/2 - s.pan) / screen
+
+		// Determine panning position
+		if s.x != nil {
+			// Pan: pan based on the sound's position relative to the screen edges
+			r = ((rightEdge - s.localscl**s.x) - s.pan) / screenWidth
+		} else {
+			// Absolute pan: treat pan as an offset from center of screen
+			r = ((rightEdge-leftEdge)/2 - s.pan) / screenWidth
 		}
+
 		sc := sys.cfg.Sound.PanningRange / 100
 		of := (100 - sys.cfg.Sound.PanningRange) / 200
 		lv = Clamp(s.volume*2*(r*sc+of), 0, 512)

--- a/src/system.go
+++ b/src/system.go
@@ -137,7 +137,7 @@ type SystemStateVars struct {
 	uiRepeatFrame       int32
 
 	endMatch      bool
-	noSoundFlg    bool
+	noCharSoundFlg bool
 	fightLoopEnd  bool
 	continueFlg   bool
 	matchResetFlg bool
@@ -934,7 +934,7 @@ func (s *System) update() bool {
 
 func (s *System) tickSound() {
 	s.soundChannels.Tick()
-	if !s.noSoundFlg {
+	if !s.noCharSoundFlg {
 		for i := range sys.charSoundChannels {
 			sys.charSoundChannels[i].Tick()
 		}
@@ -2309,6 +2309,9 @@ func (s *System) resetRound() {
 	s.introSkipCall = false
 	s.roundResetFlg = false
 	s.reloadFlg, s.reloadStageFlg, s.reloadFightScreenFlg = false, false, false
+
+	// https://github.com/ikemen-engine/Ikemen-GO/issues/1400
+	s.noCharSoundFlg = false
 
 	s.resetGblEffect()
 	s.fightScreen.reset()

--- a/src/system.go
+++ b/src/system.go
@@ -2868,11 +2868,13 @@ func (s *System) explodCueDraw() {
 		if a.ontop != b.ontop {
 			return a.ontop
 		}
-		// If both are ontop, the age logic is the same as normal, but the index tiebreaker is inverted
+		// If both are ontop, the normal logic is inverted in order to emulate Mugen's memory layout
+		// However, it's impossible to cover all of Mugen's quirks without making our layout worse
 		// https://github.com/ikemen-engine/Ikemen-GO/issues/3737
+		// https://github.com/ikemen-engine/Ikemen-GO/issues/3749
 		if a.ontop && b.ontop {
 			if a.timestamp != b.timestamp {
-				return a.timestamp < b.timestamp
+				return a.timestamp >= b.timestamp
 			}
 			return a.sortindex >= b.sortindex
 		}


### PR DESCRIPTION
Fixes:
- Removed a very old render math exception that made shadow perspective ignore its scale, always ending up as 1
- `playerpush` now defaults to false in roundstate 4, like Mugen
- Reverted previous changes to `ontop` drawing order
- Reloading in victory screen no longer disables character sounds
- Sound engine being corrupted by extreme zoom values
- Sound panning range is now calculated according to screen area
- Cleaned attack/defence triggers garbage digits
- Fixes #1386
- Fixes #1400
- Fixes #3741 
- Fixes #3749 
- (Unfixes #3737)
- Fixes #3743 