### PR TITLE
fix: add explodvar animtime case

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -3820,6 +3820,8 @@ func (be BytecodeExp) run_ex2(c *Char, i *int, oc *Char) {
 		fallthrough
 	case OC_ex2_explodvar_animplayerno:
 		fallthrough
+	case OC_ex2_explodvar_animtime:
+		fallthrough
 	case OC_ex2_explodvar_spriteplayerno:
 		fallthrough
 	case OC_ex2_explodvar_drawpal_group:


### PR DESCRIPTION
Oops, the trigger caused an invalid opcode crash.