### PR TITLE
fix(android): preserve game roots and support APK upgrades

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,7 @@
 *.yml text eol=lf
 *.py text eol=lf
 *.md text eol=lf
+build/android/patches/*.patch text eol=lf -whitespace
 Dockerfile text eol=lf
 
 # Syntax
@@ -38,4 +39,3 @@ Dockerfile text eol=lf
 *.PDF	 diff=astextplain
 *.rtf	 diff=astextplain
 *.RTF	 diff=astextplain
-

--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ bin/libmain.h
 lib/*.so
 lib/*.so.*
 build/android-apk/
+build/android-signing/
 
 # Binaries
 build/android-deps/

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -215,6 +215,15 @@ ANDROID_APK_REF=main \
 docker compose -f build/docker/android/docker-compose.yml run --rm android-build
 ```
 
+Each APK gets a timestamp-based `versionCode` by default so a later build is
+recognized as an upgrade. The first build also creates a persistent debug key at
+`build/android-signing/debug.keystore`; keep a backup of that ignored file,
+because Android only accepts updates signed by the same key. You may override the
+metadata and key path with `ANDROID_VERSION_CODE`, `ANDROID_VERSION_NAME`, and
+`ANDROID_DEBUG_KEYSTORE` (the key must use the standard Android debug alias and
+password). A build made before this behavior was introduced may require one final
+uninstall before the first newly signed APK can be installed.
+
 To skip APK packaging (only build `.so` + deps):
 
 ```bash

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -224,6 +224,13 @@ metadata and key path with `ANDROID_VERSION_CODE`, `ANDROID_VERSION_NAME`, and
 password). A build made before this behavior was introduced may require one final
 uninstall before the first newly signed APK can be installed.
 
+On first launch, the Android app can open an existing Ikemen game root or
+create `/storage/emulated/0/Ikemen-GO` with the bundled starter data. Existing
+files in the selected root are treated as user data: app launches and upgrades
+only add missing bundled assets, and never replace or remove existing files.
+This preserves custom rosters, screenpacks, characters, stages, saves, and
+configuration across APK upgrades.
+
 To skip APK packaging (only build `.so` + deps):
 
 ```bash

--- a/build/android/patches/0001-upgradeable-apk.patch
+++ b/build/android/patches/0001-upgradeable-apk.patch
@@ -1,0 +1,50 @@
+diff --git a/app/build.gradle b/app/build.gradle
+index 2f7ad8c..abbc790 100644
+--- a/app/build.gradle
++++ b/app/build.gradle
+@@ -1,5 +1,8 @@
+ def buildAsLibrary = project.hasProperty('BUILD_AS_LIBRARY');
+ def buildAsApplication = !buildAsLibrary
++def ikemenVersionCode = (System.getenv('ANDROID_VERSION_CODE') ?: '1').toInteger()
++def ikemenVersionName = System.getenv('ANDROID_VERSION_NAME') ?: 'development'
++def ikemenDebugKeystore = System.getenv('ANDROID_DEBUG_KEYSTORE')
+ if (buildAsApplication) {
+     apply plugin: 'com.android.application'
+ }
+@@ -18,6 +21,16 @@ android {
+         namespace "org.libsdl.app"
+     }
+     compileSdkVersion 34
++    signingConfigs {
++        if (ikemenDebugKeystore) {
++            ikemenDebug {
++                storeFile file(ikemenDebugKeystore)
++                storePassword 'android'
++                keyAlias 'androiddebugkey'
++                keyPassword 'android'
++            }
++        }
++    }
+     defaultConfig {
+         if (buildAsApplication) {
+             applicationId "org.ikemen_engine.ikemen_go"
+@@ -26,5 +39,5 @@ android {
+         minSdkVersion 21
+         targetSdkVersion 30
+-        versionCode 1
+-        versionName "1.0"
++        versionCode ikemenVersionCode
++        versionName ikemenVersionName
+         resourceConfigurations += ["en", "de", "es", "fr", "ja", "pt", "zh"]
+@@ -44,6 +57,11 @@ android {
+         assets.srcDirs = ['src/main/assets']
+     }
+     buildTypes {
++        debug {
++            if (ikemenDebugKeystore) {
++                signingConfig signingConfigs.ikemenDebug
++            }
++        }
+         release {
+             minifyEnabled false
+             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'

--- a/build/android/patches/0002-preserve-game-root.patch
+++ b/build/android/patches/0002-preserve-game-root.patch
@@ -1,0 +1,543 @@
+diff --git a/app/src/main/java/org/libsdl/app/AssetExtractor.java b/app/src/main/java/org/libsdl/app/AssetExtractor.java
+index 417b7e4..ba2b88b 100644
+--- a/app/src/main/java/org/libsdl/app/AssetExtractor.java
++++ b/app/src/main/java/org/libsdl/app/AssetExtractor.java
+@@ -3,95 +3,126 @@ package org.libsdl.app;
+ import android.content.res.AssetManager;
+ import android.util.Log;
+ 
+-import java.io.*;
+-import java.util.zip.CRC32;
+-import java.util.zip.CheckedInputStream;
++import java.io.BufferedReader;
++import java.io.File;
++import java.io.FileOutputStream;
++import java.io.IOException;
++import java.io.InputStream;
++import java.io.InputStreamReader;
++import java.io.OutputStream;
+ 
+ public class AssetExtractor {
+ 
+-    public static long getAssetCRC(AssetManager assets, String path) {
+-        try (InputStream is = assets.open(path);
+-             CheckedInputStream cis = new CheckedInputStream(is, new CRC32())) {
+-            byte[] buffer = new byte[16384];
+-            while (cis.read(buffer) >= 0) {}
+-            return cis.getChecksum().getValue();
+-        } catch (IOException e) {
+-            return -1; // File doesn't exist in APK
+-        }
+-    }
++    private static final String MANIFEST_PATH = "manifest.txt";
+ 
+-    public static long getFileCRC(File file) {
+-        if (!file.exists()) return -2;
+-        try (InputStream is = new FileInputStream(file);
+-             CheckedInputStream cis = new CheckedInputStream(is, new CRC32())) {
+-            byte[] buffer = new byte[16384];
+-            while (cis.read(buffer) >= 0) {}
+-            return cis.getChecksum().getValue();
++    private static BufferedReader openManifest(AssetManager assets) throws IOException {
++        try {
++            return new BufferedReader(new InputStreamReader(assets.open(MANIFEST_PATH)));
+         } catch (IOException e) {
+-            return -3;
++            Log.e("AssetExtractor", "CRITICAL: Could not find manifest.txt in assets root!", e);
++            throw e;
+         }
+     }
+ 
+-    // Extract all assets in assets/ into baseDir
+-    public static void extractAll(AssetManager assets, File targetDir) throws IOException {
+-        Log.i("AssetExtractor", "Attempting to open manifest.txt...");
+-        InputStream manifestStream = null;
+-        try {
+-            manifestStream = assets.open("manifest.txt");
+-        } catch (IOException e) {
+-            Log.e("AssetExtractor", "CRITICAL: Could not find manifest.txt in assets root!", e);
+-            throw e; // Fail hard so you see it
++    private static File resolveTarget(File targetDir, String relativePath) throws IOException {
++        File canonicalRoot = targetDir.getCanonicalFile();
++        File target = new File(canonicalRoot, relativePath).getCanonicalFile();
++        String rootPath = canonicalRoot.getPath();
++        String targetPath = target.getPath();
++        if (!targetPath.equals(rootPath) && !targetPath.startsWith(rootPath + File.separator)) {
++            throw new IOException("Asset path escapes the selected game root: " + relativePath);
+         }
++        return target;
++    }
+ 
+-        BufferedReader reader = new BufferedReader(new InputStreamReader(manifestStream));
+-        String line;
+-        int count = 0;
+-        while ((line = reader.readLine()) != null) {
+-            line = line.trim();
+-            if (line.isEmpty()) continue;
++    public static boolean hasMissingAssets(AssetManager assets, File targetDir) throws IOException {
++        if (!targetDir.isDirectory()) return true;
+ 
+-            File outFile = new File(targetDir, line);
+-            count++;
++        try (BufferedReader reader = openManifest(assets)) {
++            String line;
++            while ((line = reader.readLine()) != null) {
++                line = line.trim();
++                if (line.isEmpty()) continue;
++                if (!resolveTarget(targetDir, line).exists()) return true;
++            }
++        }
++        return false;
++    }
+ 
+-            // Log every 10th file so we don't spam too hard but see progress
+-            if (count % 10 == 0) Log.d("AssetExtractor", "Extracting: " + line);
++    // Populate only missing APK assets. Existing game-root content is user data
++    // and must survive app upgrades and root changes unchanged.
++    public static void extractMissing(AssetManager assets, File targetDir) throws IOException {
++        if (targetDir.exists() && !targetDir.isDirectory()) {
++            throw new IOException("Selected game root is not a directory: " + targetDir);
++        }
++        if (!targetDir.exists() && !targetDir.mkdirs()) {
++            throw new IOException("Could not create selected game root: " + targetDir);
++        }
+ 
+-            String[] children = assets.list(line);
+-            boolean isDirectory = line.endsWith("/") || (children != null && children.length > 0);
++        Log.i("AssetExtractor", "Checking manifest for missing assets...");
++        int created = 0;
++        int preserved = 0;
++        try (BufferedReader reader = openManifest(assets)) {
++            String line;
++            while ((line = reader.readLine()) != null) {
++                line = line.trim();
++                if (line.isEmpty()) continue;
+ 
+-            if (isDirectory) {
+-                // It's a directory (even if empty), just create it and move on
+-                if (!outFile.exists() && !outFile.mkdirs()) {
+-                    Log.e("AssetExtractor", "Failed to create directory: " + outFile.getAbsolutePath());
++                File outFile = resolveTarget(targetDir, line);
++                if (outFile.exists()) {
++                    preserved++;
++                    continue;
+                 }
+-                Log.d("AssetExtractor", "Created directory from manifest: " + line);
+-                continue;
+-            }
+ 
+-            File parentDir = outFile.getParentFile();
+-            if (parentDir != null && !parentDir.exists() && !parentDir.mkdirs()) {
+-                Log.e("AssetExtractor", "Failed to create parent dir: " + parentDir.getAbsolutePath());
+-            }
++                String[] children = assets.list(line);
++                boolean isDirectory = line.endsWith("/") || (children != null && children.length > 0);
++                if (isDirectory) {
++                    if (!outFile.mkdirs() && !outFile.isDirectory()) {
++                        throw new IOException("Failed to create directory: " + outFile);
++                    }
++                    created++;
++                    continue;
++                }
+ 
+-            try (InputStream in = assets.open(line);
+-                 OutputStream out = new FileOutputStream(outFile)) {
++                File parentDir = outFile.getParentFile();
++                if (parentDir != null && !parentDir.isDirectory()
++                        && !parentDir.mkdirs() && !parentDir.isDirectory()) {
++                    throw new IOException("Failed to create parent directory: " + parentDir);
++                }
+ 
+-                if (in == null) throw new IOException("Could not open asset: " + line);
++                String temporaryPrefix = outFile.getName();
++                if (temporaryPrefix.length() < 3) temporaryPrefix += "___";
++                File temporaryFile = File.createTempFile(temporaryPrefix, ".tmp", parentDir);
++                boolean installed = false;
++                try {
++                    try (InputStream in = assets.open(line);
++                         OutputStream out = new FileOutputStream(temporaryFile)) {
++                        byte[] buffer = new byte[16384];
++                        int read;
++                        while ((read = in.read(buffer)) != -1) {
++                            out.write(buffer, 0, read);
++                        }
++                        out.flush();
++                    }
+ 
+-                byte[] buffer = new byte[16384];
+-                int read;
+-                long totalRead = 0;
+-                while ((read = in.read(buffer)) != -1) {
+-                    out.write(buffer, 0, read);
+-                    totalRead += read;
++                    // Another process may have created the file while it was copied.
++                    // Preserve that file instead of racing an overwrite.
++                    if (outFile.exists()) {
++                        preserved++;
++                    } else if (!temporaryFile.renameTo(outFile)) {
++                        throw new IOException("Failed to install asset: " + line);
++                    } else {
++                        installed = true;
++                        created++;
++                    }
++                } finally {
++                    if (!installed && temporaryFile.exists() && !temporaryFile.delete()) {
++                        Log.w("AssetExtractor", "Could not remove temporary file: " + temporaryFile);
++                    }
+                 }
+-                out.flush(); // watch it, hardware
+-                Log.d("AssetExtractor", "Wrote " + totalRead + " bytes to " + line);
+-            } catch (IOException e) {
+-                Log.e("AssetExtractor", "Failed to extract file: " + line, e);
+             }
+         }
+-        Log.i("AssetExtractor", "Extraction complete. Total files: " + count);
+-        reader.close();
++        Log.i("AssetExtractor", "Asset initialization complete. Created: " + created
++                + ", preserved: " + preserved);
+     }
+ }
+diff --git a/app/src/main/java/org/libsdl/app/SDLActivity.java b/app/src/main/java/org/libsdl/app/SDLActivity.java
+index bd0080d..1a7df89 100644
+--- a/app/src/main/java/org/libsdl/app/SDLActivity.java
++++ b/app/src/main/java/org/libsdl/app/SDLActivity.java
+@@ -1,5 +1,6 @@
+ package org.libsdl.app;
+ 
++import android.Manifest;
+ import android.app.Activity;
+ import android.app.AlertDialog;
+ import android.app.Dialog;
+@@ -330,8 +331,12 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
+         return new SDLSurface(context);
+     }
+     private static final int FOLDER_PICKER_CODE = 42;
++    private static final int STORAGE_PERMISSION_CODE = 43;
++    private static final String DEFAULT_ROOT_FOLDER = "Ikemen-GO";
++    private enum PendingRootAction { NONE, PICK_EXISTING, CREATE_DEFAULT }
+     private SharedPreferences mSharedPrefs;
+     private static String mBasePath;
++    private PendingRootAction mPendingRootAction = PendingRootAction.NONE;
+     private Button mSDButton;
+     private ControllerOverlay mControllerOverlay;
+     private final Runnable hideRunnable = () -> {
+@@ -339,11 +344,6 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
+     };
+     private Handler mUIHandler = new Handler(android.os.Looper.getMainLooper());
+ 
+-    // Update this with the directories you wish to check every time for file updates.
+-    private final String[] UPDATE_FILE_CHECK_DIRS = new String[] {
+-        "external/script"
+-    };
+-
+     // Uses folder selection logic if set to true. Set to false for full game scenarios.
+     private final boolean USE_FOLDER_SELECT = true;
+ 
+@@ -520,7 +520,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
+         }
+ 
+         if (mBasePath.isEmpty()) {
+-            checkAndPickFolder();
++            showRootChoiceDialog();
+         } else {
+             setupContent();
+         }
+@@ -549,26 +549,94 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
+         return super.dispatchTouchEvent(ev);
+     }
+ 
++    private void showRootChoiceDialog() {
++        new AlertDialog.Builder(this)
++                .setTitle(R.string.game_root_title)
++                .setMessage(R.string.game_root_msg)
++                .setPositiveButton(R.string.create_root_str, (dialog, which) -> createDefaultRoot())
++                .setNegativeButton(R.string.select_existing_root_str,
++                        (dialog, which) -> checkAndPickFolder())
++                .setCancelable(false)
++                .show();
++    }
++
+     public void checkAndPickFolder() {
+-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+-            if (!Environment.isExternalStorageManager()) {
+-                // Send user to Settings to grant "All Files Access"
+-                try {
+-                    Intent intent = new Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION);
+-                    intent.addCategory("android.intent.category.DEFAULT");
+-                    intent.setData(Uri.parse(String.format("package:%s", getPackageName())));
+-                    startActivity(intent);
+-                } catch (Exception e) {
+-                    Intent intent = new Intent();
+-                    intent.setAction(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION);
+-                    startActivity(intent);
+-                }
+-            } else {
+-                openDirectoryPicker();
++        requestStorageAccess(PendingRootAction.PICK_EXISTING);
++    }
++
++    private void createDefaultRoot() {
++        requestStorageAccess(PendingRootAction.CREATE_DEFAULT);
++    }
++
++    private void requestStorageAccess(PendingRootAction action) {
++        mPendingRootAction = action;
++        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
++                && !Environment.isExternalStorageManager()) {
++            try {
++                Intent intent = new Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION);
++                intent.addCategory("android.intent.category.DEFAULT");
++                intent.setData(Uri.parse(String.format("package:%s", getPackageName())));
++                startActivity(intent);
++            } catch (Exception e) {
++                Intent intent = new Intent(Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION);
++                startActivity(intent);
+             }
+-        } else {
+-            // Legacy permissions (Read/Write External) for older Android
++            return;
++        }
++
++        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
++                && Build.VERSION.SDK_INT < Build.VERSION_CODES.R
++                && checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE)
++                != PackageManager.PERMISSION_GRANTED) {
++            requestPermissions(new String[] {
++                    Manifest.permission.READ_EXTERNAL_STORAGE,
++                    Manifest.permission.WRITE_EXTERNAL_STORAGE
++            }, STORAGE_PERMISSION_CODE);
++            return;
++        }
++
++        performPendingRootAction();
++    }
++
++    private void performPendingRootAction() {
++        PendingRootAction action = mPendingRootAction;
++        mPendingRootAction = PendingRootAction.NONE;
++        if (action == PendingRootAction.PICK_EXISTING) {
+             openDirectoryPicker();
++        } else if (action == PendingRootAction.CREATE_DEFAULT) {
++            createDefaultRootInternal();
++        }
++    }
++
++    private void createDefaultRootInternal() {
++        File root = new File(Environment.getExternalStorageDirectory(), DEFAULT_ROOT_FOLDER);
++        if (!root.isDirectory() && !root.mkdirs() && !root.isDirectory()) {
++            new AlertDialog.Builder(this)
++                    .setTitle(R.string.update_error_title)
++                    .setMessage(getString(R.string.create_root_error_msg, root.getAbsolutePath()))
++                    .setPositiveButton(android.R.string.ok, (dialog, which) -> {
++                        if (mBasePath == null || mBasePath.isEmpty()) showRootChoiceDialog();
++                    })
++                    .show();
++            return;
++        }
++
++        mBasePath = root.getAbsolutePath();
++        mSharedPrefs.edit().putString(getString(R.string.game_folder_key), mBasePath).apply();
++        setupContent();
++    }
++
++    private void handleStoragePermissionResult(int[] grantResults) {
++        boolean granted = grantResults.length > 0;
++        for (int result : grantResults) {
++            granted &= result == PackageManager.PERMISSION_GRANTED;
++        }
++        if (granted) {
++            performPendingRootAction();
++        } else {
++            mPendingRootAction = PendingRootAction.NONE;
++            Toast.makeText(this, R.string.storage_permission_required, Toast.LENGTH_LONG).show();
++            if (mBasePath == null || mBasePath.isEmpty()) showRootChoiceDialog();
+         }
+     }
+ 
+@@ -601,26 +669,29 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
+     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+         super.onActivityResult(requestCode, resultCode, data);
+         if (requestCode == FOLDER_PICKER_CODE) {
+-            boolean isFreshRun = (mBasePath == null);
+-            if (resultCode == RESULT_OK) {
+-                if (data != null) {
+-                    Uri treeUri = data.getData();
+-                    // Take persistent permission so it can be accessed again after reboot
+-                    getContentResolver().takePersistableUriPermission(treeUri,
+-                            Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+-                    String selectedPath = getFullPathFromTreeUri(treeUri); // convert Uri to File path
+-                    if (selectedPath != null && !selectedPath.isEmpty()) {
+-                        mBasePath = selectedPath;
+-                    } else {
+-                        mBasePath = getExternalFilesDir(null).getAbsolutePath();
+-                    }
+-                } else if (isFreshRun) {
+-                    mBasePath = getExternalFilesDir(null).getAbsolutePath();
+-                }
+-            } else if (isFreshRun) {
+-                mBasePath = getExternalFilesDir(null).getAbsolutePath();
++            boolean isFreshRun = mBasePath == null || mBasePath.isEmpty();
++            if (resultCode != RESULT_OK || data == null || data.getData() == null) {
++                if (isFreshRun) showRootChoiceDialog();
++                return;
+             }
+-            mSharedPrefs.edit().putString(getString(R.string.game_folder_key), mBasePath).commit();
++
++            Uri treeUri = data.getData();
++            try {
++                getContentResolver().takePersistableUriPermission(treeUri,
++                        Intent.FLAG_GRANT_READ_URI_PERMISSION
++                                | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
++            } catch (SecurityException e) {
++                Log.w(TAG, "The selected provider did not grant persistent URI access", e);
++            }
++            String selectedPath = getFullPathFromTreeUri(treeUri);
++            if (selectedPath == null || selectedPath.isEmpty()) {
++                Toast.makeText(this, R.string.unsupported_root_location, Toast.LENGTH_LONG).show();
++                if (isFreshRun) showRootChoiceDialog();
++                return;
++            }
++
++            mBasePath = selectedPath;
++            mSharedPrefs.edit().putString(getString(R.string.game_folder_key), mBasePath).apply();
+ 
+             if (isFreshRun) {
+                 setupContent();
+@@ -638,51 +709,35 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
+ 
+     public void openDirectoryPicker() {
+         Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
++        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION
++                | Intent.FLAG_GRANT_WRITE_URI_PERMISSION
++                | Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
+         startActivityForResult(intent, FOLDER_PICKER_CODE);
+     }
+ 
+-    private boolean filesNeedUpdate(File baseDir, String[] dirsToCheck) {
+-        try {
+-            // List all files in the APK's directories to check
+-            for (String checkDir : dirsToCheck) {
+-                String[] files = getAssets().list(checkDir);
+-                if (files == null || files.length == 0) return false;
+-
+-                for (String fileName : files) {
+-                    String relativePath = checkDir + "/" + fileName;
+-                    File localFile = new File(baseDir, relativePath);
+-
+-                    // If a script is missing locally, update
+-                    if (!localFile.exists()) return true;
+-
+-                    // If the CRC doesn't match, update
+-                    long apkCRC = AssetExtractor.getAssetCRC(getAssets(), relativePath);
+-                    long localCRC = AssetExtractor.getFileCRC(localFile);
+-                    if (apkCRC != localCRC) {
+-                        Log.i("AssetExtractor", "Mismatch detected: " + fileName);
+-                        return true;
+-                    }
+-                }
+-            }
+-        } catch (java.io.IOException e) {
+-            Log.e("AssetExtractor", "Error checking scripts", e);
+-            return true; // Safety first: update if we can't be sure
+-        }
+-        return false; // Everything matches
+-    }
+-
+     private void setupContent() {
+         File baseDir = new File(mBasePath);
+ 
+-        // Run the comparison in the background
++        // Check and initialize the selected root without replacing user files.
+         new Thread(() -> {
+-            boolean updateRequired = filesNeedUpdate(baseDir, UPDATE_FILE_CHECK_DIRS);
++            final boolean initializationRequired;
++            try {
++                initializationRequired = AssetExtractor.hasMissingAssets(getAssets(), baseDir);
++            } catch (Exception e) {
++                Log.e("AssetExtractor", "Could not inspect selected game root", e);
++                runOnUiThread(() -> new AlertDialog.Builder(this)
++                        .setTitle(R.string.update_error_title)
++                        .setMessage(e.getMessage())
++                        .setPositiveButton(R.string.exit_str, (d, w) -> finish())
++                        .show());
++                return;
++            }
+ 
+-            if (!updateRequired) {
+-                Log.i("SDLActivity", "Scripts match APK. Skipping extraction.");
++            if (!initializationRequired) {
++                Log.i("SDLActivity", "Game root is initialized. Preserving existing content.");
+                 runOnUiThread(this::onSDLReady);
+             } else {
+-                Log.i("SDLActivity", "Specified files are outdated or missing. Beginning extraction...");
++                Log.i("SDLActivity", "Game root has missing assets. Initializing without overwrite...");
+ 
+                 // Switch to UI thread to show the progress dialog
+                 runOnUiThread(() -> {
+@@ -695,7 +750,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
+                     // Start actual extraction thread
+                     new Thread(() -> {
+                         try {
+-                            AssetExtractor.extractAll(getAssets(), baseDir);
++                            AssetExtractor.extractMissing(getAssets(), baseDir);
+                             runOnUiThread(() -> {
+                                 progress.dismiss();
+                                 onSDLReady();
+@@ -768,14 +823,15 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
+         Log.v(TAG, "onResume()");
+         super.onResume();
+ 
+-        // If we were waiting for the "All Files Access" permission...
+-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+-            // Permission is now granted?
++        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
++                && mPendingRootAction != PendingRootAction.NONE) {
+             if (Environment.isExternalStorageManager()) {
+-                // If mBasePath is still empty, let's open the picker now.
+-                if (mBasePath == null || mBasePath.isEmpty()) {
+-                    openDirectoryPicker();
+-                }
++                performPendingRootAction();
++            } else {
++                mPendingRootAction = PendingRootAction.NONE;
++                Toast.makeText(this, R.string.storage_permission_required,
++                        Toast.LENGTH_LONG).show();
++                if (mBasePath == null || mBasePath.isEmpty()) showRootChoiceDialog();
+             }
+         }
+ 
+@@ -2102,6 +2158,11 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
+ 
+     @Override
+     public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
++        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
++        if (requestCode == STORAGE_PERMISSION_CODE) {
++            handleStoragePermissionResult(grantResults);
++            return;
++        }
+         boolean result = (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED);
+         nativePermissionResult(requestCode, result);
+     }
+@@ -2429,4 +2490,3 @@ class SDLClipboardHandler implements
+         SDLActivity.onNativeClipboardChanged();
+     }
+ }
+-
+diff --git a/app/src/main/res/values/strings.xml b/app/src/main/res/values/strings.xml
+index 6ad91f6..3658900 100644
+--- a/app/src/main/res/values/strings.xml
++++ b/app/src/main/res/values/strings.xml
+@@ -3,6 +3,13 @@
+     <string name="prefs_key" translatable="false">"IkemenPrefs"</string>
+     <string name="game_folder_key" translatable="false">game_folder</string>
+     <string name="game_folder_str">Select Game Folder</string>
++    <string name="game_root_title">Choose an Ikemen game root</string>
++    <string name="game_root_msg">Use an existing game root without replacing its files, or create a new Ikemen-GO root with the bundled starter data.</string>
++    <string name="create_root_str">Create New Root</string>
++    <string name="select_existing_root_str">Use Existing Root</string>
++    <string name="create_root_error_msg">Could not create the game root at %1$s.</string>
++    <string name="storage_permission_required">Storage access is required to use an Ikemen game root.</string>
++    <string name="unsupported_root_location">This storage location cannot be used as a direct Ikemen game root.</string>
+     <string name="first_run_dialog_title">First Run</string>
+     <string name="first_run_dialog_msg">Extracting game assets… Please wait.</string>
+     <string name="extraction_error_title">Extraction Error</string>

--- a/build/build.sh
+++ b/build/build.sh
@@ -87,6 +87,7 @@ ANDROID_APK_REPO="${ANDROID_APK_REPO:-https://github.com/Jesuszilla/ikemen-droid
 ANDROID_APK_REF="${ANDROID_APK_REF:-main}"
 ANDROID_APK_DIR="$REPO_ROOT/$BUILDDIR/android-apk/ikemen-droid"
 ANDROID_APK_OUT="${ANDROID_APK_OUT:-$REPO_ROOT/bin/ikemen-go.apk}"
+ANDROID_APK_PATCH_DIR="$REPO_ROOT/$BUILDDIR/android/patches"
 
 # FFmpeg config
 FFMPEG_REV="${FFMPEG_REV:-release/7.1}"
@@ -100,6 +101,9 @@ FFMPEG_REBUILT=0
 # ---- App metadata (overridden by CI)
 APP_VERSION="${APP_VERSION:-nightly}"
 APP_BUILDTIME="${APP_BUILDTIME:-$(date '+%Y.%m.%d')}"
+ANDROID_VERSION_CODE="${ANDROID_VERSION_CODE:-}"
+ANDROID_VERSION_NAME="${ANDROID_VERSION_NAME:-$APP_VERSION}"
+ANDROID_DEBUG_KEYSTORE="${ANDROID_DEBUG_KEYSTORE:-$REPO_ROOT/$BUILDDIR/android-signing/debug.keystore}"
 
 # --- Always pause on Windows on exit (covers success and failure) ----------
 pause_always_windows() {
@@ -922,6 +926,75 @@ function sync_android_apk_repo() {
 	git config --system --add safe.directory "$ANDROID_APK_DIR" >/dev/null 2>&1 || true
 }
 
+function apply_android_apk_patches() {
+	[[ -d "$ANDROID_APK_PATCH_DIR" ]] || return 0
+
+	local patch
+	for patch in "$ANDROID_APK_PATCH_DIR"/*.patch; do
+		[[ -f "$patch" ]] || continue
+		if git -C "$ANDROID_APK_DIR" apply --check "$patch"; then
+			echo "==> Applying Android wrapper patch: $(basename "$patch")"
+			git -C "$ANDROID_APK_DIR" apply "$patch"
+		elif git -C "$ANDROID_APK_DIR" apply --reverse --check "$patch"; then
+			echo "==> Android wrapper patch already applied: $(basename "$patch")"
+		else
+			echo "ERROR: Android wrapper patch does not apply cleanly: $patch" >&2
+			echo "       Check ANDROID_APK_REF and refresh the patch for that wrapper revision." >&2
+			exit 1
+		fi
+	done
+}
+
+function configure_android_apk_identity() {
+	if [[ -z "$ANDROID_VERSION_CODE" ]]; then
+		# Epoch seconds are monotonic across normal successive builds and stay below
+		# Android's 2,100,000,000 versionCode limit until 2036.
+		ANDROID_VERSION_CODE="$(date -u '+%s')"
+	fi
+	if [[ ! "$ANDROID_VERSION_CODE" =~ ^[0-9]+$ ]] \
+		|| ((ANDROID_VERSION_CODE < 1 || ANDROID_VERSION_CODE > 2100000000)); then
+		echo "ERROR: ANDROID_VERSION_CODE must be an integer from 1 through 2100000000." >&2
+		exit 1
+	fi
+
+	case "$ANDROID_DEBUG_KEYSTORE" in
+		/*) ;;
+		*) ANDROID_DEBUG_KEYSTORE="$REPO_ROOT/$ANDROID_DEBUG_KEYSTORE" ;;
+	esac
+
+	if [[ ! -f "$ANDROID_DEBUG_KEYSTORE" ]]; then
+		command -v keytool >/dev/null 2>&1 || {
+			echo "ERROR: keytool is required to create the persistent Android debug keystore." >&2
+			exit 1
+		}
+		echo "==> Creating persistent Android debug keystore: $ANDROID_DEBUG_KEYSTORE"
+		(
+			umask 077
+			mkdir -p "$(dirname "$ANDROID_DEBUG_KEYSTORE")"
+			keytool -genkeypair -noprompt \
+				-keystore "$ANDROID_DEBUG_KEYSTORE" \
+				-storepass android \
+				-alias androiddebugkey \
+				-keypass android \
+				-dname "CN=Android Debug,O=Android,C=US" \
+				-keyalg RSA \
+				-keysize 2048 \
+				-validity 10000 >/dev/null
+		)
+	fi
+
+	if ! keytool -list -keystore "$ANDROID_DEBUG_KEYSTORE" -storepass android \
+		-alias androiddebugkey >/dev/null 2>&1; then
+		echo "ERROR: ANDROID_DEBUG_KEYSTORE is not a compatible Android debug keystore." >&2
+		echo "       Expected alias 'androiddebugkey' with the standard debug password." >&2
+		exit 1
+	fi
+
+	export ANDROID_VERSION_CODE ANDROID_VERSION_NAME ANDROID_DEBUG_KEYSTORE
+	echo "==> Android APK identity: versionCode=$ANDROID_VERSION_CODE versionName=$ANDROID_VERSION_NAME"
+	echo "==> Android APK signing key: $ANDROID_DEBUG_KEYSTORE"
+}
+
 function stage_android_apk_libs() {
 	local app_dir="$ANDROID_APK_DIR/app"
 	# Clean any pre-existing native libs that Gradle might pick up
@@ -987,6 +1060,8 @@ function build_android_apk() {
 
 	ensure_android_sdk_for_gradle
 	sync_android_apk_repo
+	apply_android_apk_patches
+	configure_android_apk_identity
 	ensure_android_runtime_assets
 	stage_android_apk_libs
 	stage_android_apk_assets

--- a/build/build_android.sh
+++ b/build/build_android.sh
@@ -59,7 +59,8 @@ Builds the Docker image and runs the android-build container to produce:
   - lib/*.so
 
 Environment overrides (optional):
-  APP_VERSION, APP_BUILDTIME, ANDROID_APK_REPO, ANDROID_APK_REF, BUILD_ANDROID_APK
+  APP_VERSION, APP_BUILDTIME, ANDROID_VERSION_CODE, ANDROID_VERSION_NAME,
+  ANDROID_DEBUG_KEYSTORE, ANDROID_APK_REPO, ANDROID_APK_REF, BUILD_ANDROID_APK
 EOF
       exit 0
       ;;

--- a/build/docker/android/docker-compose.yml
+++ b/build/docker/android/docker-compose.yml
@@ -27,6 +27,9 @@ services:
       GOEXPERIMENT: "arenas"
       APP_VERSION: "${APP_VERSION:-docker-test}"
       APP_BUILDTIME: "${APP_BUILDTIME:-2026.01.13}"
+      ANDROID_VERSION_CODE: "${ANDROID_VERSION_CODE:-}"
+      ANDROID_VERSION_NAME: "${ANDROID_VERSION_NAME:-}"
+      ANDROID_DEBUG_KEYSTORE: "${ANDROID_DEBUG_KEYSTORE:-}"
       # Build APK automatically (default is 1, but make it explicit in compose)
       BUILD_ANDROID_APK: "${BUILD_ANDROID_APK:-1}"
     command: >


### PR DESCRIPTION
## Summary

- give successive Android APK builds increasing `versionCode` values and reuse a persistent signing keystore when the build workspace is retained
- preserve an existing user-selected Ikemen root by adding only missing bundled assets instead of replacing or removing user files
- offer first-launch choices to use an existing root or create `/storage/emulated/0/Ikemen-GO`
- keep the external `ikemen-droid` wrapper changes reproducible as patches applied by the main build

## Motivation and root cause

The Android wrapper currently hard-codes `versionCode 1`, while clean build environments receive a newly generated debug signing identity. Android accepts an APK update only when its package identity and signing certificate match the installed app and its version metadata permits the update. The wrapper asset extractor also writes every manifest entry into the selected game root, which can overwrite custom files such as `data/select.def` (related to #3328).

This change keeps the package ID unchanged, assigns a timestamp-based `versionCode`, and stores the locally generated signing key under the ignored `build/android-signing/` directory so normal successive builds from the same persistent checkout remain compatible. Root initialization now treats existing files as user data and only restores packaged files that are missing.

## User impact

- after the first APK using a stable signing identity is installed, later APKs produced with that same identity can update it in place
- custom rosters, screenpacks, characters, stages, saves, configuration, and other selected-root data survive launches and APK upgrades
- users without an existing root can create and initialize one from the app

An APK installed from an older build may require one final uninstall because its previous signing certificate cannot be recovered. The existing external game root can then be selected again.

## Validation

- apply both tracked wrapper patches cleanly against `Jesuszilla/ikemen-droid` at the tested revision
- run `./gradlew --no-daemon clean assembleDebug` successfully with both patches applied
- run the full Docker Android build twice successfully
- verify version codes increase from `1786908975` to `1786909402`
- verify both full-build APKs use package ID `org.ikemen_engine.ikemen_go` and the same signing-certificate digest
- exercise `AssetExtractor` with a focused harness and verify that it:
  - preserves a customized `data/select.def`
  - creates missing bundled assets
  - does not replace existing files when packaged content changes
  - restores a packaged file after that file is removed
  - rejects manifest path traversal
- run `git diff --check`

A physical Android device was not connected during validation. Installing build one, updating it with build two, and exercising the first-launch root-selection UI on a device remain recommended before marking this ready for review.

## Related Android persistence report and behavior trade-off

Related: #3328.

This is the only matching upstream report found for Android folder-data persistence. It describes `data/select.def` being replaced after selecting another game folder, and a commenter reports the same replacement after updates. The issue is closed with the `not an issue` label; the maintainer response treats updating the default root assets as intentional and recommends keeping custom screenpack files in a separate data subfolder.

This draft deliberately proposes a more conservative policy for an arbitrary user-selected root: preserve every existing file and add only missing packaged assets. That protects customized root data, but it also means a changed bundled asset will not replace an older copy already present in that root. Maintainer confirmation of this policy trade-off is requested before the draft is marked ready for review.

## Maintainer-owned signing identity required for official CI releases

This draft intentionally does **not** create, commit, or select a permanent production signing certificate. Establishing the private signing identity for official Ikemen GO releases is a repository-owner responsibility.

The current implementation persists a generated key only when the checkout itself persists. The upstream `releases` workflow uses fresh GitHub-hosted runners and does not currently restore a signing key. If official Actions builds use the fallback unchanged, each run will generate a different debug certificate and those published CI APKs will not update one another.

Before distributing this as the canonical update path, maintainers should consider a follow-up that:

1. generates one dedicated, long-lived Ikemen GO release keystore with strong credentials
2. stores the Base64 keystore and its credentials in protected GitHub repository or environment secrets, with a separate encrypted offline backup
3. restores the keystore only for trusted Android release jobs and fails the build when signing material is missing rather than silently generating a new identity
4. makes the Gradle signing alias and passwords environment-driven and builds a properly signed release variant instead of relying on the conventional debug identity
5. verifies every APK with `apksigner`, checks the expected certificate fingerprint, and documents the public fingerprint for future release validation

The signing key used for the first canonical APK should then be treated as a lifetime application identity. Losing or replacing it would prevent direct-download APKs from updating existing installations.
