### PR TITLE
fix: noguard during pause, shadow palettes, zero width, GetHitVarSet attr

### DIFF
--- a/src/anim.go
+++ b/src/anim.go
@@ -1112,9 +1112,10 @@ func (a *Animation) ShadowDraw(window *[4]int32, x, y, xscl, yscl, vscl, rxadd f
 	if a.spr.coldepth <= 8 && (color != 0 || intensity > 0) {
 		if a.sff.header.Version[0] == 2 && a.sff.header.Version[2] == 1 {
 			pal, _ := a.pal(pfx)
-			if a.spr.PalTex == nil {
-				a.spr.PalTex = a.spr.CachePalTex(pal)
-			}
+			// This nil check broke the rare instance where the palette affects the shadow, such as palettes with alpha
+			//if a.spr.PalTex == nil {
+			a.spr.PalTex = a.spr.CachePalTex(pal)
+			//}
 			rp.paltex = a.spr.PalTex
 		} else {
 			rp.paltex = sys.whitePalTex

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3004,9 +3004,9 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 	case OC_ex_matchover:
 		sys.bcStack.PushB(sys.matchOver())
 	case OC_ex_matchno:
-		sys.bcStack.PushI(sys.match)
+		sys.bcStack.PushI(sys.matchNo)
 	case OC_ex_roundno:
-		sys.bcStack.PushI(sys.round)
+		sys.bcStack.PushI(sys.roundNo)
 	case OC_ex_roundsexisted:
 		sys.bcStack.PushI(c.roundsExisted())
 	case OC_ex_ishometeam:

--- a/src/char.go
+++ b/src/char.go
@@ -13686,30 +13686,11 @@ func (cl *CharList) pushDetection(getter *Char) {
 		gybot := (getter.pos[1] + gbox[3]) * getter.localscl
 
 		overlapY := Min(cybot, gybot) - Max(cytop, gytop)
-		if overlapY <= 0 {
-			continue
-		}
 
-		// Clamp width
-		// Mugen secretly does this for some reason
-		// https://github.com/ikemen-engine/Ikemen-GO/issues/3164
-		if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
-			minwidth := 5.0 / c.localscl
-			if cbox[0] > -minwidth {
-				cbox[0] = -minwidth
-			}
-			if cbox[2] < minwidth {
-				cbox[2] = minwidth
-			}
-		}
-		if getter.stWgi().ikemenver[0] == 0 && getter.stWgi().ikemenver[1] == 0 {
-			minwidth := 5.0 / getter.localscl
-			if gbox[0] > -minwidth {
-				gbox[0] = -minwidth
-			}
-			if gbox[2] < minwidth {
-				gbox[2] = minwidth
-			}
+		// For the y-axis, an overlap of exactly 0 is also valid for pushing characters away from each other, hence '<'
+		// We don't need a "zero-height case" because the y-overlap is only used as a filter, not to calculate the push distance
+		if overlapY < 0 {
+			continue
 		}
 
 		// X-axis check
@@ -13733,25 +13714,84 @@ func (cl *CharList) pushDetection(getter *Char) {
 
 		overlapX := Min(gxright, cxright) - Max(gxleft, cxleft)
 
-		// X-axis fail
+		// Zero width case
+		// These can also push in Mugen
+		// https://github.com/ikemen-engine/Ikemen-GO/issues/3164
+		if overlapX == 0 && (cxleft == cxright || gxleft == gxright) {
+			cHalfW := (cxright - cxleft) * 0.5
+			gHalfW := (gxright - gxleft) * 0.5
+			cCenterX := (cxright + cxleft) * 0.5
+			gCenterX := (gxright + gxleft) * 0.5
+
+			overlapX = (cHalfW + gHalfW) - Abs(cCenterX - gCenterX)
+		}
+
+		/*
+		// In addition to the normal width check, Mugen also checks overlap between an undocumented "internal width" of 5 pixels
+		// The normal and fallback width checks are not mixed with each other
+		// Update: The addition of the zero width case makes this seemingly unnecessary
 		if overlapX <= 0 {
+			// We will only do it for Mugen characters because it defeats the purpose of lowering width
+			cIsOld := c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0
+			gIsOld := getter.stWgi().ikemenver[0] == 0 && getter.stWgi().ikemenver[1] == 0
+			if cIsOld || gIsOld {
+				if cIsOld {
+					minwidth := 5.0 / c.localscl
+					cxleft = cposx - minwidth
+					cxright = cposx + minwidth
+				}
+				if gIsOld {
+					minwidth := 5.0 / getter.localscl
+					gxleft = gposx - minwidth
+					gxright = gposx + minwidth
+				}
+				overlapX = Min(gxright, cxright) - Max(gxleft, cxleft)
+			}
+		}
+		*/
+
+		// X-axis fail
+		// An overlap of exactly 0 is still valid because pushing may happen along the z-axis
+		if overlapX < 0 {
 			continue
 		}
 
 		// Z-axis check
 		// We don't use the zAxisCheck function because we need the actual overlap amount
-		cposz := c.pos[2] * c.localscl
-		cztop := cposz - c.sizeDepth[0]*c.localscl
-		czbot := cposz + c.sizeDepth[1]*c.localscl
+		// We'll also declare all the vars upfront but only use them if z-axis is enabled
+		var overlapZ float32
+		var cposz, cztop, czbot, gposz, gztop, gzbot float32
 
-		gposz := getter.pos[2] * getter.localscl
-		gztop := gposz - getter.sizeDepth[0]*getter.localscl
-		gzbot := gposz + getter.sizeDepth[1]*getter.localscl
+		if sys.zEnabled() {
+			cposz = c.pos[2] * c.localscl
+			cztop = cposz - c.sizeDepth[0]*c.localscl
+			czbot = cposz + c.sizeDepth[1]*c.localscl
 
-		overlapZ := Min(gzbot, czbot) - Max(gztop, cztop)
+			gposz = getter.pos[2] * getter.localscl
+			gztop = gposz - getter.sizeDepth[0]*getter.localscl
+			gzbot = gposz + getter.sizeDepth[1]*getter.localscl
+
+			overlapZ = Min(gzbot, czbot) - Max(gztop, cztop)
+
+			// Zero depth case
+			if overlapZ == 0 && (cztop == czbot || gztop == gzbot) {
+				cHalfD := (czbot - cztop) * 0.5
+				gHalfD := (gzbot - gztop) * 0.5
+				cCenterZ := (czbot + cztop) * 0.5
+				gCenterZ := (gzbot + gztop) * 0.5
+
+				overlapZ = (cHalfD + gHalfD) - Abs(cCenterZ-gCenterZ)
+			}
+		}
 
 		// Z-axis fail
-		if overlapZ <= 0 {
+		// An overlap of exactly 0 is still valid because pushing may happen along the x-axis
+		if overlapZ < 0 {
+			continue
+		}
+
+		// If players are barely touching but the pushing distance will be 0, just skip the no-op math
+		if overlapX == 0 && overlapZ == 0 {
 			continue
 		}
 

--- a/src/char.go
+++ b/src/char.go
@@ -2089,7 +2089,7 @@ func (e *Explod) update() {
 			for i := range e.velocity {
 				e.velocity[i] *= e.friction[i]
 				e.velocity[i] += e.accel[i]
-				if math.Abs(float64(e.velocity[i])) < 0.1 && math.Abs(float64(e.friction[i])) < 1 {
+				if Abs(e.velocity[i]) < 0.1 && Abs(e.friction[i]) < 1 {
 					e.velocity[i] = 0
 				}
 			}
@@ -4340,7 +4340,8 @@ func (c *Char) loadPalettes() {
 
 				// Allocate space if necessary
 				gi.palettedata.palList.SetSource(targetIdx, pl)
-				gi.palettedata.palList.PalTable[[...]uint16{1, uint16(i + 1)}] = targetIdx
+				gi.palettedata.palList.PalTable[[2]uint16{1, uint16(i + 1)}] = targetIdx
+				gi.palettedata.palList.numcols[[2]uint16{1, uint16(i + 1)}] = 256 // ACT files are always 256 colors
 
 				// Redirect index 0 without destroying the unique SFFv1 palette at physical index 0
 				if tmp == 0 && i > 0 {
@@ -6013,7 +6014,7 @@ func (c *Char) roundsExisted() int32 {
 				return 0
 			}
 		}
-		return sys.round - 1
+		return sys.roundNo - 1
 	}
 	return sys.roundsExisted[c.playerNo&1]
 }
@@ -6471,14 +6472,6 @@ func (c *Char) stateChange1(no int32, pn int) bool {
 		LogMessage("Maximum ChangeState loops: %v, %v, %v -> %v -> %v", sys.changeStateNest, c.name, c.ss.prevno, c.ss.no, no)
 		return false
 	}
-	var ctrlsps_backup []int32
-	if c.hitPause() {
-		// If in hitpause, back up the current state's persistent.
-		ctrlsps_backup = make([]int32, len(c.ss.sb.ctrlsps))
-		copy(ctrlsps_backup, c.ss.sb.ctrlsps)
-	} else {
-		ctrlsps_backup = nil
-	}
 
 	c.ss.prevno = c.ss.no
 	c.ss.no = Max(0, no)
@@ -6527,7 +6520,7 @@ func (c *Char) stateChange1(no int32, pn int) bool {
 
 		c.localscl = newLs
 	}
-	var ok bool
+
 	// Check if player is trying to change to a negative state.
 	if no < 0 {
 		sys.appendToConsole(c.warn() + "attempted to change to negative state")
@@ -6542,7 +6535,16 @@ func (c *Char) stateChange1(no int32, pn int) bool {
 			LogMessage("Changed to out of bounds state number: P%v:%v", pn+1, no)
 		}
 	}
+
+	// If in hitpause, back up the current state's persistent.
+	var ctrlsps_backup []int32
+	if c.hitPause() {
+		ctrlsps_backup = make([]int32, len(c.ss.sb.ctrlsps))
+		copy(ctrlsps_backup, c.ss.sb.ctrlsps)
+	}
+
 	// Always attempt to change to the state we set to.
+	var ok bool
 	if c.ss.sb, ok = sys.cgi[pn].states[c.ss.no]; !ok {
 		sys.appendToConsole(c.warn() + fmt.Sprintf("changed to invalid state %v (from state %v)", no, c.ss.prevno))
 		if !sys.ignoreMostErrors {
@@ -6551,6 +6553,7 @@ func (c *Char) stateChange1(no int32, pn int) bool {
 		c.ss.sb = *newStateBytecode(pn)
 		c.ss.sb.stateType, c.ss.sb.moveType, c.ss.sb.physics = ST_U, MT_U, ST_U
 	}
+
 	// Reset persistent counters for this state (Ikemen chars)
 	// This used to belong to (*StateBytecode).init(), but was moved outside there
 	// due to a MUGEN 1.1 problem where persistent was not getting reset until the end
@@ -6575,6 +6578,7 @@ func (c *Char) stateChange1(no int32, pn int) bool {
 			c.hitStateChangeIdx = -1
 		}
 	}
+
 	c.stchtmp = true
 	return true
 }
@@ -8975,12 +8979,12 @@ func (c *Char) rdDistX(rd *Char, oc *Char) BytecodeValue {
 		return BytecodeUndefined()
 	}
 	dist := c.facing * c.distX(rd, oc)
-	if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
-		if c.stWgi().mugenver[0] != 1 {
-			// Before Mugen 1.0, rounding down to the nearest whole number was performed.
-			dist = float32(int32(dist))
-		}
+
+	// Before Mugen 1.0, rounding down to the nearest whole number was performed.
+	if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 && c.stWgi().mugenver[0] != 1 {
+		dist = float32(int32(dist))
 	}
+
 	return BytecodeFloat(dist)
 }
 
@@ -8989,12 +8993,12 @@ func (c *Char) rdDistY(rd *Char, oc *Char) BytecodeValue {
 		return BytecodeUndefined()
 	}
 	dist := c.distY(rd, oc)
-	if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 {
-		if c.stWgi().mugenver[0] != 1 {
-			// Before Mugen 1.0, rounding down to the nearest whole number was performed.
-			dist = float32(int32(dist))
-		}
+
+	// Before Mugen 1.0, rounding down to the nearest whole number was performed.
+	if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 && c.stWgi().mugenver[0] != 1 {
+		dist = float32(int32(dist))
 	}
+
 	return BytecodeFloat(dist)
 }
 
@@ -11624,7 +11628,7 @@ func (c *Char) actionPrepare() {
 					c.setCSF(CSF_playerpush)
 				}
 			}
-			// Reset player pushing priority
+			// Reset player pushing properties
 			c.pushPriority = 0
 			c.pushAffectTeam = 1
 			// HitBy timers

--- a/src/char.go
+++ b/src/char.go
@@ -11551,18 +11551,19 @@ func (c *Char) actionPrepare() {
 	if c.minus != 3 || c.csf(CSF_destroy) || c.scf(SCF_disabled) {
 		return
 	}
+
 	c.pauseBool = false
-	if c.cmd != nil {
-		if sys.supertime > 0 {
-			c.pauseBool = c.superMovetime == 0
-		} else if sys.pausetime > 0 && c.pauseMovetime == 0 {
-			c.pauseBool = true
-		}
+	if sys.supertime > 0 {
+		c.pauseBool = c.superMovetime == 0
+	} else if sys.pausetime > 0 && c.pauseMovetime == 0 {
+		c.pauseBool = true
 	}
-	c.acttmp = -int8(Btoi(c.pauseBool)) * 2
 	// Due to the nature of how pauses are processed, these are needed to fix an "off by 1" error in the PauseTime trigger
 	c.prevSuperMovetime = c.superMovetime
 	c.prevPauseMovetime = c.pauseMovetime
+
+	c.acttmp = -int8(Btoi(c.pauseBool)) * 2
+
 	if !c.pauseBool {
 		// Perform basic actions
 		if c.keyctrl[0] && c.cmd != nil && (c.helperIndex == 0 || c.controller >= 0) {
@@ -11668,6 +11669,11 @@ func (c *Char) actionPrepare() {
 		// This AssertSpecial flag is special in that it must always reset regardless of hitpause
 		c.unsetASF(ASF_animatehitpause)
 
+		// This variable is necessary because NoStandGuard is reset before the walking instructions are checked
+		// https://github.com/ikemen-engine/Ikemen-GO/issues/1966
+		// Update: No longer strictly necessary but we'll leave it in for now
+		c.prevNoStandGuard = c.asf(ASF_nostandguard)
+
 		// The flags in this block are to be reset even during hitpause
 		// Exception for WinMugen chars, where they persisted during hitpause
 		if c.stWgi().ikemenver[0] != 0 || c.stWgi().ikemenver[1] != 0 || c.stWgi().mugenver[0] == 1 || !c.hitPause() {
@@ -11677,8 +11683,10 @@ func (c *Char) actionPrepare() {
 			c.alpha = [2]int32{255, 0}
 			c.offset = [2]float32{}
 			// Reset all AssertSpecial flags except the following, which are reset elsewhere in the code
-			c.assertFlag = (c.assertFlag&ASF_nostandguard | c.assertFlag&ASF_nocrouchguard | c.assertFlag&ASF_noairguard |
-				c.assertFlag&ASF_runfirst | c.assertFlag&ASF_runlast)
+			// TODO: Maybe these don't need special treatment anymore either
+			// All this does right now is make IsAsserted more accurate, but that's already inaccurate in other places
+			keptflags := ASF_runfirst | ASF_runlast
+			c.assertFlag &= keptflags
 		}
 
 		// The flags below also reset during hitpause, but are new to Ikemen and don't need the exception above
@@ -11777,6 +11785,7 @@ func (c *Char) actionRun() {
 		c.minus = 0
 		c.ss.sb.run(c)
 	}
+
 	// Guarding instructions
 	c.unsetSCF(SCF_guard)
 	if ((c.scf(SCF_ctrl) || c.ss.no == 52) &&
@@ -11787,6 +11796,7 @@ func (c *Char) actionRun() {
 			c.ss.stateType == ST_A && !c.asf(ASF_noairguard)) {
 		c.setSCF(SCF_guard)
 	}
+
 	if !c.pauseBool {
 		if c.keyctrl[0] && c.cmd != nil {
 			if c.ctrl() && (c.controller >= 0 || c.helperIndex == 0) {
@@ -12005,6 +12015,7 @@ func (c *Char) actionFinish() {
 	if c.minus < 1 || c.csf(CSF_destroy) || c.scf(SCF_disabled) {
 		return
 	}
+
 	if !c.pauseBool {
 		if c.palfx != nil && c.ownpal {
 			c.palfx.step()
@@ -12013,18 +12024,18 @@ func (c *Char) actionFinish() {
 		c.ghv.frame = false
 		c.mhv.frame = false
 	}
+
 	// Reset inguarddist flag before running hit detection (where it will be updated)
 	// https://github.com/ikemen-engine/Ikemen-GO/issues/2328
 	c.inguarddist = false
-	// This variable is necessary because NoStandGuard is reset before the walking instructions are checked
-	// https://github.com/ikemen-engine/Ikemen-GO/issues/1966
-	c.prevNoStandGuard = c.asf(ASF_nostandguard)
-	c.unsetASF(ASF_nostandguard | ASF_nocrouchguard | ASF_noairguard)
+
 	// Save current HitFall value before hit detection
 	c.prevfallflag = c.ghv.fallflag
+
 	// Update Z scale
 	// Must be placed after posUpdate()
 	c.zScale = sys.updateZScale(c.pos[2], c.localscl)
+
 	// KO behavior
 	if !c.hitPause() && !c.pauseBool {
 		if c.alive() && c.life <= 0 && !sys.gsf(GSF_globalnoko) && !c.asf(ASF_noko) && (!c.ghv.guarded || !c.asf(ASF_noguardko)) {
@@ -12050,6 +12061,7 @@ func (c *Char) actionFinish() {
 			}
 		}
 	}
+
 	// Over flags (char is finished for the round)
 	if c.alive() && c.life > 0 && !sys.roundEnded() {
 		c.unsetSCF(SCF_over_alive | SCF_over_ko)
@@ -12057,6 +12069,7 @@ func (c *Char) actionFinish() {
 	if c.ss.no == 5150 && !c.scf(SCF_over_ko) { // Actual KO is not required in Mugen
 		c.setSCF(SCF_over_ko)
 	}
+
 	// Signal that "actionFinish" has finished
 	c.minus = 2
 }

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -6500,8 +6500,14 @@ func (c *CharCompiler) getHitVarSet(is IniSection, sc *StateControllerBase) (Sta
 			getHitVarSet_animtype, VT_Int, 1, false); err != nil {
 			return err
 		}
-		if err := c.paramValue(is, sc, "attr",
-			getHitVarSet_attr, VT_Int, 1, false); err != nil {
+		if err := c.stateParam(is, "attr", false, func(data string) error {
+			attr, err := c.attr(data, false)
+			if err != nil {
+				return err
+			}
+			sc.add(getHitVarSet_attr, sc.iToExp(attr))
+			return nil
+		}); err != nil {
 			return err
 		}
 		if err := c.paramValue(is, sc, "chainid",

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -3494,7 +3494,7 @@ func (ro *FightScreenRound) handleRoundIntro() {
 
 	// Round call
 	if ro.roundDisplayPhase < 2 {
-		roundNum := sys.round
+		roundNum := sys.roundNo
 		if sys.sel.gameParams.PersistRounds {
 			roundNum = sys.persistRoundCount
 		}
@@ -3632,11 +3632,11 @@ func (ro *FightScreenRound) handleRoundIntro() {
 // Consists of KO screen and winner messages
 func (ro *FightScreenRound) handleRoundOutro() {
 	if ro.timerActive {
-		if sys.matchTime-sys.timerCount[sys.round-1] > 0 {
-			sys.timerCount[sys.round-1] = sys.matchTime - sys.timerCount[sys.round-1]
+		if sys.matchTime-sys.timerCount[sys.roundNo-1] > 0 {
+			sys.timerCount[sys.roundNo-1] = sys.matchTime - sys.timerCount[sys.roundNo-1]
 			sys.timerRounds = append(sys.timerRounds, sys.timeElapsed())
 		} else {
-			sys.timerCount[sys.round-1] = 0
+			sys.timerCount[sys.roundNo-1] = 0
 		}
 		ro.timerActive = false
 	}
@@ -3874,7 +3874,7 @@ func (ro *FightScreenRound) draw(layerno int16, f map[int]*Fnt) {
 
 		// Check round number
 		var round_ref AnimTextSnd
-		roundNum := sys.round
+		roundNum := sys.roundNo
 		if sys.sel.gameParams.PersistRounds {
 			roundNum = sys.persistRoundCount
 		}
@@ -4390,7 +4390,7 @@ func (ma *FightScreenMatch) bgDraw(layerno int16) {
 func (ma *FightScreenMatch) draw(layerno int16, f map[int]*Fnt) {
 	if ma.active && ma.text.font[0] >= 0 && getFont(f, ma.text.font[0]) != nil {
 		text := ma.text.text
-		text = strings.Replace(text, "%s", fmt.Sprintf("%v", sys.match), 1)
+		text = strings.Replace(text, "%s", fmt.Sprintf("%v", sys.matchNo), 1)
 		ma.text.lay.DrawText(float32(ma.pos[0])+sys.fightScreen.offsetX, float32(ma.pos[1]), sys.fightScreen.scale, layerno,
 			text, getFont(f, ma.text.font[0]), ma.text.font[1], ma.text.font[2], ma.text.palfx, ma.text.frgba)
 		ma.top.Draw(float32(ma.pos[0])+sys.fightScreen.offsetX, float32(ma.pos[1]), layerno, sys.fightScreen.scale)

--- a/src/motif.go
+++ b/src/motif.go
@@ -3178,7 +3178,7 @@ func (m *Motif) act() {
 
 		// Dialogue
 		// Normal start: right before "Fight" in round 1, or at match end.
-		introStart := sys.round == 1 && sys.intro == sys.fightScreen.round.ctrl_time
+		introStart := sys.roundNo == 1 && sys.intro == sys.fightScreen.round.ctrl_time
 		matchEndStart := sys.shouldStartMatchEndDialogue()
 		normalStart := introStart || matchEndStart
 		// Forced start: ignore normal timing.
@@ -6683,7 +6683,7 @@ func (wi *MotifWin) initResultsVariant(m *Motif, sectionName string) bool {
 			tal := tallyRun()
 			rs.WinsText.TextSpriteData.text = m.sprintf(rs.WinsText.Text, tal.winP1, tal.loseP1)
 		}
-		if wouldPlace && rs.RoundsToWin > 0 && sys.match >= rs.RoundsToWin {
+		if wouldPlace && rs.RoundsToWin > 0 && sys.matchNo >= rs.RoundsToWin {
 			wi.assignStates(
 				[4][]int32{rs.P1.Win.State, rs.P3.Win.State, rs.P5.Win.State, rs.P7.Win.State},
 				[4][]int32{rs.P2.Win.State, rs.P4.Win.State, rs.P6.Win.State, rs.P8.Win.State},

--- a/src/music.go
+++ b/src/music.go
@@ -450,8 +450,8 @@ func (m Music) act() {
 		return
 	}
 	//fmt.Printf("[music] act: tickCount=%d round=%d match=%d bgmState=%d\n", sys.tickCount, sys.round, sys.match, sys.stage.bgmState)
-	if sys.tickCount == 0 && sys.round == 1 && !sys.roundResetMatchStart &&
-		(sys.match == 1 || !sys.sel.gameParams.PersistMusic || sys.stage.bgmState != BGMStateRound) {
+	if sys.tickCount == 0 && sys.roundNo == 1 && !sys.roundResetMatchStart &&
+		(sys.matchNo == 1 || !sys.sel.gameParams.PersistMusic || sys.stage.bgmState != BGMStateRound) {
 		sys.bgm.Stop()
 		sys.stage.bgmState = BGMStateIdle
 	}
@@ -472,8 +472,8 @@ func (m Music) act() {
 				sys.tickCount == 0 {
 				switch {
 				case sys.roundIsFinal() && cmusic.tryPlay("final", sys.stage.def):
-				case sys.sel.gameParams.PersistMusic && cmusic.tryPlay(fmt.Sprintf("round%d", sys.match), sys.stage.def):
-				case cmusic.tryPlay(fmt.Sprintf("round%d", sys.round), sys.stage.def):
+				case sys.sel.gameParams.PersistMusic && cmusic.tryPlay(fmt.Sprintf("round%d", sys.matchNo), sys.stage.def):
+				case cmusic.tryPlay(fmt.Sprintf("round%d", sys.roundNo), sys.stage.def):
 				case cmusic.tryPlay("", sys.stage.def):
 				}
 				sys.stage.bgmState = BGMStateRound

--- a/src/script.go
+++ b/src/script.go
@@ -3041,7 +3041,7 @@ func systemScriptInit(l *lua.LState) {
 			// Anonymous function to perform gameplay
 			fight := func() (int32, error) {
 				// Reset character list
-				if sys.round == 1 {
+				if sys.roundNo == 1 {
 					sys.charList.clear()
 				}
 
@@ -3054,7 +3054,7 @@ func systemScriptInit(l *lua.LState) {
 				}
 
 				// Build Turns teammate portraits after loading, when Lua order selection is complete.
-				if sys.round == 1 {
+				if sys.roundNo == 1 {
 					for side, tm := range sys.tmode {
 						if tm != TM_Turns {
 							continue
@@ -3091,7 +3091,7 @@ func systemScriptInit(l *lua.LState) {
 							continue
 						}
 						// Add or replace in charList
-						if sys.round == 1 {
+						if sys.roundNo == 1 {
 							sys.charList.add(c[0])
 						} else if c[0].roundsExisted() == 0 {
 							// BG-loaded Turns switching updates CharList inside activateNextTurnsFighters().
@@ -3118,7 +3118,7 @@ func systemScriptInit(l *lua.LState) {
 				}
 
 				// If first round
-				if sys.round == 1 {
+				if sys.roundNo == 1 {
 					// Update wins, reset stage
 					sys.endMatch = false
 					sys.teamLeader = [2]int{0, 1}
@@ -6622,7 +6622,7 @@ func systemScriptInit(l *lua.LState) {
 		@function setMatchNo
 		@tparam int32 matchNo Match index/number.
 		function setMatchNo(matchNo) end*/
-		sys.match = int32(numArg(l, 1))
+		sys.matchNo = int32(numArg(l, 1))
 		return 0
 	})
 	luaRegister(l, "setMatchWins", func(l *lua.LState) int {
@@ -9640,7 +9640,7 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "matchNo", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.match))
+		l.Push(lua.LNumber(sys.matchNo))
 		return 1
 	})
 	luaRegister(l, "matchOver", func(*lua.LState) int {
@@ -10351,7 +10351,7 @@ func triggerFunctions(l *lua.LState) {
 		return 1
 	})
 	luaRegister(l, "roundNo", func(*lua.LState) int {
-		l.Push(lua.LNumber(sys.round))
+		l.Push(lua.LNumber(sys.roundNo))
 		return 1
 	})
 	luaRegister(l, "roundsExisted", func(*lua.LState) int {

--- a/src/stats.go
+++ b/src/stats.go
@@ -151,7 +151,7 @@ func (s *StatsLog) finalizeMatch() {
 
 	// Copy outcome/tallies directly from engine state.
 	m.WinSide = sys.winTeam
-	// Last round played should be derived from what we recorded, not from sys.round math.
+	// Last round played should be derived from what we recorded, not from sys.roundNo math.
 	if len(m.Rounds) > 0 {
 		m.LastRound = m.Rounds[len(m.Rounds)-1].Index
 	} else {
@@ -242,7 +242,7 @@ func (s *StatsLog) nextRound() {
 
 	// Record the round into the current stats match.
 	// We fill timers later in finalizeMatch.
-	roundIdx := sys.round
+	roundIdx := sys.roundNo
 	roundScore := [2]int32{int32(sys.scorePoints[0]), int32(sys.scorePoints[1])}
 	s.addRound(roundIdx, 0, roundScore, fighters)
 }

--- a/src/system.go
+++ b/src/system.go
@@ -73,8 +73,8 @@ type SystemStateVars struct {
 	brightnessOld           float32
 	maxRoundTime            int32
 	curFramesPerCount       int32 // The mutatable value for the current match
-	match                   int32
-	round                   int32
+	matchNo                 int32
+	roundNo                 int32
 	intro                   int32
 	lastHitter              [2]int
 	winTeam                 int
@@ -190,7 +190,7 @@ var sys = System{
 		heightScale:         1,
 		brightness:          1,
 		maxRoundTime:        -1,
-		match:               1,
+		matchNo:             1,
 		numSimul:            [...]int32{2, 2},
 		numTurns:            [...]int32{2, 2},
 		oldNextAddTime:      1,
@@ -987,7 +987,7 @@ func (s *System) resetRemapInput() {
 }
 
 func (s *System) loaderReset() {
-	s.round, s.wins, s.roundsExisted, s.decisiveRound = 1, [2]int32{}, [2]int32{}, [2]bool{}
+	s.roundNo, s.wins, s.roundsExisted, s.decisiveRound = 1, [2]int32{}, [2]int32{}, [2]bool{}
 	s.turnsPreloadMember = [2]int{-1, -1}
 	s.loader.reset()
 }
@@ -1750,7 +1750,7 @@ func (s *System) roundStateTicks() int32 {
 
 // Check if the match consists of a single round
 func (s *System) roundIsSingle() bool {
-	return !s.sel.gameParams.PersistRounds && s.round == 1 && s.decisiveRound[0] && s.decisiveRound[1]
+	return !s.sel.gameParams.PersistRounds && s.roundNo == 1 && s.decisiveRound[0] && s.decisiveRound[1]
 }
 
 func (s *System) maxDrawsReached(team int) bool {
@@ -1765,7 +1765,7 @@ func (s *System) roundIsFinal() bool {
 		return false
 	}
 	// The first round is never already final
-	if s.round <= 1 {
+	if s.roundNo <= 1 {
 		return false
 	}
 	// Both teams must be on their decisive round
@@ -2020,7 +2020,7 @@ func (s *System) initPlayerID() {
 
 		c := sys.chars[i][0]
 
-		if sys.round == 1 || c.roundsExisted() == 0 {
+		if sys.roundNo == 1 || c.roundsExisted() == 0 {
 			// In BG-loaded Turns, promoted fighters already have a valid ID
 			if sys.cfg.Config.TurnsLoading && sys.tmode[i&1] == TM_Turns && c.id >= 0 {
 				return
@@ -2030,7 +2030,7 @@ func (s *System) initPlayerID() {
 	}
 
 	// Free some ID's in subsequent rounds
-	if sys.round > 1 {
+	if sys.roundNo > 1 {
 		sys.pruneCharId()
 	}
 
@@ -2224,10 +2224,10 @@ func (s *System) clearPlayerAssets(pn int, forceDestroy bool) {
 // Select correct stage for current round
 func (s *System) handleStageSwap() bool {
 	var roundRef int32
-	if s.round == 1 {
+	if s.roundNo == 1 {
 		s.stageLoopNo = 0
 	} else {
-		roundRef = s.round
+		roundRef = s.roundNo
 	}
 
 	if s.stageLoop && !s.roundResetFlg {
@@ -2246,7 +2246,7 @@ func (s *System) handleStageSwap() bool {
 	swap := false
 	if _, ok := s.stageList[roundRef]; ok {
 		s.stage = s.stageList[roundRef]
-		if s.round > 1 && !s.roundResetFlg {
+		if s.roundNo > 1 && !s.roundResetFlg {
 			swap = true
 		}
 		if s.stage.model != nil {
@@ -2260,7 +2260,7 @@ func (s *System) handleStageSwap() bool {
 }
 
 func (s *System) updateMusicMaps() {
-	newMatchMusic := s.round == 1 && !s.roundResetFlg
+	newMatchMusic := s.roundNo == 1 && !s.roundResetFlg
 
 	if newMatchMusic {
 		s.matchMusicSel = s.matchMusicSel[:0]
@@ -3786,7 +3786,7 @@ func (s *System) runMatch() (reload bool) {
 	s.roundBackup.Save()
 
 	// Save round 1 backup separately
-	if s.round == 1 {
+	if s.roundNo == 1 {
 		s.matchBackup = s.roundBackup
 	}
 
@@ -3871,7 +3871,7 @@ func (s *System) runMatch() (reload bool) {
 						s.saveCharVars(i)
 					}
 				}
-				s.round = 1
+				s.roundNo = 1
 				s.roundsExisted = [2]int32{}
 
 				s.statsLog.abortMatch()
@@ -4036,7 +4036,7 @@ func (s *System) SetupCharRoundStart() {
 	// Initialize each character's state
 	for i, p := range s.chars {
 		if len(p) > 0 {
-			if p[0].roundsExisted() == 0 && (s.round == 1 || s.tmode[i&1] == TM_Turns) {
+			if p[0].roundsExisted() == 0 && (s.roundNo == 1 || s.tmode[i&1] == TM_Turns) {
 				// If round 1 or a new character in Turns mode, initialize values
 				if p[0].ocd().life != -1 {
 					p[0].life = Clamp(p[0].ocd().life, 0, p[0].lifeMax)
@@ -4045,7 +4045,7 @@ func (s *System) SetupCharRoundStart() {
 					p[0].life = p[0].lifeMax
 					p[0].redLife = p[0].lifeMax
 				}
-				if s.round == 1 {
+				if s.roundNo == 1 {
 					if s.maxPowerMode {
 						p[0].power = p[0].powerMax
 					} else if p[0].ocd().power != -1 {
@@ -4075,7 +4075,7 @@ func (s *System) runNextRound() bool {
 			!(s.tmode[0] == TM_Turns && s.effectiveLoss[0]) &&
 			!(s.tmode[1] == TM_Turns && s.effectiveLoss[1]) {
 			// Prepare for the next round
-			s.round++
+			s.roundNo++
 			for i := range s.roundsExisted {
 				s.roundsExisted[i]++
 			}
@@ -4111,7 +4111,7 @@ func (s *System) runNextRound() bool {
 			// If match isn't over, presumably this is turns mode,
 			// so break to restart fight for the next character
 			if !s.matchOver() {
-				s.round++
+				s.roundNo++
 				for i := range s.roundsExisted {
 					s.roundsExisted[i]++
 				}
@@ -5714,7 +5714,7 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 	if l.cancelRequested() || l.state == LS_Cancel || sys.gameEnd {
 		return 0
 	}
-	if attached && sys.round != 1 {
+	if attached && sys.roundNo != 1 {
 		return 1
 	}
 
@@ -6093,7 +6093,7 @@ func (l *Loader) prepareTurnsFaces(pn int, fa *FightScreenFace, nm *FightScreenN
 }
 
 func (l *Loader) loadStage() bool {
-	if sys.round == 1 {
+	if sys.roundNo == 1 {
 		if l.cancelRequested() || l.state == LS_Cancel || sys.gameEnd {
 			l.state = LS_Cancel
 			return false
@@ -6327,7 +6327,7 @@ func (l *Loader) reset() {
 	l.cancelCh = nil
 	l.cancelOnce = sync.Once{}
 	for i := range sys.cgi {
-		keepPreloadedTurnsPal := sys.cfg.Config.TurnsLoading && sys.round > 1 && sys.tmode[i&1] == TM_Turns
+		keepPreloadedTurnsPal := sys.cfg.Config.TurnsLoading && sys.roundNo > 1 && sys.tmode[i&1] == TM_Turns
 		if sys.roundsExisted[i&1] == 0 && !keepPreloadedTurnsPal {
 			sys.cgi[i].palno = -1
 		}


### PR DESCRIPTION
Fixes:
- Fixed AssertSpecial nostandguard etc not working during pauses
- Fixed RemapPal to a palette with alpha not affecting the character's shadow
- Adjusted push code so that an overlap of exactly 0 is also valid for pushing
- Fixes #3759 (prematurely closed)
- Fixes https://discord.com/channels/233345562261323776/233363722934943744/1525080055770906655

Refactor:
- Disabled Mugen compatibility code that forced a minimum width of 5. It seems unnecessary to make all test cases work as long as the 0 overlap is allowed
- GetHitVarSet attr works with flags instead of integers, matching the update to the getHitVar(attr) trigger
- Fixes https://discord.com/channels/233345562261323776/282927929548210177/1526156173110280313