### PR TITLE
fix: netplay and replay fixes

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -8102,14 +8102,20 @@ func varRangeSetSub[T int32 | float32](c *Char, m *map[int32]T, first, last int3
 	loopCount := 0
 
 	if val == 0 {
-		// Delete specific keys. Optimized for sparse maps
+		// Map iteration order is randomized. Collect and sort matching keys so
+		// the MaxLoop cap clears the same variables on every peer.
+		keys := make([]int, 0, Min(len(*m), MaxLoop))
 		for k := range *m {
 			if k >= first && k <= last {
-				delete(*m, k)
-				loopCount++
-				if loopCount >= MaxLoop {
-					break
-				}
+				keys = append(keys, int(k))
+			}
+		}
+		sort.Ints(keys)
+		for _, k := range keys {
+			delete(*m, int32(k))
+			loopCount++
+			if loopCount >= MaxLoop {
+				break
 			}
 		}
 	} else {

--- a/src/char.go
+++ b/src/char.go
@@ -5249,7 +5249,7 @@ func (c *Char) comboCount() int32 {
 	if c.teamside == -1 {
 		return 0
 	}
-	return sys.fightScreen.combos[c.teamside].trueHits
+	return sys.comboCount[c.teamside]
 }
 
 func (c *Char) command(pn, i int) bool {
@@ -8767,14 +8767,14 @@ func (c *Char) score() float32 {
 	if c.teamside == -1 {
 		return 0
 	}
-	return sys.fightScreen.scores[c.teamside].scorePoints
+	return sys.scorePoints[c.teamside]
 }
 
 func (c *Char) scoreAdd(val float32) {
 	if val == 0 || c.teamside == -1 || c.asf(ASF_noscore) {
 		return
 	}
-	sys.fightScreen.scores[c.teamside].scorePoints += val
+	sys.scorePoints[c.teamside] += val
 }
 
 func (c *Char) scoreTotal() float32 {

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -5311,6 +5311,7 @@ func (c *CharCompiler) modifyBGCtrl(is IniSection, sc *StateControllerBase) (Sta
 		}
 		return nil
 	})
+	sys.cgi[c.playerNo].canMutateStage = true
 	return *ret, err
 }
 
@@ -5330,6 +5331,7 @@ func (c *CharCompiler) modifyBGCtrl3d(is IniSection, sc *StateControllerBase) (S
 		}
 		return nil
 	})
+	sys.cgi[c.playerNo].canMutateStage = true
 	return *ret, err
 }
 

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -811,25 +811,31 @@ func (c *CharCompiler) helper(is IniSection, sc *StateControllerBase) (StateCont
 			return err
 		}
 
-		// Handle the "map." parameters
-		// Must be placed after extendsmap or that operation may write over these maps
-		for k, data := range is {
-			lowK := strings.ToLower(k)
-			if strings.HasPrefix(lowK, "map.") {
-				mapKey := k[4:]
-				if mapKey == "" {
-					return Error("Empty map key in helper parameters")
-				}
-				// Compile value expression
-				mapValBes, err := c.exprs(data, VT_Float, 1)
-				if err != nil {
-					return err
-				}
-				// String hack like with most name parameters
-				mapKeyBes := sc.beToExp(BytecodeExp(mapKey))
-				sc.add(helper_map, append(mapKeyBes, mapValBes...))
-				delete(is, k)
+		// Handle the "map." parameters. Must be placed after extendsmap or that
+		// operation may write over these maps. Sort keys because parameter
+		// expressions are evaluated in the generated controller order and may
+		// consume deterministic state such as Random.
+		mapParams := make([]string, 0)
+		for k := range is {
+			if strings.HasPrefix(strings.ToLower(k), "map.") {
+				mapParams = append(mapParams, k)
 			}
+		}
+		sort.Strings(mapParams)
+		for _, k := range mapParams {
+			mapKey := k[4:]
+			if mapKey == "" {
+				return Error("Empty map key in helper parameters")
+			}
+			// Compile value expression
+			mapValBes, err := c.exprs(is[k], VT_Float, 1)
+			if err != nil {
+				return err
+			}
+			// String hack like with most name parameters
+			mapKeyBes := sc.beToExp(BytecodeExp(mapKey))
+			sc.add(helper_map, append(mapKeyBes, mapValBes...))
+			delete(is, k)
 		}
 
 		return nil

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -2351,7 +2351,6 @@ type FightScreenCombo struct {
 	hidespeed    float32
 	separator    string
 	places       int32
-	trueHits     int32
 	shownHits    int32
 	shownDmg     int32
 	shownPct     float32
@@ -2471,7 +2470,7 @@ func readFightScreenCombo(pre string, is IniSection,
 	return co
 }
 
-func (co *FightScreenCombo) step(hits, damage int32, percentage float32) {
+func (co *FightScreenCombo) step(side int, hits, damage int32, percentage float32) {
 	co.bg.Action()
 	co.top.Action()
 
@@ -2482,11 +2481,9 @@ func (co *FightScreenCombo) step(hits, damage int32, percentage float32) {
 
 	// Reset team combo if no player was found getting hit
 	if hits == 0 {
-		co.trueHits = 0
+		sys.comboCount[side] = 0
 	}
-
-	// True hits are only updated by Char(). The live tally is only used for combo display behavior
-	//co.trueHits = hits
+	trueHits := sys.comboCount[side]
 
 	// Handle show/hide speed
 	if co.resttime > 0 {
@@ -2496,7 +2493,7 @@ func (co *FightScreenCombo) step(hits, damage int32, percentage float32) {
 		if Abs(co.counterX) < 1 {
 			co.counterX = 0
 		}
-	} else if co.trueHits < 2 {
+	} else if trueHits < 2 {
 		// Slide out when combo ends
 		co.counterX -= sys.fightScreen.fnt_scale * co.hidespeed * float32(sys.fightScreen.localcoord[0]) / 320
 		// Snap to starting position
@@ -2513,9 +2510,9 @@ func (co *FightScreenCombo) step(hits, damage int32, percentage float32) {
 	}
 
 	// Update if number of hits or total damage change
-	if co.trueHits >= 2 && (co.newCombo || co.shownHits != co.trueHits || co.shownDmg != damage) {
+	if trueHits >= 2 && (co.newCombo || co.shownHits != trueHits || co.shownDmg != damage) {
 		// Reset visuals when hits changed
-		if co.newCombo || co.shownHits != co.trueHits {
+		if co.newCombo || co.shownHits != trueHits {
 			co.counterShake.restart()
 			co.textShake.restart()
 			for i := range co.counter {
@@ -2528,7 +2525,7 @@ func (co *FightScreenCombo) step(hits, damage int32, percentage float32) {
 		// Time resets if either hits or damage changed
 		co.resttime = co.displaytime
 		// Update state
-		co.shownHits = co.trueHits
+		co.shownHits = trueHits
 		co.shownDmg = damage
 		co.shownPct = percentage
 		co.newCombo = false
@@ -2563,7 +2560,6 @@ func (co *FightScreenCombo) step(hits, damage int32, percentage float32) {
 func (co *FightScreenCombo) reset() {
 	co.bg.Reset()
 	co.top.Reset()
-	co.trueHits = 0
 	co.shownHits = 0
 	co.shownDmg = 0
 	co.shownPct = 0
@@ -4253,7 +4249,6 @@ type FightScreenScore struct {
 	places      int32
 	min         float32
 	max         float32
-	scorePoints float32
 	enabled     map[string]bool
 	active      bool
 }
@@ -4296,7 +4291,6 @@ func (sc *FightScreenScore) step() {
 func (sc *FightScreenScore) reset() {
 	sc.bg.Reset()
 	sc.top.Reset()
-	sc.scorePoints = 0
 }
 
 func (sc *FightScreenScore) bgDraw(layerno int16) {
@@ -5442,7 +5436,7 @@ func (fs *FightScreen) step() {
 		}
 	}
 	for i := range fs.combos {
-		fs.combos[i].step(cb[i], cd[i], cp[i]) // Combo hits, combo damage, combo damage percentage
+		fs.combos[i].step(i, cb[i], cd[i], cp[i]) // Combo hits, combo damage, combo damage percentage
 	}
 	// Action
 	for i := range fs.actions {
@@ -6016,7 +6010,7 @@ func (fs *FightScreen) addComboHits(side int, n int32) {
 	if side < 0 || side >= len(fs.combos) {
 		return
 	}
-	fs.combos[side].trueHits += n
+	sys.comboCount[side] += n
 }
 
 // Update team order based on the actual character member numbers

--- a/src/input.go
+++ b/src/input.go
@@ -141,7 +141,7 @@ func OnKeyPressed(key Key, mk ModifierKey) {
 		if key == KeyF12 {
 			captureScreen()
 		}
-		if key == StringToKeyLUT[sys.motif.AttractMode.Credits.KeyCode] && sys.credits != -1 {
+		if !sys.netplay() && key == StringToKeyLUT[sys.motif.AttractMode.Credits.KeyCode] && sys.credits != -1 {
 			sys.credits += 1
 			sys.motif.Snd.play(sys.motif.AttractMode.Credits.Snd, 100, 0, 0, 0, 0)
 		}

--- a/src/music.go
+++ b/src/music.go
@@ -4,16 +4,18 @@
 //
 // Goal
 // -----
-// Unify every place that can set BGM (screenpack/motif, stage, storyboard,
-// select.def, and Lua launch parameters) into one runtime type.
+// Normalize configured BGM sources from screenpack/motif, stage, storyboard,
+// select.def, and Lua launch parameters into one runtime type. Lua playBgm
+// may also play an explicitly supplied file directly.
 //
 // Core type
 // ---------
 // Music is a map[string][]*bgMusic keyed by a *prefix* (e.g. "", "title",
-// "round1", "life", "victory", "final", "scene1", ...). Each key holds a list
+// "round1", "life", "victory", "final", ...). Each key holds a list
 // of candidate tracks with playback options. Read() randomly picks one entry
 // for the prefix and returns the resolved file and options. Play() delegates
 // to Read() and opens the BGM.
+// Automatic in-match playback uses rollbacked matchSelection state instead.
 //
 // Where values come from (all normalized into Music struct)
 // --------------------------------------------------
@@ -26,7 +28,8 @@
 //   Stored in sys.stage.music.
 //
 // • Storyboard (per-scene bgm, declared under [Scene X])
-//   Parsed by parseMusicSection() into prefixes like "scene1", ...
+//   Each scene section is parsed into its own Scene[X].Music map.
+//   The ordinary scene BGM uses the empty prefix "".
 //   Stored in sys.storyboard.Scene[X].Music
 //
 // • select.def – character parameters (Lua addChar)
@@ -59,42 +62,35 @@
 // NOTE: select_params.go additionally supports "music=path vol loopstart loopend"
 // by expanding it into the above "<prefix>.bgm*" keys before calling AppendParams.
 //
-// Normalization of naming
-// -----------------------
-// Elecbyte used inconsistent keys across files. Both the INI loader
-// (parseMusicSection) and the runtime parameter path (AppendParams) accept
-// synonyms and normalize them into bgMusic fields:
-//
-//   bgm / bgmusic / music
-//   bgm.loop / bgmloop
-//   bgm.volume / bgmvolume
-//   bgm.loopstart / bgmloopstart
-//   bgm.loopend / bgmloopend
-//   bgm.startposition / bgmstartposition
-//   bgm.freqmul / bgmfreqmul
-//   bgm.loopcount / bgmloopcount
+// Accepted naming
+// ---------------
+// parseMusicSection accepts bgm/bgmusic and both dotted and compact option
+// names, such as bgm.loop/bgmloop and bgm.volume/bgmvolume.
+// AppendParams accepts bgmusic/music and compact bgm* option names.
 //
 // Prefix handling
 // ---------------
-// Keys may be written as "<prefix>.<field>" (e.g. "round2.bgmusic").
-// Everything before the first dot is the Music map key; the rest selects a
-// bgMusic field. When no prefix is present the empty key "" is used.
+// The last recognized ".bgmusic", ".music", or ".bgm" anchor separates the
+// prefix from the field, allowing dots inside prefixes. Prefix dots are
+// flattened to underscores. When no prefix is present the empty key "" is used.
 //
 // Resolution order (per character)
 // --------------------------------------------
 // The final playable list is computed and stored per character slot so that
-// per-character or per-stage overrides can win over defaults; custom character
-// music (or stage music coming from select.def) can override the stage's .def
-// music, and launch-time Lua must be able to override both.
+// stage parameters add candidates to the stage definition. Character and
+// launch parameters can replace corresponding candidates by index.
 
-// In resetRoundState the code does (for each sys.chars index i):
+// During resetRound(), updateMusicMaps() does the following for each non-empty
+// character slot:
 // • 1. Clear
 //   sys.cgi[i].music = make(Music)
 // • 2. Base: stage.def [Music]
 //   sys.cgi[i].music.Append(sys.stage.music)
 // • 3. select.def stage params (addStage)
 //   sys.cgi[i].music.Append(sys.stage.si().music)
-// • 4. select.def character params (addChar) – override stage
+// • 4. select.def character params (addChar)
+//   Override all prefixes when CharParamMusic is enabled;
+//   otherwise apply only the character's "victory" prefix.
 //   sys.cgi[i].music.Override(p[0].si().music)
 // • 5. launchFight params (loadStart) – last word
 //   sys.cgi[i].music.Override(sys.sel.music)
@@ -103,12 +99,13 @@
 // -----------------
 // During a match, Music.act() reacts to state and tries to play a suitable
 // prefix in this order:
-// • round start: "final" (if decisive) or "round<sys.round>"
+// • round start: "final", then optionally "round<sys.match>", then
+//   "round<sys.round>", then the empty prefix
 // • low life (team leader): "life"
 // • victory (decisive, winner alive): "victory"
-// tryPlay() checks if a prefix exists and has any defined track, then calls
-// Play. Read() randomizes among multiple entries for the prefix and resolves
-// the path using SearchFile.
+// tryPlay() checks if a prefix has a defined track, reuses or chooses its
+// rollbacked match candidate, resolves the path, and opens it when needed.
+// Generic Play() callers choose a candidate through Read().
 //
 // ----------------------------------------------------------------------------
 
@@ -140,7 +137,6 @@ type bgMusic struct {
 	bgmstartposition int32
 	bgmfreqmul       float32
 	bgmloopcount     int32
-	selected         bool
 }
 
 func newBgMusic() *bgMusic {
@@ -212,43 +208,51 @@ func musicKeyPrefix(key string) string {
 	return normalizeMusicPrefix(prefix)
 }
 
-func (m Music) ClearSelection() {
-	for _, lst := range m {
-		for _, bg := range lst {
-			if bg != nil {
-				bg.selected = false
+// matchSelection reuses or chooses an automatic match candidate.
+// Stored pointers preserve choices across overlapping source lists.
+func (m Music) matchSelection(key string) *bgMusic {
+	prefix := musicKeyPrefix(key)
+	lst := m[prefix]
+	if len(lst) == 0 {
+		return nil
+	}
+	if len(lst) == 1 {
+		return lst[0]
+	}
+
+	for _, bg := range lst {
+		if bg == nil {
+			continue
+		}
+		for _, selected := range sys.matchMusicSel {
+			if selected == bg {
+				return bg
 			}
 		}
 	}
-}
 
-// pinSelection chooses one candidate for automatic in-match playback and keeps
-// that choice across round resets. The merged cgi music map is rebuilt every
-// round, so the flag lives on the shared source bgMusic entry.
-func (m Music) pinSelection(key string) {
-	prefix := musicKeyPrefix(key)
-	lst := m[prefix]
-	if len(lst) < 2 {
-		return
-	}
-	for _, bg := range lst {
-		if bg != nil && bg.selected {
-			m[prefix] = []*bgMusic{bg}
-			return
-		}
-	}
-	idx := int(RandI(0, int32(len(lst))-1))
-	bg := lst[idx]
+	bg := lst[int(RandI(0, int32(len(lst))-1))]
 	if bg == nil {
-		return
+		return nil
 	}
-	for _, v := range lst {
-		if v != nil {
-			v.selected = false
+
+	// Drop prior choices from this list while preserving unrelated choices.
+	previous := sys.matchMusicSel
+	sys.matchMusicSel = sys.matchMusicSel[:0]
+	for _, selected := range previous {
+		belongsToList := false
+		for _, candidate := range lst {
+			if candidate == selected {
+				belongsToList = true
+				break
+			}
+		}
+		if !belongsToList {
+			sys.matchMusicSel = append(sys.matchMusicSel, selected)
 		}
 	}
-	bg.selected = true
-	m[prefix] = []*bgMusic{bg}
+	sys.matchMusicSel = append(sys.matchMusicSel, bg)
+	return bg
 }
 
 // AppendParams parses comma-separated "key=value" pairs (as passed from
@@ -368,7 +372,6 @@ func (m Music) Read(key, def string) (string, int, int, int, int, int, float32, 
 
 // Play opens the chosen track in the global BGM player.
 func (m Music) Play(key, path string) bool {
-	m.pinSelection(key)
 	track, loop, volume, loopstart, loopend, startposition, freqmul, loopcount := m.Read(key, path)
 	//fmt.Printf("[music] Play: key='%s' def='%s' -> track='%s'\n", key, path, track)
 
@@ -395,12 +398,9 @@ const (
 	BGMStateVictory                 // victory track chosen/playing
 )
 
-// tryPlay is a guarded helper used by act(): if a prefix exists and has at
-// least one non-empty entry, it delegates to Play("<prefix>.bgmusic", def).
+// tryPlay handles rollbacked automatic match music.
+// A valid track completes the transition even if it is already playing.
 func (m Music) tryPlay(key, def string) bool {
-	//if dot := strings.Index(key, "."); dot != -1 {
-	//	key = key[:dot]
-	//}
 	nkey := normalizeMusicPrefix(key)
 	lst, ok := m[nkey]
 	if !ok || len(lst) == 0 {
@@ -419,9 +419,26 @@ func (m Music) tryPlay(key, def string) bool {
 		//fmt.Printf("[music] tryPlay: prefix '%s' has no defined bgmusic entries\n", key)
 		return false
 	}
-	ok = m.Play(nkey+".bgmusic", def)
-	//fmt.Printf("[music] tryPlay: Play('%s.bgmusic') -> %v\n", key, ok)
-	return ok
+	bg := m.matchSelection(nkey)
+	if bg == nil {
+		return false
+	}
+
+	// Preserve the RandI(0, 0) call made by the old pinned Play path.
+	// This keeps existing gameplay RNG sequences unchanged.
+	_ = RandI(0, 0)
+
+	track := SearchFile(bg.bgmusic, []string{def, "", "data/"}, "sound/")
+	if track == "" {
+		return false
+	}
+	if track != sys.bgm.filename {
+		sys.bgm.Open(track, int(bg.bgmloop), int(bg.bgmvolume),
+			int(bg.bgmloopstart), int(bg.bgmloopend), int(bg.bgmstartposition),
+			bg.bgmfreqmul, int(bg.bgmloopcount))
+		sys.playBgmFlg = sys.playBgmFlg || !sys.sel.gameParams.PersistMusic
+	}
+	return true
 }
 
 // act drives in-fight music state transitions:

--- a/src/netplay.go
+++ b/src/netplay.go
@@ -710,8 +710,9 @@ func (nc *NetConnection) Synchronize() error {
 		}
 	})
 
-	// Update game state after synchronization
-	nc.Update()
+	// Update delay-netplay state after sync. Skip rollback-entry samples;
+	// replay frames are appended later from the authoritative GGPO timeline.
+	nc.update(sys.rollback.session == nil)
 
 	// Log status
 	log.Printf("Network synchronized: seed=%d pmTime=%d time=%d host=%v", seed, pmTime, nc.time, nc.host)
@@ -838,6 +839,12 @@ func (nc *NetConnection) LoadingReady() (bool, error) {
 }
 
 func (nc *NetConnection) Update() bool {
+	return nc.update(true)
+}
+
+// Advance delay-netplay by one frame. Skip recording the final sync frame before rollback,
+// since it belongs to neither the pre-match replay nor the rollback match replay.
+func (nc *NetConnection) update(recordReplay bool) bool {
 	if nc.st != NS_Stopped {
 		nc.stoppedcnt = 0
 	}
@@ -884,7 +891,7 @@ func (nc *NetConnection) Update() bool {
 				nc.buf[nc.remIn].curT = nc.time
 
 				// Write inputs to replay file
-				if nc.recording != nil {
+				if recordReplay && nc.recording != nil {
 					for i := range nc.buf {
 						ringIdx := nc.time & (NETBUF_NUM_FRAMES - 1)
 						if err := writeReplayInput(nc.recording, nc.buf[i].buf[ringIdx], nc.buf[i].axisBuf[ringIdx]); err != nil {

--- a/src/rollback.go
+++ b/src/rollback.go
@@ -134,6 +134,7 @@ func (rs *RollbackSystem) postMatchSetup() {
 	// sys.esc = true
 
 	sys.netConnection = rs.netConnection
+	rs.netConnection = nil
 	rs.session.backend.Close()
 
 	// Prep for the next match.

--- a/src/rollback.go
+++ b/src/rollback.go
@@ -797,6 +797,10 @@ func (rs *RollbackSession) LiveChecksum() uint32 {
 	buf := writeI32(sys.randseed)
 	buf = append(buf, writeI32(sys.matchTime)...)
 	buf = append(buf, writeI32(sys.curRoundTime)...)
+	for i := range sys.scorePoints {
+		buf = binary.BigEndian.AppendUint32(buf, math.Float32bits(sys.scorePoints[i]))
+		buf = binary.BigEndian.AppendUint32(buf, uint32(sys.comboCount[i]))
+	}
 
 	// Round start checks. Ensure both players have the same selection
 	if sys.roundState() == 1 {

--- a/src/script.go
+++ b/src/script.go
@@ -5966,7 +5966,7 @@ func systemScriptInit(l *lua.LState) {
 		if tn < 1 || tn > 2 {
 			l.RaiseError("\nInvalid team side: %v\n", tn)
 		}
-		sys.fightScreen.scores[tn-1].scorePoints = 0
+		sys.scorePoints[tn-1] = 0
 		return 0
 	})
 	luaRegister(l, "resetTokenGuard", func(*lua.LState) int {

--- a/src/state.go
+++ b/src/state.go
@@ -425,7 +425,8 @@ func (gs *GameState) Checksum() int {
 // Returns some state variables as a string for debugging
 func (gs *GameState) String() (str string) {
 	// Add match data
-	str = fmt.Sprintf("MatchTime %d CurRoundTime: %d\n", gs.matchTime, gs.curRoundTime)
+	str = fmt.Sprintf("MatchTime %d CurRoundTime: %d ScorePoints: %v ComboCount: %v\n",
+		gs.matchTime, gs.curRoundTime, gs.scorePoints, gs.comboCount)
 
 	// Add bytecode data
 	// TODO: Every log seems to have these empty. May not be needed

--- a/src/state.go
+++ b/src/state.go
@@ -48,7 +48,9 @@ type GameState struct {
 	//debugDisplay            bool
 
 	timerRounds []int32
+	stageRef    *Stage
 	stage       *Stage
+	stageState  stageRollbackState
 	scoreRounds [][2]float32
 	sel         Select
 	//stringPool      [MaxPlayerNo]StringPool // Only mutated while compiling
@@ -103,9 +105,15 @@ func (gs *GameState) LoadState(stateID int) {
 	sys.bcVar = arena.MakeSlice[BytecodeValue](a, len(gs.bcVar), len(gs.bcVar))
 	copy(sys.bcVar, gs.bcVar)
 
-	// Only try loading the stage if it was saved
+	// Load the full stage only when character code can mutate its definition.
+	// Otherwise restore the small gameplay-visible runtime subset.
 	if gs.stage != nil {
 		sys.stage = gs.stage.Clone(a, gsp)
+	} else {
+		// A speculative round transition may have switched sys.stage to a different roundXdef entry.
+		// Restore the saved stage identity before applying its lightweight runtime snapshot.
+		sys.stage = gs.stageRef
+		gs.stageState.Load(sys.stage)
 	}
 
 	sys.workBe = arena.MakeSlice[BytecodeExp](a, len(gs.workBe), len(gs.workBe))
@@ -209,10 +217,17 @@ func (gs *GameState) SaveState(stateID int) {
 	gs.bcVar = arena.MakeSlice[BytecodeValue](a, len(sys.bcVar), len(sys.bcVar))
 	copy(gs.bcVar, sys.bcVar)
 
-	// We only save the stage's state if any existing characters can modify it
+	// A pooled GameState may still contain stage data from an older save.
+	gs.stageRef = sys.stage
+	gs.stage = nil
+	gs.stageState = stageRollbackState{}
+
+	// Character-controlled stage mutations need the full clone.
 	if sys.rollback.session != nil || sys.cfg.Netplay.Rollback.DesyncTestFrames > 0 {
 		if gs.stageCanMutate() || sys.cfg.Netplay.Rollback.SaveStageData {
 			gs.stage = sys.stage.Clone(a, gsp)
+		} else {
+			gs.stageState = sys.stage.CloneRollbackState(a)
 		}
 	} else {
 		// Save anyway if using debug keys

--- a/src/state.go
+++ b/src/state.go
@@ -50,6 +50,7 @@ type GameState struct {
 	timerRounds []int32
 	stageRef    *Stage
 	stage       *Stage
+	stageList   map[int32]*Stage
 	stageState  stageRollbackState
 	statsState  statsRollbackState
 	scoreRounds [][2]float32
@@ -112,7 +113,7 @@ func (gs *GameState) LoadState(stateID int) {
 	// Load the full stage only when character code can mutate its definition.
 	// Otherwise restore the small gameplay-visible runtime subset.
 	if gs.stage != nil {
-		sys.stage = gs.stage.Clone(a, gsp)
+		sys.stageList, sys.stage = cloneStageList(a, gsp, gs.stageList, gs.stage)
 	} else {
 		// A speculative round transition may have switched sys.stage to a different roundXdef entry.
 		// Restore the saved stage identity before applying its lightweight runtime snapshot.
@@ -227,18 +228,19 @@ func (gs *GameState) SaveState(stateID int) {
 	// A pooled GameState may still contain stage data from an older save.
 	gs.stageRef = sys.stage
 	gs.stage = nil
+	gs.stageList = nil
 	gs.stageState = stageRollbackState{}
 
 	// Character-controlled stage mutations need the full clone.
 	if sys.rollback.session != nil || sys.cfg.Netplay.Rollback.DesyncTestFrames > 0 {
 		if gs.stageCanMutate() || sys.cfg.Netplay.Rollback.SaveStageData {
-			gs.stage = sys.stage.Clone(a, gsp)
+			gs.stageList, gs.stage = cloneStageList(a, gsp, sys.stageList, sys.stage)
 		} else {
 			gs.stageState = sys.stage.CloneRollbackState(a)
 		}
 	} else {
 		// Save anyway if using debug keys
-		gs.stage = sys.stage.Clone(a, gsp)
+		gs.stageList, gs.stage = cloneStageList(a, gsp, sys.stageList, sys.stage)
 	}
 
 	gs.workBe = arena.MakeSlice[BytecodeExp](a, len(sys.workBe), len(sys.workBe))

--- a/src/state.go
+++ b/src/state.go
@@ -587,11 +587,17 @@ func NewGameStatePool() GameStatePool {
 }
 
 func (gsp *GameStatePool) Get(item interface{}) (result interface{}) {
-	objs, ok := gsp.poolObjs[gsp.curStateID]
+	stateID := gsp.curStateID
+	objs, ok := gsp.poolObjs[stateID]
 	if !ok {
-		gsp.poolObjs[gsp.curStateID] = make([]interface{}, 0, 50)
-		objs = gsp.poolObjs[gsp.curStateID]
+		gsp.poolObjs[stateID] = make([]interface{}, 0, 50)
+		objs = gsp.poolObjs[stateID]
 	}
+
+	// A map stores a copy of a slice header, so appending only to the local variable would leave the map entry at its old length.
+	defer func() {
+		gsp.poolObjs[stateID] = objs
+	}()
 
 	switch item.(type) {
 	case (map[string]float32):

--- a/src/state.go
+++ b/src/state.go
@@ -525,6 +525,8 @@ type GameStatePool struct {
 	int32CharPointerMapPool sync.Pool
 	int32int32MapPool       sync.Pool
 	int32float32MapPool     sync.Pool
+	remapPresetPool         sync.Pool
+	remapTablePool          sync.Pool
 
 	animFrameSlicePool sync.Pool
 	poolObjs           map[int][]interface{}
@@ -582,6 +584,18 @@ func NewGameStatePool() GameStatePool {
 				return &if3
 			},
 		},
+		remapPresetPool: sync.Pool{
+			New: func() interface{} {
+				rp := make(RemapPreset)
+				return &rp
+			},
+		},
+		remapTablePool: sync.Pool{
+			New: func() interface{} {
+				rt := make(RemapTable)
+				return &rt
+			},
+		},
 		poolObjs: make(map[int][]interface{}),
 	}
 }
@@ -621,6 +635,12 @@ func (gsp *GameStatePool) Get(item interface{}) (result interface{}) {
 	case (map[int32]float32):
 		objs = append(objs, gsp.int32float32MapPool.Get())
 		return objs[len(objs)-1]
+	case (RemapPreset):
+		objs = append(objs, gsp.remapPresetPool.Get())
+		return objs[len(objs)-1]
+	case (RemapTable):
+		objs = append(objs, gsp.remapTablePool.Get())
+		return objs[len(objs)-1]
 	default:
 		return nil
 	}
@@ -642,6 +662,10 @@ func (gsp *GameStatePool) Put(item interface{}) {
 		gsp.int32int32MapPool.Put(item)
 	case (*map[int32]float32):
 		gsp.int32float32MapPool.Put(item)
+	case (*RemapPreset):
+		gsp.remapPresetPool.Put(item)
+	case (*RemapTable):
+		gsp.remapTablePool.Put(item)
 	default:
 	}
 }

--- a/src/state.go
+++ b/src/state.go
@@ -61,6 +61,7 @@ type GameState struct {
 	timerCount []int32
 
 	commandLists []*CommandList
+	matchMusicSel []*bgMusic
 
 	// Rollback
 	netTime int32
@@ -92,6 +93,8 @@ func (gs *GameState) LoadState(stateID int) {
 
 	sys.SystemStateVars = gs.SystemStateVars
 	sys.frameCounter = gs.frame
+	sys.matchMusicSel = arena.MakeSlice[*bgMusic](a, len(gs.matchMusicSel), len(gs.matchMusicSel))
+	copy(sys.matchMusicSel, gs.matchMusicSel)
 
 	gs.loadCharData(a, gsp)
 	gs.loadProjectileData(a, gsp)
@@ -205,6 +208,8 @@ func (gs *GameState) SaveState(stateID int) {
 	gs.frame = sys.frameCounter
 	gs.isSpeculativeFrame = sys.isSpeculativeFrame()
 	gs.SystemStateVars = sys.SystemStateVars
+	gs.matchMusicSel = arena.MakeSlice[*bgMusic](a, len(sys.matchMusicSel), len(sys.matchMusicSel))
+	copy(gs.matchMusicSel, sys.matchMusicSel)
 
 	gs.saveCharData(a, gsp)
 	gs.saveProjectileData(a, gsp)

--- a/src/state.go
+++ b/src/state.go
@@ -51,6 +51,7 @@ type GameState struct {
 	stageRef    *Stage
 	stage       *Stage
 	stageState  stageRollbackState
+	statsState  statsRollbackState
 	scoreRounds [][2]float32
 	sel         Select
 	//stringPool      [MaxPlayerNo]StringPool // Only mutated while compiling
@@ -151,6 +152,7 @@ func (gs *GameState) LoadState(stateID int) {
 
 	sys.scoreRounds = arena.MakeSlice[[2]float32](a, len(gs.scoreRounds), len(gs.scoreRounds))
 	copy(sys.scoreRounds, gs.scoreRounds)
+	gs.statsState.load(&sys.statsLog)
 
 	//sys.sel = gs.sel.Clone(a)
 	// for i := 0; i < len(sys.stringPool); i++ {
@@ -263,6 +265,7 @@ func (gs *GameState) SaveState(stateID int) {
 	copy(gs.timerRounds, sys.timerRounds)
 	gs.scoreRounds = arena.MakeSlice[[2]float32](a, len(sys.scoreRounds), len(sys.scoreRounds))
 	copy(gs.scoreRounds, sys.scoreRounds)
+	gs.statsState = sys.statsLog.saveRollbackState()
 
 	//gs.sel = sys.sel.Clone(a)
 	// for i := 0; i < len(sys.stringPool); i++ {

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -805,6 +805,28 @@ func (ss *stageRollbackState) Load(s *Stage) {
 	}
 }
 
+// cloneStageList snapshots all loaded stage definitions as one object graph.
+// Multiple roundXdef entries may alias the same Stage, so preserve pointer identity.
+func cloneStageList(a *arena.Arena, gsp *GameStatePool, src map[int32]*Stage, active *Stage) (map[int32]*Stage, *Stage) {
+	result := make(map[int32]*Stage, len(src))
+	cloned := make(map[*Stage]*Stage, len(src)+1)
+	cloneOne := func(s *Stage) *Stage {
+		if s == nil {
+			return nil
+		}
+		if c, ok := cloned[s]; ok {
+			return c
+		}
+		c := s.Clone(a, gsp)
+		cloned[s] = c
+		return c
+	}
+	for k, s := range src {
+		result[k] = cloneOne(s)
+	}
+	return result, cloneOne(active)
+}
+
 func (s *Stage) Clone(a *arena.Arena, gsp *GameStatePool) *Stage {
 	result := &Stage{}
 	*result = *s
@@ -819,12 +841,9 @@ func (s *Stage) Clone(a *arena.Arena, gsp *GameStatePool) *Stage {
 		result.constants[k] = v
 	}
 
-	// Clone animation table
-	result.animTable = *gsp.Get(s.animTable).(*AnimationTable)
-	maps.Clear(result.animTable.anims)
-	for k, v := range s.animTable.anims {
-		result.animTable.anims[k] = v.Clone(a, gsp)
-	}
+	// Stage animation definitions are immutable after loading. Runtime BG
+	// animations are separate Animation objects cloned below.
+	result.animTable = s.animTable
 
 	// Clone backgrounds and rebuild mapping
 	bgMap := make(map[*backGround]*backGround, len(s.bg))

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -476,6 +476,11 @@ func (cl *CommandList) Clone(a *arena.Arena) (result CommandList) {
 
 	result.Buffer = arena.New[InputBuffer](a)
 	*result.Buffer = *cl.Buffer
+	if cl.Buffer.InputReader != nil {
+		// Preserve SOCD direction history in command snapshots.
+		result.Buffer.InputReader = arena.New[InputReader](a)
+		*result.Buffer.InputReader = *cl.Buffer.InputReader
+	}
 
 	result.Commands = arena.MakeSlice[[]Command](a, len(cl.Commands), len(cl.Commands))
 	for i := 0; i < len(cl.Commands); i++ {

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -290,6 +290,27 @@ func (ss *StateState) Clone(a *arena.Arena) (result StateState) {
 	return result
 }
 
+func cloneRemapPreset(src RemapPreset, gsp *GameStatePool) RemapPreset {
+	if src == nil {
+		return nil
+	}
+	result := *gsp.Get(src).(*RemapPreset)
+	maps.Clear(result)
+	for group, table := range src {
+		if table == nil {
+			result[group] = nil
+			continue
+		}
+		tableCopy := *gsp.Get(table).(*RemapTable)
+		maps.Clear(tableCopy)
+		for number, remap := range table {
+			tableCopy[number] = remap
+		}
+		result[group] = tableCopy
+	}
+	return result
+}
+
 func (c *Char) Clone(a *arena.Arena, gsp *GameStatePool) (result Char) {
 	result = Char{}
 	result = *c
@@ -299,6 +320,16 @@ func (c *Char) Clone(a *arena.Arena, gsp *GameStatePool) (result Char) {
 	}
 	if c.animBackup != nil {
 		result.animBackup = c.animBackup.Clone(a, gsp)
+	}
+
+	// RemapSprite mutates a nested map, and SpriteVar exposes its result to character logic.
+	// Keep each saved state isolated and make the cloned animations point at the cloned preset.
+	result.remapSpr = cloneRemapPreset(c.remapSpr, gsp)
+	if result.anim != nil {
+		result.anim.remap = result.remapSpr
+	}
+	if result.animBackup != nil {
+		result.animBackup.remap = result.remapSpr
 	}
 
 	// Since curFrame is desynced from anim's state, we must save it as well

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -194,8 +194,18 @@ func (ai *AfterImage) Clone(a *arena.Arena, gsp *GameStatePool) *AfterImage {
 		return nil
 	}
 
-	result := &AfterImage{}
+	result := arena.New[AfterImage](a)
 	*result = *ai
+
+	// Allocate the slice backing arrays before replacing nested pointers.
+	if ai.imgs != nil {
+		result.imgs = arena.MakeSlice[SpriteData](a, len(ai.imgs), len(ai.imgs))
+		copy(result.imgs, ai.imgs)
+	}
+	if ai.palfx != nil {
+		result.palfx = arena.MakeSlice[*PalFX](a, len(ai.palfx), len(ai.palfx))
+		copy(result.palfx, ai.palfx)
+	}
 
 	// Deep copy Animations
 	for i := range ai.imgs {

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -396,6 +396,12 @@ func (c *Char) Clone(a *arena.Arena, gsp *GameStatePool) (result Char) {
 	result.clipboardText = arena.MakeSlice[string](a, len(c.clipboardText), len(c.clipboardText))
 	copy(result.clipboardText, c.clipboardText)
 
+	// Dialogue controllers append to this queue, and motif dialogue can hold round/match progression.
+	if c.dialogue != nil {
+		result.dialogue = arena.MakeSlice[string](a, len(c.dialogue), len(c.dialogue))
+		copy(result.dialogue, c.dialogue)
+	}
+
 	if c.keyctrl[0] {
 		result.cmd = arena.MakeSlice[CommandList](a, len(c.cmd), len(c.cmd))
 		for i, c := range c.cmd {

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -758,6 +758,7 @@ type stageRollbackBgState struct {
 type stageRollbackState struct {
 	stageTime int32
 	bga       bgAction
+	bgmState  BGMState
 	bg        []stageRollbackBgState
 }
 
@@ -768,6 +769,7 @@ func (s *Stage) CloneRollbackState(a *arena.Arena) (result stageRollbackState) {
 
 	result.stageTime = s.stageTime
 	result.bga = s.bga
+	result.bgmState = s.bgmState
 	result.bg = arena.MakeSlice[stageRollbackBgState](a, len(s.bg), len(s.bg))
 	for i, bg := range s.bg {
 		if bg == nil {
@@ -789,6 +791,7 @@ func (ss *stageRollbackState) Load(s *Stage) {
 
 	s.stageTime = ss.stageTime
 	s.bga = ss.bga
+	s.bgmState = ss.bgmState
 	for i := range ss.bg {
 		if i >= len(s.bg) {
 			break

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -109,6 +109,16 @@ func (a *Animation) Clone(ar *arena.Arena, gsp *GameStatePool) (result *Animatio
 	return
 }
 
+// CloneState copies an animation's mutable playback state while sharing its immutable frame/interpolation data.
+func (anim *Animation) CloneState(a *arena.Arena) *Animation {
+	if anim == nil {
+		return nil
+	}
+	result := arena.New[Animation](a)
+	*result = *anim
+	return result
+}
+
 func (af *AnimFrame) Clone(a *arena.Arena) (result *AnimFrame) {
 	result = arena.New[AnimFrame](a)
 	*result = *af
@@ -478,44 +488,108 @@ func (cl *CommandList) Clone(a *arena.Arena) (result CommandList) {
 	return
 }
 
+type fightScreenAnimationStateCloner struct {
+	a *arena.Arena
+	// Current FightScreenRound has ~40 logic-bearing AnimTextSnd values.
+	src   [64]*Animation
+	dst   [64]*Animation
+	count int
+}
+
+func (cl *fightScreenAnimationStateCloner) clone(anim *Animation) *Animation {
+	if anim == nil {
+		return nil
+	}
+
+	for i := 0; i < cl.count; i++ {
+		if cl.src[i] == anim {
+			return cl.dst[i]
+		}
+	}
+	result := anim.CloneState(cl.a)
+	if cl.count >= len(cl.src) {
+		return result
+	}
+	cl.src[cl.count] = anim
+	cl.dst[cl.count] = result
+	cl.count++
+	return result
+}
+
+func (cl *fightScreenAnimationStateCloner) cloneAnimTextSnd(src AnimTextSnd) (result AnimTextSnd) {
+	result = src
+	result.animLayout.anim = cl.clone(src.animLayout.anim)
+	return
+}
+
+func (ro *FightScreenRound) Clone(a *arena.Arena) *FightScreenRound {
+	if ro == nil {
+		return nil
+	}
+
+	result := arena.New[FightScreenRound](a)
+	*result = *ro
+	result.fadeIn = ro.fadeIn.Clone(a)
+	result.fadeOut = ro.fadeOut.Clone(a)
+
+	// AnimTextSnd.End reads mutable Animation playback fields to advance the round/fight/KO/win phases.
+	// Purely visual top/background animations are intentionally not rollbacked.
+	cl := fightScreenAnimationStateCloner{a: a}
+	for i := range ro.round {
+		result.round[i] = cl.cloneAnimTextSnd(ro.round[i])
+	}
+	result.round_default = cl.cloneAnimTextSnd(ro.round_default)
+	result.round_single = cl.cloneAnimTextSnd(ro.round_single)
+	result.round_final = cl.cloneAnimTextSnd(ro.round_final)
+	result.fight = cl.cloneAnimTextSnd(ro.fight)
+	result.ko = cl.cloneAnimTextSnd(ro.ko)
+	result.dko = cl.cloneAnimTextSnd(ro.dko)
+	result.to = cl.cloneAnimTextSnd(ro.to)
+	result.drawgame = cl.cloneAnimTextSnd(ro.drawgame)
+	for i := range ro.win {
+		for side := range ro.win[i].text {
+			result.win[i].text[side] = cl.cloneAnimTextSnd(ro.win[i].text[side])
+			result.aiLose[i].text[side] = cl.cloneAnimTextSnd(ro.aiLose[i].text[side])
+			result.aiWin[i].text[side] = cl.cloneAnimTextSnd(ro.aiWin[i].text[side])
+		}
+	}
+
+	return result
+}
+
 func (fs *FightScreen) Clone(a *arena.Arena) (result FightScreen) {
 	result = *fs
 
-	// Round
-	if fs.round != nil {
-		result.round = &FightScreenRound{} // Shallow copy
-		*result.round = *fs.round
-		// Fade state
-		result.round.fadeIn = fs.round.fadeIn.Clone(a)
-		result.round.fadeOut = fs.round.fadeOut.Clone(a)
-	}
+	// FightScreenRound timers/phases, timerActive, shutter, fades and selected announcement playback
+	// state affect when control starts, when the round timer runs and when a round/match can finish.
+	result.round = fs.round.Clone(a)
 
-	// WinCount
-	for i := 0; i < len(fs.winCounts); i++ {
-		if fs.winCounts[i] != nil {
-			result.winCounts[i] = arena.New[FightScreenWinCount](a)
-			*result.winCounts[i] = *fs.winCounts[i]
-		}
-	}
-
-	// Combo
-	for i := 0; i < len(fs.combos); i++ {
-		if fs.combos[i] != nil {
-			result.combos[i] = arena.New[FightScreenCombo](a)
-			*result.combos[i] = *fs.combos[i]
-		}
-	}
-
-	// Score
-	for i := 0; i < len(fs.scores); i++ {
-		if fs.scores[i] != nil {
-			result.scores[i] = arena.New[FightScreenScore](a)
-			*result.scores[i] = *fs.scores[i]
-		}
-	}
-
-	// We probably don't need a deep copy of these
+	// Presentation-only state is intentionally shared across rollback snapshots.
 	/*
+		// WinCount
+		for i := 0; i < len(fs.winCounts); i++ {
+			if fs.winCounts[i] != nil {
+				result.winCounts[i] = arena.New[FightScreenWinCount](a)
+				*result.winCounts[i] = *fs.winCounts[i]
+			}
+		}
+
+		// Combo widget (ComboCount itself is in SystemStateVars)
+		for i := 0; i < len(fs.combos); i++ {
+			if fs.combos[i] != nil {
+				result.combos[i] = arena.New[FightScreenCombo](a)
+				*result.combos[i] = *fs.combos[i]
+			}
+		}
+
+		// Score widget (scorePoints itself is in SystemStateVars)
+		for i := 0; i < len(fs.scores); i++ {
+			if fs.scores[i] != nil {
+				result.scores[i] = arena.New[FightScreenScore](a)
+				*result.scores[i] = *fs.scores[i]
+			}
+		}
+
 		//UIT
 		if fs.ti != nil {
 			result.ti = arena.New[FightScreenTime](a)
@@ -599,24 +673,24 @@ func (fs *FightScreen) Clone(a *arena.Arena) (result FightScreen) {
 				*result.names[i][j] = *fs.names[i][j]
 			}
 		}
-	*/
 
-	// Action
-	for i := range result.actions {
-		if fs.actions[i] != nil {
-			result.actions[i] = arena.New[FightScreenAction](a)
+		// Action
+		for i := range result.actions {
+			if fs.actions[i] != nil {
+				result.actions[i] = arena.New[FightScreenAction](a)
+				*result.actions[i] = *fs.actions[i]
 
-			*result.actions[i] = *fs.actions[i]
-
-			if fs.actions[i].messages != nil {
-				result.actions[i].messages = arena.MakeSlice[*FSMsg](a, len(fs.actions[i].messages), len(fs.actions[i].messages))
-				for j := 0; j < len(fs.actions[i].messages); j++ {
-					result.actions[i].messages[j] = arena.New[FSMsg](a)
-					*result.actions[i].messages[j] = *fs.actions[i].messages[j]
+				if fs.actions[i].messages != nil {
+					result.actions[i].messages = arena.MakeSlice[*FSMsg](a,
+						len(fs.actions[i].messages), len(fs.actions[i].messages))
+					for j := 0; j < len(fs.actions[i].messages); j++ {
+						result.actions[i].messages[j] = arena.New[FSMsg](a)
+						*result.actions[i].messages[j] = *fs.actions[i].messages[j]
+					}
 				}
 			}
 		}
-	}
+	*/
 
 	return
 }

--- a/src/state_clone.go
+++ b/src/state_clone.go
@@ -695,6 +695,61 @@ func (fs *FightScreen) Clone(a *arena.Arena) (result FightScreen) {
 	return
 }
 
+// Background fields that are either exposed through StageBGVar or affect their future values.
+type stageRollbackBgState struct {
+	bga      bgAction
+	actionno int32
+	enabled  bool
+}
+
+// Subset that is authoritative even when character code cannot modify the stage definition.
+type stageRollbackState struct {
+	stageTime int32
+	bga       bgAction
+	bg        []stageRollbackBgState
+}
+
+func (s *Stage) CloneRollbackState(a *arena.Arena) (result stageRollbackState) {
+	if s == nil {
+		return
+	}
+
+	result.stageTime = s.stageTime
+	result.bga = s.bga
+	result.bg = arena.MakeSlice[stageRollbackBgState](a, len(s.bg), len(s.bg))
+	for i, bg := range s.bg {
+		if bg == nil {
+			continue
+		}
+		result.bg[i] = stageRollbackBgState{
+			bga:      bg.bga,
+			actionno: bg.actionno,
+			enabled:  bg.enabled,
+		}
+	}
+	return
+}
+
+func (ss *stageRollbackState) Load(s *Stage) {
+	if ss == nil || s == nil {
+		return
+	}
+
+	s.stageTime = ss.stageTime
+	s.bga = ss.bga
+	for i := range ss.bg {
+		if i >= len(s.bg) {
+			break
+		}
+		if s.bg[i] == nil {
+			continue
+		}
+		s.bg[i].bga = ss.bg[i].bga
+		s.bg[i].actionno = ss.bg[i].actionno
+		s.bg[i].enabled = ss.bg[i].enabled
+	}
+}
+
 func (s *Stage) Clone(a *arena.Arena, gsp *GameStatePool) *Stage {
 	result := &Stage{}
 	*result = *s

--- a/src/stats.go
+++ b/src/stats.go
@@ -68,6 +68,36 @@ type StatsLog struct {
 	Matches []StatsMatch `json:"matches"`
 }
 
+// statsRollbackState tracks the append-only part of StatsLog that can change inside rollback simulation.
+type statsRollbackState struct {
+	matches int
+	rounds  int
+}
+
+func (s *StatsLog) saveRollbackState() (result statsRollbackState) {
+	result.matches = len(s.Matches)
+	if result.matches > 0 {
+		result.rounds = len(s.Matches[result.matches-1].Rounds)
+	}
+	return
+}
+
+func (state statsRollbackState) load(s *StatsLog) {
+	if s == nil {
+		return
+	}
+	if len(s.Matches) > state.matches {
+		s.Matches = s.Matches[:state.matches]
+	}
+	if state.matches == 0 || len(s.Matches) < state.matches {
+		return
+	}
+	rounds := &s.Matches[state.matches-1].Rounds
+	if len(*rounds) > state.rounds {
+		*rounds = (*rounds)[:state.rounds]
+	}
+}
+
 // resets all gathered stats
 func (s *StatsLog) reset() {
 	s.Matches = nil

--- a/src/stats.go
+++ b/src/stats.go
@@ -213,6 +213,6 @@ func (s *StatsLog) nextRound() {
 	// Record the round into the current stats match.
 	// We fill timers later in finalizeMatch.
 	roundIdx := sys.round
-	roundScore := [2]int32{int32(sys.fightScreen.scores[0].scorePoints), int32(sys.fightScreen.scores[1].scorePoints)}
+	roundScore := [2]int32{int32(sys.scorePoints[0]), int32(sys.scorePoints[1])}
 	s.addRound(roundIdx, 0, roundScore, fighters)
 }

--- a/src/system.go
+++ b/src/system.go
@@ -222,6 +222,7 @@ type System struct {
 	debugLastID         int32
 	soundMixer          *beep.Mixer
 	bgm                 Bgm
+	matchMusicSel       []*bgMusic
 	pauseVolumeApplied  bool
 	soundChannels       SoundChannels // System sounds. Lifebars etc
 	charSoundChannels   [MaxPlayerNo]SoundChannels
@@ -2259,9 +2260,7 @@ func (s *System) updateMusicMaps() {
 	newMatchMusic := s.round == 1 && !s.roundResetFlg
 
 	if newMatchMusic {
-		s.stage.music.ClearSelection()
-		s.stage.si().music.ClearSelection()
-		s.sel.music.ClearSelection()
+		s.matchMusicSel = s.matchMusicSel[:0]
 	}
 
 	for i, p := range s.chars {
@@ -2269,9 +2268,6 @@ func (s *System) updateMusicMaps() {
 			continue
 		}
 		isSelectableChar := i < MaxSimul*2
-		if newMatchMusic && isSelectableChar {
-			p[0].si().music.ClearSelection()
-		}
 		// Reset music map
 		s.cgi[i].music = make(Music)
 		// Append stage def file music parameters

--- a/src/system.go
+++ b/src/system.go
@@ -116,6 +116,8 @@ type SystemStateVars struct {
 	teamLeader              [2]int
 	postMatchFlg            bool
 	scoreStart              [2]float32
+	scorePoints             [2]float32
+	comboCount              [2]int32
 	decisiveRound           [2]bool
 	gameMode                string
 
@@ -2314,6 +2316,8 @@ func (s *System) resetRound() {
 	s.noCharSoundFlg = false
 
 	s.resetGblEffect()
+	s.scorePoints = [2]float32{}
+	s.comboCount = [2]int32{}
 	s.fightScreen.reset()
 	s.motif.reset()
 	s.saveStateFlag = false
@@ -4055,7 +4059,7 @@ func (s *System) runNextRound() bool {
 		}
 		s.clearAllSound()
 		s.statsLog.nextRound()
-		s.scoreRounds = append(s.scoreRounds, [2]float32{s.fightScreen.scores[0].scorePoints, s.fightScreen.scores[1].scorePoints})
+		s.scoreRounds = append(s.scoreRounds, s.scorePoints)
 
 		if !s.matchOver() &&
 			!(s.tmode[0] == TM_Turns && s.effectiveLoss[0]) &&

--- a/src/system.go
+++ b/src/system.go
@@ -120,6 +120,7 @@ type SystemStateVars struct {
 	comboCount              [2]int32
 	decisiveRound           [2]bool
 	gameMode                string
+	credits                 int32
 
 	consecutiveWins  [2]int32
 	firstAttack      [3]int
@@ -288,7 +289,6 @@ type System struct {
 	cmdFlags            map[string]string
 	whitePalTex         Texture
 	usePalette          bool
-	credits             int32
 	gameRunning         bool
 
 	msaa               int32

--- a/src/system.go
+++ b/src/system.go
@@ -2384,13 +2384,16 @@ func (s *System) resetRound() {
 		if len(p) == 0 {
 			continue
 		}
-		// Select anim 0
+		// Select anim 0. If it is missing, choose the lowest available action
+		// instead of depending on Go map iteration order.
 		firstAnim := int32(0)
-		// Default to first anim in .AIR if 0 was not found
 		if p[0].gi().animTable.anims[0] == nil {
+			found := false
 			for k := range p[0].gi().animTable.anims {
-				firstAnim = k
-				break
+				if !found || k < firstAnim {
+					firstAnim = k
+					found = true
+				}
 			}
 		}
 		p[0].selfState(5900, firstAnim, -1, 0, "")

--- a/src/system.go
+++ b/src/system.go
@@ -3786,6 +3786,9 @@ func (s *System) runMatch() (reload bool) {
 
 	if s.cfg.Config.TurnsLoading {
 		s.startNextTurnsPreload()
+		if (s.rollback.session != nil || s.cfg.Netplay.Rollback.DesyncTestFrames > 0) && !s.finishTurnsPreloadForRollback() {
+			return false
+		}
 	}
 
 	// Reset the clock right before entering the loop to ensure we start with a clean timeline
@@ -5514,6 +5517,33 @@ func (s *System) startNextTurnsPreload() {
 	if s.loader.state == LS_NotYet {
 		s.loader.runTread()
 	}
+}
+
+// Rollback snapshots must not race the asynchronous Turns loader. The loader mutates
+// character slots and compilation globals that are not safe to update between save/load.
+func (s *System) finishTurnsPreloadForRollback() bool {
+	if !s.turnsPreloadActive() {
+		return true
+	}
+	for s.loader.state != LS_Complete {
+		switch s.loader.state {
+		case LS_Error:
+			if s.loader.err != nil {
+				panic(s.loader.err)
+			}
+			return false
+		case LS_Cancel:
+			return false
+		case LS_NotYet:
+			if !s.loader.runTread() {
+				return false
+			}
+		}
+		if !s.await(s.gameRenderSpeed()) {
+			return false
+		}
+	}
+	return true
 }
 
 // Rewrite slot-indexed fields inside chars when a preloaded Turns member is promoted into P1/P2.

--- a/src/system.go
+++ b/src/system.go
@@ -879,7 +879,10 @@ func (s *System) renderFrame() {
 func (s *System) update() bool {
 	s.frameCounter++
 
-	if s.matchTime == 0 {
+	// preMatchTime normally follows the local UI clock until gameplay begins.
+	// Preserve the synchronized prematch time while rollback waits for its first frame.
+	rollbackMatchStarting := s.rollback.session != nil && s.rollback.netConnection != nil
+	if s.matchTime == 0 && !rollbackMatchStarting && s.replayFile == nil {
 		s.preMatchTime = s.frameCounter
 	}
 

--- a/src/system.go
+++ b/src/system.go
@@ -3912,8 +3912,13 @@ func (s *System) runMatch() (reload bool) {
 		// Render frame
 		s.renderFrame()
 
-		// Update system. Break if update returns false (game ended)
+		// Update system. Break if update returns false (engine shutdown).
 		if !s.update() {
+			break
+		}
+
+		// Exit the replay match loop before EOF can reuse the last input sample.
+		if s.replayFile != nil && s.replayFile.file == nil {
 			break
 		}
 


### PR DESCRIPTION
Fixes:
* Move score and combo state into SystemStateVars and avoid cloning presentation-only FightScreen data.
* Always restore gameplay-visible stage timing and BG state. Treat BG controller changes as full stage mutations.
* Store updated per-state object lists so pooled clone data is released correctly.
* Preserve SOCD direction history in command snapshots.
* Copy AfterImage slice storage before cloning nested animation and PalFX state.
* Deep-copy RemapSprite tables and reconnect cloned animations to the saved preset.
* Copy dialogue queue storage so speculative updates cannot alter saved round flow.
* Restore append-only match and round log lengths when loading a rollback state.
* Restore automatic match music choices and BGM transition state during rollback.
* credits moved to SystemStateVars. local coin input disabled in netplay
* Wait for an active Turns preload to finish before entering rollback or desync-test simulation. Offline play keeps the asynchronous behavior.
* Share immutable stage animation definitions in rollback clones.
* Select the lowest available AIR action when action 0 is missing instead of relying on Go map iteration order, keeping round resets deterministic across peers and rollback re-simulation.
* Sort matching sparse variable indexes before applying the MaxLoop cap so every peer clears the same variables instead of depending on Go map iteration order.
* Sort Helper map parameters before emitting bytecode so expression evaluation order, including Random consumption, is identical across peers.
* Do not record the final delay-netplay synchronization update when control is being transferred to rollback.
* Keep the negotiated preMatchTime frozen after the delay-netplay connection is transferred into rollback.
* Exit the active match as soon as replay EOF closes the input stream, before action can reuse the last loaded sample.