### PR TITLE
fix: face.slot/random spacing and slot indicator persistence

### DIFF
--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -785,25 +785,33 @@ local function getParams(side, member, t, subname)
 	return paramsSide, params
 end
 
-local function drawPortraitRandom(randomCfg)
+local function drawPortraitRandom(randomCfg, side, member, paramsSide, params)
 	if not randomCfg then
 		return false
 	end
 	local spr = randomCfg.spr
 	if randomCfg.anim >= 0 or (spr and spr[1] >= 0 and spr[2] >= 0) then
-		main.f_animPosDraw(randomCfg.AnimData)
+		local x = f_portraitsXCalc(side, member, paramsSide, params)
+		local y = paramsSide.pos[2] + params.offset[2] + (member - 1) * paramsSide.spacing[2]
+		animSetPos(randomCfg.AnimData, x, y)
+		animDraw(randomCfg.AnimData)
+		animUpdate(randomCfg.AnimData)
 		return true
 	end
 	return false
 end
 
-local function drawPortraitSlot(slotCfg)
+local function drawPortraitSlot(slotCfg, side, member, paramsSide, params)
 	if not slotCfg then
 		return false
 	end
 	local spr = slotCfg.spr
 	if slotCfg.anim >= 0 or (spr and spr[1] >= 0 and spr[2] >= 0) then
-		main.f_animPosDraw(slotCfg.AnimData)
+		local x = f_portraitsXCalc(side, member, paramsSide, params)
+		local y = paramsSide.pos[2] + params.offset[2] + (member - 1) * paramsSide.spacing[2]
+		animSetPos(slotCfg.AnimData, x, y)
+		animDraw(slotCfg.AnimData)
+		animUpdate(slotCfg.AnimData)
 		return true
 	end
 	return false
@@ -891,11 +899,12 @@ function start.f_drawPortraits(t_portraits, side, t, subname, last, iconDone)
 	end
 	-- draw random portraits (per member; required for co-op)
 	for m = 1, #t_portraits do
+		local paramsSide, params = getParams(side, m, t, subname)
 		if t_portraits[m].inRandom then
 			local pn = 2 * (m - 1) + side
 			local pData = f_getMotifP(t, pn, side)
 			-- face2 layer random portrait
-			if pData.face2.random and drawPortraitRandom(pData.face2.random) then
+			if pData.face2.random and drawPortraitRandom(pData.face2.random, side, m, paramsSide, params) then
 				t_portraits[m].skipCurrent = true
 			end
 			-- primary face random portrait
@@ -903,7 +912,7 @@ function start.f_drawPortraits(t_portraits, side, t, subname, last, iconDone)
 			if subname and subname ~= '' then
 				baseFace = baseFace[subname]
 			end
-			if baseFace.random and drawPortraitRandom(baseFace.random) then
+			if baseFace.random and drawPortraitRandom(baseFace.random, side, m, paramsSide, params) then
 				t_portraits[m].skipCurrent = true
 			end
 		end
@@ -917,16 +926,18 @@ function start.f_drawPortraits(t_portraits, side, t, subname, last, iconDone)
 		if subname and subname ~= '' then
 			baseFace = baseFace[subname]
 		end
-		if t_portraits[m].ref ~= nil then
+		-- only show slot indicator while the char is not confirmed
+		if t_portraits[m].ref ~= nil and not start.p[side].t_selTemp[m].slotConfirmed then
+			local paramsSide, params = getParams(side, m, t, subname)
 			local charInfo = main.t_selChars[t_portraits[m].ref + 1]
 			if charInfo and charInfo.hasSlot then
 				-- face2 slot
 				if pData.face2.slot then
-					drawPortraitSlot(pData.face2.slot)
+					drawPortraitSlot(pData.face2.slot, side, m, paramsSide, params)
 				end
 				-- primary face slot
 				if baseFace.slot then
-					drawPortraitSlot(baseFace.slot)
+					drawPortraitSlot(baseFace.slot, side, m, paramsSide, params)
 				end
 			end
 		end
@@ -3483,6 +3494,7 @@ function start.f_selectMenu(side, cmd, player, member, selectState)
 					ref = start.c[player].selRef,
 					cell = start.c[player].cell,
 					inRandom = false,
+					slotConfirmed = false,
 					face_anim = pCfg.face.anim,
 					face_data = start.f_animGet(start.c[player].selRef, side, member, pCfg.face, nil, true),
 					face2_anim = pCfg.face2.anim,
@@ -3593,6 +3605,7 @@ function start.f_selectMenu(side, cmd, player, member, selectState)
 					end
 					start.p[side].t_selTemp[member].pal = main.f_btnPalNo(cmd)
 					start.p[side].t_selTemp[member].inRandom = false
+					start.p[side].t_selTemp[member].slotConfirmed = true
 					if start.p[side].t_selTemp[member].pal == nil or start.p[side].t_selTemp[member].pal == 0 then
 						start.p[side].t_selTemp[member].pal = 1
 					end

--- a/src/motif.go
+++ b/src/motif.go
@@ -2107,6 +2107,16 @@ func (m *Motif) mergeWithInheritance(specs []InheritSpec) {
 		for suf := range suffixes {
 			dstKey := sp.DstPrefix + suf
 			srcKey := sp.SrcPrefix + suf
+			// Skip face.random/face2.random and face.slot/face2.slot anim/spr inheritance
+			lowerDst := strings.ToLower(sp.DstPrefix)
+			if (strings.Contains(lowerDst, ".face.random.") ||
+				strings.Contains(lowerDst, ".face2.random.") || 
+				strings.Contains(lowerDst, "face.slot.") || 
+				strings.Contains(lowerDst, "face2.slot.")) &&
+				(strings.EqualFold(suf, "anim") ||
+				strings.EqualFold(suf, "spr")) {
+				continue
+			}
 			lowerFull := strings.ToLower(dstKey)
 			if shouldSkip(lowerFull) {
 				continue
@@ -2231,12 +2241,20 @@ func (m *Motif) overrideParams() {
 		{SrcSec: "Option Info", SrcPrefix: "menu.", DstSec: "Option Info", DstPrefix: "keymenu."},
 		// [Select Info]
 		{SrcSec: "Select Info", SrcPrefix: "p1.face.", DstSec: "Select Info", DstPrefix: "p1.face.done."},
+		{SrcSec: "Select Info", SrcPrefix: "p1.face.", DstSec: "Select Info", DstPrefix: "p1.face.random."},
+		{SrcSec: "Select Info", SrcPrefix: "p1.face.", DstSec: "Select Info", DstPrefix: "p1.face.slot."},
 		{SrcSec: "Select Info", SrcPrefix: "p1.face.", DstSec: "Select Info", DstPrefix: "p1.face.loading."},
 		{SrcSec: "Select Info", SrcPrefix: "p1.face2.", DstSec: "Select Info", DstPrefix: "p1.face2.done."},
+		{SrcSec: "Select Info", SrcPrefix: "p1.face2.", DstSec: "Select Info", DstPrefix: "p1.face2.random."},
+		{SrcSec: "Select Info", SrcPrefix: "p1.face2.", DstSec: "Select Info", DstPrefix: "p1.face2.slot."},
 		{SrcSec: "Select Info", SrcPrefix: "p1.face2.", DstSec: "Select Info", DstPrefix: "p1.face2.loading."},
 		{SrcSec: "Select Info", SrcPrefix: "p2.face.", DstSec: "Select Info", DstPrefix: "p2.face.done."},
+		{SrcSec: "Select Info", SrcPrefix: "p2.face.", DstSec: "Select Info", DstPrefix: "p2.face.random."},
+		{SrcSec: "Select Info", SrcPrefix: "p2.face.", DstSec: "Select Info", DstPrefix: "p2.face.slot."},
 		{SrcSec: "Select Info", SrcPrefix: "p2.face.", DstSec: "Select Info", DstPrefix: "p2.face.loading."},
 		{SrcSec: "Select Info", SrcPrefix: "p2.face2.", DstSec: "Select Info", DstPrefix: "p2.face2.done."},
+		{SrcSec: "Select Info", SrcPrefix: "p2.face2.", DstSec: "Select Info", DstPrefix: "p2.face2.random."},
+		{SrcSec: "Select Info", SrcPrefix: "p2.face2.", DstSec: "Select Info", DstPrefix: "p2.face2.slot."},
 		{SrcSec: "Select Info", SrcPrefix: "p2.face2.", DstSec: "Select Info", DstPrefix: "p2.face2.loading."},
 		{SrcSec: "Select Info", SrcPrefix: "p1.face.", DstSec: "Select Info", DstPrefix: "p1.palmenu.preview."},
 		{SrcSec: "Select Info", SrcPrefix: "p2.face.", DstSec: "Select Info", DstPrefix: "p2.palmenu.preview."},


### PR DESCRIPTION
Fix:
 - ``face.slot`` and ``face.random`` now inherit undefined parameters from ``pn.face.``
 - ``face.slot`` and ``face.random`` now respect ``pn.face.spacing``
 - Remove face.slot indicator after char confirmation