### PR TITLE
fix: face.random, bgmtrigger, cursor interpolation, palette issues

### DIFF
--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -848,6 +848,7 @@ end
 
 local function drawPortraitLayer(t_portraits, side, t, subname, last, dataField)
 	local lastIdx = #t_portraits
+	local skipField = dataField == 'face2_data' and 'skipCurrentFace2' or 'skipCurrentFace'
 	-- "next player replaces previous one" case
 	local idx = clamp(t_portraitPriority[side] or 1, 1, lastIdx)
 	local paramsSide, params = getParams(side, idx, t, subname)
@@ -856,7 +857,7 @@ local function drawPortraitLayer(t_portraits, side, t, subname, last, dataField)
 	if paramsSide.num == 1 and last then
 		local v = t_portraits[idx]
 		local data, drawParams, skipOffset = getPortraitDrawData(v, side, idx, params, dataField)
-		if not v.skipCurrent and data ~= nil then
+		if not v[skipField] and data ~= nil then
 			main.f_animPosDraw(
 				data,
 				f_portraitsXCalc(side, 1, paramsSide, drawParams, skipOffset, offsetKey),
@@ -885,7 +886,7 @@ local function drawPortraitLayer(t_portraits, side, t, subname, last, dataField)
 		local pn = 2 * (member - 1) + side
 		local offsetKey = 'select_info.p' .. pn .. '.face.offset'
 		local data, drawParams, skipOffset = getPortraitDrawData(v, side, member, params, dataField)
-		if member <= paramsSide.num and not v.skipCurrent and data ~= nil then
+		if member <= paramsSide.num and not v[skipField] and data ~= nil then
 			main.f_animPosDraw(
 				data,
 				f_portraitsXCalc(side, member, paramsSide, drawParams, skipOffset, offsetKey),
@@ -902,7 +903,8 @@ function start.f_drawPortraits(t_portraits, side, t, subname, last, iconDone)
 	end
 	-- reset skip flags
 	for m = 1, #t_portraits do
-		t_portraits[m].skipCurrent = false
+		t_portraits[m].skipCurrentFace = false
+		t_portraits[m].skipCurrentFace2 = false
 	end
 	-- draw random portraits (per member; required for co-op)
 	for m = 1, #t_portraits do
@@ -912,7 +914,7 @@ function start.f_drawPortraits(t_portraits, side, t, subname, last, iconDone)
 			local pData = f_getMotifP(t, pn, side)
 			-- face2 layer random portrait
 			if pData.face2.random and drawPortraitRandom(pData.face2.random, side, m, paramsSide, 'select_info.p' .. pn .. '.face2.random.offset') then
-				t_portraits[m].skipCurrent = true
+				t_portraits[m].skipCurrentFace2 = true
 			end
 			-- primary face random portrait
 			local baseFace = pData
@@ -920,7 +922,7 @@ function start.f_drawPortraits(t_portraits, side, t, subname, last, iconDone)
 				baseFace = baseFace[subname]
 			end
 			if baseFace.random and drawPortraitRandom(baseFace.random, side, m, paramsSide, 'select_info.p' .. pn .. '.face.random.offset') then
-				t_portraits[m].skipCurrent = true
+				t_portraits[m].skipCurrentFace = true
 			end
 		end
 	end

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -1101,7 +1101,7 @@ function start.f_getCursorData(pn)
 end
 
 -- Reset cursor animation for a specific slot only
-local function resetCursorData(pn, store, param)
+local function resetCursorData(pn, param)
 	local pData = start.f_getCursorData(pn)
 	local cursorCfg = pData.cursor[param]
 	local key = start.c[pn].selX .. '-' .. start.c[pn].selY
@@ -1109,25 +1109,10 @@ local function resetCursorData(pn, store, param)
 	if cursorCfg[key] then
 		cursorParams = cursorCfg[key]
 	end
-	local src = cursorParams.AnimData
-	if not src then
-		return
-	end
-	store[pn] = store[pn] or {}
-	local cd = store[pn]
-	cd.animCache = cd.animCache or {}
-	local cache = cd.animCache[param]
-	if cache == nil or cache.src ~= src then
-		cache = {src = src, anim = animCopy(src)}
-		cd.animCache[param] = cache
-		if cache.anim then
-			animReset(cache.anim)
-			animUpdate(cache.anim)
-		end
-	end
-	if cache.anim then
-		animReset(cache.anim)
-		animUpdate(cache.anim)
+	local anim = cursorParams.AnimData
+	if anim then
+		animReset(anim)
+		animUpdate(anim)
 	end
 end
 
@@ -1294,16 +1279,6 @@ function start.f_drawCursor(pn, x, y, param, done)
 		params = pData.cursor[param][key]
 	end
 	local a = params.AnimData
-	cd.animCache = cd.animCache or {}
-	local cache = cd.animCache[param]
-	if cache == nil or cache.src ~= a then
-		cache = {src = a, anim = animCopy(a)}
-		cd.animCache[param] = cache
-		if cache.anim then
-			animReset(cache.anim)
-		end
-	end
-	a = cache.anim
 	animSetFacing(a, getCellFacing(params.facing, x, y))
 	local scale = getCellTransform(x, y, "scale", params.scale)
 	animSetScale(a, scale[1], scale[2])
@@ -1313,7 +1288,6 @@ function start.f_drawCursor(pn, x, y, param, done)
 	animSetYAngle(a, getCellTransform(x, y, "yangle", params.yangle))
 	animSetProjection(a, getCellTransform(x, y, "projection", params.projection))
 	animSetFocalLength(a, getCellTransform(x, y, "focallength", params.focallength))
-	animUpdate(a)
 	main.f_animPosDraw(a, cd.currentPos[1], cd.currentPos[2], getCellFacing(params.facing, x, y))
 end
 
@@ -3536,7 +3510,7 @@ function start.f_selectMenu(side, cmd, player, member, selectState)
 					start.p[side].t_selTemp[member].face_anim = pCfg.face.anim
 					start.p[side].t_selTemp[member].face2_anim = pCfg.face2.anim
 					if start.f_getCursorData(player).cursor.reset then
-						resetCursorData(player, cursorActive, 'active')
+						resetCursorData(player, 'active')
 					end
 					updateAnim = true
 				end
@@ -3612,7 +3586,7 @@ function start.f_selectMenu(side, cmd, player, member, selectState)
 						start.f_playWave(start.c[player].selRef, 'cursor', motif.select_info['p' .. side].select.snd[1], motif.select_info['p' .. side].select.snd[2])
 					end
 					if motif.select_info.paletteselect > 0 then
-						resetCursorData(player, cursorActive, 'done')
+						resetCursorData(player, 'done')
 					end
 					start.p[side].t_selTemp[member].pal = main.f_btnPalNo(cmd)
 					start.p[side].t_selTemp[member].inRandom = false

--- a/src/anim.go
+++ b/src/anim.go
@@ -2104,7 +2104,11 @@ func (a *Anim) Copy() *Anim {
 	newAnim.anim.totaltime = a.anim.totaltime
 	newAnim.anim.frames = a.anim.frames
 	newAnim.anim.interpolate_blend_srcalpha = a.anim.interpolate_blend_srcalpha
+	newAnim.anim.interpolate_blend_dstalpha = a.anim.interpolate_blend_dstalpha
 	newAnim.anim.interpolate_scale = a.anim.interpolate_scale
+	newAnim.anim.interpolate_blend = a.anim.interpolate_blend
+	newAnim.anim.interpolate_offset = a.anim.interpolate_offset
+	newAnim.anim.interpolate_angle = a.anim.interpolate_angle
 	newAnim.anim.mask = a.anim.mask
 	newAnim.anim.srcAlpha = a.anim.srcAlpha
 	newAnim.anim.dstAlpha = a.anim.dstAlpha

--- a/src/char.go
+++ b/src/char.go
@@ -4387,8 +4387,13 @@ func (c *Char) loadPalettes() {
 			gi.palInfo[i] = pal
 		}
 
-		// If no ACT files were successfully loaded, remove the default [1, 1] mapping
-		if tmp == 0 {
+		if tmp > 0 {
+			// Ensure [1, 1] exists so RemapPal can use the SFFv1 base palette as source.
+			if _, ok := gi.palettedata.palList.PalTable[[...]uint16{1, 1}]; !ok {
+				gi.palettedata.palList.PalTable[[...]uint16{1, 1}] = 0
+			}
+		} else {
+			// If no ACT files were successfully loaded, remove the default [1, 1] mapping.
 			delete(gi.palettedata.palList.PalTable, [...]uint16{1, 1})
 		}
 	} else {

--- a/src/char.go
+++ b/src/char.go
@@ -9361,6 +9361,29 @@ func (c *Char) remapPal(pfx *PalFX, src [2]int32, dst [2]int32) {
 		// Always remap the requested source palette
 		plist.Remap(si, di)
 
+		// Also remap logical palettes that contain the same palette data.
+		// This handles SFFv2 sprites using a duplicated palette entry.
+		// https://github.com/ikemen-engine/Ikemen-GO/issues/3854
+		for i := range plist.paletteMap {
+			physical := plist.paletteMap[i]
+			if physical < 0 || physical >= len(plist.palettes) {
+				continue
+			}
+			pal := plist.palettes[physical]
+			if len(pal) != len(srcPal) {
+				continue
+			}
+			same := true
+			for j := range pal {
+				if pal[j] != srcPal[j] {
+					same = false
+					break
+				}
+			}
+			if same {
+				plist.Remap(i, di)
+			}
+		}
 		// For SFFv1, remapping 1,1 should also remap whatever palettes sprites 0,0 and 9000,0 use
 		// TODO: Because 9000,0 is not hardcoded in Ikemen, this might create trouble for custom portraits
 		if src[0] == 1 && src[1] == 1 && c.gi().sff.header.Version[0] == 1 {
@@ -9425,11 +9448,15 @@ func (c *Char) getDrawPal(palIndex int) [2]int32 {
 }
 
 func (c *Char) drawPal() [2]int32 {
-	palMap := c.getPalMap()
-	if len(palMap) == 0 {
+	if c.anim == nil || c.anim.spr == nil {
 		return [2]int32{0, 0}
 	}
-	return c.getDrawPal(palMap[0])
+	palMap := c.getPalMap()
+	source := c.anim.spr.palidx
+	if source >= 0 && source < len(palMap) {
+		source = palMap[source]
+	}
+	return c.getDrawPal(source)
 }
 
 type RemapTable map[int32][2]int32

--- a/src/motif.go
+++ b/src/motif.go
@@ -2042,6 +2042,21 @@ func (m *Motif) mergeWithInheritance(specs []InheritSpec) {
 		return strings.Contains(fullKeyLower, ".itemname.") || strings.Contains(fullKeyLower, ".valuename.")
 	}
 
+	shouldSkipAnimSpr := func(dstPrefix, suf string) bool {
+		// Avoid inheriting anim/spr for parameters that represent optional independent elements. 
+		if !strings.EqualFold(suf, "anim") && !strings.EqualFold(suf, "spr") {
+			return false
+		}
+
+		lowerPrefix := strings.ToLower(dstPrefix)
+		for _, prefix := range []string{".face.random.", ".face2.random.", ".face.slot.", ".face2.slot.", ".palmenu.preview."} {
+			if strings.Contains(lowerPrefix, prefix) {
+				return true
+			}
+		}
+		return false
+	}
+
 	// Ensure a section exists in the user ini when we need to mirror
 	// a user-originated inherited key into it.
 	ensureUserSection := func(name string) *ini.Section {
@@ -2106,6 +2121,9 @@ func (m *Motif) mergeWithInheritance(specs []InheritSpec) {
 			lowerDst := strings.ToLower(sp.DstPrefix)
 			if strings.Contains(lowerDst, ".palmenu.preview.") &&
 				(strings.EqualFold(suf, "anim") || strings.EqualFold(suf, "spr")) {
+				continue
+			}
+			if shouldSkipAnimSpr(sp.DstPrefix, suf) {
 				continue
 			}
 			lowerFull := strings.ToLower(dstKey)

--- a/src/music.go
+++ b/src/music.go
@@ -492,7 +492,9 @@ func (m Music) act() {
 						break
 					}
 				}
-				if lowLife && cmusic.tryPlay("life", sys.stage.def) {
+				if lowLife &&
+					(sys.stage.bgmtrigger == 1 || sys.decisiveRound[(c.playerNo+1)&1]) &&
+					cmusic.tryPlay("life", sys.stage.def) {
 					sys.stage.bgmState = BGMStateLowLife
 					continue
 				}

--- a/src/stage.go
+++ b/src/stage.go
@@ -934,6 +934,7 @@ type Stage struct {
 	music           Music
 	bgmState        BGMState
 	bgmratio        float32
+	bgmtrigger      int32
 	constants       map[string]float32
 	partnerspacing  int32
 	ikemenver       [3]uint16
@@ -960,6 +961,7 @@ func newStage(def string) *Stage {
 		stageCamera:    *newStageCamera(),
 		music:          make(Music),
 		bgmratio:       0.3,
+		bgmtrigger:     0,
 		constants:      make(map[string]float32),
 		partnerspacing: 25,
 	}
@@ -1258,6 +1260,7 @@ func loadStage(def string, maindef bool) (*Stage, error) {
 		}
 
 		sec.ReadF32("bgmratio", &s.bgmratio)
+		sec.ReadI32("bgmtrigger", &s.bgmtrigger)
 		s.music = parseMusicSection(iniFile.Section(secName))
 		s.music.DebugDump(fmt.Sprintf("Stage %s [%s]", def, secName))
 	}


### PR DESCRIPTION
Fixes:
- `pn.face.random` and ``pn.face2.random`` incorrectly inheriting animation from `pn.face` and `pn.face2`.
- ``pn.face.random`` and ``pn.face2.random`` handling when only one is defined. 
  The other can now be left empty and will fall back to the default behavior of cycling portraits.
- ``Copy()`` not copying interpolation state correctly.
- ``drawPal`` trigger returning incorrect palette groups and indices.
- Fixes: https://discord.com/channels/233345562261323776/682025384849834018/1533861212541030481
- Fixes: #3850
- Fixes: #3851
- Fixes #3854 