### PR TITLE
refactor: drawPal trigger syntax, motifIsInherited

### DIFF
--- a/src/compiler.go
+++ b/src/compiler.go
@@ -2358,14 +2358,20 @@ func (c *CharCompiler) expValue(out *BytecodeExp, in *string,
 	case "drawgame":
 		out.append(OC_ex_, OC_ex_drawgame)
 	case "drawpal":
-		c.token = c.tokenizer(in)
+		if err := c.checkOpeningParenthesis(in); err != nil {
+			return bvNone(), err
+		}
 		switch c.token {
 		case "group":
 			out.append(OC_ex2_, OC_ex2_drawpal_group)
 		case "index":
 			out.append(OC_ex2_, OC_ex2_drawpal_index)
 		default:
-			return bvNone(), Error("Invalid data: " + c.token)
+			return bvNone(), Error("Invalid DrawPal argument: " + c.token)
+		}
+		c.token = c.tokenizer(in)
+		if err := c.checkClosingParenthesis(); err != nil {
+			return bvNone(), err
 		}
 	case "explodvar":
 		if err := c.checkOpeningParenthesis(in); err != nil {
@@ -2431,17 +2437,10 @@ func (c *CharCompiler) expValue(out *BytecodeExp, in *string,
 			opc = OC_ex2_explodvar_bindid
 		case "bindtime":
 			opc = OC_ex2_explodvar_bindtime
-		case "drawpal":
-			c.token = c.tokenizer(in)
-
-			switch c.token {
-			case "group":
-				opc = OC_ex2_explodvar_drawpal_group
-			case "index":
-				opc = OC_ex2_explodvar_drawpal_index
-			default:
-				return bvNone(), Error("Invalid data: " + c.token)
-			}
+		case "drawpal.group":
+			opc = OC_ex2_explodvar_drawpal_group
+		case "drawpal.index":
+			opc = OC_ex2_explodvar_drawpal_index
 		case "facing":
 			opc = OC_ex2_explodvar_facing
 		case "friction":
@@ -3357,17 +3356,10 @@ func (c *CharCompiler) expValue(out *BytecodeExp, in *string,
 		case "attr":
 			opc = OC_ex2_projvar_attr
 			isFlag = true
-		case "drawpal":
-			c.token = c.tokenizer(in)
-
-			switch c.token {
-			case "group":
-				opc = OC_ex2_projvar_drawpal_group
-			case "index":
-				opc = OC_ex2_projvar_drawpal_index
-			default:
-				return bvNone(), Error("Invalid data: " + c.token)
-			}
+		case "drawpal.group":
+			opc = OC_ex2_projvar_drawpal_group
+		case "drawpal.index":
+			opc = OC_ex2_projvar_drawpal_index
 		case "facing":
 			opc = OC_ex2_projvar_facing
 		case "guardflag":

--- a/src/script.go
+++ b/src/script.go
@@ -5058,6 +5058,16 @@ func systemScriptInit(l *lua.LState) {
 		sys.debugWC.mapSet(strArg(l, 1), float32(numArg(l, 2)), scType)
 		return 0
 	})
+	luaRegister(l, "motifIsInherited", func(l *lua.LState) int {
+		/*Returns whether a motif value was inherited from another motif parameter.
+		@function motifIsInherited
+		@tparam string key Motif key path.
+		@treturn boolean
+		function motifIsInherited(key) end*/
+		key := strings.ToLower(l.CheckString(1))
+		l.Push(lua.LBool(sys.motif.inheritedKeys[key]))
+		return 1
+	})
 	luaRegister(l, "storyboardCanceled", func(l *lua.LState) int {
 		/*Check whether the most recent storyboard was canceled by the player.
 		@function storyboardCanceled
@@ -9684,16 +9694,6 @@ func triggerFunctions(l *lua.LState) {
 		default:
 			l.RaiseError("\nInvalid argument: %v\n", strArg(l, 1))
 		}
-		return 1
-	})
-	luaRegister(l, "motifIsInherited", func(l *lua.LState) int {
-		/*Returns whether a motif value was inherited from another motif parameter.
-		@function motifIsInherited
-		@tparam string key Motif key path.
-		@treturn boolean
-		function motifIsInherited(key) end*/
-		key := strings.ToLower(l.CheckString(1))
-		l.Push(lua.LBool(sys.motif.inheritedKeys[key]))
 		return 1
 	})
 	luaRegister(l, "motifVar", func(l *lua.LState) int {


### PR DESCRIPTION
Refactor:
- Changed the `drawPal` trigger syntax to `drawPal(argument)`, and to `drawPal.argument` when used with `ExplodVar`/`ProjVar`, keeping the syntax consistent with other triggers.
- Moved ``motifIsInherited()`` to the right section