### PR TITLE
fix: motif fixes, minor refactors

### DIFF
--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -785,14 +785,14 @@ local function getParams(side, member, t, subname)
 	return paramsSide, params
 end
 
-local function drawPortraitRandom(randomCfg, side, member, paramsSide, params)
+local function drawPortraitRandom(randomCfg, side, member, paramsSide)
 	if not randomCfg then
 		return false
 	end
 	local spr = randomCfg.spr
 	if randomCfg.anim >= 0 or (spr and spr[1] >= 0 and spr[2] >= 0) then
-		local x = f_portraitsXCalc(side, member, paramsSide, params)
-		local y = paramsSide.pos[2] + params.offset[2] + (member - 1) * paramsSide.spacing[2]
+		local x = f_portraitsXCalc(side, member, paramsSide, randomCfg)
+		local y = paramsSide.pos[2] + randomCfg.offset[2] + (member - 1) * paramsSide.spacing[2]
 		animSetPos(randomCfg.AnimData, x, y)
 		animDraw(randomCfg.AnimData)
 		animUpdate(randomCfg.AnimData)
@@ -801,14 +801,14 @@ local function drawPortraitRandom(randomCfg, side, member, paramsSide, params)
 	return false
 end
 
-local function drawPortraitSlot(slotCfg, side, member, paramsSide, params)
+local function drawPortraitSlot(slotCfg, side, member, paramsSide)
 	if not slotCfg then
 		return false
 	end
 	local spr = slotCfg.spr
 	if slotCfg.anim >= 0 or (spr and spr[1] >= 0 and spr[2] >= 0) then
-		local x = f_portraitsXCalc(side, member, paramsSide, params)
-		local y = paramsSide.pos[2] + params.offset[2] + (member - 1) * paramsSide.spacing[2]
+		local x = f_portraitsXCalc(side, member, paramsSide, slotCfg)
+		local y = paramsSide.pos[2] + slotCfg.offset[2] + (member - 1) * paramsSide.spacing[2]
 		animSetPos(slotCfg.AnimData, x, y)
 		animDraw(slotCfg.AnimData)
 		animUpdate(slotCfg.AnimData)
@@ -904,7 +904,7 @@ function start.f_drawPortraits(t_portraits, side, t, subname, last, iconDone)
 			local pn = 2 * (m - 1) + side
 			local pData = f_getMotifP(t, pn, side)
 			-- face2 layer random portrait
-			if pData.face2.random and drawPortraitRandom(pData.face2.random, side, m, paramsSide, params) then
+			if pData.face2.random and drawPortraitRandom(pData.face2.random, side, m, paramsSide) then
 				t_portraits[m].skipCurrent = true
 			end
 			-- primary face random portrait
@@ -912,7 +912,7 @@ function start.f_drawPortraits(t_portraits, side, t, subname, last, iconDone)
 			if subname and subname ~= '' then
 				baseFace = baseFace[subname]
 			end
-			if baseFace.random and drawPortraitRandom(baseFace.random, side, m, paramsSide, params) then
+			if baseFace.random and drawPortraitRandom(baseFace.random, side, m, paramsSide) then
 				t_portraits[m].skipCurrent = true
 			end
 		end
@@ -933,11 +933,11 @@ function start.f_drawPortraits(t_portraits, side, t, subname, last, iconDone)
 			if charInfo and charInfo.hasSlot then
 				-- face2 slot
 				if pData.face2.slot then
-					drawPortraitSlot(pData.face2.slot, side, m, paramsSide, params)
+					drawPortraitSlot(pData.face2.slot, side, m, paramsSide)
 				end
 				-- primary face slot
 				if baseFace.slot then
-					drawPortraitSlot(baseFace.slot, side, m, paramsSide, params)
+					drawPortraitSlot(baseFace.slot, side, m, paramsSide)
 				end
 			end
 		end
@@ -3412,6 +3412,7 @@ function start.f_palMenu(side, cmd, player, member, selectState)
 		selectState = 0
 		st.currentIdx = nil
 		st.validPals = nil
+		start.p[side].t_selTemp[member].slotConfirmed = false
 		sndPlay(motif.Snd, motif.select_info['p' .. side].palmenu.cancel.snd[1], motif.select_info['p' .. side].palmenu.cancel.snd[2])
 	end
 	-- random hotkey

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -763,13 +763,16 @@ function start.f_animGet(ref, side, member, params, velParams, loop, srcAnim)
 end
 
 --calculate portraits x pos
-local function f_portraitsXCalc(side, member, paramsSide, params, skipOffset)
+local function f_portraitsXCalc(side, member, paramsSide, params, skipOffset, offsetKey)
 	local x = paramsSide.pos[1]
 	if not skipOffset then
 		x = x + params.offset[1]
 	end
 	if paramsSide.padding then
 		return x + (2 * member - 1) * paramsSide.spacing[1] * paramsSide.num / (2 * math.min(paramsSide.num, math.max(start.p[side].numChars, #start.p[side].t_selected)))
+	end
+	if offsetKey and not motifIsInherited(offsetKey) then
+		return x
 	end
 	return x + (member - 1) * paramsSide.spacing[1]
 end
@@ -785,13 +788,13 @@ local function getParams(side, member, t, subname)
 	return paramsSide, params
 end
 
-local function drawPortraitRandom(randomCfg, side, member, paramsSide)
+local function drawPortraitRandom(randomCfg, side, member, paramsSide, offsetKey)
 	if not randomCfg then
 		return false
 	end
 	local spr = randomCfg.spr
 	if randomCfg.anim >= 0 or (spr and spr[1] >= 0 and spr[2] >= 0) then
-		local x = f_portraitsXCalc(side, member, paramsSide, randomCfg)
+		local x = f_portraitsXCalc(side, member, paramsSide, randomCfg, false, offsetKey)
 		local y = paramsSide.pos[2] + randomCfg.offset[2] + (member - 1) * paramsSide.spacing[2]
 		animSetPos(randomCfg.AnimData, x, y)
 		animDraw(randomCfg.AnimData)
@@ -801,13 +804,13 @@ local function drawPortraitRandom(randomCfg, side, member, paramsSide)
 	return false
 end
 
-local function drawPortraitSlot(slotCfg, side, member, paramsSide)
+local function drawPortraitSlot(slotCfg, side, member, paramsSide, offsetKey)
 	if not slotCfg then
 		return false
 	end
 	local spr = slotCfg.spr
 	if slotCfg.anim >= 0 or (spr and spr[1] >= 0 and spr[2] >= 0) then
-		local x = f_portraitsXCalc(side, member, paramsSide, slotCfg)
+		local x = f_portraitsXCalc(side, member, paramsSide, slotCfg, false, offsetKey)
 		local y = paramsSide.pos[2] + slotCfg.offset[2] + (member - 1) * paramsSide.spacing[2]
 		animSetPos(slotCfg.AnimData, x, y)
 		animDraw(slotCfg.AnimData)
@@ -848,13 +851,15 @@ local function drawPortraitLayer(t_portraits, side, t, subname, last, dataField)
 	-- "next player replaces previous one" case
 	local idx = clamp(t_portraitPriority[side] or 1, 1, lastIdx)
 	local paramsSide, params = getParams(side, idx, t, subname)
+	local pn = 2 * (1 - 1) + side
+	local offsetKey = 'select_info.p' .. pn .. '.face.offset'
 	if paramsSide.num == 1 and last then
 		local v = t_portraits[idx]
 		local data, drawParams, skipOffset = getPortraitDrawData(v, side, idx, params, dataField)
 		if not v.skipCurrent and data ~= nil then
 			main.f_animPosDraw(
 				data,
-				f_portraitsXCalc(side, 1, paramsSide, drawParams, skipOffset),
+				f_portraitsXCalc(side, 1, paramsSide, drawParams, skipOffset, offsetKey),
 				paramsSide.pos[2] + (skipOffset and 0 or drawParams.offset[2])
 			)
 		end
@@ -877,11 +882,13 @@ local function drawPortraitLayer(t_portraits, side, t, subname, last, dataField)
 		local member = it.m
 		local paramsSide, params = getParams(side, member, t, subname)
 		local v = t_portraits[member]
+		local pn = 2 * (member - 1) + side
+		local offsetKey = 'select_info.p' .. pn .. '.face.offset'
 		local data, drawParams, skipOffset = getPortraitDrawData(v, side, member, params, dataField)
 		if member <= paramsSide.num and not v.skipCurrent and data ~= nil then
 			main.f_animPosDraw(
 				data,
-				f_portraitsXCalc(side, member, paramsSide, drawParams, skipOffset),
+				f_portraitsXCalc(side, member, paramsSide, drawParams, skipOffset, offsetKey),
 				paramsSide.pos[2] + (skipOffset and 0 or drawParams.offset[2]) + (member - 1) * paramsSide.spacing[2]
 			)
 		end
@@ -904,7 +911,7 @@ function start.f_drawPortraits(t_portraits, side, t, subname, last, iconDone)
 			local pn = 2 * (m - 1) + side
 			local pData = f_getMotifP(t, pn, side)
 			-- face2 layer random portrait
-			if pData.face2.random and drawPortraitRandom(pData.face2.random, side, m, paramsSide) then
+			if pData.face2.random and drawPortraitRandom(pData.face2.random, side, m, paramsSide, 'select_info.p' .. pn .. '.face2.random.offset') then
 				t_portraits[m].skipCurrent = true
 			end
 			-- primary face random portrait
@@ -912,7 +919,7 @@ function start.f_drawPortraits(t_portraits, side, t, subname, last, iconDone)
 			if subname and subname ~= '' then
 				baseFace = baseFace[subname]
 			end
-			if baseFace.random and drawPortraitRandom(baseFace.random, side, m, paramsSide) then
+			if baseFace.random and drawPortraitRandom(baseFace.random, side, m, paramsSide, 'select_info.p' .. pn .. '.face.random.offset') then
 				t_portraits[m].skipCurrent = true
 			end
 		end
@@ -933,11 +940,11 @@ function start.f_drawPortraits(t_portraits, side, t, subname, last, iconDone)
 			if charInfo and charInfo.hasSlot then
 				-- face2 slot
 				if pData.face2.slot then
-					drawPortraitSlot(pData.face2.slot, side, m, paramsSide)
+					drawPortraitSlot(pData.face2.slot, side, m, paramsSide, 'select_info.p' .. pn .. '.face2.slot.offset')
 				end
 				-- primary face slot
 				if baseFace.slot then
-					drawPortraitSlot(baseFace.slot, side, m, paramsSide)
+					drawPortraitSlot(baseFace.slot, side, m, paramsSide, 'select_info.p' .. pn .. '.face.slot.offset')
 				end
 			end
 		end

--- a/src/motif.go
+++ b/src/motif.go
@@ -2171,16 +2171,13 @@ func (m *Motif) mergeWithInheritance(specs []InheritSpec) {
 				continue
 			}
 
-			// Remember only anim/spr values that were actually inherited into the destination.
+			// Remember only values that were actually inherited into the destination.
 			// Direct destination values from system.def must keep warning on missing sprites.
-			switch strings.ToLower(suf) {
-			case "anim", "spr":
-				switch src {
-				case srcUserSrc, srcDefSrc:
-					m.inheritedKeys[query] = true
-				default:
-					delete(m.inheritedKeys, query)
-				}
+			switch src {
+			case srcUserSrc, srcDefSrc:
+				m.inheritedKeys[query] = true
+			default:
+				delete(m.inheritedKeys, query)
 			}
 
 			// If a value comes from the user INI (directly or via src), copy it into m.UserIniFile

--- a/src/motif.go
+++ b/src/motif.go
@@ -2107,16 +2107,6 @@ func (m *Motif) mergeWithInheritance(specs []InheritSpec) {
 		for suf := range suffixes {
 			dstKey := sp.DstPrefix + suf
 			srcKey := sp.SrcPrefix + suf
-			// Skip face.random/face2.random and face.slot/face2.slot anim/spr inheritance
-			lowerDst := strings.ToLower(sp.DstPrefix)
-			if (strings.Contains(lowerDst, ".face.random.") ||
-				strings.Contains(lowerDst, ".face2.random.") ||
-				strings.Contains(lowerDst, "face.slot.") ||
-				strings.Contains(lowerDst, "face2.slot.")) &&
-				(strings.EqualFold(suf, "anim") ||
-					strings.EqualFold(suf, "spr")) {
-				continue
-			}
 			lowerFull := strings.ToLower(dstKey)
 			if shouldSkip(lowerFull) {
 				continue

--- a/src/motif.go
+++ b/src/motif.go
@@ -2018,11 +2018,6 @@ func (m *Motif) mergeWithInheritance(specs []InheritSpec) {
 	defs := m.DefaultOnlyIni
 	merged := m.IniFile
 
-	isPreviewAnim := func(dstKey string) bool {
-		l := strings.ToLower(dstKey)
-		return strings.HasSuffix(l, ".palmenu.preview.anim")
-	}
-
 	get := func(f *ini.File, sec, key string) (string, bool) {
 		if f == nil {
 			return "", false
@@ -2107,6 +2102,12 @@ func (m *Motif) mergeWithInheritance(specs []InheritSpec) {
 		for suf := range suffixes {
 			dstKey := sp.DstPrefix + suf
 			srcKey := sp.SrcPrefix + suf
+			// Skip palmenu.preview anim/spr inheritance
+			lowerDst := strings.ToLower(sp.DstPrefix)
+			if strings.Contains(lowerDst, ".palmenu.preview.") &&
+				(strings.EqualFold(suf, "anim") || strings.EqualFold(suf, "spr")) {
+				continue
+			}
 			lowerFull := strings.ToLower(dstKey)
 			if shouldSkip(lowerFull) {
 				continue
@@ -2120,18 +2121,6 @@ func (m *Motif) mergeWithInheritance(specs []InheritSpec) {
 						// Nothing to inherit here; keep the existing (possibly resolved) value.
 						continue
 					}
-				}
-			}
-
-			// palmenu.preview only inherits when palmenu.preview.anim is defined
-			if isPreviewAnim(dstKey) {
-				if v, ok := get(user, sp.DstSec, dstKey); ok {
-					tv := strings.TrimSpace(v)
-					if !IsInt(tv) || Atoi(tv) < 0 {
-						continue
-					}
-				} else {
-					continue
 				}
 			}
 

--- a/src/script.go
+++ b/src/script.go
@@ -9687,6 +9687,16 @@ func triggerFunctions(l *lua.LState) {
 		}
 		return 1
 	})
+	luaRegister(l, "motifIsInherited", func(l *lua.LState) int {
+	/*Returns whether a motif value was inherited from another motif parameter.
+	@function motifIsInherited
+	@tparam string key Motif key path.
+	@treturn boolean
+	function motifIsInherited(key) end*/
+	key := strings.ToLower(l.CheckString(1))
+	l.Push(lua.LBool(sys.motif.inheritedKeys[key]))
+	return 1
+	})
 	luaRegister(l, "motifVar", func(l *lua.LState) int {
 		value, err := sys.motif.GetValue(strArg(l, 1))
 		if err == nil {


### PR DESCRIPTION
Fix:
- face.slot/random offsets not being applied correctly
- face.slot indicators not being reset when leaving palette select
- Fixed user defined offsets not overriding inherited motif spacing parameters
  - Added `motifIsInherited` to allow Lua to check whether a motif parameter was inherited

Refactor:
- Removed redundant motif inheritance special cases
- Simplified palmenu.preview anim/spr inheritance rules