### PR TITLE
feat: Loading additional textures for custom shader

### DIFF
--- a/src/anim.go
+++ b/src/anim.go
@@ -903,7 +903,7 @@ func (a *Animation) drawSub1(angle, facing float32) (h, v, agl float32) {
 func (a *Animation) Draw(window *[4]int32, x, y, xcs, ycs, xs, xbs, ys,
 	rxadd float32, rot Rotation, rcx float32, pfx *PalFX, facing float32,
 	airOffsetFix [2]float32, projectionMode int32, fLength float32, color uint32,
-	isReflection bool, shader string, shaderParams [16]float32) {
+	isReflection bool, shader CustomShaderRenderData) {
 
 	// Skip blank animations
 	if a == nil || a.isBlank() {
@@ -1032,15 +1032,14 @@ func (a *Animation) Draw(window *[4]int32, x, y, xcs, ycs, xs, xbs, ys,
 		fLength:        fLength * sys.heightScale,
 		xOffset:        xoff * sys.widthScale,
 		yOffset:        yoff * sys.heightScale,
-		shader:         shader,
-		shaderParams:   shaderParams,
+		customShader:   shader,
 	}
 
 	RenderSprite(rp)
 }
 
 func (a *Animation) ShadowDraw(window *[4]int32, x, y, xscl, yscl, vscl, rxadd float32, rot Rotation,
-	pfx *PalFX, color uint32, intensity int32, facing float32, airOffsetFix [2]float32, projectionMode int32, fLength float32, shader string, shaderParams [16]float32) {
+	pfx *PalFX, color uint32, intensity int32, facing float32, airOffsetFix [2]float32, projectionMode int32, fLength float32, shader CustomShaderRenderData) {
 
 	// Skip blank shadows
 	if a == nil || a.isBlank() {
@@ -1085,8 +1084,7 @@ func (a *Animation) ShadowDraw(window *[4]int32, x, y, xscl, yscl, vscl, rxadd f
 		fLength:        fLength,
 		xOffset:        xoff,
 		yOffset:        yoff,
-		shader:         shader,
-		shaderParams:   shaderParams,
+		customShader:   shader,
 	}
 
 	// TODO: This is redundant now that rp.tint is used to colorise the shadow
@@ -1286,8 +1284,7 @@ type SpriteData struct {
 	syncGroup    int   // Used to group syncId's in chunks before drawing
 	sortindex    int   // For faster sorting
 	under        bool
-	shader       string
-	shaderParams [16]float32
+	customShader CustomShaderRenderData
 }
 
 func newSpriteData() *SpriteData {
@@ -1451,7 +1448,7 @@ func (dl DrawList) draw(layerno int32, under bool, cameraX, cameraY, cameraScl f
 
 		s.anim.Draw(drawwindow, pos[0]-xsoffset, pos[1], cs, cs, s.scl[0], s.scl[0],
 			s.scl[1], xshear, s.rot, float32(sys.gameWidth)/2, s.pfx, s.facing,
-			s.airOffsetFix, s.projection, s.fLength, 0, false, s.shader, s.shaderParams)
+			s.airOffsetFix, s.projection, s.fLength, 0, false, s.customShader)
 
 		// Restore original animation transparency just in case
 		s.anim.transType = oldTransType
@@ -1717,7 +1714,7 @@ func (sl ShadowList) draw(x, y, scl float32) {
 			sys.cam.GroundLevel()+(sys.cam.Offset[1]-shake[1])-y-(sdwPosY*yscale-offsetY)*scl,
 			scl*s.scl[0]*xscale, scl*-s.scl[1],
 			yscale, xshear, rot,
-			s.pfx, uint32(color), intensity, s.facing, s.airOffsetFix, projection, fLength, s.shader, s.shaderParams)
+			s.pfx, uint32(color), intensity, s.facing, s.airOffsetFix, projection, fLength, s.customShader)
 	}
 }
 
@@ -1988,7 +1985,7 @@ func (rl ReflectionList) draw(x, y, scl float32) {
 			scl, scl,
 			s.scl[0]*xscale, s.scl[0]*xscale,
 			-s.scl[1]*yscale, xshear, rot, float32(sys.gameWidth)/2,
-			s.pfx, s.facing, s.airOffsetFix, projection, fLength, color, true, s.shader, s.shaderParams)
+			s.pfx, s.facing, s.airOffsetFix, projection, fLength, color, true, s.customShader)
 
 		// Restore original animation transparency just in case
 		s.anim.transType = oldTransType
@@ -2321,7 +2318,7 @@ func (a *Anim) Draw(ln int16) {
 
 	a.anim.Draw(&a.window, a.x+a.vel[0]-xsoffset+float32(sys.gameWidth-320)/2,
 		a.y+a.vel[1]+float32(sys.gameHeight-240), 1, 1, xscl, xscl, a.yscl,
-		xshear, a.rot, 0, a.palfx, a.facing, [2]float32{1, 1}, a.projection, a.fLength, 0, false, "", [16]float32{})
+		xshear, a.rot, 0, a.palfx, a.facing, [2]float32{1, 1}, a.projection, a.fLength, 0, false, CustomShaderRenderData{})
 }
 
 func (a *Anim) Reset() {

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -4190,7 +4190,7 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushB(c.parentExist())
 	case OC_ex2_shader:
 		shaderName := strings.ToLower(be.ReadPoolStringAt(i))
-		sys.bcStack.PushB(c.shader == shaderName)
+		sys.bcStack.PushB(c.customShader.name == shaderName)
 	default:
 		LogMessage("%v", be[*i-1])
 		c.panic("Invalid bytecode OpCode encountered")
@@ -6145,6 +6145,11 @@ const (
 	explod_syncid
 	explod_shader
 	explod_shaderparam
+	explod_shader_tex1_anim
+	explod_shader_tex1_spr
+	explod_shader_tex2_anim
+	explod_shader_tex2_spr
+	explod_shadertime
 	explod_last = iota + palFX_last + afterImage_last + 1 - 1
 	explod_redirectid
 )
@@ -6383,7 +6388,7 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 		case explod_shader:
 			shader := exp[0].evalS()
 			if shader == "" || sys.isValidCustomShader(shader) {
-				e.shader = shader
+				e.customShader.name = shader
 			} else {
 				sys.appendToConsole(crun.warn() + fmt.Sprintf("invalid explod shader name: %s", shader))
 			}
@@ -6392,8 +6397,35 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 			for j := 0; j < numParams; j++ {
 				idx := int(exp[1+j*2].evalI(c))
 				val := exp[2+j*2].evalF(c)
-				e.shaderParams[idx] = val
+				e.customShader.params[idx] = val
 			}
+		case explod_shader_tex1_anim:
+			animNo := exp[0].evalI(c)
+			e.customShader.tex1.AnimNo = animNo
+			e.customShader.tex1.Anim = crun.getSelfAnimSprite(animNo, "", true)
+			if e.customShader.tex1.Anim != nil {
+				e.customShader.tex1.Anim.Reset()
+			}
+		case explod_shader_tex1_spr:
+			g := exp[0].evalI(c)
+			n := exp[1].evalI(c)
+			e.customShader.tex1.SprNo = [2]int32{g, n}
+			e.customShader.tex1.Spr = crun.gi().sff.GetSprite(uint16(g), uint16(n))
+
+		case explod_shader_tex2_anim:
+			animNo := exp[0].evalI(c)
+			e.customShader.tex2.AnimNo = animNo
+			e.customShader.tex2.Anim = crun.getSelfAnimSprite(animNo, "", true)
+			if e.customShader.tex2.Anim != nil {
+				e.customShader.tex2.Anim.Reset()
+			}
+		case explod_shader_tex2_spr:
+			g := exp[0].evalI(c)
+			n := exp[1].evalI(c)
+			e.customShader.tex2.SprNo = [2]int32{g, n}
+			e.customShader.tex2.Spr = crun.gi().sff.GetSprite(uint16(g), uint16(n))
+		case explod_shadertime:
+			e.customShader.time = exp[0].evalI(c)
 		case explod_redirectid:
 			return true // Already handled. Avoid default
 		default:
@@ -7004,7 +7036,7 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 			case explod_shader:
 				s := exp[0].evalS()
 				eachExpl(func(e *Explod) {
-					e.shader = s
+					e.customShader.name = s
 				})
 			case explod_shaderparam:
 				numParams := int(exp[0].evalI(c))
@@ -7013,9 +7045,49 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 					val := exp[2+j*2].evalF(c)
 
 					eachExpl(func(e *Explod) {
-						e.shaderParams[idx] = val
+						e.customShader.params[idx] = val
 					})
 				}
+			case explod_shader_tex1_anim:
+				animNo := exp[0].evalI(c)
+				eachExpl(func(e *Explod) {
+					e.customShader.tex1.AnimNo = animNo
+					e.customShader.tex1.Anim = crun.getSelfAnimSprite(animNo, "", true)
+					if e.customShader.tex1.Anim != nil {
+						e.customShader.tex1.Anim.Reset()
+					}
+				})
+			case explod_shader_tex1_spr:
+				g := exp[0].evalI(c)
+				n := exp[1].evalI(c)
+				eachExpl(func(e *Explod) {
+					e.customShader.tex1.SprNo = [2]int32{g, n}
+					e.customShader.tex1.Spr = crun.gi().sff.GetSprite(uint16(g), uint16(n))
+				})
+			case explod_shader_tex2_anim:
+				animNo := exp[0].evalI(c)
+				eachExpl(func(e *Explod) {
+					e.customShader.tex2.AnimNo = animNo
+					e.customShader.tex2.Anim = crun.getSelfAnimSprite(animNo, "", true)
+					if e.customShader.tex2.Anim != nil {
+						e.customShader.tex2.Anim.Reset()
+					}
+				})
+			case explod_shader_tex2_spr:
+				g := exp[0].evalI(c)
+				n := exp[1].evalI(c)
+				eachExpl(func(e *Explod) {
+					e.customShader.tex2.SprNo = [2]int32{g, n}
+					e.customShader.tex2.Spr = crun.gi().sff.GetSprite(uint16(g), uint16(n))
+				})
+			case explod_shadertime:
+				v1 := exp[0].evalI(c)
+				eachExpl(func(e *Explod) {
+					e.customShader.time = v1
+					if e.customShader.time == 0 {
+						e.customShader.clear()
+					}
+				})
 			case explod_interpolation:
 				if c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 {
 					interpolation := exp[0].evalB(c)
@@ -7950,6 +8022,11 @@ const (
 	projectile_projfocallength
 	projectile_shader
 	projectile_shaderparam
+	projectile_shader_tex1_anim
+	projectile_shader_tex1_spr
+	projectile_shader_tex2_anim
+	projectile_shader_tex2_spr
+	projectile_shadertime
 	// projectile_platform
 	// projectile_platformwidth
 	// projectile_platformheight
@@ -8127,14 +8204,41 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 		case projectile_projprojection:
 			p.projection = Projection(exp[0].evalI(c))
 		case projectile_shader:
-			p.shader = exp[0].evalS()
+			p.customShader.name = exp[0].evalS()
 		case projectile_shaderparam:
 			numParams := int(exp[0].evalI(c))
 			for j := 0; j < numParams; j++ {
 				idx := int(exp[1+j*2].evalI(c))
 				val := exp[2+j*2].evalF(c)
-				p.shaderParams[idx] = val
+				p.customShader.params[idx] = val
 			}
+		case projectile_shader_tex1_anim:
+			animNo := exp[0].evalI(c)
+			p.customShader.tex1.AnimNo = animNo
+			p.customShader.tex1.Anim = crun.getSelfAnimSprite(animNo, "", true)
+			if p.customShader.tex1.Anim != nil {
+				p.customShader.tex1.Anim.Reset()
+			}
+		case projectile_shader_tex1_spr:
+			g := exp[0].evalI(c)
+			n := exp[1].evalI(c)
+			p.customShader.tex1.SprNo = [2]int32{g, n}
+			p.customShader.tex1.Spr = crun.gi().sff.GetSprite(uint16(g), uint16(n))
+
+		case projectile_shader_tex2_anim:
+			animNo := exp[0].evalI(c)
+			p.customShader.tex2.AnimNo = animNo
+			p.customShader.tex2.Anim = crun.getSelfAnimSprite(animNo, "", true)
+			if p.customShader.tex2.Anim != nil {
+				p.customShader.tex2.Anim.Reset()
+			}
+		case projectile_shader_tex2_spr:
+			g := exp[0].evalI(c)
+			n := exp[1].evalI(c)
+			p.customShader.tex2.SprNo = [2]int32{g, n}
+			p.customShader.tex2.Spr = crun.gi().sff.GetSprite(uint16(g), uint16(n))
+		case projectile_shadertime:
+			p.customShader.time = exp[0].evalI(c)
 		// case projectile_platform:
 		// 	p.platform = exp[0].evalB(c)
 		// case projectile_platformwidth:
@@ -8578,7 +8682,7 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 			case projectile_shader:
 				v1 := exp[0].evalS()
 				eachProj(func(p *Projectile) {
-					p.shader = v1
+					p.customShader.name = v1
 				})
 			case projectile_shaderparam:
 				numParams := int(exp[0].evalI(c))
@@ -8590,7 +8694,47 @@ func (sc modifyProjectile) Run(c *Char, _ []int32) bool {
 				}
 				eachProj(func(p *Projectile) {
 					for j := 0; j < numParams; j++ {
-						p.shaderParams[indices[j]] = vals[j]
+						p.customShader.params[indices[j]] = vals[j]
+					}
+				})
+			case projectile_shader_tex1_anim:
+				animNo := exp[0].evalI(c)
+				eachProj(func(p *Projectile) {
+					p.customShader.tex1.AnimNo = animNo
+					p.customShader.tex1.Anim = crun.getSelfAnimSprite(animNo, "", true)
+					if p.customShader.tex1.Anim != nil {
+						p.customShader.tex1.Anim.Reset()
+					}
+				})
+			case projectile_shader_tex1_spr:
+				g := exp[0].evalI(c)
+				n := exp[1].evalI(c)
+				eachProj(func(p *Projectile) {
+					p.customShader.tex1.SprNo = [2]int32{g, n}
+					p.customShader.tex1.Spr = crun.gi().sff.GetSprite(uint16(g), uint16(n))
+				})
+			case projectile_shader_tex2_anim:
+				animNo := exp[0].evalI(c)
+				eachProj(func(p *Projectile) {
+					p.customShader.tex2.AnimNo = animNo
+					p.customShader.tex2.Anim = crun.getSelfAnimSprite(animNo, "", true)
+					if p.customShader.tex2.Anim != nil {
+						p.customShader.tex2.Anim.Reset()
+					}
+				})
+			case projectile_shader_tex2_spr:
+				g := exp[0].evalI(c)
+				n := exp[1].evalI(c)
+				eachProj(func(p *Projectile) {
+					p.customShader.tex2.SprNo = [2]int32{g, n}
+					p.customShader.tex2.Spr = crun.gi().sff.GetSprite(uint16(g), uint16(n))
+				})
+			case projectile_shadertime:
+				v1 := exp[0].evalI(c)
+				eachProj(func(p *Projectile) {
+					p.customShader.time = v1
+					if p.customShader.time == 0 {
+						p.customShader.clear()
 					}
 				})
 			case hitDef_attr:
@@ -12649,6 +12793,10 @@ type shaderSet StateControllerBase
 const (
 	shaderSet_shader byte = iota
 	shaderSet_shaderparam
+	shaderSet_tex1_anim
+	shaderSet_tex1_spr
+	shaderSet_tex2_anim
+	shaderSet_tex2_spr
 	shaderSet_time
 	shaderSet_redirectid
 )
@@ -12666,7 +12814,7 @@ func (sc shaderSet) Run(c *Char, _ []int32) bool {
 		case shaderSet_shader:
 			shader := exp[0].evalS()
 			if shader == "" || sys.isValidCustomShader(shader) {
-				crun.shader = shader
+				crun.customShader.name = shader
 			} else {
 				sys.appendToConsole(crun.warn() + fmt.Sprintf("invalid shader name: %s", shader))
 			}
@@ -12675,15 +12823,39 @@ func (sc shaderSet) Run(c *Char, _ []int32) bool {
 			for j := 0; j < numParams; j++ {
 				idx := int(exp[1+j*2].evalI(c))
 				val := exp[2+j*2].evalF(c)
-				crun.shaderParams[idx] = val
+				crun.customShader.params[idx] = val
 			}
+		case shaderSet_tex1_anim:
+			animNo := exp[0].evalI(c)
+			crun.customShader.tex1.AnimNo = animNo
+			crun.customShader.tex1.Anim = crun.getSelfAnimSprite(animNo, "", true)
+			if crun.customShader.tex1.Anim != nil {
+				crun.customShader.tex1.Anim.Reset()
+			}
+		case shaderSet_tex1_spr:
+			g := exp[0].evalI(c)
+			n := exp[1].evalI(c)
+			crun.customShader.tex1.SprNo = [2]int32{g, n}
+			crun.customShader.tex1.Spr = crun.gi().sff.GetSprite(uint16(g), uint16(n))
+
+		case shaderSet_tex2_anim:
+			animNo := exp[0].evalI(c)
+			crun.customShader.tex2.AnimNo = animNo
+			crun.customShader.tex2.Anim = crun.getSelfAnimSprite(animNo, "", true)
+			if crun.customShader.tex2.Anim != nil {
+				crun.customShader.tex2.Anim.Reset()
+			}
+		case shaderSet_tex2_spr:
+			g := exp[0].evalI(c)
+			n := exp[1].evalI(c)
+			crun.customShader.tex2.SprNo = [2]int32{g, n}
+			crun.customShader.tex2.Spr = crun.gi().sff.GetSprite(uint16(g), uint16(n))
 		}
 		return true
 	})
-	crun.shaderTime = st
-	if crun.shaderTime == 0 {
-		crun.shader = ""
-		crun.shaderParams = [16]float32{}
+	crun.customShader.time = st
+	if crun.customShader.time == 0 {
+		crun.customShader.clear()
 	}
 	return false
 }

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6168,6 +6168,7 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 	}
 
 	e.id = 0
+	var shaderTime int32 = -1
 
 	// Mugenversion 1.1 chars default postype to "None"
 	if c.stWgi().mugenver[0] == 1 && c.stWgi().mugenver[1] == 1 {
@@ -6425,7 +6426,7 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 			e.customShader.tex2.SprNo = [2]int32{g, n}
 			e.customShader.tex2.Spr = crun.gi().sff.GetSprite(uint16(g), uint16(n))
 		case explod_shadertime:
-			e.customShader.time = exp[0].evalI(c)
+			shaderTime = exp[0].evalI(c)
 		case explod_redirectid:
 			return true // Already handled. Avoid default
 		default:
@@ -6452,6 +6453,12 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 
 	if e.aimg != nil && e.aimg.time != 0 {
 		e.aimg.setup(crun)
+	}
+	if e.customShader.name != "" {
+		e.customShader.time = shaderTime
+		if e.customShader.time == 0 {
+			e.customShader.clear()
+		}
 	}
 
 	e.setPos(crun)
@@ -8055,6 +8062,7 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 	if p == nil {
 		return false
 	}
+	var shaderTime int32 = -1
 
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
@@ -8238,7 +8246,7 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 			p.customShader.tex2.SprNo = [2]int32{g, n}
 			p.customShader.tex2.Spr = crun.gi().sff.GetSprite(uint16(g), uint16(n))
 		case projectile_shadertime:
-			p.customShader.time = exp[0].evalI(c)
+			shaderTime = exp[0].evalI(c)
 		// case projectile_platform:
 		// 	p.platform = exp[0].evalB(c)
 		// case projectile_platformwidth:
@@ -8288,7 +8296,12 @@ func (sc projectile) Run(c *Char, _ []int32) bool {
 	if p.aimg != nil && p.aimg.time != 0 {
 		p.aimg.setup(crun)
 	}
-
+	if p.customShader.name != "" {
+		p.customShader.time = shaderTime
+		if p.customShader.time == 0 {
+			p.customShader.clear()
+		}
+	}
 	crun.commitProjectile(p, pt, offx, offy, offz, op, rp[0], rp[1], clsnscale)
 	return false
 }

--- a/src/char.go
+++ b/src/char.go
@@ -1675,8 +1675,7 @@ type Explod struct {
 	timestamp            int32 // Determines run order
 	sortindex            int   // For faster run order sorting
 
-	shader       string
-	shaderParams [16]float32
+	customShader CustomShader
 }
 
 func newExplod() *Explod {
@@ -2010,8 +2009,7 @@ func (e *Explod) update() {
 				e.alpha = syncChar.alpha
 				e.palfx = syncChar.getPalfx()
 				e.facing = syncChar.facing
-				e.shader = syncChar.shader
-				e.shaderParams = syncChar.shaderParams
+				e.customShader = syncChar.customShader
 
 				if syncChar.aimg != nil && syncChar.aimg.time != 0 {
 					if e.aimg == nil {
@@ -2104,6 +2102,17 @@ func (e *Explod) update() {
 			e.time++
 			if e.bindtime > 0 {
 				e.bindtime--
+			}
+			if e.customShader.name != "" {
+				e.customShader.sTime++
+				e.customShader.tex1.step()
+				e.customShader.tex2.step()
+				if e.customShader.time > 0 {
+					e.customShader.time--
+				}
+				if e.customShader.time == 0 {
+					e.customShader.clear()
+				}
 			}
 		} else {
 			e.setAllPosX(e.pos[0])
@@ -2219,8 +2228,14 @@ func (e *Explod) cueDraw() {
 	sd.fLength = fLength
 	sd.window = ewin
 	sd.xshear = xshear
-	sd.shader = e.shader
-	sd.shaderParams = e.shaderParams
+	sd.customShader = CustomShaderRenderData{
+		name:   e.customShader.name,
+		params: e.customShader.params,
+		time:   e.customShader.time,
+		sTime:  e.customShader.sTime,
+		tex1:   e.customShader.tex1.GetTexture(),
+		tex2:   e.customShader.tex2.GetTexture(),
+	}
 
 	if e.syncId > 0 {
 		sd.syncId = e.syncId
@@ -2424,8 +2439,7 @@ type Projectile struct {
 	contactflag     bool
 	time            int32
 	removeDone      bool
-	shader          string
-	shaderParams    [16]float32
+	customShader    CustomShader
 }
 
 func newProjectile() *Projectile {
@@ -2793,6 +2807,17 @@ func (p *Projectile) tick() {
 			if p.pausemovetime > 0 {
 				p.pausemovetime--
 			}
+			if p.customShader.name != "" {
+				p.customShader.sTime++
+				p.customShader.tex1.step()
+				p.customShader.tex2.step()
+				if p.customShader.time > 0 {
+					p.customShader.time--
+				}
+				if p.customShader.time == 0 {
+					p.customShader.clear()
+				}
+			}
 			p.freezeflag = false
 		} else {
 			p.hitpause--
@@ -2898,8 +2923,14 @@ func (p *Projectile) cueDraw() {
 	sd.fLength = fLength
 	sd.window = pwin
 	sd.xshear = p.xshear
-	sd.shader = p.shader
-	sd.shaderParams = p.shaderParams
+	sd.customShader = CustomShaderRenderData{
+		name:   p.customShader.name,
+		params: p.customShader.params,
+		time:   p.customShader.time,
+		sTime:  p.customShader.sTime,
+		tex1:   p.customShader.tex1.GetTexture(),
+		tex2:   p.customShader.tex2.GetTexture(),
+	}
 
 	// Add sprite to the appropriate layer's drawlist
 	sys.spriteList.add(sd)
@@ -3366,9 +3397,7 @@ type Char struct {
 	currentSctrlIndex    int32
 	analogAxes           [6]float32
 	enableSyncId         bool
-	shader               string
-	shaderParams         [16]float32
-	shaderTime           int32
+	customShader         CustomShader
 	pctype               ProjContact
 	pctime, pcid         int32
 	//soundChannels        SoundChannels // Moved to system
@@ -3479,9 +3508,7 @@ func (c *Char) clearState() {
 	c.makeDustSpacing = 0
 	c.hitStateChangeIdx = -1
 	c.pushAffectTeam = 1
-	c.shader = ""
-	c.shaderParams = [16]float32{}
-	c.shaderTime = 0
+	c.customShader.clear()
 }
 
 func (c *Char) clsnOverlapTrigger(box1, pid, box2 int32) bool {
@@ -3556,9 +3583,7 @@ func (c *Char) prepareNextRound() {
 	c.enemyNearP2Clear()
 	c.targets = c.targets[:0]
 	c.cpucmd = -1
-	c.shader = ""
-	c.shaderParams = [16]float32{}
-	c.shaderTime = 0
+	c.customShader.clear()
 }
 
 // Return Char Global Info normally
@@ -11592,11 +11617,10 @@ func (c *Char) actionPrepare() {
 					}
 				}
 			}
-			if c.shaderTime > 0 {
-				c.shaderTime--
-				if c.shaderTime == 0 {
-					c.shader = ""
-					c.shaderParams = [16]float32{}
+			if c.customShader.time > 0 {
+				c.customShader.time--
+				if c.customShader.time == 0 {
+					c.customShader = CustomShader{}
 				}
 			}
 			if sys.supertime > 0 {
@@ -12099,6 +12123,11 @@ func (c *Char) update() {
 					c.setPosZ(c.pos[2]+c.ghv.zoff, false)
 					c.ghv.zoff = 0
 				}
+			}
+			if c.customShader.name != "" {
+				c.customShader.sTime++
+				c.customShader.tex1.step()
+				c.customShader.tex2.step()
 			}
 			// Engine dust effects
 			// Moved to system.zss
@@ -12704,8 +12733,14 @@ func (c *Char) cueDraw() {
 		charSD.fLength = fLength
 		charSD.xshear = c.xshear
 		charSD.window = cwin
-		charSD.shader = c.shader
-		charSD.shaderParams = c.shaderParams
+		charSD.customShader = CustomShaderRenderData{
+			name:   c.customShader.name,
+			params: c.customShader.params,
+			time:   c.customShader.time,
+			sTime:  c.customShader.sTime,
+			tex1:   c.customShader.tex1.GetTexture(),
+			tex2:   c.customShader.tex2.GetTexture(),
+		}
 
 		if c.enableSyncId {
 			charSD.syncId = c.id

--- a/src/common.go
+++ b/src/common.go
@@ -1303,7 +1303,7 @@ func (l *Layout) DrawAnim(r *[4]int32, x, y, scl, xscl, yscl float32, ln int16, 
 		a.Draw(drawwindow, x+l.offset[0]-xsoffset, y+l.offset[1]+float32(sys.gameHeight-240),
 			scl, scl, (l.scale[0]*xscl)*float32(l.facing), (l.scale[0]*xscl)*float32(l.facing),
 			(l.scale[1]*yscl)*float32(l.vfacing), xshear, l.rot,
-			float32(sys.gameWidth-320)/2, palfx, 1, [2]float32{1, 1}, int32(l.projection), l.fLength, 0, false, "", [16]float32{})
+			float32(sys.gameWidth-320)/2, palfx, 1, [2]float32{1, 1}, int32(l.projection), l.fLength, 0, false, CustomShaderRenderData{})
 	}
 }
 

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -922,7 +922,10 @@ func (c *CharCompiler) explodSub(is IniSection, sc *StateControllerBase) error {
 		explod_syncid, VT_Int, 1, false); err != nil {
 		return err
 	}
-	if err := c.shaderSub(is, sc, explod_shader, explod_shaderparam); err != nil {
+	if err := c.paramValue(is, sc, "shadertime", explod_shadertime, VT_Int, 1, false); err != nil {
+		return err
+	}
+	if err := c.shaderSub(is, sc, explod_shader, ""); err != nil {
 		return err
 	}
 	if err := c.paramValue(is, sc, "bindid",
@@ -2527,7 +2530,10 @@ func (c *CharCompiler) projectileSub(is IniSection, sc *StateControllerBase) err
 	if err := c.afterImageSub(is, sc, "afterimage."); err != nil {
 		return err
 	}
-	if err := c.shaderSub(is, sc, projectile_shader, projectile_shaderparam); err != nil {
+	if err := c.paramValue(is, sc, "shadertime", projectile_shadertime, VT_Int, 1, false); err != nil {
+		return err
+	}
+	if err := c.shaderSub(is, sc, projectile_shader, ""); err != nil {
 		return err
 	}
 	return nil
@@ -5585,7 +5591,7 @@ func (c *CharCompiler) shaderSet(is IniSection, sc *StateControllerBase) (StateC
 		if err := c.paramValue(is, sc, "time", shaderSet_time, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.shaderSub(is, sc, shaderSet_shader, shaderSet_shaderparam); err != nil {
+		if err := c.shaderSub(is, sc, shaderSet_shader, ""); err != nil {
 			return err
 		}
 		return nil
@@ -6906,13 +6912,21 @@ func (c *CharCompiler) modifyStageBG(is IniSection, sc *StateControllerBase) (St
 	sys.cgi[c.playerNo].canMutateStage = true
 	return *ret, err
 }
-func (c *CharCompiler) shaderSub(is IniSection, sc *StateControllerBase, shaderOpCode, paramOpCode byte) error {
-	if err := c.stateParam(is, "shader", false, func(data string) error {
+
+func (c *CharCompiler) shaderSub(is IniSection, sc *StateControllerBase, baseOp byte, prefix string) error {
+	opShader := baseOp
+	opShaderParam := baseOp + 1
+	opTex1Anim := baseOp + 2
+	opTex1Spr := baseOp + 3
+	opTex2Anim := baseOp + 4
+	opTex2Spr := baseOp + 5
+
+	if err := c.stateParam(is, prefix+"shader", false, func(data string) error {
 		if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
 			return Error("Shader name not enclosed in \"")
 		}
 		shaderName := strings.ToLower(data[1 : len(data)-1])
-		sc.add(shaderOpCode, sc.beToExp(BytecodeExp(shaderName)))
+		sc.add(opShader, sc.beToExp(BytecodeExp(shaderName)))
 		return nil
 	}); err != nil {
 		return err
@@ -6921,8 +6935,8 @@ func (c *CharCompiler) shaderSub(is IniSection, sc *StateControllerBase, shaderO
 	var shaderParams []BytecodeExp
 	var paramIndices []int
 	for k, v := range is {
-		if strings.HasPrefix(strings.ToLower(k), "shaderparam.p") {
-			numStr := k[len("shaderparam.p"):]
+		if strings.HasPrefix(strings.ToLower(k), prefix+"shaderparam.p") {
+			numStr := k[len(prefix+"shaderparam.p"):]
 			idx, err := strconv.Atoi(numStr)
 			if err != nil || idx < 0 || idx > 15 {
 				return Error("Invalid shader parameter: " + k + " (must be p0 to p15)")
@@ -6950,7 +6964,55 @@ func (c *CharCompiler) shaderSub(is IniSection, sc *StateControllerBase, shaderO
 			beIdx.appendValue(BytecodeInt(int32(idx)))
 			allParams = append(allParams, beIdx, shaderParams[i])
 		}
-		sc.add(paramOpCode, allParams)
+		sc.add(opShaderParam, allParams)
+	}
+
+	// tex1.anim
+	if err := c.stateParam(is, prefix+"shadertex1.anim", false, func(data string) error {
+		be, err := c.argExpression(&data, VT_Int)
+		if err != nil {
+			return err
+		}
+		sc.add(opTex1Anim, sc.beToExp(be))
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	// tex1.spr
+	if err := c.stateParam(is, prefix+"shadertex1.spr", false, func(data string) error {
+		be, err := c.exprs(data, VT_Int, 2)
+		if err != nil {
+			return err
+		}
+		sc.add(opTex1Spr, be)
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	// tex2.anim
+	if err := c.stateParam(is, prefix+"shadertex2.anim", false, func(data string) error {
+		be, err := c.argExpression(&data, VT_Int)
+		if err != nil {
+			return err
+		}
+		sc.add(opTex2Anim, sc.beToExp(be))
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	// tex2.spr
+	if err := c.stateParam(is, prefix+"shadertex2.spr", false, func(data string) error {
+		be, err := c.exprs(data, VT_Int, 2)
+		if err != nil {
+			return err
+		}
+		sc.add(opTex2Spr, be)
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	return nil

--- a/src/render.go
+++ b/src/render.go
@@ -34,7 +34,7 @@ type Renderer interface {
 	LoadCustomSpriteShader(shaderName string, shaderData []byte) uint32
 	UnloadCustomSpriteShader(shaderName string)
 	SetSpritePipeline(shaderName string)
-	SetCustomUniforms(cs CustomShaderRenderData)
+	SetCustomUniforms(params [16]float32)
 	NeedsGrabPass() bool
 	ResolveBackBuffer() Texture
 
@@ -734,7 +734,7 @@ func RenderSprite(rp RenderParams) {
 		if rp.customShader.tex2 != nil {
 			gfx.SetTexture("tex2", rp.customShader.tex2)
 		}
-		gfx.SetCustomUniforms(rp.customShader)
+		gfx.SetCustomUniforms(rp.customShader.params)
 	}
 	// Texture binding
 	gfx.SetTexture("tex", rp.tex)

--- a/src/render.go
+++ b/src/render.go
@@ -34,7 +34,7 @@ type Renderer interface {
 	LoadCustomSpriteShader(shaderName string, shaderData []byte) uint32
 	UnloadCustomSpriteShader(shaderName string)
 	SetSpritePipeline(shaderName string)
-	SetCustomUniforms(params [16]float32)
+	SetCustomUniforms(cs CustomShaderRenderData)
 	NeedsGrabPass() bool
 	ResolveBackBuffer() Texture
 
@@ -216,7 +216,66 @@ type RenderParams struct {
 	xOffset        float32
 	yOffset        float32
 	shader         string
-	shaderParams   [16]float32
+	customShader   CustomShaderRenderData
+}
+
+type ShaderTexture struct {
+	AnimNo int32
+	Anim   *Animation
+	SprNo  [2]int32
+	Spr    *Sprite
+}
+
+func (st *ShaderTexture) clear() {
+	st.AnimNo = -1
+	st.Anim = nil
+	st.SprNo = [2]int32{-1, -1}
+	st.Spr = nil
+}
+
+func (st *ShaderTexture) GetTexture() Texture {
+	if st.Anim != nil {
+		if st.Anim.spr != nil {
+			return st.Anim.spr.Tex
+		}
+	} else if st.Spr != nil {
+		return st.Spr.Tex
+	}
+	return nil
+}
+
+func (st *ShaderTexture) step() {
+	if st.Anim != nil {
+		st.Anim.Action()
+		st.Anim.UpdateSprite()
+	}
+}
+
+type CustomShader struct {
+	name   string
+	params [16]float32
+	time   int32
+	sTime  float32
+	tex1   ShaderTexture
+	tex2   ShaderTexture
+}
+
+func (cs *CustomShader) clear() {
+	cs.name = ""
+	cs.params = [16]float32{}
+	cs.time = 0
+	cs.sTime = 0
+	cs.tex1.clear()
+	cs.tex2.clear()
+}
+
+type CustomShaderRenderData struct {
+	name   string
+	params [16]float32
+	time   int32
+	sTime  float32
+	tex1   Texture
+	tex2   Texture
 }
 
 func (rp *RenderParams) IsValid() bool {
@@ -630,7 +689,7 @@ func RenderSprite(rp RenderParams) {
 
 	// Heavy state change
 	// Because renderWithBlending() sometimes needs 2 passes, we'll do most of the setup outside of render()
-	gfx.SetSpritePipeline(rp.shader)
+	gfx.SetSpritePipeline(rp.customShader.name)
 
 	gfx.EnableScissor(rp.window[0], rp.window[1], rp.window[2], rp.window[3])
 
@@ -650,7 +709,7 @@ func RenderSprite(rp RenderParams) {
 		gfx.SetUniformI("isRgba", 0)
 	}
 
-	if rp.shader != "" {
+	if rp.customShader.name != "" {
 		var timeSec float32
 		if sys.middleOfMatch() {
 			timeSec = float32(sys.gameTime())
@@ -658,6 +717,7 @@ func RenderSprite(rp RenderParams) {
 			timeSec = float32(sys.frameCounter)
 		}
 		gfx.SetUniformF("iTime", timeSec/60.0)
+		gfx.SetUniformF("sTime", rp.customShader.sTime)
 		gfx.SetUniformF("iResolution", float32(sys.scrrect[2]), float32(sys.scrrect[3]))
 		aspectRatio := sys.getCurrentAspect() / sys.getFightAspect()
 		gfx.SetUniformF("aspectRatio", aspectRatio)
@@ -668,7 +728,13 @@ func RenderSprite(rp RenderParams) {
 				gfx.SetTexture("bgl_RenderedTexture", grabTex)
 			}
 		}
-		gfx.SetCustomUniforms(rp.shaderParams)
+		if rp.customShader.tex1 != nil {
+			gfx.SetTexture("tex1", rp.customShader.tex1)
+		}
+		if rp.customShader.tex2 != nil {
+			gfx.SetTexture("tex2", rp.customShader.tex2)
+		}
+		gfx.SetCustomUniforms(rp.customShader)
 	}
 	// Texture binding
 	gfx.SetTexture("tex", rp.tex)

--- a/src/render_gl33.go
+++ b/src/render_gl33.go
@@ -2266,8 +2266,8 @@ func (r *Renderer_GL33) LoadCustomSpriteShader(shaderName string, shaderData []b
 	shader.RegisterAttributes("position", "uv")
 	shader.RegisterUniforms("modelview", "projection", "x1x2x4x3",
 		"alpha", "tint", "mask", "neg", "gray", "add", "mult", "isFlat", "isRgba", "isTrapez", "hue",
-		"iTime", "iResolution", "aspectRatio")
-	shader.RegisterTextures("pal", "tex", "bgl_RenderedTexture")
+		"iTime", "iResolution", "aspectRatio", "sTime")
+	shader.RegisterTextures("pal", "tex", "tex1", "tex2", "bgl_RenderedTexture")
 
 	shader.needsGrabPass = strings.Contains(fragSource, "bgl_RenderedTexture")
 
@@ -2311,14 +2311,14 @@ func (r *Renderer_GL33) SetSpritePipeline(shaderName string) {
 	}
 }
 
-func (r *Renderer_GL33) SetCustomUniforms(params [16]float32) {
+func (r *Renderer_GL33) SetCustomUniforms(cs CustomShaderRenderData) {
 	if r.currentProgram == nil {
 		return
 	}
 	for i := 0; i < 16; i++ {
 		loc := gl.GetUniformLocation(r.currentProgram.program, gl.Str(fmt.Sprintf("p%d\x00", i)))
 		if loc >= 0 {
-			gl.Uniform1f(loc, params[i])
+			gl.Uniform1f(loc, cs.params[i])
 		}
 	}
 }

--- a/src/render_gl33.go
+++ b/src/render_gl33.go
@@ -2311,14 +2311,14 @@ func (r *Renderer_GL33) SetSpritePipeline(shaderName string) {
 	}
 }
 
-func (r *Renderer_GL33) SetCustomUniforms(cs CustomShaderRenderData) {
+func (r *Renderer_GL33) SetCustomUniforms(params [16]float32) {
 	if r.currentProgram == nil {
 		return
 	}
 	for i := 0; i < 16; i++ {
 		loc := gl.GetUniformLocation(r.currentProgram.program, gl.Str(fmt.Sprintf("p%d\x00", i)))
 		if loc >= 0 {
-			gl.Uniform1f(loc, cs.params[i])
+			gl.Uniform1f(loc, params[i])
 		}
 	}
 }

--- a/src/render_gles32.go
+++ b/src/render_gles32.go
@@ -2263,8 +2263,8 @@ func (r *Renderer_GLES32) LoadCustomSpriteShader(shaderName string, shaderData [
 	shader.RegisterAttributes("position", "uv")
 	shader.RegisterUniforms("modelview", "projection", "x1x2x4x3",
 		"alpha", "tint", "mask", "neg", "gray", "add", "mult", "isFlat", "isRgba", "isTrapez", "hue",
-		"iTime", "iResolution", "aspectRatio")
-	shader.RegisterTextures("pal", "tex", "bgl_RenderedTexture")
+		"iTime", "iResolution", "aspectRatio", "sTime")
+	shader.RegisterTextures("pal", "tex", "tex1", "tex2", "bgl_RenderedTexture")
 
 	shader.needsGrabPass = strings.Contains(fragSource, "bgl_RenderedTexture")
 
@@ -2308,14 +2308,14 @@ func (r *Renderer_GLES32) SetSpritePipeline(shaderName string) {
 	}
 }
 
-func (r *Renderer_GLES32) SetCustomUniforms(params [16]float32) {
+func (r *Renderer_GLES32) SetCustomUniforms(cs CustomShaderRenderData) {
 	if r.currentProgram == nil {
 		return
 	}
 	for i := 0; i < 16; i++ {
 		loc := gl.GetUniformLocation(r.currentProgram.program, gl.Str(fmt.Sprintf("p%d\x00", i)))
 		if loc >= 0 {
-			gl.Uniform1f(loc, params[i])
+			gl.Uniform1f(loc, cs.params[i])
 		}
 	}
 }

--- a/src/render_gles32.go
+++ b/src/render_gles32.go
@@ -2308,14 +2308,14 @@ func (r *Renderer_GLES32) SetSpritePipeline(shaderName string) {
 	}
 }
 
-func (r *Renderer_GLES32) SetCustomUniforms(cs CustomShaderRenderData) {
+func (r *Renderer_GLES32) SetCustomUniforms(params [16]float32) {
 	if r.currentProgram == nil {
 		return
 	}
 	for i := 0; i < 16; i++ {
 		loc := gl.GetUniformLocation(r.currentProgram.program, gl.Str(fmt.Sprintf("p%d\x00", i)))
 		if loc >= 0 {
-			gl.Uniform1f(loc, cs.params[i])
+			gl.Uniform1f(loc, params[i])
 		}
 	}
 }

--- a/src/render_vk.go
+++ b/src/render_vk.go
@@ -8187,13 +8187,11 @@ func (r *Renderer_VK) SetSpritePipeline(shaderName string) {
 	r.VKState.currentProgram = targetProgram
 }
 
-func (r *Renderer_VK) SetCustomUniforms(cs CustomShaderRenderData) {
+func (r *Renderer_VK) SetCustomUniforms(params [16]float32) {
 	if r.VKState.currentProgram == nil {
 		return
 	}
-	var pushData [16]float32
-	copy(pushData[:16], cs.params[:])
-	vk.CmdPushConstants(r.commandBuffers[0], r.VKState.currentProgram.pipelineLayout, vk.ShaderStageFlags(vk.ShaderStageFragmentBit), 16, 64, unsafe.Pointer(&pushData[0]))
+	vk.CmdPushConstants(r.commandBuffers[0], r.VKState.currentProgram.pipelineLayout, vk.ShaderStageFlags(vk.ShaderStageFragmentBit), 16, 64, unsafe.Pointer(&params[0]))
 }
 
 func (r *Renderer_VK) NeedsGrabPass() bool {

--- a/src/render_vk.go
+++ b/src/render_vk.go
@@ -862,6 +862,8 @@ type VulkanPalTexture struct {
 type VulkanSpriteTexture struct {
 	spriteTexture *Texture_VK
 	palTexture    *Texture_VK
+	customTex1    *Texture_VK
+	customTex2    *Texture_VK
 }
 type VulkanModelTexture struct {
 	lambertianEnvSampler *Texture_VK
@@ -1089,7 +1091,7 @@ type VulkanSpriteProgramFragUniformBufferObject struct {
 	iTime                         float32    // 4 bytes
 	iResolution                   [2]float32 // 8 bytes
 	aspectRatio                   float32
-	_padding2                     uint32 // 4 bytes
+	sTime                         float32 // 4 bytes
 }
 
 type VulkanLightUniform struct {
@@ -5026,8 +5028,12 @@ func (r *Renderer_VK) BeginFrame(clearColor bool) {
 	r.spriteProgram.uniformBufferOffset = 0
 	r.currentSpriteTexture.spriteTexture = r.dummyTexture
 	r.currentSpriteTexture.palTexture = r.dummyTexture
+	r.currentSpriteTexture.customTex1 = nil
+	r.currentSpriteTexture.customTex2 = nil
 	r.VKState.spriteTexture = r.dummyTexture
 	r.VKState.palTexture = r.dummyTexture
+	r.VKState.customTex1 = nil
+	r.VKState.customTex2 = nil
 	if r.modelProgram != nil {
 		r.modelProgram.uniformOffsetMap = make(map[interface{}]uint32)
 		r.modelProgram.uniformBufferOffset = 0
@@ -5738,6 +5744,8 @@ func (r *Renderer_VK) SetUniformF(name string, values ...float32) {
 		}
 	case "aspectRatio":
 		r.VKState.VulkanSpriteProgramFragUniformBufferObject.aspectRatio = values[0]
+	case "sTime":
+		r.VKState.VulkanSpriteProgramFragUniformBufferObject.sTime = values[0]
 	}
 }
 
@@ -5760,6 +5768,18 @@ func (r *Renderer_VK) SetTexture(name string, tex Texture) {
 		r.VKState.spriteTexture = tex.(*Texture_VK)
 	} else if name == "pal" {
 		r.VKState.palTexture = tex.(*Texture_VK)
+	} else if name == "tex1" {
+		if tex == nil {
+			r.VKState.customTex1 = nil
+			return
+		}
+		r.VKState.customTex1 = tex.(*Texture_VK)
+	} else if name == "tex2" {
+		if tex == nil {
+			r.VKState.customTex2 = nil
+			return
+		}
+		r.VKState.customTex2 = tex.(*Texture_VK)
 	}
 
 }
@@ -6350,12 +6370,17 @@ func (r *Renderer_VK) RenderQuad() {
 		r.currentSpriteTexture.palTexture = r.VKState.palTexture
 	}
 
-	// Assign the texture for GrabPass to Binding 4 (custom shader only)
-	if targetProgram != r.spriteProgram && r.grabTexture != nil {
+	// Assign the texture (custom shader only)
+	if targetProgram != r.spriteProgram {
+		// --- Binding 4: GrabPass ---
+		texGrab := r.grabTexture
+		if texGrab == nil {
+			texGrab = r.dummyTexture
+		}
 		grabImageInfo := []vk.DescriptorImageInfo{
 			{
 				ImageLayout: vk.ImageLayoutShaderReadOnlyOptimal,
-				ImageView:   r.grabTexture.imageView,
+				ImageView:   texGrab.imageView,
 				Sampler:     r.spriteSamplers[0],
 			},
 		}
@@ -6367,6 +6392,62 @@ func (r *Renderer_VK) RenderQuad() {
 			DescriptorType:  vk.DescriptorTypeCombinedImageSampler,
 			PImageInfo:      grabImageInfo,
 		})
+
+		// --- Binding 5: tex1 ---
+		if switchedProgram || r.VKState.customTex1 != r.currentSpriteTexture.customTex1 {
+			r.currentSpriteTexture.customTex1 = r.VKState.customTex1
+
+			tex1 := r.VKState.customTex1
+			if tex1 == nil {
+				tex1 = r.dummyTexture // 未指定時はクラッシュ防止のためダミーを送る
+			}
+			imageInfo1 := []vk.DescriptorImageInfo{
+				{
+					ImageLayout: vk.ImageLayoutShaderReadOnlyOptimal,
+					ImageView:   tex1.imageView,
+					Sampler:     r.spriteSamplers[0],
+				},
+			}
+			if tex1.filter {
+				imageInfo1[0].Sampler = r.spriteSamplers[1]
+			}
+			descriptorWrites = append(descriptorWrites, vk.WriteDescriptorSet{
+				SType:           vk.StructureTypeWriteDescriptorSet,
+				DstBinding:      5,
+				DstArrayElement: 0,
+				DescriptorCount: 1,
+				DescriptorType:  vk.DescriptorTypeCombinedImageSampler,
+				PImageInfo:      imageInfo1,
+			})
+		}
+
+		// --- Binding 6: tex2 ---
+		if switchedProgram || r.VKState.customTex2 != r.currentSpriteTexture.customTex2 {
+			r.currentSpriteTexture.customTex2 = r.VKState.customTex2
+
+			tex2 := r.VKState.customTex2
+			if tex2 == nil {
+				tex2 = r.dummyTexture
+			}
+			imageInfo2 := []vk.DescriptorImageInfo{
+				{
+					ImageLayout: vk.ImageLayoutShaderReadOnlyOptimal,
+					ImageView:   tex2.imageView,
+					Sampler:     r.spriteSamplers[0],
+				},
+			}
+			if tex2.filter {
+				imageInfo2[0].Sampler = r.spriteSamplers[1]
+			}
+			descriptorWrites = append(descriptorWrites, vk.WriteDescriptorSet{
+				SType:           vk.StructureTypeWriteDescriptorSet,
+				DstBinding:      6,
+				DstArrayElement: 0,
+				DescriptorCount: 1,
+				DescriptorType:  vk.DescriptorTypeCombinedImageSampler,
+				PImageInfo:      imageInfo2,
+			})
+		}
 	}
 
 	if len(descriptorWrites) > 0 {
@@ -7809,6 +7890,8 @@ func (r *Renderer_VK) createCustomSpriteProgram(fragSpv []byte) (*VulkanProgramI
 		{Binding: 2, DescriptorCount: 1, DescriptorType: vk.DescriptorTypeCombinedImageSampler, StageFlags: vk.ShaderStageFlags(vk.ShaderStageFragmentBit)},
 		{Binding: 3, DescriptorCount: 1, DescriptorType: vk.DescriptorTypeCombinedImageSampler, StageFlags: vk.ShaderStageFlags(vk.ShaderStageFragmentBit)},
 		{Binding: 4, DescriptorCount: 1, DescriptorType: vk.DescriptorTypeCombinedImageSampler, StageFlags: vk.ShaderStageFlags(vk.ShaderStageFragmentBit)}, // GrabPass
+		{Binding: 5, DescriptorCount: 1, DescriptorType: vk.DescriptorTypeCombinedImageSampler, StageFlags: vk.ShaderStageFlags(vk.ShaderStageFragmentBit)}, // tex1
+		{Binding: 6, DescriptorCount: 1, DescriptorType: vk.DescriptorTypeCombinedImageSampler, StageFlags: vk.ShaderStageFlags(vk.ShaderStageFragmentBit)}, // tex2
 	}
 	layoutInfo := vk.DescriptorSetLayoutCreateInfo{
 		SType:        vk.StructureTypeDescriptorSetLayoutCreateInfo,
@@ -8104,11 +8187,13 @@ func (r *Renderer_VK) SetSpritePipeline(shaderName string) {
 	r.VKState.currentProgram = targetProgram
 }
 
-func (r *Renderer_VK) SetCustomUniforms(params [16]float32) {
+func (r *Renderer_VK) SetCustomUniforms(cs CustomShaderRenderData) {
 	if r.VKState.currentProgram == nil {
 		return
 	}
-	vk.CmdPushConstants(r.commandBuffers[0], r.VKState.currentProgram.pipelineLayout, vk.ShaderStageFlags(vk.ShaderStageFragmentBit), 16, 64, unsafe.Pointer(&params[0]))
+	var pushData [16]float32
+	copy(pushData[:16], cs.params[:])
+	vk.CmdPushConstants(r.commandBuffers[0], r.VKState.currentProgram.pipelineLayout, vk.ShaderStageFlags(vk.ShaderStageFragmentBit), 16, 64, unsafe.Pointer(&pushData[0]))
 }
 
 func (r *Renderer_VK) NeedsGrabPass() bool {
@@ -8199,6 +8284,8 @@ func (r *Renderer_VK) ResolveBackBuffer() Texture {
 	r.VKState.modelUniformBufferOffset2 = 0xFFFFFFFF
 	r.currentSpriteTexture.spriteTexture = nil
 	r.currentSpriteTexture.palTexture = nil
+	r.currentSpriteTexture.customTex1 = nil
+	r.currentSpriteTexture.customTex2 = nil
 
 	return r.grabTexture
 }

--- a/src/script.go
+++ b/src/script.go
@@ -10431,9 +10431,9 @@ func triggerFunctions(l *lua.LState) {
 	luaRegister(l, "shader", func(l *lua.LState) int {
 		if !nilArg(l, 1) {
 			shaderName := strings.ToLower(strArg(l, 1))
-			l.Push(lua.LBool(sys.debugWC.shader == shaderName))
+			l.Push(lua.LBool(sys.debugWC.customShader.name == shaderName))
 		} else {
-			l.Push(lua.LBool(sys.debugWC.shader != ""))
+			l.Push(lua.LBool(sys.debugWC.customShader.name != ""))
 		}
 		return 1
 	})

--- a/src/stage.go
+++ b/src/stage.go
@@ -715,7 +715,7 @@ func (bg backGround) draw(pos [2]float32, drawscl, bgscl, stglscl float32,
 			bg.xscale[0]*bgscl*(scalestartX+xs)*xs3,
 			xbs*bgscl*(scalestartX+xs)*xs3,
 			ys*ys3, xras*x/(Abs(ys*ys3)*lscl[1]*float32(bg.anim.spr.Size[1])*bg.scalestart[1])*sclx_recip*bg.scalestart[1]-bg.xshear,
-			bg.rot, rcx, bg.palfx, 1, [2]float32{1, 1}, int32(bg.projection), bg.fLength, 0, false, "", [16]float32{})
+			bg.rot, rcx, bg.palfx, 1, [2]float32{1, 1}, int32(bg.projection), bg.fLength, 0, false, CustomShaderRenderData{})
 	}
 }
 

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -216,6 +216,10 @@ func (e *Explod) Clone(a *arena.Arena, gsp *GameStatePool) *Explod {
 		result.anim = e.anim.Clone(a, gsp)
 	}
 
+	if e.customShader.name != "" {
+		result.customShader = e.customShader.Clone(a, gsp)
+	}
+
 	if e.palfx != nil {
 		result.palfx = e.palfx.Clone(a)
 	}
@@ -237,6 +241,10 @@ func (p *Projectile) clone(a *arena.Arena, gsp *GameStatePool) *Projectile {
 
 	if p.anim != nil {
 		result.anim = p.anim.Clone(a, gsp)
+	}
+
+	if p.customShader.name != "" {
+		result.customShader = p.customShader.Clone(a, gsp)
 	}
 
 	if p.palfx != nil {
@@ -284,7 +292,9 @@ func (c *Char) Clone(a *arena.Arena, gsp *GameStatePool) (result Char) {
 	if c.reflectAnim != nil {
 		result.reflectAnim = c.reflectAnim.Clone(a, gsp)
 	}
-
+	if c.customShader.name != "" {
+		result.customShader = c.customShader.Clone(a, gsp)
+	}
 	// TODO: Profiling shows this is hotter than it should be
 	// Maybe we ought to clear animation data from them when their timer expires
 	// Update: Done already but copying 60 PalFX's is still a problem
@@ -1042,5 +1052,16 @@ func (s *Storyboard) Clone(a *arena.Arena) (result Storyboard) {
 		}
 	}
 
+	return result
+}
+
+func (cs *CustomShader) Clone(a *arena.Arena, gsp *GameStatePool) CustomShader {
+	result := *cs
+	if cs.tex1.Anim != nil {
+		result.tex1.Anim = cs.tex1.Anim.Clone(a, gsp)
+	}
+	if cs.tex2.Anim != nil {
+		result.tex2.Anim = cs.tex2.Anim.Clone(a, gsp)
+	}
 	return result
 }


### PR DESCRIPTION
Shader parameters
・float sTime;
This value represents the number of frames since the shader was called. The count stops when the pause process is entered.

・uniform sampler2D tex1;
・uniform sampler2D tex2;
Can store additional textures loaded from the Anim number or SFF sprite number. Note that since textures are loaded as raw data, images with palettes may not display correctly as is.

ShaderSet/Explod/Projectile Parameters

・ShaderTex1.spr = Group, No
・ShaderTex1.anim = AnimNo

・ShaderTex2.spr = Group, No
・ShaderTex2.anim = AnimNo

Each of these will load the Anim or sprite specified in either of these as a texture. FightFX is not yet supported.

Explod/Projectile Parameters

・ShaderTime = int
Specifies the time the shader is active in Explod and Projectile. Default is -1 (persistent). In ShaderSet SCTRL, this is the Time parameter.

[kfm_zss_s.zip](https://github.com/user-attachments/files/29797730/kfm_zss_s.zip)
<img width="640" height="480" alt="Ikemen_GO011" src="https://github.com/user-attachments/assets/5f767990-741d-430a-872c-4757218badc6" />
