### PR TITLE
fix: rollback replay sync, replay preloads wait and replay VS screen ESC exit

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -3085,10 +3085,13 @@ function main.f_replay()
 		elseif getKey(motif.replay_info.menu.item.rename.keycode) then
 			t, item = main.f_renameReplay(item, t)
 		elseif getInput(-1, motif[main.group].menu.done.key) then
+			main.f_waitForPreloads(true)
 			sndPlay(motif.Snd, motif[main.group].cursor.done.snd.default[1], motif[main.group].cursor.done.snd.default[2])
 			if enterReplay(t[item].itemname) and synchronize() then
+				main.replayActive = true
 				enterSyncedNetplayMenu()
 			end
+			main.replayActive = false
 			replayStop()
 			exitNetPlay()
 			exitReplay()

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -4193,6 +4193,9 @@ function start.f_selectVersus(active, t_orderSelect, loadStartArg)
 				loadCancel()
 				clearSelected()
 			end
+			if main.replayActive then
+				start.exit = true
+			end
 			fadeOutInit(motif.vs_screen.fadeout.FadeData)
 			fadeOutStarted = true
 			escFlag = true

--- a/src/netplay.go
+++ b/src/netplay.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
@@ -26,8 +27,10 @@ const (
 	REPLAY_INPUT_BYTES = 2 + 6
 
 	syncConfigVersion   uint16 = 1
-	replayFormatVersion uint16 = 1
+	replayFormatVersion uint16 = 2
 	replayMagic                = "IKRPLCFG"
+	replaySyncMagic            = "IKRPLSYN"
+	replaySyncSearchLimit      = int64(64 << 20)
 
 	netLoadingPollTimeout = time.Millisecond
 
@@ -600,8 +603,13 @@ func (nc *NetConnection) Synchronize() error {
 
 	// Write seed and pre-match time to replay file
 	if nc.recording != nil {
-		binary.Write(nc.recording, binary.LittleEndian, &seed)
-		binary.Write(nc.recording, binary.LittleEndian, &pmTime)
+		if off, err := nc.recording.Seek(0, io.SeekCurrent); err == nil {
+			log.Printf("Replay sync write: offset=%d seed=%d pmTime=%d gameRunning=%t rollback=%t",
+				off, seed, pmTime, sys.gameRunning, sys.cfg.Netplay.RollbackNetcode)
+		}
+		if err := writeReplaySync(nc.recording, seed, pmTime); err != nil {
+			return err
+		}
 	}
 
 	// Verify connection time synchronization
@@ -944,19 +952,20 @@ func readReplayHeader(f *os.File) (*ReplayHeader, error) {
 	magic := make([]byte, len(replayMagic))
 	if _, err := io.ReadFull(f, magic); err != nil {
 		if err == io.EOF || err == io.ErrUnexpectedEOF {
-			_, _ = f.Seek(0, io.SeekStart)
-			return nil, nil
+			return nil, fmt.Errorf("missing replay header")
 		}
 		return nil, err
 	}
 	if string(magic) != replayMagic {
-		_, _ = f.Seek(0, io.SeekStart)
-		return nil, nil
+		return nil, fmt.Errorf("invalid replay header magic")
 	}
 
 	var version uint16
 	if err := binary.Read(f, binary.LittleEndian, &version); err != nil {
 		return nil, err
+	}
+	if version != replayFormatVersion {
+		return nil, fmt.Errorf("unsupported replay format version: %d", version)
 	}
 	var size uint32
 	if err := binary.Read(f, binary.LittleEndian, &size); err != nil {
@@ -975,6 +984,16 @@ func readReplayHeader(f *os.File) (*ReplayHeader, error) {
 	return &header, nil
 }
 
+func writeReplaySync(w io.Writer, seed, pmTime int32) error {
+	if _, err := w.Write([]byte(replaySyncMagic)); err != nil {
+		return err
+	}
+	if err := binary.Write(w, binary.LittleEndian, seed); err != nil {
+		return err
+	}
+	return binary.Write(w, binary.LittleEndian, pmTime)
+}
+
 type ReplayFile struct {
 	file               *os.File
 	ibit               [REPLAY_NUM_INPUTS]InputBits
@@ -983,7 +1002,6 @@ type ReplayFile struct {
 	strictSettings     []SyncSetting
 	hostSettings       []SyncSetting
 	contentFingerprint string
-	warning            string
 }
 
 func OpenReplayFile(filename string) *ReplayFile {
@@ -1000,19 +1018,14 @@ func OpenReplayFile(filename string) *ReplayFile {
 	}
 
 	out := &ReplayFile{file: rf}
-	if header != nil {
-		out.strictSettings = cloneSyncSettings(header.Strict)
-		out.hostSettings = cloneSyncSettings(header.Host)
-		out.contentFingerprint = header.ContentFingerprint
-		if header.SyncVersion != syncConfigVersion {
-			out.warning = fmt.Sprintf(
-				"replay sync config version mismatch (replay=%d engine=%d); playback is best-effort",
-				header.SyncVersion, syncConfigVersion,
-			)
-		}
-	} else {
-		out.warning = "legacy replay without sync config header; playback is best-effort"
+	if header.SyncVersion != syncConfigVersion {
+		log.Printf("Replay sync config version mismatch: replay=%d engine=%d", header.SyncVersion, syncConfigVersion)
+		rf.Close()
+		return nil
 	}
+	out.strictSettings = cloneSyncSettings(header.Strict)
+	out.hostSettings = cloneSyncSettings(header.Host)
+	out.contentFingerprint = header.ContentFingerprint
 
 	log.Printf("Replay file opened: %s", filename)
 	return out
@@ -1054,23 +1067,80 @@ func (rf *ReplayFile) AnyButton() bool {
 	return false
 }
 
+func seekReplaySyncMarker(f *os.File) (int64, error) {
+	start, err := f.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return 0, err
+	}
+	data, err := io.ReadAll(io.LimitReader(f, replaySyncSearchLimit))
+	if err != nil {
+		_, _ = f.Seek(start, io.SeekStart)
+		return 0, err
+	}
+	idx := bytes.Index(data, []byte(replaySyncMagic))
+	if idx < 0 {
+		_, _ = f.Seek(start, io.SeekStart)
+		return 0, fmt.Errorf("replay sync marker not found from offset %d", start)
+	}
+	skipped := int64(idx)
+	_, err = f.Seek(start+skipped+int64(len(replaySyncMagic)), io.SeekStart)
+	return skipped, err
+}
+
+func (rf *ReplayFile) readReplaySync() (seed, pmTime int32, err error) {
+	if rf == nil || rf.file == nil {
+		return 0, 0, io.ErrClosedPipe
+	}
+
+	start, _ := rf.file.Seek(0, io.SeekCurrent)
+	skipped, err := seekReplaySyncMarker(rf.file)
+	if err != nil {
+		return 0, 0, err
+	}
+	if skipped > 0 {
+		log.Printf("Replay sync read: skipped %d byte(s) to recover sync marker from offset %d", skipped, start)
+	}
+
+	if err := binary.Read(rf.file, binary.LittleEndian, &seed); err != nil {
+		return 0, 0, err
+	}
+	if err := binary.Read(rf.file, binary.LittleEndian, &pmTime); err != nil {
+		return 0, 0, err
+	}
+	if off, err := rf.file.Seek(0, io.SeekCurrent); err == nil {
+		log.Printf("Replay sync read: offset=%d seed=%d pmTime=%d", off, seed, pmTime)
+	}
+	return seed, pmTime, nil
+}
+
+func (rf *ReplayFile) atReplaySyncMarker() bool {
+	if rf == nil || rf.file == nil {
+		return false
+	}
+	pos, err := rf.file.Seek(0, io.SeekCurrent)
+	if err != nil {
+		return false
+	}
+	var magic [len(replaySyncMagic)]byte
+	_, err = io.ReadFull(rf.file, magic[:])
+	_, _ = rf.file.Seek(pos, io.SeekStart)
+	return err == nil && string(magic[:]) == replaySyncMagic
+}
+
 // Read system variables from replay file
 func (rf *ReplayFile) Synchronize() {
 	if rf.file != nil {
-		// Read random seed
-		var seed int32
-		if err := binary.Read(rf.file, binary.LittleEndian, &seed); err == nil {
-			Srand(seed)
+		seed, pmTime, err := rf.readReplaySync()
+		if err != nil {
+			log.Printf("Replay synchronization failed: %v", err)
+			sys.esc = true
+			rf.Close()
+			return
 		}
-
-		// Read pre-match time
-		var pmTime int32
-		if err := binary.Read(rf.file, binary.LittleEndian, &pmTime); err == nil {
-			rf.preMatchTime = pmTime
-			// Advance first frame
-			rf.Update()
-		}
-
+		Srand(seed)
+		rf.preMatchTime = pmTime
+		sys.preMatchTime = pmTime
+		rf.Update()
 		// Log status
 		log.Printf("Replay synchronized: seed=%d pmTime=%d", seed, pmTime)
 	}
@@ -1082,6 +1152,11 @@ func (rf *ReplayFile) Update() bool {
 		sys.esc = true
 	} else {
 		if sys.oldNextAddTime > 0 {
+			if rf.atReplaySyncMarker() {
+				rf.ibit = [REPLAY_NUM_INPUTS]InputBits{}
+				rf.iaxes = [REPLAY_NUM_INPUTS][6]int8{}
+				return !sys.gameEnd
+			}
 			rf.ibit = [REPLAY_NUM_INPUTS]InputBits{}
 			rf.iaxes = [REPLAY_NUM_INPUTS][6]int8{}
 
@@ -1615,13 +1690,10 @@ func (s *System) beginReplaySession(rf *ReplayFile) error {
 	if rf == nil {
 		return nil
 	}
-	if rf.warning != "" {
-		log.Printf("Replay compatibility warning: %s", rf.warning)
-	}
 	log.Printf("Replay sync header loaded: strict=%d host=%d fingerprint=%q",
 		len(rf.strictSettings), len(rf.hostSettings), rf.contentFingerprint)
 	if len(rf.hostSettings) == 0 && len(rf.strictSettings) == 0 {
-		log.Printf("Replay sync config: no header settings to apply (legacy/best-effort replay)")
+		log.Printf("Replay sync config: no header settings to apply")
 		return nil
 	}
 


### PR DESCRIPTION
Replay sync data was written unframed, so playback could read input bytes as the match seed/time and start the replay with the wrong RNG state.