### PR TITLE
fix: round progress while char is turning, uneven pushfactor, debug text AllPalFX

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -13900,9 +13900,11 @@ func (cl *CharList) pushDetection(getter *Char) {
 			default:
 				// Compare player weights and apply pushing factors
 				// Weight determines which player is pushed more. Factor determines how fast the player overlap is resolved
+				// We use the average factor so that the constant affects resolution speed without affecting who wins the struggle
+				averageFactor := (c.size.pushfactor + getter.size.pushfactor) / 2
 				totalWeight := float32(c.size.weight + getter.size.weight)
-				cFactor = c.size.pushfactor * float32(getter.size.weight) / totalWeight
-				gFactor = getter.size.pushfactor * float32(c.size.weight) / totalWeight
+				cFactor = averageFactor * float32(getter.size.weight) / totalWeight
+				gFactor = averageFactor * float32(c.size.weight) / totalWeight
 			}
 
 			// Determine in which axes to push the players

--- a/src/char.go
+++ b/src/char.go
@@ -13889,21 +13889,20 @@ func (cl *CharList) pushDetection(getter *Char) {
 			c.pushed, getter.pushed = true, true
 
 			// Determine who gets pushed and the multipliers
-			var cfactor, gfactor float32
+			var cFactor, gFactor float32
 			switch {
 			case c.pushPriority > getter.pushPriority:
-				cfactor = 0
-				gfactor = getter.size.pushfactor // Maybe use other character's constant?
+				cFactor = 0
+				gFactor = getter.size.pushfactor // Maybe use other character's constant?
 			case c.pushPriority < getter.pushPriority:
-				cfactor = c.size.pushfactor
-				gfactor = 0
+				cFactor = c.size.pushfactor
+				gFactor = 0
 			default:
 				// Compare player weights and apply pushing factors
 				// Weight determines which player is pushed more. Factor determines how fast the player overlap is resolved
-				cfactor = float32(getter.size.weight) / float32(c.size.weight+getter.size.weight)
-				gfactor = float32(c.size.weight) / float32(c.size.weight+getter.size.weight) * getter.size.pushfactor
-				cfactor *= c.size.pushfactor
-				gfactor *= getter.size.pushfactor
+				totalWeight := float32(c.size.weight + getter.size.weight)
+				cFactor = c.size.pushfactor * float32(getter.size.weight) / totalWeight
+				gFactor = getter.size.pushfactor * float32(c.size.weight) / totalWeight
 			}
 
 			// Determine in which axes to push the players
@@ -13973,17 +13972,17 @@ func (cl *CharList) pushDetection(getter *Char) {
 
 				if tmp > 0 {
 					if c.pushPriority >= getter.pushPriority {
-						getter.pos[0] -= overlapX * gfactor / getter.localscl
+						getter.pos[0] -= overlapX * gFactor / getter.localscl
 					}
 					if c.pushPriority <= getter.pushPriority {
-						c.pos[0] += overlapX * cfactor / c.localscl
+						c.pos[0] += overlapX * cFactor / c.localscl
 					}
 				} else {
 					if c.pushPriority >= getter.pushPriority {
-						getter.pos[0] += overlapX * gfactor / getter.localscl
+						getter.pos[0] += overlapX * gFactor / getter.localscl
 					}
 					if c.pushPriority <= getter.pushPriority {
-						c.pos[0] -= overlapX * cfactor / c.localscl
+						c.pos[0] -= overlapX * cFactor / c.localscl
 					}
 				}
 
@@ -14001,17 +14000,17 @@ func (cl *CharList) pushDetection(getter *Char) {
 			if pushz {
 				if gposz < cposz {
 					if c.pushPriority >= getter.pushPriority {
-						getter.pos[2] -= overlapZ * gfactor / getter.localscl
+						getter.pos[2] -= overlapZ * gFactor / getter.localscl
 					}
 					if c.pushPriority <= getter.pushPriority {
-						c.pos[2] += overlapZ * cfactor / c.localscl
+						c.pos[2] += overlapZ * cFactor / c.localscl
 					}
 				} else if gposz > cposz {
 					if c.pushPriority >= getter.pushPriority {
-						getter.pos[2] += overlapZ * gfactor / getter.localscl
+						getter.pos[2] += overlapZ * gFactor / getter.localscl
 					}
 					if c.pushPriority <= getter.pushPriority {
-						c.pos[2] -= overlapZ * cfactor / c.localscl
+						c.pos[2] -= overlapZ * cFactor / c.localscl
 					}
 				}
 

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -220,7 +220,6 @@ type FSText struct {
 	lay        Layout
 	palfx      *PalFX
 	frgba      [4]float32 // ttf fonts
-	forcecolor bool
 	pfxinit    int32
 }
 
@@ -267,14 +266,12 @@ func readFSText(pre string, is IniSection, str string, ln int16, f map[int]*Fnt,
 }
 
 func (txt *FSText) SetColor(r, g, b, a int32) {
-	txt.forcecolor = true
 	txt.palfx.setColor(r, g, b)
-	txt.frgba = [...]float32{float32(r) / 255, float32(g) / 255,
-		float32(b) / 255, float32(a) / 255}
+	txt.frgba = [4]float32{float32(r) / 255, float32(g) / 255, float32(b) / 255, float32(a) / 255}
 }
 
 func (txt *FSText) step() {
-	if txt.palfx != nil && !txt.forcecolor {
+	if txt.palfx != nil {
 		txt.palfx.step()
 	}
 }

--- a/src/font.go
+++ b/src/font.go
@@ -773,7 +773,6 @@ type TextSprite struct {
 	layerno        int16
 	palfx          *PalFX
 	frgba          [4]float32 // ttf fonts
-	forcecolor     bool
 	removetime     int32 // text sctrl
 	elapsedTicks   float32
 	textSpacing    [2]float32
@@ -949,10 +948,8 @@ func (ts *TextSprite) drawWindow() [4]int32 {
 }
 
 func (ts *TextSprite) SetColor(r, g, b, a int32) {
-	ts.forcecolor = true
 	ts.palfx.setColor(r, g, b)
-	ts.frgba = [...]float32{float32(r) / 255, float32(g) / 255,
-		float32(b) / 255, float32(a) / 255}
+	ts.frgba = [4]float32{float32(r) / 255, float32(g) / 255, float32(b) / 255, float32(a) / 255}
 }
 
 func (ts *TextSprite) SetTextSpacing(xs, ys float32) {
@@ -1366,7 +1363,7 @@ func (ts *TextSprite) updateVel() {
 func (ts *TextSprite) Update() {
 	ts.elapsedTicks++
 	ts.updateVel()
-	if ts.palfx != nil && !ts.forcecolor {
+	if ts.palfx != nil {
 		ts.palfx.step()
 	}
 }
@@ -1433,12 +1430,8 @@ func (ts *TextSprite) draw(ln int16, clip *[4]int32) {
 
 		// Draw the visible line
 		if ts.fnt.Type == "truetype" {
-			var ttfPalFX *PalFX
-			if !ts.forcecolor {
-				ttfPalFX = ts.palfx
-			}
 			ts.fnt.DrawTtf(line[:charsToShow], ts.x+ts.vel[0]-xsoffset+phantomX, newY+ts.vel[1], ts.xscl, ts.yscl,
-				xshear, ts.rot, ts.projection, ts.fLength, ts.align, true, &window, ts.frgba, ttfPalFX, float32(spacingXAdd))
+				xshear, ts.rot, ts.projection, ts.fLength, ts.align, true, &window, ts.frgba, ts.palfx, float32(spacingXAdd))
 		} else {
 			ts.fnt.DrawText(line[:charsToShow], ts.x+ts.vel[0]-xsoffset+phantomX, newY+ts.vel[1], ts.xscl, ts.yscl,
 				xshear, ts.rot, ts.projection, ts.fLength, ts.bank, ts.align, &window, ts.palfx, ts.frgba[3], spacingXAdd)

--- a/src/image.go
+++ b/src/image.go
@@ -60,6 +60,7 @@ type PalFX struct {
 	allowNeg     bool // Can use negative color math
 	sintime      [4]int32
 	enable       bool
+    ignoreAllPalFX bool // TODO: Probably expose this as a parameter
 	eAllowNeg    bool
 	eInvertall   bool
 	eInvertblend int32
@@ -92,6 +93,10 @@ func (pf *PalFX) clear() {
 }
 
 func (pf *PalFX) getSynFx(blendMode TransType, alpha [2]int32) *PalFX {
+    if pf != nil && pf.ignoreAllPalFX {
+        return pf
+    }
+
 	if pf == nil || !pf.enable {
 		if blendMode == TT_sub && sys.allPalFX.enable {
 			if pf == nil {
@@ -107,9 +112,11 @@ func (pf *PalFX) getSynFx(blendMode TransType, alpha [2]int32) *PalFX {
 			return sys.allPalFX
 		}
 	}
+
 	if !sys.allPalFX.enable {
 		return pf
 	}
+
 	synth := *pf
 	synth.synthesize(sys.allPalFX, blendMode, alpha)
 	return &synth
@@ -363,6 +370,7 @@ func (pf *PalFX) synthesize(pfx *PalFX, blendMode TransType, alpha [2]int32) {
 
 }
 
+// Sets the PalFX to render a simple solid color. Normally used by fonts
 func (pf *PalFX) setColor(r, g, b int32) {
 	rNormalized := Clamp(r, 0, 255)
 	gNormalized := Clamp(g, 0, 255)

--- a/src/script.go
+++ b/src/script.go
@@ -4311,6 +4311,7 @@ func systemScriptInit(l *lua.LState) {
 		@tparam[opt=1.0] float32 scale Uniform scale applied to debug text (both X and Y).
 		function loadDebugFont(filename, scale) end*/
 		ts := NewTextSprite()
+		ts.palfx.ignoreAllPalFX = true
 		f, err := loadFnt(strArg(l, 1), -1)
 		if err != nil {
 			l.RaiseError("\nCan't load %v: %v\n", strArg(l, 1), err.Error())

--- a/src/system.go
+++ b/src/system.go
@@ -3257,9 +3257,9 @@ func (s *System) stepRoundState() {
 						if p[0].scf(SCF_over_alive) || p[0].scf(SCF_over_ko) {
 							continue
 						}
-						// Mugen seems to skip this anim 5 check on time overs
-						// It also seems a bit pointless here to begin with because the char has already turned by the time anim 5 starts
-						if p[0].scf(SCF_ctrl) && p[0].ss.moveType == MT_I && p[0].ss.stateType == ST_S && p[0].animNo != 5 {
+						// We used to wait for players that were in animation 5 (turning) here, but that doesn't seem to be the case in Mugen
+						// https://github.com/ikemen-engine/Ikemen-GO/issues/2919
+						if p[0].scf(SCF_ctrl) && p[0].ss.moveType == MT_I && p[0].ss.stateType == ST_S {
 							continue
 						}
 						// Freeze timer if any player is not ready to proceed yet


### PR DESCRIPTION
Fixes:
- Fixed debug text being affected by AllPalFX
- Fixed double multiplication typo in pushfactor code
- Round progress no longer waits for characters stuck in their turning animations
- Fixes #2919
- Fixes https://discord.com/channels/233345562261323776/233363722934943744/1537197158430806189

Refactor:
- Removed outdated font "forcecolor" bool as it made the color parameter override AllPalFX for TTF fonts, unlike with sprite fonts
- Adjusted so that two players pushing each other use the average factor between both. This makes the constant affect push resolution speed as intended, without affecting who wins the struggle