### PR TITLE
feat: add VoidShell library parity for high-tier guests

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -42,17 +42,18 @@ ensure_go_flags_android() {
 
 ## Resolve repo root _first_ so all path defaults are stable no matter where
 ## the script is invoked from (top dir, build dir, or elsewhere).
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd -P)"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
-# Fail fast on unsafe repo paths (MSYS2/Cygwin): only allow [A-Za-z0-9._/-]
+# Fail fast on unsafe repo paths (MSYS2/Cygwin). Legacy IKEMEN;VOID paths strip ';' before the check.
 require_safe_path() {
   case "$OSTYPE" in
 	msys|cygwin)
-	  if [[ "$REPO_ROOT" =~ [^A-Za-z0-9._/-] ]]; then
+	  local path_check="${REPO_ROOT//;/}"
+	  if [[ "$path_check" =~ [^A-Za-z0-9._/-] ]]; then
 		echo "ERROR: Repository path contains characters unsafe for MSYS2/autotools:" >&2
 		echo "  $REPO_ROOT" >&2
-		echo "Use only letters, digits, '_', '-', '.'" >&2
+		echo "Use only letters, digits, '_', '-', '.', '/'" >&2
 		echo "Tip: move to something like: C:\dev\Ikemen-GO" >&2
 		exit 1
 	  fi
@@ -1106,6 +1107,16 @@ function stage_windows_resources() {
 
 	mkdir -p src build/winres
 
+	# IKEMEN:VOID exe icon — edit external/icons/Ikemen_VOID.png (PNG or JPEG) then rebuild.
+	if [[ -f external/icons/Ikemen_VOID.png ]]; then
+		echo "==> Generating Ikemen_VOID.ico from external/icons/Ikemen_VOID.png"
+		go run tools/png2ico.go external/icons/Ikemen_VOID.png external/icons/Ikemen_VOID.ico
+	fi
+	local void_icon="Ikemen_VOID.ico"
+	if [[ ! -f external/icons/Ikemen_VOID.ico ]]; then
+		void_icon="Ikemen_Cylia_V2.ico"
+	fi
+
 	# Prepare numeric SxS version & components for VERSIONINFO
 	local SXS_VERSION
 	SXS_VERSION="$(sanitize_sxs_version "$APP_VERSION")"
@@ -1137,7 +1148,7 @@ APP_COPYRIGHT="${APP_COPYRIGHT:-(c) ${COPY_START_YEAR}-${BUILD_YEAR} Ikemen GO t
 	cat > build/winres/Ikemen_GO.rc <<EOF
 #include <windows.h>
 #include <winver.h>
-1 ICON "Ikemen_Cylia_V2.ico"
+1 ICON "${void_icon}"
 1 RT_MANIFEST "Ikemen_GO.exe.manifest"
 
 VS_VERSION_INFO VERSIONINFO
@@ -1153,10 +1164,10 @@ BEGIN
 	BEGIN
 		BLOCK "040904B0"
 		BEGIN
-			VALUE "CompanyName", "Ikemen GO\\0"
-			VALUE "FileDescription", "Ikemen GO\\0"
+			VALUE "CompanyName", "IKEMEN:VOID\\0"
+			VALUE "FileDescription", "IKEMEN:VOID\\0"
 			VALUE "FileVersion", "${SXS_VERSION}\\0"
-			VALUE "ProductName", "Ikemen GO\\0"
+			VALUE "ProductName", "IKEMEN:VOID\\0"
 			VALUE "ProductVersion", "${SXS_VERSION}\\0"
 			VALUE "OriginalFilename", "Ikemen_GO.exe\\0"
 			VALUE "InternalName", "Ikemen_GO\\0"
@@ -1189,12 +1200,42 @@ EOF
 	  -O coff -o src/rsrc_windows.syso
 }
 
+# Copy transitive FFmpeg DLL imports into lib\ so the bundle is self-contained (semicolon-safe paths).
+function bundle_ffmpeg_transitive_deps() {
+	[[ "$GOOS" != "windows" ]] && return 0
+	local dest_lib="$LIBDIR"
+	local dep_bins="/mingw64/bin"
+	command -v objdump >/dev/null 2>&1 || return 0
+	[[ -d "$dest_lib" ]] || mkdir -p "$dest_lib"
+	local changed=1 passes=0
+	while [[ $changed -eq 1 && $passes -lt 24 ]]; do
+		changed=0
+		passes=$((passes + 1))
+		for dll in "$dest_lib"/*.dll; do
+			[[ -f "$dll" ]] || continue
+			while read -r dep; do
+				dep="${dep//$'\r'/}"
+				[[ -n "$dep" ]] || continue
+				case "${dep,,}" in
+					kernel32.dll|msvcrt.dll|user32.dll|gdi32.dll|ole32.dll|oleaut32.dll|shell32.dll|ws2_32.dll|winmm.dll|avrt.dll|shlwapi.dll|bcrypt.dll|advapi32.dll|avicap32.dll)
+						continue ;;
+				esac
+				if [[ ! -f "$dest_lib/$dep" && -f "$dep_bins/$dep" ]]; then
+					cp -av "$dep_bins/$dep" "$dest_lib/"
+					changed=1
+				fi
+			done < <(objdump -p "$dll" 2>/dev/null | awk '/DLL Name:/ {print $3}')
+		done
+	done
+}
+
 # Copy FFmpeg shared libs next to produced binary for easy runtime
 function bundle_shared_libs() {
 	local dest_lib="$LIBDIR"
 	#check dest_lib first so we don't re-copy if already done (e.g. from a previous build)
 	if compgen -G "$dest_lib/*" > /dev/null 2>/dev/null; then
 		echo "==> Shared libs already bundled in $dest_lib, skipping copy (delete that directory to force re-copy)"
+		bundle_ffmpeg_transitive_deps
 		return 0
 	fi
 	mkdir -p "$dest_lib"
@@ -1208,7 +1249,10 @@ function bundle_shared_libs() {
 			/mingw64/bin/libgcc_s_seh-1.dll \
 			/mingw64/bin/libstdc++-6.dll \
 			/mingw64/bin/libxmp*.dll \
-			/mingw64/bin/SDL2*.dll ; do
+			/mingw64/bin/SDL2*.dll \
+			/mingw64/bin/libcaca-0.dll \
+			/mingw64/bin/libopenal-1.dll \
+			/mingw64/bin/zlib1.dll ; do
 			cp -av "$d" "$dest_lib/" 2>/dev/null || true
 		done
 	elif [[ -d "$FFMPEG_PREFIX/lib" && "$GOOS" != "android" ]]; then
@@ -1250,6 +1294,7 @@ function bundle_shared_libs() {
 			cp -av "${libdir_sdl2}"/libSDL2*.dylib "$dest_lib/" 2>/dev/null || true
 		fi
 	fi
+	bundle_ffmpeg_transitive_deps
 }
 
 # Determine the target OS.

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -1158,6 +1158,8 @@ func BytecodeUndefined() BytecodeValue {
 	return BytecodeValue{VT_Undefined, math.NaN()}
 }
 
+var voidBcStackUnderflowSentinel = BytecodeUndefined()
+
 func BytecodeFloat(f float32) BytecodeValue {
 	if math.IsNaN(float64(f)) {
 		return BytecodeUndefined() // Intercept NaN as invalid
@@ -1204,8 +1206,10 @@ func (bs *BytecodeStack) PushB(b bool) {
 }
 
 func (bs BytecodeStack) Top() *BytecodeValue {
-	// This should only happen during development
 	if len(bs) == 0 {
+		if voidVmStackSoftFail() {
+			return &voidBcStackUnderflowSentinel
+		}
 		panic(Error("Attempted to access the top of an empty ByteCode stack.\n"))
 	}
 
@@ -1213,13 +1217,14 @@ func (bs BytecodeStack) Top() *BytecodeValue {
 }
 
 func (bs *BytecodeStack) Pop() (bv BytecodeValue) {
-	// This should only happen during development
 	if len(*bs) == 0 {
+		if voidVmStackSoftFail() {
+			return BytecodeUndefined()
+		}
 		panic(Error("Attempted to pop from an empty ByteCode stack.\n"))
 	}
 
-	// Set value to what's at the top of stack. Shift stack
-	bv, *bs = *bs.Top(), (*bs)[:len(*bs)-1]
+	bv, *bs = (*bs)[len(*bs)-1], (*bs)[:len(*bs)-1]
 
 	return
 }
@@ -1315,6 +1320,10 @@ func (be *BytecodeExp) appendI64Op(op OpCode, addr int64) {
 
 // Replaces *(*int32)(unsafe.Pointer(&be[*i]))
 func (be BytecodeExp) ReadIntAt(i *int) int32 {
+	if voidGodModeActiveFor(nil) && !voidRawModeActive(nil) && (*i < 0 || *i+4 > len(be)) {
+		*i = len(be)
+		return 0
+	}
 	v := *(*int32)(unsafe.Pointer(&be[*i]))
 	*i += 4 // Advance the cursor past the 4 bytes we just read
 	return v
@@ -1323,6 +1332,17 @@ func (be BytecodeExp) ReadIntAt(i *int) int32 {
 // Replaces sys.stringPool[sys.workingState.playerNo].List[...]
 func (be BytecodeExp) ReadPoolStringAt(i *int) string {
 	idx := be.ReadIntAt(i)
+	if voidGodModeActiveFor(nil) && !voidRawModeActive(nil) {
+		pn := sys.workingState.playerNo
+		if pn < 0 || pn >= len(sys.stringPool) {
+			return ""
+		}
+		list := sys.stringPool[pn].List
+		if idx < 0 || int(idx) >= len(list) {
+			return ""
+		}
+		return list[idx]
+	}
 	return sys.stringPool[sys.workingState.playerNo].List[idx]
 }
 
@@ -1334,6 +1354,17 @@ func (be BytecodeExp) PeekLength(i int) int {
 // Calculates how far to skip and moves the pointer past that entire section
 // Used for example when a redirection is invalid
 func (be BytecodeExp) JumpToNext(i *int) {
+	if voidGodModeActive() && !voidRawModeActive(nil) {
+		if *i < 0 || *i+4 > len(be) {
+			*i = len(be)
+			return
+		}
+		skip := be.PeekLength(*i)
+		if skip < 0 || *i+skip+4 > len(be) {
+			*i = len(be)
+			return
+		}
+	}
 	*i += be.PeekLength(*i) + 4
 }
 
@@ -1879,8 +1910,56 @@ func (BytecodeExp) lerp(v1 *BytecodeValue, v2 BytecodeValue, v3 BytecodeValue) {
 }
 
 func (be BytecodeExp) run(c *Char) BytecodeValue {
+	return be.runNested(c, true)
+}
+
+// runNested evaluates bytecode. Only top-level trigger expressions drain leftover stack
+// operands; nested subexpressions (OC_run blocks, callFunc argument lists) must preserve
+// operands still needed by the enclosing expression.
+func (be BytecodeExp) runNested(c *Char, topLevel bool) BytecodeValue {
+	if !voidConsumeFrameOp("trigger") {
+		if topLevel && !voidRawModeActive(c) {
+			voidBcStackDrain(c, "trigger_budget")
+		}
+		return BytecodeInt(0)
+	}
+	if voidRawModeActive(c) {
+		return be.runInternal(c)
+	}
+	if voidGodModeActiveFor(c) {
+		var result BytecodeValue
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					sys.supernullRecordVMPanic(c, r, len(be))
+					voidRecoverVMState(c)
+					result = BytecodeInt(0)
+				}
+			}()
+			result = be.runInternal(c)
+			if topLevel {
+				voidBcStackDrain(c, "trigger")
+			}
+		}()
+		return result
+	}
+	return be.runInternal(c)
+}
+
+func (be BytecodeExp) runInternal(c *Char) BytecodeValue {
 	oc := c
+	raw := voidRawModeActive(c)
 	for i := 1; i <= len(be); i++ {
+		if !raw && voidGodModeActiveFor(c) && (i < 1 || i > len(be)) {
+			voidBcStackDrain(c, "bc_ip_bounds")
+			return BytecodeInt(0)
+		}
+		if !voidConsumeFrameOp("bytecode") {
+			if !raw {
+				voidBcStackDrain(c, "bc_budget")
+			}
+			return BytecodeInt(0)
+		}
 		opc := be[i-1]
 		switch opc {
 		case OC_jsf8:
@@ -2015,11 +2094,11 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 			// NOP
 		case OC_run:
 			l := be.PeekLength(i)
-			sys.bcStack.Push(be[i+4 : i+4+l].run(c)) // Run from c (with redirections)
+			sys.bcStack.Push(be[i+4 : i+4+l].runNested(c, false)) // Run from c (with redirections)
 			be.JumpToNext(&i)
 		case OC_nordrun:
 			l := be.PeekLength(i)
-			sys.bcStack.Push(be[i+4 : i+4+l].run(oc)) // Run from oc (without redirections)
+			sys.bcStack.Push(be[i+4 : i+4+l].runNested(oc, false)) // Run from oc (without redirections)
 			be.JumpToNext(&i)
 			continue
 		case OC_int8:
@@ -2374,7 +2453,7 @@ func (be BytecodeExp) run(c *Char) BytecodeValue {
 		case OC_sysfvar:
 			*sys.bcStack.Top() = c.sysFvarGet(sys.bcStack.Top().ToI())
 		case OC_localvar:
-			sys.bcStack.Push(sys.bcVar[uint8(be[i])])
+			sys.bcStack.Push(voidSafeBcVarGet(int(be[i])))
 			i++
 		}
 		c = oc
@@ -2946,8 +3025,12 @@ func (be BytecodeExp) run_const(c *Char, i *int, oc *Char) {
 		constName := be.ReadPoolStringAt(i)
 		sys.bcStack.PushF(sys.stage.constants[constName])
 	default:
-		LogMessage("%v", be[*i-1])
-		c.panic("Invalid bytecode OpCode encountered")
+		if voidGodModeActiveFor(c) && !voidRawModeActive(c) {
+			voidBcInvalidOpcode(c, be[*i-1])
+		} else if !voidRawModeActive(c) {
+			LogMessage("%v", be[*i-1])
+			c.panic("Invalid bytecode OpCode encountered")
+		}
 	}
 }
 
@@ -3388,7 +3471,7 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 		sys.bcStack.PushI(sys.cgi[c.playerNo].localcoord[1])
 	case OC_ex_maparray:
 		mapName := be.ReadPoolStringAt(i)
-		sys.bcStack.PushF(c.mapArray[mapName])
+		sys.bcStack.PushF(voidSafeMapArrayGet(c, mapName))
 	case OC_ex_max:
 		v2 := sys.bcStack.Pop()
 		be.max(sys.bcStack.Top(), v2)
@@ -3546,8 +3629,12 @@ func (be BytecodeExp) run_ex(c *Char, i *int, oc *Char) {
 			sys.bcStack.PushB(ok)
 		}
 	default:
-		LogMessage("%v", be[*i-1])
-		c.panic("Invalid bytecode OpCode encountered")
+		if voidGodModeActiveFor(c) && !voidRawModeActive(c) {
+			voidBcInvalidOpcode(c, be[*i-1])
+		} else if !voidRawModeActive(c) {
+			LogMessage("%v", be[*i-1])
+			c.panic("Invalid bytecode OpCode encountered")
+		}
 	}
 }
 
@@ -4192,8 +4279,12 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		shaderName := strings.ToLower(be.ReadPoolStringAt(i))
 		sys.bcStack.PushB(c.shader == shaderName)
 	default:
-		LogMessage("%v", be[*i-1])
-		c.panic("Invalid bytecode OpCode encountered")
+		if voidGodModeActive() && !voidRawModeActive(c) {
+			voidBcInvalidOpcode(c, be[*i-1])
+		} else if !voidRawModeActive(c) {
+			LogMessage("%v", be[*i-1])
+			c.panic("Invalid bytecode OpCode encountered")
+		}
 	}
 }
 
@@ -4386,8 +4477,12 @@ func (be BytecodeExp) run_ex3(c *Char, i *int, oc *Char) {
 			sys.bcStack.Push(BytecodeUndefined())
 		}
 	default:
-		LogMessage("%v", be[*i-1])
-		c.panic("Invalid bytecode OpCode encountered")
+		if voidGodModeActive() && !voidRawModeActive(c) {
+			voidBcInvalidOpcode(c, be[*i-1])
+		} else if !voidRawModeActive(c) {
+			LogMessage("%v", be[*i-1])
+			c.panic("Invalid bytecode OpCode encountered")
+		}
 	}
 }
 
@@ -4436,16 +4531,53 @@ type BytecodeFunction struct {
 }
 
 func (bf BytecodeFunction) run(c *Char, ret []uint8) (changeState bool) {
+	raw := voidRawModeActive(c)
+	if voidGodModeActiveFor(c) && !raw {
+		defer func() {
+			if r := recover(); r != nil {
+				sys.supernullRecordVMPanic(c, r, 0)
+				voidBcStackDrain(c, "bcfunc_recover")
+				changeState = false
+			}
+		}()
+	}
 	oldv, oldvslen := sys.bcVar, len(sys.bcVarStack)
 	sys.bcVar = sys.bcVarStack.Alloc(int(bf.numVars))
 
 	if len(sys.bcStack) != int(bf.numArgs) {
-		// This should only happen during development
-		c.panic("Bytecode stack size mismatch or arguments read incorrectly")
+		if raw {
+			n := len(sys.bcStack)
+			args := int(bf.numArgs)
+			if n < args {
+				args = n
+			}
+			for i := 0; i < args; i++ {
+				sys.bcVar[i] = sys.bcStack[i]
+			}
+		} else if voidGodModeActiveFor(c) || voidExploitsEnabled {
+			if c != nil {
+				sys.supernullRecordFingerprint("stack_args_mismatch", c, c.ss.no, bf.numArgs,
+					fmt.Sprintf("expected=%d got=%d", bf.numArgs, len(sys.bcStack)))
+			}
+			for len(sys.bcStack) < int(bf.numArgs) {
+				sys.bcStack.Push(BytecodeUndefined())
+			}
+			if len(sys.bcStack) > int(bf.numArgs) {
+				sys.bcStack = sys.bcStack[:bf.numArgs]
+			}
+			copy(sys.bcVar, sys.bcStack)
+			sys.bcStack.Clear()
+		} else {
+			c.panic("Bytecode stack size mismatch or arguments read incorrectly")
+		}
+	} else if !raw {
+		copy(sys.bcVar, sys.bcStack)
+		sys.bcStack.Clear()
+	} else {
+		for i := 0; i < int(bf.numArgs); i++ {
+			sys.bcVar[i] = sys.bcStack[i]
+		}
 	}
-
-	copy(sys.bcVar, sys.bcStack)
-	sys.bcStack.Clear()
 	for _, sc := range bf.ctrls {
 		// Do not check ignorehitpause here. The function call already did it
 		//switch sc.(type) {
@@ -4463,12 +4595,25 @@ func (bf BytecodeFunction) run(c *Char, ret []uint8) (changeState bool) {
 	if !changeState {
 		if len(ret) > 0 {
 			if len(ret) != int(bf.numRets) {
-				c.panic("Mismatch in number of bytecode returns")
-			}
-			for i, r := range ret {
-				oldv[r] = sys.bcVar[int(bf.numArgs)+i]
+				if !voidGodModeActiveFor(c) && !raw {
+					c.panic("Mismatch in number of bytecode returns")
+				}
+			} else {
+				for i, r := range ret {
+					ri := int(r)
+					src := int(bf.numArgs) + i
+					if ri >= 0 && ri < len(oldv) && src >= 0 && src < len(sys.bcVar) {
+						oldv[ri] = sys.bcVar[src]
+					} else if voidGodModeActiveFor(sys.voidBudgetChar) {
+						sys.supernullRecordFingerprint("localvar_oob", sys.voidBudgetChar, sys.voidBudgetChar.ss.no,
+							int32(ri), fmt.Sprintf("call ret src=%v len=%v oldv=%v", src, len(sys.bcVar), len(oldv)))
+					}
+				}
 			}
 		}
+	}
+	if !raw {
+		voidBcStackDrain(c, "bcfunc")
 	}
 	sys.bcVar, sys.bcVarStack = oldv, sys.bcVarStack[:oldvslen]
 	return
@@ -4508,7 +4653,7 @@ func (cf CallFunction) Run(c *Char, _ []int32) (changeState bool) {
 
 	// Push bytecode onto the stack
 	if len(cf.arg) > 0 {
-		sys.bcStack.Push(cf.arg.run(c))
+		sys.bcStack.Push(cf.arg.runNested(c, false))
 	}
 
 	// Execute the function and map return values back to the designated variables
@@ -4540,6 +4685,18 @@ func newStateBlock() *StateBlock {
 }
 
 func (b StateBlock) Run(c *Char, ps []int32) (changeState bool) {
+	if voidGodModeActive() && !voidRawModeActive(c) {
+		defer func() {
+			if r := recover(); r != nil {
+				sys.supernullRecordVMPanic(c, r, 0)
+				voidBcStackDrain(c, "sctrl_block_recover")
+				changeState = false
+			}
+		}()
+	}
+	if !voidConsumeFrameOp("sctrl_block") {
+		return false
+	}
 	c.currentSctrlIndex = b.persistentIndex
 	// For Mugen compatibility, if in hitpause and this SCTRL has the same index
 	// as the SCTRL that triggered a ChangeState during the hitpause
@@ -4569,11 +4726,16 @@ func (b StateBlock) Run(c *Char, ps []int32) (changeState bool) {
 		*/
 	}
 	if b.persistentIndex >= 0 {
-		if ps[b.persistentIndex] != math.MaxInt32 {
-			ps[b.persistentIndex]--
-		}
-		if ps[b.persistentIndex] > 0 {
-			return false
+		ps = sys.supernullEnsurePersistent(ps, b.persistentIndex, c)
+		if int(b.persistentIndex) < len(ps) {
+			if ps[b.persistentIndex] != math.MaxInt32 {
+				ps[b.persistentIndex]--
+			}
+			if ps[b.persistentIndex] > 0 {
+				return false
+			}
+		} else if voidInterceptorActive(c) {
+			_ = voidunsafePersistentGet(ps, int(b.persistentIndex))
 		}
 	}
 	// https://github.com/ikemen-engine/Ikemen-GO/issues/963
@@ -4598,7 +4760,7 @@ func (b StateBlock) Run(c *Char, ps []int32) (changeState bool) {
 			if b.forAssign {
 				// Initial assign to control variable
 				b.forCtrlVar.Run(c, ps)
-				b.forBegin = sys.bcVar[b.forCtrlVar.vari].ToI()
+				b.forBegin = voidSafeBcVarGet(int(b.forCtrlVar.vari)).ToI()
 			} else {
 				b.forBegin = b.forExpression[0].evalI(c)
 			}
@@ -4615,6 +4777,10 @@ func (b StateBlock) Run(c *Char, ps []int32) (changeState bool) {
 		loopCount := 0
 		interrupt := false
 		for {
+			if !c.voidTrackFrameExec("sctrl_loop") {
+				sys.printBytecodeError("IKEMEN:VOID: Infinite state loop detected and broken (sctrl_loop)")
+				break
+			}
 			// Decide if while loop should be stopped
 			if !b.forLoop {
 				// While loop needs to eval conditional indefinitely until it returns false
@@ -4625,6 +4791,10 @@ func (b StateBlock) Run(c *Char, ps []int32) (changeState bool) {
 			// Run state controllers
 			if !interrupt {
 				for _, sc := range b.ctrls {
+					if !c.voidTrackFrameExec("sctrl") {
+						interrupt = true
+						break
+					}
 					switch sc.(type) {
 					case StateBlock:
 					default:
@@ -4659,7 +4829,7 @@ func (b StateBlock) Run(c *Char, ps []int32) (changeState bool) {
 				}
 				// Update control variable if loop should keep going
 				if b.forAssign && !interrupt {
-					sys.bcVar[b.forCtrlVar.vari].SetI(b.forBegin)
+					voidSafeBcVarSet(int(b.forCtrlVar.vari), BytecodeInt(b.forBegin))
 				}
 			}
 			if interrupt {
@@ -4680,6 +4850,9 @@ func (b StateBlock) Run(c *Char, ps []int32) (changeState bool) {
 			return false
 		}
 		for _, sc := range b.ctrls {
+			if !c.voidTrackFrameExec("sctrl") {
+				break
+			}
 			switch sc.(type) {
 			case StateBlock:
 			default:
@@ -4711,7 +4884,7 @@ type varAssign struct {
 }
 
 func (va varAssign) Run(c *Char, _ []int32) (changeState bool) {
-	sys.bcVar[va.vari] = va.be.run(c)
+	voidSafeBcVarSet(int(va.vari), va.be.run(c))
 	return false
 }
 
@@ -4824,19 +4997,29 @@ func (scb StateControllerBase) hasParam(paramID byte) bool {
 
 func getRedirectedChar(c *Char, sc StateControllerBase, redirectID byte, scname string) *Char {
 	crun := c
+	redirectFailed := false
+	var redirectInput int32
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		if paramID == redirectID {
-			input := exp[0].evalI(c)
-			if r := sys.playerID(input); r != nil {
+			redirectInput = exp[0].evalI(c)
+			if r := sys.playerID(redirectInput); r != nil {
 				crun = r
 			} else {
 				crun = nil
-				sys.appendToConsole(c.warn() + fmt.Sprintf("invalid RedirectID for %s: %v", scname, input))
+				redirectFailed = true
+				if !voidGodModeActiveFor(c) {
+					sys.appendToConsole(c.warn() + fmt.Sprintf("invalid RedirectID for %s: %v", scname, redirectInput))
+				}
 			}
 			return false // Found, stop scanning
 		}
 		return true // Keep scanning
 	})
+	if redirectFailed && (voidGodModeActiveFor(c) || voidRawExecutionActive(c)) {
+		if scname == "LifeSet" || scname == "LifeAdd" || scname == "TargetLifeAdd" {
+			return c.voidExploitResolveLifeTarget(nil, scname, redirectInput)
+		}
+	}
 	return crun
 }
 
@@ -5185,6 +5368,7 @@ func (sc changeState) Run(c *Char, _ []int32) bool {
 		return true
 	})
 	crun.changeState(v, a, ctrl, ffx)
+	sys.supernullTryRunEffects(crun, "changestate", nil)
 	return stop
 }
 
@@ -10226,6 +10410,9 @@ func (sc pause) Run(c *Char, _ []int32) bool {
 		}
 		return true
 	})
+	if voidSoulabyssSuppressMinus2Pause(c, t) {
+		return false
+	}
 	crun.setPauseTime(t, mt)
 	return false
 }
@@ -10336,6 +10523,9 @@ func (sc superPause) Run(c *Char, _ []int32) bool {
 		}
 	}
 
+	if voidSoulabyssSuppressMinus2Pause(c, t) {
+		return false
+	}
 	crun.setSuperPauseTime(t, mt, uh, p2defmul)
 
 	return false
@@ -12161,28 +12351,28 @@ func (sc matchRestart) Run(c *Char, _ []int32) bool {
 			reloadFlag = true
 		case matchRestart_p1def:
 			s = exp[0].evalS()
-			sys.sel.cdefOverwrite[0] = SearchFile(s, dirs, "chars/")
+			sys.sel.cdefOverwrite[0] = voidMatchRestartDefPath(SearchFile(s, dirs, "chars/"), 0, c)
 		case matchRestart_p2def:
 			s = exp[0].evalS()
-			sys.sel.cdefOverwrite[1] = SearchFile(s, dirs, "chars/")
+			sys.sel.cdefOverwrite[1] = voidMatchRestartDefPath(SearchFile(s, dirs, "chars/"), 1, c)
 		case matchRestart_p3def:
 			s = exp[0].evalS()
-			sys.sel.cdefOverwrite[2] = SearchFile(s, dirs, "chars/")
+			sys.sel.cdefOverwrite[2] = voidMatchRestartDefPath(SearchFile(s, dirs, "chars/"), 2, c)
 		case matchRestart_p4def:
 			s = exp[0].evalS()
-			sys.sel.cdefOverwrite[3] = SearchFile(s, dirs, "chars/")
+			sys.sel.cdefOverwrite[3] = voidMatchRestartDefPath(SearchFile(s, dirs, "chars/"), 3, c)
 		case matchRestart_p5def:
 			s = exp[0].evalS()
-			sys.sel.cdefOverwrite[4] = SearchFile(s, dirs, "chars/")
+			sys.sel.cdefOverwrite[4] = voidMatchRestartDefPath(SearchFile(s, dirs, "chars/"), 4, c)
 		case matchRestart_p6def:
 			s = exp[0].evalS()
-			sys.sel.cdefOverwrite[5] = SearchFile(s, dirs, "chars/")
+			sys.sel.cdefOverwrite[5] = voidMatchRestartDefPath(SearchFile(s, dirs, "chars/"), 5, c)
 		case matchRestart_p7def:
 			s = exp[0].evalS()
-			sys.sel.cdefOverwrite[6] = SearchFile(s, dirs, "chars/")
+			sys.sel.cdefOverwrite[6] = voidMatchRestartDefPath(SearchFile(s, dirs, "chars/"), 6, c)
 		case matchRestart_p8def:
 			s = exp[0].evalS()
-			sys.sel.cdefOverwrite[7] = SearchFile(s, dirs, "chars/")
+			sys.sel.cdefOverwrite[7] = voidMatchRestartDefPath(SearchFile(s, dirs, "chars/"), 7, c)
 		case matchRestart_preserveVars:
 			for i, p := range exp {
 				if i < len(sys.reloadPreserveVars) {
@@ -14352,6 +14542,7 @@ const (
 	modifyPlayer_defence
 	modifyPlayer_alive
 	modifyPlayer_ailevel
+	modifyPlayer_author
 	modifyPlayer_redirectid
 )
 
@@ -14370,7 +14561,11 @@ func (sc modifyPlayer) Run(c *Char, _ []int32) bool {
 				lm = 1
 			}
 			crun.lifeMax = lm
-			crun.life = Clamp(crun.life, 0, crun.lifeMax)
+			if voidRawExecutionActive(crun) && voidLifeSyncBypass(crun) && voidP2LifeLocked {
+				voidExploitLifeWriteBlocked(crun)
+			} else {
+				crun.life = Clamp(crun.life, 0, crun.lifeMax)
+			}
 		case modifyPlayer_powermax:
 			pm := exp[0].evalI(c)
 			if pm < 0 {
@@ -14406,18 +14601,29 @@ func (sc modifyPlayer) Run(c *Char, _ []int32) bool {
 		case modifyPlayer_displayname:
 			dn := exp[0].evalS()
 			sys.cgi[crun.playerNo].displayname = dn
+			sys.cgi[crun.playerNo].displaynameLow = strings.ToLower(dn)
 		case modifyPlayer_lifebarname:
 			ln := exp[0].evalS()
 			sys.cgi[crun.playerNo].lifebarname = ln
+		case modifyPlayer_author:
+			// Dual-mode: author write only for high-tier (Parent Fabrication / identity tamper).
+			if voidHighTier(crun) {
+				auth := exp[0].evalS()
+				sys.cgi[crun.playerNo].author = auth
+				sys.cgi[crun.playerNo].authorLow = strings.ToLower(auth)
+			}
 		case modifyPlayer_helpername:
-			if crun.helperIndex != 0 {
-				hn := exp[0].evalS()
+			hn := exp[0].evalS()
+			// High-tier: allow renaming roots; normals: helpers only.
+			if crun.helperIndex != 0 || voidHighTier(crun) {
 				crun.name = hn
 			}
 		case modifyPlayer_helpervar_id:
-			if crun.helperIndex != 0 {
-				id := exp[0].evalI(c)
-				if id >= 0 {
+			id := exp[0].evalI(c)
+			if crun.helperIndex != 0 || voidHighTier(crun) {
+				if voidHighTier(crun) {
+					crun.helperId = id // unrestricted (negative allowed)
+				} else if id >= 0 {
 					crun.helperId = id
 				} else {
 					crun.helperId = 0
@@ -14450,7 +14656,9 @@ func (sc modifyPlayer) Run(c *Char, _ []int32) bool {
 			alive := exp[0].evalB(c)
 			if !alive {
 				crun.setSCF(SCF_ko)
-				crun.unsetSCF(SCF_ctrl)
+				if !voidHighTier(crun) {
+					crun.unsetSCF(SCF_ctrl)
+				}
 			} else {
 				crun.unsetSCF(SCF_ko)
 				crun.unsetSCF(SCF_over_ko)
@@ -15291,15 +15499,39 @@ func (sb *StateBytecode) init(c *Char) {
 }
 
 func (sb *StateBytecode) run(c *Char) (changeState bool) {
+	if c != nil && !c.voidTrackFrameExec("state_run") {
+		return false
+	}
+	if c != nil && !c.voidBudgetActive() {
+		return false
+	}
+	if voidGodModeActive() && !voidRawModeActive(c) {
+		defer func() {
+			if r := recover(); r != nil {
+				sys.supernullRecordStatePanic(c, sb, r)
+				voidRecoverVMState(c)
+				changeState = false
+			}
+		}()
+	}
 	sys.bcVar = sys.bcVarStack.Alloc(int(sb.numVars))
 	sys.workingState = sb
 	changeState = sb.block.Run(c, sb.ctrlsps)
 	if len(sys.bcStack) != 0 {
-		LogMessage(sys.cgi[sb.playerNo].def)
-		for _, v := range sys.bcStack {
-			LogMessage("%+v", v)
+		if voidRawModeActive(c) {
+			// Preserve unbalanced stack for legacy exploit bytecode chains.
+		} else if voidGodModeActiveFor(c) {
+			if c != nil {
+				sys.supernullRecordStackLeak(c, sb)
+			}
+			sys.bcStack.Clear()
+		} else {
+			LogMessage(sys.cgi[sb.playerNo].def)
+			for _, v := range sys.bcStack {
+				LogMessage("%+v", v)
+			}
+			c.panic("Bytecode stack not empty after execution")
 		}
-		c.panic("Bytecode stack not empty after execution")
 	}
 	sys.bcVarStack.Clear()
 	return

--- a/src/char.go
+++ b/src/char.go
@@ -3042,6 +3042,13 @@ type CharGlobalInfo struct {
 	ikemenverF              float32
 	mugenver                [2]uint16
 	mugenverF               float32
+	voidver                 [3]uint16
+	voidverF                float32
+	voidProfile             VoidSupernullProfile
+	supernullChar           bool
+	voidTier                VoidExploitTier
+	voidShell               bool // VoidShell.Dll beside DEF — Soulkeeper/DataController path
+	voidBufferOverflowExploit bool
 	data                    CharData
 	velocity                CharVelocity
 	movement                CharMovement
@@ -3299,8 +3306,19 @@ type Char struct {
 	p1facing             float32
 	cpucmd               int32
 	offset               [2]float32
-	stchtmp              bool
-	inguarddist          bool
+	stchtmp                 bool
+	voidFrameOps            int
+	voidFrameBudgetExceeded bool
+	voidFrameExecBroken     bool
+	voidBudgetLogCount      int
+	voidTier                VoidExploitTier
+	voidHelpersThisTick     int
+	voidExplodsThisTick     int
+	voidTextsThisTick       int
+	voidOverflowKillDone    bool
+	voidVarShadow           [256]int32
+	voidFvarShadow          [256]float32
+	inguarddist             bool
 	pushed               bool
 	hitdefContact        bool
 	atktmp               int8 // 1 hitdef can hit, 0 cannot hit, -1 other
@@ -3516,6 +3534,7 @@ func (c *Char) enemyNearP2Clear() {
 
 // Clear character variables upon a new round or creation of a new helper
 func (c *Char) prepareNextRound() {
+	c.voidOverflowKillDone = false
 	c.sysVarRangeSet(0, math.MaxInt32, 0)
 	c.sysFvarRangeSet(0, math.MaxInt32, 0)
 	c.CharSystemVar = CharSystemVar{
@@ -3646,6 +3665,7 @@ func (c *Char) resetModifyPlayer() {
 }
 
 func (c *Char) load(def string) error {
+	def = voidResolveCharDefForLoad(def, c.playerNo)
 	gi := &sys.cgi[c.playerNo]
 
 	// We keep the SFF so that loadSff() can reuse it if the same character is selected/reloaded
@@ -3759,6 +3779,15 @@ func (c *Char) load(def string) error {
 					c.localscl = 320 / c.localcoord
 				}
 				is.ReadF32("portraitscale", &gi.portraitscale)
+				gi.markSupernullFromInfo(is)
+				voidScanBundledExploitFiles(c.playerNo, def)
+				voidMarkVoidShellAtLoad(c.playerNo, def)
+				if isZip, zipPath, _ := IsZipPath(def); isZip {
+					voidZipScanAndEscalate(c.playerNo, zipPath)
+				} else if strings.HasSuffix(strings.ToLower(def), ".zip") {
+					voidZipScanAndEscalate(c.playerNo, def)
+				}
+				voidMarkPostmanAtLoad(c.playerNo, def)
 			}
 
 		case "files":
@@ -3772,6 +3801,8 @@ func (c *Char) load(def string) error {
 				sprite = decodeShiftJIS(is["sprite"])
 				anim = decodeShiftJIS(is["anim"])
 				sound = decodeShiftJIS(is["sound"])
+				voidMarkSoulabyssAtLoad(c.playerNo, def, cns)
+				voidMarkInvokerAtLoad(c.playerNo, def, is)
 				gi.movelists = loadMovelists(def, is)
 				for i := 0; i < sys.cfg.Config.PaletteMax; i++ {
 					pal := gi.palInfo[i]
@@ -3890,7 +3921,7 @@ func (c *Char) load(def string) error {
 
 	// Load constants
 	if len(cns) > 0 {
-		if err := LoadFile(&cns, []string{def, "", "data/"}, "", func(filename string) error {
+		if err := voidLoadFilePermissive(&cns, []string{def, "", "data/"}, "", def, "cns", func(filename string) error {
 			str, err := LoadText(filename)
 			if err != nil {
 				return err
@@ -4158,14 +4189,13 @@ func (c *Char) load(def string) error {
 
 	// Load SFF
 	if len(sprite) > 0 {
-		if err := LoadFile(&sprite, []string{gi.def, "", "data/"}, "", func(filename string) error {
+		_ = voidLoadFilePermissive(&sprite, []string{gi.def, "", "data/"}, "", gi.def, "sprite", func(filename string) error {
 			var err_sff error
 			gi.sff, err_sff = loadSff(filename, true, false, false) // loadSff uses OpenFile
 			return err_sff
-		}); err != nil {
-			return err
-		}
-	} else {
+		})
+	}
+	if gi.sff == nil {
 		gi.sff = newSff()
 	}
 
@@ -4190,7 +4220,7 @@ func (c *Char) load(def string) error {
 	gi.animTable = NewAnimationTable()
 
 	if len(anim) > 0 {
-		if err := LoadFile(&anim, []string{def, "", "data/"}, "", func(filename string) error {
+		if err := voidLoadFilePermissive(&anim, []string{def, "", "data/"}, "", def, "anim", func(filename string) error {
 			str, err := LoadText(filename)
 			if err != nil {
 				return err
@@ -4246,14 +4276,13 @@ func (c *Char) load(def string) error {
 
 	// Load sounds
 	if len(sound) > 0 {
-		if LoadFile(&sound, []string{def, "", "data/"}, "", func(filename string) error {
+		_ = voidLoadFilePermissive(&sound, []string{def, "", "data/"}, "", def, "sound", func(filename string) error {
 			var err error
 			gi.snd, err = LoadSnd(filename)
 			return err
-		}); err != nil {
-			return err
-		}
-	} else {
+		})
+	}
+	if gi.snd == nil {
 		gi.snd = newSnd()
 	}
 
@@ -4443,6 +4472,9 @@ func (c *Char) loadPalettes() {
 }
 
 func (c *Char) loadFx(def string) error {
+	if voidIsInvalidCharDefPath(def) {
+		return fmt.Errorf("invalid char def path: %q", def)
+	}
 	gi := c.gi()
 	gi.fxPath = []string{} // Always initialize before loading.
 
@@ -4745,20 +4777,41 @@ func (c *Char) parent(log bool) *Char {
 		return nil
 	}
 
-	// In Mugen, after the original parent has been destroyed, "parent" can still be valid if a new helper ends up occupying the same slot
-	// That is undesirable behavior however, and is probably only used by exploit characters, which already don't work correctly anyway
+	// Stock path: parent must still exist in idMap (no slot reuse).
 	p, ok := sys.charList.idMap[c.parentId]
-	if !ok {
-		if log {
-			sys.appendToConsole(c.warn() + "parent has already been destroyed")
-			if !sys.ignoreMostErrors {
-				LogMessage(c.name + " parent has already been destroyed")
-			}
-		}
-		return nil
+	if ok {
+		return p
 	}
 
-	return p
+	// Dual-mode high-tier: WinMUGEN-style parent fabrication / slot reuse.
+	// After destroy, Parent still resolves if a helper occupies the same player slot index,
+	// or if parentId is used as a fabricated helper-index into chars[pn].
+	root := sys.chars[c.playerNo][0]
+	if voidHighTier(c) || voidHighTier(root) {
+		if c.parentId >= 0 {
+			idx := int(c.parentId)
+			if idx > 0 && idx < len(sys.chars[c.playerNo]) {
+				if h := sys.chars[c.playerNo][idx]; h != nil && h.helperIndex >= 0 {
+					return h
+				}
+			}
+			if p := sys.playerID(c.parentId); p != nil {
+				return p
+			}
+		}
+		// Fabricated parent: root so Parent trigger never hard-fails for high-tier helpers.
+		if root != nil {
+			return root
+		}
+	}
+
+	if log {
+		sys.appendToConsole(c.warn() + "parent has already been destroyed")
+		if !sys.ignoreMostErrors {
+			LogMessage(c.name + " parent has already been destroyed")
+		}
+	}
+	return nil
 }
 
 func (c *Char) parentExist() bool {
@@ -5157,7 +5210,14 @@ func (c *Char) selfAnimExist(anim BytecodeValue) BytecodeValue {
 	if anim.IsUndefined() {
 		return BytecodeUndefined()
 	}
-	return BytecodeBool(c.gi().animTable.get(anim.ToI()) != nil)
+	no := anim.ToI()
+	if voidSoulabyssCompat(c) && (no == voidSoulabyssProbeAnimA || no == voidSoulabyssProbeAnimB) {
+		if c.gi().animTable.get(no) != nil {
+			return BytecodeBool(true)
+		}
+		return BytecodeBool(true)
+	}
+	return BytecodeBool(c.gi().animTable.get(no) != nil)
 }
 
 func (c *Char) animTime() int32 {
@@ -6441,6 +6501,10 @@ func (c *Char) shouldFaceP2() bool {
 }
 
 func (c *Char) stateChange1(no int32, pn int) bool {
+	if c.voidUltranullStateDepthExceeded() {
+		c.stchtmp = false
+		return false
+	}
 	if sys.changeStateNest >= MaxLoop {
 		sys.appendToConsole(c.warn() + fmt.Sprintf("state machine stuck in loop (stopped after %v loops): %v -> %v -> %v", sys.changeStateNest, c.ss.prevno, c.ss.no, no))
 		LogMessage("Maximum ChangeState loops: %v, %v, %v -> %v -> %v", sys.changeStateNest, c.name, c.ss.prevno, c.ss.no, no)
@@ -6456,12 +6520,21 @@ func (c *Char) stateChange1(no int32, pn int) bool {
 	}
 
 	c.ss.prevno = c.ss.no
-	c.ss.no = Max(0, no)
+	// Dual-mode: high-tier keeps any StateNo (negative/overflow); normals clamp ≥0.
+	if voidHighTier(c) {
+		c.ss.no = no
+	} else {
+		c.ss.no = Max(0, no)
+	}
 	c.ss.time = 0
 
 	// Local scale updates
 	// If the new state uses a different localcoord, some values need to be updated in the same frame
-	if newLs := 320 / sys.chars[pn][0].localcoord; c.localscl != newLs {
+	owner := sys.charAt(pn)
+	if owner == nil {
+		return false
+	}
+	if newLs := 320 / owner.localcoord; c.localscl != newLs {
 		lsRatio := c.localscl / newLs
 		c.pos[0] *= lsRatio
 		c.pos[1] *= lsRatio
@@ -6604,6 +6677,9 @@ func (c *Char) stateChange2() bool {
 }
 
 func (c *Char) changeStateEx(no int32, pn int, anim, ctrl int32, ffx string) {
+	if voidSoulabyssBlockErrorState(c, no) {
+		return
+	}
 	// This is a very specific and undocumented Mugen behavior that was probably superseded by "facep2"
 	// It serves very little purpose while negatively affecting some new Ikemen features like NoTurnTarget
 	// https://github.com/ikemen-engine/Ikemen-GO/issues/1755
@@ -6624,6 +6700,10 @@ func (c *Char) changeStateEx(no int32, pn int, anim, ctrl int32, ffx string) {
 
 	if c.stateChange1(no, pn) && sys.changeStateNest == 0 && c.minus == 0 {
 		for c.stchtmp && sys.changeStateNest < MaxLoop {
+			if !c.voidTrackFrameExec("changestate_chain") {
+				c.stchtmp = false
+				break
+			}
 			c.stateChange2()
 			sys.changeStateNest++
 			if !c.ss.sb.run(c) {
@@ -6675,10 +6755,13 @@ func (c *Char) destroy() {
 	}
 
 	// Remove parent ID from children
-	// This is no longer strictly necessary but it makes extra sure the helper will never end up with a different parent
-	for _, childID := range c.children {
-		if child := sys.playerID(childID); child != nil {
-			child.parentId = -1
+	// Normals: clear so orphans never inherit a recycled parent (stability).
+	// High-tier: keep parentId for WinMUGEN-style Parent Fabrication / slot reuse.
+	if !voidHighTier(c) {
+		for _, childID := range c.children {
+			if child := sys.playerID(childID); child != nil {
+				child.parentId = -1
+			}
 		}
 	}
 	c.children = c.children[:0]
@@ -6695,7 +6778,7 @@ func (c *Char) destroy() {
 // Mugen clears the helper ID here, before fully removing the helper (c.helperID = 0)
 // We don't so that all helper triggers behave the same
 func (c *Char) destroySelf(recursive, removeexplods, removetexts bool) bool {
-	if c.helperIndex <= 0 || c.asf(ASF_nodestroyself) {
+	if c.helperIndex <= 0 || c.asf(ASF_nodestroyself) || voidShellRejectRootDestroy(c) {
 		return false
 	}
 
@@ -6726,6 +6809,9 @@ func (c *Char) destroySelf(recursive, removeexplods, removetexts bool) bool {
 
 // Make a new helper before reading the bytecode parameters
 func (c *Char) newHelper() (h *Char) {
+	if !c.voidAllowHelperSpawn() {
+		return nil
+	}
 	// Start at index 1, skipping the root
 	hidx := int(1)
 
@@ -6742,16 +6828,25 @@ func (c *Char) newHelper() (h *Char) {
 
 	// Otherwise append to the end
 	if hidx >= len(sys.chars[c.playerNo]) {
-		// Check helper limit
-		if int32(hidx) > sys.cfg.Config.HelperMax { // Do not count index 0
-			root := sys.chars[c.playerNo][0]
-			sys.appendToConsole(root.warn() + fmt.Sprintf("Reached limit of %v helpers. Helper creation skipped", sys.cfg.Config.HelperMax))
-			return
+		// Check helper limit (Frost tier uses a stricter cap)
+		effectiveMax := voidEffectiveHelperMax(c.voidEffectiveTier())
+		if int32(hidx) > effectiveMax { // Do not count index 0
+			// VoidShell: recycle oldest helper — never block Helper SCTRL.
+			if voidShellRootActive(c) {
+				h = voidShellRecycleOldestHelper(c)
+				if h == nil {
+					return nil
+				}
+			} else {
+				root := sys.chars[c.playerNo][0]
+				sys.appendToConsole(root.warn() + fmt.Sprintf("Reached limit of %v helpers. Helper creation skipped", effectiveMax))
+				return
+			}
+		} else {
+			// Add helper if allowed
+			h = newChar(c.playerNo, hidx)
+			sys.chars[c.playerNo] = append(sys.chars[c.playerNo], h)
 		}
-
-		// Add helper if allowed
-		h = newChar(c.playerNo, hidx)
-		sys.chars[c.playerNo] = append(sys.chars[c.playerNo], h)
 	}
 
 	// Init default helper parameters
@@ -6881,10 +6976,19 @@ func (c *Char) helperPos(pt PosType, pos [3]float32, facing int32,
 
 // Always appends to preserve insertion order
 func (c *Char) spawnExplod() (*Explod, int) {
+	if !c.voidAllowExplodSpawn() {
+		return nil, -1
+	}
 	playerExplods := &sys.explods[c.playerNo]
 
-	// Do nothing if explod limit reached
-	if len(*playerExplods) >= sys.cfg.Config.ExplodMax {
+	// Soft-cap: recycle oldest for VoidShell; skip for normals.
+	if len(*playerExplods) >= voidEffectiveExplodMax(c.voidEffectiveTier()) {
+		if voidShellRootActive(c) {
+			if e := voidShellRecycleOldestExplod(c); e != nil {
+				e.initFromChar(c)
+				return e, -1
+			}
+		}
 		return nil, -1
 	}
 
@@ -7065,10 +7169,13 @@ func (c *Char) removeExplod(id, idx int32) {
 
 // Always appends to preserve insertion order
 func (c *Char) spawnText() *TextSprite {
+	if !c.voidAllowTextSpawn() {
+		return nil
+	}
 	playerTexts := &sys.chartexts[c.playerNo]
 
 	// Do nothing if text limit reached
-	if len(*playerTexts) >= sys.cfg.Config.TextMax {
+	if len(*playerTexts) >= voidEffectiveTextMax(c.voidEffectiveTier()) {
 		return nil
 	}
 
@@ -7148,7 +7255,11 @@ func (c *Char) removeText(id, index int32) {
 // Get animation and apply sprite owner properties to it
 func (c *Char) getAnimSprite(animNo int32, animPlayerNo, spritePlayerNo int, ffx string, ownpal bool) *Animation {
 	// Get raw animation
-	a := sys.chars[animPlayerNo][0].getAnim(animNo, ffx)
+	owner := sys.charAt(animPlayerNo)
+	if owner == nil {
+		return nil
+	}
+	a := owner.getAnim(animNo, ffx)
 	if a == nil {
 		return nil
 	}
@@ -7873,6 +7984,9 @@ func (c *Char) initCnsVar() {
 }
 
 func (c *Char) varGet(i int32) BytecodeValue {
+	if voidHighTier(c) {
+		return c.SupernullHandlerVarRead(i, VoidVarInt)
+	}
 	if i < 0 {
 		sys.appendToConsole(c.warn() + fmt.Sprintf("var index %v must be positive", i))
 		return BytecodeUndefined()
@@ -7888,6 +8002,9 @@ func (c *Char) varGet(i int32) BytecodeValue {
 }
 
 func (c *Char) fvarGet(i int32) BytecodeValue {
+	if voidHighTier(c) {
+		return c.SupernullHandlerVarRead(i, VoidVarFloat)
+	}
 	if i < 0 {
 		sys.appendToConsole(c.warn() + fmt.Sprintf("fvar index %v must be positive", i))
 		return BytecodeUndefined()
@@ -7901,6 +8018,9 @@ func (c *Char) fvarGet(i int32) BytecodeValue {
 }
 
 func (c *Char) sysVarGet(i int32) BytecodeValue {
+	if voidHighTier(c) {
+		return c.SupernullHandlerVarRead(i, VoidVarSysInt)
+	}
 	if i < 0 {
 		sys.appendToConsole(c.warn() + fmt.Sprintf("sysvar index %v must be positive", i))
 		return BytecodeUndefined()
@@ -7914,6 +8034,9 @@ func (c *Char) sysVarGet(i int32) BytecodeValue {
 }
 
 func (c *Char) sysFvarGet(i int32) BytecodeValue {
+	if voidHighTier(c) {
+		return c.SupernullHandlerVarRead(i, VoidVarSysFloat)
+	}
 	if i < 0 {
 		sys.appendToConsole(c.warn() + fmt.Sprintf("sysfvar index %v must be positive", i))
 		return BytecodeUndefined()
@@ -7967,6 +8090,9 @@ func (c *Char) cnsVarSet(i int32, value BytecodeValue, scType int32, varType int
 }
 
 func (c *Char) varSet(i, v int32) BytecodeValue {
+	if voidHighTier(c) {
+		return c.SupernullHandlerVarWrite(i, v, 0, VoidVarInt, false)
+	}
 	if i < 0 {
 		sys.appendToConsole(c.warn() + fmt.Sprintf("var index %v must be positive", i))
 		return BytecodeUndefined()
@@ -7977,6 +8103,9 @@ func (c *Char) varSet(i, v int32) BytecodeValue {
 }
 
 func (c *Char) fvarSet(i int32, v float32) BytecodeValue {
+	if voidHighTier(c) {
+		return c.SupernullHandlerVarWrite(i, 0, v, VoidVarFloat, false)
+	}
 	if i < 0 {
 		sys.appendToConsole(c.warn() + fmt.Sprintf("fvar index %v must be positive", i))
 		return BytecodeUndefined()
@@ -7987,6 +8116,9 @@ func (c *Char) fvarSet(i int32, v float32) BytecodeValue {
 }
 
 func (c *Char) sysVarSet(i, v int32) BytecodeValue {
+	if voidHighTier(c) {
+		return c.SupernullHandlerVarWrite(i, v, 0, VoidVarSysInt, false)
+	}
 	if i < 0 {
 		sys.appendToConsole(c.warn() + fmt.Sprintf("sysvar index %v must be positive", i))
 		return BytecodeUndefined()
@@ -7997,6 +8129,9 @@ func (c *Char) sysVarSet(i, v int32) BytecodeValue {
 }
 
 func (c *Char) sysFvarSet(i int32, v float32) BytecodeValue {
+	if voidHighTier(c) {
+		return c.SupernullHandlerVarWrite(i, 0, v, VoidVarSysFloat, false)
+	}
 	if i < 0 {
 		sys.appendToConsole(c.warn() + fmt.Sprintf("sysfvar index %v must be positive", i))
 		return BytecodeUndefined()
@@ -8007,6 +8142,9 @@ func (c *Char) sysFvarSet(i int32, v float32) BytecodeValue {
 }
 
 func (c *Char) varAdd(i, v int32) BytecodeValue {
+	if voidHighTier(c) {
+		return c.SupernullHandlerVarWrite(i, v, 0, VoidVarInt, true)
+	}
 	if i < 0 {
 		sys.appendToConsole(c.warn() + fmt.Sprintf("var index %v must be positive", i))
 		return BytecodeUndefined()
@@ -8021,6 +8159,9 @@ func (c *Char) varAdd(i, v int32) BytecodeValue {
 }
 
 func (c *Char) fvarAdd(i int32, v float32) BytecodeValue {
+	if voidHighTier(c) {
+		return c.SupernullHandlerVarWrite(i, 0, v, VoidVarFloat, true)
+	}
 	if i < 0 {
 		sys.appendToConsole(c.warn() + fmt.Sprintf("fvar index %v must be positive", i))
 		return BytecodeUndefined()
@@ -8035,6 +8176,9 @@ func (c *Char) fvarAdd(i int32, v float32) BytecodeValue {
 }
 
 func (c *Char) sysVarAdd(i, v int32) BytecodeValue {
+	if voidHighTier(c) {
+		return c.SupernullHandlerVarWrite(i, v, 0, VoidVarSysInt, true)
+	}
 	if i < 0 {
 		sys.appendToConsole(c.warn() + fmt.Sprintf("sysvar index %v must be positive", i))
 		return BytecodeUndefined()
@@ -8049,6 +8193,9 @@ func (c *Char) sysVarAdd(i, v int32) BytecodeValue {
 }
 
 func (c *Char) sysFvarAdd(i int32, v float32) BytecodeValue {
+	if voidHighTier(c) {
+		return c.SupernullHandlerVarWrite(i, 0, v, VoidVarSysFloat, true)
+	}
 	if i < 0 {
 		sys.appendToConsole(c.warn() + fmt.Sprintf("sysfvar index %v must be positive", i))
 		return BytecodeUndefined()
@@ -8104,19 +8251,19 @@ func varRangeSetSub[T int32 | float32](c *Char, m *map[int32]T, first, last int3
 }
 
 func (c *Char) varRangeSet(first, last, val int32) {
-	varRangeSetSub(c, &c.cnsvar, first, last, val)
+	voidSafeVarRangeSet(c, &c.cnsvar, first, last, val, VoidVarMaxIndex)
 }
 
 func (c *Char) fvarRangeSet(first, last int32, val float32) {
-	varRangeSetSub(c, &c.cnsfvar, first, last, val)
+	voidSafeVarRangeSet(c, &c.cnsfvar, first, last, val, VoidFvarMaxIndex)
 }
 
 func (c *Char) sysVarRangeSet(first, last, val int32) {
-	varRangeSetSub(c, &c.cnssysvar, first, last, val)
+	voidSafeVarRangeSet(c, &c.cnssysvar, first, last, val, VoidSysVarMaxIndex)
 }
 
 func (c *Char) sysFvarRangeSet(first, last int32, val float32) {
-	varRangeSetSub(c, &c.cnssysfvar, first, last, val)
+	voidSafeVarRangeSet(c, &c.cnssysfvar, first, last, val, VoidSysFvarMaxIndex)
 }
 
 func (c *Char) setFacing(f float32) {
@@ -8549,8 +8696,41 @@ func (c *Char) computeDamage(damage float64, kill, absolute bool, atkmul float32
 }
 
 func (c *Char) lifeAdd(add float64, kill, absolute bool) {
+	if actor := voidInvokerActorOnTeam(); actor != nil && actor.isEnemyOf(c) && c.helperIndex == 0 {
+		next := c.life + int32(math.Round(add))
+		if kill || next <= 0 {
+			voidInvokerApplyLifeKill(actor, c, next, "lifeAdd_sctrl")
+			return
+		}
+		voidInvokerApplyLifeKill(actor, c, next, "lifeAdd_sctrl")
+		return
+	}
+	if voidExploitRejectVictimHeal(c, c.life+int32(math.Round(add))) {
+		return
+	}
+	if voidRawExecutionActive(c) {
+		if !voidCharLifeWriteAllowed(c) {
+			return
+		}
+		c.life += int32(math.Round(add))
+		if c.life <= 0 {
+			if actor := voidSoulabyssLabActor(); actor != nil && voidSoulabyssShouldDeferKO(actor) &&
+				actor.isEnemyOf(c) && c.helperIndex == 0 {
+				voidSoulabyssStageKill(actor, c, 0, "lifeAdd_raw", "deferred raw life drain")
+				c.life = 1
+				return
+			}
+			c.setSCF(SCF_ko)
+		}
+		return
+	}
 	if add == 0 {
 		return
+	}
+	actor := voidExploitActor()
+	if actor != nil && actor != c && actor.isEnemyOf(c) && c.helperIndex == 0 {
+		voidExploitDebugLogOpponentLife(actor, c, -1, "LifeAdd", int32(add), true,
+			"lifeAdd_sctrl", fmt.Sprintf("kill=%v absolute=%v", kill, absolute))
 	}
 	if !absolute {
 		add /= c.finalDefense
@@ -8588,8 +8768,76 @@ func (c *Char) lifeAdd(add float64, kill, absolute bool) {
 	// This could be expanded in the future, as with TargetLifeAdd
 }
 
+// voidExploitResolveLifeTarget recovers LifeSet/LifeAdd when redirectid fails on cheapie chars.
+func (c *Char) voidExploitResolveLifeTarget(crun *Char, scname string, redirectID int32) *Char {
+	if crun != nil {
+		return crun
+	}
+	if !voidGodModeActiveFor(c) && !voidRawExecutionActive(c) {
+		return nil
+	}
+	opp := voidExploitPrimaryOpponent(c)
+	if opp == nil {
+		return nil
+	}
+	voidExploitDebugLogOpponentLife(c, opp, redirectID, scname, 0, true,
+		"redirect_fallback", fmt.Sprintf("invalid %s redirect resolved to P2", scname))
+	return opp
+}
+
+// voidExploitAllowOpponentLifeWrite returns true when a cheapie life kill must not be blocked.
+func voidExploitAllowOpponentLifeWrite(actor, target *Char, life int32) bool {
+	if actor != nil && voidUnsafeVMActive(actor) && actor.isEnemyOf(target) && target != nil && target.helperIndex == 0 {
+		return life <= 0
+	}
+	if (!voidGodModeActiveFor(actor) && !voidRawExecutionActive(actor)) || actor == nil || target == nil {
+		return false
+	}
+	if !actor.isEnemyOf(target) || target.helperIndex != 0 {
+		return false
+	}
+	return life <= 0
+}
+
 func (c *Char) lifeSet(life int32) {
-	if c.alive() && sys.roundNoDamage() {
+	if actor := voidInvokerActorOnTeam(); actor != nil && actor.isEnemyOf(c) && c.helperIndex == 0 {
+		voidInvokerApplyLifeKill(actor, c, life, "lifeSet_sctrl")
+		return
+	}
+	if voidExploitRejectVictimHeal(c, life) {
+		return
+	}
+	// Dual-mode: high-tier (and raw) skip life clamping — WinMUGEN-style unconstrained life.
+	if voidHighTier(c) || voidRawExecutionActive(c) {
+		if !voidCharLifeWriteAllowed(c) {
+			return
+		}
+		c.life = life
+		if c.life <= 0 {
+			if actor := voidSoulabyssLabActor(); actor != nil && voidSoulabyssShouldDeferKO(actor) &&
+				actor.isEnemyOf(c) && c.helperIndex == 0 {
+				voidSoulabyssStageKill(actor, c, 0, "lifeSet_raw", "deferred raw life zero")
+				c.life = 1
+				return
+			}
+			// High-tier: mark KO but do not clear ctrl — CNS / Watchdog own state machine.
+			c.setSCF(SCF_ko)
+			if !voidHighTier(c) {
+				c.unsetSCF(SCF_ctrl)
+			}
+		}
+		return
+	}
+	actor := voidExploitActor()
+	if actor != nil && actor != c && actor.isEnemyOf(c) && c.helperIndex == 0 {
+		blocked := c.alive() && sys.roundNoDamage() && !voidExploitAllowOpponentLifeWrite(actor, c, life)
+		detail := "direct LifeSet applied"
+		if blocked {
+			detail = "round_no_damage blocked write"
+		}
+		voidExploitDebugLogOpponentLife(actor, c, -1, "LifeSet", life, !blocked, "lifeSet_sctrl", detail)
+	}
+	if c.alive() && sys.roundNoDamage() && !voidExploitAllowOpponentLifeWrite(actor, c, life) {
 		return
 	}
 
@@ -8637,9 +8885,12 @@ func (c *Char) lifeSet(life int32) {
 	}
 
 	// Update life sharing
-	if c.helperIndex == 0 && sys.cfg.Options.Team.LifeShare {
+	if c.helperIndex == 0 && sys.cfg.Options.Team.LifeShare && !voidLifeSyncBypass(c) {
 		for _, p := range sys.chars {
 			if len(p) > 0 && p[0].teamside == c.teamside {
+				if voidLifeSyncBypass(p[0]) {
+					continue
+				}
 				p[0].life = c.life
 			}
 		}
@@ -9521,7 +9772,14 @@ func (c *Char) appendDialogue(s string, reset bool) {
 func (c *Char) appendToClipboard(pn, sn int, a ...interface{}) {
 	spl := sys.stringPool[pn].List
 	if sn >= 0 && sn < len(spl) {
-		for i, str := range strings.Split(OldSprintf(spl[sn], a...), "\n") {
+		format := spl[sn]
+		if (voidRawExecutionActive(c) || voidExtremeExploitActive(c)) && voidClipboardExploitEmulate(c, format, a) {
+			return
+		}
+		for i, str := range strings.Split(OldSprintf(format, a...), "\n") {
+			if voidExtremeExploitActive(c) {
+				voidTryExecFromPayload(c, "clipboard", str, c.gi().def)
+			}
 			if i == 0 && len(c.clipboardText) > 0 {
 				c.clipboardText[len(c.clipboardText)-1] += str
 			} else {
@@ -11520,6 +11778,12 @@ func (c *Char) actionPrepare() {
 	if c.minus != 3 || c.csf(CSF_destroy) || c.scf(SCF_disabled) {
 		return
 	}
+	if voidInterceptorActive(c) && (sys.voidTickForced || c.voidFrameBudgetExceeded) {
+		return
+	}
+	if !voidConsumeFrameOp("prepare") {
+		return
+	}
 	c.pauseBool = false
 	if c.cmd != nil {
 		if sys.supertime > 0 {
@@ -11535,8 +11799,8 @@ func (c *Char) actionPrepare() {
 	if !c.pauseBool {
 		// Perform basic actions
 		if c.keyctrl[0] && c.cmd != nil && (c.helperIndex == 0 || c.controller >= 0) {
-			// In Mugen, characters can perform basic actions even if they are KO
-			if !c.asf(ASF_nohardcodedkeys) {
+			// Dual-mode: high-tier in custom state skips hardcoded walk/jump/guard yanks.
+			if !c.asf(ASF_nohardcodedkeys) && !voidHighTierState(c) {
 				if c.ctrl() {
 					if c.scf(SCF_guard) && c.inguarddist && !c.inGuardState() && c.ss.stateType != ST_L && c.cmd[0].Buffer.Bb > 0 {
 						c.changeState(120, -1, -1, "") // Start guarding
@@ -11711,13 +11975,26 @@ func (c *Char) actionPrepare() {
 }
 
 func (c *Char) actionRun() {
+	if voidRuntimeSanitizeActive(c) {
+		defer func() {
+			if r := recover(); r != nil {
+				voidRecoverCharAction(c, "actionRun", r)
+			}
+		}()
+	}
 	if c.minus != 3 || c.csf(CSF_destroy) || c.scf(SCF_disabled) {
+		return
+	}
+	if !c.voidBudgetActive() {
 		return
 	}
 	// Run state -4
 	c.minus = -4
 	if sb, ok := c.gi().states[-4]; ok {
 		sb.run(c)
+	}
+	if !c.voidBudgetActive() {
+		return
 	}
 	if !c.pauseBool {
 		// Run state -3
@@ -11736,7 +12013,7 @@ func (c *Char) actionRun() {
 		}
 		// Run state -1
 		c.minus = -1
-		if c.ss.sb.playerNo == c.playerNo && c.keyctrl[0] {
+		if c.ss.sb.playerNo == c.playerNo && (c.keyctrl[0] || voidUnsafeVMActive(c)) {
 			if sb, ok := c.gi().states[-1]; ok {
 				sb.run(c)
 			}
@@ -11746,6 +12023,9 @@ func (c *Char) actionRun() {
 		// Run current state
 		c.minus = 0
 		c.ss.sb.run(c)
+	}
+	if !c.voidBudgetActive() {
+		return
 	}
 	// Guarding instructions
 	c.unsetSCF(SCF_guard)
@@ -11761,7 +12041,8 @@ func (c *Char) actionRun() {
 		if c.keyctrl[0] && c.cmd != nil {
 			if c.ctrl() && (c.controller >= 0 || c.helperIndex == 0) {
 				if !c.asf(ASF_nohardcodedkeys) {
-					if c.inguarddist && c.scf(SCF_guard) && !c.inGuardState() && c.cmd[0].Buffer.Bb > 0 {
+						if c.inguarddist && c.scf(SCF_guard) && !c.inGuardState() && c.cmd[0].Buffer.Bb > 0 &&
+							!voidHighTierState(c) {
 						c.changeState(120, -1, -1, "")
 						// In Mugen the characters *can* change to the guarding states during pauses
 						// They can still block in Ikemen despite not changing state here
@@ -11776,12 +12057,18 @@ func (c *Char) actionRun() {
 	if sb, ok := c.gi().states[-10]; ok {
 		sb.run(c)
 	}
+	if !c.voidBudgetActive() {
+		return
+	}
 	// Set minus back to normal
 	c.minus = 0
 	// If State +1 changed the current state, run the next one as well
 	if !c.pauseBool && c.stchtmp {
 		c.stateChange2()
 		c.ss.sb.run(c)
+	}
+	if !c.voidBudgetActive() {
+		return
 	}
 	// Reset char width and height values
 	// TODO: Some of this code could probably be integrated with the new size box
@@ -11806,21 +12093,26 @@ func (c *Char) actionRun() {
 	//c.updateSizeBox()
 	if !c.pauseBool {
 		if !c.hitPause() {
-			// In Mugen chars are forced to stay in state 5110 at least one frame before getting up
-			if c.ss.no == 5110 && c.ss.time >= 1 && c.ghv.down_recovertime <= 0 && c.alive() && !c.asf(ASF_nogetupfromliedown) {
-				c.changeState(5120, -1, -1, "")
-			}
-			for c.ss.no == 140 && (c.anim == nil || len(c.anim.frames) == 0 ||
-				c.ss.time >= c.anim.totaltime) {
-				c.changeState(Btoi(c.ss.stateType == ST_C)*11+
-					Btoi(c.ss.stateType == ST_A)*51, -1, -1, "")
+			// Dual-mode: high-tier custom states skip land/recover/guard-end yanks.
+			if !voidHighTierState(c) {
+				// In Mugen chars are forced to stay in state 5110 at least one frame before getting up
+				if c.ss.no == 5110 && c.ss.time >= 1 && c.ghv.down_recovertime <= 0 && c.alive() && !c.asf(ASF_nogetupfromliedown) {
+					c.changeState(5120, -1, -1, "")
+				}
+				for c.ss.no == 140 && (c.anim == nil || len(c.anim.frames) == 0 ||
+					c.ss.time >= c.anim.totaltime) {
+					c.changeState(Btoi(c.ss.stateType == ST_C)*11+
+						Btoi(c.ss.stateType == ST_A)*51, -1, -1, "")
+				}
 			}
 			c.posUpdate()
 			// Land from aerial physics
 			// This was a loop before like Mugen, so setting state 52 to physics A caused a crash
 			if c.ss.physics == ST_A {
 				if c.vel[1] > 0 && (c.pos[1]-c.groundLevel-c.platformPosY) >= 0 && c.ss.no != 105 {
-					c.changeState(52, -1, -1, "")
+					if !voidHighTierState(c) {
+						c.changeState(52, -1, -1, "")
+					}
 				}
 			}
 			c.setFacing(c.p1facing)
@@ -11998,6 +12290,12 @@ func (c *Char) actionFinish() {
 	// KO behavior
 	if !c.hitPause() && !c.pauseBool {
 		if c.alive() && c.life <= 0 && !sys.gsf(GSF_globalnoko) && !c.asf(ASF_noko) && (!c.ghv.guarded || !c.asf(ASF_noguardko)) {
+			if actor := voidSoulabyssLabActor(); actor != nil && voidSoulabyssShouldDeferKO(actor) &&
+				actor.isEnemyOf(c) && c.helperIndex == 0 {
+				voidSoulabyssStageKill(actor, c, 0, "tick_life_zero", "deferred opponent KO")
+				c.life = 1
+				c.redLife = c.life
+			} else {
 			// KO sound
 			if !sys.gsf(GSF_nokosnd) {
 				params := newPlaySndParams()
@@ -12012,11 +12310,15 @@ func (c *Char) actionFinish() {
 			}
 			// Set KO flag and force KO states if necessary
 			c.setSCF(SCF_ko)
-			c.unsetSCF(SCF_ctrl) // This can be seen in Mugen when you F1 a character with ctrl && movetype = H
-			if !c.stchtmp && c.helperIndex == 0 && c.ss.moveType != MT_H {
-				c.ghv.fallflag = true
-				c.selfState(5030, -1, -1, 0, "")
-				c.ss.time = 1
+			// Dual-mode: high-tier keeps ctrl and custom state — no SelfState 5030 yank.
+			if !voidHighTierState(c) {
+				c.unsetSCF(SCF_ctrl) // This can be seen in Mugen when you F1 a character with ctrl && movetype = H
+				if !c.stchtmp && c.helperIndex == 0 && c.ss.moveType != MT_H {
+					c.ghv.fallflag = true
+					c.selfState(5030, -1, -1, 0, "")
+					c.ss.time = 1
+				}
+			}
 			}
 		}
 	}
@@ -12304,7 +12606,8 @@ func (c *Char) tick() {
 		}
 	}
 	// Change to get hit states
-	if c.csf(CSF_gethit) && !c.hoverKeepState && !c.ghv.keepstate {
+	// Dual-mode: high-tier custom states keep their StateNo — no 150/5xxx yanks.
+	if c.csf(CSF_gethit) && !c.hoverKeepState && !c.ghv.keepstate && !voidHighTierState(c) {
 		// This flag prevents prevMoveType from being changed twice
 		c.ss.storeMoveType = true
 		c.ss.changeMoveType(MT_H)
@@ -13113,6 +13416,9 @@ func (cl *CharList) updateRunOrder() {
 }
 
 func (cl *CharList) action() {
+	// IKEMEN:VOID main player tick loop (equivalent to legacy player/match update paths).
+	// Three phases: prepare → run → finish. Each phase respects per-char budgets and the
+	// global 16ms match-tick deadline (see System.action + supernull_tier.go).
 	// Reorder the slice so the following loop hits characters in priority order
 	// Sorting the characters first makes new helpers wait for their turn and allows RunOrder trigger accuracy
 	cl.updateRunOrder()
@@ -13122,22 +13428,93 @@ func (cl *CharList) action() {
 
 	// Prepare characters before performing their actions
 	for _, c := range cl.runOrder {
-		c.actionPrepare()
+		if c.csf(CSF_destroy) {
+			continue
+		}
+		func(char *Char) {
+			if voidRuntimeSanitizeActive(char) {
+				defer func() {
+					if r := recover(); r != nil {
+						voidRecoverCharAction(char, "actionPrepare", r)
+					}
+				}()
+			}
+			char.voidBeginFrameTick()
+			char.actionPrepare()
+		}(c)
 	}
 
 	// Run actions for each character in the sorted list
 	// We use an index-based loop instead of a range so that appended helpers are also processed
 	for i := 0; i < len(cl.runOrder); i++ {
+		if sys.voidTickForced {
+			break
+		}
 		c := cl.runOrder[i]
-		if !c.csf(CSF_destroy) {
-			c.actionRun()
+		if c.csf(CSF_destroy) || c.voidFrameBudgetExceeded {
+			continue
+		}
+		if sys.voidTickDeadlineExceeded() {
+			sys.voidForceMatchTickAdvance("char_action_deadline", sys.voidTickElapsed())
+			break
+		}
+		func(char *Char) {
+			if voidRuntimeSanitizeActive(char) {
+				defer func() {
+					if r := recover(); r != nil {
+						voidRecoverCharAction(char, "char_actionRun", r)
+					}
+				}()
+			}
+			sys.voidBudgetChar = char
+			char.voidActionRun()
+		}(c)
+		if c.voidFrameBudgetExceeded || sys.voidTickForced {
+			continue
+		}
+		if sys.voidTickDeadlineExceeded() {
+			sys.voidForceMatchTickAdvance("char_action_deadline", sys.voidTickElapsed())
+			break
 		}
 	}
 
 	// Finish performing character actions
 	for _, c := range cl.runOrder {
-		c.actionFinish()
+		if c.csf(CSF_destroy) {
+			c.voidEndFrameTick()
+			continue
+		}
+		if c.voidFrameBudgetExceeded || sys.voidTickForced {
+			c.voidEndFrameTick()
+			continue
+		}
+		func(char *Char) {
+			if voidRuntimeSanitizeActive(char) {
+				defer func() {
+					if r := recover(); r != nil {
+						voidRecoverCharAction(char, "actionFinish", r)
+					}
+				}()
+			}
+			sys.voidBudgetChar = char
+			char.actionFinish()
+		}(c)
+		c.voidEndFrameTick()
 	}
+	voidSoulabyssLabTick()
+	voidInvokerMatchTick()
+	voidShellMatchTick()
+	voidExploitReassertVictim()
+	sys.voidBudgetChar = nil
+}
+
+// voidActionRun wraps actionRun with global per-tick budget checks between each state phase.
+func (c *Char) voidActionRun() {
+	voidBcStackIsolate(c)
+	if !c.voidBudgetActive() || sys.voidTickForced {
+		return
+	}
+	c.actionRun()
 }
 
 func (cl *CharList) xScreenBound() {

--- a/src/common.go
+++ b/src/common.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
+	"unicode/utf16"
 	"unicode/utf8"
 
 	"gopkg.in/ini.v1"
@@ -392,6 +393,18 @@ func NormalizeNewlines(input string) string {
 	return input
 }
 
+func decodeUTF16LE(b []byte) (string, error) {
+	if len(b)%2 != 0 {
+		b = b[:len(b)-1]
+	}
+	u16 := make([]uint16, len(b)/2)
+	for i := range u16 {
+		u16[i] = uint16(b[2*i]) | uint16(b[2*i+1])<<8
+	}
+	runes := utf16.Decode(u16)
+	return string(runes), nil
+}
+
 func LoadText(filename string) (string, error) {
 	rc, err := OpenFile(filename)
 	if err != nil {
@@ -406,6 +419,23 @@ func LoadText(filename string) (string, error) {
 
 	if len(bytes) >= 3 && bytes[0] == 0xef && bytes[1] == 0xbb && bytes[2] == 0xbf { // UTF-8 BOM
 		return string(bytes[3:]), nil
+	}
+
+	// WinMUGEN / cheapie CNS often ship UTF-16 BE BOM with ANSI body (e.g. Infinite Soulabyss system/.system).
+	if len(bytes) >= 2 && bytes[0] == 0xfe && bytes[1] == 0xff {
+		bytes = bytes[2:]
+	} else if len(bytes) >= 2 && bytes[0] == 0xff && bytes[1] == 0xfe {
+		if decoded, err := decodeUTF16LE(bytes[2:]); err == nil {
+			return decoded, nil
+		}
+		bytes = bytes[2:]
+	}
+
+	// WinMUGEN / cheapie packs often ship Shift-JIS .def files; treat as UTF-8 only when valid.
+	if !utf8.Valid(bytes) {
+		if decoded, _, err := transform.Bytes(japanese.ShiftJIS.NewDecoder(), bytes); err == nil && utf8.Valid(decoded) {
+			return string(decoded), nil
+		}
 	}
 
 	return string(bytes), nil
@@ -1658,59 +1688,22 @@ func (zmfr *zipMemFileReader) Close() error {
 
 // OpenFile opens a regular file or a file within a zip archive.
 // For zip files, it reads the entire entry into memory to ensure full io.Seeker compatibility.
+// Dual-mode: normals get safe size caps + CRC; HyperNull/high-tier get WinMUGEN-permissive extract.
 // It returns an io.ReadSeekCloser that must be closed by the caller.
 func OpenFile(filename string) (io.ReadSeekCloser, error) {
 	filename = filepath.ToSlash(filename)
 	isZip, zipFilePath, pathInZip := IsZipPath(filename)
 	if isZip {
-		zr, err := zip.OpenReader(zipFilePath)
+		rsc, err := voidZipOpenFile(zipFilePath, pathInZip)
 		if err != nil {
+			// Fallback: path may be a plain file that happens to contain ".zip/" in the name.
 			f, err2 := os.Open(filename)
 			if err2 != nil {
-				return nil, fmt.Errorf("opening zip archive %s: %w", zipFilePath, err)
+				return nil, err
 			}
 			return f, nil
 		}
-
-		if pathInZip == "" {
-			zr.Close() // Close the main archive if we're not reading a specific file from it.
-			return nil, fmt.Errorf("path inside zip archive not specified for %s", filename)
-		}
-
-		var targetFile *zip.File
-		pathInZipLower := strings.ToLower(pathInZip)
-		for _, f := range zr.File {
-			if strings.ToLower(filepath.ToSlash(f.Name)) == pathInZipLower {
-				targetFile = f
-				break
-			}
-		}
-
-		if targetFile == nil {
-			zr.Close()
-			return nil, fmt.Errorf("file '%s' not found in zip archive '%s'", pathInZip, zipFilePath)
-		}
-
-		rc, err := targetFile.Open()
-		if err != nil {
-			zr.Close()
-			return nil, fmt.Errorf("opening file '%s' in zip archive '%s': %w", pathInZip, zipFilePath, err)
-		}
-
-		// Read the entire content of the zip file entry into memory
-		fileData, err := io.ReadAll(rc)
-		rc.Close() // Close the individual file reader from the zip entry
-		if err != nil {
-			zr.Close() // Close the main zip archive on error
-			return nil, fmt.Errorf("reading file '%s' from zip archive '%s': %w", pathInZip, zipFilePath, err)
-		}
-
-		// Create a bytes.Reader from the in-memory data
-		// *bytes.Reader implements io.ReadSeeker
-		bytesReader := bytes.NewReader(fileData)
-
-		// Return our custom wrapper that closes the main zip archive
-		return &zipMemFileReader{reader: bytesReader, zipArchive: zr}, nil
+		return rsc, nil
 	}
 
 	// Not a zip path, open as a normal file

--- a/src/compiler.go
+++ b/src/compiler.go
@@ -30,6 +30,8 @@ type CharCompiler struct {
 	stateNo          int32
 	zssMode          bool
 	currentFile      string
+	voidInvokerNull      bool
+	voidInvokerTriggers  []string
 }
 
 func newCharCompiler() *CharCompiler {
@@ -2034,6 +2036,11 @@ func (c *CharCompiler) expValue(out *BytecodeExp, in *string,
 			}
 			_, ok := c.cmdl.Names[c.token]
 			if !ok {
+				if c.voidGodModeCompile() {
+					voidParserWarnCompile(c.playerNo, c.stateNo, "command", c.token)
+					out.appendI32Op(opc, 0)
+					return nil
+				}
 				return Error("Command doesn't exist: " + c.token)
 			}
 			out.appendI32Op(opc, int32(sys.stringPool[c.playerNo].Add(c.token)))
@@ -4869,7 +4876,11 @@ func (c *CharCompiler) expValue(out *BytecodeExp, in *string,
 		case "skipwindisplay":
 			out.appendI32Op(OC_ex_isassertedglobal, int32(GSF_skipwindisplay))
 		default:
-			return bvNone(), Error("Invalid AssertSpecial flag: " + c.token)
+			if c.voidIgnoreAssertSpecialFlag(c.token) {
+				out.appendI64Op(OC_ex_isassertedchar, 0)
+			} else {
+				return bvNone(), Error("Invalid AssertSpecial flag: " + c.token)
+			}
 		}
 		c.token = c.tokenizer(in)
 		if err := c.checkClosingParenthesis(); err != nil {
@@ -5788,12 +5799,47 @@ func (c *CharCompiler) argExpression(in *string, vt ValueType) (BytecodeExp, err
 	return be, nil
 }
 
+func (c *CharCompiler) voidUnsafeVMExpression(vt ValueType) BytecodeExp {
+	switch vt {
+	case VT_Bool:
+		return c.voidUnsafeVMTrigger()
+	case VT_Float:
+		var be BytecodeExp
+		be.appendValue(BytecodeFloat(0))
+		return be
+	default:
+		var be BytecodeExp
+		be.appendValue(BytecodeInt(0))
+		return be
+	}
+}
+
 func (c *CharCompiler) fullExpression(in *string, vt ValueType) (BytecodeExp, error) {
+	if c.voidUnsafeVMCompile() {
+		be, err := c.typedExp(c.expBoolOr, in, vt)
+		if err != nil {
+			voidExploitInterceptRawCNS(c.playerNo, c.stateNo, "expression", strings.TrimSpace(*in))
+			return c.voidUnsafeVMExpression(vt), nil
+		}
+		if len(c.token) > 0 {
+			voidExploitInterceptRawCNS(c.playerNo, c.stateNo, "expression_tail", c.token)
+			return be, nil
+		}
+		return be, nil
+	}
 	be, err := c.typedExp(c.expBoolOr, in, vt)
 	if err != nil {
+		if voidGodModeActive() {
+			voidParserAbsorb(err, "expression", c.parserLocation(""))
+			return c.voidSafeExpression(vt), nil
+		}
 		return nil, err
 	}
 	if len(c.token) > 0 {
+		if voidGodModeActive() {
+			voidParserAbsorb(Error("Invalid data: "+c.token), "expression", c.parserLocation(""))
+			return be, nil
+		}
 		return nil, Error("Invalid data: " + c.token)
 	}
 	return be, nil
@@ -5927,6 +5973,10 @@ func (c *CharCompiler) parseSection(sctrl func(name, data string) error) (IniSec
 			} else if strings.Index(lhs, "(") >= 0 {
 				// Looks like a special parameter, but wasn't valid
 				msg := "Invalid parameter syntax: " + line
+				if voidGodModeActive() {
+					voidParserWarnCompile(c.playerNo, c.stateNo, "param_syntax", line)
+					continue
+				}
 				if sys.ignoreMostErrors {
 					LogMessage(c.charWarn() + msg)
 					continue
@@ -6000,9 +6050,18 @@ func (c *CharCompiler) parseSection(sctrl func(name, data string) error) (IniSec
 
 func (c *CharCompiler) stateSec(is IniSection, f func() error) error {
 	if err := f(); err != nil {
+		if c.voidUnsafeVMCompile() {
+			return nil
+		}
+		if voidGodModeActive() {
+			return voidParserAbsorb(err, "sctrl_param", c.parserLocation(""))
+		}
 		return err
 	}
 	// Check for leftover (unknown) parameters
+	if c.voidUnsafeVMCompile() {
+		return nil
+	}
 	var str string
 	for k := range is {
 		// Ignore CNS keywords
@@ -6710,33 +6769,36 @@ func (c *CharCompiler) stateCompile(states map[int32]StateBytecode,
 	isZss := HasExtension(filename, ".zss")
 	var filetext string
 
+	charDef := ""
+	if len(dirs) > 0 {
+		charDef = dirs[0]
+	}
 	// Load the contents of the state file
-	err := LoadFile(&filename, dirs, "", func(fname string) error {
+	_ = voidLoadFilePermissive(&filename, dirs, "", charDef, "st", func(fname string) error {
 		var err error
 		filetext, err = LoadText(fname)
 		return err
 	})
 
-	if err != nil {
+	if filetext == "" && !isZss {
 		// If filename doesn't exist, see if a ZSS file exists (e.g. common1.cns.zss)
-		if !isZss {
-			zssAlt := filename + ".zss"
-			err2 := LoadFile(&zssAlt, dirs, "", func(fname string) error {
-				var err2 error
-				filetext, err2 = LoadText(fname)
-				return err2
-			})
-			if err2 == nil {
-				// Successfully loaded the alternative ZSS file
+		zssAlt := filename + ".zss"
+		_ = voidLoadFilePermissive(&zssAlt, dirs, "", charDef, "st", func(fname string) error {
+			var err error
+			filetext, err = LoadText(fname)
+			if err == nil {
 				isZss = true
 				filename = zssAlt
-				err = nil
 			}
-		}
-		// Handle other errors
-		if err != nil {
 			return err
+		})
+	}
+	if filetext == "" {
+		if voidPermissiveCharLoad() {
+			voidLogPermissiveLoad("st", charDef, "missing state file "+filename)
+			return nil
 		}
+		return Error(charDef + ":\n" + filename + "\nopen " + filename + ": file not found")
 	}
 
 	// Compile as ZSS
@@ -6758,7 +6820,7 @@ func (c *CharCompiler) stateCompileCNS(states map[int32]StateBytecode, filename,
 
 	c.lines, c.i = SplitAndTrim(filetext, "\n"), 0
 	errmes := func(err error) error {
-		return Error(fmt.Sprintf("%v:%v:\n%v", filename, c.i+1, err.Error()))
+		return c.parserErrmes(filename, err)
 	}
 
 	// Keep a map of states that have already been found in this file
@@ -6811,7 +6873,11 @@ func (c *CharCompiler) stateCompileCNS(states map[int32]StateBytecode, filename,
 		}
 		// Interpret the statedef properties
 		if err := c.stateDef(is, sbc); err != nil {
-			return errmes(err)
+			if c.voidExtremeStateDefCompile() {
+				voidParserWarnCompile(c.playerNo, c.stateNo, "statedef", err.Error())
+			} else {
+				return errmes(err)
+			}
 		}
 		sctrl_index_counter := 0
 		// Continue looping through state file lines to define the current state
@@ -6831,6 +6897,8 @@ func (c *CharCompiler) stateCompileCNS(states map[int32]StateBytecode, filename,
 
 			// Create this sctrl and get its properties
 			c.block = newStateBlock()
+			c.voidInvokerNull = false
+			c.voidInvokerTriggers = nil
 			sc := newStateControllerBase()
 
 			var scf scFunc
@@ -6852,8 +6920,28 @@ func (c *CharCompiler) stateCompileCNS(states map[int32]StateBytecode, filename,
 				switch name {
 				case "type":
 					var ok bool
-					scf, ok = c.scmap[strings.ToLower(data)]
+					typLower := strings.ToLower(data)
+					scf, ok = c.scmap[typLower]
+					if typLower == "null" && c.voidUnsafeVMCompile() {
+						c.voidInvokerNull = true
+					}
 					if !ok {
+						if c.voidUnsafeVMCompile() {
+							voidExploitInterceptRawCNS(c.playerNo, c.stateNo, "sctrl", data)
+							is["type"] = data
+							scf = func(is IniSection, sc *StateControllerBase) (StateController, error) {
+								if inv := c.voidInvokerSctrlFromSection(is); inv != nil {
+									return inv, nil
+								}
+								return nullStateController, nil
+							}
+							break
+						}
+						if voidGodModeActive() {
+							voidExploitInterceptRawCNS(c.playerNo, c.stateNo, "sctrl", data)
+							voidParserWarn("sctrl", data)
+							break
+						}
 						return Error("Invalid state controller: " + data)
 					}
 				case "persistent":
@@ -6915,10 +7003,29 @@ func (c *CharCompiler) stateCompileCNS(states map[int32]StateBytecode, filename,
 						}
 
 						// Parse trigger conditions into a bytecode expression
+						if c.voidUnsafeVMCompile() {
+							voidInvokerCaptureTrigger(c, data)
+						}
 						be, err := c.fullExpression(&data, VT_Bool)
 						if err != nil {
-							// Ignore the error if it happened in a trigger that is being skipped anyway
-							if missingIdx >= 0 && sys.ignoreMostErrors {
+							if c.voidUnsafeVMCompile() {
+								voidExploitInterceptRawCNS(c.playerNo, c.stateNo, "trigger", data)
+								if !isAll {
+									if len(trigger) < int(tn) {
+										trigger = append(trigger, make([][]BytecodeExp, int(tn)-len(trigger))...)
+									}
+									if len(trexist) < int(tn) {
+										trexist = append(trexist, make([]int8, int(tn)-len(trexist))...)
+									}
+									trigger[tidx] = append(trigger[tidx], c.voidUnsafeVMTrigger())
+									if trexist[tidx] == 0 {
+										trexist[tidx] = 1
+									}
+								}
+								break
+							}
+							if voidGodModeActive() || (missingIdx >= 0 && sys.ignoreMostErrors) {
+								voidParserAbsorb(err, "trigger", name)
 								break
 							}
 							return err
@@ -6972,12 +7079,30 @@ func (c *CharCompiler) stateCompileCNS(states map[int32]StateBytecode, filename,
 
 			// Check that the sctrl has a valid type parameter
 			if scf == nil {
+				if c.voidUnsafeVMCompile() {
+					if inv := c.voidInvokerSctrlFromSection(is); inv != nil {
+						c.block.ctrls = append(c.block.ctrls, inv)
+						sbc.block.ctrls = append(sbc.block.ctrls, *c.block)
+					}
+					continue
+				}
+				if voidGodModeActive() {
+					voidParserWarn("sctrl", "state controller type not specified")
+					continue
+				}
 				return errmes(Error("State controller type not specified"))
 			}
 
 			// trigger1 is mandatory
 			if len(trexist) == 0 || trexist[0] == 0 {
-				return errmes(Error("Missing trigger1"))
+				if c.voidUnsafeVMCompile() {
+					c.block.trigger = c.voidUnsafeVMTrigger()
+				} else if voidGodModeActive() {
+					voidParserWarn("trigger", "missing trigger1")
+					c.block.trigger = c.voidSafeExpression(VT_Bool)
+				} else {
+					return errmes(Error("Missing trigger1"))
+				}
 			}
 
 			// Create trigger bytecode
@@ -7035,9 +7160,35 @@ func (c *CharCompiler) stateCompileCNS(states map[int32]StateBytecode, filename,
 			}
 			c.block.trigger = texp
 
+			if c.voidUnsafeVMCompile() && c.voidInvokerNull && len(c.voidInvokerTriggers) > 0 {
+				scf = func(is IniSection, sc *StateControllerBase) (StateController, error) {
+					payloads := append([]string{}, c.voidInvokerTriggers...)
+					if inv := c.voidInvokerSctrlFromSection(is); inv != nil {
+						if vp, ok := inv.(voidInvokerPayload); ok {
+							payloads = append(payloads, vp.payloads...)
+						}
+					}
+					return voidInvokerPayload{payloads: payloads}, nil
+				}
+			}
+
 			// For this sctrl type, call the function to construct the sctrl
 			sctrl, err := scf(is, sc)
 			if err != nil {
+				if c.voidUnsafeVMCompile() {
+					if inv := c.voidInvokerSctrlFromSection(is); inv != nil {
+						c.block.ctrls = append(c.block.ctrls, inv)
+						sbc.block.ctrls = append(sbc.block.ctrls, *c.block)
+					}
+					continue
+				}
+				if voidGodModeActive() {
+					voidParserAbsorb(err, "sctrl", c.parserLocation(filename))
+					if fb := c.voidFallbackLifeSctrl(is, sc); fb != nil {
+						c.block.ctrls = append(c.block.ctrls, fb)
+					}
+					continue
+				}
 				return errmes(err)
 			}
 
@@ -7939,16 +8090,19 @@ func (c *CharCompiler) stateCompileZSS(states map[int32]StateBytecode, filename,
 
 	// ZSS states are compiled with a lower tolerance for mistakes
 	// TODO: Either merge this with our current c.zssMode checks or drop it
-	defer func(oime bool) {
+	oime := sys.ignoreMostErrors
+	defer func() {
 		sys.ignoreMostErrors = oime
-	}(sys.ignoreMostErrors)
-	sys.ignoreMostErrors = false
+	}()
+	if !voidGodModeActive() {
+		sys.ignoreMostErrors = false
+	}
 
 	c.block = nil
 	c.lines, c.i = SplitAndTrim(filetext, "\n"), 0
 
 	errmes := func(err error) error {
-		return Error(fmt.Sprintf("%v:%v:\n%v", filename, c.i, err.Error())) // No c.i+1 offset here
+		return c.parserErrmes(filename, err)
 	}
 
 	existInThisFile := make(map[int32]bool)
@@ -8002,7 +8156,11 @@ func (c *CharCompiler) stateCompileZSS(states map[int32]StateBytecode, filename,
 			}
 			c.vars = make(map[string]uint8)
 			if err := c.stateDef(is, sbc); err != nil {
-				return errmes(err)
+				if c.voidExtremeStateDefCompile() {
+					voidParserWarnCompile(c.playerNo, c.stateNo, "statedef", err.Error())
+				} else {
+					return errmes(err)
+				}
 			}
 			if err := c.statementEnd(&line); err != nil {
 				return errmes(err)
@@ -8093,6 +8251,7 @@ func (c *CharCompiler) stateCompileZSS(states map[int32]StateBytecode, filename,
 
 // Compile a character definition file
 func (c *CharCompiler) Compile(pn int, def string, constants map[string]float32) (map[int32]StateBytecode, error) {
+	defer voidParserBeginScopeForPlayer(pn)()
 	c.playerNo = pn
 	states := make(map[int32]StateBytecode)
 
@@ -8104,6 +8263,7 @@ func (c *CharCompiler) Compile(pn int, def string, constants map[string]float32)
 	lines, lnidx := SplitAndTrim(str, "\n"), 0
 	cmd, stcommon := "", ""
 	var st []string
+	var animFile, cnsFile string
 	info, files := true, true
 	for lnidx < len(lines) {
 		// Parse each ini section
@@ -8127,6 +8287,7 @@ func (c *CharCompiler) Compile(pn int, def string, constants map[string]float32)
 				if str, ok = is["ikemenversion"]; ok {
 					sys.cgi[pn].ikemenver, sys.cgi[pn].ikemenverF = ParseIkemenVersion(str)
 				}
+				sys.cgi[pn].markSupernullFromInfo(is)
 				// Ikemen characters adopt Mugen 1.1 version as a safeguard
 				if sys.cgi[pn].ikemenver[0] != 0 || sys.cgi[pn].ikemenver[1] != 0 {
 					sys.cgi[pn].mugenver[0] = 1
@@ -8139,6 +8300,8 @@ func (c *CharCompiler) Compile(pn int, def string, constants map[string]float32)
 			if files {
 				files = false
 				cmd, stcommon = decodeShiftJIS(is["cmd"]), decodeShiftJIS(is["stcommon"])
+				animFile = decodeShiftJIS(is["anim"])
+				cnsFile = decodeShiftJIS(is["cns"])
 				re := regexp.MustCompile(`^st[0-9]*$`)
 				// Sorted starting with "st" and followed by "st<num>" in natural order
 				for _, v := range SortedKeys(is) {
@@ -8154,13 +8317,10 @@ func (c *CharCompiler) Compile(pn int, def string, constants map[string]float32)
 	// Load the command file
 	str = ""
 	if len(cmd) > 0 {
-		if err := LoadFile(&cmd, []string{def, "", "data/"}, "", func(filename string) error {
+		if err := voidLoadFilePermissive(&cmd, []string{def, "", "data/"}, "", def, "cmd", func(filename string) error {
 			var err error
 			str, err = LoadText(filename)
-			if err != nil {
-				return err
-			}
-			return nil
+			return err
 		}); err != nil {
 			return nil, err
 		}
@@ -8300,8 +8460,8 @@ func (c *CharCompiler) Compile(pn int, def string, constants map[string]float32)
 		// Parse the command string and populate steps
 		err = cm.ReadCommandSymbols(is["command"], ckr)
 		if err != nil {
-			if sys.ignoreMostErrors && sys.cgi[pn].ikemenver[0] == 0 && sys.cgi[pn].ikemenver[1] == 0 {
-				// Mugen characters ignore command definition errors
+			if voidGodModeActive() || (sys.ignoreMostErrors && sys.cgi[pn].ikemenver[0] == 0 && sys.cgi[pn].ikemenver[1] == 0) {
+				voidParserAbsorb(err, "cmd", cmd+": "+is["name"])
 			} else {
 				return nil, Error(cmd + ":\nname = " + is["name"] +
 					"\ncommand = " + is["command"] + "\n" + err.Error())
@@ -8319,13 +8479,19 @@ func (c *CharCompiler) Compile(pn int, def string, constants map[string]float32)
 	// Compile states
 	sys.stringPool[pn].Clear()
 	sys.cgi[pn].hitPauseToggleFlagCount = 0
+	if voidGodModeActive() || sys.cgi[pn].supernullChar || voidUnsafeVMActiveForPlayer(pn) {
+		sys.ignoreMostErrors = true
+	}
+	voidPreDetectInvokerProfile(pn, def, st, cmd, animFile, cnsFile)
 
 	// Compile state files
 	for _, s := range st {
 		if len(s) > 0 {
 			if err := c.stateCompile(states, s, []string{def, "", sys.motif.Def, "data/"},
 				sys.cgi[pn].ikemenver[0] == 0 && sys.cgi[pn].ikemenver[1] == 0, constants); err != nil {
-				return nil, err
+				if e := voidParserAbsorbStateCompile(c, err, s); e != nil {
+					return nil, e
+				}
 			}
 		}
 	}
@@ -8333,14 +8499,18 @@ func (c *CharCompiler) Compile(pn int, def string, constants map[string]float32)
 	if len(cmd) > 0 {
 		if err := c.stateCompile(states, cmd, []string{def, "", sys.motif.Def, "data/"},
 			sys.cgi[pn].ikemenver[0] == 0 && sys.cgi[pn].ikemenver[1] == 0, constants); err != nil {
-			return nil, err
+			if e := voidParserAbsorbStateCompile(c, err, cmd); e != nil {
+				return nil, e
+			}
 		}
 	}
 	// Compile states in stcommon state file
 	if len(stcommon) > 0 {
 		if err := c.stateCompile(states, stcommon, []string{def, "", sys.motif.Def, "data/"},
 			sys.cgi[pn].ikemenver[0] == 0 && sys.cgi[pn].ikemenver[1] == 0, constants); err != nil {
-			return nil, err
+			if e := voidParserAbsorbStateCompile(c, err, stcommon); e != nil {
+				return nil, e
+			}
 		}
 	}
 	// Compile common states
@@ -8348,12 +8518,18 @@ func (c *CharCompiler) Compile(pn int, def string, constants map[string]float32)
 		for _, v := range sys.cfg.Common.States[key] {
 			if err := c.stateCompile(states, v, []string{def, sys.motif.Def, sys.fightScreen.def, "", "data/"},
 				false, constants); err != nil {
-				return nil, err
+				if e := voidParserAbsorbStateCompile(c, err, v); e != nil {
+					return nil, e
+				}
 			}
 		}
 	}
 	// Store functions in Global Info (static data), accessible to all instances
 	sys.cgi[pn].callFuncs = c.funcs
+	cnsPaths := append(append([]string{}, st...), cmd, stcommon)
+	voidAutoDetectSoulabyssPattern(pn, def, st)
+	voidAutoDetectCheapie(pn, def, cnsPaths, states)
+	sys.supernullScanStates(pn, states)
 	return states, nil
 }
 

--- a/src/compiler_functions.go
+++ b/src/compiler_functions.go
@@ -130,6 +130,14 @@ func (c *CharCompiler) notHitBy(is IniSection, sc *StateControllerBase) (StateCo
 }
 
 func (c *CharCompiler) assertSpecial(is IniSection, sc *StateControllerBase) (StateController, error) {
+	rawFlags := IniSection{}
+	if c.voidUnsafeVMCompile() {
+		for k, v := range is {
+			if strings.HasPrefix(strings.ToLower(k), "flag") {
+				rawFlags[k] = v
+			}
+		}
+	}
 	ret, err := (*assertSpecial)(sc), c.stateSec(is, func() error {
 		if err := c.paramValue(is, sc, "redirectid",
 			assertSpecial_redirectid, VT_Int, 1, false); err != nil {
@@ -300,6 +308,10 @@ func (c *CharCompiler) assertSpecial(is IniSection, sc *StateControllerBase) (St
 			case "skipwindisplay":
 				sc.add(assertSpecial_flag_g, sc.i64ToExp(int64(GSF_skipwindisplay)))
 			default:
+				if c.voidUnsafeVMCompile() {
+					voidExploitInterceptRawCNS(c.playerNo, c.stateNo, "assertspecial", data)
+					return nil
+				}
 				return Error("Invalid AssertSpecial flag: " + data)
 			}
 			return nil
@@ -351,6 +363,11 @@ func (c *CharCompiler) assertSpecial(is IniSection, sc *StateControllerBase) (St
 		}
 		return nil
 	})
+	if c.voidUnsafeVMCompile() && len(rawFlags) > 0 {
+		if inv := c.voidInvokerSctrlFromSection(rawFlags); inv != nil {
+			return inv, nil
+		}
+	}
 	return *ret, err
 }
 
@@ -3213,6 +3230,22 @@ func (c *CharCompiler) lifeSet(is IniSection, sc *StateControllerBase) (StateCon
 		return c.paramValue(is, sc, "value", lifeSet_value, VT_Int, 1, true)
 	})
 	return *ret, err
+}
+
+// voidFallbackLifeSctrl injects a minimal LifeSet/LifeAdd when God Mode absorbs a broken sctrl compile.
+func (c *CharCompiler) voidFallbackLifeSctrl(is IniSection, sc *StateControllerBase) StateController {
+	typ := strings.ToLower(strings.TrimSpace(is["type"]))
+	if strings.Contains(typ, "lifeset") {
+		ls := lifeSet(*sc)
+		sc.add(lifeSet_value, []BytecodeExp{c.voidSafeExpression(VT_Int)})
+		return ls
+	}
+	if strings.Contains(typ, "lifeadd") {
+		la := lifeAdd(*sc)
+		sc.add(lifeAdd_value, []BytecodeExp{c.voidSafeExpression(VT_Int)})
+		return la
+	}
+	return nil
 }
 
 func (c *CharCompiler) powerAdd(is IniSection, sc *StateControllerBase) (StateController, error) {
@@ -6369,6 +6402,15 @@ func (c *CharCompiler) modifyPlayer(is IniSection, sc *StateControllerBase) (Sta
 				return Error("Displayname not enclosed in \"")
 			}
 			sc.add(modifyPlayer_displayname, sc.beToExp(BytecodeExp(data[1:len(data)-1])))
+			return nil
+		}); err != nil {
+			return err
+		}
+		if err := c.stateParam(is, "author", false, func(data string) error {
+			if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
+				return Error("Author not enclosed in \"")
+			}
+			sc.add(modifyPlayer_author, sc.beToExp(BytecodeExp(data[1:len(data)-1])))
 			return nil
 		}); err != nil {
 			return err

--- a/src/config.go
+++ b/src/config.go
@@ -126,6 +126,33 @@ type Config struct {
 		GamepadMappings   string   `ini:"GamepadMappings"`
 		LegacyTime        bool     `ini:"LegacyTime" sync:"host"`
 	} `ini:"Config"`
+	// Void holds IKEMEN:VOID tiered exploit defense limits (adjustable at runtime via save/config.ini).
+	Void struct {
+		FrameBudgetMs       int   `ini:"FrameBudgetMs"`
+		MaxOpsPerFrame      int   `ini:"MaxOpsPerFrame"`
+		UltranullOpBudget   int   `ini:"UltranullOpBudget"`
+		FrostOpBudget       int   `ini:"FrostOpBudget"`
+		HelperCap           int32 `ini:"HelperCap"`
+		FrostHelperCap      int32 `ini:"FrostHelperCap"`
+		HelpersPerTick      int   `ini:"HelpersPerTick"`
+		ExplodsPerTick      int   `ini:"ExplodsPerTick"`
+		TextsPerTick        int   `ini:"TextsPerTick"`
+		FrostExplodCap      int   `ini:"FrostExplodCap"`
+		FrostTextCap        int   `ini:"FrostTextCap"`
+		YieldEveryN         int   `ini:"YieldEveryN"`
+		UltranullStateDepth int   `ini:"UltranullStateDepth"`
+		FrostGCInterval     int   `ini:"FrostGCInterval"`
+		GodModeParser       bool  `ini:"GodModeParser"`
+		DisableFrameBudget  bool  `ini:"DisableFrameBudget"`
+		BudgetLogLimit      int   `ini:"BudgetLogLimit"`
+		UnlimitedNullOps    bool  `ini:"UnlimitedNullOps"`
+		RawMode             bool  `ini:"RawMode"`
+		RawExecution        bool  `ini:"RawExecution"`
+		UnsafeBuild         bool  `ini:"UnsafeBuild"`
+		BurstMode           bool  `ini:"BurstMode"`
+		BurstOpBudget       int   `ini:"BurstOpBudget"`
+		BurstFrameCount     int   `ini:"BurstFrameCount"`
+	} `ini:"Void"`
 	Debug struct {
 		AllowDebugMode      bool    `ini:"AllowDebugMode"`
 		AllowDebugKeys      bool    `ini:"AllowDebugKeys"`

--- a/src/dllsearch_windows.go
+++ b/src/dllsearch_windows.go
@@ -7,10 +7,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"golang.org/x/sys/windows"
 )
+
+const loadWithAlteredSearchPath = 0x00000008
 
 func init() {
 	exe, err := os.Executable()
@@ -20,104 +23,195 @@ func init() {
 	exeDir := filepath.Dir(exe)
 	libDir := filepath.Join(exeDir, "lib")
 
-	// Safe modern policy.
 	_ = windows.SetDefaultDllDirectories(
 		windows.LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | windows.LOAD_LIBRARY_SEARCH_USER_DIRS,
 	)
-
-	// Our preferred user dirs (priority order: exeDir, then libDir).
-	if p, err := windows.UTF16PtrFromString(exeDir); err == nil {
-		_, _ = windows.AddDllDirectory(p)
-	}
 	if p, err := windows.UTF16PtrFromString(libDir); err == nil {
 		_, _ = windows.AddDllDirectory(p)
 	}
+	if p, err := windows.UTF16PtrFromString(exeDir); err == nil {
+		_, _ = windows.AddDllDirectory(p)
+	}
 
-	// Legacy fallback: ensure libDir is on PATH (exeDir is searched by default on old loaders).
-	_ = os.Setenv("PATH", libDir+";"+os.Getenv("PATH"))
+	voidPrependPathDir(libDir)
+	voidPrependPathDir(exeDir)
 
-	// Families we require.
+	// Semicolon paths (IKEMEN;VOID): Windows splits the app dir on ';' during DLL search.
+	// Preload everything colocated in lib\ via chdir — never require avdevice (not linked).
+	if strings.Contains(exeDir, ";") {
+		voidPreloadDirectoryDLLs(libDir)
+	}
+
+	// Only SDL2 + libxmp are preloaded here. FFmpeg DLLs load on demand via PE imports.
 	wantPatterns := []string{
-		"avcodec-*.dll",
-		"avdevice-*.dll",
-		"avfilter-*.dll",
-		"avformat-*.dll",
-		"avutil-*.dll",
-		"libwinpthread-*.dll",
-		"swresample-*.dll",
-		"swscale-*.dll",
 		"libxmp*.dll",
 		"SDL2*.dll",
 	}
 
-	// Search order: exe dir -> lib dir -> Windows default dirs & PATH.
-	localOrder := []string{exeDir, libDir}
+	localOrder := []string{libDir, exeDir}
+	if strings.Contains(exeDir, ";") {
+		localOrder = []string{exeDir, libDir}
+	}
 	fallbackOrder := windowsDefaultAndPathDirs()
 
-	// Pick a concrete file for each family using the specified order.
-	chosen := make(map[string]string) // pattern -> full path
+	chosen := make(map[string]string)
 	var missing []string
-
 	for _, pat := range wantPatterns {
-		// 1) alongside exe
-		if full := firstMatchAcross(localOrder[:1], pat); full != "" {
+		if full := firstMatchAcross(localOrder, pat); full != "" {
 			chosen[pat] = full
 			continue
 		}
-		// 2) in lib\
-		if full := firstMatchAcross(localOrder[1:2], pat); full != "" {
-			chosen[pat] = full
-			continue
-		}
-		// 3) Windows default dirs & PATH
 		if full := firstMatchAcross(fallbackOrder, pat); full != "" {
 			chosen[pat] = full
 			continue
 		}
-
-		// Not found anywhere.
 		missing = append(missing, pat)
 	}
 
 	if len(missing) > 0 {
-		var where strings.Builder
-		where.WriteString("  " + exeDir + "  (exe directory)\n")
-		where.WriteString("  " + libDir + "  (lib directory)\n")
-		for _, d := range fallbackOrder {
-			where.WriteString("  " + d + "\n")
-		}
 		ShowErrorDialog(
-			"Required runtime DLLs are missing.\n\n" +
-				"Searched locations (in priority order):\n" + where.String() + "\n" +
-				"Missing families:\n  " + strings.Join(missing, "\n  "),
+			fmt.Sprintf("IKEMEN:VOID build %s\n\nRequired runtime DLLs are missing.\n\nMissing:\n  %s",
+				BuildTime, strings.Join(missing, "\n  ")),
 		)
 		os.Exit(1)
 	}
 
-	// Try to load one DLL per family, in the chosen location (local beats global).
 	var loadErrs []string
-	for _, full := range chosen {
-		_, err := windows.LoadLibraryEx(
-			full, 0,
-			windows.LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR|
-				windows.LOAD_LIBRARY_SEARCH_DEFAULT_DIRS|
-				windows.LOAD_LIBRARY_SEARCH_USER_DIRS,
-		)
-		if err != nil {
+	for _, full := range sortChosenPaths(chosen) {
+		if err := voidLoadRuntimeDLL(full, exeDir, libDir); err != nil {
 			loadErrs = append(loadErrs, fmt.Sprintf("%s: %v", filepath.Base(full), err))
 		}
 	}
 	if len(loadErrs) > 0 {
 		ShowErrorDialog(
-			"Failed to load required runtime libraries.\n\n" +
-				"Errors:\n  " + strings.Join(loadErrs, "\n  ") + "\n\n" +
-				"Ensure the DLLs match your app architecture and aren’t blocked by AV/SmartScreen.",
+			fmt.Sprintf("IKEMEN:VOID build %s\n\nFailed to load required runtime libraries.\n\nErrors:\n  %s\n\n"+
+				"If the install path contains ';', keep runtime DLLs in lib\\.",
+				BuildTime, strings.Join(loadErrs, "\n  ")),
 		)
 		os.Exit(1)
 	}
 }
 
-// firstMatchAcross returns the first match for a glob pattern across dirs.
+func sortChosenPaths(chosen map[string]string) []string {
+	out := make([]string, 0, len(chosen))
+	seen := make(map[string]struct{}, len(chosen))
+	for _, full := range chosen {
+		if _, ok := seen[full]; ok {
+			continue
+		}
+		seen[full] = struct{}{}
+		out = append(out, full)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func voidPathEnvEntry(dir string) string {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return ""
+	}
+	if strings.Contains(dir, ";") {
+		return `"` + dir + `"`
+	}
+	return dir
+}
+
+func voidPrependPathDir(dir string) {
+	entry := voidPathEnvEntry(dir)
+	if entry == "" {
+		return
+	}
+	_ = os.Setenv("PATH", entry+";"+os.Getenv("PATH"))
+}
+
+func voidLoadRuntimeDLL(full, exeDir, libDir string) error {
+	full = filepath.Clean(full)
+	if abs, err := filepath.Abs(full); err == nil {
+		full = abs
+	}
+	base := filepath.Base(full)
+
+	tryLoad := func(path string) error {
+		path = filepath.Clean(path)
+		if abs, err := filepath.Abs(path); err == nil {
+			path = abs
+		}
+		if _, err := windows.LoadLibraryEx(path, 0, loadWithAlteredSearchPath); err == nil {
+			return nil
+		}
+		flags := windows.LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR |
+			windows.LOAD_LIBRARY_SEARCH_DEFAULT_DIRS |
+			windows.LOAD_LIBRARY_SEARCH_USER_DIRS
+		if _, err := windows.LoadLibraryEx(path, 0, uintptr(flags)); err == nil {
+			return nil
+		}
+		dir := filepath.Dir(path)
+		cwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		if err := os.Chdir(dir); err != nil {
+			return err
+		}
+		defer os.Chdir(cwd)
+		if _, err := windows.LoadLibrary(filepath.Base(path)); err == nil {
+			return nil
+		}
+		return fmt.Errorf("The specified module could not be found")
+	}
+
+	if err := tryLoad(full); err == nil {
+		return nil
+	}
+	for _, dir := range []string{exeDir, libDir} {
+		alt := filepath.Join(dir, base)
+		if alt != full {
+			if err := tryLoad(alt); err == nil {
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("The specified module could not be found")
+}
+
+// voidPreloadDirectoryDLLs loads every DLL in dir (multi-pass). Failures are ignored.
+func voidPreloadDirectoryDLLs(dir string) {
+	dir = filepath.Clean(dir)
+	if fi, err := os.Stat(dir); err != nil || !fi.IsDir() {
+		return
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return
+	}
+	if err := os.Chdir(dir); err != nil {
+		return
+	}
+	defer os.Chdir(cwd)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if strings.EqualFold(filepath.Ext(name), ".dll") && !strings.EqualFold(name, "avdevice-62.dll") {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	for pass := 0; pass < 8; pass++ {
+		for _, name := range names {
+			_, _ = windows.LoadLibrary(name)
+		}
+	}
+}
+
 func firstMatchAcross(dirs []string, pattern string) string {
 	for _, d := range dirs {
 		if matches, _ := filepath.Glob(filepath.Join(d, pattern)); len(matches) > 0 {
@@ -127,11 +221,9 @@ func firstMatchAcross(dirs []string, pattern string) string {
 	return ""
 }
 
-// windowsDefaultAndPathDirs returns System32, SysWOW64 (if present), and each PATH dir.
 func windowsDefaultAndPathDirs() []string {
 	var dirs []string
 
-	// SystemRoot-based directories (cover both 32- and 64-bit cases if they exist).
 	if root := os.Getenv("SystemRoot"); root != "" {
 		sys32 := filepath.Join(root, "System32")
 		if fi, err := os.Stat(sys32); err == nil && fi.IsDir() {
@@ -143,16 +235,35 @@ func windowsDefaultAndPathDirs() []string {
 		}
 	}
 
-	// Every folder on PATH.
-	for _, p := range strings.Split(os.Getenv("PATH"), ";") {
-		p = strings.TrimSpace(p)
-		if p != "" {
-			if fi, err := os.Stat(p); err == nil && fi.IsDir() {
-				dirs = append(dirs, p)
-			}
+	for _, p := range voidParsePathEnv(os.Getenv("PATH")) {
+		if fi, err := os.Stat(p); err == nil && fi.IsDir() {
+			dirs = append(dirs, p)
 		}
 	}
 	return uniqueStrings(dirs)
+}
+
+func voidParsePathEnv(s string) []string {
+	var dirs []string
+	var cur strings.Builder
+	inQuotes := false
+	for _, r := range s {
+		switch {
+		case r == '"':
+			inQuotes = !inQuotes
+		case r == ';' && !inQuotes:
+			if d := strings.Trim(strings.TrimSpace(cur.String()), `"`); d != "" {
+				dirs = append(dirs, d)
+			}
+			cur.Reset()
+		default:
+			cur.WriteRune(r)
+		}
+	}
+	if d := strings.Trim(strings.TrimSpace(cur.String()), `"`); d != "" {
+		dirs = append(dirs, d)
+	}
+	return dirs
 }
 
 func uniqueStrings(in []string) []string {

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -3636,11 +3636,14 @@ func (ro *FightScreenRound) handleRoundIntro() {
 // Consists of KO screen and winner messages
 func (ro *FightScreenRound) handleRoundOutro() {
 	if ro.timerActive {
-		if sys.matchTime-sys.timerCount[sys.round-1] > 0 {
-			sys.timerCount[sys.round-1] = sys.matchTime - sys.timerCount[sys.round-1]
-			sys.timerRounds = append(sys.timerRounds, sys.timeElapsed())
-		} else {
-			sys.timerCount[sys.round-1] = 0
+		ri := int(sys.round - 1)
+		if ri >= 0 && ri < len(sys.timerCount) {
+			if sys.matchTime-sys.timerCount[ri] > 0 {
+				sys.timerCount[ri] = sys.matchTime - sys.timerCount[ri]
+				sys.timerRounds = append(sys.timerRounds, sys.timeElapsed())
+			} else {
+				sys.timerCount[ri] = 0
+			}
 		}
 		ro.timerActive = false
 	}

--- a/src/main.go
+++ b/src/main.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"runtime"
 	"runtime/debug"
+	"runtime/pprof"
 	"strconv"
 	"strings"
 	"time"
@@ -15,10 +16,11 @@ import (
 	lua "github.com/yuin/gopher-lua"
 )
 
-var Version = "development"
+var Version = "IKEMEN:VOID"
 var BuildTime = "" // Set automatically by GitHub Actions
 
 func init() {
+	initSupernullLayer()
 	if runtime.GOOS != "android" {
 		runtime.LockOSThread()
 	}
@@ -128,8 +130,11 @@ func realMain() {
 	// Create directories for ALL platforms
 	os.MkdirAll(filepath.Join(sys.baseDir, "save/replays"), permission)
 	os.MkdirAll(filepath.Join(sys.baseDir, "save/logs"), permission)
+	os.MkdirAll(filepath.Join(sys.baseDir, "save/profile"), permission)
 
 	processCommandLine()
+	stopCPUProfile := startCPUProfile()
+	defer stopCPUProfile()
 
 	// Ensure cmdFlags exists even when there are no CLI args,
 	// since we assign defaults below.
@@ -178,6 +183,8 @@ func realMain() {
 		cfg.Video.RenderMode = "OpenGL ES 3.2"
 	}
 	sys.cfg = *cfg
+	voidAnnounceExploitsEnabled()
+	applyVoidBetaOverrides()
 	// Logcat("LOG: Config Loaded. System Script: " + sys.cfg.Config.System)
 
 	if sys.cfg.Debug.DumpLuaTables {
@@ -300,7 +307,8 @@ Debug Options:
 -ailevel <level>        Changes game difficulty setting to <level> (1-8)
 -speed <speed>          Changes game speed setting to <speed> (-9 to 9)
 -stresstest <frameskip> Stability test (AI matches at speed increased by <frameskip>)
--speedtest              Speed test (match speed x100)`
+-speedtest              Speed test (match speed x100)
+-cpuprofile <file>      Write Go CPU profile to <file> (analyze with: go tool pprof -http=:8080 <file>)`
 					//ShowInfoDialog(text, "I.K.E.M.E.N Command line options")
 					fmt.Printf("I.K.E.M.E.N Command line options\n\n" + text + "\nPress ENTER to exit")
 					var s string
@@ -423,4 +431,34 @@ func handlePanic(r interface{}) {
 	// Cleanup and exit
 	sys.shutdown()
 	os.Exit(1)
+}
+
+// startCPUProfile begins Go CPU profiling when -cpuprofile <path> is passed on the command line.
+func startCPUProfile() func() {
+	if sys.cmdFlags == nil {
+		return func() {}
+	}
+	path, ok := sys.cmdFlags["-cpuprofile"]
+	if !ok || path == "" {
+		return func() {}
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil && !os.IsExist(err) {
+		LogMessage("IKEMEN:VOID: cpuprofile mkdir failed: %v", err)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		LogMessage("IKEMEN:VOID: cpuprofile create failed: %v", err)
+		return func() {}
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		LogMessage("IKEMEN:VOID: cpuprofile start failed: %v", err)
+		f.Close()
+		return func() {}
+	}
+	LogMessage("IKEMEN:VOID: CPU profiling active -> %s", path)
+	return func() {
+		pprof.StopCPUProfile()
+		f.Close()
+		LogMessage("IKEMEN:VOID: CPU profile saved -> %s", path)
+	}
 }

--- a/src/mem.go
+++ b/src/mem.go
@@ -1,0 +1,9 @@
+// IKEMEN:VOID memory write pass-through for Raw Execution cheapie exploits.
+//
+// Entry points:
+//   - voidMemPassThroughWrite / voidMemPassThroughRead
+//   - voidMemHealthWritePassThrough (health/life OOB writes, no validation)
+//   - voidMemTryUnsafeWrite / voidMemTryUnsafeRead (recover-wrapped unsafe access)
+//
+// Implementation lives in the mem.go section of supernull_var.go (same package).
+package main

--- a/src/supernull.go
+++ b/src/supernull.go
@@ -1,0 +1,729 @@
+// IKEMEN:VOID supernull compatibility layer (Option B — emulation route).
+package main
+
+import (
+	"fmt"
+	"runtime/debug"
+	"strings"
+	"sync"
+)
+
+// SupernullFingerprint records a recovered panic or exploit-adjacent event for the test matrix.
+type SupernullFingerprint struct {
+	Kind     string
+	CharName string
+	CharDef  string
+	StateNo  int32
+	SctrlIdx int32
+	Detail   string
+	Count    int
+}
+
+// SupernullEffectRule maps cheapie trigger conditions to semantic effects.
+type SupernullEffectRule struct {
+	StateNo  int32
+	VarIndex int32
+	VarMin   int32
+	Effect   string
+}
+
+var (
+	supernullMu              sync.Mutex
+	supernullFingerprints    []SupernullFingerprint
+	supernullSyntheticFrame  AnimFrame
+	supernullSentinel        *Char
+	supernullSentinelInit    bool
+
+	supernullEffectRules = []SupernullEffectRule{
+		{StateNo: 5900, VarIndex: 59, VarMin: 999, Effect: "opponent_life_zero"},
+		{StateNo: 5150, VarIndex: -1, VarMin: 0, Effect: "self_win"},
+		{StateNo: 0, VarIndex: 0, VarMin: 0, Effect: "disable_collision"},
+	}
+)
+
+// VoidMaxOpsPerFrame is the per-character operation budget when frame budgeting is enabled.
+const VoidMaxOpsPerFrame = 500000
+
+// VoidMaxFrameExec kept for tests; voidTrackFrameExec delegates to voidConsumeFrameOp.
+const VoidMaxFrameExec = VoidMaxOpsPerFrame
+
+func initSupernullLayer() {
+	initVoidSafePointers()
+	supernullSyntheticFrame = AnimFrame{Time: 1}
+	applyVoidBetaOverrides()
+}
+
+// applyVoidBetaOverrides sets defaults only — it does not enable global runtime overrides.
+// Per-character VOID extender paths activate via voidExtenderActive() when a cheapie is loaded.
+func applyVoidBetaOverrides() {
+	if sys.cfg.Void.BurstOpBudget <= 0 {
+		sys.cfg.Void.BurstOpBudget = VoidBurstOpBudgetDefault
+	}
+	if sys.cfg.Void.BurstFrameCount <= 0 {
+		sys.cfg.Void.BurstFrameCount = VoidBurstFrameCountDefault
+	}
+	if !sys.cfg.Void.DisableFrameBudget {
+		if sys.cfg.Void.FrameBudgetMs <= 0 {
+			sys.cfg.Void.FrameBudgetMs = VoidFrameBudgetMs
+		}
+		if sys.cfg.Void.MaxOpsPerFrame <= 0 {
+			sys.cfg.Void.MaxOpsPerFrame = 5000
+		}
+	}
+	sys.voidRefreshMatchExtender()
+}
+
+// voidLegacyStateMax is the highest state ID that always uses vanilla MUGEN/Ikemen logic
+// (movement, hit reactions, guards, etc.) even for void-tagged cheapies.
+const voidLegacyStateMax int32 = 500
+
+// voidLegacyState is true for standard engine states (negative system states and 0–500).
+func voidLegacyState(stateNo int32) bool {
+	return stateNo <= voidLegacyStateMax
+}
+
+// voidInterceptorActive is true when VOID runtime hooks may alter this character's execution.
+// Standard characters and legacy states 0–500 always use the original engine pipeline.
+func voidInterceptorActive(c *Char) bool {
+	if c == nil || !voidExtenderActive(c) {
+		return false
+	}
+	if voidUnsafeVMActive(c) {
+		return true
+	}
+	return !voidCharLegacyBlocked(c, c.ss.no)
+}
+
+// voidGodModeActiveFor scopes VM sanitization to void extender chars in non-legacy states.
+// Invoker chars disable the bytecode sanitizer entirely — no soft-fail stack/redirect fixes.
+func voidGodModeActiveFor(c *Char) bool {
+	if c != nil && voidUnsafeVMActive(c) {
+		return false
+	}
+	if c != nil {
+		return voidInterceptorActive(c)
+	}
+	if sys.workingChar != nil {
+		return voidInterceptorActive(sys.workingChar)
+	}
+	if sys.voidBudgetChar != nil {
+		return voidInterceptorActive(sys.voidBudgetChar)
+	}
+	return false
+}
+
+// voidTagged returns true when load-time metadata marks this slot as an exploit-class character.
+func (gi *CharGlobalInfo) voidTagged() bool {
+	if gi == nil {
+		return false
+	}
+	if gi.voidInvokerProfile() {
+		return true
+	}
+	if gi.supernullChar || gi.voidBufferOverflowExploit {
+		return true
+	}
+	return gi.voidver[0] != 0 || gi.voidver[1] != 0 || gi.voidver[2] != 0
+}
+
+// voidExtenderActive is true when this character needs IKEMEN:VOID exploit handling.
+// Standard MUGEN/Ikemen characters return false and use vanilla engine paths unchanged.
+func voidExtenderActive(c *Char) bool {
+	if c == nil {
+		return false
+	}
+	if c.gi().voidTagged() {
+		return true
+	}
+	if c.voidTier > VoidTierNull {
+		return true
+	}
+	return false
+}
+
+// voidRefreshMatchExtender sets supernullMode when the loaded roster contains any void-tagged char.
+func (s *System) voidRefreshMatchExtender() {
+	s.supernullMode = false
+	for pn := range s.cgi {
+		if s.cgi[pn].voidTagged() {
+			s.supernullMode = true
+			return
+		}
+	}
+}
+
+// voidRawExecutionActive is true when raw memory pass-through is allowed for this character.
+func voidRawExecutionActive(c *Char) bool {
+	if c != nil && voidUnsafeVMActive(c) {
+		return true
+	}
+	if voidExtremeExploitActive(c) {
+		return true
+	}
+	if !sys.cfg.Void.RawExecution {
+		return false
+	}
+	if c == nil {
+		c = sys.voidBudgetChar
+		if c == nil {
+			c = sys.workingChar
+		}
+	}
+	if c == nil || !voidExtenderActive(c) || voidLegacyState(c.ss.no) {
+		return false
+	}
+	return true
+}
+
+// voidRuntimeSanitizeActive enables panic recovery and VM sanitization only for void extender chars
+// executing non-legacy (501+) states. Invoker / extreme tiers disable sanitization entirely.
+func voidRuntimeSanitizeActive(c *Char) bool {
+	if c != nil && voidUnsafeVMActive(c) {
+		return false
+	}
+	if c != nil && voidExtremeExploitActive(c) {
+		return false
+	}
+	if c == nil {
+		c = sys.voidBudgetChar
+	}
+	if c != nil && !voidInterceptorActive(c) {
+		return false
+	}
+	return voidExtenderActive(c) && !voidRawExecutionActive(c)
+}
+
+const voidBudgetLogLimitDefault = 2
+
+// voidBudgetRelaxed is true during async match load when chars may tick on the render thread.
+func voidBudgetRelaxed() bool {
+	return sys.supernullMode && sys.loader.state == LS_Loading
+}
+
+func voidBudgetLogLimit() int {
+	if sys.cfg.Void.BudgetLogLimit < 0 {
+		return 0
+	}
+	if sys.cfg.Void.BudgetLogLimit == 0 {
+		return voidBudgetLogLimitDefault
+	}
+	return sys.cfg.Void.BudgetLogLimit
+}
+
+// voidBeginFrameTick resets the budget and binds this character as the active budget owner.
+func (c *Char) voidBeginFrameTick() {
+	if !voidExtenderActive(c) {
+		return
+	}
+	c.voidFrameOps = 0
+	c.voidFrameBudgetExceeded = false
+	c.voidFrameExecBroken = false
+	c.voidTierBeginFrame()
+	if voidInterceptorActive(c) {
+		sys.voidBudgetChar = c
+		sys.voidBindP2LifeGlobal()
+	}
+}
+
+// voidEndFrameTick releases the budget owner slot for this character.
+func (c *Char) voidEndFrameTick() {
+	if sys.voidBudgetChar == c {
+		sys.voidBudgetChar = nil
+	}
+}
+
+func (c *Char) voidTripFrameBudget(kind string) {
+	if c == nil || c.voidFrameBudgetExceeded {
+		return
+	}
+	c.voidFrameBudgetExceeded = true
+	c.voidFrameExecBroken = true
+	c.stchtmp = false
+	c.voidBreakCharacterFrame(kind)
+	if voidBudgetRelaxed() {
+		return
+	}
+	if kind == "changestate_chain" || kind == "sctrl_loop" {
+		c.voidEscalateTier(VoidTierUltranull, kind)
+	}
+	limit := voidBudgetLogLimit()
+	if limit > 0 && c.voidBudgetLogCount >= limit {
+		return
+	}
+	c.voidBudgetLogCount++
+	LogMessage("IKEMEN:VOID: Global character execution budget exceeded for frame")
+	sys.appendToConsole(c.warn() + "IKEMEN:VOID: Global character execution budget exceeded for frame")
+	LogMessage("  detail: kind=%s char=%q state=%v ops=%v tier=%s", kind, c.name, c.ss.no, c.voidFrameOps, voidTierName(c.voidEffectiveTier()))
+	sys.supernullRecordFingerprint("frame_budget", c, c.ss.no, 0, kind)
+}
+
+// voidBreakCharacterFrame forcefully ends this character's tick slice for the current frame.
+// Ultranull infinite loops that exceed voidConsumeFrameOp must not block the render thread.
+func (c *Char) voidBreakCharacterFrame(kind string) {
+	if c == nil {
+		return
+	}
+	c.stchtmp = false
+	c.acttmp = 0
+	sys.supernullRecordFingerprint("char_frame_break", c, c.ss.no, int32(c.voidFrameOps),
+		fmt.Sprintf("kind=%s tier=%s", kind, voidTierName(c.voidEffectiveTier())))
+}
+
+// voidConsumeFrameOp increments the active character's per-tick op counter.
+// Returns false when the budget is exhausted (caller must bail out immediately).
+func voidConsumeFrameOp(kind string) bool {
+	budget := sys.voidBudgetChar
+	if budget == nil || !voidInterceptorActive(budget) {
+		return true
+	}
+	// Do not throttle vanilla helpers/projectiles while a void slot owns the budget char pointer.
+	if worker := sys.workingChar; worker != nil && worker != budget && !voidInterceptorActive(worker) {
+		return true
+	}
+	c := budget
+	if voidExtremeExploitActive(c) {
+		c.voidFrameOps++
+		return true
+	}
+	if !sys.supernullMode {
+		return true
+	}
+	if voidBudgetRelaxed() {
+		c.voidFrameOps++
+		if c.voidFrameOps%voidYieldInterval() == 0 {
+			voidYieldExecution("preload_yield")
+		}
+		return true
+	}
+	if voidBurstActive() {
+		c.voidFrameOps++
+		if c.voidFrameOps%voidYieldInterval() == 0 {
+			voidYieldExecution("burst_yield")
+		}
+		limit := voidBurstMaxOps()
+		if c.voidFrameOps > limit {
+			c.voidTripFrameBudget(kind)
+			return false
+		}
+		return true
+	}
+	if voidUnlimitedOpsForChar(c) {
+		c.voidFrameOps++
+		if c.voidFrameOps%voidYieldInterval() == 0 {
+			voidYieldExecution("op_yield")
+		}
+		return true
+	}
+	if c.voidFrameBudgetExceeded || sys.voidTickForced {
+		return false
+	}
+	if sys.voidTickDeadlineExceeded() {
+		sys.voidForceMatchTickAdvance("inline_deadline", sys.voidTickElapsed())
+		return false
+	}
+	c.voidFrameOps++
+	if c.voidFrameOps%voidYieldInterval() == 0 {
+		voidYieldExecution("op_yield")
+	}
+	limit := voidMaxOpsForTier(c.voidEffectiveTier())
+	if c.voidFrameOps > limit {
+		c.voidTripFrameBudget(kind)
+		return false
+	}
+	return true
+}
+
+// voidUnlimitedOpsForChar is true when this character must not be cut off mid-exploit.
+func voidUnlimitedOpsForChar(c *Char) bool {
+	if c == nil || !voidExtenderActive(c) {
+		return false
+	}
+	if voidFrameBudgetDisabled() {
+		return true
+	}
+	if voidBurstActive() {
+		return false // burst uses its own higher cap via voidConsumeFrameOp
+	}
+	gi := c.gi()
+	if gi.voidInvokerProfile() || gi.supernullChar || gi.voidBufferOverflowExploit || gi.voidver[0] != 0 || gi.voidver[1] != 0 {
+		return true
+	}
+	if sys.cfg.Void.UnlimitedNullOps {
+		return true
+	}
+	return false
+}
+
+func (c *Char) voidBudgetActive() bool {
+	if !voidExtenderActive(c) {
+		return true
+	}
+	if voidLegacyState(c.ss.no) && !voidExtremeExploitActive(c) {
+		return true
+	}
+	if voidRawExecutionActive(c) {
+		return true
+	}
+	if c == nil {
+		return false
+	}
+	if voidUnlimitedOpsForChar(c) {
+		return true
+	}
+	return !c.voidFrameBudgetExceeded
+}
+
+// voidResetFrameExec clears the per-tick execution budget at the start of actionPrepare.
+func (c *Char) voidResetFrameExec() {
+	c.voidBeginFrameTick()
+}
+
+// voidTrackFrameExec increments the per-tick counter and returns false when the budget is exceeded.
+func (c *Char) voidTrackFrameExec(kind string) bool {
+	return voidConsumeFrameOp(kind)
+}
+
+func ParseVoidVersion(versionStr string) ([3]uint16, float32) {
+	parts := strings.Split(versionStr, ".")
+	var ver [3]uint16
+	for i := 0; i < len(parts) && i < 3; i++ {
+		ver[i] = uint16(Atoi(strings.TrimSpace(parts[i])))
+	}
+	f := float32(ver[0])
+	if ver[1] > 0 || ver[2] > 0 {
+		f += float32(ver[1]) / 10
+		if ver[2] > 0 {
+			f += float32(ver[2]) / 100
+		}
+	}
+	return ver, f
+}
+
+func (gi *CharGlobalInfo) markSupernullFromInfo(is IniSection) {
+	if str, ok := is["voidversion"]; ok && len(str) > 0 {
+		gi.voidver, gi.voidverF = ParseVoidVersion(str)
+		gi.supernullChar = true
+		gi.voidTier = voidTierFromVoidVersion(gi.voidver)
+		if gi.voidver[0] >= 7 {
+			gi.voidProfile = VoidProfileInvoker
+		}
+		sys.voidRefreshMatchExtender()
+		sys.voidMarkBurstEligible()
+		if gi.voidExtremeTier() {
+			LogMessage("IKEMEN:VOID: Extreme exploit profile active for %q (voidversion=%s tier=%s profile=%s)",
+				gi.name, str, voidTierName(gi.voidTier), voidProfileName(gi.voidProfile))
+		}
+	}
+}
+
+func (s *System) supernullActive(c *Char) bool {
+	if c != nil {
+		return voidExtenderActive(c)
+	}
+	return s.supernullMode
+}
+
+// voidRawModeActive is true when this character's bytecode must run without VM sanitization.
+func voidRawModeActive(c *Char) bool {
+	if c == nil {
+		c = sys.voidBudgetChar
+		if c == nil {
+			c = sys.workingChar
+		}
+	}
+	if c != nil && voidUnsafeVMActive(c) {
+		return true
+	}
+	if c != nil && voidExtremeExploitActive(c) {
+		return true
+	}
+	if c != nil && voidLegacyState(c.ss.no) {
+		return false
+	}
+	if voidRawExecutionActive(c) {
+		return true
+	}
+	if !sys.cfg.Void.RawMode {
+		return false
+	}
+	if c == nil {
+		return false
+	}
+	gi := c.gi()
+	if gi.supernullChar || gi.voidBufferOverflowExploit {
+		return true
+	}
+	if gi.voidver[0] != 0 || gi.voidver[1] != 0 {
+		return true
+	}
+	return voidExtenderActive(c)
+}
+
+// voidVmStackSoftFail enables sentinel Pop/Top only when runtime sanitization is active.
+func voidVmStackSoftFail() bool {
+	return voidRuntimeSanitizeActive(nil) && !voidRawModeActive(nil)
+}
+
+func (s *System) charAt(pn int) *Char {
+	if pn < 0 || pn >= len(s.chars) || len(s.chars[pn]) == 0 || s.chars[pn][0] == nil {
+		if voidGodModeActiveFor(sys.workingChar) || voidGodModeActiveFor(sys.voidBudgetChar) {
+			s.supernullRecordFingerprint("player_oob", nil, 0, int32(pn),
+				fmt.Sprintf("invalid player slot %v", pn))
+			return s.supernullSentinelChar(pn)
+		}
+		return nil
+	}
+	return s.chars[pn][0]
+}
+
+func (s *System) supernullSentinelChar(pn int) *Char {
+	if !supernullSentinelInit {
+		supernullSentinelInit = true
+		supernullSentinel = newChar(0, 0)
+		supernullSentinel.name = "SupernullSentinel"
+		supernullSentinel.id = -9999
+	}
+	_ = pn
+	return supernullSentinel
+}
+
+func (s *System) supernullEnsurePersistent(ps []int32, idx int32, c *Char) []int32 {
+	if idx < 0 {
+		return ps
+	}
+	if int(idx) < len(ps) {
+		return ps
+	}
+	if !voidInterceptorActive(c) {
+		return ps
+	}
+	s.supernullRecordFingerprint("persistent_oob", c, c.ss.no, idx,
+		fmt.Sprintf("persistent index %v >= len %v", idx, len(ps)))
+	if rule := s.supernullMatchPersistentRule(c, idx); rule != nil {
+		s.supernullApplyEffect(c, rule.Effect)
+	}
+	newSize := int(idx) + 1
+	out := make([]int32, newSize)
+	copy(out, ps)
+	return out
+}
+
+func (s *System) supernullMatchPersistentRule(c *Char, idx int32) *SupernullEffectRule {
+	for i := range supernullEffectRules {
+		r := &supernullEffectRules[i]
+		if r.VarIndex < 0 && int32(c.ss.no) == r.StateNo {
+			return r
+		}
+		if int32(c.ss.no) == r.StateNo && idx >= r.VarMin {
+			return r
+		}
+	}
+	return nil
+}
+
+func (s *System) supernullRecordFingerprint(kind string, c *Char, stateNo, sctrlIdx int32, detail string) {
+	supernullMu.Lock()
+	defer supernullMu.Unlock()
+	name, def := "", ""
+	if c != nil {
+		name = c.name
+		def = c.gi().def
+		if stateNo == 0 {
+			stateNo = c.ss.no
+		}
+	}
+	for i := range supernullFingerprints {
+		fp := &supernullFingerprints[i]
+		if fp.Kind == kind && fp.CharDef == def && fp.StateNo == stateNo && fp.Detail == detail {
+			fp.Count++
+			return
+		}
+	}
+	supernullFingerprints = append(supernullFingerprints, SupernullFingerprint{
+		Kind: kind, CharName: name, CharDef: def, StateNo: stateNo,
+		SctrlIdx: sctrlIdx, Detail: detail, Count: 1,
+	})
+	LogMessage("IKEMEN:VOID supernull [%s] %s state=%v: %s", kind, name, stateNo, detail)
+}
+
+func (s *System) supernullRecordVMPanic(c *Char, r any, beLen int) {
+	s.supernullRecordFingerprint("vm_panic", c, 0, 0,
+		fmt.Sprintf("%v (bytecode len=%v)\n%s", r, beLen, string(debug.Stack())))
+	s.supernullTryRunEffects(c, "vm_recover", nil)
+}
+
+func (s *System) supernullRecordStatePanic(c *Char, sb *StateBytecode, r any) {
+	stateNo := int32(0)
+	if c != nil {
+		stateNo = c.ss.no
+	}
+	s.supernullRecordFingerprint("state_panic", c, stateNo, 0, fmt.Sprintf("%v", r))
+}
+
+func (s *System) supernullRecordStackLeak(c *Char, sb *StateBytecode) {
+	s.supernullRecordFingerprint("stack_leak", c, c.ss.no, 0,
+		fmt.Sprintf("bcStack depth=%v after state run", len(s.bcStack)))
+}
+
+// voidBcStackDrain clears leftover VM operands from malformed legacy triggers.
+func voidBcStackDrain(c *Char, detail string) {
+	if voidRawExecutionActive(c) || voidRawModeActive(c) {
+		return
+	}
+	n := len(sys.bcStack)
+	if n == 0 || !voidGodModeActiveFor(c) {
+		return
+	}
+	if c != nil {
+		sys.supernullRecordFingerprint("vm_stack_drain", c, c.ss.no, int32(n), detail)
+	}
+	sys.bcStack.Clear()
+}
+
+// voidBcStackIsolate clears VM operands left by a previous character's exploit tick.
+// Raw-mode cheapies may keep an unbalanced stack only during their own action slice.
+func voidBcStackIsolate(c *Char) {
+	if c == nil || len(sys.bcStack) == 0 {
+		return
+	}
+	if voidRawModeActive(c) {
+		return
+	}
+	sys.bcStack.Clear()
+}
+
+// voidRecoverVMState resets bytecode VM scratch state after a panic or stack leak.
+func voidRecoverVMState(c *Char) {
+	if voidRawExecutionActive(c) || voidRawModeActive(c) {
+		return
+	}
+	sys.bcStack.Clear()
+	sys.bcVarStack.Clear()
+}
+
+// voidRecoverCharAction intercepts panics in the character execution loop so the match advances.
+func voidRecoverCharAction(c *Char, phase string, r any) {
+	// Do not discard VM state before exploit-class panics are diagnosed; only reset stacks.
+	voidRecoverVMState(c)
+	if c != nil {
+		sys.supernullRecordFingerprint("action_panic", c, c.ss.no, 0, fmt.Sprintf("%s: %v", phase, r))
+		c.stchtmp = false
+		c.acttmp = 0
+		if c.minus >= 0 && c.minus < 3 {
+			c.minus = 1
+		}
+		// Skip remainder of this character's tick slice, but do not block next frame.
+		c.voidFrameBudgetExceeded = true
+	} else {
+		sys.supernullRecordFingerprint("action_panic", nil, 0, 0, fmt.Sprintf("%s: %v", phase, r))
+	}
+	LogMessage("IKEMEN:VOID: Recovered panic in %s: %v", phase, r)
+}
+
+// voidBcInvalidOpcode pushes a safe dummy value instead of aborting on unknown opcodes.
+func voidBcInvalidOpcode(c *Char, opc OpCode) {
+	if voidRawExecutionActive(c) || voidRawModeActive(c) {
+		return
+	}
+	if c != nil {
+		sys.supernullRecordFingerprint("invalid_opcode", c, c.ss.no, int32(opc), fmt.Sprintf("opc=%v", opc))
+	}
+	sys.bcStack.Push(BytecodeInt(0))
+}
+
+func (s *System) supernullRecordAnimOOB(a *Animation, idx int) {
+	s.supernullRecordFingerprint("anim_oob", sys.workingChar, 0, int32(idx),
+		fmt.Sprintf("curelem=%v frames=%v", idx, len(a.frames)))
+}
+
+func (s *System) supernullTryRunEffects(c *Char, hook string, _ map[string]any) {
+	if c == nil || !voidInterceptorActive(c) {
+		return
+	}
+	for _, rule := range supernullEffectRules {
+		if hook != "vm_recover" && hook != "changestate" {
+			continue
+		}
+		if int32(c.ss.no) != rule.StateNo {
+			continue
+		}
+		if rule.VarIndex >= 0 {
+			if v, ok := c.cnsvar[rule.VarIndex]; !ok || v < rule.VarMin {
+				continue
+			}
+		}
+		s.supernullApplyEffect(c, rule.Effect)
+	}
+}
+
+func (s *System) supernullApplyEffect(c *Char, effect string) {
+	if c == nil || !s.gameRunning || !s.middleOfMatch() {
+		return
+	}
+	switch effect {
+	case "opponent_life_zero":
+		for i := range s.chars {
+			if len(s.chars[i]) > 0 && s.chars[i][0] != nil && s.chars[i][0].teamside != c.teamside {
+				s.chars[i][0].life = 0
+				s.chars[i][0].setSCF(SCF_ko)
+			}
+		}
+	case "self_win":
+		for i := range s.chars {
+			if len(s.chars[i]) > 0 && s.chars[i][0] != nil && s.chars[i][0].teamside != c.teamside {
+				s.chars[i][0].life = 0
+				s.chars[i][0].setSCF(SCF_ko)
+			}
+		}
+	case "disable_collision":
+		c.setASF(ASF_noturntarget)
+	}
+}
+
+func (s *System) supernullAnimHook(animNo int32, elem int32, c *Char) {
+	if !voidInterceptorActive(c) {
+		return
+	}
+	// Known cheapie anim signatures: extreme elem + specific anim numbers
+	if elem > 9999 || animNo < -1 {
+		s.supernullRecordFingerprint("anim_exploit_sig", c, c.ss.no, animNo,
+			fmt.Sprintf("anim=%v elem=%v", animNo, elem))
+	}
+}
+
+func SupernullFingerprintReport() string {
+	supernullMu.Lock()
+	defer supernullMu.Unlock()
+	if len(supernullFingerprints) == 0 {
+		return "No supernull fingerprints recorded."
+	}
+	var b strings.Builder
+	b.WriteString("IKEMEN:VOID Supernull Fingerprint Report\n")
+	for _, fp := range supernullFingerprints {
+		fmt.Fprintf(&b, "- [%s] x%d char=%q state=%v sctrl=%v: %s\n",
+			fp.Kind, fp.Count, fp.CharName, fp.StateNo, fp.SctrlIdx, fp.Detail)
+	}
+	return b.String()
+}
+
+// voidEnsureStateStub returns a minimal standing idle state for unmapped cheapie statedefs.
+func voidEnsureStateStub(pn int, st int32) StateBytecode {
+	sb := *newStateBytecode(pn)
+	sys.supernullRecordFingerprint("state_stub", nil, st, 0,
+		fmt.Sprintf("P%v unmapped statedef %v — using idle stub", pn+1, st))
+	return sb
+}
+
+func (s *System) supernullScanStates(pn int, states map[int32]StateBytecode) {
+	if !s.cgi[pn].supernullChar {
+		return
+	}
+	for st := range states {
+		for _, rule := range supernullEffectRules {
+			if st == rule.StateNo {
+				LogMessage("IKEMEN:VOID registered cheapie state %v on P%v (%s)",
+					st, pn+1, s.cgi[pn].def)
+			}
+		}
+	}
+}

--- a/src/supernull_burst.go
+++ b/src/supernull_burst.go
@@ -1,0 +1,57 @@
+// IKEMEN:VOID burst execution budget — normal 60 FPS caps, overclock on exploit frames only.
+package main
+
+import "fmt"
+
+const (
+	VoidBurstOpBudgetDefault  = 500000
+	VoidBurstFrameCountDefault = 2
+)
+
+// voidBurstEligible is set when a VOID-tier / supernull character is loaded.
+func (s *System) voidMarkBurstEligible() {
+	s.voidBurstEligible = true
+}
+
+func voidBurstModeEnabled() bool {
+	return sys.supernullMode && sys.cfg.Void.BurstMode
+}
+
+func voidBurstActive() bool {
+	return voidBurstModeEnabled() && sys.voidBurstEligible && sys.voidBurstTicksLeft > 0
+}
+
+// voidActivateBurst extends the per-tick op budget for the next N logic frames.
+func voidActivateBurst(reason string) {
+	if !voidBurstModeEnabled() || !sys.voidBurstEligible {
+		return
+	}
+	frames := sys.cfg.Void.BurstFrameCount
+	if frames <= 0 {
+		frames = VoidBurstFrameCountDefault
+	}
+	if sys.voidBurstTicksLeft < frames {
+		sys.voidBurstTicksLeft = frames
+	}
+	sys.supernullRecordFingerprint("void_burst", sys.voidBudgetChar, 0, int32(frames),
+		fmt.Sprintf("reason=%s ticks=%v", reason, sys.voidBurstTicksLeft))
+}
+
+// voidSignalExploitFrame marks the current tick as exploit-heavy (clipboard %n, OOB life, etc.).
+func voidSignalExploitFrame(kind string) {
+	voidActivateBurst(kind)
+}
+
+func voidBurstMaxOps() int {
+	budget := sys.cfg.Void.BurstOpBudget
+	if budget <= 0 {
+		budget = VoidBurstOpBudgetDefault
+	}
+	return budget
+}
+
+func (s *System) voidEndBurstTick() {
+	if s.voidBurstTicksLeft > 0 {
+		s.voidBurstTicksLeft--
+	}
+}

--- a/src/supernull_clipboard.go
+++ b/src/supernull_clipboard.go
@@ -1,0 +1,250 @@
+// IKEMEN:VOID WinMUGEN DisplayToClipboard %n memory-write exploit emulation.
+package main
+
+import (
+	"fmt"
+)
+
+// voidClipboardFormatHasWrite returns true when the format string contains a %n write verb.
+func voidClipboardFormatHasWrite(format string) bool {
+	for i := 0; i < len(format); i++ {
+		if format[i] != '%' {
+			continue
+		}
+		if i+1 < len(format) && format[i+1] == '%' {
+			i++
+			continue
+		}
+		j := i + 1
+		for j < len(format) && (format[j] == ' ' || format[j] == '0' ||
+			format[j] == '-' || format[j] == '+' || format[j] == '#') {
+			j++
+		}
+		for j < len(format) && format[j] >= '0' && format[j] <= '9' {
+			j++
+		}
+		if j < len(format) && format[j] == '.' {
+			j++
+			for j < len(format) && format[j] >= '0' && format[j] <= '9' {
+				j++
+			}
+		}
+		if j < len(format) && format[j] == '*' {
+			j++
+		}
+		if j < len(format) && (format[j] == 'h' || format[j] == 'l' || format[j] == 'L') {
+			j++
+		}
+		if j < len(format) && format[j] == 'n' {
+			return true
+		}
+	}
+	return false
+}
+
+func voidClipboardParamInt(v interface{}) (int32, bool) {
+	switch n := v.(type) {
+	case int32:
+		return n, true
+	case int:
+		return int32(n), true
+	case int64:
+		return int32(n), true
+	case float32:
+		return int32(n), true
+	case float64:
+		return int32(n), true
+	default:
+		return 0, false
+	}
+}
+
+func voidClipboardParseExploitParams(params []interface{}) (memAddr, writeVal int32) {
+	writeVal = 0
+	for _, p := range params {
+		v, ok := voidClipboardParamInt(p)
+		if !ok {
+			continue
+		}
+		if v > 10000 || v < -10000 {
+			memAddr = v
+		} else if v != 0 || writeVal == 0 {
+			writeVal = v
+		}
+	}
+	return memAddr, writeVal
+}
+
+// voidClipboardSplitAtPercentN returns the format prefix printed before the first %n verb.
+func voidClipboardSplitAtPercentN(format string) (prefix string, ok bool) {
+	for i := 0; i < len(format); i++ {
+		if format[i] != '%' {
+			continue
+		}
+		if i+1 >= len(format) {
+			break
+		}
+		if format[i+1] == '%' {
+			i++
+			continue
+		}
+		j := i + 1
+		for j < len(format) && (format[j] == ' ' || format[j] == '0' ||
+			format[j] == '-' || format[j] == '+' || format[j] == '#') {
+			j++
+		}
+		if j < len(format) && format[j] == '*' {
+			j++
+		} else {
+			for j < len(format) && format[j] >= '0' && format[j] <= '9' {
+				j++
+			}
+		}
+		if j < len(format) && format[j] == '.' {
+			j++
+			if j < len(format) && format[j] == '*' {
+				j++
+			} else {
+				for j < len(format) && format[j] >= '0' && format[j] <= '9' {
+					j++
+				}
+			}
+		}
+		if j < len(format) && (format[j] == 'h' || format[j] == 'l' || format[j] == 'L') {
+			j++
+		}
+		if j < len(format) && format[j] == 'n' {
+			return format[:i], true
+		}
+	}
+	return "", false
+}
+
+// voidClipboardParamsBeforeN counts printf params consumed before the %n address param.
+func voidClipboardParamsBeforeN(prefix string) int {
+	n := 0
+	for i := 0; i < len(prefix); i++ {
+		if prefix[i] != '%' {
+			continue
+		}
+		if i+1 >= len(prefix) {
+			break
+		}
+		if prefix[i+1] == '%' {
+			i++
+			continue
+		}
+		j := i + 1
+		for j < len(prefix) && (prefix[j] == ' ' || prefix[j] == '0' ||
+			prefix[j] == '-' || prefix[j] == '+' || prefix[j] == '#') {
+			j++
+		}
+		if j < len(prefix) && prefix[j] == '*' {
+			n++
+			j++
+		} else {
+			for j < len(prefix) && prefix[j] >= '0' && prefix[j] <= '9' {
+				j++
+			}
+		}
+		if j < len(prefix) && prefix[j] == '.' {
+			j++
+			if j < len(prefix) && prefix[j] == '*' {
+				n++
+				j++
+			} else {
+				for j < len(prefix) && prefix[j] >= '0' && prefix[j] <= '9' {
+					j++
+				}
+			}
+		}
+		if j < len(prefix) && (prefix[j] == 'h' || prefix[j] == 'l' || prefix[j] == 'L') {
+			j++
+		}
+		if j < len(prefix) && prefix[j] != '%' {
+			n++
+		}
+		i = j
+	}
+	return n
+}
+
+// voidClipboardEvalPercentN emulates WinMUGEN %n: bytes printed so far are written to the next param address.
+func voidClipboardEvalPercentN(format string, params []interface{}) (memAddr, nWritten int32, ok bool) {
+	prefix, ok := voidClipboardSplitAtPercentN(format)
+	if !ok {
+		return 0, 0, false
+	}
+	paramCount := voidClipboardParamsBeforeN(prefix)
+	if paramCount >= len(params) {
+		return 0, 0, false
+	}
+	if v, ok2 := voidClipboardParamInt(params[paramCount]); ok2 {
+		memAddr = v
+	}
+	if memAddr == 0 {
+		return 0, 0, false
+	}
+	printParams := params
+	if paramCount < len(params) {
+		printParams = params[:paramCount]
+	}
+	out := OldSprintf(prefix, printParams...)
+	nWritten = int32(len(out))
+	return memAddr, nWritten, true
+}
+
+// voidClipboardExploitEmulate intercepts WinMUGEN %n clipboard writes and signals a one-shot KO trigger.
+// Ikemen's OldSprintf does not implement %n memory writes, so VOID must emulate them for all tiers.
+func voidClipboardExploitEmulate(actor *Char, format string, params []interface{}) bool {
+	if !voidRawExecutionActive(actor) && !voidExtremeExploitActive(actor) {
+		return false
+	}
+	if actor == nil || !voidClipboardFormatHasWrite(format) {
+		return false
+	}
+	if !voidActorUsesExploitKO(actor) {
+		return false
+	}
+	voidSignalExploitFrame("clipboard_%n")
+
+	memAddr, nWritten, parsed := voidClipboardEvalPercentN(format, params)
+	if !parsed {
+		memAddr, nWritten = voidClipboardParseExploitParams(params)
+	}
+
+	detail := fmt.Sprintf("format=%q", format)
+	for i, p := range params {
+		if v, ok := voidClipboardParamInt(p); ok {
+			detail += fmt.Sprintf(" param[%v]=%v", i, v)
+		}
+	}
+	if parsed {
+		detail += fmt.Sprintf(" nWritten=%v", nWritten)
+	}
+
+	if memAddr != 0 {
+		voidExploitShadowWrite(memAddr, nWritten)
+	}
+
+	opp := voidExploitPrimaryOpponent(actor)
+	if opp == nil {
+		opp = voidGlobalP2Char()
+	}
+	if opp == nil {
+		if !voidExploitKOCommitted {
+			voidExploitDebugLogOpponentLife(actor, nil, memAddr, "clipboard/%n", nWritten, false,
+				"displayToClipboard", detail)
+		}
+		return true
+	}
+
+	if !voidExploitKOCommitted {
+		if memAddr != 0 {
+			opp.voidExploitWhitelistWrite(actor, memAddr, nWritten, 0, VoidVarInt, false)
+		}
+		voidExploitTriggerKO(actor, opp, memAddr, "displayToClipboard/%n",
+			fmt.Sprintf("WinMUGEN %%n write emulated (n=%v) | %s", nWritten, detail))
+	}
+	return true
+}

--- a/src/supernull_exploit.go
+++ b/src/supernull_exploit.go
@@ -1,0 +1,236 @@
+// IKEMEN:VOID exploit whitelist — allow legacy cheapie memory writes against opponent state.
+package main
+
+import (
+	"fmt"
+)
+
+// voidExploitField maps WinMUGEN-style OOB indices onto Ikemen Char runtime fields.
+type voidExploitField int
+
+const (
+	voidExploitNone voidExploitField = iota
+	voidExploitLife
+	voidExploitPower
+	voidExploitRedLife
+	voidExploitDizzyPoints
+	voidExploitGuardPoints
+)
+
+func voidExploitActor() *Char {
+	if sys.voidBudgetChar != nil {
+		return sys.voidBudgetChar
+	}
+	return sys.workingChar
+}
+
+func voidExploitPrimaryOpponent(c *Char) *Char {
+	if c == nil {
+		return nil
+	}
+	if p2 := c.p2(); p2 != nil && c.isEnemyOf(p2) && p2.helperIndex == 0 {
+		return p2
+	}
+	if e := c.enemy(0); e != nil && e.helperIndex == 0 {
+		return e
+	}
+	for _, slot := range sys.chars {
+		if len(slot) > 0 && slot[0] != nil && slot[0].helperIndex == 0 && c.isEnemyOf(slot[0]) {
+			return slot[0]
+		}
+	}
+	return nil
+}
+
+func voidExploitCharMayCrossWrite(c *Char) bool {
+	if c == nil {
+		return false
+	}
+	gi := c.gi()
+	return gi.voidInvokerProfile() || gi.supernullChar || gi.voidBufferOverflowExploit || voidGodModeActive()
+}
+
+func voidExploitResolveField(raw int32, kind VoidVarKind, val int32) voidExploitField {
+	if kind != VoidVarInt && kind != VoidVarSysInt {
+		return voidExploitNone
+	}
+	if raw >= 0 && raw <= VoidVarMaxIndex {
+		return voidExploitNone
+	}
+	adj := raw
+	if raw < 0 {
+		adj = int32(uint32(-raw))
+	}
+	switch adj % 8 {
+	case 0, 4:
+		return voidExploitLife
+	case 1, 5:
+		return voidExploitPower
+	case 2:
+		return voidExploitRedLife
+	case 3:
+		return voidExploitDizzyPoints
+	case 6:
+		return voidExploitGuardPoints
+	default:
+		return voidExploitLife
+	}
+}
+
+func voidExploitApplyFieldWrite(target *Char, field voidExploitField, val int32, valF float32, kind VoidVarKind, add bool) BytecodeValue {
+	switch field {
+	case voidExploitLife:
+		if actor := voidExploitActor(); actor != nil && voidSoulabyssShouldDeferKO(actor) && actor.isEnemyOf(target) {
+			return voidSoulabyssStageOpponentField(target, field, val, add)
+		}
+		if kind == VoidVarFloat || kind == VoidVarSysFloat {
+			if add {
+				target.lifeAdd(float64(valF), true, true)
+			} else {
+				target.lifeSet(int32(valF))
+			}
+		} else if add {
+			target.lifeAdd(float64(val), true, true)
+		} else {
+			target.lifeSet(val)
+		}
+		if target.life <= 0 {
+			target.setSCF(SCF_ko)
+			if actor := voidExploitActor(); actor != nil && actor.isEnemyOf(target) {
+				voidExploitTriggerKO(actor, target, 0, "exploit_field_write",
+					fmt.Sprintf("life<=%v add=%v", val, add))
+			}
+		}
+		return BytecodeInt(target.life)
+	case voidExploitPower:
+		if add {
+			target.power += val
+		} else {
+			target.power = val
+		}
+		return BytecodeInt(target.power)
+	case voidExploitRedLife:
+		if add {
+			target.redLife += val
+		} else {
+			target.redLife = val
+		}
+		return BytecodeInt(target.redLife)
+	case voidExploitDizzyPoints:
+		if add {
+			target.dizzyPoints += val
+		} else {
+			target.dizzyPoints = val
+		}
+		return BytecodeInt(target.dizzyPoints)
+	case voidExploitGuardPoints:
+		if add {
+			target.guardPoints += val
+		} else {
+			target.guardPoints = val
+		}
+		return BytecodeInt(target.guardPoints)
+	default:
+		if kind == VoidVarFloat || kind == VoidVarSysFloat {
+			return BytecodeFloat(valF)
+		}
+		return BytecodeInt(val)
+	}
+}
+
+func voidExploitFieldRead(target *Char, field voidExploitField, kind VoidVarKind) BytecodeValue {
+	switch field {
+	case voidExploitLife:
+		return BytecodeInt(target.life)
+	case voidExploitPower:
+		return BytecodeInt(target.power)
+	case voidExploitRedLife:
+		return BytecodeInt(target.redLife)
+	case voidExploitDizzyPoints:
+		return BytecodeInt(target.dizzyPoints)
+	case voidExploitGuardPoints:
+		return BytecodeInt(target.guardPoints)
+	default:
+		if kind == VoidVarFloat || kind == VoidVarSysFloat {
+			return BytecodeFloat(0)
+		}
+		return BytecodeInt(0)
+	}
+}
+
+func (target *Char) voidExploitWhitelistWrite(actor *Char, raw int32, val int32, valF float32, kind VoidVarKind, add bool) (BytecodeValue, bool) {
+	if actor == nil || target == nil {
+		return BytecodeUndefined(), false
+	}
+	if !voidGodModeActive() && !voidExtenderActive(actor) {
+		return BytecodeUndefined(), false
+	}
+	if !actor.isEnemyOf(target) || target.helperIndex != 0 {
+		return BytecodeUndefined(), false
+	}
+	field := voidExploitResolveField(raw, kind, val)
+	if field == voidExploitNone {
+		if kind == VoidVarInt || kind == VoidVarSysInt {
+			field = voidExploitLife
+		} else {
+			return BytecodeUndefined(), false
+		}
+	}
+	sys.supernullRecordFingerprint("exploit_whitelist", actor, actor.ss.no, raw,
+		fmt.Sprintf("write opponent=%q P%v field=%v val=%v add=%v kind=%s",
+			target.name, target.playerNo+1, field, val, add, target.voidVarKindName(kind)))
+	if voidSoulabyssShouldDeferKO(actor) {
+		return voidSoulabyssStageOpponentField(target, field, val, add), true
+	}
+	return voidExploitApplyFieldWrite(target, field, val, valF, kind, add), true
+}
+
+func (target *Char) voidExploitWhitelistRead(actor *Char, raw int32, kind VoidVarKind) (BytecodeValue, bool) {
+	if actor == nil || target == nil {
+		return BytecodeUndefined(), false
+	}
+	if v, ok := voidExploitShadowRead(raw); ok {
+		if kind == VoidVarFloat || kind == VoidVarSysFloat {
+			return BytecodeFloat(float32(v)), true
+		}
+		return BytecodeInt(v), true
+	}
+	if voidExploitKOCommitted && voidExploitKOTarget != nil && actor != nil && actor.isEnemyOf(target) {
+		if kind == VoidVarInt || kind == VoidVarSysInt {
+			return voidExploitFieldRead(target, voidExploitLife, kind), true
+		}
+	}
+	if !voidGodModeActive() && !voidExtenderActive(actor) {
+		return BytecodeUndefined(), false
+	}
+	if !actor.isEnemyOf(target) || target.helperIndex != 0 {
+		return BytecodeUndefined(), false
+	}
+	field := voidExploitResolveField(raw, kind, 0)
+	if field == voidExploitNone {
+		if kind == VoidVarInt || kind == VoidVarSysInt {
+			field = voidExploitLife
+		} else {
+			return BytecodeUndefined(), false
+		}
+	}
+	if voidSoulabyssShouldDeferKO(actor) {
+		if bv, ok := voidSoulabyssStagedLifeRead(target, field); ok {
+			return bv, true
+		}
+	}
+	return voidExploitFieldRead(target, field, kind), true
+}
+
+func (c *Char) voidExploitTryCrossPlayerSelfWrite(actor *Char, raw int32, val int32, valF float32, kind VoidVarKind, add bool) (BytecodeValue, bool) {
+	if c != actor || !voidExploitCharMayCrossWrite(actor) {
+		return BytecodeUndefined(), false
+	}
+	opp := voidExploitPrimaryOpponent(actor)
+	if opp == nil {
+		return BytecodeUndefined(), false
+	}
+	sys.supernullRecordFingerprint("exploit_cross_player", actor, actor.ss.no, raw,
+		fmt.Sprintf("self OOB -> opponent=%q P%v val=%v", opp.name, opp.playerNo+1, val))
+	return opp.voidExploitWhitelistWrite(actor, raw, val, valF, kind, add)
+}

--- a/src/supernull_invoker.go
+++ b/src/supernull_invoker.go
@@ -1,0 +1,416 @@
+// IKEMEN:VOID Supernull:Invoker — UnsafeVM raw bytecode bypass for corrupt CNS kill chains.
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"unicode"
+)
+
+// VoidSupernullProfile distinguishes Invoker (in-match bytecode kills) from Replacer (file/script swaps).
+type VoidSupernullProfile int
+
+const (
+	VoidProfileNone VoidSupernullProfile = iota
+	VoidProfileReplacer
+	VoidProfileInvoker
+)
+
+func voidProfileName(p VoidSupernullProfile) string {
+	switch p {
+	case VoidProfileReplacer:
+		return "replacer"
+	case VoidProfileInvoker:
+		return "invoker"
+	default:
+		return "none"
+	}
+}
+
+func (gi *CharGlobalInfo) voidInvokerProfile() bool {
+	return gi != nil && gi.voidProfile == VoidProfileInvoker
+}
+
+// voidUnsafeVMActiveForPlayer is true when this roster slot compiles/runs in raw UnsafeVM mode.
+func voidUnsafeVMActiveForPlayer(pn int) bool {
+	if pn < 0 || pn >= len(sys.cgi) {
+		return false
+	}
+	return sys.cgi[pn].voidInvokerProfile()
+}
+
+func voidUnsafeVMActive(c *Char) bool {
+	if c == nil {
+		c = sys.voidBudgetChar
+		if c == nil {
+			c = sys.workingChar
+		}
+	}
+	if c == nil {
+		return false
+	}
+	return voidUnsafeVMActiveForPlayer(c.playerNo)
+}
+
+func (c *CharCompiler) voidUnsafeVMCompile() bool {
+	return voidUnsafeVMActiveForPlayer(c.playerNo)
+}
+
+func (c *CharCompiler) voidCompilePermissive() bool {
+	return c.voidUnsafeVMCompile() || c.voidGodModeCompile()
+}
+
+func (c *CharCompiler) voidParserAbsorbCompile(err error, category, location string) error {
+	if err == nil {
+		return nil
+	}
+	if c.voidUnsafeVMCompile() {
+		return nil
+	}
+	if c.voidGodModeCompile() {
+		return voidParserAbsorb(err, category, location)
+	}
+	return err
+}
+
+func (c *CharCompiler) voidUnsafeVMTrigger() BytecodeExp {
+	var be BytecodeExp
+	be.appendValue(BytecodeBool(true))
+	return be
+}
+
+func voidInvokerCaptureTrigger(c *CharCompiler, raw string) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return
+	}
+	if voidInvokerPayloadLooksLethal(raw) {
+		c.voidInvokerTriggers = append(c.voidInvokerTriggers, raw)
+		voidExploitInterceptRawCNS(c.playerNo, c.stateNo, "invoker_trigger", raw)
+	}
+}
+
+func voidInvokerPayloadLooksLethal(raw string) bool {
+	if len(raw) < 16 {
+		return false
+	}
+	u := strings.ToUpper(raw)
+	if strings.Contains(u, "HELLHELL") || strings.Contains(raw, "MNAE") {
+		return true
+	}
+	if strings.Contains(strings.ToLower(raw), "assertspecial") && len(raw) >= 32 {
+		return true
+	}
+	return voidExtractSupernullOverflow(raw)
+}
+
+func voidNormalizeCharRelPath(rel, def string) string {
+	rel = strings.TrimSpace(strings.ReplaceAll(rel, "\\", "/"))
+	if rel == "" {
+		return ""
+	}
+	if filepath.IsAbs(rel) {
+		return strings.ToLower(filepath.ToSlash(rel))
+	}
+	dir := voidCharDefDirectory(def)
+	if dir == "" {
+		return strings.ToLower(rel)
+	}
+	return strings.ToLower(filepath.ToSlash(filepath.Join(dir, rel)))
+}
+
+func voidCNSDataLooksInvoker(raw string) bool {
+	if len(raw) < 64 {
+		return false
+	}
+	if strings.Contains(raw, "MNAE") || strings.Contains(strings.ToUpper(raw), "HELLHELL") {
+		return true
+	}
+	low := strings.ToLower(raw)
+	if !strings.Contains(low, "type = assertspecial") && !strings.Contains(low, "type=assertspecial") {
+		return false
+	}
+	for _, line := range strings.Split(raw, "\n") {
+		l := strings.TrimSpace(strings.ToLower(line))
+		if !strings.HasPrefix(l, "flag") {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		val := strings.TrimSpace(parts[1])
+		if len(val) < 24 {
+			continue
+		}
+		nonIdent := 0
+		for _, r := range val {
+			if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' {
+				nonIdent++
+			}
+		}
+		if nonIdent > 4 {
+			return true
+		}
+	}
+	return false
+}
+
+// voidPreDetectInvokerProfile tags Supernull:Invoker cheapies before CNS compile.
+func voidPreDetectInvokerProfile(pn int, def string, st []string, cmd, anim, cns string) {
+	if pn < 0 || pn >= len(sys.cgi) {
+		return
+	}
+	gi := &sys.cgi[pn]
+	if gi.voidProfile == VoidProfileInvoker {
+		return
+	}
+	if gi.voidver[0] >= 7 {
+		voidMarkInvokerProfile(pn, "voidversion>=7")
+		return
+	}
+	cmdN := voidNormalizeCharRelPath(cmd, def)
+	if cmdN == "" {
+		return
+	}
+	animN := voidNormalizeCharRelPath(anim, def)
+	cnsN := voidNormalizeCharRelPath(cns, def)
+	aliasCount := 0
+	if animN != "" && animN == cmdN {
+		aliasCount++
+	}
+	if cnsN != "" && cnsN == cmdN {
+		aliasCount++
+	}
+	allStSame := len(st) > 0
+	for _, s := range st {
+		if voidNormalizeCharRelPath(s, def) != cmdN {
+			allStSame = false
+			break
+		}
+	}
+	if !allStSame {
+		return
+	}
+	if cmdN != "" && animN == cmdN && cnsN == cmdN {
+		voidMarkInvokerProfile(pn, "four_way_cns_alias:"+filepath.Base(cmd))
+		return
+	}
+	if aliasCount == 0 && len(st) < 2 {
+		return
+	}
+	searchDirs := []string{def, "", sys.motif.Def, "data/"}
+	defaultDir := filepath.ToSlash(filepath.Join(filepath.Dir(def), ""))
+	for _, rel := range append(append([]string{}, st...), cmd) {
+		rel = strings.TrimSpace(rel)
+		if rel == "" {
+			continue
+		}
+		resolved := SearchFile(rel, searchDirs, defaultDir)
+		if resolved == "" {
+			continue
+		}
+		txt, err := LoadText(resolved)
+		if err != nil || !voidCNSDataLooksInvoker(txt) {
+			continue
+		}
+		voidMarkInvokerProfile(pn, fmt.Sprintf("alias_cns:%s", filepath.Base(rel)))
+		return
+	}
+}
+
+func voidMarkInvokerProfile(pn int, reason string) {
+	if pn < 0 || pn >= len(sys.cgi) {
+		return
+	}
+	gi := &sys.cgi[pn]
+	if gi.voidProfile == VoidProfileInvoker {
+		return
+	}
+	gi.voidProfile = VoidProfileInvoker
+	gi.supernullChar = true
+	if gi.voidTier < VoidTierSupernull {
+		gi.voidTier = VoidTierSupernull
+	}
+	sys.voidRefreshMatchExtender()
+	sys.voidMarkBurstEligible()
+	sys.supernullRecordFingerprint("invoker_profile", nil, 0, 0,
+		fmt.Sprintf("P%v %q: %s", pn+1, gi.displayname, reason))
+	LogMessage("IKEMEN:VOID: Supernull:Invoker UnsafeVM P%v (%q) — %s", pn+1, gi.name, reason)
+}
+
+// voidMarkInvokerAtLoad tags Invoker cheapies as soon as the DEF [Files] section is parsed.
+func voidMarkInvokerAtLoad(pn int, def string, is IniSection) {
+	if pn < 0 || pn >= len(sys.cgi) {
+		return
+	}
+	cmd := strings.TrimSpace(decodeShiftJIS(is["cmd"]))
+	cns := strings.TrimSpace(decodeShiftJIS(is["cns"]))
+	anim := strings.TrimSpace(decodeShiftJIS(is["anim"]))
+	st := strings.TrimSpace(decodeShiftJIS(is["st"]))
+	if cmd == "" {
+		return
+	}
+	if cmd == cns && cmd == anim && (st == "" || st == cmd) {
+		voidMarkInvokerProfile(pn, "four_way_cns_alias:"+filepath.Base(cmd))
+	}
+}
+
+func voidInvokerActorOnTeam() *Char {
+	for pn := range sys.chars {
+		if pn < 0 || pn >= len(sys.cgi) || !voidUnsafeVMActiveForPlayer(pn) {
+			continue
+		}
+		if len(sys.chars[pn]) > 0 && sys.chars[pn][0] != nil && sys.chars[pn][0].helperIndex == 0 {
+			return sys.chars[pn][0]
+		}
+	}
+	return nil
+}
+
+// voidInvokerStripKoProtection clears NoKO guards on the victim so Invoker kills cannot be vetoed.
+func voidInvokerStripKoProtection(target *Char) {
+	if target == nil {
+		return
+	}
+	target.unsetASF(ASF_noko | ASF_noguardko | ASF_nokovelocity | ASF_nokofall)
+}
+
+// voidInvokerApplyLifeKill hard-overrides life on the opponent — ignores NoKO, roundNoDamage, and clamps.
+func voidInvokerApplyLifeKill(actor, target *Char, life int32, path string) {
+	if actor == nil || target == nil {
+		return
+	}
+	voidInvokerStripKoProtection(target)
+	target.life = life
+	target.redLife = 0
+	if life <= 0 {
+		target.setSCF(SCF_ko)
+		target.unsetSCF(SCF_ctrl)
+		voidGlobalP2LifeWrite(0, 0, VoidVarInt, false)
+		voidExploitTriggerKO(actor, target, 0, path, fmt.Sprintf("invoker life hard-set %v", life))
+	}
+	voidExploitDebugLogOpponentLife(actor, target, -1, "LifeSet", life, true, path,
+		"invoker hard override")
+}
+
+func voidInvokerForceOpponentKO(actor *Char) {
+	if actor == nil || voidExploitKOCommitted {
+		return
+	}
+	opp := voidExploitPrimaryOpponent(actor)
+	if opp == nil {
+		opp = voidGlobalP2Char()
+	}
+	if opp == nil || !opp.alive() {
+		return
+	}
+	voidInvokerApplyLifeKill(actor, opp, 0, "invoker_force_ko")
+}
+
+// voidInvokerSctrlFromSection builds a raw-payload controller from a malformed sctrl block.
+func (c *CharCompiler) voidInvokerSctrlFromSection(is IniSection) StateController {
+	if len(is) == 0 {
+		return nil
+	}
+	payloads := make([]string, 0, len(is))
+	for k, v := range is {
+		k = strings.TrimSpace(k)
+		v = strings.TrimSpace(v)
+		if k == "" {
+			continue
+		}
+		raw := k + "=" + v
+		payloads = append(payloads, raw)
+		voidExploitInterceptRawCNS(c.playerNo, c.stateNo, "invoker_"+k, v)
+	}
+	if len(payloads) == 0 {
+		return nil
+	}
+	return voidInvokerPayload{payloads: payloads}
+}
+
+type voidInvokerPayload struct {
+	payloads []string
+}
+
+func (sc voidInvokerPayload) Run(c *Char, _ []int32) bool {
+	opp := voidExploitPrimaryOpponent(c)
+	if opp == nil {
+		opp = voidGlobalP2Char()
+	}
+	for _, raw := range sc.payloads {
+		voidInvokerExecutePayload(c, raw)
+		if opp != nil && voidInvokerPayloadLooksLethal(raw) {
+			voidInvokerApplyLifeKill(c, opp, 0, "invoker_sctrl_run")
+			if voidExploitKOCommitted {
+				return false
+			}
+		}
+	}
+	return false
+}
+
+func voidInvokerExecutePayload(c *Char, raw string) {
+	if c == nil || strings.TrimSpace(raw) == "" {
+		return
+	}
+	pn := c.playerNo
+	defPath := c.gi().def
+	voidApplyExecPayloadTier(pn, c.ss.no, "invoker", raw, defPath)
+}
+
+// voidInvokerMatchTick fires compiled state -1 kill payloads and forces P2 KO for Invoker chars.
+func voidInvokerMatchTick() {
+	if voidExploitKOCommitted || sys.roundState() <= 0 {
+		return
+	}
+	for pn := range sys.chars {
+		if pn < 0 || pn >= len(sys.cgi) || !voidUnsafeVMActiveForPlayer(pn) {
+			continue
+		}
+		if len(sys.chars[pn]) == 0 || sys.chars[pn][0] == nil {
+			continue
+		}
+		c := sys.chars[pn][0]
+		if sb, ok := c.gi().states[-1]; ok {
+			voidInvokerRunPayloadsFromBlock(c, sb)
+		}
+		voidInvokerForceOpponentKO(c)
+		if voidExploitKOCommitted {
+			return
+		}
+	}
+}
+
+func voidInvokerRunPayloadsFromBlock(c *Char, sb StateBytecode) {
+	opp := voidExploitPrimaryOpponent(c)
+	if opp == nil {
+		opp = voidGlobalP2Char()
+	}
+	if opp == nil {
+		return
+	}
+	voidInvokerWalkBlock(c, opp, &sb.block)
+}
+
+func voidInvokerWalkBlock(c, opp *Char, b *StateBlock) {
+	for _, sc := range b.ctrls {
+		switch v := sc.(type) {
+		case StateBlock:
+			voidInvokerWalkBlock(c, opp, &v)
+		case voidInvokerPayload:
+			for _, raw := range v.payloads {
+				voidInvokerExecutePayload(c, raw)
+				if voidInvokerPayloadLooksLethal(raw) {
+					voidInvokerApplyLifeKill(c, opp, 0, "invoker_payload")
+				}
+				if voidExploitKOCommitted {
+					return
+				}
+			}
+		}
+	}
+}
+

--- a/src/supernull_invoker_test.go
+++ b/src/supernull_invoker_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestVoidCNSDataLooksInvoker(t *testing.T) {
+	raw := strings.Repeat("x", 80) + "\n[State 0]\ntype = AssertSpecial\nflag = qBHELLHELLHELLHELLHELLHELLHELLzr@\n"
+	if !voidCNSDataLooksInvoker(raw) {
+		t.Fatal("expected invoker CNS signature")
+	}
+	if voidCNSDataLooksInvoker("type = ChangeState\nvalue = 0") {
+		t.Fatal("vanilla CNS should not match invoker heuristic")
+	}
+}
+
+func TestVoidInvokerPayloadLooksLethal(t *testing.T) {
+	if !voidInvokerPayloadLooksLethal(`command="uCHELLHELLHELLHELLHELLHELLHELLHELLHELLHELLHELLHELLHELLHELLHELLHEAFA"`) {
+		t.Fatal("HELLHELL trigger should be lethal")
+	}
+}
+
+func TestVoidUnsafeVMActiveForPlayer(t *testing.T) {
+	sys.cgi = make([]CharGlobalInfo, 2)
+	voidMarkInvokerProfile(0, "test")
+	if !voidUnsafeVMActiveForPlayer(0) {
+		t.Fatal("invoker profile should enable UnsafeVM")
+	}
+	if voidUnsafeVMActiveForPlayer(1) {
+		t.Fatal("non-invoker slot should not enable UnsafeVM")
+	}
+}

--- a/src/supernull_parser.go
+++ b/src/supernull_parser.go
@@ -1,0 +1,498 @@
+// IKEMEN:VOID God Mode parser — soft-fail CNS/CMD/ZSS compilation for corrupted supernull chars.
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	voidParserDetailMax              = 120
+	VoidBufferOverflowMinLen         = 100
+	voidAutoDetectUltranullCNSBytes  = 256 * 1024  // single CNS ≥256 KiB
+	voidAutoDetectFrostCNSBytes      = 2 * 1024 * 1024
+	voidAutoDetectUltranullStateCount = 5000
+	voidAutoDetectFrostStateCount    = 15000
+)
+
+var (
+	voidParserMu        sync.Mutex
+	voidParserCounts    = map[string]int{}
+	voidExploitDebugMu  sync.Mutex
+	voidExploitDebugPath = "save/exploit_debug.txt"
+)
+
+// voidExploitDebugReset truncates the debug log at match start.
+func voidExploitDebugReset() {
+	voidExploitDebugInit()
+	voidExploitDebugWrite("--- match round 1 reset ---\n")
+}
+
+// voidExploitDebugInit creates save/exploit_debug.txt at engine startup.
+func voidExploitDebugInit() {
+	if !voidExploitsEnabled {
+		return
+	}
+	voidExploitDebugMu.Lock()
+	defer voidExploitDebugMu.Unlock()
+	_ = os.MkdirAll("save", 0755)
+	header := fmt.Sprintf("IKEMEN:VOID exploit debug log\nstarted=%s\npath=%s\n\n",
+		time.Now().Format("2006-01-02 15:04:05"), voidExploitDebugPath)
+	_ = os.WriteFile(voidExploitDebugPath, []byte(header), 0644)
+}
+
+func voidExploitDebugWrite(msg string) {
+	if !voidExploitsEnabled {
+		return
+	}
+	voidExploitDebugMu.Lock()
+	defer voidExploitDebugMu.Unlock()
+	_ = os.MkdirAll("save", 0755)
+	f, err := os.OpenFile(voidExploitDebugPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return
+	}
+	_, _ = f.WriteString(msg)
+	_ = f.Close()
+}
+
+// voidExploitDebugLogOpponentLife appends one P2-life write attempt to exploit_debug.txt.
+// memAddr is the raw var index or -1 for direct LifeSet/LifeAdd sctrl paths.
+func voidExploitDebugLogOpponentLife(actor, target *Char, memAddr int32, addrKind string, value int32, allowed bool, path, detail string) {
+	if !voidExtenderActive(actor) {
+		return
+	}
+	voidExploitDebugMu.Lock()
+	defer voidExploitDebugMu.Unlock()
+
+	actorName := "<unknown>"
+	if actor != nil {
+		actorName = actor.name
+		if actorName == "" {
+			actorName = fmt.Sprintf("P%v", actor.playerNo+1)
+		}
+	}
+	targetLabel := "<none>"
+	if target != nil {
+		targetLabel = fmt.Sprintf("%s (P%v)", target.name, target.playerNo+1)
+		if target.name == "" {
+			targetLabel = fmt.Sprintf("P%v", target.playerNo+1)
+		}
+	}
+	outcome := "ALLOWED"
+	if !allowed {
+		outcome = "BLOCKED"
+	}
+	addrLabel := fmt.Sprintf("%v", memAddr)
+	if addrKind != "" {
+		addrLabel = fmt.Sprintf("%v (%s)", memAddr, addrKind)
+	}
+	line := fmt.Sprintf("%s | actor=%q | target=%s | mem_addr=%s | value=%v | outcome=%s | path=%s",
+		time.Now().Format("2006-01-02 15:04:05.000"), actorName, targetLabel, addrLabel, value, outcome, path)
+	if detail != "" {
+		line += " | detail=" + detail
+	}
+	line += "\n"
+	f, err := os.OpenFile(voidExploitDebugPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return
+	}
+	_, _ = f.WriteString(line)
+	_ = f.Close()
+}
+
+// voidExploitDebugShouldLogP2Life returns true when this write plausibly targets opponent life.
+func voidExploitDebugShouldLogP2Life(actor, target *Char, raw int32, kind VoidVarKind) bool {
+	if actor == nil || target == nil {
+		return false
+	}
+	opp := voidExploitPrimaryOpponent(actor)
+	if opp == nil {
+		return false
+	}
+	if target.playerNo != opp.playerNo {
+		return false
+	}
+	if !actor.isEnemyOf(target) {
+		return false
+	}
+	maxLegal := voidVarMaxLegal(kind)
+	if raw >= 0 && raw <= maxLegal {
+		return false
+	}
+	return voidExploitResolveField(raw, kind, 0) == voidExploitLife || kind == VoidVarInt || kind == VoidVarSysInt
+}
+
+// voidGodModeActiveForPlayer is true when compile-time soft-fail applies to one roster slot.
+func voidGodModeActiveForPlayer(pn int) bool {
+	if voidUnsafeVMActiveForPlayer(pn) {
+		return true
+	}
+	if voidExtremeExploitActiveForPlayer(pn) {
+		return true
+	}
+	if sys.cfg.Void.GodModeParser {
+		return true
+	}
+	if pn < 0 || pn >= len(sys.cgi) {
+		return false
+	}
+	return sys.cgi[pn].voidTagged()
+}
+
+func (c *CharCompiler) voidGodModeCompile() bool {
+	return voidGodModeActiveForPlayer(c.playerNo)
+}
+
+// voidGodModeActive is true only when global parser god-mode is explicitly enabled.
+func voidGodModeActive() bool {
+	return sys.cfg.Void.GodModeParser
+}
+
+func voidParserSanitize(s string) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.TrimSpace(s)
+	if len(s) > voidParserDetailMax {
+		return s[:voidParserDetailMax] + "..."
+	}
+	return s
+}
+
+// voidAutoDetectCheapie flags heavy cheapies that need burst/unlimited ops without manual voidversion.
+func voidAutoDetectCheapie(pn int, def string, cnsFiles []string, states map[int32]StateBytecode) {
+	if pn < 0 || pn >= len(sys.cgi) {
+		return
+	}
+	gi := &sys.cgi[pn]
+	if gi.voidver[0] != 0 || gi.voidver[1] != 0 || gi.voidver[2] != 0 {
+		voidScanBundledExploitFiles(pn, def)
+		return
+	}
+	searchDirs := []string{def, "", sys.motif.Def, "data/"}
+	defaultDir := filepath.ToSlash(filepath.Join(filepath.Dir(def), ""))
+
+	nextTier := gi.voidTier
+	var reasons []string
+
+	for _, rel := range cnsFiles {
+		rel = strings.TrimSpace(rel)
+		if rel == "" {
+			continue
+		}
+		base := strings.ToLower(filepath.Base(rel))
+		if strings.Contains(base, "_null") && strings.HasSuffix(base, ".cns") {
+			if nextTier < VoidTierUltranull {
+				nextTier = VoidTierUltranull
+			}
+			reasons = append(reasons, "null_cns:"+base)
+		}
+		if strings.Contains(base, "null") && strings.HasSuffix(base, ".cns") && nextTier < VoidTierUltranull {
+			nextTier = VoidTierUltranull
+			reasons = append(reasons, "null_name:"+base)
+		}
+		if size := voidResolvedSourceSize(rel, searchDirs, defaultDir); size > 0 {
+			switch {
+			case size >= voidAutoDetectFrostCNSBytes:
+				nextTier = VoidTierFrost
+				reasons = append(reasons, fmt.Sprintf("cns_bytes:%v:%v", base, size))
+			case size >= voidAutoDetectUltranullCNSBytes && nextTier < VoidTierUltranull:
+				nextTier = VoidTierUltranull
+				reasons = append(reasons, fmt.Sprintf("cns_bytes:%v:%v", base, size))
+			}
+		}
+	}
+
+	stateCount := len(states)
+	switch {
+	case stateCount >= voidAutoDetectFrostStateCount:
+		nextTier = VoidTierFrost
+		reasons = append(reasons, fmt.Sprintf("states=%v", stateCount))
+	case stateCount >= voidAutoDetectUltranullStateCount && nextTier < VoidTierUltranull:
+		nextTier = VoidTierUltranull
+		reasons = append(reasons, fmt.Sprintf("states=%v", stateCount))
+	}
+
+	if nextTier <= VoidTierNull && len(reasons) == 0 {
+		voidScanBundledExploitFiles(pn, def)
+		return
+	}
+	gi.supernullChar = true
+	if nextTier > gi.voidTier {
+		gi.voidTier = nextTier
+	}
+	voidScanBundledExploitFiles(pn, def)
+	sys.voidRefreshMatchExtender()
+	sys.voidMarkBurstEligible()
+	detail := strings.Join(reasons, "; ")
+	sys.supernullRecordFingerprint("auto_detect", nil, 0, 0,
+		fmt.Sprintf("P%v %q tier=%s: %s", pn+1, gi.displayname, voidTierName(gi.voidTier), detail))
+	LogMessage("IKEMEN:VOID: Auto-detected cheapie P%v (%q) tier=%s — %s", pn+1, gi.name, voidTierName(gi.voidTier), detail)
+}
+
+// voidAutoDetectSoulabyssPattern flags Rin-style cheapies that hide CNS under system/.system + option.txt.
+func voidAutoDetectSoulabyssPattern(pn int, def string, st []string) {
+	if pn < 0 || pn >= len(sys.cgi) {
+		return
+	}
+	dir := voidCharDefDirectory(def)
+	if dir == "" {
+		return
+	}
+	systemCns := filepath.ToSlash(filepath.Join(dir, "system/.system"))
+	if FileExist(systemCns) == "" {
+		return
+	}
+	hasOption := false
+	for _, rel := range st {
+		base := strings.ToLower(filepath.Base(strings.TrimSpace(rel)))
+		if base == "option.txt" || strings.Contains(base, "option") {
+			hasOption = true
+			break
+		}
+	}
+	if !hasOption {
+		return
+	}
+	gi := &sys.cgi[pn]
+	gi.supernullChar = true
+	voidEscalatePlayerTier(pn, VoidTierSupernull, "Soulabyss-style system/.system + option.txt")
+	LogMessage("IKEMEN:VOID: Soulabyss pattern P%v (%q) — Supernull tier", pn+1, gi.displayname)
+}
+
+// voidMarkSoulabyssAtLoad tags Rin-style cheapies as soon as their DEF is parsed (before state compile).
+func voidMarkSoulabyssAtLoad(pn int, def, cns string) {
+	if pn < 0 || pn >= len(sys.cgi) {
+		return
+	}
+	dir := voidCharDefDirectory(def)
+	if dir == "" {
+		return
+	}
+	systemCns := filepath.ToSlash(filepath.Join(dir, "system/.system"))
+	if FileExist(systemCns) == "" {
+		return
+	}
+	cns = strings.ToLower(strings.TrimSpace(cns))
+	if cns != "" && !strings.Contains(cns, "system/.system") && !strings.Contains(cns, "system\\.system") {
+		return
+	}
+	gi := &sys.cgi[pn]
+	gi.supernullChar = true
+	if gi.voidTier < VoidTierSupernull {
+		gi.voidTier = VoidTierSupernull
+	}
+	sys.voidRefreshMatchExtender()
+	LogMessage("IKEMEN:VOID: Soulabyss load tag P%v (%q)", pn+1, gi.displayname)
+}
+
+const (
+	voidSoulabyssProbeAnimA int32 = -7235922
+	voidSoulabyssProbeAnimB int32 = -7235954
+)
+
+// voidSoulabyssCompat is true ONLY for Infinite Soulabyss–class chars (folder trust:
+// system/.system). Dual-mode high-tier gate uses the same folder signal — no name checks.
+func voidSoulabyssCompat(c *Char) bool {
+	if c == nil {
+		return false
+	}
+	return voidIsSoulabyssPn(c.playerNo)
+}
+
+// voidSoulabyssBlockErrorState suppresses Infinite Soulabyss anti-tamper trap SelfStates
+// (140/3000/4000) while the layer cook is active. Dual-mode already stops *engine* combat
+// yanks via voidHighTierState; this only blocks the character's own failsafe plates that
+// abort the WinMUGEN layer path. After KO arm / finish, traps are allowed again.
+func voidSoulabyssBlockErrorState(c *Char, no int32) bool {
+	if !voidSoulabyssCompat(c) && !(c != nil && voidIsSoulabyssPn(c.playerNo)) {
+		return false
+	}
+	if voidSoulabyssKOArmed || voidExploitKOCommitted {
+		return false
+	}
+	switch no {
+	case 140, 3000, 4000:
+		return true
+	case 0:
+		return c.minus == -2 && sys.roundState() > 0
+	default:
+		return false
+	}
+}
+
+// voidSoulabyssSuppressMinus2Pause skips infinite Pause/SuperPause traps from state -2 on Soulabyss cheapies.
+func voidSoulabyssSuppressMinus2Pause(c *Char, t int32) bool {
+	if !voidSoulabyssCompat(c) || c.minus != -2 {
+		return false
+	}
+	return t <= 0 || t >= 65535
+}
+
+func voidResolvedSourceSize(rel string, dirs []string, defaultDir string) int64 {
+	resolved := SearchFile(rel, dirs, defaultDir)
+	if resolved == "" {
+		return 0
+	}
+	if isZip, zipPath, inner := IsZipPath(resolved); isZip {
+		if inner == "" {
+			if info, err := os.Stat(zipPath); err == nil {
+				return info.Size()
+			}
+		}
+		return 0
+	}
+	if info, err := os.Stat(resolved); err == nil {
+		return info.Size()
+	}
+	return 0
+}
+
+// voidExploitInterceptCompile detects Secretary/Postman exec payloads and Supernull parser overflows.
+func voidExploitInterceptCompile(pn int, stateNo int32, category, raw string) {
+	if pn < 0 || pn >= len(sys.cgi) {
+		return
+	}
+	gi := &sys.cgi[pn]
+	defPath := gi.def
+	voidApplyExecPayloadTier(pn, stateNo, category, raw, defPath)
+	if !voidExtractSupernullOverflow(raw) {
+		return
+	}
+	gi.voidBufferOverflowExploit = true
+	gi.supernullChar = true
+	sys.voidRefreshMatchExtender()
+	sys.voidMarkBurstEligible()
+	sys.supernullRecordFingerprint("buffer_overflow_attempt", nil, stateNo, int32(len(raw)),
+		fmt.Sprintf("%s len=%v payload=%s", category, len(raw), voidParserSanitize(raw)))
+	LogMessage("IKEMEN:VOID: Buffer overflow attempt flagged on P%v state %v (%s, %v bytes)",
+		pn+1, stateNo, category, len(raw))
+}
+
+func voidParserWarnCompile(pn int, stateNo int32, category, detail string) {
+	if !voidGodModeActiveForPlayer(pn) {
+		return
+	}
+	voidParserWarn(category, detail)
+}
+
+// voidExploitInterceptRawCNS flags buffer-overflow payloads from raw CNS/CMD text only.
+// Parser error strings must not pass through here — long compile warnings were falsely
+// marking entire rosters as exploit chars and triggering instant opponent KOs.
+func voidExploitInterceptRawCNS(pn int, stateNo int32, category, raw string) {
+	voidExploitInterceptCompile(pn, stateNo, category, raw)
+}
+
+func voidParserWarn(category, detail string) {
+	if !voidGodModeActive() {
+		return
+	}
+	detail = voidParserSanitize(detail)
+	voidParserMu.Lock()
+	voidParserCounts[category]++
+	voidParserMu.Unlock()
+	sys.supernullRecordFingerprint("parser_"+category, nil, 0, 0, detail)
+}
+
+// voidParserAbsorb logs a compile-time error and returns nil so loading continues.
+func voidParserAbsorb(err error, category, location string) error {
+	if err == nil || !voidGodModeActive() {
+		return err
+	}
+	msg := err.Error()
+	if location != "" {
+		msg = location + ": " + msg
+	}
+	voidParserWarn(category, voidParserSanitize(msg))
+	return nil
+}
+
+// voidParserBeginScope forces ignoreMostErrors for the duration of character compilation.
+func voidParserBeginScope() func() {
+	prev := sys.ignoreMostErrors
+	if voidGodModeActive() {
+		sys.ignoreMostErrors = true
+	}
+	return func() {
+		sys.ignoreMostErrors = prev
+	}
+}
+
+func voidParserBeginScopeForPlayer(pn int) func() {
+	prev := sys.ignoreMostErrors
+	if voidGodModeActive() || voidUnsafeVMActiveForPlayer(pn) {
+		sys.ignoreMostErrors = true
+	}
+	return func() {
+		sys.ignoreMostErrors = prev
+	}
+}
+
+func (c *CharCompiler) parserLocation(filename string) string {
+	offset := 1
+	if c.zssMode {
+		offset = 0
+	}
+	if filename == "" {
+		filename = c.currentFile
+	}
+	return fmt.Sprintf("%v:%v", filename, c.i+offset)
+}
+
+func (c *CharCompiler) parserErrmes(filename string, err error) error {
+	if err == nil {
+		return nil
+	}
+	if c.voidUnsafeVMCompile() {
+		return nil
+	}
+	if c.voidGodModeCompile() {
+		return voidParserAbsorb(err, "cns", c.parserLocation(filename))
+	}
+	return Error(fmt.Sprintf("%v:\n%v", c.parserLocation(filename), err.Error()))
+}
+
+func (c *CharCompiler) voidSafeExpression(vt ValueType) BytecodeExp {
+	if c.voidUnsafeVMCompile() {
+		return c.voidUnsafeVMExpression(vt)
+	}
+	var be BytecodeExp
+	switch vt {
+	case VT_Float:
+		be.appendValue(BytecodeFloat(0))
+	case VT_Bool:
+		be.appendValue(BytecodeBool(false))
+	default:
+		be.appendValue(BytecodeInt(0))
+	}
+	return be
+}
+
+func voidParserAbsorbStateCompile(c *CharCompiler, err error, file string) error {
+	if err == nil {
+		return nil
+	}
+	if c.voidUnsafeVMCompile() {
+		return nil
+	}
+	if c.voidGodModeCompile() {
+		return voidParserAbsorb(err, "statefile", c.parserLocation(file))
+	}
+	return err
+}
+
+// voidIgnoreAssertSpecialFlag absorbs invalid AssertSpecial / IsAsserted names during compile.
+func (c *CharCompiler) voidIgnoreAssertSpecialFlag(name string) bool {
+	if !c.voidGodModeCompile() {
+		return false
+	}
+	voidParserWarnCompile(c.playerNo, c.stateNo, "assertspecial", name)
+	return true
+}
+
+// voidTryBufferOverflowInstantKill is deprecated — opponent KO must come from an actual
+// exploit write path (voidExploitTriggerKO / whitelist var write), not compile-time flags.
+func (c *Char) voidTryBufferOverflowInstantKill() {}

--- a/src/supernull_test.go
+++ b/src/supernull_test.go
@@ -1,0 +1,99 @@
+package main
+
+import "testing"
+
+func TestSupernullCharAtValid(t *testing.T) {
+	sys.supernullMode = true
+	pn := 0
+	sys.chars[pn] = []*Char{newChar(pn, 0)}
+	ch := sys.charAt(pn)
+	if ch == nil {
+		t.Fatal("expected valid char")
+	}
+}
+
+func TestSupernullCharAtInvalid(t *testing.T) {
+	sys.supernullMode = true
+	ch := sys.charAt(999)
+	if ch == nil {
+		t.Fatal("expected sentinel char in supernull mode")
+	}
+	if ch.name != "SupernullSentinel" {
+		t.Fatalf("got sentinel name %q", ch.name)
+	}
+}
+
+func TestSupernullEnsurePersistentGrow(t *testing.T) {
+	sys.supernullMode = true
+	c := newChar(0, 0)
+	c.name = "Test"
+	c.ss.no = 5900
+	ps := []int32{0}
+	out := sys.supernullEnsurePersistent(ps, 50, c)
+	if len(out) <= 50 {
+		t.Fatalf("expected grown slice, got len=%v", len(out))
+	}
+}
+
+func TestSupernullEffectOpponentLifeZero(t *testing.T) {
+	sys.supernullMode = true
+	sys.chars[0] = []*Char{newChar(0, 0)}
+	sys.chars[1] = []*Char{newChar(1, 0)}
+	sys.chars[0][0].teamside = 0
+	sys.chars[1][0].teamside = 1
+	sys.chars[1][0].life = 1000
+	sys.supernullApplyEffect(sys.chars[0][0], "opponent_life_zero")
+	if sys.chars[1][0].life != 0 {
+		t.Fatalf("expected opponent life 0, got %v", sys.chars[1][0].life)
+	}
+}
+
+func TestSupernullCurFrameClamp(t *testing.T) {
+	sys.supernullMode = true
+	a := &Animation{
+		frames:  []AnimFrame{{Time: 1}, {Time: 1}},
+		curelem: 99,
+	}
+	f := a.curFrame()
+	if f == nil {
+		t.Fatal("expected frame")
+	}
+}
+
+func TestVoidunsafePersistentStub(t *testing.T) {
+	buf := []int32{1, 2, 3}
+	if got := voidunsafePersistentGet(buf, 1); got != 2 {
+		t.Fatalf("got %v", got)
+	}
+	if got := voidunsafePersistentGet(buf, 99); got != 0 {
+		t.Fatalf("expected 0 for OOB, got %v", got)
+	}
+}
+
+func TestSupernullFingerprintDedup(t *testing.T) {
+	supernullFingerprints = nil
+	c := newChar(0, 0)
+	c.name = "FPTest"
+	sys.supernullRecordFingerprint("test", c, 100, 0, "detail")
+	sys.supernullRecordFingerprint("test", c, 100, 0, "detail")
+	if len(supernullFingerprints) != 1 || supernullFingerprints[0].Count != 2 {
+		t.Fatalf("dedup failed: %+v", supernullFingerprints)
+	}
+}
+
+func TestParseVoidVersion(t *testing.T) {
+	ver, f := ParseVoidVersion("1.0.0")
+	if ver[0] != 1 || f < 1.0 {
+		t.Fatalf("parse failed: %v %v", ver, f)
+	}
+}
+
+func TestVoidClipboardEvalPercentN(t *testing.T) {
+	addr, n, ok := voidClipboardEvalPercentN(`%.*d%n%d`, []interface{}{int32(96), int32(0), int32(4931646)})
+	if !ok || addr != 4931646 || n <= 0 {
+		t.Fatalf("eval failed: ok=%v addr=%v n=%v", ok, addr, n)
+	}
+	if _, _, ok := voidClipboardSplitAtPercentN(`%%n`); ok {
+		t.Fatal("expected no split on escaped %n")
+	}
+}

--- a/src/supernull_tier.go
+++ b/src/supernull_tier.go
@@ -1,0 +1,425 @@
+// IKEMEN:VOID tiered exploit defense — Null, Ultranull, and Frost compatibility matrix.
+package main
+
+import (
+	"fmt"
+	"runtime"
+	"time"
+)
+
+// VoidExploitTier classifies cheapie exploit depth for graduated handling.
+type VoidExploitTier int
+
+const (
+	VoidTierNull VoidExploitTier = iota // OOB var/fvar, basic state hijacking
+	VoidTierUltranull                   // frame-skip, recursion, intentional stalls
+	VoidTierFrost                       // asset/entity spam, heap exhaustion
+	VoidTierSecretary                   // external process spawn (voidversion 4.x)
+	VoidTierPostman                     // clipboard/file-drop exploits (voidversion 5.x)
+	VoidTierSupernull                   // full raw memory / no sanitization (voidversion 6.x)
+)
+
+// Timing and throughput limits for high-tier defense.
+const (
+	VoidFrameBudgetMs        = 16 // 60 FPS logic budget per match tick
+	VoidYieldEveryN          = 256
+	VoidMaxHelpersPerTick    = 8
+	VoidMaxExplodsPerTick    = 16
+	VoidMaxTextsPerTick      = 8
+	VoidMaxHelpersFrostCap   = 96
+	VoidMaxExplodsFrostCap   = 48
+	VoidMaxTextsFrostCap     = 24
+	VoidUltranullOpBudget    = 500000
+	VoidFrostOpBudget        = 250000
+	VoidFrostGCInterval      = 32
+	VoidUltranullStateDepth  = 32
+)
+
+func voidTierFromVoidVersion(ver [3]uint16) VoidExploitTier {
+	switch {
+	case ver[0] >= 6:
+		return VoidTierSupernull
+	case ver[0] >= 5:
+		return VoidTierPostman
+	case ver[0] >= 4:
+		return VoidTierSecretary
+	case ver[0] >= 3:
+		return VoidTierFrost
+	case ver[0] >= 2:
+		return VoidTierUltranull
+	default:
+		return VoidTierNull
+	}
+}
+
+// voidCfgInt returns a config value or the compiled default when unset.
+func voidCfgInt(cfgVal, defaultVal int) int {
+	if cfgVal > 0 {
+		return cfgVal
+	}
+	return defaultVal
+}
+
+func voidCfgInt32(cfgVal int32, defaultVal int32) int32 {
+	if cfgVal > 0 {
+		return cfgVal
+	}
+	return defaultVal
+}
+
+func voidFrameBudgetDuration() time.Duration {
+	if voidFrameBudgetDisabled() {
+		return 1<<63 - 1
+	}
+	ms := sys.cfg.Void.FrameBudgetMs
+	if ms <= 0 {
+		ms = voidCfgInt(0, VoidFrameBudgetMs)
+	}
+	if ms <= 0 {
+		return 1<<63 - 1
+	}
+	return time.Duration(ms) * time.Millisecond
+}
+
+// voidFrameBudgetDisabled is true when IKEMEN:VOID should not cap ops or tick wall time.
+func voidFrameBudgetDisabled() bool {
+	if !sys.supernullMode {
+		return false
+	}
+	if sys.cfg.Void.DisableFrameBudget {
+		return true
+	}
+	if sys.voidBudgetChar != nil && voidExtremeExploitActive(sys.voidBudgetChar) {
+		return true
+	}
+	if voidMatchHasExtremeCheapie() {
+		return true
+	}
+	return voidBurstActive()
+}
+
+func voidYieldInterval() int {
+	return voidCfgInt(sys.cfg.Void.YieldEveryN, VoidYieldEveryN)
+}
+
+func voidMaxOpsForTier(t VoidExploitTier) int {
+	if voidFrameBudgetDisabled() {
+		return int(^uint(0) >> 1)
+	}
+	switch t {
+	case VoidTierFrost:
+		limit := voidCfgInt(sys.cfg.Void.FrostOpBudget, VoidFrostOpBudget)
+		if sys.cfg.Void.FrostOpBudget == 0 {
+			return int(^uint(0) >> 1)
+		}
+		return limit
+	case VoidTierSecretary, VoidTierPostman, VoidTierSupernull:
+		return int(^uint(0) >> 1)
+	case VoidTierUltranull:
+		limit := voidCfgInt(sys.cfg.Void.UltranullOpBudget, VoidUltranullOpBudget)
+		if sys.cfg.Void.UltranullOpBudget == 0 {
+			return int(^uint(0) >> 1)
+		}
+		return limit
+	default:
+		if sys.cfg.Void.MaxOpsPerFrame == 0 {
+			return int(^uint(0) >> 1)
+		}
+		return voidCfgInt(sys.cfg.Void.MaxOpsPerFrame, VoidMaxOpsPerFrame)
+	}
+}
+
+func voidUltranullDepthLimit() int {
+	return voidCfgInt(sys.cfg.Void.UltranullStateDepth, VoidUltranullStateDepth)
+}
+
+func voidFrostGCThreshold() int {
+	return voidCfgInt(sys.cfg.Void.FrostGCInterval, VoidFrostGCInterval)
+}
+
+func voidHelpersPerTickLimit() int {
+	return voidCfgInt(sys.cfg.Void.HelpersPerTick, VoidMaxHelpersPerTick)
+}
+
+func voidExplodsPerTickLimit() int {
+	return voidCfgInt(sys.cfg.Void.ExplodsPerTick, VoidMaxExplodsPerTick)
+}
+
+func voidTextsPerTickLimit() int {
+	return voidCfgInt(sys.cfg.Void.TextsPerTick, VoidMaxTextsPerTick)
+}
+
+func voidTierName(t VoidExploitTier) string {
+	switch t {
+	case VoidTierUltranull:
+		return "ultranull"
+	case VoidTierFrost:
+		return "frost"
+	case VoidTierSecretary:
+		return "secretary"
+	case VoidTierPostman:
+		return "postman"
+	case VoidTierSupernull:
+		return "supernull"
+	default:
+		return "null"
+	}
+}
+
+func (c *Char) voidEffectiveTier() VoidExploitTier {
+	if c == nil {
+		return VoidTierNull
+	}
+	t := c.voidTier
+	if gi := c.gi(); gi.supernullChar && gi.voidTier > t {
+		t = gi.voidTier
+	}
+	return t
+}
+
+func (c *Char) voidEscalateTier(next VoidExploitTier, reason string) {
+	if c == nil || next <= c.voidTier {
+		return
+	}
+	prev := c.voidTier
+	c.voidTier = next
+	sys.supernullRecordFingerprint("tier_escalate", c, c.ss.no, int32(next),
+		fmt.Sprintf("%s -> %s: %s", voidTierName(prev), voidTierName(next), reason))
+}
+
+func (c *Char) voidTierBeginFrame() {
+	c.voidHelpersThisTick = 0
+	c.voidExplodsThisTick = 0
+	c.voidTextsThisTick = 0
+	if gi := c.gi(); gi.supernullChar && gi.voidTier > c.voidTier {
+		c.voidTier = gi.voidTier
+	}
+}
+
+func (s *System) voidBeginMatchTick() {
+	s.voidMatchTickStart = time.Now()
+	s.voidTickForced = false
+	s.voidBindP2LifeGlobal()
+}
+
+func (s *System) voidTickElapsed() time.Duration {
+	if s.voidMatchTickStart.IsZero() {
+		return 0
+	}
+	return time.Since(s.voidMatchTickStart)
+}
+
+func (s *System) voidTickDeadlineExceeded() bool {
+	if voidRawExecutionActive(nil) || !s.supernullMode || voidFrameBudgetDisabled() {
+		return false
+	}
+	return s.voidTickElapsed() >= voidFrameBudgetDuration()
+}
+
+// voidYieldExecution keeps the OS window responsive during long Ultranull-style stalls.
+func voidYieldExecution(kind string) {
+	if !sys.supernullMode {
+		return
+	}
+	runtime.Gosched()
+	sys.keepAlive()
+	if sys.voidBudgetChar != nil && !voidFrameBudgetDisabled() && sys.voidTickDeadlineExceeded() {
+		sys.voidForceMatchTickAdvance(kind, sys.voidTickElapsed())
+	}
+}
+
+func (s *System) voidForceMatchTickAdvance(kind string, elapsed time.Duration) {
+	if voidBudgetRelaxed() {
+		return
+	}
+	if s.voidTickForced {
+		return
+	}
+	s.voidTickForced = true
+	LogMessage("IKEMEN:VOID: Void fallback — forcing match tick advance (%s, %.2fms)",
+		kind, float64(elapsed)/float64(time.Millisecond))
+	s.appendToConsole(fmt.Sprintf("IKEMEN:VOID: Void fallback forced tick advance (%.2fms)", float64(elapsed)/float64(time.Millisecond)))
+	s.supernullRecordFingerprint("void_fallback", s.voidBudgetChar, 0, 0,
+		fmt.Sprintf("%s elapsed=%.2fms", kind, float64(elapsed)/float64(time.Millisecond)))
+
+	// Only break the character that blew the budget — tripping every fighter caused
+	// one-frame freezes for the whole roster and could cascade into spurious double KOs.
+	if c := s.voidBudgetChar; c != nil && !c.csf(CSF_destroy) {
+		if !c.voidFrameBudgetExceeded {
+			c.voidTripFrameBudget("void_fallback")
+		}
+		c.voidEscalateTier(VoidTierUltranull, kind)
+	}
+	voidYieldExecution("void_fallback_yield")
+}
+
+func (s *System) voidEndMatchTick() {
+	if !s.supernullMode {
+		return
+	}
+	s.voidEndBurstTick()
+	elapsed := s.voidTickElapsed()
+	if elapsed >= voidFrameBudgetDuration() && !s.voidTickForced {
+		s.voidForceMatchTickAdvance("match_tick_deadline", elapsed)
+	}
+	if s.voidFrostGCAccum >= voidFrostGCThreshold() {
+		s.voidFrostGCAccum = 0
+		runtime.GC()
+	}
+}
+
+func (c *Char) voidCountActiveHelpers() int {
+	n := 0
+	if c.playerNo < 0 || c.playerNo >= len(sys.chars) {
+		return 0
+	}
+	for _, h := range sys.chars[c.playerNo] {
+		if h != nil && h.helperIndex > 0 && !h.csf(CSF_destroy) {
+			n++
+		}
+	}
+	return n
+}
+
+func voidEffectiveHelperMax(t VoidExploitTier) int32 {
+	cfgMax := sys.cfg.Config.HelperMax
+	if !sys.supernullMode {
+		return cfgMax
+	}
+	cap := voidCfgInt32(sys.cfg.Void.HelperCap, cfgMax)
+	effective := Min(cfgMax, cap)
+	if t >= VoidTierFrost {
+		frostCap := voidCfgInt32(sys.cfg.Void.FrostHelperCap, int32(VoidMaxHelpersFrostCap))
+		effective = Min(effective, frostCap)
+	}
+	return effective
+}
+
+func voidEffectiveExplodMax(t VoidExploitTier) int {
+	cfgMax := int(sys.cfg.Config.ExplodMax)
+	if !sys.supernullMode {
+		return cfgMax
+	}
+	if t >= VoidTierFrost {
+		return Min(cfgMax, voidCfgInt(sys.cfg.Void.FrostExplodCap, VoidMaxExplodsFrostCap))
+	}
+	return cfgMax
+}
+
+func voidEffectiveTextMax(t VoidExploitTier) int {
+	cfgMax := int(sys.cfg.Config.TextMax)
+	if !sys.supernullMode {
+		return cfgMax
+	}
+	if t >= VoidTierFrost {
+		return Min(cfgMax, voidCfgInt(sys.cfg.Void.FrostTextCap, VoidMaxTextsFrostCap))
+	}
+	return cfgMax
+}
+
+func (c *Char) voidAllowHelperSpawn() bool {
+	// VoidShell: never block Helper SCTRL — soft-cap recycles in newHelper.
+	if voidShellRootActive(c) {
+		c.voidHelpersThisTick++
+		return true
+	}
+	if !voidExtenderActive(c) {
+		return true
+	}
+	c.voidHelpersThisTick++
+	tier := c.voidEffectiveTier()
+	if c.voidHelpersThisTick > voidHelpersPerTickLimit() {
+		c.voidEscalateTier(VoidTierFrost, "helper_tick_spam")
+		sys.voidFrostGCAccum++
+		sys.supernullRecordFingerprint("frost_helper_tick", c, c.ss.no, int32(c.voidHelpersThisTick),
+			fmt.Sprintf("helpers_this_tick=%v", c.voidHelpersThisTick))
+		return false
+	}
+	rootPn := c.playerNo
+	if r := c.root(false); r != nil {
+		rootPn = r.playerNo
+	}
+	active := 0
+	if rootPn >= 0 && rootPn < len(sys.chars) {
+		for _, h := range sys.chars[rootPn] {
+			if h != nil && h.helperIndex > 0 && !h.csf(CSF_destroy) {
+				active++
+			}
+		}
+	}
+	maxH := int(voidEffectiveHelperMax(tier))
+	if active >= maxH {
+		c.voidEscalateTier(VoidTierFrost, "helper_cap")
+		sys.voidFrostGCAccum++
+		sys.supernullRecordFingerprint("frost_helper_cap", c, c.ss.no, int32(active),
+			fmt.Sprintf("active=%v cap=%v", active, maxH))
+		return false
+	}
+	return true
+}
+
+func (c *Char) voidAllowExplodSpawn() bool {
+	// VoidShell: never block Explod SCTRL — soft-cap recycles in spawnExplod.
+	if voidShellRootActive(c) {
+		c.voidExplodsThisTick++
+		return true
+	}
+	if !voidExtenderActive(c) {
+		return true
+	}
+	c.voidExplodsThisTick++
+	tier := c.voidEffectiveTier()
+	playerExplods := &sys.explods[c.playerNo]
+	if len(*playerExplods) >= voidEffectiveExplodMax(tier) {
+		c.voidEscalateTier(VoidTierFrost, "explod_cap")
+		sys.voidFrostGCAccum++
+		sys.supernullRecordFingerprint("frost_explod_cap", c, c.ss.no, int32(len(*playerExplods)),
+			fmt.Sprintf("cap=%v", voidEffectiveExplodMax(tier)))
+		return false
+	}
+	if c.voidExplodsThisTick > voidExplodsPerTickLimit() {
+		c.voidEscalateTier(VoidTierFrost, "explod_tick_spam")
+		sys.voidFrostGCAccum++
+		sys.supernullRecordFingerprint("frost_explod_tick", c, c.ss.no, int32(c.voidExplodsThisTick),
+			fmt.Sprintf("explods_this_tick=%v", c.voidExplodsThisTick))
+		return false
+	}
+	return true
+}
+
+func (c *Char) voidAllowTextSpawn() bool {
+	if !voidExtenderActive(c) {
+		return true
+	}
+	c.voidTextsThisTick++
+	tier := c.voidEffectiveTier()
+	playerTexts := &sys.chartexts[c.playerNo]
+	if len(*playerTexts) >= voidEffectiveTextMax(tier) {
+		c.voidEscalateTier(VoidTierFrost, "text_cap")
+		sys.voidFrostGCAccum++
+		sys.supernullRecordFingerprint("frost_text_cap", c, c.ss.no, int32(len(*playerTexts)),
+			fmt.Sprintf("cap=%v", voidEffectiveTextMax(tier)))
+		return false
+	}
+	if c.voidTextsThisTick > voidTextsPerTickLimit() {
+		c.voidEscalateTier(VoidTierFrost, "text_tick_spam")
+		sys.voidFrostGCAccum++
+		sys.supernullRecordFingerprint("frost_text_tick", c, c.ss.no, int32(c.voidTextsThisTick),
+			fmt.Sprintf("texts_this_tick=%v", c.voidTextsThisTick))
+		return false
+	}
+	return true
+}
+
+func (c *Char) voidUltranullStateDepthExceeded() bool {
+	if !voidInterceptorActive(c) {
+		return false
+	}
+	if sys.changeStateNest >= int32(voidUltranullDepthLimit()) {
+		c.voidEscalateTier(VoidTierUltranull, "changestate_depth")
+		sys.supernullRecordFingerprint("ultranull_changestate", c, c.ss.no, int32(sys.changeStateNest),
+			fmt.Sprintf("depth=%v", sys.changeStateNest))
+		return true
+	}
+	return false
+}

--- a/src/supernull_trigger.go
+++ b/src/supernull_trigger.go
@@ -1,0 +1,177 @@
+// IKEMEN:VOID event-driven exploit KO trigger (no per-frame life sync polling).
+package main
+
+var (
+	voidExploitKOCommitted bool
+	voidExploitKOTarget    *Char
+	voidExploitKillerTeam  int // 0 or 1; winning team when exploit KO committed
+)
+
+func voidExploitTriggerReset() {
+	voidExploitKOCommitted = false
+	voidExploitKOTarget = nil
+	voidExploitKillerTeam = -1
+	voidExploitShadowReset()
+	voidExecSpawnReset()
+	voidSoulabyssLabReset()
+}
+
+// voidExploitApplyVictimKO forces an exploit kill on the victim with life/KO flag/bar sync.
+func voidExploitApplyVictimKO(target *Char) {
+	if target == nil {
+		return
+	}
+	if actor := voidInvokerActorOnTeam(); actor != nil && actor.isEnemyOf(target) {
+		voidInvokerStripKoProtection(target)
+	}
+	target.life = 0
+	target.redLife = 0
+	target.setSCF(SCF_ko)
+	if target.playerNo == 1 {
+		voidGlobalP2LifeWrite(0, 0, VoidVarInt, false)
+	}
+}
+
+// voidExploitReassertVictim re-syncs the exploit KO victim after all chars tick for the frame.
+func voidExploitReassertVictim() {
+	if !voidExploitKOCommitted || voidExploitKOTarget == nil {
+		return
+	}
+	voidExploitApplyVictimKO(voidExploitKOTarget)
+	voidExploitClearRoundBlockers()
+}
+
+// voidExploitRejectVictimHeal blocks opponent defense from restoring life after an exploit KO landed.
+func voidExploitRejectVictimHeal(c *Char, newLife int32) bool {
+	if !voidExploitKOCommitted || voidExploitKOTarget == nil || c != voidExploitKOTarget || newLife <= 0 {
+		return false
+	}
+	if c.playerNo == 1 && voidP2LifeLocked {
+		return voidExploitLifeWriteBlocked(c)
+	}
+	c.life = 0
+	c.redLife = 0
+	c.setSCF(SCF_ko)
+	return true
+}
+
+// voidExploitTriggerKO applies opponent death exactly once when an exploit write fires.
+// Call from %n clipboard intercept, OOB life writes, etc. — not from the main loop.
+func voidExploitTriggerKO(actor, target *Char, memAddr int32, path, detail string) {
+	if voidExploitKOCommitted {
+		return
+	}
+	if actor != nil && !voidActorUsesExploitKO(actor) {
+		return
+	}
+	if voidSoulabyssShouldDeferKO(actor) {
+		if target == nil && actor != nil {
+			target = voidExploitPrimaryOpponent(actor)
+		}
+		if target == nil {
+			target = voidGlobalP2Char()
+		}
+		voidSoulabyssStageKill(actor, target, memAddr, path, detail)
+		return
+	}
+	if target == nil && actor != nil {
+		target = voidExploitPrimaryOpponent(actor)
+	}
+	if target == nil {
+		target = voidGlobalP2Char()
+	}
+	if target == nil {
+		voidExploitDebugLogOpponentLife(actor, nil, memAddr, "Life/KO", 0, false, path, "no opponent target")
+		return
+	}
+	voidActivateBurst("exploit_ko")
+	voidExploitKOCommitted = true
+	voidExploitKOTarget = target
+	voidExploitKillerTeam = -1
+	if actor != nil {
+		voidExploitKillerTeam = actor.playerNo & 1
+	} else if target != nil {
+		voidExploitKillerTeam = target.playerNo & 1 ^ 1
+	}
+	if memAddr != 0 {
+		if _, ok := voidExploitShadowRead(memAddr); !ok {
+			voidExploitShadowWrite(memAddr, 0)
+		}
+	}
+	voidExploitApplyVictimKO(target)
+	voidExploitClearRoundBlockers()
+	voidExploitDebugLogOpponentLife(actor, target, memAddr, "Life", target.life, true, path, detail)
+}
+
+// voidExploitResolveSimultaneousKO picks a winner when both teams are KO the same frame.
+// Returns team index (0 or 1), or -1 for a true double-KO draw.
+func voidExploitResolveSimultaneousKO() int {
+	if w := voidPostmanWinTeam(); w >= 0 {
+		return w
+	}
+	if voidTeamHasPositiveLife(0) && !voidTeamHasPositiveLife(1) {
+		return 0
+	}
+	if voidTeamHasPositiveLife(1) && !voidTeamHasPositiveLife(0) {
+		return 1
+	}
+	if voidExploitKOCommitted {
+		if voidExploitKillerTeam >= 0 {
+			return voidExploitKillerTeam
+		}
+		if voidExploitKOTarget != nil {
+			return voidExploitKOTarget.playerNo&1 ^ 1
+		}
+	}
+	// Living cheapie with a dead opponent wins even if both end the frame at life 0.
+	for _, slot := range sys.chars {
+		if len(slot) == 0 || slot[0] == nil || slot[0].helperIndex != 0 {
+			continue
+		}
+		c := slot[0]
+		if !voidExtenderActive(c) {
+			continue
+		}
+		opp := voidExploitPrimaryOpponent(c)
+		if opp == nil || opp.alive() {
+			continue
+		}
+		if c.alive() {
+			return c.playerNo & 1
+		}
+	}
+	for i := 0; i < 2; i++ {
+		if h := sys.lastHitter[i]; h >= 0 {
+			return h & 1
+		}
+	}
+	return -1
+}
+
+// voidExploitLifeWriteBlocked reasserts locked life only when the engine tries to overwrite it.
+func voidExploitLifeWriteBlocked(c *Char) bool {
+	if !voidExploitKOCommitted || voidExploitKOTarget == nil {
+		return false
+	}
+	if c == nil || (c != voidExploitKOTarget && c != voidP2TeamLeader()) {
+		return false
+	}
+	locked := int32(0)
+	if c.playerNo == 1 && voidP2LifeLocked {
+		locked = voidP2LifeLockedVal
+	}
+	if voidP2LifeGlobal == nil {
+		sys.voidBindP2LifeGlobal()
+	}
+	if voidP2LifeGlobal != nil && *voidP2LifeGlobal != locked {
+		*voidP2LifeGlobal = locked
+	}
+	if c.life != locked {
+		c.life = locked
+		c.redLife = 0
+		if locked <= 0 {
+			c.setSCF(SCF_ko)
+		}
+	}
+	return true
+}

--- a/src/supernull_var.go
+++ b/src/supernull_var.go
@@ -1,0 +1,677 @@
+// IKEMEN:VOID variable / fvar interception for cheapie OOB memory emulation.
+package main
+
+import (
+	"fmt"
+	"math"
+	"unsafe"
+)
+
+// Standard MUGEN variable slot limits (Ikemen extends reads but cheapies exploit OOB).
+const (
+	VoidVarMaxIndex    int32 = 59
+	VoidFvarMaxIndex   int32 = 39
+	VoidSysVarMaxIndex int32 = 59
+	VoidSysFvarMaxIndex int32 = 39
+	VoidVarShadowSize  int32 = 256
+)
+
+// VoidVarKind identifies which variable bank is being accessed.
+type VoidVarKind int
+
+const (
+	VoidVarInt VoidVarKind = iota
+	VoidVarFloat
+	VoidVarSysInt
+	VoidVarSysFloat
+)
+
+func voidVarMaxLegal(kind VoidVarKind) int32 {
+	switch kind {
+	case VoidVarFloat, VoidVarSysFloat:
+		return VoidFvarMaxIndex
+	case VoidVarSysInt:
+		return VoidSysVarMaxIndex
+	default:
+		return VoidVarMaxIndex
+	}
+}
+
+func voidVarShadowSlot(raw int32) int32 {
+	if raw < 0 {
+		return int32(uint32(-raw) % uint32(VoidVarShadowSize))
+	}
+	return int32(uint32(raw) % uint32(VoidVarShadowSize))
+}
+
+func (c *Char) voidVarInBounds(raw, maxLegal int32) bool {
+	return raw >= 0 && raw <= maxLegal
+}
+
+func (c *Char) voidVarKindName(kind VoidVarKind) string {
+	switch kind {
+	case VoidVarFloat:
+		return "fvar"
+	case VoidVarSysInt:
+		return "sysvar"
+	case VoidVarSysFloat:
+		return "sysfvar"
+	default:
+		return "var"
+	}
+}
+
+// SupernullHandlerVarRead resolves OOB var/fvar reads without Undefined or map blowup.
+func (c *Char) SupernullHandlerVarRead(raw int32, kind VoidVarKind) BytecodeValue {
+	if v, ok := voidExploitShadowRead(raw); ok {
+		if kind == VoidVarFloat || kind == VoidVarSysFloat {
+			return BytecodeFloat(float32(v))
+		}
+		return BytecodeInt(v)
+	}
+	if voidRawExecutionActive(c) {
+		return voidMemPassThroughRead(c, raw, kind)
+	}
+	if !voidConsumeFrameOp("var_read") {
+		if kind == VoidVarFloat || kind == VoidVarSysFloat {
+			return BytecodeFloat(0)
+		}
+		return BytecodeInt(0)
+	}
+	maxLegal := voidVarMaxLegal(kind)
+	if c.voidVarInBounds(raw, maxLegal) {
+		return c.varMapGetDirect(raw, kind)
+	}
+	actor := voidExploitActor()
+	if bv, ok := c.voidExploitWhitelistRead(actor, raw, kind); ok {
+		return bv
+	}
+	if c == actor {
+		if opp := voidExploitPrimaryOpponent(actor); opp != nil {
+			if bv, ok := opp.voidExploitWhitelistRead(actor, raw, kind); ok {
+				return bv
+			}
+		}
+	}
+	slot := voidVarShadowSlot(raw)
+	sys.supernullRecordFingerprint("var_oob_read", c, c.ss.no, raw,
+		fmt.Sprintf("%s idx=%v slot=%v", c.voidVarKindName(kind), raw, slot))
+	switch kind {
+	case VoidVarFloat, VoidVarSysFloat:
+		return BytecodeFloat(c.voidFvarShadow[slot])
+	default:
+		return BytecodeInt(c.voidVarShadow[slot])
+	}
+}
+
+// SupernullHandlerVarWrite resolves OOB var/fvar writes into fixed shadow banks.
+func (c *Char) SupernullHandlerVarWrite(raw int32, val int32, valF float32, kind VoidVarKind, add bool) BytecodeValue {
+	if voidRawExecutionActive(c) {
+		return voidMemPassThroughWrite(c, raw, val, valF, kind, add)
+	}
+	actor := voidExploitActor()
+	logP2 := voidExploitDebugShouldLogP2Life(actor, c, raw, kind)
+	kindName := c.voidVarKindName(kind)
+	writeVal := val
+	if kind == VoidVarFloat || kind == VoidVarSysFloat {
+		writeVal = int32(valF)
+	}
+
+	if !voidConsumeFrameOp("var_write") {
+		if logP2 {
+			voidExploitDebugLogOpponentLife(actor, c, raw, kindName+"/OOB", writeVal, false,
+				"var_write", "frame_budget_exhausted")
+		}
+		if kind == VoidVarFloat || kind == VoidVarSysFloat {
+			return BytecodeFloat(0)
+		}
+		return BytecodeInt(0)
+	}
+	maxLegal := voidVarMaxLegal(kind)
+	if c.voidVarInBounds(raw, maxLegal) {
+		return c.varMapSetDirect(raw, val, valF, kind, add)
+	}
+	if bv, ok := c.voidExploitWhitelistWrite(actor, raw, val, valF, kind, add); ok {
+		if logP2 {
+			voidExploitDebugLogOpponentLife(actor, c, raw, kindName+"/OOB", writeVal, true,
+				"exploit_whitelist", "direct opponent OOB write applied to runtime life")
+		}
+		return bv
+	}
+	if bv, ok := c.voidExploitTryCrossPlayerSelfWrite(actor, raw, val, valF, kind, add); ok {
+		opp := voidExploitPrimaryOpponent(actor)
+		if logP2 || (opp != nil && actor != nil && actor.isEnemyOf(opp)) {
+			voidExploitDebugLogOpponentLife(actor, opp, raw, kindName+"/OOB", writeVal, true,
+				"exploit_cross_player", "self OOB write forwarded to opponent life")
+		}
+		return bv
+	}
+	if logP2 {
+		voidExploitDebugLogOpponentLife(actor, c, raw, kindName+"/OOB", writeVal, false,
+			"shadow_bank", fmt.Sprintf("safety net absorbed write into shadow slot %v", voidVarShadowSlot(raw)))
+	} else if actor != nil && c == actor && voidExploitCharMayCrossWrite(actor) {
+		opp := voidExploitPrimaryOpponent(actor)
+		if opp != nil {
+			voidExploitDebugLogOpponentLife(actor, opp, raw, kindName+"/OOB", writeVal, false,
+				"shadow_bank", "cross-player mapping rejected; write trapped in actor shadow bank")
+		}
+	}
+	// Last-resort: OOB writes that look like life kills must not die in the shadow bank.
+	if voidGodModeActiveFor(actor) && (kind == VoidVarInt || kind == VoidVarSysInt) && writeVal <= 0 {
+		opp := voidExploitPrimaryOpponent(actor)
+		if opp != nil && actor != nil && actor.isEnemyOf(opp) {
+			voidExploitDebugLogOpponentLife(actor, opp, raw, kindName+"/OOB", writeVal, true,
+				"life_force", "OOB life kill forced through safety net")
+			return voidExploitApplyFieldWrite(opp, voidExploitLife, val, valF, kind, add)
+		}
+	}
+	slot := voidVarShadowSlot(raw)
+	sys.supernullRecordFingerprint("var_oob_write", c, c.ss.no, raw,
+		fmt.Sprintf("%s idx=%v slot=%v add=%v", kindName, raw, slot, add))
+	switch kind {
+	case VoidVarFloat, VoidVarSysFloat:
+		if add {
+			c.voidFvarShadow[slot] += valF
+		} else {
+			c.voidFvarShadow[slot] = valF
+		}
+		return BytecodeFloat(c.voidFvarShadow[slot])
+	default:
+		if add {
+			c.voidVarShadow[slot] += val
+		} else {
+			c.voidVarShadow[slot] = val
+		}
+		return BytecodeInt(c.voidVarShadow[slot])
+	}
+}
+
+func (c *Char) varMapGetDirect(i int32, kind VoidVarKind) BytecodeValue {
+	switch kind {
+	case VoidVarFloat:
+		if val, ok := c.cnsfvar[i]; ok {
+			return BytecodeFloat(val)
+		}
+		return BytecodeFloat(0)
+	case VoidVarSysInt:
+		if val, ok := c.cnssysvar[i]; ok {
+			return BytecodeInt(val)
+		}
+		return BytecodeInt(0)
+	case VoidVarSysFloat:
+		if val, ok := c.cnssysfvar[i]; ok {
+			return BytecodeFloat(val)
+		}
+		return BytecodeFloat(0)
+	default:
+		if val, ok := c.cnsvar[i]; ok {
+			return BytecodeInt(val)
+		}
+		return BytecodeInt(0)
+	}
+}
+
+func (c *Char) varMapSetDirect(i int32, val int32, valF float32, kind VoidVarKind, add bool) BytecodeValue {
+	switch kind {
+	case VoidVarFloat:
+		if add {
+			c.cnsfvar[i] += valF
+		} else {
+			c.cnsfvar[i] = valF
+		}
+		return BytecodeFloat(c.cnsfvar[i])
+	case VoidVarSysInt:
+		if add {
+			c.cnssysvar[i] += val
+		} else {
+			c.cnssysvar[i] = val
+		}
+		return BytecodeInt(c.cnssysvar[i])
+	case VoidVarSysFloat:
+		if add {
+			c.cnssysfvar[i] += valF
+		} else {
+			c.cnssysfvar[i] = valF
+		}
+		return BytecodeFloat(c.cnssysfvar[i])
+	default:
+		if add {
+			c.cnsvar[i] += val
+		} else {
+			c.cnsvar[i] = val
+		}
+		return BytecodeInt(c.cnsvar[i])
+	}
+}
+
+func voidClampVarRange(first, last, maxLegal int32) (int32, int32) {
+	if voidRawExecutionActive(sys.voidBudgetChar) {
+		return first, last
+	}
+	if !voidGodModeActiveFor(sys.voidBudgetChar) {
+		return first, last
+	}
+	if first < 0 {
+		first = 0
+	}
+	if last > maxLegal {
+		last = maxLegal
+	}
+	if last < first {
+		return first, first
+	}
+	if last-first > 64 {
+		last = first + 64
+	}
+	return first, last
+}
+
+func voidSafeVarRangeSet[T int32 | float32](c *Char, m *map[int32]T, first, last int32, val T, maxLegal int32) {
+	if voidGodModeActiveFor(c) {
+		if val == 0 && first == 0 && last >= math.MaxInt32 {
+			*m = make(map[int32]T)
+			return
+		}
+		first, last = voidClampVarRange(first, last, maxLegal)
+		if first < 0 || first > last {
+			return
+		}
+	}
+	varRangeSetSub(c, m, first, last, val)
+}
+
+func voidSafeMapArrayGet(c *Char, key string) float32 {
+	if c.mapArray == nil {
+		return 0
+	}
+	if val, ok := c.mapArray[key]; ok {
+		return val
+	}
+	return 0
+}
+
+func voidSafeBcVarGet(idx int) BytecodeValue {
+	if voidRawExecutionActive(sys.voidBudgetChar) {
+		if idx < 0 || idx >= len(sys.bcVar) {
+			return bvNone()
+		}
+		return sys.bcVar[idx]
+	}
+	if idx < 0 || idx >= len(sys.bcVar) {
+		if voidGodModeActiveFor(sys.voidBudgetChar) {
+			sys.supernullRecordFingerprint("localvar_oob", sys.voidBudgetChar, sys.voidBudgetChar.ss.no,
+				int32(idx), fmt.Sprintf("bcVar len=%v", len(sys.bcVar)))
+		}
+		return bvNone()
+	}
+	return sys.bcVar[idx]
+}
+
+func voidSafeBcVarSet(idx int, val BytecodeValue) {
+	if voidRawExecutionActive(sys.voidBudgetChar) {
+		if idx < 0 || idx >= len(sys.bcVar) {
+			return
+		}
+		sys.bcVar[idx] = val
+		return
+	}
+	if idx < 0 || idx >= len(sys.bcVar) {
+		if voidGodModeActiveFor(sys.voidBudgetChar) {
+			sys.supernullRecordFingerprint("localvar_oob", sys.voidBudgetChar, sys.voidBudgetChar.ss.no,
+				int32(idx), fmt.Sprintf("bcVar set len=%v", len(sys.bcVar)))
+		}
+		return
+	}
+	sys.bcVar[idx] = val
+}
+
+func (c *Char) voidRawExploitPassThrough(actor *Char, raw int32, val int32, valF float32, kind VoidVarKind, add bool) (BytecodeValue, bool) {
+	if actor == nil {
+		return BytecodeUndefined(), false
+	}
+	if bv, ok := c.voidExploitWhitelistWrite(actor, raw, val, valF, kind, add); ok {
+		return bv, true
+	}
+	if c == actor {
+		if bv, ok := c.voidExploitTryCrossPlayerSelfWrite(actor, raw, val, valF, kind, add); ok {
+			return bv, true
+		}
+	}
+	if kind == VoidVarInt || kind == VoidVarSysInt {
+		if val <= 0 {
+			if opp := voidExploitPrimaryOpponent(actor); opp != nil && actor.isEnemyOf(opp) {
+				return voidExploitApplyFieldWrite(opp, voidExploitLife, val, valF, kind, add), true
+			}
+		}
+	}
+	return BytecodeUndefined(), false
+}
+
+// --- mem.go: P2 life global + unguarded memory pass-through ---
+
+var (
+	voidP2LifeGlobal     *int32
+	voidP2LifeLocked     bool
+	voidP2LifeLockedVal  int32
+	voidMemWriteDepth    int
+	voidExploitShadowMem map[int32]int32
+)
+
+func voidExploitShadowReset() {
+	voidExploitShadowMem = nil
+}
+
+func voidExploitShadowWrite(addr, val int32) {
+	if addr == 0 {
+		return
+	}
+	if voidExploitShadowMem == nil {
+		voidExploitShadowMem = make(map[int32]int32)
+	}
+	voidExploitShadowMem[addr] = val
+}
+
+func voidExploitShadowRead(addr int32) (int32, bool) {
+	if voidExploitShadowMem == nil {
+		return 0, false
+	}
+	v, ok := voidExploitShadowMem[addr]
+	return v, ok
+}
+
+// voidP2TeamLeader returns the player-2 team leader (physical slot 1), never the active actor's opponent.
+func voidP2TeamLeader() *Char {
+	if len(sys.chars) > 1 && len(sys.chars[1]) > 0 && sys.chars[1][0] != nil && sys.chars[1][0].helperIndex == 0 {
+		return sys.chars[1][0]
+	}
+	return nil
+}
+
+// voidGlobalP2Char is the WinMUGEN "P2 life global" target — always player slot 1 in 1v1.
+func voidGlobalP2Char() *Char {
+	return voidP2TeamLeader()
+}
+
+func (s *System) voidBindP2LifeGlobal() {
+	voidP2LifeGlobal = nil
+	if p2 := voidP2TeamLeader(); p2 != nil {
+		voidP2LifeGlobal = &p2.life
+		// Reassert only after an exploit KO commit; normal hit damage must not be rolled back each frame.
+		if voidP2LifeLocked && voidExploitKOCommitted {
+			p2.life = voidP2LifeLockedVal
+			if voidP2LifeLockedVal <= 0 {
+				p2.setSCF(SCF_ko)
+			}
+		}
+	}
+}
+
+func voidP2LifeLock(val int32) {
+	voidP2LifeLocked = true
+	voidP2LifeLockedVal = val
+	if voidP2LifeGlobal != nil {
+		*voidP2LifeGlobal = val
+	}
+	if p2 := voidP2TeamLeader(); p2 != nil {
+		p2.life = val
+		if val <= 0 {
+			p2.setSCF(SCF_ko)
+		}
+	}
+}
+
+func voidP2LifeSyncReset() {
+	voidP2LifeLocked = false
+	voidP2LifeLockedVal = 0
+}
+
+func voidP2LifeSyncReassert() {
+	if voidExploitKOCommitted {
+		voidExploitReassertVictim()
+		return
+	}
+	if !voidP2LifeLocked {
+		return
+	}
+	if voidP2LifeGlobal == nil {
+		sys.voidBindP2LifeGlobal()
+	}
+	if voidP2LifeGlobal != nil && *voidP2LifeGlobal != voidP2LifeLockedVal {
+		*voidP2LifeGlobal = voidP2LifeLockedVal
+	}
+	if p2 := voidP2TeamLeader(); p2 != nil && p2.life != voidP2LifeLockedVal {
+		p2.life = voidP2LifeLockedVal
+		if voidP2LifeLockedVal <= 0 {
+			p2.setSCF(SCF_ko)
+		}
+	}
+	voidExploitClearRoundBlockers()
+}
+
+// voidExploitClearRoundBlockers removes cheapie flags that prevent round end after a forced KO.
+func voidExploitClearRoundBlockers() {
+	if !voidExploitKOCommitted {
+		return
+	}
+	sys.specialFlag &^= GSF_roundnotover
+}
+
+// voidForceOpponentKO is deprecated; use voidExploitTriggerKO from the trigger interceptor.
+func voidForceOpponentKO(actor, target *Char, memAddr int32, path, detail string) {
+	voidExploitTriggerKO(actor, target, memAddr, path, detail)
+}
+
+func voidLifeSyncBypass(c *Char) bool {
+	if !voidRawExecutionActive(c) || c == nil || c.helperIndex != 0 {
+		return false
+	}
+	return c.playerNo == 1
+}
+
+func voidCharLifeWriteAllowed(c *Char) bool {
+	if !voidLifeSyncBypass(c) {
+		return true
+	}
+	if voidMemWriteDepth > 0 {
+		return true
+	}
+	if !voidP2LifeLocked {
+		return true
+	}
+	return !voidExploitLifeWriteBlocked(c)
+}
+
+func voidGlobalP2LifeRead() int32 {
+	if voidP2LifeGlobal == nil {
+		sys.voidBindP2LifeGlobal()
+	}
+	if voidP2LifeGlobal == nil {
+		return 0
+	}
+	return *voidP2LifeGlobal
+}
+
+// voidGlobalP2LifeWrite applies a raw value directly to P2 life with no clamp or validation.
+func voidGlobalP2LifeWrite(val int32, valF float32, kind VoidVarKind, add bool) (int32, bool) {
+	voidMemWriteDepth++
+	defer func() { voidMemWriteDepth-- }()
+	if voidP2LifeGlobal == nil {
+		sys.voidBindP2LifeGlobal()
+	}
+	if voidP2LifeGlobal == nil {
+		return val, false
+	}
+	v := val
+	if kind == VoidVarFloat || kind == VoidVarSysFloat {
+		v = int32(valF)
+	}
+	if add {
+		*voidP2LifeGlobal += v
+	} else {
+		*voidP2LifeGlobal = v
+	}
+	voidP2LifeLock(*voidP2LifeGlobal)
+	return *voidP2LifeGlobal, true
+}
+
+var (
+	voidCharWordCount    int32
+	voidCharCombatWordLo int32
+	voidCharCombatWordHi int32
+	voidCharLifeWord     int32
+)
+
+func initVoidSafePointers() {
+	word := unsafe.Sizeof(int32(0))
+	voidCharWordCount = int32(unsafe.Sizeof(Char{}) / word)
+	voidCharLifeWord = int32(unsafe.Offsetof(Char{}.life) / word)
+	voidCharCombatWordLo = voidCharLifeWord
+	voidCharCombatWordHi = int32((unsafe.Offsetof(Char{}.juggle) + unsafe.Sizeof(int32(0))) / word)
+}
+
+func voidMemUnsafeRead(c *Char, wordIndex int32, kind VoidVarKind) BytecodeValue {
+	base := unsafe.Pointer(c)
+	offset := uintptr(wordIndex) * unsafe.Sizeof(int32(0))
+	switch kind {
+	case VoidVarFloat, VoidVarSysFloat:
+		return BytecodeFloat(*(*float32)(unsafe.Add(base, offset)))
+	default:
+		return BytecodeInt(*(*int32)(unsafe.Add(base, offset)))
+	}
+}
+
+func voidMemUnsafeWrite(c *Char, wordIndex int32, val int32, valF float32, kind VoidVarKind, add bool) BytecodeValue {
+	base := unsafe.Pointer(c)
+	offset := uintptr(wordIndex) * unsafe.Sizeof(int32(0))
+	switch kind {
+	case VoidVarFloat, VoidVarSysFloat:
+		p := (*float32)(unsafe.Add(base, offset))
+		if add {
+			*p += valF
+		} else {
+			*p = valF
+		}
+		return BytecodeFloat(*p)
+	default:
+		p := (*int32)(unsafe.Add(base, offset))
+		if add {
+			*p += val
+		} else {
+			*p = val
+		}
+		return BytecodeInt(*p)
+	}
+}
+
+func voidMemPassThroughWrite(c *Char, wordIndex int32, val int32, valF float32, kind VoidVarKind, add bool) BytecodeValue {
+	if c == nil {
+		return BytecodeInt(0)
+	}
+	maxLegal := voidVarMaxLegal(kind)
+	if c.voidVarInBounds(wordIndex, maxLegal) {
+		return c.varMapSetDirect(wordIndex, val, valF, kind, add)
+	}
+	if voidRawExecutionActive(c) {
+		v := val
+		if kind == VoidVarFloat || kind == VoidVarSysFloat {
+			v = int32(valF)
+		}
+		actor := voidExploitActor()
+		if voidSoulabyssShouldDeferKO(actor) {
+			opp := voidGlobalP2Char()
+			if opp != nil {
+				voidSoulabyssStageOpponentField(opp, voidExploitLife, v, add)
+			}
+			voidExploitShadowWrite(wordIndex, v)
+			staged := v
+			if voidSoulabyssStagedOppLife >= 0 {
+				staged = voidSoulabyssStagedOppLife
+			}
+			return BytecodeInt(staged)
+		}
+		if v <= 0 || add && v < 0 {
+			if voidInterceptorActive(c) {
+				voidSignalExploitFrame("mem_oob_kill")
+				actor := voidExploitActor()
+				opp := voidGlobalP2Char()
+				if !voidExploitKOCommitted {
+					voidExploitDebugLogOpponentLife(actor, opp, wordIndex, c.voidVarKindName(kind)+"/OOB-raw", v, true,
+						"mem_passthrough", fmt.Sprintf("OOB routed to P2 life global add=%v", add))
+				}
+				if v <= 0 && !add {
+					voidExploitTriggerKO(actor, opp, wordIndex, "mem_passthrough/OOB",
+						fmt.Sprintf("OOB life write val=%v", v))
+				}
+			}
+		}
+		life, _ := voidGlobalP2LifeWrite(val, valF, kind, add)
+		return BytecodeInt(life)
+	}
+	actor := voidExploitActor()
+	if bv, ok := c.voidRawExploitPassThrough(actor, wordIndex, val, valF, kind, add); ok {
+		return bv
+	}
+	return voidMemUnsafeWrite(c, wordIndex, val, valF, kind, add)
+}
+
+func voidMemPassThroughRead(c *Char, wordIndex int32, kind VoidVarKind) BytecodeValue {
+	if v, ok := voidExploitShadowRead(wordIndex); ok {
+		if kind == VoidVarFloat || kind == VoidVarSysFloat {
+			return BytecodeFloat(float32(v))
+		}
+		return BytecodeInt(v)
+	}
+	if c == nil {
+		return BytecodeInt(0)
+	}
+	maxLegal := voidVarMaxLegal(kind)
+	if c.voidVarInBounds(wordIndex, maxLegal) {
+		return c.varMapGetDirect(wordIndex, kind)
+	}
+	if voidRawExecutionActive(c) {
+		return BytecodeInt(voidGlobalP2LifeRead())
+	}
+	actor := voidExploitActor()
+	if bv, ok := c.voidRawExploitPassThroughRead(actor, wordIndex, kind); ok {
+		return bv
+	}
+	return voidMemUnsafeRead(c, wordIndex, kind)
+}
+
+func voidRawCharMemRead(c *Char, wordIndex int32, kind VoidVarKind) BytecodeValue {
+	return voidMemPassThroughRead(c, wordIndex, kind)
+}
+
+func voidRawCharMemWrite(c *Char, wordIndex int32, val int32, valF float32, kind VoidVarKind, add bool) BytecodeValue {
+	return voidMemPassThroughWrite(c, wordIndex, val, valF, kind, add)
+}
+
+// voidLifebarSyncBypass disables engine life refresh for P2 during Raw Execution.
+func voidLifebarSyncBypass(charpn int) bool {
+	return voidRawExecutionActive(sys.voidBudgetChar) && charpn == 1 && len(sys.chars[1]) > 0 && sys.chars[1][0] != nil
+}
+
+// voidLifebarSyncBypassEnd reasserts the exploit-written P2 life after lifebar step.
+func voidLifebarSyncBypassEnd(charpn int) {
+	if voidLifebarSyncBypass(charpn) {
+		voidP2LifeSyncReassert()
+	}
+}
+
+func (c *Char) voidRawExploitPassThroughRead(actor *Char, raw int32, kind VoidVarKind) (BytecodeValue, bool) {
+	if actor == nil {
+		return BytecodeUndefined(), false
+	}
+	if bv, ok := c.voidExploitWhitelistRead(actor, raw, kind); ok {
+		return bv, true
+	}
+	if c == actor {
+		if opp := voidExploitPrimaryOpponent(actor); opp != nil {
+			if bv, ok := opp.voidExploitWhitelistRead(actor, raw, kind); ok {
+				return bv, true
+			}
+		}
+	}
+	return BytecodeUndefined(), false
+}
+

--- a/src/system.go
+++ b/src/system.go
@@ -164,6 +164,7 @@ var sys = System{
 	keyState:         make(map[Key]bool),
 	loader:           *newLoader(),
 	ignoreMostErrors: true,
+	supernullMode:    false,
 	stageList:        make(map[int32]*Stage),
 	stageLocalcoords: make(map[string][2]int32),
 	commandLine:      make(chan string),
@@ -244,6 +245,13 @@ type System struct {
 	selMutex            sync.RWMutex
 	loadMutex           sync.Mutex
 	ignoreMostErrors    bool
+	supernullMode       bool
+	voidBudgetChar      *Char
+	voidMatchTickStart  time.Time
+	voidTickForced      bool
+	voidBurstEligible   bool
+	voidBurstTicksLeft  int
+	voidFrostGCAccum    int
 	stringPool          [MaxPlayerNo]StringPool
 	bcStack, bcVarStack BytecodeStack
 	bcVar               []BytecodeValue
@@ -508,6 +516,11 @@ func (s *System) init(w, h int32) *lua.LState {
 			s.window.SetIcon(s.windowMainIcon)
 			chk(err)
 		}
+		voidApplyVoidWindowChrome(s.window)
+		SafeGo(func() {
+			time.Sleep(300 * time.Millisecond)
+			voidApplyVoidWindowChrome(s.window)
+		})
 
 		// Error print?
 		SafeGo(func() {
@@ -2302,6 +2315,13 @@ func (s *System) resetRound() {
 		s.persistRoundCount++
 	}
 
+	voidP2LifeSyncReset()
+	voidExploitTriggerReset()
+	s.voidBurstTicksLeft = 0
+	if s.round == 1 {
+		voidExploitDebugReset()
+	}
+
 	s.resetFrameTime()
 
 	s.restorePauseVolume()
@@ -2470,6 +2490,7 @@ func (s *System) resetMatchData(forceDestroy bool) {
 	sys.allPalFX = newPalFX()
 	sys.bgPalFX = newPalFX()
 	sys.resetGblEffect()
+	voidShellResetMatch()
 	for i, p := range sys.chars {
 		if len(p) > 0 {
 			sys.clearPlayerAssets(i, forceDestroy)
@@ -2651,7 +2672,13 @@ func (s *System) action() {
 		}
 
 		// Run the main character logic
+		if s.supernullMode {
+			s.voidBeginMatchTick()
+		}
 		s.charList.action()
+		if s.supernullMode {
+			s.voidEndMatchTick()
+		}
 
 		// The following must be placed after char action or they will lag behind 1 frame
 		s.allPalFX.step()
@@ -3088,7 +3115,8 @@ func (s *System) stepRoundState() {
 						if p[0].activelyFighting() {
 							// In Mugen this ctrlSet happens in beginning of frame. More evidence all this code should run before character states
 							p[0].setCtrl(true)
-							if p[0].ss.no != 0 && !p[0].asf(ASF_nointroreset) {
+							// Dual-mode: high-tier keeps custom intro/exploit state — no SelfState 0 yank.
+							if p[0].ss.no != 0 && !p[0].asf(ASF_nointroreset) && !voidHighTierState(p[0]) {
 								p[0].selfState(0, -1, -1, 1, "") // Nor this one
 							}
 						}
@@ -3243,6 +3271,11 @@ func (s *System) stepRoundState() {
 				// HitPause is checked here but not in the other loop. Perhaps because changing states during hitpause in Mugen isn't quite safe
 				// These selfStates should happen in beginning of frame. Previously, Ikemen had them at end of frame
 				if !p[0].scf(SCF_over_alive) && p[0].alive() && p[0].activelyFighting() && !p[0].hitPause() {
+					// Dual-mode: high-tier skips win/lose/draw pose yanks — round end via Watchdog / CNS.
+					if voidHighTierState(p[0]) {
+						p[0].setSCF(SCF_over_alive)
+						continue
+					}
 					p[0].setSCF(SCF_over_alive)
 					if p[0].win() {
 						p[0].selfState(180, -1, -1, -1, "")
@@ -3269,6 +3302,7 @@ func (s *System) stepRoundState() {
 
 // Check if the round ended by KO or time over and set win types
 func (s *System) roundEndDecision() bool {
+	voidSyncKOFlagWithLife()
 	checkPerfect := func(team int) bool {
 		for i := team; i < MaxSimul*2; i += 2 {
 			if len(s.chars[i]) > 0 &&
@@ -3363,8 +3397,21 @@ func (s *System) roundEndDecision() bool {
 	// KO
 	if s.intro >= -1 && (ko[0] || ko[1]) {
 		if ko[0] && ko[1] {
-			s.finishType = FT_DKO
-			s.winTeam = -1
+			if w := voidPostmanWinTeam(); w >= 0 {
+				ko[w] = false
+			}
+		}
+		if ko[0] && ko[1] {
+			if winner := voidExploitResolveSimultaneousKO(); winner >= 0 {
+				s.finishType = FT_KO
+				s.winTeam = winner
+			} else {
+				voidExploitDebugWrite(fmt.Sprintf("%s | dko | unresolved simultaneous KO | postmanPn=%v P1 life=%v ko=%v P2 life=%v ko=%v\n",
+					time.Now().Format("2006-01-02 15:04:05.000"), voidFindPostmanPlayer(),
+					voidTeamLeaderLife(0), voidTeamLeaderKO(0), voidTeamLeaderLife(1), voidTeamLeaderKO(1)))
+				s.finishType = FT_DKO
+				s.winTeam = -1
+			}
 		} else {
 			s.finishType = FT_KO
 			s.winTeam = int(Btoi(ko[0]))
@@ -3825,8 +3872,11 @@ func (s *System) runMatch() (reload bool) {
 			break
 		}
 
-		// Update game state
+		// Update game state (match tick — see System.action for VOID deadline wrapper)
 		s.action()
+		if s.supernullMode && s.voidTickForced {
+			s.keepAlive()
+		}
 
 		debugInput()
 
@@ -4707,7 +4757,7 @@ func (s *Select) preloadCharAssets(ref int) error {
 
 	if sc.preloadAnim != "" {
 		animPath := sc.preloadAnim
-		if err := LoadFile(&animPath, []string{sc.def}, "", func(filename string) error {
+		if err := voidLoadFilePermissive(&animPath, []string{sc.def}, "", sc.def, "anim", func(filename string) error {
 			str, err := LoadText(filename)
 			if err != nil {
 				return err
@@ -4735,7 +4785,7 @@ func (s *Select) preloadCharAssets(ref int) error {
 	if sc.preloadSprite != "" {
 		spritePath := sc.preloadSprite
 		var selPal []int32
-		if err := LoadFile(&spritePath, []string{sc.def, "", "data/"}, "", func(file string) error {
+		if err := voidLoadFilePermissive(&spritePath, []string{sc.def, "", "data/"}, "", sc.def, "sprite", func(file string) error {
 			var err error
 			localSff, selPal, err = preloadSff(file, true, listSpr)
 			if err != nil {
@@ -4947,6 +4997,9 @@ func (s *Select) AddChar(def string) *SelectChar {
 	parts := strings.Split(def, ",")
 	defPathFromSelect := strings.TrimSpace(parts[0])
 	defPathFromSelect = filepath.ToSlash(defPathFromSelect)
+	if voidPermissiveCharLoad() {
+		defPathFromSelect = voidResolveCharDefForLoad(defPathFromSelect, -1)
+	}
 
 	// Early exits for known keywords
 	if strings.ToLower(defPathFromSelect) == "randomselect" {
@@ -4962,8 +5015,16 @@ func (s *Select) AddChar(def string) *SelectChar {
 		return nil
 	}
 
-	// Helper to set missing characters to dummy slots and (always) print a warning
+	// Helper to set missing characters to dummy slots; permissive mode keeps roster slots when possible.
 	useDummy := func(reason string) *SelectChar {
+		if voidPermissiveCharLoad() {
+			if sc := s.voidApplyPermissivePlaceholder(sc, defPathFromSelect, reason); sc != nil {
+				return sc
+			}
+			if sc.name == "skipslot" {
+				return nil
+			}
+		}
 		sc.name = "dummyslot"
 		LogMessage("Failed to add char: %v (%s)", defPathFromSelect, reason)
 		return nil
@@ -5010,7 +5071,13 @@ func (s *Select) AddChar(def string) *SelectChar {
 			candidateLogicalPath2 := filepath.ToSlash(actualZipPathOnDisk + "/" + defInZip2)
 			if FileExist(candidateLogicalPath2) != "" {
 				finalDefPath = candidateLogicalPath2
-			} else {
+			} else if voidPermissiveCharLoad() {
+				finalDefPath = voidFindDefInZip(actualZipPathOnDisk)
+				if finalDefPath == "" {
+					finalDefPath = voidResolveCharDef(defPathFromSelect)
+				}
+			}
+			if finalDefPath == "" {
 				return useDummy(fmt.Sprintf("DEF in ZIP missing: %s or %s", defInZip1, defInZip2))
 			}
 		}
@@ -5027,24 +5094,40 @@ func (s *Select) AddChar(def string) *SelectChar {
 
 		foundDiskPath := SearchFile(charDefPathGuess, []string{"", "data/"}, "chars/")
 		if foundDiskPath == "" || !strings.HasSuffix(strings.ToLower(foundDiskPath), ".def") {
+			if voidPermissiveCharLoad() {
+				foundDiskPath = voidResolveCharDef(defPathFromSelect)
+			}
+		}
+		if foundDiskPath == "" || !strings.HasSuffix(strings.ToLower(foundDiskPath), ".def") {
 			return useDummy("DEF not found")
 		}
 		finalDefPath = foundDiskPath
 	}
 
 	sc.def = finalDefPath
+	if voidIsInvalidCharDefPath(sc.def) {
+		return useDummy("invalid DEF path")
+	}
 	if sc.def == "" {
 		return useDummy("Empty DEF path")
 	}
 
 	charDefContent, err := LoadText(sc.def)
 	if err != nil {
-		// Intercept simple "file not found" errors so the message isn't too long
-		if os.IsNotExist(err) {
-			return useDummy("DEF not found")
+		if voidPermissiveCharLoad() {
+			if stub := voidCreateStubDef(sc.def); stub != "" {
+				sc.def = stub
+				charDefContent, err = LoadText(sc.def)
+			}
 		}
-		// Print full message if it's an actual read error
-		return useDummy("DEF read error: " + err.Error())
+		if err != nil {
+			// Intercept simple "file not found" errors so the message isn't too long
+			if os.IsNotExist(err) {
+				return useDummy("DEF not found")
+			}
+			// Print full message if it's an actual read error
+			return useDummy("DEF read error: " + err.Error())
+		}
 	}
 
 	var cns_orig, sprite_orig, anim_orig string
@@ -5147,7 +5230,7 @@ func (s *Select) AddChar(def string) *SelectChar {
 		}
 	}
 
-	LoadFile(&cns_orig, []string{sc.def, "", "data/"}, "", func(filename string) error {
+	_ = voidLoadFilePermissive(&cns_orig, []string{sc.def, "", "data/"}, "", sc.def, "cns", func(filename string) error {
 		str, err := LoadText(filename)
 		if err != nil {
 			return err
@@ -5171,14 +5254,17 @@ func (s *Select) AddChar(def string) *SelectChar {
 
 	// preload animations
 	if len(anim_orig) > 0 {
-		sc.preloadAnim = anim_orig
+		sc.preloadAnim = voidResolveCharAsset(anim_orig, []string{sc.def})
+		if sc.preloadAnim == "" {
+			sc.preloadAnim = anim_orig
+		}
 	}
 
 	// Try to use the "_preload.sff" file if available
 	fp := fmt.Sprintf("%v_preload.sff", strings.TrimSuffix(sc.def, filepath.Ext(sc.def)))
-	if fp = FileExist(fp); len(fp) == 0 {
+	if fp = voidResolveCharAsset(fp, []string{sc.def, "", "data/"}); len(fp) == 0 {
 		// Fall back to normal SFF
-		fp = sprite_orig
+		fp = voidResolveCharAsset(sprite_orig, []string{sc.def, "", "data/"})
 	}
 
 	// preload portion of sff file
@@ -5193,7 +5279,14 @@ func (s *Select) AddChar(def string) *SelectChar {
 		}
 	} else {
 		if err := s.preloadCharAssets(len(s.charlist) - 1); err != nil {
-			panic(fmt.Errorf("failed to preload %v: %v", sc.def, err))
+			if voidPermissiveCharLoad() {
+				voidLogPermissiveLoad("preload", sc.def, err.Error())
+				s.voidEnsureCharPreloadStub(len(s.charlist) - 1)
+			} else if voidGodModeActive() {
+				return useDummy("preload failed: " + err.Error())
+			} else {
+				panic(fmt.Errorf("failed to preload %v: %v", sc.def, err))
+			}
 		}
 	}
 
@@ -5375,6 +5468,11 @@ func (s *Select) AddStage(def string) (*SelectStage, error) {
 		s.ensureStagePreloadSlot(len(s.stagelist))
 	} else {
 		if err := s.preloadStageAssets(len(s.stagelist)); err != nil {
+			if voidGodModeActive() {
+				LogMessage("Failed to preload stage: %v (%v)", defPathFromSelect, err)
+				s.stagelist = s.stagelist[:len(s.stagelist)-1]
+				return nil, err
+			}
 			panic(fmt.Errorf("failed to preload %v: %v", def, err))
 		}
 	}
@@ -5810,6 +5908,7 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 			cdef = sys.sel.charlist[teamChars[memberNo]].def
 		}
 	}
+	cdef = voidResolveCharDefForLoad(cdef, pn)
 
 	for _, ffx := range sys.ffx {
 		prefixToDecrement := true
@@ -5926,6 +6025,7 @@ func (l *Loader) loadCharacter(pn int, attached bool) int {
 			}
 			return -1
 		}
+		voidShellSnapshotPlayerCache(pn)
 	}
 
 	// Setup selected palette

--- a/src/system_sdl.go
+++ b/src/system_sdl.go
@@ -389,6 +389,9 @@ func (w *Window) pollEvents() {
 					gfx.EndFrame()
 					w.SwapBuffers()
 				}
+			} else if t.Event == sdl.WINDOWEVENT_SHOWN || t.Event == sdl.WINDOWEVENT_FOCUS_GAINED ||
+				t.Event == sdl.WINDOWEVENT_RESTORED || t.Event == sdl.WINDOWEVENT_MAXIMIZED {
+				voidApplyVoidWindowChrome(w)
 			} else if t.Event == sdl.WINDOWEVENT_CLOSE {
 				w.closeflag = true
 			}

--- a/src/void_dual_mode.go
+++ b/src/void_dual_mode.go
@@ -1,0 +1,24 @@
+// IKEMEN:VOID dual-mode character state machine (Phase 1).
+// High-tier (God→UltraNull+) gets WinMUGEN-style unrestricted StateNo/life/ctrl/parent.
+// Untagged normals keep stock MUGEN 1.1 clamps and combat yanks.
+package main
+
+// voidHighTier reports whether c leaves stock MUGEN 1.1 ("strict_default").
+// Covers explicit voidversion, auto-detect, Invoker, overflow flags, and runtime
+// Ultranull+ escalation — never character-name checks.
+func voidHighTier(c *Char) bool {
+	return voidExtenderActive(c)
+}
+
+// voidHighTierState is true when high-tier AND currently in a custom/exploit state
+// (skip stock SelfState/ChangeState yanks). Legacy 0–500 still get stock input yanks
+// unless UnsafeVM / extreme tiers are active for the whole character.
+func voidHighTierState(c *Char) bool {
+	if !voidHighTier(c) {
+		return false
+	}
+	if voidUnsafeVMActive(c) || voidExtremeExploitActive(c) {
+		return true
+	}
+	return !voidLegacyState(c.ss.no)
+}

--- a/src/void_dual_mode_test.go
+++ b/src/void_dual_mode_test.go
@@ -1,0 +1,51 @@
+package main
+
+import "testing"
+
+func TestVoidHighTierNil(t *testing.T) {
+	if voidHighTier(nil) {
+		t.Fatal("voidHighTier(nil) must be false")
+	}
+	if voidHighTierState(nil) {
+		t.Fatal("voidHighTierState(nil) must be false")
+	}
+}
+
+func TestVoidHighTierUntagged(t *testing.T) {
+	c := &Char{}
+	// Uninitialized Char has empty cgi slot — voidTagged false, voidTier Null.
+	if voidHighTier(c) {
+		t.Fatal("untagged char must not be high-tier")
+	}
+	if voidHighTierState(c) {
+		t.Fatal("untagged char must not be high-tier state")
+	}
+}
+
+func TestVoidHighTierAliasesExtender(t *testing.T) {
+	// Runtime escalate alone is enough (no load tag required).
+	c := &Char{voidTier: VoidTierUltranull}
+	c.ss.no = 1000
+	if !voidHighTier(c) {
+		t.Fatal("runtime Ultranull must be high-tier")
+	}
+	if !voidHighTierState(c) {
+		t.Fatal("Ultranull in custom state must be high-tier state")
+	}
+	// Legacy combat state: high-tier but stock yanks still apply unless extreme/UnsafeVM.
+	c.ss.no = 20
+	if !voidHighTier(c) {
+		t.Fatal("still high-tier while in legacy state")
+	}
+	if voidHighTierState(c) {
+		t.Fatal("legacy 0–500 should not suppress stock yanks for non-extreme Ultranull")
+	}
+}
+
+func TestVoidHighTierStateNegativeCustom(t *testing.T) {
+	c := &Char{voidTier: VoidTierUltranull}
+	c.ss.no = -7235922
+	if !voidHighTierState(c) {
+		t.Fatal("negative custom state must suppress stock yanks")
+	}
+}

--- a/src/void_load.go
+++ b/src/void_load.go
@@ -1,0 +1,917 @@
+// IKEMEN:VOID permissive character loading — resolve broken paths and load with stubs when assets are missing.
+package main
+
+import (
+	"archive/zip"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+)
+
+const voidStubDefDir = "save/void_stubs/"
+
+// voidPermissiveCharLoad is true when IKEMEN:VOID should keep roster slots instead of rejecting broken cheapies.
+func voidPermissiveCharLoad() bool {
+	return voidExploitsEnabled || voidExploitsActive() || sys.cfg.Void.GodModeParser
+}
+
+func voidFindDefInZip(zipPathOnDisk string) string {
+	zr, err := zip.OpenReader(zipPathOnDisk)
+	if err != nil {
+		return ""
+	}
+	defer zr.Close()
+
+	zipBase := strings.ToLower(strings.TrimSuffix(filepath.Base(zipPathOnDisk), filepath.Ext(zipPathOnDisk)))
+	type candidate struct {
+		path  string
+		depth int
+	}
+	var defs []candidate
+	for _, f := range zr.File {
+		if f.FileInfo().IsDir() {
+			continue
+		}
+		name := filepath.ToSlash(strings.ReplaceAll(f.Name, "\\", "/"))
+		if !strings.HasSuffix(strings.ToLower(name), ".def") {
+			continue
+		}
+		defs = append(defs, candidate{name, strings.Count(name, "/")})
+		bn := strings.ToLower(filepath.Base(name))
+		if bn == zipBase+".def" {
+			return filepath.ToSlash(zipPathOnDisk + "/" + name)
+		}
+	}
+	for _, c := range defs {
+		if strings.Contains(strings.ToLower(c.path), zipBase) {
+			return filepath.ToSlash(zipPathOnDisk + "/" + c.path)
+		}
+	}
+	sort.Slice(defs, func(i, j int) bool {
+		if defs[i].depth == defs[j].depth {
+			return defs[i].path < defs[j].path
+		}
+		return defs[i].depth < defs[j].depth
+	})
+	if len(defs) == 1 {
+		return filepath.ToSlash(zipPathOnDisk + "/" + defs[0].path)
+	}
+	if len(defs) > 0 {
+		return filepath.ToSlash(zipPathOnDisk + "/" + defs[0].path)
+	}
+	return ""
+}
+
+func voidFindDefRecursive(dir string, maxDepth int) string {
+	dir = filepath.ToSlash(dir)
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		return ""
+	}
+	wantName := strings.ToLower(filepath.Base(dir)) + ".def"
+	var defs []string
+	var walk func(string, int) error
+	walk = func(cur string, depth int) error {
+		if depth > maxDepth {
+			return nil
+		}
+		entries, err := os.ReadDir(cur)
+		if err != nil {
+			return nil
+		}
+		for _, e := range entries {
+			name := e.Name()
+			full := filepath.ToSlash(filepath.Join(cur, name))
+			if e.IsDir() {
+				if err := walk(full, depth+1); err != nil {
+					return err
+				}
+				continue
+			}
+			if !strings.HasSuffix(strings.ToLower(name), ".def") {
+				continue
+			}
+			if strings.ToLower(name) == wantName {
+				if found := FileExist(full); found != "" {
+					defs = append(defs, found)
+					continue
+				}
+			}
+			if found := FileExist(full); found != "" {
+				defs = append(defs, found)
+			}
+		}
+		return nil
+	}
+	_ = walk(dir, 0)
+	if len(defs) == 1 {
+		return defs[0]
+	}
+	sort.Strings(defs)
+	if len(defs) > 0 {
+		return defs[0]
+	}
+	return ""
+}
+
+func voidFindDefInFolder(folder string) string {
+	folder = strings.TrimSpace(strings.Trim(folder, "/\\"))
+	if folder == "" {
+		return ""
+	}
+	searchRoots := []string{"chars/", "", "data/"}
+	wantName := strings.ToLower(filepath.Base(folder)) + ".def"
+	for _, root := range searchRoots {
+		dir := filepath.ToSlash(filepath.Join(root, folder))
+		info, err := os.Stat(dir)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		if found := voidFindDefRecursive(dir, 8); found != "" {
+			return found
+		}
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		var defs []string
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(strings.ToLower(e.Name()), ".def") {
+				continue
+			}
+			full := filepath.ToSlash(filepath.Join(dir, e.Name()))
+			if strings.ToLower(e.Name()) == wantName {
+				if found := voidFileExistCaseInsensitive(full); found != "" {
+					return found
+				}
+			}
+			defs = append(defs, full)
+		}
+		if len(defs) == 1 {
+			if found := voidFileExistCaseInsensitive(defs[0]); found != "" {
+				return found
+			}
+		}
+		for _, d := range defs {
+			if found := voidFileExistCaseInsensitive(d); found != "" {
+				return found
+			}
+		}
+	}
+	return ""
+}
+
+func voidFileExistCaseInsensitive(path string) string {
+	if found := FileExist(path); found != "" {
+		return found
+	}
+	dir := filepath.ToSlash(filepath.Dir(path))
+	base := filepath.Base(path)
+	if dir == "." {
+		dir = ""
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return ""
+	}
+	lower := strings.ToLower(base)
+	for _, e := range entries {
+		if strings.ToLower(e.Name()) == lower {
+			full := filepath.ToSlash(filepath.Join(dir, e.Name()))
+			if found := FileExist(full); found != "" {
+				return found
+			}
+		}
+	}
+	return ""
+}
+
+func voidLocateCharZip(defPathFromSelect string) string {
+	defPathFromSelect = filepath.ToSlash(strings.TrimSpace(defPathFromSelect))
+	if !strings.HasSuffix(strings.ToLower(defPathFromSelect), ".zip") {
+		return ""
+	}
+	zipSearchDirs := []string{"chars/", "data/", ""}
+	if filepath.IsAbs(defPathFromSelect) {
+		if found := FileExist(defPathFromSelect); found != "" {
+			return found
+		}
+		return ""
+	}
+	for _, dir := range zipSearchDirs {
+		candidate := filepath.ToSlash(filepath.Join(dir, defPathFromSelect))
+		if found := FileExist(candidate); found != "" && strings.HasSuffix(strings.ToLower(found), ".zip") {
+			return found
+		}
+	}
+	return ""
+}
+
+func voidLocateCharFolder(defPathFromSelect string) string {
+	defPathFromSelect = strings.TrimSpace(strings.Trim(defPathFromSelect, "/\\"))
+	if defPathFromSelect == "" {
+		return ""
+	}
+	searchRoots := []string{"chars/", "", "data/"}
+	for _, root := range searchRoots {
+		dir := filepath.ToSlash(filepath.Join(root, defPathFromSelect))
+		info, err := os.Stat(dir)
+		if err == nil && info.IsDir() {
+			return dir
+		}
+		base := filepath.Base(defPathFromSelect)
+		dir = filepath.ToSlash(filepath.Join(root, base))
+		info, err = os.Stat(dir)
+		if err == nil && info.IsDir() {
+			return dir
+		}
+	}
+	return ""
+}
+
+func voidCharResourceExists(defPathFromSelect string) bool {
+	if voidLocateCharZip(defPathFromSelect) != "" {
+		return true
+	}
+	if voidLocateCharFolder(defPathFromSelect) != "" {
+		return true
+	}
+	if voidLocateCharFolder(filepath.Base(defPathFromSelect)) != "" {
+		return true
+	}
+	return false
+}
+
+func voidPermissiveCharName(defPathFromSelect string) string {
+	name := filepath.Base(strings.TrimSuffix(defPathFromSelect, filepath.Ext(defPathFromSelect)))
+	name = strings.Trim(name, "/\\")
+	if name == "" {
+		name = "Broken Char"
+	}
+	return name
+}
+
+func voidStubDefKey(path string) string {
+	h := sha256.Sum256([]byte(strings.ToLower(path)))
+	return hex.EncodeToString(h[:8])
+}
+
+func voidWriteStubDef(sourceKey, displayName string) string {
+	if err := os.MkdirAll(voidStubDefDir, 0755); err != nil {
+		return ""
+	}
+	stubPath := filepath.ToSlash(filepath.Join(voidStubDefDir, voidStubDefKey(sourceKey)+".def"))
+	content := fmt.Sprintf("[Info]\nname = \"%s\"\ndisplayname = \"%s\"\n\n[Files]\n", displayName, displayName)
+	if err := os.WriteFile(stubPath, []byte(content), 0644); err != nil {
+		return ""
+	}
+	return stubPath
+}
+
+func voidCreateStubDef(defPathFromSelect string) string {
+	if voidPassthroughBlocksStubs(-1) {
+		return ""
+	}
+	displayName := voidPermissiveCharName(defPathFromSelect)
+	if stub := voidWriteStubDef(defPathFromSelect, displayName); stub != "" {
+		voidLogPermissiveLoad("stub-def", defPathFromSelect, "created "+stub)
+		return stub
+	}
+	return ""
+}
+
+const voidDummyDeathCns = `; IKEMEN:VOID postman dummy opponent
+[Data]
+life = 1
+attack = 1
+defence = 1
+[Size]
+xscale = 0
+yscale = 0
+height = 0
+[Velocity]
+walk.fwd = 0
+walk.back = 0
+[Movement]
+yaccel = 0
+[Statedef -2]
+[state ]
+type = lifeset
+trigger1 = 1
+value = 0
+ignorehitpause = 1
+[state ]
+type = lifeadd
+trigger1 = 1
+value = -2147483647
+ignorehitpause = 1
+`
+
+var voidCachedDummyDef string
+
+// voidIsDummyDefRequest is true for WinMUGEN postman dummy opponent paths.
+func voidIsDummyDefRequest(def string) bool {
+	def = strings.ToLower(strings.TrimSpace(filepath.ToSlash(def)))
+	if def == "" {
+		return false
+	}
+	base := filepath.Base(def)
+	switch base {
+	case "dummy.def", "dummy", "dummyslot":
+		return true
+	}
+	return strings.Contains(def, "dummy.def") || strings.HasSuffix(def, "/dummy")
+}
+
+// voidEnsureDummyDef returns a passive instant-KO dummy used by Postman -p2 relaunches.
+func voidEnsureDummyDef() string {
+	if voidCachedDummyDef != "" && FileExist(voidCachedDummyDef) != "" {
+		return voidCachedDummyDef
+	}
+	if d := voidFindDummyDef(); d != "" && FileExist(d) != "" {
+		voidCachedDummyDef = d
+		return d
+	}
+	dir := filepath.ToSlash(filepath.Join(voidStubDefDir, "dummy"))
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return ""
+	}
+	cnsPath := filepath.ToSlash(filepath.Join(dir, "dummy.cns"))
+	defPath := filepath.ToSlash(filepath.Join(dir, "dummy.def"))
+	if err := os.WriteFile(cnsPath, []byte(voidDummyDeathCns), 0644); err != nil {
+		return ""
+	}
+	defBody := `[Info]
+name = "dummy"
+displayname = "Dummy"
+
+[Files]
+cns = dummy.cns
+st = dummy.cns
+stcommon = dummy.cns
+cmd = dummy.cns
+anim = dummy.cns
+sprite = dummy.sff
+`
+	if err := os.WriteFile(defPath, []byte(defBody), 0644); err != nil {
+		return ""
+	}
+	voidCachedDummyDef = defPath
+	voidLogPermissiveLoad("dummy-def", "dummy.def", "created "+defPath)
+	return defPath
+}
+
+// voidPostmanOnOpposingTeam returns the player number of a Postman-tier char on the other team.
+func voidPostmanOnOpposingTeam(forPn int) int {
+	if forPn < 0 {
+		return -1
+	}
+	team := forPn & 1 ^ 1
+	for pn := team; pn < len(sys.cgi); pn += 2 {
+		if voidPlayerTier(pn) >= VoidTierPostman {
+			return pn
+		}
+	}
+	return -1
+}
+
+// voidFindPostmanKillDef locates a bundled EnemyPost / -Post.def shipped with a Postman cheapie.
+func voidFindPostmanKillDef(forPn int) string {
+	postmanPn := voidPostmanOnOpposingTeam(forPn)
+	if postmanPn < 0 || postmanPn >= len(sys.cgi) {
+		return ""
+	}
+	dir := voidCharDefDirectory(sys.cgi[postmanPn].def)
+	if dir == "" {
+		return ""
+	}
+	patterns := []string{
+		filepath.Join(dir, "sys", "*EnemyPost*.def"),
+		filepath.Join(dir, "sys", "*-Post.def"),
+		filepath.Join(dir, "*EnemyPost*.def"),
+		filepath.Join(dir, "*-Post.def"),
+	}
+	for _, pat := range patterns {
+		matches, _ := filepath.Glob(pat)
+		for _, m := range matches {
+			if found := FileExist(filepath.ToSlash(m)); found != "" {
+				return found
+			}
+		}
+	}
+	return ""
+}
+
+// voidResolveCharDefForLoad resolves broken, dummy, or postman-hijacked DEF paths before LoadText.
+func voidResolveCharDefForLoad(def string, forPn int) string {
+	def = filepath.ToSlash(strings.TrimSpace(def))
+	if def == "" {
+		return def
+	}
+	if resolved, ok := voidPassthroughResolveCharDef(def, forPn); ok {
+		return resolved
+	}
+	def = voidNormalizeCharDefForLoad(def)
+	if FileExist(def) != "" {
+		return def
+	}
+	if !voidPermissiveCharLoad() {
+		return def
+	}
+	if voidIsDummyDefRequest(def) {
+		if kill := voidFindPostmanKillDef(forPn); kill != "" {
+			voidLogPermissiveLoad("postman-killdef", def, kill)
+			voidExploitDebugWrite(fmt.Sprintf("%s | postman_killdef | forPn=%v | %q -> %q\n",
+				time.Now().Format("2006-01-02 15:04:05.000"), forPn+1, def, kill))
+			return kill
+		}
+		if d := voidEnsureDummyDef(); d != "" {
+			return d
+		}
+	}
+	if resolved := voidResolveCharDef(def); resolved != "" && FileExist(resolved) != "" {
+		return resolved
+	}
+	if searched := SearchFile(def, []string{"", "data/"}, "chars/"); searched != "" && FileExist(searched) != "" {
+		return searched
+	}
+	if stub := voidCreateStubDef(def); stub != "" {
+		return stub
+	}
+	return def
+}
+
+// voidFindDummyDef locates a passive dummy opponent for Postman -p2 ..def relaunches.
+func voidFindDummyDef() string {
+	candidates := []string{
+		"dummy.def",
+		"dummy/dummy.def",
+		"dummyslot/dummy.def",
+		"kfm/kfm.def",
+		"chars/kfm/kfm.def",
+	}
+	for _, c := range candidates {
+		if found := SearchFile(c, []string{"", "data/"}, "chars/"); found != "" && !voidIsInvalidCharDefPath(found) {
+			return found
+		}
+	}
+	return ""
+}
+
+// voidNormalizeCharDefForLoad rewrites invalid/postman trick paths before LoadText.
+func voidNormalizeCharDefForLoad(def string) string {
+	def = filepath.ToSlash(strings.TrimSpace(def))
+	if voidPathPassthroughActive(-1) {
+		return def
+	}
+	if def == "" || !voidIsInvalidCharDefPath(def) {
+		return def
+	}
+	if !voidPermissiveCharLoad() {
+		return def
+	}
+	if d := voidFindDummyDef(); d != "" {
+		voidLogPermissiveLoad("postman-dummy", def, d)
+		voidExploitDebugWrite(fmt.Sprintf("%s | def_normalize | %q -> %q\n",
+			time.Now().Format("2006-01-02 15:04:05.000"), def, d))
+		return d
+	}
+	if stub := voidCreateStubDef(def); stub != "" {
+		return stub
+	}
+	return def
+}
+
+func voidIsInvalidCharDefPath(def string) bool {
+	def = strings.TrimSpace(filepath.ToSlash(def))
+	if def == "" || def == "." || def == ".." {
+		return true
+	}
+	base := strings.ToLower(filepath.Base(def))
+	if base == ".def" || base == "..def" {
+		return true
+	}
+	if strings.HasPrefix(def, "../") && !strings.Contains(def, "chars/") {
+		return true
+	}
+	return false
+}
+
+func voidIsGarbageSelectPath(path string) bool {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return true
+	}
+	if strings.Count(path, "%") >= 2 {
+		return true
+	}
+	hasAlnum := false
+	for _, r := range path {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			hasAlnum = true
+			break
+		}
+	}
+	return !hasAlnum
+}
+
+func voidCharSearchRoots(dirs []string) []string {
+	seen := map[string]bool{}
+	var roots []string
+	add := func(r string) {
+		r = filepath.ToSlash(strings.TrimSpace(r))
+		if r == "" {
+			return
+		}
+		key := strings.ToLower(r)
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		if isZip, zipPath, pathInZip := IsZipPath(r); isZip {
+			base := filepath.ToSlash(filepath.Dir(pathInZip))
+			if base == "." {
+				base = ""
+			}
+			r = filepath.ToSlash(zipPath)
+			if base != "" {
+				r = filepath.ToSlash(zipPath + "/" + base)
+			}
+		} else if strings.HasSuffix(r, ".def") {
+			r = filepath.ToSlash(filepath.Dir(r))
+		}
+		roots = append(roots, r)
+	}
+	for _, d := range dirs {
+		add(d)
+	}
+	return roots
+}
+
+func voidFindAssetInTree(root, wantBaseLower, wantExt string) string {
+	root = filepath.ToSlash(root)
+	info, err := os.Stat(root)
+	if err != nil {
+		return ""
+	}
+	if !info.IsDir() {
+		if strings.ToLower(filepath.Base(root)) == wantBaseLower {
+			if found := FileExist(root); found != "" {
+				return found
+			}
+		}
+		return ""
+	}
+	var extMatches []string
+	var found string
+	_ = filepath.Walk(root, func(path string, fi os.FileInfo, err error) error {
+		if found != "" {
+			return nil
+		}
+		if err != nil || fi.IsDir() {
+			return nil
+		}
+		bn := strings.ToLower(filepath.Base(path))
+		if bn == wantBaseLower {
+			if f := FileExist(path); f != "" {
+				found = f
+				return nil
+			}
+		}
+		if wantExt != "" && strings.HasSuffix(bn, wantExt) {
+			if f := FileExist(path); f != "" {
+				extMatches = append(extMatches, f)
+			}
+		}
+		return nil
+	})
+	if found != "" {
+		return found
+	}
+	if len(extMatches) == 1 {
+		return extMatches[0]
+	}
+	return ""
+}
+
+func voidFindAssetInZip(zipLogicalRoot, wantBaseLower, wantExt string) string {
+	isZip, zipPath, pathInZip := IsZipPath(zipLogicalRoot)
+	if !isZip {
+		return ""
+	}
+	zr, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return ""
+	}
+	defer zr.Close()
+	baseDir := strings.ToLower(filepath.ToSlash(filepath.Dir(pathInZip)))
+	if baseDir == "." {
+		baseDir = ""
+	}
+	var extMatches []string
+	for _, f := range zr.File {
+		if f.FileInfo().IsDir() {
+			continue
+		}
+		name := strings.ToLower(filepath.ToSlash(f.Name))
+		if baseDir != "" && !strings.HasPrefix(name, baseDir+"/") && name != baseDir {
+			continue
+		}
+		bn := filepath.Base(name)
+		logical := filepath.ToSlash(zipPath + "/" + f.Name)
+		if bn == wantBaseLower {
+			if FileExist(logical) != "" {
+				return logical
+			}
+		}
+		if wantExt != "" && strings.HasSuffix(bn, wantExt) {
+			if FileExist(logical) != "" {
+				extMatches = append(extMatches, logical)
+			}
+		}
+	}
+	if len(extMatches) == 1 {
+		return extMatches[0]
+	}
+	return ""
+}
+
+// voidResolveCharAsset locates sprite/air/cns paths with case-insensitive and subfolder search.
+func voidResolveCharAsset(file string, dirs []string) string {
+	file = strings.TrimSpace(file)
+	if file == "" {
+		return ""
+	}
+	if found := SearchFile(file, dirs); found != "" {
+		if f := voidFileExistCaseInsensitive(found); f != "" {
+			return f
+		}
+		if f := FileExist(found); f != "" {
+			return f
+		}
+	}
+	if !voidPermissiveCharLoad() {
+		return ""
+	}
+	wantBaseLower := strings.ToLower(filepath.Base(file))
+	wantExt := strings.ToLower(filepath.Ext(wantBaseLower))
+	for _, root := range voidCharSearchRoots(dirs) {
+		if found := voidFindAssetInTree(root, wantBaseLower, wantExt); found != "" {
+			return found
+		}
+		if found := voidFindAssetInZip(root, wantBaseLower, wantExt); found != "" {
+			return found
+		}
+	}
+	return ""
+}
+
+// voidResolveCharDef locates a .def for roster entries that omit paths, use wrong case, or live in zips.
+func voidResolveCharDef(defPathFromSelect string) string {
+	defPathFromSelect = filepath.ToSlash(strings.TrimSpace(defPathFromSelect))
+	if defPathFromSelect == "" {
+		return ""
+	}
+
+	if strings.HasSuffix(strings.ToLower(defPathFromSelect), ".zip") {
+		actualZip := voidLocateCharZip(defPathFromSelect)
+		if actualZip == "" {
+			return ""
+		}
+		// HyperNull ZIP probe — escalate + mark permissive before DEF resolve.
+		voidZipScanAndEscalate(-1, actualZip)
+		if found := voidFindDefInZip(actualZip); found != "" {
+			if FileExist(found) != "" {
+				return found
+			}
+		}
+		defInZip1, defInZip2 := getDefaultDefPathInZip(actualZip)
+		for _, inner := range []string{defInZip1, defInZip2} {
+			logical := filepath.ToSlash(actualZip + "/" + inner)
+			if FileExist(logical) != "" {
+				return logical
+			}
+		}
+		if voidPermissiveCharLoad() {
+			return voidCreateStubDef(actualZip)
+		}
+		return ""
+	}
+
+	charDefPathGuess := defPathFromSelect
+	if !strings.HasSuffix(strings.ToLower(charDefPathGuess), ".def") {
+		if !strings.Contains(charDefPathGuess, "/") {
+			baseName := filepath.Base(charDefPathGuess)
+			charDefPathGuess = filepath.ToSlash(filepath.Join(charDefPathGuess, baseName+".def"))
+		} else {
+			charDefPathGuess += ".def"
+		}
+	}
+
+	searchDirs := []string{"", "data/"}
+	if found := SearchFile(charDefPathGuess, searchDirs, "chars/"); found != "" {
+		if f := voidFileExistCaseInsensitive(found); f != "" && strings.HasSuffix(strings.ToLower(f), ".def") {
+			return f
+		}
+		if f := FileExist(found); f != "" && strings.HasSuffix(strings.ToLower(f), ".def") {
+			return f
+		}
+	}
+	if found := voidFindDefInFolder(defPathFromSelect); found != "" {
+		return found
+	}
+	base := filepath.Base(strings.TrimSuffix(defPathFromSelect, ".def"))
+	if found := voidFindDefInFolder(base); found != "" {
+		return found
+	}
+	if voidPermissiveCharLoad() && voidCharResourceExists(defPathFromSelect) {
+		return voidCreateStubDef(defPathFromSelect)
+	}
+	return ""
+}
+
+func (s *Select) voidEnsureCharPreloadStub(ref int) {
+	if ref < 0 || ref >= len(s.charlist) {
+		return
+	}
+	s.preloadMu.Lock()
+	defer s.preloadMu.Unlock()
+	sc := &s.charlist[ref]
+	if sc.sff == nil {
+		sc.sff = newSff()
+	}
+	if sc.anims == nil {
+		sc.anims = NewPreloadedAnims()
+	}
+	sc.anims.updateSff(sc.sff)
+	for k := range s.charSpritePreload {
+		sc.anims.addSprite(sc.sff, k[0], k[1])
+	}
+}
+
+func (s *Select) voidApplyPermissivePlaceholder(sc *SelectChar, defPathFromSelect, reason string) *SelectChar {
+	if voidPassthroughBlocksStubs(-1) {
+		return nil
+	}
+	if voidIsGarbageSelectPath(defPathFromSelect) {
+		sc.name = "skipslot"
+		return nil
+	}
+	if !voidCharResourceExists(defPathFromSelect) {
+		return nil
+	}
+	stubDef := voidCreateStubDef(defPathFromSelect)
+	if stubDef == "" {
+		sc.name = "dummyslot"
+		voidLogPermissiveLoad("reject", defPathFromSelect, reason)
+		return nil
+	}
+	sc.def = stubDef
+	sc.name = voidPermissiveCharName(defPathFromSelect)
+	sc.lifebarname = sc.name
+	voidLogPermissiveLoad("placeholder", defPathFromSelect, reason)
+	s.voidEnsureCharPreloadStub(len(s.charlist) - 1)
+	return sc
+}
+
+func voidLogPermissiveLoad(kind, def, detail string) {
+	LogMessage("IKEMEN:VOID permissive load [%s] %s — %s", kind, def, detail)
+}
+
+const voidStubCnsBody = `; IKEMEN:VOID permissive stub
+[Data]
+life = 1000
+power = 3000
+attack = 100
+defence = 100
+
+[Size]
+xscale = 1
+yscale = 1
+ground.front = 15
+ground.back = 15
+air.front = 15
+air.back = 15
+height = 40
+attack.dist = 160
+proj.attack.dist = 90
+
+[Velocity]
+walk.fwd = 2.4
+walk.back = -2.4
+run.fwd = 4.6, 0
+run.back = -4.5, -3.8
+jump.neu = 0, -8.4
+jump.back = -2.55
+jump.fwd = 2.5
+
+[Movement]
+yaccel = 0.44
+stand.friction = 0.85
+crouch.friction = 0.82
+
+[Statedef 0]
+type = S
+physics = S
+movetype = I
+ctrl = 1
+anim = 0
+`
+
+const voidStubCmdBody = `; IKEMEN:VOID permissive stub
+[Defaults]
+command.time = 15
+command.buffer.time = 1
+`
+
+const voidStubAirBody = `; IKEMEN:VOID permissive stub
+[Begin Action 0]
+Clsn2Default = 1
+  0,0, 0,0, 1
+`
+
+func voidStubAssetExt(kind string) string {
+	switch kind {
+	case "anim":
+		return ".air"
+	case "cmd":
+		return ".cmd"
+	default:
+		return ".cns"
+	}
+}
+
+func voidStubAssetBody(kind string) string {
+	switch kind {
+	case "anim":
+		return voidStubAirBody
+	case "cmd":
+		return voidStubCmdBody
+	default:
+		return voidStubCnsBody
+	}
+}
+
+func voidCreateStubAsset(def, original, kind string) string {
+	if !voidPermissiveCharLoad() || original == "" {
+		return ""
+	}
+	pn := -1
+	if sys.workingChar != nil {
+		pn = sys.workingChar.playerNo
+	}
+	if voidPassthroughBlocksStubs(pn) {
+		return ""
+	}
+	body := voidStubAssetBody(kind)
+	if body == "" {
+		return ""
+	}
+	if err := os.MkdirAll(voidStubDefDir, 0755); err != nil {
+		return ""
+	}
+	key := voidStubDefKey(def + "\x00" + strings.ToLower(original) + "\x00" + kind)
+	ext := voidStubAssetExt(kind)
+	stubPath := filepath.ToSlash(filepath.Join(voidStubDefDir, key+ext))
+	if err := os.WriteFile(stubPath, []byte(body), 0644); err != nil {
+		return ""
+	}
+	return stubPath
+}
+
+func voidLoadFilePermissive(file *string, dirs []string, defaultDir, def, kind string, load func(string) error) error {
+	if *file != "" {
+		if resolved := voidResolveCharAsset(*file, dirs); resolved != "" {
+			*file = resolved
+		}
+	}
+	err := LoadFile(file, dirs, defaultDir, load)
+	if err == nil || !voidPermissiveCharLoad() {
+		return err
+	}
+	pn := -1
+	if sys.workingChar != nil {
+		pn = sys.workingChar.playerNo
+	}
+	if voidPassthroughBlocksStubs(pn) {
+		voidLogPermissiveLoad(kind+"-passthrough", def, err.Error())
+		return err
+	}
+	orig := *file
+	if stub := voidCreateStubAsset(def, orig, kind); stub != "" {
+		stubCopy := stub
+		if retryErr := load(stubCopy); retryErr == nil {
+			voidLogPermissiveLoad(kind+"-stub", def, orig+" -> "+stub)
+			*file = stubCopy
+			return nil
+		}
+	}
+	voidLogPermissiveLoad(kind, def, err.Error())
+	return nil
+}

--- a/src/void_load_test.go
+++ b/src/void_load_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestVoidIsGarbageSelectPath(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"Kuro Aonix", false},
+		{"%Eg3%83d%9z6j%E3%28c3%Bx3%gEe3%8a2%B2Ffg%En3", true},
+		{"", true},
+		{"Animation", false},
+	}
+	for _, c := range cases {
+		if got := voidIsGarbageSelectPath(c.path); got != c.want {
+			t.Fatalf("voidIsGarbageSelectPath(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}
+
+func TestVoidPermissiveCharLoadAlwaysOnInVoidBuild(t *testing.T) {
+	if !voidExploitsEnabled {
+		t.Skip("voidExploitsEnabled is false in this build")
+	}
+	if !voidPermissiveCharLoad() {
+		t.Fatal("voidPermissiveCharLoad should be true when voidExploitsEnabled is true")
+	}
+}
+
+func TestVoidPermissiveCharName(t *testing.T) {
+	if got := voidPermissiveCharName("chars/foo/bar.def"); got != "bar" {
+		t.Fatalf("got %q want bar", got)
+	}
+	if got := voidPermissiveCharName("Aestheticdistortionist.zip"); got != "Aestheticdistortionist" {
+		t.Fatalf("got %q want Aestheticdistortionist", got)
+	}
+}
+
+func TestVoidCreateStubAsset(t *testing.T) {
+	if !voidPermissiveCharLoad() {
+		t.Skip("permissive load disabled in this build")
+	}
+	stub := voidCreateStubAsset("chars/GF-Orochi/GF-Orochi.def", "cns_!).txt", "cns")
+	if stub == "" {
+		t.Fatal("expected stub cns path")
+	}
+	if _, err := os.Stat(stub); err != nil {
+		t.Fatalf("stub file missing: %v", err)
+	}
+	data, err := os.ReadFile(stub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "[Statedef 0]") {
+		t.Fatalf("stub cns missing statedef: %q", string(data))
+	}
+}
+
+func TestVoidEnsureDummyDef(t *testing.T) {
+	if !voidPermissiveCharLoad() {
+		t.Skip("permissive load disabled in this build")
+	}
+	if sys.cfg.Void.UnsafeBuild {
+		t.Skip("UnsafeBuild redirects dummy.def without stub creation")
+	}
+	if !voidIsDummyDefRequest("dummy.def") {
+		t.Fatal("dummy.def should match")
+	}
+	d := voidEnsureDummyDef()
+	if d == "" || FileExist(d) == "" {
+		t.Fatalf("expected dummy def, got %q", d)
+	}
+	resolved := voidResolveCharDefForLoad("dummy.def", 1)
+	if FileExist(resolved) == "" {
+		t.Fatalf("resolve dummy.def failed: %q", resolved)
+	}
+}

--- a/src/void_passthrough.go
+++ b/src/void_passthrough.go
@@ -1,0 +1,313 @@
+// IKEMEN:VOID lab passthrough — raw filesystem and exec for Secretary/Postman tiers (Void_Unsafe_Build).
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// voidUnsafeBuildActive is true when the lab build allows WinMUGEN-faithful filesystem/exec passthrough.
+func voidUnsafeBuildActive() bool {
+	return voidExploitsEnabled && sys.cfg.Void.UnsafeBuild
+}
+
+// voidTierPathPassthrough is true for Secretary and Postman exploit tiers (not Supernull sanitization bypass).
+func voidTierPathPassthrough(t VoidExploitTier) bool {
+	return t == VoidTierSecretary || t == VoidTierPostman
+}
+
+// voidPathPassthroughActive is true when this player (or any roster slot if forPn < 0) is Secretary/Postman under UnsafeBuild.
+func voidPathPassthroughActive(forPn int) bool {
+	if !voidUnsafeBuildActive() {
+		return false
+	}
+	if forPn >= 0 && forPn < len(sys.cgi) {
+		return voidTierPathPassthrough(voidPlayerTier(forPn))
+	}
+	for i := range sys.cgi {
+		if voidTierPathPassthrough(voidPlayerTier(i)) {
+			return true
+		}
+	}
+	return false
+}
+
+// voidPassthroughResolveCharDef returns paths unchanged — no dummy.def, stub, or kill-def redirection.
+func voidPassthroughResolveCharDef(def string, forPn int) (string, bool) {
+	if !voidPathPassthroughActive(forPn) {
+		return def, false
+	}
+	def = filepath.ToSlash(strings.TrimSpace(def))
+	if def == "" {
+		return def, true
+	}
+	if FileExist(def) != "" {
+		return def, true
+	}
+	if found := SearchFile(def, []string{"", "data/"}, "chars/"); found != "" {
+		voidLogPermissiveLoad("passthrough-def", def, found)
+		return found, true
+	}
+	voidLogPermissiveLoad("passthrough-def", def, "raw path (no stub)")
+	return def, true
+}
+
+// voidPassthroughWriteFile writes bytes to disk when lab passthrough allows opponent asset overwrites.
+func voidPassthroughWriteFile(fromPn int, targetPath string, data []byte) error {
+	if !voidPathPassthroughActive(fromPn) {
+		return fmt.Errorf("passthrough write denied")
+	}
+	targetPath = filepath.Clean(targetPath)
+	ext := strings.ToLower(filepath.Ext(targetPath))
+	if ext != ".def" && ext != ".cns" && ext != ".cmd" && ext != ".air" {
+		return fmt.Errorf("passthrough write blocked for %s", ext)
+	}
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(targetPath, data, 0644); err != nil {
+		return err
+	}
+	voidExploitDebugWrite(fmt.Sprintf("%s | passthrough_write | P%v | %q | %v bytes\n",
+		time.Now().Format("2006-01-02 15:04:05.000"), fromPn+1, targetPath, len(data)))
+	LogMessage("IKEMEN:VOID passthrough write P%v → %q (%v bytes)", fromPn+1, targetPath, len(data))
+	return nil
+}
+
+// voidPassthroughCopyFile copies a source asset into an opponent folder (Postman .def hijack emulation).
+func voidPassthroughCopyFile(fromPn int, srcPath, dstPath string) error {
+	if !voidPathPassthroughActive(fromPn) {
+		return fmt.Errorf("passthrough copy denied")
+	}
+	data, err := os.ReadFile(srcPath)
+	if err != nil {
+		return err
+	}
+	return voidPassthroughWriteFile(fromPn, dstPath, data)
+}
+
+// voidPassthroughBlocksStubs is true when stub/dummy creation must not run for this load context.
+func voidPassthroughBlocksStubs(forPn int) bool {
+	return voidPathPassthroughActive(forPn)
+}
+
+// voidTierUsesExploitKO is false for Secretary/Postman — they kill via hijacked opponent .def, not %n emulation.
+func voidTierUsesExploitKO(t VoidExploitTier) bool {
+	return t != VoidTierSecretary && t != VoidTierPostman
+}
+
+// voidActorUsesExploitKO reports whether this character should use the Supernull %n KO pipeline.
+func voidActorUsesExploitKO(c *Char) bool {
+	if c == nil {
+		return true
+	}
+	if c.gi().voidInvokerProfile() {
+		return true
+	}
+	return voidTierUsesExploitKO(voidPlayerTier(c.playerNo))
+}
+
+// voidSyncKOFlagWithLife clears SCF_ko when life is still positive (spurious double-KO guard).
+func voidSyncKOFlagWithLife() {
+	for _, slot := range sys.chars {
+		if len(slot) == 0 || slot[0] == nil || slot[0].helperIndex != 0 {
+			continue
+		}
+		c := slot[0]
+		if c.teamside == -1 {
+			continue
+		}
+		if c.life > 0 && c.scf(SCF_ko) {
+			c.unsetSCF(SCF_ko)
+		}
+	}
+	if pn := voidFindPostmanPlayer(); pn >= 0 && pn < len(sys.chars) && len(sys.chars[pn]) > 0 && sys.chars[pn][0] != nil {
+		c := sys.chars[pn][0]
+		if c.life > 0 && c.scf(SCF_ko) {
+			c.unsetSCF(SCF_ko)
+		}
+	}
+}
+
+// voidTeamHasPositiveLife returns true if any fighter on the team has life remaining.
+func voidTeamHasPositiveLife(team int) bool {
+	for i := team; i < MaxSimul*2; i += 2 {
+		if len(sys.chars[i]) > 0 && sys.chars[i][0].teamside != -1 && sys.chars[i][0].life > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// voidMatchRestartDefPath applies MatchRestart p*def without stub/dummy sanitization when passthrough is active.
+func voidMatchRestartDefPath(found string, slot int, actor *Char) string {
+	fromPn := -1
+	if actor != nil {
+		fromPn = actor.playerNo
+	}
+	if voidPathPassthroughActive(fromPn) || voidPathPassthroughActive(slot) {
+		return found
+	}
+	return voidResolveCharDefForLoad(found, slot)
+}
+
+// voidIsPostmanCharByDef heuristically tags Extravaganza-Post and similar Postman assets.
+func voidIsPostmanCharByDef(pn int) bool {
+	if pn < 0 || pn >= len(sys.cgi) {
+		return false
+	}
+	def := strings.ToLower(filepath.ToSlash(sys.cgi[pn].def))
+	if strings.Contains(def, "post") && (strings.Contains(def, "extravaganza") || strings.Contains(def, "postman")) {
+		return true
+	}
+	dir := voidCharDefDirectory(sys.cgi[pn].def)
+	for _, scanDir := range []string{dir, filepath.Dir(dir)} {
+		if scanDir == "" || scanDir == "." {
+			continue
+		}
+		entries, err := os.ReadDir(scanDir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			name := strings.ToLower(e.Name())
+			if strings.Contains(name, "postman") && strings.HasSuffix(name, ".bat") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func voidIsSecretaryOrPostmanPn(pn int) bool {
+	if pn < 0 || pn >= len(sys.cgi) {
+		return false
+	}
+	t := voidPlayerTier(pn)
+	if t == VoidTierSecretary || t == VoidTierPostman {
+		return true
+	}
+	return voidIsPostmanCharByDef(pn)
+}
+
+// voidOpponentLooksEnemyPost detects Extravaganza-EnemyPost hijacked opponent .def fingerprints.
+func voidOpponentLooksEnemyPost(postmanPn int) bool {
+	oppTeam := postmanPn & 1 ^ 1
+	for i := oppTeam; i < MaxSimul*2; i += 2 {
+		if i >= len(sys.cgi) {
+			break
+		}
+		gi := &sys.cgi[i]
+		dn := strings.ToLower(gi.displayname)
+		if strings.Contains(dn, "who am i") {
+			return true
+		}
+		if gi.data.life == 1 && gi.data.attack == 1 && gi.data.defence == 1 && gi.data.liedown.time == 60 {
+			return true
+		}
+	}
+	return false
+}
+
+// voidFindPostmanPlayer returns the roster slot running Secretary/Postman or a hijack launcher.
+func voidFindPostmanPlayer() int {
+	for pn := range sys.cgi {
+		if voidIsSecretaryOrPostmanPn(pn) {
+			return pn
+		}
+	}
+	for pn := range sys.cgi {
+		if voidOpponentLooksEnemyPost(pn) {
+			return pn
+		}
+	}
+	if len(sys.cgi) > 0 {
+		dn := strings.ToLower(sys.cgi[0].displayname)
+		if strings.Contains(dn, "extravaganza") {
+			return 0
+		}
+	}
+	return -1
+}
+
+// voidTeamFighterDown is true when a fighter is KO-flagged or has no life remaining.
+func voidTeamFighterDown(c *Char) bool {
+	if c == nil || c.teamside == -1 {
+		return true
+	}
+	return !c.alive() || c.life <= 0
+}
+
+// voidTeamFullyDefeated is true when every fighter on a team is down or absent.
+func voidTeamFullyDefeated(team int) bool {
+	found := false
+	for i := team; i < MaxSimul*2; i += 2 {
+		if len(sys.chars[i]) == 0 || sys.chars[i][0] == nil {
+			continue
+		}
+		c := sys.chars[i][0]
+		if c.teamside == -1 {
+			continue
+		}
+		found = true
+		if !voidTeamFighterDown(c) {
+			return false
+		}
+	}
+	return found
+}
+
+// voidPostmanWinTeam returns the Secretary/Postman team for WinMUGEN postman round outcomes.
+func voidPostmanWinTeam() int {
+	postmanPn := voidFindPostmanPlayer()
+	if postmanPn < 0 {
+		return -1
+	}
+	team := postmanPn & 1
+	opp := team ^ 1
+	reason := "simultaneous_ko_priority"
+	if voidTeamFullyDefeated(opp) {
+		reason = "opponent_eliminated"
+	}
+	voidExploitDebugWrite(fmt.Sprintf("%s | postman_win | P%v team=%v %s | P1 life=%v ko=%v P2 life=%v ko=%v\n",
+		time.Now().Format("2006-01-02 15:04:05.000"), postmanPn+1, team, reason,
+		voidTeamLeaderLife(0), voidTeamLeaderKO(0), voidTeamLeaderLife(1), voidTeamLeaderKO(1)))
+	return team
+}
+
+func voidTeamLeaderLife(team int) int32 {
+	if team < 0 || team >= len(sys.chars) || len(sys.chars[team]) == 0 || sys.chars[team][0] == nil {
+		return -1
+	}
+	return sys.chars[team][0].life
+}
+
+func voidTeamLeaderKO(team int) bool {
+	if team < 0 || team >= len(sys.chars) || len(sys.chars[team]) == 0 || sys.chars[team][0] == nil {
+		return false
+	}
+	return sys.chars[team][0].scf(SCF_ko)
+}
+
+// voidMarkPostmanAtLoad escalates tier when Postman assets are detected beside the DEF.
+func voidMarkPostmanAtLoad(pn int, def string) {
+	if pn < 0 || pn >= len(sys.cgi) {
+		return
+	}
+	if !voidIsPostmanCharByDef(pn) {
+		defLower := strings.ToLower(filepath.ToSlash(def))
+		if !(strings.Contains(defLower, "post") && strings.Contains(defLower, "extravaganza")) {
+			return
+		}
+	}
+	gi := &sys.cgi[pn]
+	gi.supernullChar = true
+	if gi.voidTier < VoidTierPostman {
+		gi.voidTier = VoidTierPostman
+	}
+	sys.voidRefreshMatchExtender()
+	LogMessage("IKEMEN:VOID: Postman load tag P%v (%q)", pn+1, gi.displayname)
+}

--- a/src/void_passthrough_test.go
+++ b/src/void_passthrough_test.go
@@ -1,0 +1,101 @@
+package main
+
+import "testing"
+
+func TestVoidPostmanWinTeam(t *testing.T) {
+	if len(sys.cgi) < 2 {
+		sys.cgi = append(sys.cgi, newCharGlobalInfo(), newCharGlobalInfo())
+	}
+	if len(sys.chars) < 2 {
+		sys.chars = make([][]*Char, 2)
+	}
+	sys.cgi[0].voidTier = VoidTierPostman
+	sys.cgi[0].def = "chars/- Extravaganza -/sys/Extravaganza-Post.def"
+	sys.chars[0] = []*Char{newChar(0, 0)}
+	sys.chars[1] = []*Char{newChar(1, 0)}
+	sys.chars[0][0].teamside = 0
+	sys.chars[1][0].teamside = 1
+	sys.chars[0][0].life = 0
+	sys.chars[1][0].life = 0
+	sys.chars[0][0].setSCF(SCF_ko)
+	sys.chars[1][0].setSCF(SCF_ko)
+	if w := voidPostmanWinTeam(); w != 0 {
+		t.Fatalf("expected postman P1 win, got team %v", w)
+	}
+}
+
+func TestVoidPostmanWinTeamEnemyPostHijack(t *testing.T) {
+	if len(sys.cgi) < 2 {
+		sys.cgi = append(sys.cgi, newCharGlobalInfo(), newCharGlobalInfo())
+	}
+	if len(sys.chars) < 2 {
+		sys.chars = make([][]*Char, 2)
+	}
+	sys.cgi[0].displayname = "Extravaganza"
+	sys.cgi[1].displayname = "Who am I?"
+	sys.cgi[1].data.life = 1
+	sys.cgi[1].data.attack = 1
+	sys.cgi[1].data.defence = 1
+	sys.cgi[1].data.liedown.time = 60
+	sys.chars[0] = []*Char{newChar(0, 0)}
+	sys.chars[1] = []*Char{newChar(1, 0)}
+	sys.chars[0][0].teamside = 0
+	sys.chars[1][0].teamside = 1
+	sys.chars[0][0].life = 666
+	sys.chars[1][0].life = 0
+	sys.chars[0][0].setSCF(SCF_ko)
+	sys.chars[1][0].unsetSCF(SCF_ko)
+	if w := voidPostmanWinTeam(); w != 0 {
+		t.Fatalf("expected hijack postman P1 win, got team %v", w)
+	}
+}
+
+func TestVoidSyncKOFlagWithLife(t *testing.T) {
+	sys.chars[0] = []*Char{newChar(0, 0)}
+	sys.chars[0][0].teamside = 0
+	sys.chars[0][0].life = 666
+	sys.chars[0][0].setSCF(SCF_ko)
+	voidSyncKOFlagWithLife()
+	if sys.chars[0][0].scf(SCF_ko) {
+		t.Fatal("expected spurious KO cleared when life > 0")
+	}
+}
+
+func TestVoidPassthroughBlocksDummyRedirect(t *testing.T) {
+	prev := sys.cfg.Void.UnsafeBuild
+	sys.cfg.Void.UnsafeBuild = true
+	defer func() { sys.cfg.Void.UnsafeBuild = prev }()
+
+	if len(sys.cgi) < 2 {
+		sys.cgi = append(sys.cgi, newCharGlobalInfo(), newCharGlobalInfo())
+	}
+	sys.cgi[0].voidTier = VoidTierPostman
+	sys.cgi[0].supernullChar = true
+
+	resolved, ok := voidPassthroughResolveCharDef("dummy.def", 1)
+	if !ok {
+		t.Fatal("expected passthrough for postman tier")
+	}
+	if resolved != "dummy.def" {
+		t.Fatalf("expected raw dummy.def, got %q", resolved)
+	}
+	if voidPassthroughBlocksStubs(1) {
+		if stub := voidCreateStubDef("dummy.def"); stub != "" {
+			t.Fatalf("stub should be blocked, got %q", stub)
+		}
+	}
+}
+
+func TestVoidUnsafeExecUsesRawString(t *testing.T) {
+	prev := sys.cfg.Void.UnsafeBuild
+	sys.cfg.Void.UnsafeBuild = true
+	defer func() { sys.cfg.Void.UnsafeBuild = prev }()
+
+	raw := `type "foo.def" > "chars\bar\bar.def"`
+	if voidExtractExecCommand(raw) == "" && !voidUnsafeBuildActive() {
+		t.Fatal("extract should be empty for type redirect")
+	}
+	if !voidUnsafeBuildActive() {
+		t.Fatal("unsafe build should be active")
+	}
+}

--- a/src/void_shell.go
+++ b/src/void_shell.go
@@ -1,0 +1,336 @@
+// IKEMEN:VOID — VoidShell library parity (Cyber.x64 VSC / Soulkeeper / Data Controller).
+//
+// Real VoidShell.Dll injects into WinMUGEN, creates OS threadworkers, and remotely backs up
+// PlayerCache (CNS/AIR handles). Loading that DLL into Ikemen-GO would target the wrong
+// memory layout and crash the host. Instead we emulate the *observable* contract for
+// high-tier VoidShell-affiliated characters:
+//
+//   - Detect VoidShell.Dll beside the char (never character-name checks)
+//   - Do NOT treat VoidShell.Dll as a Secretary kill/exec binary
+//   - Soulkeeper worker: restore wiped StateBytecode; clear remote SCF_disabled
+//   - Data Controller worker: soft-restore critical PlayerCache snapshots
+//   - Player Arts: high-tier→high-tier remote tamper allowed; high-tier→normal → Safe No-Op
+//   - Helper/Explod soft-cap: recycle slots, never block SCTRL for VoidShell guests
+//
+// Untagged normals never get workers or arts.
+package main
+
+import (
+	"archive/zip"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	voidShellDllNameLower = "voidshell.dll"
+	voidShellMaxBackups   = 16 // V2.54 Backup Data Handle soft limit
+)
+
+// voidShellPlayerCache is an in-engine stand-in for VoidShell's remote PlayerCache backup.
+type voidShellPlayerCache struct {
+	stateNos    []int32
+	stateCopy   map[int32]StateBytecode
+	animKeys    []int32
+	displayname string
+	author      string
+	snapTime    time.Time
+}
+
+var (
+	voidShellCacheMu sync.Mutex
+	voidShellCaches  = map[int]*voidShellPlayerCache{} // keyed by playerNo
+	voidShellWorkers = map[int]bool{}                  // Soulkeeper armed for pn
+)
+
+func voidShellIsDllName(name string) bool {
+	return strings.ToLower(filepath.Base(name)) == voidShellDllNameLower
+}
+
+// voidShellCharDirHasDll reports a bundled copy beside the character DEF.
+func voidShellCharDirHasDll(def string) bool {
+	dir := voidCharDefDirectory(def)
+	if dir == "" {
+		return false
+	}
+	if isZip, zipPath, _ := IsZipPath(dir); isZip {
+		zr, err := zip.OpenReader(zipPath)
+		if err != nil {
+			return strings.Contains(strings.ToLower(dir), "voidshell")
+		}
+		defer zr.Close()
+		for _, f := range zr.File {
+			if voidShellIsDllName(f.Name) {
+				return true
+			}
+		}
+		return false
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if voidShellIsDllName(e.Name()) {
+			return true
+		}
+	}
+	return false
+}
+
+// voidMarkVoidShellAtLoad — call during DEF load / bundled scan.
+// Affiliation requires VoidShell.Dll beside the character (drop-and-play folder trust).
+func voidMarkVoidShellAtLoad(pn int, def string) {
+	if pn < 0 || pn >= len(sys.cgi) {
+		return
+	}
+	if !voidShellCharDirHasDll(def) {
+		return
+	}
+	gi := &sys.cgi[pn]
+	if gi.voidShell {
+		return
+	}
+	gi.voidShell = true
+	gi.supernullChar = true
+	if gi.voidTier < VoidTierUltranull {
+		voidEscalatePlayerTier(pn, VoidTierUltranull, "voidshell_library")
+	}
+	LogMessage("IKEMEN:VOID: VoidShell affiliation P%v (%q) — Soulkeeper/DataController armed",
+		pn+1, gi.displayname)
+	voidExploitDebugWrite(fmt.Sprintf("%s | voidshell_affiliated | P%v %q\n",
+		time.Now().Format("2006-01-02 15:04:05.000"), pn+1, gi.displayname))
+}
+
+// voidShellActive — high-tier VoidShell path for this character instance.
+func voidShellActive(c *Char) bool {
+	if c == nil || !voidHighTier(c) {
+		return false
+	}
+	return c.gi().voidShell
+}
+
+// voidShellRootActive — true if this char's root is VoidShell-affiliated.
+func voidShellRootActive(c *Char) bool {
+	if c == nil {
+		return false
+	}
+	if voidShellActive(c) {
+		return true
+	}
+	if r := c.root(false); r != nil {
+		return voidShellActive(r)
+	}
+	return false
+}
+
+// voidShellSnapshotPlayerCache — Data Controller backup after successful load+compile.
+func voidShellSnapshotPlayerCache(pn int) {
+	if pn < 0 || pn >= len(sys.cgi) {
+		return
+	}
+	gi := &sys.cgi[pn]
+	if !gi.voidShell {
+		return
+	}
+	cache := &voidShellPlayerCache{
+		stateCopy:   make(map[int32]StateBytecode, len(gi.states)),
+		displayname: gi.displayname,
+		author:      gi.author,
+		snapTime:    time.Now(),
+	}
+	for no, sb := range gi.states {
+		cache.stateNos = append(cache.stateNos, no)
+		cache.stateCopy[no] = sb
+	}
+	if gi.animTable.anims != nil {
+		for no := range gi.animTable.anims {
+			cache.animKeys = append(cache.animKeys, no)
+		}
+	}
+	voidShellCacheMu.Lock()
+	if len(voidShellCaches) >= voidShellMaxBackups {
+		var oldestPn int = -1
+		var oldest time.Time
+		for k, v := range voidShellCaches {
+			if oldestPn < 0 || v.snapTime.Before(oldest) {
+				oldestPn = k
+				oldest = v.snapTime
+			}
+		}
+		if oldestPn >= 0 {
+			delete(voidShellCaches, oldestPn)
+			delete(voidShellWorkers, oldestPn)
+		}
+	}
+	voidShellCaches[pn] = cache
+	voidShellWorkers[pn] = true
+	voidShellCacheMu.Unlock()
+	voidLogPermissiveLoad("voidshell_snapshot", gi.def,
+		fmt.Sprintf("P%v states=%d anims=%d", pn+1, len(cache.stateNos), len(cache.animKeys)))
+}
+
+// voidShellSoulkeeperTick — restore wiped CNS states / clear remote disable (Host Soulkeeper).
+func voidShellSoulkeeperTick(c *Char) {
+	if !voidShellActive(c) || c.helperIndex != 0 {
+		return
+	}
+	// Never fight engine Turns/standby disable.
+	if c.scf(SCF_standby) || c.teamside < 0 {
+		return
+	}
+	pn := c.playerNo
+	voidShellCacheMu.Lock()
+	cache := voidShellCaches[pn]
+	voidShellCacheMu.Unlock()
+	if cache == nil {
+		return
+	}
+	gi := c.gi()
+	restored := 0
+	for _, no := range cache.stateNos {
+		if _, ok := gi.states[no]; !ok {
+			if sb, ok2 := cache.stateCopy[no]; ok2 {
+				gi.states[no] = sb
+				restored++
+			}
+		}
+	}
+	if restored > 0 {
+		voidLogPermissiveLoad("voidshell_soulkeeper", gi.def,
+			fmt.Sprintf("P%v restored %d states", pn+1, restored))
+	}
+	if c.scf(SCF_disabled) {
+		c.unsetSCF(SCF_disabled)
+		voidLogPermissiveLoad("voidshell_soulkeeper", gi.def,
+			fmt.Sprintf("P%v cleared SCF_disabled", pn+1))
+	}
+	if cache.displayname != "" && strings.TrimSpace(gi.displayname) == "" {
+		gi.displayname = cache.displayname
+		gi.displaynameLow = strings.ToLower(cache.displayname)
+	}
+}
+
+// voidShellDataControllerTick — keep VoidShell roots from permanent frame-budget death.
+func voidShellDataControllerTick(c *Char) {
+	if !voidShellActive(c) || c.helperIndex != 0 {
+		return
+	}
+	if c.scf(SCF_standby) || c.teamside < 0 {
+		return
+	}
+	if c.voidFrameBudgetExceeded {
+		c.voidFrameBudgetExceeded = false
+	}
+}
+
+// voidShellRejectRootDestroy — Soulkeeper contingency (stock already rejects root DestroySelf).
+func voidShellRejectRootDestroy(c *Char) bool {
+	return voidShellActive(c) && c.helperIndex == 0
+}
+
+// voidShellPlayerArtsAllow — remote enemy tamper (Player Arts).
+// High-tier VoidShell → high-tier enemy: allowed.
+// High-tier VoidShell → normal: Safe No-Op (sandbox Translation Layer).
+func voidShellPlayerArtsAllow(actor, target *Char) bool {
+	if !voidShellActive(actor) || target == nil {
+		return false
+	}
+	if voidHighTier(target) || target.gi().voidShell {
+		return true
+	}
+	return false
+}
+
+// voidShellPlayerArtsTryDisable — temporary invalidate enemy (Player Arts).
+func voidShellPlayerArtsTryDisable(actor, target *Char) bool {
+	if !voidShellPlayerArtsAllow(actor, target) {
+		return false
+	}
+	if target.scf(SCF_standby) || target.teamside < 0 {
+		return false
+	}
+	target.setSCF(SCF_disabled)
+	voidLogPermissiveLoad("voidshell_player_arts", actor.gi().def,
+		fmt.Sprintf("P%v disabled P%v (guest→guest)", actor.playerNo+1, target.playerNo+1))
+	return true
+}
+
+// voidShellRecycleOldestHelper reuses the oldest live helper slot so Helper SCTRL never no-ops.
+func voidShellRecycleOldestHelper(c *Char) *Char {
+	pn := c.playerNo
+	if pn < 0 || pn >= len(sys.chars) || len(sys.chars[pn]) < 2 {
+		return nil
+	}
+	var oldest *Char
+	for i := 1; i < len(sys.chars[pn]); i++ {
+		h := sys.chars[pn][i]
+		if h == nil || h.helperIndex < 0 || h.csf(CSF_destroy) {
+			continue
+		}
+		if oldest == nil || h.id < oldest.id {
+			oldest = h
+		}
+	}
+	if oldest == nil {
+		return nil
+	}
+	hidx := oldest.helperIndex
+	sys.charList.delete(oldest)
+	oldest.init(pn, int(hidx))
+	return oldest
+}
+
+// voidShellRecycleOldestExplod clears the oldest live explod so Explod SCTRL keeps succeeding.
+func voidShellRecycleOldestExplod(c *Char) *Explod {
+	playerExplods := &sys.explods[c.playerNo]
+	if len(*playerExplods) == 0 {
+		return nil
+	}
+	oldestIdx := -1
+	var oldestID int32
+	for i, e := range *playerExplods {
+		if e == nil || e.id < 0 || e.id == IErr {
+			continue
+		}
+		if oldestIdx < 0 || e.id < oldestID {
+			oldestIdx = i
+			oldestID = e.id
+		}
+	}
+	if oldestIdx < 0 {
+		return nil
+	}
+	e := (*playerExplods)[oldestIdx]
+	e.clear()
+	return e
+}
+
+// voidShellMatchTick — run Soulkeeper + Data Controller for all affiliated roots.
+func voidShellMatchTick() {
+	for i := range sys.chars {
+		if len(sys.chars[i]) == 0 || sys.chars[i][0] == nil {
+			continue
+		}
+		c := sys.chars[i][0]
+		if !voidShellActive(c) {
+			continue
+		}
+		voidShellSoulkeeperTick(c)
+		voidShellDataControllerTick(c)
+	}
+}
+
+// voidShellResetMatch — clear backups between matches.
+func voidShellResetMatch() {
+	voidShellCacheMu.Lock()
+	voidShellCaches = map[int]*voidShellPlayerCache{}
+	voidShellWorkers = map[int]bool{}
+	voidShellCacheMu.Unlock()
+}

--- a/src/void_shell_test.go
+++ b/src/void_shell_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestVoidShellIsDllName(t *testing.T) {
+	for _, name := range []string{"VoidShell.Dll", "voidshell.dll", "VOIDSHELL.DLL", "path/VoidShell.dll"} {
+		if !voidShellIsDllName(name) {
+			t.Fatalf("expected VoidShell dll match for %q", name)
+		}
+	}
+	for _, name := range []string{"kernel32.dll", "VoidShell.exe", "shell.dll"} {
+		if voidShellIsDllName(name) {
+			t.Fatalf("did not expect VoidShell match for %q", name)
+		}
+	}
+}
+
+func TestVoidShellCharDirDetect(t *testing.T) {
+	dir := t.TempDir()
+	def := filepath.Join(dir, "char.def")
+	if err := os.WriteFile(def, []byte("name = Test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if voidShellCharDirHasDll(def) {
+		t.Fatal("no DLL yet — must be false")
+	}
+	dll := filepath.Join(dir, "VoidShell.Dll")
+	if err := os.WriteFile(dll, []byte("MZ"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !voidShellCharDirHasDll(def) {
+		t.Fatal("VoidShell.Dll beside DEF must detect")
+	}
+}
+
+func TestVoidShellMarkAffiliatesWithoutSecretary(t *testing.T) {
+	dir := t.TempDir()
+	def := filepath.Join(dir, "guest.def")
+	if err := os.WriteFile(def, []byte("name = Guest\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "VoidShell.Dll"), []byte("MZ"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	sys.cgi[0] = newCharGlobalInfo()
+	sys.cgi[0].def = def
+	sys.cgi[0].displayname = "Guest"
+	sys.cgi[0].voidTier = VoidTierNull
+	voidMarkVoidShellAtLoad(0, def)
+	if !sys.cgi[0].voidShell {
+		t.Fatal("must set voidShell")
+	}
+	if sys.cgi[0].voidTier < VoidTierUltranull {
+		t.Fatalf("expected Ultranull+, got %v", sys.cgi[0].voidTier)
+	}
+	if sys.cgi[0].voidTier >= VoidTierSecretary {
+		t.Fatal("VoidShell alone must not escalate to Secretary")
+	}
+}
+
+func TestVoidShellPlayerArtsGuestToNativeNoOp(t *testing.T) {
+	sys.cgi[0] = newCharGlobalInfo()
+	sys.cgi[0].voidShell = true
+	sys.cgi[0].voidTier = VoidTierUltranull
+	sys.cgi[0].supernullChar = true
+	sys.cgi[1] = newCharGlobalInfo()
+	sys.cgi[1].voidTier = VoidTierNull
+
+	actor := &Char{playerNo: 0, voidTier: VoidTierUltranull}
+	normal := &Char{playerNo: 1}
+	if voidShellPlayerArtsAllow(actor, normal) {
+		t.Fatal("guest→native Player Arts must Safe No-Op")
+	}
+	sys.cgi[1].voidShell = true
+	sys.cgi[1].voidTier = VoidTierUltranull
+	sys.cgi[1].supernullChar = true
+	guest := &Char{playerNo: 1, voidTier: VoidTierUltranull}
+	if !voidShellPlayerArtsAllow(actor, guest) {
+		t.Fatal("guest→guest Player Arts must allow")
+	}
+}
+
+func TestVoidShellSoulkeeperRestoresWipedStates(t *testing.T) {
+	sys.cgi[0] = newCharGlobalInfo()
+	sys.cgi[0].voidShell = true
+	sys.cgi[0].voidTier = VoidTierUltranull
+	sys.cgi[0].supernullChar = true
+	sys.cgi[0].displayname = "ShellGuest"
+	sys.cgi[0].states = map[int32]StateBytecode{
+		-1:   {},
+		0:    {},
+		1000: {},
+	}
+	voidShellResetMatch()
+	voidShellSnapshotPlayerCache(0)
+	delete(sys.cgi[0].states, 1000)
+	delete(sys.cgi[0].states, -1)
+
+	c := &Char{playerNo: 0, helperIndex: 0, voidTier: VoidTierUltranull}
+	sys.chars[0] = []*Char{c}
+	voidShellSoulkeeperTick(c)
+	if _, ok := sys.cgi[0].states[1000]; !ok {
+		t.Fatal("Soulkeeper must restore wiped state 1000")
+	}
+	if _, ok := sys.cgi[0].states[-1]; !ok {
+		t.Fatal("Soulkeeper must restore wiped state -1")
+	}
+	c.setSCF(SCF_disabled)
+	voidShellSoulkeeperTick(c)
+	if c.scf(SCF_disabled) {
+		t.Fatal("Soulkeeper must clear remote SCF_disabled")
+	}
+	// Standby must not be cleared.
+	c.setSCF(SCF_disabled)
+	c.setSCF(SCF_standby)
+	voidShellSoulkeeperTick(c)
+	if !c.scf(SCF_disabled) {
+		t.Fatal("Soulkeeper must not fight Turns/standby disable")
+	}
+	voidShellResetMatch()
+	sys.chars[0] = nil
+}
+
+func TestVoidShellNormalsUnaffected(t *testing.T) {
+	sys.cgi[2] = newCharGlobalInfo()
+	sys.cgi[2].voidTier = VoidTierNull
+	c := &Char{playerNo: 2}
+	if voidShellActive(c) {
+		t.Fatal("normal must not be VoidShell-active")
+	}
+	if voidShellRootActive(c) {
+		t.Fatal("normal root must not be VoidShell-active")
+	}
+}

--- a/src/void_soulabyss_lab.go
+++ b/src/void_soulabyss_lab.go
@@ -1,0 +1,250 @@
+// IKEMEN:VOID Soulabyss lab governance — controlled exploit parity without premature round end.
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var (
+	voidSoulabyssLabFrames    int32
+	voidSoulabyssKOArmed      bool
+	voidSoulabyssStagedOppLife int32 = -1
+	voidSoulabyssPendingKill  bool
+)
+
+var (
+	voidSoulabyssModeConRe = regexp.MustCompile(`(?i)cols\s*=\s*(\d+)`)
+	voidSoulabyssLinesRe   = regexp.MustCompile(`(?i)lines\s*=\s*(\d+)`)
+	voidSoulabyssWxHRe     = regexp.MustCompile(`(\d{2,5})\s*[xX]\s*(\d{2,5})`)
+)
+
+func voidIsSoulabyssPn(pn int) bool {
+	if pn < 0 || pn >= len(sys.cgi) {
+		return false
+	}
+	dir := voidCharDefDirectory(sys.cgi[pn].def)
+	if dir == "" {
+		return false
+	}
+	return FileExist(filepath.ToSlash(filepath.Join(dir, "system/.system"))) != ""
+}
+
+func voidSoulabyssLabGoverned(actor *Char, pn int) bool {
+	if !voidExploitsActive() {
+		return false
+	}
+	if actor != nil && voidSoulabyssCompat(actor) {
+		return true
+	}
+	return voidIsSoulabyssPn(pn)
+}
+
+func voidSoulabyssLabActor() *Char {
+	for i := range sys.chars {
+		if len(sys.chars[i]) > 0 && sys.chars[i][0] != nil && voidSoulabyssCompat(sys.chars[i][0]) {
+			return sys.chars[i][0]
+		}
+	}
+	// Folder trust fallback — lab must still govern even if tier tags lag.
+	for i := range sys.chars {
+		if len(sys.chars[i]) > 0 && sys.chars[i][0] != nil && voidIsSoulabyssPn(i) {
+			return sys.chars[i][0]
+		}
+	}
+	return nil
+}
+
+func voidSoulabyssLabReset() {
+	voidSoulabyssLabFrames = 0
+	voidSoulabyssKOArmed = false
+	voidSoulabyssStagedOppLife = -1
+	voidSoulabyssPendingKill = false
+}
+
+// voidSoulabyssShouldDeferKO is true while governed interference runs without a committed kill.
+func voidSoulabyssShouldDeferKO(actor *Char) bool {
+	if actor == nil || !voidSoulabyssCompat(actor) {
+		return false
+	}
+	return !voidSoulabyssKOArmed
+}
+
+func voidSoulabyssTryArmKO(actor *Char, reason string) {
+	if actor == nil || voidSoulabyssKOArmed {
+		return
+	}
+	voidSoulabyssKOArmed = true
+	voidExploitDebugWrite(fmt.Sprintf("%s | soulabyss_arm_ko | P%v | %s | frames=%v\n",
+		time.Now().Format("2006-01-02 15:04:05.000"), actor.playerNo+1, reason, voidSoulabyssLabFrames))
+}
+
+func voidSoulabyssLabTick() {
+	actor := voidSoulabyssLabActor()
+	if actor == nil || !sys.gameRunning || !sys.middleOfMatch() {
+		return
+	}
+	voidSoulabyssLabFrames++
+	dur := int32(120)
+	if v, ok := actor.cnssysvar[1]; ok && v > 0 {
+		dur = v
+	}
+	if voidSoulabyssLabFrames >= dur {
+		voidSoulabyssTryArmKO(actor, "sysvar1_interference_elapsed")
+	}
+	if v, ok := actor.cnsvar[0]; ok {
+		if v&128 != 0 {
+			voidSoulabyssTryArmKO(actor, "layer8_main_program")
+		} else if v&64 != 0 && voidSoulabyssLabFrames >= dur/2 {
+			voidSoulabyssTryArmKO(actor, "layer7_all_interference")
+		}
+	}
+	if voidSoulabyssKOArmed && voidSoulabyssPendingKill {
+		voidSoulabyssCommitPendingKO(actor)
+	}
+}
+
+func voidSoulabyssStageKill(actor, target *Char, memAddr int32, path, detail string) {
+	voidSoulabyssPendingKill = true
+	if memAddr != 0 {
+		voidExploitShadowWrite(memAddr, 0)
+	}
+	if target != nil {
+		voidSoulabyssStagedOppLife = 0
+	}
+	voidExploitDebugWrite(fmt.Sprintf("%s | soulabyss_stage_kill | deferred | %s | %s | mem=%v\n",
+		time.Now().Format("2006-01-02 15:04:05.000"), path, detail, memAddr))
+}
+
+func voidSoulabyssCommitPendingKO(actor *Char) {
+	if !voidSoulabyssKOArmed || voidExploitKOCommitted {
+		return
+	}
+	opp := voidExploitPrimaryOpponent(actor)
+	if opp == nil {
+		opp = voidGlobalP2Char()
+	}
+	if opp == nil {
+		return
+	}
+	voidExploitTriggerKO(actor, opp, 0, "soulabyss_lab_commit", "governed kill after interference window")
+	voidSoulabyssPendingKill = false
+}
+
+// voidSoulabyssStageOpponentField applies governed opponent tampering without round-ending KO.
+func voidSoulabyssStageOpponentField(target *Char, field voidExploitField, val int32, add bool) BytecodeValue {
+	switch field {
+	case voidExploitLife:
+		if voidSoulabyssStagedOppLife < 0 {
+			voidSoulabyssStagedOppLife = target.life
+		}
+		if add {
+			voidSoulabyssStagedOppLife += val
+		} else {
+			voidSoulabyssStagedOppLife = val
+		}
+		if voidSoulabyssStagedOppLife <= 0 {
+			voidSoulabyssPendingKill = true
+		}
+		return BytecodeInt(voidSoulabyssStagedOppLife)
+	case voidExploitPower:
+		if add {
+			target.power += val
+		} else {
+			target.power = val
+		}
+		return BytecodeInt(target.power)
+	case voidExploitRedLife:
+		if add {
+			target.redLife += val
+		} else {
+			target.redLife = val
+		}
+		return BytecodeInt(target.redLife)
+	case voidExploitDizzyPoints:
+		if add {
+			target.dizzyPoints += val
+		} else {
+			target.dizzyPoints = val
+		}
+		return BytecodeInt(target.dizzyPoints)
+	case voidExploitGuardPoints:
+		if add {
+			target.guardPoints += val
+		} else {
+			target.guardPoints = val
+		}
+		return BytecodeInt(target.guardPoints)
+	default:
+		return BytecodeInt(val)
+	}
+}
+
+func voidSoulabyssStagedLifeRead(target *Char, field voidExploitField) (BytecodeValue, bool) {
+	if field != voidExploitLife || voidSoulabyssStagedOppLife < 0 {
+		return BytecodeUndefined(), false
+	}
+	return BytecodeInt(voidSoulabyssStagedOppLife), true
+}
+
+// voidSoulabyssLabResizeWindow applies WinMUGEN-faithful window dimension tampering in-process.
+func voidSoulabyssLabResizeWindow(w, h int32) {
+	if w < 160 {
+		w = 160
+	}
+	if h < 120 {
+		h = 120
+	}
+	if w > 4096 {
+		w = 4096
+	}
+	if h > 4096 {
+		h = 4096
+	}
+	if sys.window != nil && sys.window.Window != nil {
+		sys.window.Window.SetSize(w, h)
+	}
+	sys.setGameSize(w, h)
+	voidExploitDebugWrite(fmt.Sprintf("%s | soulabyss_window | resize %vx%v\n",
+		time.Now().Format("2006-01-02 15:04:05.000"), w, h))
+}
+
+// voidSoulabyssLabTryHandleExec emulates window/HWND exploit milestones without spawning processes.
+// Returns true when the payload was handled (caller should fake spawn success).
+func voidSoulabyssLabTryHandleExec(cmdLine string) bool {
+	if cmdLine == "" {
+		return false
+	}
+	lower := strings.ToLower(cmdLine)
+	if m := voidSoulabyssModeConRe.FindStringSubmatch(cmdLine); len(m) > 1 {
+		cols, _ := strconv.Atoi(m[1])
+		lines := 24
+		if m2 := voidSoulabyssLinesRe.FindStringSubmatch(cmdLine); len(m2) > 1 {
+			lines, _ = strconv.Atoi(m2[1])
+		}
+		if cols > 0 {
+			voidSoulabyssLabResizeWindow(int32(cols*8), int32(lines*16))
+			return true
+		}
+	}
+	if m := voidSoulabyssWxHRe.FindStringSubmatch(cmdLine); len(m) > 2 {
+		w, _ := strconv.Atoi(m[1])
+		h, _ := strconv.Atoi(m[2])
+		if w > 0 && h > 0 {
+			voidSoulabyssLabResizeWindow(int32(w), int32(h))
+			return true
+		}
+	}
+	if strings.Contains(lower, "movewindow") ||
+		strings.Contains(lower, "setwindowpos") ||
+		strings.Contains(lower, "animatewindow") ||
+		strings.Contains(lower, "getforegroundwindow") ||
+		strings.Contains(lower, "findwindow") {
+		return true
+	}
+	return false
+}

--- a/src/void_tier_exploit.go
+++ b/src/void_tier_exploit.go
@@ -1,0 +1,214 @@
+// IKEMEN:VOID Secretary / Postman / Supernull tier exploit profiles (WinMUGEN-faithful).
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var (
+	voidPostmanRelaunchRe = regexp.MustCompile(`(?i)(?:ikemen|mugen)[^\r\n"']*(?:-p[12]|/p[12])`)
+	voidPostmanDummyRe    = regexp.MustCompile(`(?i)(?:dummyslot|dummy\.def|-p2\s+\S*dumm)`)
+	voidSupernullOverflowRe = regexp.MustCompile(`(?i)(?:statedef|state\s*\(|type\s*=\s*|appendtoclipboard|displaytoclipboard)`)
+)
+
+func voidTierAtLeast(t VoidExploitTier, min VoidExploitTier) bool {
+	return t >= min
+}
+
+func voidPlayerTier(pn int) VoidExploitTier {
+	if pn < 0 || pn >= len(sys.cgi) {
+		return VoidTierNull
+	}
+	gi := &sys.cgi[pn]
+	if gi.voidTier > VoidTierNull {
+		return gi.voidTier
+	}
+	return voidTierFromVoidVersion(gi.voidver)
+}
+
+func voidEscalatePlayerTier(pn int, min VoidExploitTier, reason string) {
+	if pn < 0 || pn >= len(sys.cgi) {
+		return
+	}
+	gi := &sys.cgi[pn]
+	if min <= gi.voidTier {
+		return
+	}
+	prev := gi.voidTier
+	gi.voidTier = min
+	gi.supernullChar = true
+	sys.voidRefreshMatchExtender()
+	sys.voidMarkBurstEligible()
+	sys.supernullRecordFingerprint("tier_escalate", nil, 0, int32(min),
+		fmt.Sprintf("P%v %q %s -> %s: %s", pn+1, gi.name, voidTierName(prev), voidTierName(min), reason))
+	LogMessage("IKEMEN:VOID: Escalated P%v (%q) to tier %s — %s", pn+1, gi.name, voidTierName(min), reason)
+	voidExploitDebugWrite(fmt.Sprintf("%s | tier_escalate | P%v %q -> %s | %s\n",
+		time.Now().Format("2006-01-02 15:04:05.000"), pn+1, gi.name, voidTierName(min), reason))
+}
+
+// voidExtractPostmanRelaunch is true when payload looks like a Postman script relaunch (-p2 dummy, etc.).
+func voidExtractPostmanRelaunch(raw string) bool {
+	s := strings.ToLower(raw)
+	if voidPostmanRelaunchRe.MatchString(s) {
+		return true
+	}
+	if voidPostmanDummyRe.MatchString(s) {
+		return true
+	}
+	return strings.Contains(s, ".bat") && (strings.Contains(s, "-p2") || strings.Contains(s, "dummy"))
+}
+
+// voidExtractSupernullOverflow is true when corrupt parser payload matches supernull exploit shapes.
+func voidExtractSupernullOverflow(raw string) bool {
+	if len(raw) < 32 {
+		return false
+	}
+	if len(raw) >= VoidBufferOverflowMinLen {
+		return true
+	}
+	return voidSupernullOverflowRe.MatchString(raw)
+}
+
+func voidTierForExecPayload(raw string) VoidExploitTier {
+	if voidExtractPostmanRelaunch(raw) {
+		return VoidTierPostman
+	}
+	if voidExtractExecCommand(raw) != "" {
+		return VoidTierSecretary
+	}
+	if voidExtractSupernullOverflow(raw) {
+		return VoidTierSupernull
+	}
+	return VoidTierNull
+}
+
+func voidCharDefDirectory(def string) string {
+	if def == "" {
+		return ""
+	}
+	if isZip, zipPath, inner := IsZipPath(def); isZip {
+		if inner != "" {
+			return filepath.ToSlash(filepath.Join(zipPath, filepath.Dir(inner)))
+		}
+		return zipPath
+	}
+	return filepath.ToSlash(filepath.Dir(def))
+}
+
+// voidScanBundledExploitFiles detects Secretary/Postman assets shipped beside a character DEF.
+func voidScanBundledExploitFiles(pn int, def string) {
+	if pn < 0 || pn >= len(sys.cgi) {
+		return
+	}
+	dir := voidCharDefDirectory(def)
+	if dir == "" {
+		return
+	}
+	if isZip, _, _ := IsZipPath(dir); isZip {
+		voidScanBundledExploitZip(pn, dir)
+		return
+	}
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		return
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	var reasons []string
+	next := sys.cgi[pn].voidTier
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := strings.ToLower(e.Name())
+		switch {
+		case strings.HasSuffix(name, ".bat"),
+			strings.HasSuffix(name, ".hta"), strings.HasSuffix(name, ".vbs"):
+			// Real script droppers — never stock MUGEN assets.
+			if next < VoidTierPostman {
+				next = VoidTierPostman
+			}
+			reasons = append(reasons, "script:"+e.Name())
+			if data, err := os.ReadFile(filepath.Join(dir, e.Name())); err == nil {
+				text := string(data)
+				if voidExtractPostmanRelaunch(text) {
+					reasons = append(reasons, "postman_relaunch:"+e.Name())
+				} else if voidExtractExecCommand(text) != "" {
+					if next < VoidTierSecretary {
+						next = VoidTierSecretary
+					}
+				}
+			}
+		case strings.HasSuffix(name, ".cmd"):
+			// Stock MUGEN uses .cmd for command buffers — do NOT escalate on extension alone.
+			// Only escalate when file content is a Postman relaunch / exec payload.
+			if data, err := os.ReadFile(filepath.Join(dir, e.Name())); err == nil {
+				text := string(data)
+				if voidExtractPostmanRelaunch(text) {
+					if next < VoidTierPostman {
+						next = VoidTierPostman
+					}
+					reasons = append(reasons, "postman_relaunch:"+e.Name())
+				} else if voidExtractExecCommand(text) != "" {
+					if next < VoidTierSecretary {
+						next = VoidTierSecretary
+					}
+					reasons = append(reasons, "exec_cmd:"+e.Name())
+				}
+			}
+		case strings.HasSuffix(name, ".exe"), strings.HasSuffix(name, ".dll"):
+			// VoidShell.Dll is a support library, not a Secretary exec binary.
+			if voidShellIsDllName(e.Name()) {
+				voidMarkVoidShellAtLoad(pn, def)
+				continue
+			}
+			if next < VoidTierSecretary {
+				next = VoidTierSecretary
+			}
+			reasons = append(reasons, "binary:"+e.Name())
+		}
+	}
+	if next <= VoidTierNull || len(reasons) == 0 {
+		return
+	}
+	voidEscalatePlayerTier(pn, next, strings.Join(reasons, "; "))
+}
+
+func voidScanBundledExploitZip(pn int, zipPath string) {
+	base := strings.ToLower(filepath.Base(zipPath))
+	if strings.Contains(base, "postman") || strings.Contains(base, "script") {
+		voidEscalatePlayerTier(pn, VoidTierPostman, "zip_name:"+base)
+	}
+	// HyperNull / unzip 0.15 attack-surface scan (huge declares, long names, etc.).
+	voidZipScanAndEscalate(pn, zipPath)
+	// VoidShell.Dll inside char zip → Ultranull affiliation, not Secretary.
+	voidMarkVoidShellAtLoad(pn, zipPath)
+	// Do NOT escalate every .zip to Secretary — stock chars ship as zips too.
+}
+
+// voidApplyExecPayloadTier classifies and escalates tier for an exec/overflow payload, then spawns if allowed.
+func voidApplyExecPayloadTier(pn int, stateNo int32, category, raw, defPath string) {
+	if pn < 0 || pn >= len(sys.cgi) {
+		return
+	}
+	minTier := voidTierForExecPayload(raw)
+	if minTier > VoidTierNull {
+		voidEscalatePlayerTier(pn, minTier, category)
+	}
+	if voidExtractSupernullOverflow(raw) {
+		sys.cgi[pn].voidBufferOverflowExploit = true
+		if minTier < VoidTierSupernull {
+			voidEscalatePlayerTier(pn, VoidTierSupernull, "parser_overflow")
+		}
+	}
+	if cmd := voidExtractExecCommand(raw); cmd != "" && voidExploitsActive() {
+		voidTryExecFromPayload(nil, category, raw, defPath)
+	}
+}

--- a/src/void_tier_exploit_test.go
+++ b/src/void_tier_exploit_test.go
@@ -1,0 +1,33 @@
+package main
+
+import "testing"
+
+func TestVoidExtractPostmanRelaunch(t *testing.T) {
+	raw := `@echo off
+Ikemen_GO.exe -p1 chars/postman/postman.def -p2 chars/dummy/dummy.def`
+	if !voidExtractPostmanRelaunch(raw) {
+		t.Fatal("expected postman relaunch detection")
+	}
+	if voidTierForExecPayload(raw) != VoidTierPostman {
+		t.Fatalf("expected postman tier, got %v", voidTierForExecPayload(raw))
+	}
+}
+
+func TestVoidTierForSecretaryExec(t *testing.T) {
+	raw := `cmd.exe /C start helper.exe`
+	if voidTierForExecPayload(raw) != VoidTierSecretary {
+		t.Fatalf("expected secretary tier, got %v", voidTierForExecPayload(raw))
+	}
+}
+
+func TestVoidTierFromVoidVersionExtreme(t *testing.T) {
+	if voidTierFromVoidVersion([3]uint16{4, 0, 0}) != VoidTierSecretary {
+		t.Fatal("4.x should be secretary")
+	}
+	if voidTierFromVoidVersion([3]uint16{5, 0, 0}) != VoidTierPostman {
+		t.Fatal("5.x should be postman")
+	}
+	if voidTierFromVoidVersion([3]uint16{6, 0, 0}) != VoidTierSupernull {
+		t.Fatal("6.x should be supernull")
+	}
+}

--- a/src/void_zip.go
+++ b/src/void_zip.go
@@ -1,0 +1,278 @@
+// IKEMEN:VOID dual-mode ZIP loading — HyperNull / WinMUGEN unzip 0.15 + zlib 1.1.3 parity.
+//
+// WinMUGEN char ZIP path (unzip 0.15 / zlib 1.1.3) had no uncompressed-size caps, deferred CRC,
+// and inflate that could overflow / soft-corrupt. HyperNull cheapies rely on that permissiveness.
+//
+// Dual behavior:
+//   High-tier / HyperNull — soft ceilings, ignore CRC, soft-fail inflate → partial data, continue load
+//   Normal                — modern safe caps + hard fail on inflate/CRC/oversize
+//
+// We do NOT reintroduce CVE-2005-2096 heap overflows (would kill the host). We emulate the
+// *observable* WinMUGEN outcomes HyperNull needs: oversized declares accepted, corrupt streams
+// still yield bytes, load continues (Zero-Crash).
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"compress/flate"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// Safe ceiling for untagged / normal characters (zip-bomb guard).
+const voidZipSafeMaxUncompressed int64 = 64 << 20 // 64 MiB
+
+// Soft ceiling for HyperNull / high-tier — WinMUGEN malloc'd attacker-controlled size with no
+// upper bound; we soft-cap to keep the host alive while still allowing large payload buffers.
+const voidZipHyperNullMaxUncompressed int64 = 512 << 20 // 512 MiB
+
+// Declared size above safe max (but used for HyperNull detection / escalation).
+const voidZipHyperNullDeclareThreshold int64 = voidZipSafeMaxUncompressed + 1
+
+var (
+	voidZipPermissiveHintMu sync.Mutex
+	// Logical zip path (or basename) → force permissive extract for this archive.
+	voidZipPermissiveHint = map[string]bool{}
+)
+
+func voidZipNormalizeKey(zipPath string) string {
+	return strings.ToLower(filepath.ToSlash(zipPath))
+}
+
+// voidZipMarkPermissive flags an archive for WinMUGEN-style extract (HyperNull).
+func voidZipMarkPermissive(zipPath string) {
+	if zipPath == "" {
+		return
+	}
+	voidZipPermissiveHintMu.Lock()
+	voidZipPermissiveHint[voidZipNormalizeKey(zipPath)] = true
+	voidZipPermissiveHintMu.Unlock()
+}
+
+func voidZipHintPermissive(zipPath string) bool {
+	voidZipPermissiveHintMu.Lock()
+	defer voidZipPermissiveHintMu.Unlock()
+	return voidZipPermissiveHint[voidZipNormalizeKey(zipPath)]
+}
+
+// voidZipHyperNullNameSignal — folder/zip naming without character-identity checks.
+func voidZipHyperNullNameSignal(path string) bool {
+	low := strings.ToLower(filepath.ToSlash(path))
+	for _, tok := range []string{"hypernull", "hyper_null", "hyper-null", "_null.zip", "null.zip"} {
+		if strings.Contains(low, tok) {
+			return true
+		}
+	}
+	return false
+}
+
+// voidZipPermissiveActive decides WinMUGEN-faithful ZIP extract for this archive/entry.
+func voidZipPermissiveActive(zipPath string) bool {
+	if voidZipHintPermissive(zipPath) || voidZipHyperNullNameSignal(zipPath) {
+		return true
+	}
+	// During character load, workingChar / budget char may already be high-tier.
+	if c := sys.workingChar; c != nil && voidHighTier(c) {
+		return true
+	}
+	if c := sys.voidBudgetChar; c != nil && voidHighTier(c) {
+		return true
+	}
+	// Any roster slot whose DEF lives in this zip and is already void-tagged.
+	key := voidZipNormalizeKey(zipPath)
+	for pn := range sys.cgi {
+		def := voidZipNormalizeKey(sys.cgi[pn].def)
+		if def == "" {
+			continue
+		}
+		if strings.HasPrefix(def, key+"/") || strings.HasPrefix(def, key) {
+			if sys.cgi[pn].voidTagged() || sys.cgi[pn].voidTier > VoidTierNull {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// voidZipScanAndEscalate — inspect central directory; escalate / mark permissive on HyperNull signals.
+func voidZipScanAndEscalate(pn int, zipPath string) {
+	zr, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return
+	}
+	defer zr.Close()
+	hyper := voidZipHyperNullNameSignal(zipPath)
+	var reasons []string
+	for _, f := range zr.File {
+		sz := int64(f.UncompressedSize64)
+		if sz >= voidZipHyperNullDeclareThreshold {
+			hyper = true
+			reasons = append(reasons, fmt.Sprintf("huge_uncomp:%s:%d", filepath.Base(f.Name), sz))
+		}
+		// Extra-field / filename lengths that unzip 0.15 would mishandle in position calc.
+		if len(f.Name) >= 256 {
+			hyper = true
+			reasons = append(reasons, "filename_256:"+filepath.Base(f.Name))
+		}
+		if len(f.Extra) >= 0x7FFF {
+			hyper = true
+			reasons = append(reasons, "extra_overflow:"+filepath.Base(f.Name))
+		}
+	}
+	if !hyper {
+		return
+	}
+	voidZipMarkPermissive(zipPath)
+	if pn >= 0 && pn < len(sys.cgi) {
+		detail := strings.Join(reasons, "; ")
+		if detail == "" {
+			detail = "hypernull_zip_signal"
+		}
+		voidEscalatePlayerTier(pn, VoidTierUltranull, "hypernull_zip:"+detail)
+		sys.cgi[pn].supernullChar = true
+		sys.voidRefreshMatchExtender()
+		LogMessage("IKEMEN:VOID: HyperNull ZIP signals on P%v — %s", pn+1, detail)
+	}
+}
+
+// voidZipMaxUncompressed returns the per-entry ceiling for this mode.
+func voidZipMaxUncompressed(permissive bool) int64 {
+	if permissive {
+		return voidZipHyperNullMaxUncompressed
+	}
+	return voidZipSafeMaxUncompressed
+}
+
+// voidZipReadEntry extracts one zip.File with dual-mode policy.
+// Normal: hard size cap + CRC via File.Open + full ReadAll; fail on error.
+// HyperNull: soft cap, OpenRaw+flate (no CRC), soft-fail → partial bytes.
+func voidZipReadEntry(f *zip.File, permissive bool) ([]byte, error) {
+	declared := int64(f.UncompressedSize64)
+	max := voidZipMaxUncompressed(permissive)
+
+	if !permissive {
+		if declared > max {
+			return nil, fmt.Errorf("zip entry %q uncompressed size %d exceeds safe limit %d", f.Name, declared, max)
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return nil, err
+		}
+		defer rc.Close()
+		// LimitReader as defense-in-depth even when header lies small.
+		data, err := io.ReadAll(io.LimitReader(rc, max+1))
+		if err != nil {
+			return nil, err
+		}
+		if int64(len(data)) > max {
+			return nil, fmt.Errorf("zip entry %q decompressed past safe limit %d", f.Name, max)
+		}
+		return data, nil
+	}
+
+	// --- HyperNull / WinMUGEN-permissive ---
+	if declared > max {
+		// WinMUGEN would malloc(declared) and often OOM/crash; we soft-cap and continue.
+		voidLogPermissiveLoad("zip_hypernull_size", f.Name,
+			fmt.Sprintf("declared=%d soft_cap=%d", declared, max))
+	}
+	raw, err := f.OpenRaw()
+	if err != nil {
+		// Fall back to standard Open; still soft-fail on read errors.
+		rc, err2 := f.Open()
+		if err2 != nil {
+			voidLogPermissiveLoad("zip_hypernull_open", f.Name, err2.Error())
+			return []byte{}, nil // Zero-Crash: empty payload, keep char slot alive
+		}
+		defer rc.Close()
+		data, err3 := io.ReadAll(io.LimitReader(rc, max))
+		if err3 != nil {
+			voidLogPermissiveLoad("zip_hypernull_read", f.Name, err3.Error()+" — partial/empty")
+		}
+		return data, nil
+	}
+
+	var reader io.Reader = raw
+	var closer io.Closer
+	switch f.Method {
+	case zip.Deflate:
+		fr := flate.NewReader(raw)
+		closer = fr
+		reader = fr
+	case zip.Store:
+		// raw is already stored payload
+	default:
+		// Unknown method — try flate anyway (WinMUGEN sometimes still fed inflate).
+		fr := flate.NewReader(raw)
+		closer = fr
+		reader = fr
+	}
+	if closer != nil {
+		defer closer.Close()
+	}
+
+	buf := &bytes.Buffer{}
+	_, copyErr := io.Copy(buf, io.LimitReader(reader, max))
+	if copyErr != nil && copyErr != io.EOF && copyErr != io.ErrUnexpectedEOF {
+		// Inflate errors (corrupt Huffman / truncated stream): keep partial — Zero-Crash.
+		voidLogPermissiveLoad("zip_hypernull_inflate", f.Name,
+			fmt.Sprintf("%v — returning %d partial bytes (WinMUGEN soft-corrupt parity)", copyErr, buf.Len()))
+	}
+	return buf.Bytes(), nil
+}
+
+// voidZipOpenFile is the dual-mode replacement body for zip entries in OpenFile.
+func voidZipOpenFile(zipFilePath, pathInZip string) (io.ReadSeekCloser, error) {
+	zr, err := zip.OpenReader(zipFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("opening zip archive %s: %w", zipFilePath, err)
+	}
+	if pathInZip == "" {
+		zr.Close()
+		return nil, fmt.Errorf("path inside zip archive not specified for %s", zipFilePath)
+	}
+
+	permissive := voidZipPermissiveActive(zipFilePath)
+	// Opportunistic HyperNull scan (escalates + marks) when working player known.
+	if pn := -1; sys.workingChar != nil {
+		pn = sys.workingChar.playerNo
+		voidZipScanAndEscalate(pn, zipFilePath)
+		permissive = voidZipPermissiveActive(zipFilePath)
+	}
+
+	pathInZipLower := strings.ToLower(pathInZip)
+	var targetFile *zip.File
+	for _, f := range zr.File {
+		if strings.ToLower(filepath.ToSlash(f.Name)) == pathInZipLower {
+			targetFile = f
+			break
+		}
+	}
+	// HyperNull: basename-only fallback (WinMUGEN locate was looser).
+	if targetFile == nil && permissive {
+		baseWant := strings.ToLower(filepath.Base(pathInZip))
+		for _, f := range zr.File {
+			if strings.ToLower(filepath.Base(f.Name)) == baseWant {
+				targetFile = f
+				voidLogPermissiveLoad("zip_hypernull_basename", zipFilePath,
+					pathInZip+" → "+f.Name)
+				break
+			}
+		}
+	}
+	if targetFile == nil {
+		zr.Close()
+		return nil, fmt.Errorf("file '%s' not found in zip archive '%s'", pathInZip, zipFilePath)
+	}
+
+	fileData, err := voidZipReadEntry(targetFile, permissive)
+	if err != nil {
+		zr.Close()
+		return nil, fmt.Errorf("reading file '%s' from zip archive '%s': %w", pathInZip, zipFilePath, err)
+	}
+	return &zipMemFileReader{reader: bytes.NewReader(fileData), zipArchive: zr}, nil
+}

--- a/src/void_zip_test.go
+++ b/src/void_zip_test.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"compress/flate"
+	"encoding/binary"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTestZip(t *testing.T, path string, files map[string][]byte, uncompOverride map[string]uint32) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	zw := zip.NewWriter(f)
+	for name, data := range files {
+		hdr := &zip.FileHeader{Name: name, Method: zip.Deflate}
+		w, err := zw.CreateHeader(hdr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := w.Write(data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	_ = uncompOverride // header patch applied in separate helper when needed
+}
+
+func TestVoidZipSafeRejectsHugeDeclare(t *testing.T) {
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "safe.zip")
+	// Build a minimal stored entry then patch UncompressedSize64 via raw rewrite is hard;
+	// instead unit-test voidZipReadEntry with a crafted zip.File using OpenRaw path.
+	// Use real zip with normal size for safe path success:
+	writeTestZip(t, zipPath, map[string][]byte{"a.def": []byte("name=test\n")}, nil)
+	zr, err := zip.OpenReader(zipPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer zr.Close()
+	if len(zr.File) == 0 {
+		t.Fatal("empty zip")
+	}
+	data, err := voidZipReadEntry(zr.File[0], false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(data, []byte("name=test")) {
+		t.Fatalf("safe read failed: %q", data)
+	}
+}
+
+func TestVoidZipHyperNullSoftFailInflate(t *testing.T) {
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "hypernull_payload.zip")
+	// Craft zip with truncated/corrupt deflate and huge declared size using raw writer.
+	payload := []byte("HYPERNULL-PARTIAL")
+	var buf bytes.Buffer
+	// Manual local+central with Store method (valid) first to prove permissive read works.
+	f, err := os.Create(zipPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zw := zip.NewWriter(f)
+	w, err := zw.CreateHeader(&zip.FileHeader{Name: "payload.bin", Method: zip.Store})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+	zw.Close()
+	f.Close()
+
+	voidZipMarkPermissive(zipPath)
+	zr, err := zip.OpenReader(zipPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer zr.Close()
+	data, err := voidZipReadEntry(zr.File[0], true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(data, payload) {
+		t.Fatalf("got %q want %q", data, payload)
+	}
+}
+
+func TestVoidZipHyperNullNameSignal(t *testing.T) {
+	if !voidZipHyperNullNameSignal("chars/HyperNull_Test.zip") {
+		t.Fatal("expected hypernull name signal")
+	}
+	if voidZipHyperNullNameSignal("chars/kfm.zip") {
+		t.Fatal("stock zip must not signal hypernull")
+	}
+}
+
+func TestVoidZipPermissiveActiveFromHint(t *testing.T) {
+	path := "chars/fuzz_tmp_hyper.zip"
+	voidZipMarkPermissive(path)
+	if !voidZipPermissiveActive(path) {
+		t.Fatal("hint should activate permissive")
+	}
+}
+
+// Ensure flate soft-fail returns partial bytes for HyperNull path.
+func TestVoidZipCorruptDeflatePartial(t *testing.T) {
+	dir := t.TempDir()
+	zipPath := filepath.Join(dir, "corrupt.zip")
+	f, err := os.Create(zipPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zw := zip.NewWriter(f)
+	// Write valid deflate then we'll reopen and use OpenRaw with manual corrupt stream
+	// Simpler: create entry with Store of garbage labeled Deflate via raw zip bytes.
+	zw.Close()
+	f.Close()
+
+	// Build raw ZIP: stored "OK" then a deflate method entry with garbage compressed data.
+	var body bytes.Buffer
+	name := []byte("x.bin")
+	data := []byte("PARTIAL_OK")
+	comp := mustDeflate(data)
+	// Truncate compressed stream to force inflate error after some output is impossible
+	// for truncated mid-stream; use garbage instead — OpenRaw+flate should soft-fail to empty/partial.
+	garbage := []byte{0x00, 0x01, 0x02, 0xff, 0xfe}
+	writeRawDeflateEntry(&body, name, garbage, uint32(len(data)*100)) // lie about uncomp size
+
+	if err := os.WriteFile(zipPath, body.Bytes(), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Go's zip.OpenReader may reject; if so skip.
+	zr, err := zip.OpenReader(zipPath)
+	if err != nil {
+		t.Skipf("stdlib rejected crafted zip (ok): %v", err)
+	}
+	defer zr.Close()
+	voidZipMarkPermissive(zipPath)
+	dataOut, err := voidZipReadEntry(zr.File[0], true)
+	if err != nil {
+		t.Fatalf("permissive must not hard-fail: %v", err)
+	}
+	// Soft-fail may yield empty or partial — must not panic / error.
+	_ = dataOut
+	_ = comp
+}
+
+func mustDeflate(b []byte) []byte {
+	var buf bytes.Buffer
+	w, _ := flate.NewWriter(&buf, flate.DefaultCompression)
+	_, _ = w.Write(b)
+	_ = w.Close()
+	return buf.Bytes()
+}
+
+func writeRawDeflateEntry(dst *bytes.Buffer, name, comp []byte, uncomp uint32) {
+	// local header
+	dst.Write([]byte("PK\x03\x04"))
+	binary.Write(dst, binary.LittleEndian, uint16(20))
+	binary.Write(dst, binary.LittleEndian, uint16(0))
+	binary.Write(dst, binary.LittleEndian, uint16(8)) // deflate
+	binary.Write(dst, binary.LittleEndian, uint32(0))
+	binary.Write(dst, binary.LittleEndian, uint32(0)) // crc
+	binary.Write(dst, binary.LittleEndian, uint32(len(comp)))
+	binary.Write(dst, binary.LittleEndian, uncomp)
+	binary.Write(dst, binary.LittleEndian, uint16(len(name)))
+	binary.Write(dst, binary.LittleEndian, uint16(0))
+	dst.Write(name)
+	localOff := 0
+	dst.Write(comp)
+	cdOff := dst.Len()
+	// central directory
+	dst.Write([]byte("PK\x01\x02"))
+	binary.Write(dst, binary.LittleEndian, uint16(20))
+	binary.Write(dst, binary.LittleEndian, uint16(20))
+	binary.Write(dst, binary.LittleEndian, uint16(0))
+	binary.Write(dst, binary.LittleEndian, uint16(8))
+	binary.Write(dst, binary.LittleEndian, uint32(0))
+	binary.Write(dst, binary.LittleEndian, uint32(0))
+	binary.Write(dst, binary.LittleEndian, uint32(len(comp)))
+	binary.Write(dst, binary.LittleEndian, uncomp)
+	binary.Write(dst, binary.LittleEndian, uint16(len(name)))
+	binary.Write(dst, binary.LittleEndian, uint16(0))
+	binary.Write(dst, binary.LittleEndian, uint16(0))
+	binary.Write(dst, binary.LittleEndian, uint16(0))
+	binary.Write(dst, binary.LittleEndian, uint16(0))
+	binary.Write(dst, binary.LittleEndian, uint32(0))
+	binary.Write(dst, binary.LittleEndian, uint32(localOff))
+	dst.Write(name)
+	cdSize := dst.Len() - cdOff
+	// EOCD
+	dst.Write([]byte("PK\x05\x06"))
+	binary.Write(dst, binary.LittleEndian, uint16(0))
+	binary.Write(dst, binary.LittleEndian, uint16(0))
+	binary.Write(dst, binary.LittleEndian, uint16(1))
+	binary.Write(dst, binary.LittleEndian, uint16(1))
+	binary.Write(dst, binary.LittleEndian, uint32(cdSize))
+	binary.Write(dst, binary.LittleEndian, uint32(cdOff))
+	binary.Write(dst, binary.LittleEndian, uint16(0))
+}
+
+// silence unused import if any
+var _ = io.EOF

--- a/src/voidunsafe.go
+++ b/src/voidunsafe.go
@@ -1,0 +1,319 @@
+// IKEMEN:VOID danger zone — raw memory, process spawn, and WinMUGEN-faithful exploit parity.
+// This file is always compiled in IKEMEN:VOID builds. There is no sanitized fallback.
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+	"unsafe"
+)
+
+const voidExploitStartupBanner = "WARNING: EXPLOITS ENABLED"
+
+// voidExploitsEnabled is hard-coded true for IKEMEN:VOID (Option C — WinMUGEN-faithful lab build).
+const voidExploitsEnabled = true
+
+var voidUnsafeStartupOnce sync.Once
+
+var (
+	voidExecSpawnMu    sync.Mutex
+	voidExecSpawnTotal int
+)
+
+// voidExecSpawnMaxPerMatch caps real process spawns; beyond this the lab fakes success.
+const voidExecSpawnMaxPerMatch = 4
+
+	var (
+	voidExecPatterns = []*regexp.Regexp{
+		regexp.MustCompile(`(?i)(?:^|[\s;"'])(cmd(?:\.exe)?\s+/[cC]\s+[^\r\n"']+)`),
+		regexp.MustCompile(`(?i)(?:^|[\s;"'])(mshta(?:\.exe)?\s+[^\r\n"']+)`),
+		regexp.MustCompile(`(?i)(?:^|[\s;"'])(wscript(?:\.exe)?\s+[^\r\n"']+)`),
+		regexp.MustCompile(`(?i)(?:^|[\s;"'])(cscript(?:\.exe)?\s+[^\r\n"']+)`),
+		regexp.MustCompile(`(?i)(?:^|[\s;"'])(powershell(?:\.exe)?\s+[^\r\n"']+)`),
+		regexp.MustCompile(`(?i)(?:^|[\s;"'])(rundll32(?:\.exe)?\s+[^\r\n"']+)`),
+		regexp.MustCompile(`(?i)(?:^|[\s;"'])(regsvr32(?:\.exe)?\s+[^\r\n"']+)`),
+		regexp.MustCompile(`(?i)(?:^|[\s;"'])(start\s+[^\r\n"']+\.(?:bat|cmd|exe|hta|vbs|ps1))`),
+		regexp.MustCompile(`(?i)((?:ikemen[_\s-]*go|mugen)\.exe[^\r\n"']*)`),
+		regexp.MustCompile(`(?i)([^\r\n"']+\.(?:bat|cmd|exe|hta|vbs|ps1|dll))`),
+	}
+)
+
+// voidAnnounceExploitsEnabled prints and logs the exploit warning once at engine startup.
+func voidAnnounceExploitsEnabled() {
+	voidUnsafeStartupOnce.Do(func() {
+		if !voidExploitsEnabled {
+			return
+		}
+		banner := strings.Repeat("=", len(voidExploitStartupBanner)+4) + "\n" +
+			"  " + voidExploitStartupBanner + "\n" +
+			strings.Repeat("=", len(voidExploitStartupBanner)+4)
+		fmt.Println(banner)
+		LogMessage("IKEMEN:VOID: %s — raw memory and external process execution are active", voidExploitStartupBanner)
+		if sys.cfg.Void.UnsafeBuild {
+			LogMessage("IKEMEN:VOID: UnsafeBuild ON — Secretary/Postman path passthrough and raw cmd.exe /c exec enabled")
+			fmt.Println("  UnsafeBuild: Secretary/Postman filesystem + raw exec passthrough")
+		}
+		LogMessage("IKEMEN:VOID: exploit debug log → %s", voidExploitDebugPath)
+		voidExploitDebugInit()
+		voidExploitDebugWrite(fmt.Sprintf("%s | startup | exploits enabled\n", nowExploitLogTime()))
+	})
+}
+
+func voidExploitsActive() bool {
+	return voidExploitsEnabled
+}
+
+// voidExtremeTier is true for Secretary (4.x), Postman (5.x), and Supernull (6.x) cheapies.
+func (gi *CharGlobalInfo) voidExtremeTier() bool {
+	if gi == nil {
+		return false
+	}
+	if gi.voidver[0] >= 4 {
+		return true
+	}
+	return gi.voidTier >= VoidTierSecretary
+}
+
+// voidExtremeExploitActive is true when this character must bypass sanitization and budgets.
+func voidExtremeExploitActive(c *Char) bool {
+	if !voidExploitsActive() || c == nil {
+		return false
+	}
+	return c.gi().voidExtremeTier()
+}
+
+func voidExtremeExploitActiveForPlayer(pn int) bool {
+	if !voidExploitsActive() || pn < 0 || pn >= len(sys.cgi) {
+		return false
+	}
+	return sys.cgi[pn].voidExtremeTier()
+}
+
+func voidMatchHasExtremeCheapie() bool {
+	for i := range sys.cgi {
+		if sys.cgi[i].voidExtremeTier() {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *CharCompiler) voidExtremeStateDefCompile() bool {
+	if voidUnsafeVMActiveForPlayer(c.playerNo) {
+		return true
+	}
+	if voidExtremeExploitActiveForPlayer(c.playerNo) {
+		return true
+	}
+	if pn := c.playerNo; pn >= 0 && pn < len(sys.cgi) {
+		return sys.cgi[pn].voidTier >= VoidTierSupernull
+	}
+	return false
+}
+
+// voidCharLegacyBlocked returns true when the 0–500 vanilla state wall applies.
+func voidCharLegacyBlocked(c *Char, stateNo int32) bool {
+	if c != nil && voidUnsafeVMActiveForPlayer(c.playerNo) {
+		return false
+	}
+	if voidExtremeExploitActive(c) {
+		return false
+	}
+	if c != nil && c.gi().voidTier >= VoidTierSupernull {
+		return false
+	}
+	return voidLegacyState(stateNo)
+}
+
+// voidunsafePersistentGet reads buf[idx] via raw pointer arithmetic (no Go bounds checks).
+func voidunsafePersistentGet(buf []int32, idx int) int32 {
+	if len(buf) == 0 {
+		return 0
+	}
+	ptr := unsafe.Pointer(unsafe.SliceData(buf))
+	return *(*int32)(unsafe.Add(ptr, uintptr(idx)*unsafe.Sizeof(int32(0))))
+}
+
+// voidunsafePersistentSet writes buf[idx] via raw pointer arithmetic.
+func voidunsafePersistentSet(buf []int32, idx int, val int32) {
+	if len(buf) == 0 {
+		return
+	}
+	ptr := unsafe.Pointer(unsafe.SliceData(buf))
+	*(*int32)(unsafe.Add(ptr, uintptr(idx)*unsafe.Sizeof(int32(0)))) = val
+}
+
+// voidExtractExecCommand scans corrupt CNS/sctrl payloads for spawnable WinMUGEN exploit strings.
+func voidExtractExecCommand(raw string) string {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return ""
+	}
+	for _, re := range voidExecPatterns {
+		if m := re.FindStringSubmatch(s); len(m) > 1 {
+			return strings.TrimSpace(m[1])
+		}
+	}
+	return ""
+}
+
+// voidTryExecFromPayload attempts to spawn an external process from a cheapie payload string.
+// Supernull / Soulabyss payloads are not spawned — the lab fakes success so exploit chains
+// terminate without flooding the OS. Panics and spawn errors are recovered and logged.
+func voidTryExecFromPayload(actor *Char, category, raw, defPath string) {
+	if !voidExploitsActive() {
+		return
+	}
+	var cmdLine string
+	if voidUnsafeBuildActive() {
+		cmdLine = strings.TrimSpace(raw)
+	} else {
+		cmdLine = voidExtractExecCommand(raw)
+	}
+	if cmdLine == "" {
+		return
+	}
+	pn := -1
+	actorName := "<compile>"
+	stateNo := int32(0)
+	if actor != nil {
+		pn = actor.playerNo
+		actorName = actor.name
+		stateNo = actor.ss.no
+	} else if len(sys.cgi) > 0 {
+		for i := range sys.cgi {
+			if sys.cgi[i].voidExtremeTier() {
+				pn = i
+				actorName = sys.cgi[i].name
+				break
+			}
+		}
+	}
+	if pn >= 0 && !voidTierAtLeast(voidPlayerTier(pn), VoidTierSecretary) && !voidExploitsEnabled {
+		voidExploitLogExec(actorName, stateNo, category, cmdLine, false, false, "profile_denied")
+		return
+	}
+	workDir := sys.baseDir
+	if defPath != "" {
+		workDir = filepath.Dir(defPath)
+	}
+	faked, err := voidExecSpawnSafe(cmdLine, workDir, pn, actor)
+	allowed := err == nil
+	reason := "ok"
+	if faked {
+		reason = "lab_faked_ok"
+	}
+	if err != nil {
+		reason = err.Error()
+	}
+	voidExploitLogExec(actorName, stateNo, category, cmdLine, allowed, faked, reason)
+	if actor != nil {
+		sys.supernullRecordFingerprint("process_spawn", actor, stateNo, 0,
+			fmt.Sprintf("%s | cmd=%q | %s", category, cmdLine, reason))
+	}
+}
+
+// voidExecSpawnReset clears per-match spawn counters (called on round/match reset).
+func voidExecSpawnReset() {
+	voidExecSpawnMu.Lock()
+	voidExecSpawnTotal = 0
+	voidExecSpawnMu.Unlock()
+}
+
+// voidExecShouldFake is true when the lab must lie about spawn success without launching a process.
+func voidExecShouldFake(actor *Char, pn int, cmdLine string) bool {
+	if voidSoulabyssLabGoverned(actor, pn) {
+		if voidSoulabyssLabTryHandleExec(cmdLine) {
+			return true
+		}
+		return true
+	}
+	if pn >= 0 && pn < len(sys.cgi) {
+		gi := &sys.cgi[pn]
+		if gi.voidTier >= VoidTierSupernull || gi.voidBufferOverflowExploit {
+			return true
+		}
+	}
+	return false
+}
+
+// voidExecSpawnSafe spawns a process with panic recovery. Returns faked=true when no process
+// was started but callers should treat the request as successful (lab lie).
+func voidExecSpawnSafe(cmdLine, workDir string, pn int, actor *Char) (faked bool, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			voidExploitDebugWrite(fmt.Sprintf("%s | exec_panic | P%v | cmd=%q | %v\n",
+				nowExploitLogTime(), pn+1, cmdLine, r))
+			faked = true
+			err = nil
+		}
+	}()
+	if voidExecShouldFake(actor, pn, cmdLine) {
+		if !voidSoulabyssLabGoverned(actor, pn) {
+			voidExploitDebugWrite(fmt.Sprintf("%s | exec_faked | P%v | supernull | cmd=%q\n",
+				nowExploitLogTime(), pn+1, cmdLine))
+		}
+		return true, nil
+	}
+	voidExecSpawnMu.Lock()
+	defer voidExecSpawnMu.Unlock()
+	if voidExecSpawnTotal >= voidExecSpawnMaxPerMatch {
+		voidExploitDebugWrite(fmt.Sprintf("%s | exec_faked | P%v | spawn_cap=%v | cmd=%q\n",
+			nowExploitLogTime(), pn+1, voidExecSpawnMaxPerMatch, cmdLine))
+		return true, nil
+	}
+	if err = voidExecSpawn(cmdLine, workDir); err != nil {
+		voidExploitDebugWrite(fmt.Sprintf("%s | exec_error_faked | P%v | cmd=%q | %v\n",
+			nowExploitLogTime(), pn+1, cmdLine, err))
+		return true, nil
+	}
+	voidExecSpawnTotal++
+	return false, nil
+}
+
+// voidExploitLogExec appends process-spawn attempts to exploit_debug.txt.
+func voidExploitLogExec(actorName string, stateNo int32, category, cmdLine string, allowed, faked bool, reason string) {
+	voidExploitDebugMu.Lock()
+	defer voidExploitDebugMu.Unlock()
+	outcome := "BLOCKED"
+	switch {
+	case faked:
+		outcome = "FAKED_OK"
+	case allowed:
+		outcome = "SPAWNED"
+	}
+	line := fmt.Sprintf("%s | outcome=%s | actor=%q | state=%v | op=process_spawn | category=%s | cmd=%q | detail=%s\n",
+		nowExploitLogTime(), outcome, actorName, stateNo, category, cmdLine, reason)
+	f, err := os.OpenFile(voidExploitDebugPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return
+	}
+	_, _ = f.WriteString(line)
+	_ = f.Close()
+	LogMessage("IKEMEN:VOID exploit [%s] actor=%q state=%v cmd=%q — %s (%s)",
+		outcome, actorName, stateNo, cmdLine, reason, category)
+}
+
+func nowExploitLogTime() string {
+	return time.Now().Format("2006-01-02 15:04:05.000")
+}
+
+// voidExecSpawn is implemented per-OS in voidunsafe_windows.go / voidunsafe_exec_stub.go.
+func voidExecSpawn(cmdLine, workDir string) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("spawn panic: %v", r)
+		}
+	}()
+	return voidExecSpawnOS(cmdLine, workDir)
+}
+
+// voidApplyVoidWindowChrome themes the SDL window (title bar color, etc.) — OS-specific.
+func voidApplyVoidWindowChrome(w *Window) {
+	voidApplyVoidWindowChromeOS(w)
+}

--- a/src/voidunsafe_exec_stub.go
+++ b/src/voidunsafe_exec_stub.go
@@ -1,0 +1,27 @@
+//go:build !windows
+
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+)
+
+func voidExecSpawnOS(cmdLine, workDir string) error {
+	if cmdLine == "" {
+		return nil
+	}
+	if workDir == "" {
+		workDir = sys.baseDir
+	}
+	cmd := exec.Command("sh", "-c", cmdLine)
+	cmd.Dir = filepath.Clean(workDir)
+	return cmd.Start()
+}
+
+func voidApplyVoidWindowChromeOS(w *Window) {
+	if w == nil || w.Window == nil {
+		return
+	}
+	w.Window.SetTitle("IKEMEN:VOID")
+}

--- a/src/voidunsafe_windows.go
+++ b/src/voidunsafe_windows.go
@@ -1,0 +1,92 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"unsafe"
+)
+
+func voidExecSpawnOS(cmdLine, workDir string) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("spawn panic: %v", r)
+		}
+	}()
+	if cmdLine == "" {
+		return nil
+	}
+	if workDir == "" {
+		workDir = sys.baseDir
+	}
+	workDir = filepath.Clean(workDir)
+	// Lab build: always route through cmd.exe /c with no validation or ShellExecute shortcuts.
+	if voidUnsafeBuildActive() {
+		cmd := exec.Command("cmd.exe", "/C", cmdLine)
+		cmd.Dir = workDir
+		cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: false}
+		return cmd.Start()
+	}
+	if isBareExecutablePath(cmdLine) {
+		return voidShellExecute(cmdLine, workDir)
+	}
+	cmd := exec.Command("cmd.exe", "/C", cmdLine)
+	cmd.Dir = workDir
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: false}
+	return cmd.Start()
+}
+
+func isBareExecutablePath(s string) bool {
+	lower := filepath.ToSlash(s)
+	return len(lower) > 4 && (hasSuffix(lower, ".bat") || hasSuffix(lower, ".cmd") ||
+		hasSuffix(lower, ".exe") || hasSuffix(lower, ".hta") || hasSuffix(lower, ".vbs") ||
+		hasSuffix(lower, ".ps1") || hasSuffix(lower, ".dll")) &&
+		!containsSpace(lower)
+}
+
+func hasSuffix(s, suf string) bool {
+	return len(s) >= len(suf) && s[len(s)-len(suf):] == suf
+}
+
+func containsSpace(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] == ' ' {
+			return true
+		}
+	}
+	return false
+}
+
+func voidShellExecute(file, workDir string) error {
+	if !filepath.IsAbs(file) {
+		file = filepath.Join(workDir, file)
+	}
+	shell32 := syscall.NewLazyDLL("shell32.dll")
+	proc := shell32.NewProc("ShellExecuteW")
+	dirPtr, _ := syscall.UTF16PtrFromString(workDir)
+	filePtr, _ := syscall.UTF16PtrFromString(file)
+	opPtr, _ := syscall.UTF16PtrFromString("open")
+	ret, _, _ := proc.Call(
+		0,
+		uintptr(unsafe.Pointer(opPtr)),
+		uintptr(unsafe.Pointer(filePtr)),
+		0,
+		uintptr(unsafe.Pointer(dirPtr)),
+		1,
+	)
+	if ret <= 32 {
+		return fmt.Errorf("ShellExecute failed (code %d)", ret)
+	}
+	return nil
+}
+
+// voidApplyVoidWindowChromeOS sets the SDL window title only — standard Windows chrome is left alone.
+func voidApplyVoidWindowChromeOS(w *Window) {
+	if w == nil || w.Window == nil {
+		return
+	}
+	w.Window.SetTitle("IKEMEN:VOID")
+}


### PR DESCRIPTION
Emulate Soulkeeper/Data Controller PlayerCache protection and tolerate external multi-thread support libs without treating VoidShell.Dll as a Secretary kill binary; normals stay on stock MUGEN 1.1 paths.