### PR TITLE
fix: x axis off-by-one error when rendering anims

### DIFF
--- a/src/anim.go
+++ b/src/anim.go
@@ -2209,8 +2209,9 @@ func (a *Anim) SetWindow(window [4]float32) {
 	y := window[1] / a.localScale
 	w := (window[2] - window[0]) / a.localScale
 	h := (window[3] - window[1]) / a.localScale
-	a.window[0] = int32((x + float32(sys.gameWidth-320)/2) * sys.widthScale)
-	a.window[1] = int32((y + float32(sys.gameHeight-240)) * sys.heightScale)
+	// Truncate to int32 first, like before PR #3575, to avoid an off-by-one error
+	a.window[0] = int32((x + float32(int32(sys.gameWidth)-320)/2) * sys.widthScale)
+	a.window[1] = int32((y + float32(int32(sys.gameHeight)-240)) * sys.heightScale)
 	a.window[2] = int32(w*sys.widthScale + 0.5)
 	a.window[3] = int32(h*sys.heightScale + 0.5)
 }
@@ -2317,8 +2318,14 @@ func (a *Anim) Draw(ln int16) {
 		xscl *= -1
 	}
 
-	a.anim.Draw(&a.window, a.x+a.vel[0]-xsoffset+float32(sys.gameWidth-320)/2,
-		a.y+a.vel[1]+float32(sys.gameHeight-240), 1, 1, xscl, xscl, a.yscl,
+	// Truncate to int32 first, like before PR #3575, to avoid an off-by-one error
+	// sys.gameWidth used to be an int32 before PR #3575.
+	// unfortunately that PR introduces an off-by-one error here,
+	// so we force integer divsion by casting
+	// the result of sys.gameWidth subtraction to int.
+	// we do the same thing to sys.gameHeight just in case
+	a.anim.Draw(&a.window, a.x+a.vel[0]-xsoffset+float32(int(sys.gameWidth-320)/2),
+		a.y+a.vel[1]+float32(int(sys.gameHeight-240)), 1, 1, xscl, xscl, a.yscl,
 		xshear, a.rot, 0, a.palfx, a.facing, [2]float32{1, 1}, a.projection, a.fLength, 0, false, CustomShaderRenderData{})
 }
 

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -662,8 +662,9 @@ func (lb *LifeBar) draw(layerno int16, charpn int, lbr *LifeBar, f map[int]*Fnt)
 	redlife := float32(refChar.redLife) / float32(refChar.lifeMax)
 	redval := refChar.redLife - refChar.life
 
-	var MidPosX = (float32(sys.gameWidth-320) / 2)
-	var MidPosY = (float32(sys.gameHeight-240) / 2)
+	// Truncate to int32 first, like before PR #3575, to avoid an off-by-one error
+	var MidPosX = float32(int32(sys.gameWidth)-320) / 2
+	var MidPosY = float32(int32(sys.gameHeight)-240) / 2
 	// Calculates the clipping rectangle based on current bar settings
 	getBarClipRect := func(life float32) [4]int32 {
 		r := sys.scrrect
@@ -1101,8 +1102,9 @@ func (pb *PowerBar) draw(layerno int16, charpn int, pbr *PowerBar, f map[int]*Fn
 		power = float32(pbval)/1000 - Min(float32(level), float32(refChar.powerMax)/1000-1)
 	}
 
-	var MidPosX = (float32(sys.gameWidth-320) / 2)
-	var MidPosY = (float32(sys.gameHeight-240) / 2)
+	// Truncate to int32 first, like before PR #3575, to avoid an off-by-one error
+	var MidPosX = float32(int32(sys.gameWidth)-320) / 2
+	var MidPosY = float32(int32(sys.gameHeight)-240) / 2
 	getBarClipRect := func(power float32) [4]int32 {
 		r := sys.scrrect
 
@@ -1353,8 +1355,9 @@ func (gb *GuardBar) draw(layerno int16, charpn int, gbr *GuardBar, f map[int]*Fn
 		points = 1 - points
 	}
 
-	var MidPosX = (float32(sys.gameWidth-320) / 2)
-	var MidPosY = (float32(sys.gameHeight-240) / 2)
+	// Truncate to int32 first, like before PR #3575, to avoid an off-by-one error
+	var MidPosX = float32(int32(sys.gameWidth)-320) / 2
+	var MidPosY = float32(int32(sys.gameHeight)-240) / 2
 	getBarClipRect := func(points float32) [4]int32 {
 		r := sys.scrrect
 
@@ -1598,8 +1601,9 @@ func (sb *StunBar) draw(layerno int16, charpn int, sbr *StunBar, f map[int]*Fnt)
 		points = 1 - points
 	}
 
-	var MidPosX = (float32(sys.gameWidth-320) / 2)
-	var MidPosY = (float32(sys.gameHeight-240) / 2)
+	// Truncate to int32 first, like before PR #3575, to avoid an off-by-one error
+	var MidPosX = float32(int32(sys.gameWidth)-320) / 2
+	var MidPosY = float32(int32(sys.gameHeight)-240) / 2
 	getBarClipRect := func(points float32) [4]int32 {
 		r := sys.scrrect
 


### PR DESCRIPTION
This PR fixes a regression/imprecision introduced by PR #3575. It affects anim objects.

Should fix #3799.