### PR TITLE
refactor: optimize duplicate SFFv2 palette handling

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -4409,6 +4409,14 @@ func (c *Char) loadPalettes() {
 			}
 		}
 
+		// Copy duplicate palette mappings from the SFFv2.
+		plist := &gi.palettedata.palList
+		plist.duplicatePals = make(map[int][]int)
+
+		for physical, duplicates := range gi.sff.palList.duplicatePals {
+			plist.duplicatePals[physical] = append([]int(nil), duplicates...)
+		}
+
 		// Overwrite SFF palettes with ACT palettes
 		for i := 0; i < maxPal; i++ {
 			pal := gi.palInfo[i]
@@ -9364,25 +9372,8 @@ func (c *Char) remapPal(pfx *PalFX, src [2]int32, dst [2]int32) {
 		// Also remap logical palettes that contain the same palette data.
 		// This handles SFFv2 sprites using a duplicated palette entry.
 		// https://github.com/ikemen-engine/Ikemen-GO/issues/3854
-		for i := range plist.paletteMap {
-			physical := plist.paletteMap[i]
-			if physical < 0 || physical >= len(plist.palettes) {
-				continue
-			}
-			pal := plist.palettes[physical]
-			if len(pal) != len(srcPal) {
-				continue
-			}
-			same := true
-			for j := range pal {
-				if pal[j] != srcPal[j] {
-					same = false
-					break
-				}
-			}
-			if same {
-				plist.Remap(i, di)
-			}
+		for _, duplicate := range plist.duplicatePals[si] {
+			plist.Remap(duplicate, di)
 		}
 		// For SFFv1, remapping 1,1 should also remap whatever palettes sprites 0,0 and 9000,0 use
 		// TODO: Because 9000,0 is not hardcoded in Ikemen, this might create trouble for custom portraits

--- a/src/image.go
+++ b/src/image.go
@@ -393,11 +393,12 @@ func newPaldata() (p *Palette) {
 }
 
 type PaletteList struct {
-	palettes   [][]uint32        // The actual (unordered) palettes
-	paletteMap []int             // Logical index to actual index mapping. For remapping
-	PalTable   map[[2]uint16]int // Group/index key to original index value
-	numcols    map[[2]uint16]int
-	PalTex     []Texture
+	palettes      [][]uint32        // The actual (unordered) palettes
+	paletteMap    []int             // Logical index to actual index mapping. For remapping
+	PalTable      map[[2]uint16]int // Group/index key to original index value
+	numcols       map[[2]uint16]int
+	PalTex        []Texture
+	duplicatePals map[int][]int
 }
 
 func (pl *PaletteList) init() {
@@ -406,6 +407,7 @@ func (pl *PaletteList) init() {
 	pl.PalTable = make(map[[2]uint16]int)
 	pl.numcols = make(map[[2]uint16]int)
 	pl.PalTex = nil
+	pl.duplicatePals = make(map[int][]int)
 }
 
 func (pl *PaletteList) SetSource(i int, p []uint32) {
@@ -1964,6 +1966,11 @@ func (s *Sff) loadPalettes(f io.ReadSeeker, lofs uint32) error {
 		uniquePals[[2]uint16{gn[0], gn[1]}] = idx
 		s.palList.SetSource(i, pal)
 		s.palList.PalTable[[2]uint16{gn[0], gn[1]}] = idx
+
+		// Track SFFv2 palette entries that share the same physical palette.
+		if idx != i {
+			s.palList.duplicatePals[idx] = append(s.palList.duplicatePals[idx], i)
+		}
 		// Number of colors as specified in the SFF
 		// We'll use a length check later instead because that's more reliable
 		s.palList.numcols[[2]uint16{gn[0], gn[1]}] = int(gn[2])


### PR DESCRIPTION
Refactor:
- Refactored duplicate SFFv2 palette handling to precompute duplicate palette mappings during SFFv2 loading instead of scanning all palettes during `remapPal`. This avoids unnecessary palette comparisons on every remap while preserving compatibility with SFFv2 files containing duplicated palette entries.