### PR TITLE
fix: sound reloading, GetHitVar(isbound) timing, paused explods, window values

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -6401,7 +6401,15 @@ func (sc explod) Run(c *Char, _ []int32) bool {
 		case explod_projection:
 			e.projection = Projection(exp[0].evalI(c))
 		case explod_window:
-			e.window = [4]float32{exp[0].evalF(c) * redirscale, exp[1].evalF(c) * redirscale, exp[2].evalF(c) * redirscale, exp[3].evalF(c) * redirscale}
+			// In Mugen, BG windows require at least 4 values to work. So we'll do the same in sctrl's
+			if len(exp) >= 4 {
+				e.window[0] = exp[0].evalF(c) * redirscale
+				e.window[1] = exp[1].evalF(c) * redirscale
+				e.window[2] = exp[2].evalF(c) * redirscale
+				e.window[3] = exp[3].evalF(c) * redirscale
+			} else {
+				sys.appendToConsole(crun.warn() + "invalid explod window")
+			}
 		case explod_shader:
 			shader := exp[0].evalS()
 			if shader == "" || sys.isValidCustomShader(shader) {
@@ -7029,9 +7037,16 @@ func (sc modifyExplod) Run(c *Char, _ []int32) bool {
 					e.fLength = exp[0].evalF(c)
 				})
 			case explod_window:
-				eachExpl(func(e *Explod) {
-					e.window = [4]float32{exp[0].evalF(c) * redirscale, exp[1].evalF(c) * redirscale, exp[2].evalF(c) * redirscale, exp[3].evalF(c) * redirscale}
-				})
+				if len(exp) >= 4 {
+					eachExpl(func(e *Explod) {
+						e.window[0] = exp[0].evalF(c) * redirscale
+						e.window[1] = exp[1].evalF(c) * redirscale
+						e.window[2] = exp[2].evalF(c) * redirscale
+						e.window[3] = exp[3].evalF(c) * redirscale
+					})
+				} else {
+					sys.appendToConsole(crun.warn() + "invalid explod window")
+				}
 			case explod_ignorehitpause:
 				ihp := exp[0].evalB(c)
 				eachExpl(func(e *Explod) {
@@ -7571,7 +7586,7 @@ func (sc hitDef) runSub(c *Char, hd *HitDef, paramID byte, exp []BytecodeExp) {
 		if n < 0 || n > 2 {
 			// TODO: We should do this in more parameters
 			// This could also be more specific and use crun, but right now adding that to runSub is more trouble than it's worth
-			sys.appendToConsole(c.warn() + fmt.Sprintf("invalid teamside: %d", n))
+			sys.appendToConsole(c.warn() + fmt.Sprintf("invalid HitDef teamside: %d", n))
 		} else {
 			hd.teamside = int(n - 1)
 		}
@@ -11960,7 +11975,7 @@ func (sc changeMovelist) Run(c *Char, _ []int32) bool {
 		return true
 	})
 	if _, ok := crun.gi().movelists[int(v)]; !ok {
-		sys.appendToConsole(c.warn() + fmt.Sprintf("changed to invalid movelist: %d", v))
+		sys.appendToConsole(crun.warn() + fmt.Sprintf("changed to invalid movelist: %d", v))
 		return false
 	}
 	crun.movelist = v
@@ -14368,15 +14383,13 @@ func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 				s.sdw.offset[1] = exp[1].evalF(c) * scaleratio
 			}
 		case modifyStageVar_shadow_window:
-			s.sdw.window[0] = exp[0].evalF(c) * scaleratio
-			if len(exp) > 1 {
+			if len(exp) >= 4 {
+				s.sdw.window[0] = exp[0].evalF(c) * scaleratio
 				s.sdw.window[1] = exp[1].evalF(c) * scaleratio
-			}
-			if len(exp) > 2 {
 				s.sdw.window[2] = exp[2].evalF(c) * scaleratio
-			}
-			if len(exp) > 3 {
 				s.sdw.window[3] = exp[3].evalF(c) * scaleratio
+			} else {
+				sys.appendToConsole(c.warn() + "invalid shadow.window")
 			}
 		// Reflection group
 		case modifyStageVar_reflection_intensity:
@@ -14418,15 +14431,13 @@ func (sc modifyStageVar) Run(c *Char, _ []int32) bool {
 				s.reflection.offset[1] = exp[1].evalF(c) * scaleratio
 			}
 		case modifyStageVar_reflection_window:
-			s.reflection.window[0] = exp[0].evalF(c) * scaleratio
-			if len(exp) > 1 {
+			if len(exp) >= 4 {
+				s.reflection.window[0] = exp[0].evalF(c) * scaleratio
 				s.reflection.window[1] = exp[1].evalF(c) * scaleratio
-			}
-			if len(exp) > 2 {
 				s.reflection.window[2] = exp[2].evalF(c) * scaleratio
-			}
-			if len(exp) > 3 {
 				s.reflection.window[3] = exp[3].evalF(c) * scaleratio
+			} else {
+				sys.appendToConsole(c.warn() + "invalid reflection.window")
 			}
 		}
 		return true
@@ -14950,7 +14961,14 @@ func (sc transformSprite) Run(c *Char, _ []int32) bool {
 	StateControllerBase(sc).run(c, func(paramID byte, exp []BytecodeExp) bool {
 		switch paramID {
 		case transformSprite_window:
-			crun.window = [4]float32{exp[0].evalF(c) * redirscale, exp[1].evalF(c) * redirscale, exp[2].evalF(c) * redirscale, exp[3].evalF(c) * redirscale}
+			if len(exp) >= 4 {
+				crun.window[0] = exp[0].evalF(c) * redirscale
+				crun.window[1] = exp[1].evalF(c) * redirscale
+				crun.window[2] = exp[2].evalF(c) * redirscale
+				crun.window[3] = exp[3].evalF(c) * redirscale
+			} else {
+				sys.appendToConsole(crun.warn() + "invalid TransformSprite window")
+			}
 		case transformSprite_xshear:
 			crun.xshear = exp[0].evalF(c)
 		case transformSprite_focallength:
@@ -15206,7 +15224,14 @@ func (sc modifyShadow) Run(c *Char, _ []int32) bool {
 				crun.shadowOffset[1] = exp[1].evalF(c) * redirscale
 			}
 		case modifyShadow_window:
-			crun.shadowWindow = [4]float32{exp[0].evalF(c), exp[1].evalF(c), exp[2].evalF(c), exp[3].evalF(c)}
+			if len(exp) >= 4 {
+				crun.shadowWindow[0] = exp[0].evalF(c) * redirscale
+				crun.shadowWindow[1] = exp[1].evalF(c) * redirscale
+				crun.shadowWindow[2] = exp[2].evalF(c) * redirscale
+				crun.shadowWindow[3] = exp[3].evalF(c) * redirscale
+			} else {
+				sys.appendToConsole(crun.warn() + "invalid ModifyShadow window")
+			}
 		case modifyShadow_xscale:
 			crun.shadowXscale = exp[0].evalF(c)
 		case modifyShadow_xshear:
@@ -15299,7 +15324,14 @@ func (sc modifyReflection) Run(c *Char, _ []int32) bool {
 				crun.reflectOffset[1] = exp[1].evalF(c) * redirscale
 			}
 		case modifyReflection_window:
-			crun.reflectWindow = [4]float32{exp[0].evalF(c), exp[1].evalF(c), exp[2].evalF(c), exp[3].evalF(c)}
+			if len(exp) >= 4 {
+				crun.reflectWindow[0] = exp[0].evalF(c) * redirscale
+				crun.reflectWindow[1] = exp[1].evalF(c) * redirscale
+				crun.reflectWindow[2] = exp[2].evalF(c) * redirscale
+				crun.reflectWindow[3] = exp[3].evalF(c) * redirscale
+			} else {
+				sys.appendToConsole(crun.warn() + "invalid ModifyReflection window")
+			}
 		case modifyReflection_xscale:
 			crun.reflectXscale = exp[0].evalF(c)
 		case modifyReflection_xshear:

--- a/src/char.go
+++ b/src/char.go
@@ -8572,7 +8572,7 @@ func (c *Char) targetDrop(excludeid int32, excludechar int32, keepone bool) {
 					if c.csf(CSF_gethit) {
 						t.selfState(5050, -1, -1, -1, "")
 					}
-					t.setBindTime(0)
+					t.resetBind()
 				}
 				t.ghv.dropPlayerId(c.id)
 			}
@@ -9850,11 +9850,17 @@ func (c *Char) targetAddSctrl(id int32) {
 }
 
 func (c *Char) setBindTime(time int32) {
-	c.bindTime = time
 	if time == 0 {
-		c.bindToId = -1
-		c.bindFacing = 0
+		c.resetBind()
+		return
 	}
+	c.bindTime = time
+}
+
+func (c *Char) resetBind() {
+	c.bindTime = 0
+	c.bindToId = -1
+	c.bindFacing = 0
 }
 
 func (c *Char) setBindToId(to *Char, isTargetBind bool) {
@@ -9870,13 +9876,22 @@ func (c *Char) setBindToId(to *Char, isTargetBind bool) {
 		c.bindFacing = to.facing * 2
 	}
 
+	// Prevent mutual binding
 	if to.bindToId == c.id {
-		to.setBindTime(0)
+		to.resetBind()
 	}
 }
 
-// Updates binding position and velocity only. Time and ID handled elsewhere
 func (c *Char) updateBinding() {
+	// Clear leftover bindToId
+	// This clears TargetBind and thus getHitVar(isbound)
+	// https://github.com/ikemen-engine/Ikemen-GO/issues/3882
+	// TODO: Maybe there's a way to merge all the bind code instead of treating helper and target binds so differently
+	if c.bindTime == 0 && c.bindToId > 0 {
+		c.resetBind()
+	}
+
+	// If no bind is active
 	if c.bindToId < 0 || c.bindTime == 0 {
 		return
 	}
@@ -9884,6 +9899,7 @@ func (c *Char) updateBinding() {
 	bt := sys.playerID(c.bindToId)
 
 	if bt == nil {
+		c.resetBind()
 		return
 	}
 
@@ -10007,7 +10023,7 @@ func (c *Char) xPlatformBound(pxmin, pxmax float32) {
 
 func (c *Char) gethitBindClear() {
 	if c.isTargetBound() {
-		c.setBindTime(0)
+		c.resetBind()
 	}
 }
 
@@ -10952,7 +10968,7 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 			}
 		}
 		if getter.bindToId == c.id {
-			getter.setBindTime(0)
+			getter.resetBind()
 		}
 		if hd.KeepState && ghvset {
 			getter.ghv.keepstate = hd.KeepState
@@ -11204,7 +11220,7 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 					getter.bindPos[2] = float32(math.NaN())
 				}
 			} else if getter.bindToId == c.id {
-				getter.setBindTime(0)
+				getter.resetBind()
 			}
 			// Save other gethitvars that don't directly affect gameplay
 			ghv.ground_velocity[0] = hd.ground_velocity[0] * scaleratio * -byf
@@ -12390,21 +12406,19 @@ func (c *Char) tick() {
 				c.selfState(5050, -1, -1, -1, "")
 				c.gethitBindClear()
 			} else if !bt.pause() {
-				// Use setBindTime so that the bind variables are cleared when the timer reaches 0
-				// Manual decrement was only needed so setBindTime() would not clear the bind for a dying helper
-				// destroy() handles that case now
-				// c.bindTime -= 1
-				c.setBindTime(c.bindTime - 1)
+				// We step the timer but don't clear the bind yet, because that makes getHitVar(isbound) clear too soon
+				// https://github.com/ikemen-engine/Ikemen-GO/issues/3882
+				c.bindTime--
 			}
 		} else {
 			if !c.pause() {
-				c.setBindTime(c.bindTime - 1)
-				// The fix below was necessary before because bindTime should not be decremented directly but rather via setBindTime
+				c.bindTime--
+				// Unlike TargetBind, we clear this one immediately
 				// Fixes BindToRoot/BindToParent of 1 immediately after PosSets (MUGEN 1.0/1.1 behavior)
 				// This must not run for target binds so that they end the same time as MUGEN's do.
-				//if c.bindToId > 0 {
-				//	c.setBindTime(c.bindTime)
-				//}
+				if c.bindTime == 0 {
+					c.resetBind()
+				}
 			}
 		}
 	}

--- a/src/char.go
+++ b/src/char.go
@@ -1964,9 +1964,11 @@ func (e *Explod) update() {
 
 	act := e.canAct()
 
-	if sys.tickFrame() {
+	// Explods aren't removed while they are paused
+	// https://github.com/ikemen-engine/Ikemen-GO/issues/3889
+	if act && sys.tickFrame() {
 		if e.removetime >= 0 && e.time >= e.removetime ||
-			act && e.removetime <= -2 && e.anim.loopend {
+			e.removetime <= -2 && e.anim.loopend {
 			e.id, e.anim = IErr, nil
 			return
 		}

--- a/src/common.go
+++ b/src/common.go
@@ -1368,13 +1368,11 @@ func (al *AnimLayout) Draw(x, y float32, layerno int16, scale float32) {
 	al.lay.DrawAnim(&al.lay.window, x, y, scale, 1, 1, layerno, al.anim, al.palfx)
 }
 
-func ReadPalFX(pre string, is IniSection, pfx *PalFX) int32 {
+func ReadPalFX(pre string, is IniSection, pfx *PalFX) {
 	pfx.clear()
 	pfx.time = -1
-	tInit := int32(-1)
-	if is.ReadI32(pre+"time", &pfx.time) {
-		tInit = pfx.time
-	}
+
+	is.ReadI32(pre+"time", &pfx.time)
 	is.ReadI32(pre+"add", &pfx.add[0], &pfx.add[1], &pfx.add[2])
 	is.ReadI32(pre+"mul", &pfx.mul[0], &pfx.mul[1], &pfx.mul[2])
 	var s [4]int32
@@ -1432,7 +1430,6 @@ func ReadPalFX(pre string, is IniSection, pfx *PalFX) int32 {
 	if is.ReadF32(pre+"hue", &n) {
 		pfx.hue = n / 512
 	}
-	return tInit
 }
 
 type AnimTextSnd struct {

--- a/src/common.go
+++ b/src/common.go
@@ -1059,6 +1059,29 @@ func (is IniSection) readI32ForStage(name string, out ...*int32) bool {
 	return true
 }
 
+// This version only accepts the parameter if it has enough values
+func (is IniSection) readI32ForStageMinLength(name string, out ...*int32) bool {
+	str := is[name]
+	if len(str) == 0 {
+		return false
+	}
+	parts := strings.Split(is[name], ",")
+	// Also reject empty values
+	n := 0
+	for _, p := range parts {
+		if strings.TrimSpace(p) != "" {
+			n++
+		}
+	}
+	// Mugen is still lenient when it's being strict and won't reject parameters with excessive values
+	if n < len(out) {
+		LogMessage("WARNING: '%s' expected at least %d values but found only %d", name, len(out), n)
+		return false
+	}
+	// Use the normal path after validation
+	return is.readI32ForStage(name, out...)
+}
+
 func (is IniSection) readF32ForStage(name string, out ...*float32) bool {
 	str := is[name]
 	if len(str) == 0 {

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -273,9 +273,9 @@ func readFSText(pre string, is IniSection, str string, ln int16, f map[int]*Fnt,
 	txt.pfxtime = txt.palfx.time
 
 	// The color parameter overrides the PalFX for sprite fonts, so it must be parsed after it
+	// Update: No longer true, but this new order is still harmless
 	if txt.font[3] >= 0 && txt.font[4] >= 0 && txt.font[5] >= 0 {
 		txt.SetColor(txt.font[3], txt.font[4], txt.font[5], txt.font[6])
-		txt.pfxtime = -1
 	}
 
 	return txt
@@ -284,10 +284,6 @@ func readFSText(pre string, is IniSection, str string, ln int16, f map[int]*Fnt,
 // Same as in TextSprite except it doesn't need debug font fallback
 func (txt *FSText) SetColor(r, g, b, a int32) {
 	txt.frgba = [4]float32{float32(r) / 255, float32(g) / 255, float32(b) / 255, float32(a) / 255}
-
-	if txt.fnt != nil && txt.fnt.Type != "truetype" {
-		txt.palfx.setColor(r, g, b)
-	}
 }
 
 func (txt *FSText) step() {
@@ -3053,11 +3049,6 @@ func (ac *FightScreenAction) draw(layerno int16, f map[int]*Fnt, side int) {
 				if v.fontAlign != IErr {
 					align = v.fontAlign
 				}
-				palfx := ac.text.palfx
-
-				if v.palfx != nil {
-					palfx = v.palfx
-				}
 
 				frgba := ac.text.frgba
 				if v.fontColorSet {
@@ -3070,19 +3061,12 @@ func (ac *FightScreenAction) draw(layerno int16, f map[int]*Fnt, side int) {
 					frgba[1] = float32(g) / 255
 					frgba[2] = float32(b) / 255
 					frgba[3] = float32(a) / 255
-
-					pf := newPalFX()
-					if palfx != nil {
-						*pf = *palfx
-					}
-					pf.setColor(r, g, b)
-					palfx = pf
 				}
 
 				ac.text.lay.DrawText(x+sys.fightScreen.offsetX+float32(k)*float32(ac.spacing[0]),
 					float32(ac.pos[1])+float32(k)*float32(ac.spacing[1]),
 					sys.fightScreen.scale, layerno, v.text, ff, bank, align,
-					palfx, frgba)
+					v.palfx, frgba)
 			}
 		}
 	}

--- a/src/fightscreen.go
+++ b/src/fightscreen.go
@@ -216,18 +216,19 @@ func loadFightFx(def string, isCharFX bool, isMainThread bool) error {
 
 type FSText struct {
 	font    [8]int32 // to match Lua arg count regardless
+	fnt     *Fnt
 	text    string
 	lay     Layout
 	palfx   *PalFX
 	frgba   [4]float32 // ttf fonts
-	pfxinit int32
+	pfxtime int32
 }
 
-func newFSText(align int32) *FSText {
+func newFSText() *FSText {
 	return &FSText{
-		font:  [...]int32{-1, 0, align, 255, 255, 255, 255, -1},
+		font:  [8]int32{-1, 0, 0, -1, -1, -1, 255, -1},
 		palfx: newPalFX(),
-		frgba: [...]float32{1.0, 1.0, 1.0, 1.0},
+		frgba: [4]float32{1.0, 1.0, 1.0, 1.0},
 	}
 }
 
@@ -243,31 +244,50 @@ func getFont(f map[int]*Fnt, idx int32) *Fnt {
 }
 
 func readFSText(pre string, is IniSection, str string, ln int16, f map[int]*Fnt, align int32) *FSText {
-	txt := newFSText(align)
+	txt := newFSText()
+	txt.font[2] = align
 
-	txt.font[3], txt.font[4], txt.font[5], txt.font[6], txt.font[7] = -1, -1, -1, 255, -1
 	is.ReadI32(pre+"font", &txt.font[0], &txt.font[1], &txt.font[2],
 		&txt.font[3], &txt.font[4], &txt.font[5], &txt.font[6], &txt.font[7])
-	if txt.font[0] >= 0 && getFont(f, txt.font[0]) == nil {
-		LogMessage("Undefined font %v referenced by fight screen parameter: %v", txt.font[0], pre+"font")
-		txt.font[0] = -1
+
+	// Retrieve font from map once and save the pointer
+	if txt.font[0] >= 0 {
+		txt.fnt = getFont(f, txt.font[0])
+		if txt.fnt == nil {
+			LogMessage("Undefined font %v referenced by fight screen parameter: %v", txt.font[0], pre+"font")
+			txt.font[0] = -1
+		}
 	}
+
 	if _, ok := is[pre+"text"]; ok {
 		txt.text, _, _ = is.getText(pre + "text")
 	} else {
 		txt.text = str
 	}
+
 	txt.lay = *ReadLayout(pre, is, ln)
+
+	ReadPalFX(pre+"palfx.", is, txt.palfx)
+
+	// Save the PalFX's initial time for later resetting
+	txt.pfxtime = txt.palfx.time
+
+	// The color parameter overrides the PalFX for sprite fonts, so it must be parsed after it
 	if txt.font[3] >= 0 && txt.font[4] >= 0 && txt.font[5] >= 0 {
 		txt.SetColor(txt.font[3], txt.font[4], txt.font[5], txt.font[6])
+		txt.pfxtime = -1
 	}
-	txt.pfxinit = ReadPalFX(pre+"palfx.", is, txt.palfx)
+
 	return txt
 }
 
+// Same as in TextSprite except it doesn't need debug font fallback
 func (txt *FSText) SetColor(r, g, b, a int32) {
-	txt.palfx.setColor(r, g, b)
 	txt.frgba = [4]float32{float32(r) / 255, float32(g) / 255, float32(b) / 255, float32(a) / 255}
+
+	if txt.fnt != nil && txt.fnt.Type != "truetype" {
+		txt.palfx.setColor(r, g, b)
+	}
 }
 
 func (txt *FSText) step() {
@@ -277,7 +297,7 @@ func (txt *FSText) step() {
 }
 
 func (txt *FSText) resetTxtPfx() {
-	txt.palfx.time = txt.pfxinit
+	txt.palfx.time = txt.pfxtime
 }
 
 type FSBgTextSnd struct {
@@ -333,10 +353,9 @@ func (bts *FSBgTextSnd) bgDraw(layerno int16) {
 }
 
 func (bts *FSBgTextSnd) draw(layerno int16, f map[int]*Fnt) {
-	if bts.timer > bts.time && bts.timer <= bts.time+bts.displaytime &&
-		bts.text.font[0] >= 0 && getFont(f, bts.text.font[0]) != nil {
+	if bts.timer > bts.time && bts.timer <= bts.time+bts.displaytime && bts.text.fnt != nil {
 		bts.text.lay.DrawText(float32(bts.pos[0])+sys.fightScreen.offsetX, float32(bts.pos[1]), sys.fightScreen.scale, layerno,
-			bts.text.text, getFont(f, bts.text.font[0]), bts.text.font[1], bts.text.font[2], bts.text.palfx, bts.text.frgba)
+			bts.text.text, bts.text.fnt, bts.text.font[1], bts.text.font[2], bts.text.palfx, bts.text.frgba)
 	}
 }
 
@@ -729,7 +748,7 @@ func (lb *LifeBar) draw(layerno int16, charpn int, lbr *LifeBar, f map[int]*Fnt)
 		lb.red[rv].lay.DrawAnim(&rr, float32(lb.pos[0])+sys.fightScreen.offsetX, float32(lb.pos[1])+sys.fightScreen.offsetY, sys.fightScreen.scale, rxs, rys,
 			layerno, lb.red[rv].anim, lb.red[rv].palfx)
 
-		if lb.red_value[0].font[0] >= 0 && getFont(f, lb.red_value[0].font[0]) != nil {
+		if lb.red_value[0].fnt != nil {
 			// Multiple red_value fonts according to redval
 			var rv2 int32
 			for k := range lb.red_value {
@@ -744,7 +763,7 @@ func (lb *LifeBar) draw(layerno int16, charpn int, lbr *LifeBar, f map[int]*Fnt)
 				float32(lb.pos[1])+sys.fightScreen.offsetY, sys.fightScreen.scale,
 				layerno,
 				text,
-				getFont(f, lb.red_value[rv2].font[0]),
+				lb.red_value[rv2].fnt,
 				lb.red_value[rv2].font[1],
 				lb.red_value[rv2].font[2],
 				lb.red_value[rv2].palfx,
@@ -774,7 +793,7 @@ func (lb *LifeBar) draw(layerno int16, charpn int, lbr *LifeBar, f map[int]*Fnt)
 	lb.shift.lay.DrawAnim(&lr, float32(lb.pos[0])+sys.fightScreen.offsetX, float32(lb.pos[1])+sys.fightScreen.offsetY, sys.fightScreen.scale, lxs, lys,
 		layerno, lb.shift.anim, lb.shift.palfx)
 
-	if lb.value[0].font[0] >= 0 && getFont(f, lb.value[0].font[0]) != nil {
+	if lb.value[0].fnt != nil {
 		// Multiple value fonts according to life value
 		var fv2 int32
 		for k := range lb.value {
@@ -789,7 +808,7 @@ func (lb *LifeBar) draw(layerno int16, charpn int, lbr *LifeBar, f map[int]*Fnt)
 			float32(lb.pos[1])+sys.fightScreen.offsetY, sys.fightScreen.scale,
 			layerno,
 			text,
-			getFont(f, lb.value[fv2].font[0]),
+			lb.value[fv2].fnt,
 			lb.value[fv2].font[1],
 			lb.value[fv2].font[2],
 			lb.value[fv2].palfx,
@@ -1156,7 +1175,7 @@ func (pb *PowerBar) draw(layerno int16, charpn int, pbr *PowerBar, f map[int]*Fn
 		layerno, pb.shift.anim, pb.shift.palfx)
 
 	// Powerbar text.
-	if pb.counter[0].font[0] >= 0 && getFont(f, pb.counter[0].font[0]) != nil {
+	if pb.counter[0].fnt != nil {
 		// Multiple counter fonts according to powerbar level
 		cv := resolvePBKey(pb.counter, pbval, refChar.powerMax)
 
@@ -1166,7 +1185,7 @@ func (pb *PowerBar) draw(layerno int16, charpn int, pbr *PowerBar, f map[int]*Fn
 			sys.fightScreen.scale,
 			layerno,
 			strings.Replace(pb.counter[cv].text, "%i", fmt.Sprintf("%v", pbval/pb.counter_rounding), 1),
-			getFont(f, pb.counter[cv].font[0]),
+			pb.counter[cv].fnt,
 			pb.counter[cv].font[1],
 			pb.counter[cv].font[2],
 			pb.counter[cv].palfx,
@@ -1175,7 +1194,7 @@ func (pb *PowerBar) draw(layerno int16, charpn int, pbr *PowerBar, f map[int]*Fn
 	}
 
 	// Per-level powerbar text.
-	if pb.value[0].font[0] >= 0 && getFont(f, pb.value[0].font[0]) != nil {
+	if pb.value[0].fnt != nil {
 		// Multiple value fonts according to powerbar level
 		cv2 := resolvePBKey(pb.counter, pbval, refChar.powerMax)
 		text := strings.Replace(pb.value[cv2].text, "%d", fmt.Sprintf("%v", pbval/pb.value_rounding), 1)
@@ -1187,7 +1206,7 @@ func (pb *PowerBar) draw(layerno int16, charpn int, pbr *PowerBar, f map[int]*Fn
 			sys.fightScreen.scale,
 			layerno,
 			text,
-			getFont(f, pb.value[cv2].font[0]),
+			pb.value[cv2].fnt,
 			pb.value[cv2].font[1],
 			pb.value[cv2].font[2],
 			pb.value[cv2].palfx,
@@ -1414,7 +1433,7 @@ func (gb *GuardBar) draw(layerno int16, charpn int, gbr *GuardBar, f map[int]*Fn
 	gb.shift.lay.DrawAnim(&pr, float32(gb.pos[0])+sys.fightScreen.offsetX, float32(gb.pos[1])+sys.fightScreen.offsetY, sys.fightScreen.scale, pxs, pys,
 		layerno, gb.shift.anim, gb.shift.palfx)
 
-	if gb.value[0].font[0] >= 0 && getFont(f, gb.value[0].font[0]) != nil {
+	if gb.value[0].fnt != nil {
 		// Multiple value fonts according to guardbar points
 		var mv2 int32
 		for k := range gb.value {
@@ -1430,7 +1449,7 @@ func (gb *GuardBar) draw(layerno int16, charpn int, gbr *GuardBar, f map[int]*Fn
 			sys.fightScreen.scale,
 			layerno,
 			text,
-			getFont(f, gb.value[mv2].font[0]),
+			gb.value[mv2].fnt,
 			gb.value[mv2].font[1],
 			gb.value[mv2].font[2],
 			gb.value[mv2].palfx,
@@ -1660,7 +1679,7 @@ func (sb *StunBar) draw(layerno int16, charpn int, sbr *StunBar, f map[int]*Fnt)
 	sb.shift.lay.DrawAnim(&pr, float32(sb.pos[0])+sys.fightScreen.offsetX, float32(sb.pos[1])+sys.fightScreen.offsetY, sys.fightScreen.scale, pxs, pys,
 		layerno, sb.shift.anim, sb.shift.palfx)
 
-	if sb.value[0].font[0] >= 0 && getFont(f, sb.value[0].font[0]) != nil {
+	if sb.value[0].fnt != nil {
 		// Multiple value fonts according to stunbar points
 		var mv2 int32
 		for k := range sb.value {
@@ -1676,7 +1695,7 @@ func (sb *StunBar) draw(layerno int16, charpn int, sbr *StunBar, f map[int]*Fnt)
 			sys.fightScreen.scale,
 			layerno,
 			text,
-			getFont(f, sb.value[mv2].font[0]),
+			sb.value[mv2].fnt,
 			sb.value[mv2].font[1],
 			sb.value[mv2].font[2],
 			sb.value[mv2].palfx,
@@ -2032,9 +2051,9 @@ func (nm *FightScreenName) bgDraw(layerno int16) {
 }
 
 func (nm *FightScreenName) draw(layerno int16, charpn int, f map[int]*Fnt, side int) {
-	if nm.name.font[0] >= 0 && getFont(f, nm.name.font[0]) != nil {
+	if nm.name.fnt != nil {
 		nm.name.lay.DrawText((float32(nm.pos[0]) + sys.fightScreen.offsetX), float32(nm.pos[1]), sys.fightScreen.scale, layerno,
-			sys.cgi[charpn].lifebarname, getFont(f, nm.name.font[0]), nm.name.font[1], nm.name.font[2], nm.name.palfx, nm.name.frgba)
+			sys.cgi[charpn].lifebarname, nm.name.fnt, nm.name.font[1], nm.name.font[2], nm.name.palfx, nm.name.frgba)
 	}
 
 	nm.top.Draw(float32(nm.pos[0])+sys.fightScreen.offsetX, float32(nm.pos[1]), layerno, sys.fightScreen.scale)
@@ -2075,9 +2094,9 @@ func (nm *FightScreenName) drawTeammates(layerno int16, f map[int]*Fnt, side int
 		nm.teammate_bg.Draw((x + sys.fightScreen.offsetX), y, layerno, sys.fightScreen.scale)
 
 		// Draw pre-compiled name text
-		if nm.teammate_name.font[0] >= 0 && getFont(f, nm.teammate_name.font[0]) != nil {
+		if nm.teammate_name.fnt != nil {
 			nm.teammate_name.lay.DrawText((x + sys.fightScreen.offsetX), y, sys.fightScreen.scale, layerno,
-				nm.teammate_name_strings[i], getFont(f, nm.teammate_name.font[0]),
+				nm.teammate_name_strings[i], nm.teammate_name.fnt,
 				nm.teammate_name.font[1], nm.teammate_name.font[2], nm.teammate_name.palfx, nm.teammate_name.frgba)
 		}
 
@@ -2200,10 +2219,10 @@ func (wi *FightScreenWinIcon) draw(layerno int16, f map[int]*Fnt, side int) {
 
 	if len(wi.wins) > int(wi.useiconupto) {
 		// Use the generic win count icon if icon limit exceeded
-		if wi.counter.font[0] >= 0 && getFont(f, wi.counter.font[0]) != nil {
+		if wi.counter.fnt != nil {
 			wi.counter.lay.DrawText(float32(wi.pos[0])+sys.fightScreen.offsetX, float32(wi.pos[1]), sys.fightScreen.scale,
 				layerno, strings.Replace(wi.counter.text, "%i", fmt.Sprintf("%v", len(wi.wins)), 1),
-				getFont(f, wi.counter.font[0]), wi.counter.font[1], wi.counter.font[2], wi.counter.palfx, wi.counter.frgba)
+				wi.counter.fnt, wi.counter.font[1], wi.counter.font[2], wi.counter.palfx, wi.counter.frgba)
 		}
 	} else {
 		// Use the specific win type icons
@@ -2305,8 +2324,7 @@ func (ti *FightScreenTime) bgDraw(layerno int16) {
 }
 
 func (ti *FightScreenTime) draw(layerno int16, f map[int]*Fnt) {
-	if sys.curFramesPerCount > 0 &&
-		ti.counter[0].font[0] >= 0 && getFont(f, ti.counter[0].font[0]) != nil {
+	if sys.curFramesPerCount > 0 && ti.counter[0].fnt != nil {
 		var timeval int32 = -1
 		time := "o"
 		if sys.curRoundTime >= 0 {
@@ -2334,7 +2352,7 @@ func (ti *FightScreenTime) draw(layerno int16, f map[int]*Fnt) {
 		}
 		ti.activeIdx = tv
 		ti.counter[tv].lay.DrawText(float32(ti.pos[0])+sys.fightScreen.offsetX, float32(ti.pos[1]), sys.fightScreen.scale, layerno,
-			time, getFont(f, ti.counter[tv].font[0]), ti.counter[tv].font[1], ti.counter[tv].font[2], ti.counter[tv].palfx,
+			time, ti.counter[tv].fnt, ti.counter[tv].font[1], ti.counter[tv].font[2], ti.counter[tv].palfx,
 			ti.counter[tv].frgba)
 	}
 	ti.top.Draw(float32(ti.pos[0])+sys.fightScreen.offsetX, float32(ti.pos[1]), layerno, sys.fightScreen.scale)
@@ -2603,11 +2621,9 @@ func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 			x += co.counterX
 		}
 		// Apply autoalign
-		if co.counter[cv].font[0] >= 0 && co.autoalign {
-			if ff := getFont(f, co.counter[cv].font[0]); ff != nil {
-				x += float32(ff.TextWidth(counter, co.counter[cv].font[1], 0)) *
-					co.counter[cv].lay.scale[0] * sys.fightScreen.fnt_scale
-			}
+		if co.autoalign && co.counter[cv].fnt != nil {
+			x += float32(co.counter[cv].fnt.TextWidth(counter, co.counter[cv].font[1], 0)) *
+				co.counter[cv].lay.scale[0] * sys.fightScreen.fnt_scale
 		}
 	} else {
 		if co.start_x <= 0 {
@@ -2623,7 +2639,7 @@ func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 	var textBlockWidth float32
 	var lineHeight float32
 	var lines []string
-	if co.text[tv].font[0] >= 0 && getFont(f, co.text[tv].font[0]) != nil {
+	if co.text[tv].fnt != nil {
 		// Replace operator with current combo hits
 		text := strings.Replace(co.text[tv].text, "%i", fmt.Sprintf("%v", co.shownHits), 1)
 		// Replace operator with current combo damage
@@ -2647,8 +2663,8 @@ func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 		lines = strings.Split(text, "\\n")
 
 		// Compute text block dimensions
-		ffText = getFont(f, co.text[tv].font[0])
-		if ffText != nil {
+		ffText = co.text[tv].fnt
+		if ffText := co.text[tv].fnt; ffText != nil {
 			lineHeight = float32(ffText.Size[1])*co.text[tv].lay.scale[1]*sys.fightScreen.fnt_scale +
 				float32(ffText.Spacing[1])*co.text[tv].lay.scale[1]*sys.fightScreen.fnt_scale
 			for _, line := range lines {
@@ -2684,11 +2700,11 @@ func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 	}
 
 	// Counter
-	if co.counter[cv].font[0] >= 0 && getFont(f, co.counter[cv].font[0]) != nil {
+	if co.counter[cv].fnt != nil {
 		// Apply autoalign
 		var counterShift float32
 		if side == 0 && co.autoalign {
-			if ff := getFont(f, co.counter[cv].font[0]); ff != nil {
+			if ff := co.counter[cv].fnt; ff != nil {
 				counterShift = float32(ff.TextWidth(counter, co.counter[cv].font[1], 0)) *
 					co.counter[cv].lay.scale[0] * sys.fightScreen.fnt_scale
 			}
@@ -2706,7 +2722,7 @@ func (co *FightScreenCombo) draw(layerno int16, f map[int]*Fnt, side int) {
 		finalScale := shakeScale * sys.fightScreen.scale
 
 		co.counter[cv].lay.DrawText(drawX, drawY, finalScale, layerno,
-			counter, getFont(f, co.counter[cv].font[0]), co.counter[cv].font[1], co.counter[cv].font[2],
+			counter, co.counter[cv].fnt, co.counter[cv].font[1], co.counter[cv].font[2],
 			co.counter[cv].palfx, co.counter[cv].frgba)
 	}
 
@@ -4244,8 +4260,7 @@ func (tr *FightScreenTimer) bgDraw(layerno int16) {
 }
 
 func (tr *FightScreenTimer) draw(layerno int16, f map[int]*Fnt) {
-	if tr.active && sys.curFramesPerCount > 0 &&
-		tr.text.font[0] >= 0 && getFont(f, tr.text.font[0]) != nil {
+	if tr.active && sys.curFramesPerCount > 0 && tr.text.fnt != nil {
 		text := tr.text.text
 		totalSec := float64(sys.timeTotal()) / 60
 		h := math.Floor(totalSec / 3600)
@@ -4266,7 +4281,7 @@ func (tr *FightScreenTimer) draw(layerno int16, f map[int]*Fnt) {
 		text = strings.Replace(text, "%s", ss, 1)
 		text = strings.Replace(text, "%x", xs, 1)
 		tr.text.lay.DrawText(float32(tr.pos[0])+sys.fightScreen.offsetX, float32(tr.pos[1]), sys.fightScreen.scale, layerno,
-			text, getFont(f, tr.text.font[0]), tr.text.font[1], tr.text.font[2], tr.text.palfx, tr.text.frgba)
+			text, tr.text.fnt, tr.text.font[1], tr.text.font[2], tr.text.palfx, tr.text.frgba)
 		tr.top.Draw(float32(tr.pos[0])+sys.fightScreen.offsetX, float32(tr.pos[1]), layerno, sys.fightScreen.scale)
 	}
 }
@@ -4332,7 +4347,7 @@ func (sc *FightScreenScore) bgDraw(layerno int16) {
 }
 
 func (sc *FightScreenScore) draw(layerno int16, f map[int]*Fnt, side int) {
-	if sc.active && sc.text.font[0] >= 0 && getFont(f, sc.text.font[0]) != nil {
+	if sc.active && sc.text.fnt != nil {
 		text := sc.text.text
 		total := sys.chars[side][0].scoreTotal()
 		if total == 0 && sc.pad == 0 {
@@ -4365,7 +4380,7 @@ func (sc *FightScreenScore) draw(layerno int16, f map[int]*Fnt, side int) {
 		// replace %s with formatted string
 		text = strings.Replace(text, "%s", s[0]+ds+s[1], 1)
 		sc.text.lay.DrawText(float32(sc.pos[0])+sys.fightScreen.offsetX, float32(sc.pos[1]), sys.fightScreen.scale, layerno,
-			text, getFont(f, sc.text.font[0]), sc.text.font[1], sc.text.font[2], sc.text.palfx, sc.text.frgba)
+			text, sc.text.fnt, sc.text.font[1], sc.text.font[2], sc.text.palfx, sc.text.frgba)
 		sc.top.Draw(float32(sc.pos[0])+sys.fightScreen.offsetX, float32(sc.pos[1]), layerno, sys.fightScreen.scale)
 	}
 }
@@ -4420,11 +4435,11 @@ func (ma *FightScreenMatch) bgDraw(layerno int16) {
 }
 
 func (ma *FightScreenMatch) draw(layerno int16, f map[int]*Fnt) {
-	if ma.active && ma.text.font[0] >= 0 && getFont(f, ma.text.font[0]) != nil {
+	if ma.active && ma.text.fnt != nil {
 		text := ma.text.text
 		text = strings.Replace(text, "%s", fmt.Sprintf("%v", sys.matchNo), 1)
 		ma.text.lay.DrawText(float32(ma.pos[0])+sys.fightScreen.offsetX, float32(ma.pos[1]), sys.fightScreen.scale, layerno,
-			text, getFont(f, ma.text.font[0]), ma.text.font[1], ma.text.font[2], ma.text.palfx, ma.text.frgba)
+			text, ma.text.fnt, ma.text.font[1], ma.text.font[2], ma.text.palfx, ma.text.frgba)
 		ma.top.Draw(float32(ma.pos[0])+sys.fightScreen.offsetX, float32(ma.pos[1]), layerno, sys.fightScreen.scale)
 	}
 }
@@ -4483,7 +4498,7 @@ func (ai *FightScreenAiLevel) bgDraw(layerno int16) {
 }
 
 func (ai *FightScreenAiLevel) draw(layerno int16, f map[int]*Fnt, ailv float32) {
-	if ai.active && ailv > 0 && ai.text.font[0] >= 0 && getFont(f, ai.text.font[0]) != nil {
+	if ai.active && ailv > 0 && ai.text.fnt != nil {
 		text := ai.text.text
 		// split float value
 		s := strings.Split(fmt.Sprintf("%f", ailv), ".")
@@ -4502,7 +4517,7 @@ func (ai *FightScreenAiLevel) draw(layerno int16, f map[int]*Fnt, ailv float32) 
 		p := ailv / 8 * 100
 		text = strings.Replace(text, "%p", fmt.Sprintf("%.0f", p), 1)
 		ai.text.lay.DrawText(float32(ai.pos[0])+sys.fightScreen.offsetX, float32(ai.pos[1]), sys.fightScreen.scale, layerno,
-			text, getFont(f, ai.text.font[0]), ai.text.font[1], ai.text.font[2], ai.text.palfx, ai.text.frgba)
+			text, ai.text.fnt, ai.text.font[1], ai.text.font[2], ai.text.palfx, ai.text.frgba)
 		ai.top.Draw(float32(ai.pos[0])+sys.fightScreen.offsetX, float32(ai.pos[1]), layerno, sys.fightScreen.scale)
 	}
 }
@@ -4558,13 +4573,14 @@ func (wc *FightScreenWinCount) bgDraw(layerno int16) {
 }
 
 func (wc *FightScreenWinCount) draw(layerno int16, f map[int]*Fnt, side int) {
-	if wc.active && wc.text.font[0] >= 0 && getFont(f, wc.text.font[0]) != nil {
-		text := wc.text.text
-		text = strings.Replace(text, "%s", fmt.Sprintf("%v", wc.wins), 1)
-		wc.text.lay.DrawText(float32(wc.pos[0])+sys.fightScreen.offsetX, float32(wc.pos[1]), sys.fightScreen.scale, layerno,
-			text, getFont(f, wc.text.font[0]), wc.text.font[1], wc.text.font[2], wc.text.palfx, wc.text.frgba)
-		wc.top.Draw(float32(wc.pos[0])+sys.fightScreen.offsetX, float32(wc.pos[1]), layerno, sys.fightScreen.scale)
+	if !wc.active || wc.text.fnt == nil {
+		return
 	}
+	text := wc.text.text
+	text = strings.Replace(text, "%s", fmt.Sprintf("%v", wc.wins), 1)
+	wc.text.lay.DrawText(float32(wc.pos[0])+sys.fightScreen.offsetX, float32(wc.pos[1]), sys.fightScreen.scale, layerno,
+		text, wc.text.fnt, wc.text.font[1], wc.text.font[2], wc.text.palfx, wc.text.frgba)
+	wc.top.Draw(float32(wc.pos[0])+sys.fightScreen.offsetX, float32(wc.pos[1]), layerno, sys.fightScreen.scale)
 }
 
 type FightScreenMode struct {
@@ -4612,9 +4628,9 @@ func (mo *FightScreenMode) bgDraw(layerno int16) {
 }
 
 func (mo *FightScreenMode) draw(layerno int16, f map[int]*Fnt) {
-	if sys.fightScreen.mode && mo.text.font[0] >= 0 && getFont(f, mo.text.font[0]) != nil {
+	if sys.fightScreen.mode && mo.text.fnt != nil {
 		mo.text.lay.DrawText(float32(mo.pos[0])+sys.fightScreen.offsetX, float32(mo.pos[1]), sys.fightScreen.scale, layerno,
-			mo.text.text, getFont(f, mo.text.font[0]), mo.text.font[1], mo.text.font[2], mo.text.palfx, mo.text.frgba)
+			mo.text.text, mo.text.fnt, mo.text.font[1], mo.text.font[2], mo.text.palfx, mo.text.frgba)
 		mo.top.Draw(float32(mo.pos[0])+sys.fightScreen.offsetX, float32(mo.pos[1]), layerno, sys.fightScreen.scale)
 	}
 }

--- a/src/font.go
+++ b/src/font.go
@@ -948,8 +948,17 @@ func (ts *TextSprite) drawWindow() [4]int32 {
 }
 
 func (ts *TextSprite) SetColor(r, g, b, a int32) {
-	ts.palfx.setColor(r, g, b)
 	ts.frgba = [4]float32{float32(r) / 255, float32(g) / 255, float32(b) / 255, float32(a) / 255}
+
+	// Sprite fonts use PalFX for color instead of frgba
+	// TTF skips PalFX here so that it won't stack with frgba
+	fnt := ts.fnt
+	if fnt == nil {
+		fnt = sys.debugFont.fnt
+	}
+	if fnt == nil || fnt.Type != "truetype" {
+		ts.palfx.setColor(r, g, b)
+	}
 }
 
 func (ts *TextSprite) SetTextSpacing(xs, ys float32) {

--- a/src/font.go
+++ b/src/font.go
@@ -603,14 +603,15 @@ func (f *Fnt) Print(txt string, x, y, xscl, yscl, rxadd float32, rot Rotation, p
 		if f.Type == "truetype" {
 			f.DrawTtf(txt, x, y, xscl, yscl, rxadd, rot, projectionMode, fLength, align, true, window, frgba, palfx, 0)
 		} else {
-			f.DrawText(txt, x, y, xscl, yscl, rxadd, rot, projectionMode, fLength, bank, align, window, palfx, frgba[3], 0)
+			f.DrawText(txt, x, y, xscl, yscl, rxadd, rot, projectionMode, fLength, bank, align, window, frgba, palfx, 0)
 		}
 	}
 }
 
 // DrawText prints on screen a specified text with the current font sprites
 func (f *Fnt) DrawText(txt string, x, y, xscl, yscl, rxadd float32,
-	rot Rotation, projectionMode int32, fLength float32, bank, align int32, window *[4]int32, palfx *PalFX, alpha float32, spacingXAdd int32) {
+	rot Rotation, projectionMode int32, fLength float32, bank, align int32, window *[4]int32,
+	frgba [4]float32, palfx *PalFX, spacingXAdd int32) {
 
 	if len(txt) == 0 || xscl == 0 || yscl == 0 {
 		return
@@ -668,13 +669,17 @@ func (f *Fnt) DrawText(txt string, x, y, xscl, yscl, rxadd float32,
 		f.lastPalBase = nil
 	}
 
+	alpha := frgba[3]
+	alphaVal := int32(255 * sys.brightness * alpha)
+
 	// Set the trans type
 	tt := TT_none
 	if alpha < 1.0 {
 		tt = TT_add
 	}
 
-	alphaVal := int32(255 * sys.brightness * alpha)
+	// Sprite fonts can't use frgba like TTF can, so we will leverage PalFX.mul to apply color
+	pfxCopy := palfx.withFontRgba(frgba)
 
 	// Initialize common render parameters
 	rp := RenderParams{
@@ -696,7 +701,7 @@ func (f *Fnt) DrawText(txt string, x, y, xscl, yscl, rxadd float32,
 		blendMode:      tt,
 		blendAlpha:     [2]int32{alphaVal, 255 - alphaVal},
 		mask:           0,
-		pfx:            palfx,
+		pfx:            pfxCopy,
 		window:         window,
 		rcx:            rcx,
 		rcy:            rcy,
@@ -949,16 +954,6 @@ func (ts *TextSprite) drawWindow() [4]int32 {
 
 func (ts *TextSprite) SetColor(r, g, b, a int32) {
 	ts.frgba = [4]float32{float32(r) / 255, float32(g) / 255, float32(b) / 255, float32(a) / 255}
-
-	// Sprite fonts use PalFX for color instead of frgba
-	// TTF skips PalFX here so that it won't stack with frgba
-	fnt := ts.fnt
-	if fnt == nil {
-		fnt = sys.debugFont.fnt
-	}
-	if fnt == nil || fnt.Type != "truetype" {
-		ts.palfx.setColor(r, g, b)
-	}
 }
 
 func (ts *TextSprite) SetTextSpacing(xs, ys float32) {
@@ -1389,6 +1384,7 @@ func (ts *TextSprite) draw(ln int16, clip *[4]int32) {
 	if ts.hidewithbars && sys.shouldHideWithBars() {
 		return
 	}
+
 	window := ts.drawWindow()
 	if clip != nil {
 		window = intersectRect(window, *clip)
@@ -1443,7 +1439,7 @@ func (ts *TextSprite) draw(ln int16, clip *[4]int32) {
 				xshear, ts.rot, ts.projection, ts.fLength, ts.align, true, &window, ts.frgba, ts.palfx, float32(spacingXAdd))
 		} else {
 			ts.fnt.DrawText(line[:charsToShow], ts.x+ts.vel[0]-xsoffset+phantomX, newY+ts.vel[1], ts.xscl, ts.yscl,
-				xshear, ts.rot, ts.projection, ts.fLength, ts.bank, ts.align, &window, ts.palfx, ts.frgba[3], spacingXAdd)
+				xshear, ts.rot, ts.projection, ts.fLength, ts.bank, ts.align, &window, ts.frgba, ts.palfx, spacingXAdd)
 		}
 
 		totalCharsShown += charsToShow

--- a/src/image.go
+++ b/src/image.go
@@ -370,32 +370,42 @@ func (pf *PalFX) synthesize(pfx *PalFX, blendMode TransType, alpha [2]int32) {
 
 }
 
-// Sets the PalFX to render a simple solid color. Normally used by fonts
-func (pf *PalFX) setColor(r, g, b int32) {
-	rNormalized := Clamp(r, 0, 255)
-	gNormalized := Clamp(g, 0, 255)
-	bNormalized := Clamp(b, 0, 255)
-
-	// Force PalFX to always enabled
-	pf.time = -1
-	pf.enable = true
-
-	// Set the minimum parameters required to achieve intended color
-	// This allows the other PalFX parameters to still work
-	pf.mul = [3]int32{
-		256 * rNormalized >> 8,
-		256 * gNormalized >> 8,
-		256 * bNormalized >> 8,
+// Returns a copy of the PalFX with font frgba applied as a base color
+// To do this perfectly correctly we'd need more shader uniforms
+// However, this should still be better than making font color parameter overwrite PalFX like before
+func (pf *PalFX) withFontRgba(frgba [4]float32) *PalFX {
+	usesColor := frgba[0] != 1.0 || frgba[1] != 1.0 || frgba[2] != 1.0
+	if !usesColor {
+		return pf
 	}
 
-	// Save sine effects timer
-	oldSintime := pf.sintime
+	var pfx *PalFX
+	if pf == nil {
+		// No existing PalFX: create a new one because RenderSprite expects a non-nil PalFX to apply color
+		pfx = newPalFX()
+	} else {
+		// Create a shallow copy of the original PalFX
+		tmp := *pf
+		pfx = &tmp
+	}
 
-	// Step the PalFX to update all effective values
-	pf.step()
+	// Force the copy to be enabled
+	pfx.enable = true
 
-	// Restore timer to prevent advancement
-	pf.sintime = oldSintime
+	// Check status of the original PalFX
+	if pf == nil || (!pf.enable && pf.time == 0) {
+		// Uninitialized or disabled: set color directly from frgba
+		pfx.eMul[0] = int32(256 * frgba[0])
+		pfx.eMul[1] = int32(256 * frgba[1])
+		pfx.eMul[2] = int32(256 * frgba[2])
+	} else {
+		// Active: stack frgba on top of existing eMul
+		pfx.eMul[0] = int32(float32(pf.eMul[0]) * frgba[0])
+		pfx.eMul[1] = int32(float32(pf.eMul[1]) * frgba[1])
+		pfx.eMul[2] = int32(float32(pf.eMul[2]) * frgba[2])
+	}
+
+	return pfx
 }
 
 type Palette struct {

--- a/src/image.go
+++ b/src/image.go
@@ -1454,22 +1454,6 @@ func newSff() (s *Sff) {
 	return
 }
 
-/*
-// A simple SFF cache storing shallow copies
-type SffCacheEntry struct {
-	sffData  Sff
-	refCount int
-}
-
-var SffCache = map[string]*SffCacheEntry{}
-
-func removeSFFCache(filename string) {
-	if _, ok := SffCache[filename]; ok {
-		delete(SffCache, filename)
-	}
-}
-*/
-
 // Find an already loaded SFF we can borrow. Replaces SFF caching
 func findActiveSff(filename string) *Sff {
 	// This would be clean, but it'd make multiple instances of the same character all do a full SFF reload
@@ -1613,18 +1597,6 @@ func loadSff(filename string, char bool, isMainThread bool, isActPal bool) (*Sff
 	if loadingCanceled() {
 		return nil, ErrLoadingCanceled
 	}
-
-	/*
-		SffCache[filename] = &SffCacheEntry{*s, 1}
-		runtime.SetFinalizer(s, func(s *Sff) {
-			if cached, ok := SffCache[filename]; ok {
-				cached.refCount--
-				if cached.refCount == 0 {
-					delete(SffCache, filename)
-				}
-			}
-		})
-	*/
 
 	return s, nil
 }

--- a/src/image.go
+++ b/src/image.go
@@ -376,14 +376,26 @@ func (pf *PalFX) setColor(r, g, b int32) {
 	gNormalized := Clamp(g, 0, 255)
 	bNormalized := Clamp(b, 0, 255)
 
+	// Force PalFX to always enabled
+	pf.time = -1
 	pf.enable = true
-	pf.eColor = 1
-	pf.eHue = 0
-	pf.eMul = [...]int32{
+
+	// Set the minimum parameters required to achieve intended color
+	// This allows the other PalFX parameters to still work
+	pf.mul = [3]int32{
 		256 * rNormalized >> 8,
 		256 * gNormalized >> 8,
 		256 * bNormalized >> 8,
 	}
+
+	// Save sine effects timer
+	oldSintime := pf.sintime
+
+	// Step the PalFX to update all effective values
+	pf.step()
+
+	// Restore timer to prevent advancement
+	pf.sintime = oldSintime
 }
 
 type Palette struct {

--- a/src/script.go
+++ b/src/script.go
@@ -3148,10 +3148,11 @@ func systemScriptInit(l *lua.LState) {
 						if !reload {
 							continue
 						}
-						if sys.cgi[i].sff != nil && !sys.cfg.Debug.KeepSpritesOnReload {
-							// removeSFFCache(sys.cgi[i].sff.filename)
+						// Drop sprites and sounds so that the cache systems won't reuse them
+						if !sys.cfg.Debug.KeepSpritesOnReload {
 							sys.cgi[i].sff = nil
 						}
+						sys.cgi[i].snd = nil
 						sys.cgi[i].customShaders = nil
 						if sys.reloadPreserveVars[i] {
 							sys.saveCharVars(i)
@@ -6856,10 +6857,6 @@ func systemScriptInit(l *lua.LState) {
 		sys.fightScreen.winCounts[tn-1].wins = int32(numArg(l, 2))
 		return 0
 	})
-	//luaRegister(l, "sffCacheDelete", func(l *lua.LState) int {
-	//	removeSFFCache(strArg(l, 1))
-	//	return 0
-	//})
 	luaRegister(l, "sffNew", func(l *lua.LState) int {
 		/*Load an SFF file or create an empty SFF.
 		@function sffNew

--- a/src/stage.go
+++ b/src/stage.go
@@ -433,13 +433,14 @@ func readBackGround(is IniSection, link *backGround,
 			}
 		}
 	}
-	if is.readI32ForStage("window", &bg.startrect[0], &bg.startrect[1],
+	// Unusually, Mugen only accepts these when they do have at least 4 values
+	if is.readI32ForStageMinLength("window", &bg.startrect[0], &bg.startrect[1],
 		&bg.startrect[2], &bg.startrect[3]) {
 		bg.startrect[2] = Max(0, bg.startrect[2]+1-bg.startrect[0])
 		bg.startrect[3] = Max(0, bg.startrect[3]+1-bg.startrect[1])
 		bg.notmaskwindow = 1
 	}
-	if is.readI32ForStage("maskwindow", &bg.startrect[0], &bg.startrect[1],
+	if is.readI32ForStageMinLength("maskwindow", &bg.startrect[0], &bg.startrect[1],
 		&bg.startrect[2], &bg.startrect[3]) {
 		bg.startrect[2] = Max(0, bg.startrect[2]-bg.startrect[0])
 		bg.startrect[3] = Max(0, bg.startrect[3]-bg.startrect[1])
@@ -1394,6 +1395,7 @@ func loadStage(def string, maindef bool) (*Stage, error) {
 			}
 		}
 		sec.readF32ForStage("offset", &s.sdw.offset[0], &s.sdw.offset[1])
+		// TODO: This should probably require 4 values
 		sec.readF32ForStage("window", &s.sdw.window[0], &s.sdw.window[1], &s.sdw.window[2], &s.sdw.window[3])
 		sec.ReadF32("ydelta", &s.sdw.ydelta)
 		// Shadow group warnings
@@ -1436,6 +1438,7 @@ func loadStage(def string, maindef bool) (*Stage, error) {
 			}
 		}
 		sec.readF32ForStage("offset", &s.reflection.offset[0], &s.reflection.offset[1])
+		// TODO: This should probably require 4 values
 		sec.readF32ForStage("window", &s.reflection.window[0], &s.reflection.window[1], &s.reflection.window[2], &s.reflection.window[3])
 		sec.ReadF32("ydelta", &s.reflection.ydelta)
 	}

--- a/src/stage.go
+++ b/src/stage.go
@@ -281,7 +281,7 @@ func readBackGround(is IniSection, link *backGround,
 				bg.anim = a
 				hasAnim = true
 			} else {
-				return nil, Error(fmt.Sprint("Missing action: %d", bg.actionno))
+				return nil, Error(fmt.Sprintf("Invalid BG action: %d", bg.actionno))
 			}
 		}
 		if hasAnim {


### PR DESCRIPTION
Fixes:
- Reloading now sets sound file to nil so that the cache system can't reuse the old file
- GetHitVar(isbound) clearing too early 
- Incorrect BG "missing action" error formatting
- Fixed "removetime >= 0" explods respecting pauses differently from "removetime <= -2"
- BG window/maskwindow parameters are now only accepted when they have at least 4 values
- Fixed sctrl window parameters crashing when less than 4 values are specified. The parameters are now rejected instead
- Fixes https://github.com/ikemen-engine/Ikemen-GO/issues/3882
- Fixes https://github.com/ikemen-engine/Ikemen-GO/issues/3884
- Fixes https://github.com/ikemen-engine/Ikemen-GO/issues/3889
- Fixes https://github.com/ikemen-engine/Ikemen-GO/issues/3890
- Fixes https://discord.com/channels/233345562261323776/233363722934943744/1538965272759631882

Refactor:
- Changed the way sprite font color is applied. Should stack with PalFX a bit better