### PR TITLE
feat(motif): select screen slot indicator

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -1430,6 +1430,10 @@ function main.f_addChar(line, playable, loading, slot)
 		table.insert(main.t_selGrid, {['chars'] = {row}, ['slot'] = 1})
 	else
 		table.insert(main.t_selGrid[#main.t_selGrid].chars, row)
+		-- marks all chars using this slot
+		for _, idx in ipairs(main.t_selGrid[#main.t_selGrid].chars) do
+			main.t_selChars[idx].hasSlot = true
+		end
 	end
 	for _, v in ipairs({'next', 'previous', 'select'}) do
 		if main.t_selChars[row][v] ~= nil then

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -797,6 +797,18 @@ local function drawPortraitRandom(randomCfg)
 	return false
 end
 
+local function drawPortraitSlot(slotCfg)
+	if not slotCfg then
+		return false
+	end
+	local spr = slotCfg.spr
+	if slotCfg.anim >= 0 or (spr and spr[1] >= 0 and spr[2] >= 0) then
+		main.f_animPosDraw(slotCfg.AnimData)
+		return true
+	end
+	return false
+end
+
 local function hasPortraitAnim(params)
 	return params ~= nil and params.AnimData ~= nil and ((params.anim or -1) ~= -1 or (params.spr ~= nil and params.spr[1] ~= -1))
 end
@@ -893,6 +905,29 @@ function start.f_drawPortraits(t_portraits, side, t, subname, last, iconDone)
 			end
 			if baseFace.random and drawPortraitRandom(baseFace.random) then
 				t_portraits[m].skipCurrent = true
+			end
+		end
+	end
+	-- draw slot indicator
+	for m = 1, #t_portraits do
+		local pn = 2 * (m - 1) + side
+		local pData = f_getMotifP(t, pn, side)
+
+		local baseFace = pData
+		if subname and subname ~= '' then
+			baseFace = baseFace[subname]
+		end
+		if t_portraits[m].ref ~= nil then
+			local charInfo = main.t_selChars[t_portraits[m].ref + 1]
+			if charInfo and charInfo.hasSlot then
+				-- face2 slot
+				if pData.face2.slot then
+					drawPortraitSlot(pData.face2.slot)
+				end
+				-- primary face slot
+				if baseFace.slot then
+					drawPortraitSlot(baseFace.slot)
+				end
 			end
 		end
 	end
@@ -2505,6 +2540,16 @@ function start.updateDrawList()
 						end
 					end
 					table.insert(drawList, item)
+					local grid = main.t_selGrid[cellIndex]
+					local hasMultipleChars = grid ~= nil and #grid.chars > 1
+					-- draw slot indicator
+					if hasMultipleChars and hasPortraitAnim(motif.select_info.cell.slot) then
+						local icon = getTransforms(motif.select_info.cell.slot)
+						icon.anim = motif.select_info.cell.slot.AnimData
+						icon.x = motif.select_info.pos[1] + t.x + motif.select_info.cell.slot.offset[1]
+						icon.y = motif.select_info.pos[2] + t.y + motif.select_info.cell.slot.offset[2]
+						table.insert(drawList, icon)
+					end
 				end
 			end
 		end

--- a/src/motif.go
+++ b/src/motif.go
@@ -417,6 +417,7 @@ type FaceProperties struct {
 	} `ini:"done"`
 	Random   AnimationProperties `ini:"random"`  // only used by [Select Info]
 	Loading  AnimationProperties `ini:"loading"` // only used by [Select Info] and [VS Screen]
+	Slot     AnimationProperties `ini:"slot"`    // only used by [Select Info]
 	Velocity [2]float32          `ini:"velocity"`
 	MaxDist  [2]float32          `ini:"maxdist"`
 	Accel    [2]float32          `ini:"accel"`
@@ -691,6 +692,7 @@ type SelectInfoProperties struct {
 			SwitchTime int32 `ini:"switchtime"`
 		} `ini:"random"`
 		MapCell map[string]*CellOverrideProperties `ini:"map:^[0-9*]+-[0-9*]+$" lua:""`
+		Slot    AnimationProperties `ini:"slot"`
 	} `ini:"cell"`
 	P1      PlayerSelectProperties `ini:"p1"`
 	P2      PlayerSelectProperties `ini:"p2"`
@@ -2662,6 +2664,10 @@ func (m *Motif) applyPostParsePosAdjustments() {
 		// Face.Random and Face2.Random
 		offsetAnims(ps.Face.Pos[0], ps.Face.Pos[1], ps.Face.Random.AnimData)
 		offsetAnims(ps.Face2.Pos[0], ps.Face2.Pos[1], ps.Face2.Random.AnimData)
+
+		// Face.Slot and Face2.Slot
+		offsetAnims(ps.Face.Pos[0], ps.Face.Pos[1], ps.Face.Slot.AnimData)
+		offsetAnims(ps.Face2.Pos[0], ps.Face2.Pos[1], ps.Face2.Slot.AnimData)
 	}
 
 	// Select Screen: Players

--- a/src/resources/defaultMotif.ini
+++ b/src/resources/defaultMotif.ini
@@ -717,6 +717,22 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	;cell.<col>-<row>.focallength = 2048
 	;cell.<col>-<row>.skip = 0
 
+	; If defined draws a sprite or anim from the screenpack on cells using the slot parameter in select.def.
+	cell.slot.anim = -1
+	cell.slot.spr = -1, 0
+	cell.slot.offset = 0, 0
+	cell.slot.facing = 1
+	cell.slot.scale = 1.0, 1.0
+	cell.slot.xshear = 0
+	cell.slot.angle = 0
+	cell.slot.xangle = 0
+	cell.slot.yangle = 0
+	cell.slot.projection = orthographic
+	cell.slot.focallength = 2048
+	cell.slot.layerno = 0
+	cell.slot.window = 
+	cell.slot.localcoord = 320, 240
+
 	; All cursor parameters can be specified for player 1-8.
 	; p3-p8 assignments defaults to p1 and p2 values, if not specified
 	p1.cursor.startcell = 0, 0
@@ -891,6 +907,22 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	p1.face.random.window = 
 	p1.face.random.localcoord = 320, 240
 
+	; If defined draws a sprite or anim from the screenpack on chars using the slot parameter in select.def.
+	p1.face.slot.anim = -1
+	p1.face.slot.spr = -1, 1
+	p1.face.slot.offset = 0, 0
+	p1.face.slot.facing = 1
+	p1.face.slot.scale = 1.0, 1.0
+	p1.face.slot.xshear = 0
+	p1.face.slot.angle = 0
+	p1.face.slot.xangle = 0
+	p1.face.slot.yangle = 0
+	p1.face.slot.projection = orthographic
+	p1.face.slot.focallength = 2048
+	p1.face.slot.layerno = 0
+	p1.face.slot.window = 
+	p1.face.slot.localcoord = 320, 240
+
 	; If defined draws a sprite or anim from the screenpack during char assets boot loading
 	p1.face.loading.anim = -1
 	p1.face.loading.spr = -1, 1
@@ -980,6 +1012,21 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	p1.face2.random.layerno = 0
 	p1.face2.random.window = 
 	p1.face2.random.localcoord = 320, 240
+
+	p1.face2.slot.anim = -1
+	p1.face2.slot.spr = -1, 1
+	p1.face2.slot.offset = 0, 0
+	p1.face2.slot.facing = 1
+	p1.face2.slot.scale = 1.0, 1.0
+	p1.face2.slot.xshear = 0
+	p1.face2.slot.angle = 0
+	p1.face2.slot.xangle = 0
+	p1.face2.slot.yangle = 0
+	p1.face2.slot.projection = orthographic
+	p1.face2.slot.focallength = 2048
+	p1.face2.slot.layerno = 0
+	p1.face2.slot.window = 
+	p1.face2.slot.localcoord = 320, 240
 
 	p1.face2.loading.anim = -1
 	p1.face2.loading.spr = -1, 1
@@ -1465,6 +1512,21 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	p2.face.random.window = 
 	p2.face.random.localcoord = 320, 240
 
+	p2.face.slot.anim = -1
+	p2.face.slot.spr = -1, 1
+	p2.face.slot.offset = 0, 0
+	p2.face.slot.facing = 1
+	p2.face.slot.scale = 1.0, 1.0
+	p2.face.slot.xshear = 0
+	p2.face.slot.angle = 0
+	p2.face.slot.xangle = 0
+	p2.face.slot.yangle = 0
+	p2.face.slot.projection = orthographic
+	p2.face.slot.focallength = 2048
+	p2.face.slot.layerno = 0
+	p2.face.slot.window = 
+	p2.face.slot.localcoord = 320, 240
+
 	p2.face.loading.anim = -1
 	p2.face.loading.spr = -1, 1
 	p2.face.loading.offset = 0, 0
@@ -1545,6 +1607,21 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	p2.face2.random.layerno = 0
 	p2.face2.random.window = 
 	p2.face2.random.localcoord = 320, 240
+
+	p2.face2.slot.anim = -1
+	p2.face2.slot.spr = -1, 1
+	p2.face2.slot.offset = 0, 0
+	p2.face2.slot.facing = 1
+	p2.face2.slot.scale = 1.0, 1.0
+	p2.face2.slot.xshear = 0
+	p2.face2.slot.angle = 0
+	p2.face2.slot.xangle = 0
+	p2.face2.slot.yangle = 0
+	p2.face2.slot.projection = orthographic
+	p2.face2.slot.focallength = 2048
+	p2.face2.slot.layerno = 0
+	p2.face2.slot.window = 
+	p2.face2.slot.localcoord = 320, 240
 
 	p2.face2.loading.anim = -1
 	p2.face2.loading.spr = -1, 1


### PR DESCRIPTION
Feat:
- Added indicators for the select.def slot param
  - ``cell.slot`` If defined, draws a sprite or animation on cells using the `slot` parameter from `select.def`. Accepts all standard parameters.
  - ``pn.face.slot`` and ``pn.face2.slot``
If assigned, draws a sprite or animation on the portrait when the cursor is on a cell with a slot. Accepts all standard parameters.