### PR TITLE
fix: explod pausing, helper binding; refactor: motif logic stepping

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -1923,6 +1923,7 @@ func (e *Explod) pauseStatus() bool {
 	act := !paused
 
 	// Check ignorehitpause
+	// Unlike projectiles, an explod's hitpause seems to act the same as a full pause
 	if act && !e.ignorehitpause {
 		if parent := e.parent(); parent != nil {
 			act = parent.acttmp%2 >= 0
@@ -2472,6 +2473,7 @@ type Projectile struct {
 	time            int32
 	removeDone      bool
 	customShader    CustomShader
+	pauseBool       bool
 }
 
 func newProjectile() *Projectile {
@@ -2556,7 +2558,7 @@ func (p *Projectile) isActive() bool {
 	return p.status == ProjActive
 }
 
-func (p *Projectile) paused() bool {
+func (p *Projectile) pauseStatus() bool {
 	if sys.supertime > 0 {
 		if p.supermovetime == 0 || p.supermovetime < -1 {
 			return true
@@ -2574,9 +2576,14 @@ func (p *Projectile) update() {
 		return
 	}
 
+	// Update the paused state
+	// This used to be checked on every function call, which meant the same frame could have two values
+	if sys.tickNextFrame() {
+		p.pauseBool = p.pauseStatus()
+	}
+
 	// Check projectile removal conditions
-	// TODO: p.paused() should probably only be checked in one place, like explods
-	if sys.tickFrame() && !p.paused() && p.hitpause == 0 {
+	if sys.tickFrame() && !p.pauseBool && p.hitpause == 0 {
 		// Check if timer has expired or boundaries were reached
 		if p.status == ProjActive {
 			if p.removetime == 0 ||
@@ -2666,7 +2673,7 @@ func (p *Projectile) update() {
 		}
 	}
 
-	if p.paused() || p.hitpause > 0 || p.freezeflag {
+	if p.pauseBool || p.hitpause > 0 || p.freezeflag {
 		p.setAllPos(p.pos)
 		// There's a minor issue here where a projectile will lag behind one frame relative to Mugen if created during a pause
 	} else {
@@ -2834,7 +2841,7 @@ func (p *Projectile) tick() {
 		p.hitdef.air_juggle = 0
 	}
 
-	if !p.paused() {
+	if !p.pauseBool {
 		if p.hitpause <= 0 {
 			p.time++ // Only used in ProjVar currently
 			if p.removetime > 0 {
@@ -2877,10 +2884,11 @@ func (p *Projectile) cueDraw() {
 		return
 	}
 
+	isPaused := p.hitpause > 0 || p.pauseBool
+
 	// TODO: Gating UpdateSprite() during pauses makes it go out of sync with the animation data
 	// In the case of projectiles this can be seen with Clsn display
-	notpause := p.hitpause <= 0 && !p.paused()
-	if notpause && sys.tickFrame() {
+	if !isPaused && sys.tickFrame() {
 		p.anim.UpdateSprite()
 	}
 
@@ -2902,10 +2910,8 @@ func (p *Projectile) cueDraw() {
 		}
 	}
 
-	if sys.tickNextFrame() && (notpause || !p.paused()) {
-		if notpause {
-			p.anim.Action() // TODO: Placing this in cueDraw is a bit unusual. Confirm if it's right
-		}
+	if sys.tickNextFrame() && !isPaused {
+		p.anim.Action() // TODO: Placing this in cueDraw is a bit unusual. Confirm if it's right
 	}
 
 	// Set position
@@ -2988,7 +2994,7 @@ func (p *Projectile) cueDraw() {
 	// Record afterimage
 	if p.aimg != nil {
 		if p.aimg.isActive() {
-			p.aimg.recAndCue(sd, p.playerno, sys.tickNextFrame() && notpause, false)
+			p.aimg.recAndCue(sd, p.playerno, sys.tickNextFrame() && !isPaused, false)
 		} else {
 			p.aimg = nil
 		}

--- a/src/char.go
+++ b/src/char.go
@@ -1909,12 +1909,6 @@ func (e *Explod) setAnimElem() {
 }
 
 func (e *Explod) canAct() bool {
-	// Challenger screen also pauses the explod
-	// https://github.com/ikemen-engine/Ikemen-GO/issues/3684
-	if sys.motif.ch.active && sys.pausetime > 0 {
-		return false
-	}
-
 	// Determine pause state
 	paused := false
 	if sys.supertime > 0 {

--- a/src/char.go
+++ b/src/char.go
@@ -1613,7 +1613,6 @@ type Explod struct {
 	removeongethit      bool
 	removeonchangestate bool
 	hidewithbars        bool
-	statehaschanged     bool
 	removetime          int32
 	velocity            [3]float32
 	friction            [3]float32
@@ -1929,10 +1928,14 @@ func (e *Explod) canAct() bool {
 	return act
 }
 
+func (e *Explod) flagForRemoval() {
+	e.id = IErr
+	e.anim = nil
+}
+
 func (e *Explod) update() {
 	if e.id == IErr || e.anim == nil {
-		e.id = IErr
-		e.anim = nil
+		e.flagForRemoval()
 		return
 	}
 
@@ -1944,16 +1947,11 @@ func (e *Explod) update() {
 	parent := e.parent()
 
 	// Remove on get hit
-	if sys.tickNextFrame() && e.removeongethit &&
-		parent != nil && parent.csf(CSF_gethit) && !parent.inGuardState() {
-		e.id, e.anim = IErr, nil
-		return
-	}
-
-	// Remove on ChangeState
-	if sys.tickNextFrame() && e.removeonchangestate && e.statehaschanged {
-		e.id, e.anim = IErr, nil
-		return
+	if sys.tickNextFrame() {
+		if e.removeongethit && parent != nil && parent.csf(CSF_gethit) && !parent.inGuardState() {
+			e.flagForRemoval()
+			return
+		}
 	}
 
 	act := e.canAct()
@@ -1961,9 +1959,8 @@ func (e *Explod) update() {
 	// Explods aren't removed while they are paused
 	// https://github.com/ikemen-engine/Ikemen-GO/issues/3889
 	if act && sys.tickFrame() {
-		if e.removetime >= 0 && e.time >= e.removetime ||
-			e.removetime <= -2 && e.anim.loopend {
-			e.id, e.anim = IErr, nil
+		if e.removetime >= 0 && e.time >= e.removetime || e.removetime <= -2 && e.anim.loopend {
+			e.flagForRemoval()
 			return
 		}
 	}
@@ -6650,11 +6647,11 @@ func (c *Char) persistentChangeStateHitpauseCorrection(sbc *StateBytecode) {
 func (c *Char) stateChange2() bool {
 	if c.stchtmp && !c.hitPause() {
 		c.ss.sb.init(c)
-		// Flag RemoveOnChangeState explods for removal
+		// Execute explod removeOnChangeState
 		for i := range sys.explods[c.playerNo] {
 			e := sys.explods[c.playerNo][i]
 			if e.ownerId == c.id && e.removeonchangestate {
-				e.statehaschanged = true
+				e.flagForRemoval()
 			}
 		}
 		// Stop flagged sound channels

--- a/src/char.go
+++ b/src/char.go
@@ -7082,19 +7082,26 @@ func (c *Char) commitExplod(i int) {
 	// Init "ownpal" PalFX and RemapPal
 	// Note: Must be placed after setting up interpolation
 	if e.ownpal {
-		if !e.anim.isCommonFX() {
+		// Give the explod its own independent PalFX
+		e.palfx = newPalFX()
+
+		// Load the sctrl parameters into it
+		e.palfx.PalFXDef = e.palfxdef
+
+		// Handle RemapPal
+		if e.anim.isCommonFX() {
+			e.palfx.remap = nil
+		} else {
 			// Keep parent's remapped palette while resetting PalFX
 			parentRemap := make([]int, len(c.getPalfx().remap))
 			copy(parentRemap, c.getPalfx().remap)
-			e.palfx = newPalFX()
 			e.palfx.remap = parentRemap
-			e.palfx.PalFXDef = e.palfxdef
 			c.forceRemapPal(e.palfx, e.remappal)
-		} else {
-			e.palfx = newPalFX()
-			e.palfx.PalFXDef = e.palfxdef
-			e.palfx.remap = nil
 		}
+
+		// Update the PalFX immediately without advancing timers
+		// https://github.com/ikemen-engine/Ikemen-GO/issues/1693
+		e.palfx.refresh()
 	}
 
 	// Explod ready

--- a/src/char.go
+++ b/src/char.go
@@ -12135,9 +12135,12 @@ func (c *Char) actionRun() {
 	// Update binding others and binding to others
 	// In Mugen, binding to a target allows one to exit screen boundaries, hence being placed after xScreenBound()
 	if !c.pauseBool {
-		if !c.isTargetBound() {
-			c.updateBinding()
-		}
+		// This placement causes timing issues
+		// Maybe what needs to happen is actionRun() updates all binds related to this player
+		// That is, call updateBinding() for this player and the ones that are bound to it
+		//if !c.isTargetBound() {
+		//	c.updateBinding()
+		//}
 		for _, tid := range c.targets {
 			if t := sys.playerID(tid); t != nil && t.bindToId == c.id {
 				t.updateBinding()
@@ -12281,6 +12284,12 @@ func (c *Char) update() {
 				return
 			}
 		*/
+		// At the moment player binding must be handled differently between targets and helpers, or timing issues arise
+		// https://github.com/ikemen-engine/Ikemen-GO/issues/3915
+		// TODO: Better integration
+		if !c.pauseBool && !c.isTargetBound() {
+			c.updateBinding()
+		}
 		if c.acttmp > 0 {
 			if c.inGuardState() {
 				c.setSCF(SCF_guard)

--- a/src/char.go
+++ b/src/char.go
@@ -1674,6 +1674,7 @@ type Explod struct {
 	interpolate_xshear   [2]float32
 	timestamp            int32 // Determines run order
 	sortindex            int   // For faster run order sorting
+	pauseBool            bool
 
 	customShader CustomShader
 }
@@ -1907,8 +1908,11 @@ func (e *Explod) setAnimElem() {
 	}
 }
 
-func (e *Explod) canAct() bool {
-	// Determine pause state
+func (e *Explod) pauseStatus() bool {
+	// Check system pauses
+	// There's a difference here in how Ikemen and Mugen handle pauses
+	// In Mugen, explods will be paused in the same frame the pause is called
+	// In Ikemen, they still move during that frame like characters do, which arguably makes more sense
 	paused := false
 	if sys.supertime > 0 {
 		paused = (e.supermovetime >= 0 && e.time >= e.supermovetime) || e.supermovetime < -2
@@ -1918,14 +1922,14 @@ func (e *Explod) canAct() bool {
 
 	act := !paused
 
-	// Apply ignorehitpause
+	// Check ignorehitpause
 	if act && !e.ignorehitpause {
 		if parent := e.parent(); parent != nil {
 			act = parent.acttmp%2 >= 0
 		}
 	}
 
-	return act
+	return !act
 }
 
 func (e *Explod) flagForRemoval() {
@@ -1943,50 +1947,60 @@ func (e *Explod) update() {
 		return
 	}
 
-	// Fetch parent once. It's a more expensive operation than root()
-	parent := e.parent()
-
-	// Remove on get hit
-	if sys.tickNextFrame() {
-		if e.removeongethit && parent != nil && parent.csf(CSF_gethit) && !parent.inGuardState() {
+	// Remove time
+	// Removed during tickFrame() or a removetime of 0 would still be drawn during slow game speeds
+	// Note: e.update() runs on sys.tickNextFrame(), so sys.tickFrame() can only be true starting from the explod's second frame
+	if sys.tickFrame() {
+		if e.removetime >= 0 && e.time >= e.removetime ||
+			e.removetime <= -2 && e.anim.loopend {
 			e.flagForRemoval()
 			return
 		}
 	}
 
-	act := e.canAct()
-
-	// Explods aren't removed while they are paused
-	// https://github.com/ikemen-engine/Ikemen-GO/issues/3889
-	if act && sys.tickFrame() {
-		if e.removetime >= 0 && e.time >= e.removetime || e.removetime <= -2 && e.anim.loopend {
-			e.flagForRemoval()
-			return
+	// Remove on get hit
+	// Parent() should only be fetched once per function. It's a more expensive operation than root()
+	if sys.tickNextFrame() {
+		if e.removeongethit {
+			if parent := e.parent(); parent != nil {
+				if parent.csf(CSF_gethit) && !parent.inGuardState() {
+					e.flagForRemoval()
+					return
+				}
+			}
 		}
+	}
+
+	// Update the paused state
+	// This used to be checked on every function call, which meant the same frame could have two values
+	if sys.tickNextFrame() {
+		e.pauseBool = e.pauseStatus()
 	}
 
 	oldVer := e.root().gi().mugenver[0] != 1 || e.root().gi().mugenver[1] != 1
 
-	// Bind explod to parent
-	// In Mugen this only happens if the explod is not paused, hence "act"
-	if act && e.bindtime != 0 &&
-		(e.space == Space_stage || (e.space == Space_screen && (e.postype <= PT_P2 || oldVer))) {
-		if bindchar := sys.playerID(e.bindId); bindchar != nil {
-			e.pos[0] = bindchar.interPos[0]*bindchar.localscl/e.localscl + bindchar.offsetX()*bindchar.localscl/e.localscl
-			e.pos[1] = bindchar.interPos[1]*bindchar.localscl/e.localscl + bindchar.offsetY()*bindchar.localscl/e.localscl
-			e.pos[2] = bindchar.interPos[2] * bindchar.localscl / e.localscl
+	if !e.pauseBool {
+		// Bind explod to player
+		// In Mugen, this only happens while the explod is not paused
+		if e.bindtime != 0 &&
+			(e.space == Space_stage || (e.space == Space_screen && (e.postype <= PT_P2 || oldVer))) {
+			if bindchar := sys.playerID(e.bindId); bindchar != nil {
+				e.pos[0] = bindchar.interPos[0]*bindchar.localscl/e.localscl + bindchar.offsetX()*bindchar.localscl/e.localscl
+				e.pos[1] = bindchar.interPos[1]*bindchar.localscl/e.localscl + bindchar.offsetY()*bindchar.localscl/e.localscl
+				e.pos[2] = bindchar.interPos[2] * bindchar.localscl / e.localscl
+			} else {
+				// Doesn't seem necessary to do this, since MUGEN 1.1 seems to carry bindtime even if
+				// you change bindId to something that doesn't point to any character
+				// e.bindtime = 0
+				// e.setAllPosX(e.pos[0])
+				// e.setAllPosY(e.pos[1])
+			}
 		} else {
-			// Doesn't seem necessary to do this, since MUGEN 1.1 seems to carry bindtime even if
-			// you change bindId to something that doesn't point to any character
-			// e.bindtime = 0
-			// e.setAllPosX(e.pos[0])
-			// e.setAllPosY(e.pos[1])
-		}
-	} else {
-		// Explod position interpolation
-		spd := sys.tickInterpolation()
-		for i := range e.pos {
-			e.pos[i] = e.newPos[i] - (e.newPos[i]-e.oldPos[i])*(1-spd)
+			// Interpolate position
+			spd := sys.tickInterpolation()
+			for i := range e.pos {
+				e.pos[i] = e.newPos[i] - (e.newPos[i]-e.oldPos[i])*(1-spd)
+			}
 		}
 	}
 
@@ -2047,7 +2061,8 @@ func (e *Explod) update() {
 		}
 	}
 
-	if sys.tickFrame() && act {
+	// TODO: Gating UpdateSprite() during pauses makes it go out of sync with the animation data
+	if !e.pauseBool && sys.tickFrame() {
 		e.anim.UpdateSprite()
 	}
 
@@ -2059,35 +2074,45 @@ func (e *Explod) update() {
 		e.pos[2] + e.offset[2] + off[2] + e.interpolate_pos[2],
 	}
 
-	if sys.tickNextFrame() {
+	//if e.space == Space_screen && e.bindtime == 0 {
+	//	if e.space <= Space_none {
+	//		switch e.postype {
+	//		case PT_Left:
+	//			for i := range e.pos {
+	//				e.pos[i] = sys.cam.ScreenPos[i] + e.offset[i]/sys.cam.Scale
+	//			}
+	//		case PT_Right:
+	//			e.pos[0] = sys.cam.ScreenPos[0] +
+	//				(float32(sys.gameWidth)+e.offset[0])/sys.cam.Scale
+	//			e.pos[1] = sys.cam.ScreenPos[1] + e.offset[1]/sys.cam.Scale
+	//		}
+	//	} else if e.space == Space_screen {
+	//		for i := range e.pos {
+	//			e.pos[i] = sys.cam.ScreenPos[i] + e.offset[i]/sys.cam.Scale
+	//		}
+	//	}
+	//}
 
-		//if e.space == Space_screen && e.bindtime == 0 {
-		//	if e.space <= Space_none {
-		//		switch e.postype {
-		//		case PT_Left:
-		//			for i := range e.pos {
-		//				e.pos[i] = sys.cam.ScreenPos[i] + e.offset[i]/sys.cam.Scale
-		//			}
-		//		case PT_Right:
-		//			e.pos[0] = sys.cam.ScreenPos[0] +
-		//				(float32(sys.gameWidth)+e.offset[0])/sys.cam.Scale
-		//			e.pos[1] = sys.cam.ScreenPos[1] + e.offset[1]/sys.cam.Scale
-		//		}
-		//	} else if e.space == Space_screen {
-		//		for i := range e.pos {
-		//			e.pos[i] = sys.cam.ScreenPos[i] + e.offset[i]/sys.cam.Scale
-		//		}
-		//	}
-		//}
-
-		if act {
+	if !e.pauseBool {
+		// Step timers
+		if sys.tickFrame() {
+			e.time++
+			// In Mugen, bindTime uses a regular stepping timer, while movetime uses "e.time" comparison
+			if e.bindtime > 0 {
+				e.bindtime--
+			}
+		}
+		if sys.tickNextFrame() {
+			// Update PalFX
 			if e.palfx != nil && e.ownpal {
 				e.palfx.step()
 			}
+
 			e.oldPos = e.pos
 			e.newPos[0] = e.pos[0] + e.velocity[0]*e.facing
 			e.newPos[1] = e.pos[1] + e.velocity[1]
 			e.newPos[2] = e.pos[2] + e.velocity[2]
+
 			for i := range e.velocity {
 				e.velocity[i] *= e.friction[i]
 				e.velocity[i] += e.accel[i]
@@ -2095,16 +2120,15 @@ func (e *Explod) update() {
 					e.velocity[i] = 0
 				}
 			}
+
 			eleminterpolate := e.interpolate && e.interpolate_time[1] > 0 && e.interpolate_animelem[1] >= 0
 			if e.animfreeze || eleminterpolate {
 				e.setAnimElem()
 			} else {
 				e.anim.Action()
 			}
-			e.time++
-			if e.bindtime > 0 {
-				e.bindtime--
-			}
+
+			// Update shader effects
 			if e.customShader.name != "" {
 				e.customShader.sTime++
 				e.customShader.tex1.step()
@@ -2116,11 +2140,14 @@ func (e *Explod) update() {
 					e.customShader.clear()
 				}
 			}
-		} else {
-			e.setAllPosX(e.pos[0])
-			e.setAllPosY(e.pos[1])
-			e.setAllPosZ(e.pos[2])
 		}
+	}
+
+	// Freeze position while paused
+	if e.pauseBool && sys.tickNextFrame() {
+		e.setAllPosX(e.pos[0])
+		e.setAllPosY(e.pos[1])
+		e.setAllPosZ(e.pos[2])
 	}
 }
 
@@ -2136,7 +2163,6 @@ func (e *Explod) cueDraw() {
 	}
 
 	parent := e.parent()
-	act := e.canAct()
 
 	var pfx *PalFX
 	if e.palfx != nil && (!e.anim.isCommonFX() || e.ownpal) {
@@ -2154,7 +2180,7 @@ func (e *Explod) cueDraw() {
 	xshear := e.xshear
 
 	if e.interpolate {
-		e.Interpolate(act, &scale, &alp, &anglerot, &fLength, &xshear)
+		e.Interpolate(&scale, &alp, &anglerot, &fLength, &xshear)
 	}
 
 	if alp[0] < 0 {
@@ -2250,7 +2276,7 @@ func (e *Explod) cueDraw() {
 	// Record afterimage
 	if e.aimg != nil {
 		if e.aimg.isActive() {
-			e.aimg.recAndCue(sd, e.playerno, sys.tickNextFrame() && act,
+			e.aimg.recAndCue(sd, e.playerno, sys.tickNextFrame() && !e.pauseBool,
 				sys.tickNextFrame() && e.ignorehitpause && (e.supermovetime != 0 || e.pausemovetime != 0))
 		} else {
 			e.aimg = nil
@@ -2298,8 +2324,9 @@ func (e *Explod) cueDraw() {
 	}
 }
 
-func (e *Explod) Interpolate(act bool, scale *[2]float32, alpha *[2]int32, anglerot *[3]float32, fLength *float32, xshear *float32) {
-	if sys.tickNextFrame() && act {
+func (e *Explod) Interpolate(scale *[2]float32, alpha *[2]int32, anglerot *[3]float32, fLength *float32, xshear *float32) {
+	if !e.pauseBool && sys.tickNextFrame() {
+		// Determine progress (inverted)
 		t := float32(e.interpolate_time[1]) / float32(e.interpolate_time[0])
 		e.interpolate_fLength[0] = Lerp(e.interpolate_fLength[1], e.start_fLength, t)
 		e.interpolate_xshear[0] = Lerp(e.interpolate_xshear[1], e.start_xshear, t)
@@ -2548,6 +2575,7 @@ func (p *Projectile) update() {
 	}
 
 	// Check projectile removal conditions
+	// TODO: p.paused() should probably only be checked in one place, like explods
 	if sys.tickFrame() && !p.paused() && p.hitpause == 0 {
 		// Check if timer has expired or boundaries were reached
 		if p.status == ProjActive {
@@ -2849,6 +2877,8 @@ func (p *Projectile) cueDraw() {
 		return
 	}
 
+	// TODO: Gating UpdateSprite() during pauses makes it go out of sync with the animation data
+	// In the case of projectiles this can be seen with Clsn display
 	notpause := p.hitpause <= 0 && !p.paused()
 	if notpause && sys.tickFrame() {
 		p.anim.UpdateSprite()

--- a/src/image.go
+++ b/src/image.go
@@ -275,40 +275,77 @@ func (pf *PalFX) interpolationUpdate() {
 	pf.eHue = pf.eiHue + pf.hue
 }
 
-func (pf *PalFX) step() {
+// Updates the effective values. Does not step timers
+// Explods need this separation because they appear at tickFrame() but their PalFX only updates at tickNextFrame()
+func (pf *PalFX) refresh() {
 	pf.enable = pf.time != 0
-	if pf.enable {
-		pf.eInterpolate = pf.interpolate
-		if pf.eInterpolate {
-			pf.interpolationUpdate()
-		} else {
-			pf.eMul = pf.mul
-			pf.eAdd = pf.add
-			pf.eColor = pf.color
-			pf.eHue = pf.hue
+	if !pf.enable {
+		return
+	}
+
+	pf.eInterpolate = pf.interpolate
+
+	if pf.eInterpolate {
+		// Calculate interpolated values
+		t := float32(0)
+		if pf.itime > 0 {
+			t = float32(pf.eiTime) / float32(pf.itime)
 		}
-		pf.eInvertall = pf.invertall
-		if pf.invertblend <= -2 && pf.eInvertall {
-			pf.eInvertblend = 3
-		} else {
-			pf.eInvertblend = pf.invertblend
+		for i := 0; i < 3; i++ {
+			pf.eiMul[i] = int32(Lerp(float32(pf.imul[i+3]), float32(pf.imul[i]), t))
+			pf.eMul[i]  = int32(float32(pf.eiMul[i]) * float32(pf.mul[i]) / 256)
+			pf.eiAdd[i] = int32(Lerp(float32(pf.iadd[i+3]), float32(pf.iadd[i]), t))
+			pf.eAdd[i]  = pf.eiAdd[i] + pf.add[i]
 		}
-		pf.eAllowNeg = pf.allowNeg
-		pf.sinAdd(&pf.eAdd)
-		pf.sinMul(&pf.eMul)
-		pf.sinColor(&pf.eColor)
-		pf.sinHueshift(&pf.eHue)
-		if sys.tickFrame() {
-			for i := 0; i < 4; i++ {
-				if pf.cycletime[i] > 0 {
-					pf.sintime[i] = (pf.sintime[i] + 1) % pf.cycletime[i]
-				}
-			}
-			if pf.time > 0 {
-				pf.time--
-			}
+		pf.eiColor = Lerp(pf.icolor[1], pf.icolor[0], t)
+		pf.eColor  = pf.eiColor * pf.color
+		pf.eiHue   = Lerp(pf.ihue[1], pf.ihue[0], t)
+		pf.eHue    = pf.eiHue + pf.hue
+	} else {
+		// Static values
+		pf.eMul   = pf.mul
+		pf.eAdd   = pf.add
+		pf.eColor = pf.color
+		pf.eHue   = pf.hue
+	}
+
+	pf.eAllowNeg = pf.allowNeg
+	pf.eInvertall = pf.invertall
+	if pf.invertblend <= -2 && pf.eInvertall {
+		pf.eInvertblend = 3
+	} else {
+		pf.eInvertblend = pf.invertblend
+	}
+
+	// Sin effects
+	pf.sinAdd(&pf.eAdd)
+	pf.sinMul(&pf.eMul)
+	pf.sinColor(&pf.eColor)
+	pf.sinHueshift(&pf.eHue)
+}
+
+// Only responsible for stepping the timers
+func (pf *PalFX) tickTimers() {
+	if !pf.enable || !sys.tickFrame() {
+		return
+	}
+	for i := 0; i < 4; i++ {
+		if pf.cycletime[i] > 0 {
+			pf.sintime[i] = (pf.sintime[i] + 1) % pf.cycletime[i]
 		}
 	}
+	if pf.eInterpolate && pf.eiTime < pf.itime {
+		pf.eiTime++
+	}
+	if pf.time > 0 {
+		pf.time--
+	}
+}
+
+// The main PalFX update call
+func (pf *PalFX) step() {
+	pf.refresh()
+	pf.tickTimers()
 }
 
 func (pf *PalFX) synthesize(pfx *PalFX, blendMode TransType, alpha [2]int32) {

--- a/src/motif.go
+++ b/src/motif.go
@@ -3381,6 +3381,12 @@ func (me *MotifMenu) step(m *Motif) {
 		m.fadeIn.step()
 	}
 
+	// Drive the fightscreen's fade when quitting since sys.action() is paused
+	// TODO: Maybe we should be using the motif's fadeout here. Would require no workarounds
+	if sys.endMatch && me.state == ME_ClosingOut {
+		sys.fightScreen.round.fadeOut.step()
+	}
+
 	pm := me.pauseMenu(m)
 	switch me.state {
 	case ME_OpeningOut:
@@ -3399,6 +3405,15 @@ func (me *MotifMenu) step(m *Motif) {
 			me.state = ME_Open
 		}
 	case ME_ClosingOut:
+		// If exiting match from the pause menu
+		if sys.endMatch {
+			if sys.fightScreen.round.fadeOut.isActive() {
+				return
+			}
+			me.reopenLock = true
+			me.reset(m)
+			return
+		}
 		if m.fadeOut.isActive() {
 			return
 		}
@@ -3424,7 +3439,7 @@ func (me *MotifMenu) runLua(m *Motif) {
 	}
 	if ok, err := ExecFunc(sys.luaLState, "menuRun"); err != nil {
 		sys.luaLState.RaiseError("Error executing Lua code: %v\n", err.Error())
-	} else if !ok && !sys.endMatch {
+	} else if !ok {
 		me.requestClose(m)
 	}
 }
@@ -3499,11 +3514,16 @@ func (ch *MotifChallenger) step(m *Motif) {
 		startFadeOut(m.ChallengerInfo.FadeOut.FadeData, m.fadeOut, false, m.fadePolicy)
 		ch.endTimer = ch.counter + m.fadeOut.timeRemaining
 	}
-	sys.setGSF(GSF_nobardisplay)
-	sys.setGSF(GSF_nomusic)
-	sys.setGSF(GSF_timerfreeze)
+
+	// These were a convenience. Motif should block these things directly or with system flags instead
+	//sys.setGSF(GSF_nobardisplay) // They already hide without this
+	//sys.setGSF(GSF_nomusic) // Checked in tickSound()
+	//sys.setGSF(GSF_timerfreeze) // Now redundant because game pauses
+
 	if ch.counter == m.ChallengerInfo.Pause.Time {
-		sys.pausetime = m.ChallengerInfo.Time + m.ChallengerInfo.FadeOut.FadeData.duration()
+		// Motif shouldn't touch game variables
+		// https://github.com/ikemen-engine/Ikemen-GO/issues/3684
+		//sys.pausetime = m.ChallengerInfo.Time + m.ChallengerInfo.FadeOut.FadeData.duration()
 		sys.stopAllCharSounds()
 	}
 	if ch.counter == m.ChallengerInfo.Snd.Time {

--- a/src/system.go
+++ b/src/system.go
@@ -1023,7 +1023,8 @@ func (s *System) tickSound() {
 	}
 
 	// Always pause if noMusic flag set, pause master volume is 0, or freqmul is 0.
-	s.bgm.SetPaused(s.nomusic || (s.paused && s.cfg.Sound.PauseMasterVolume == 0) || (s.bgm.freqmul == 0))
+	bgmPause := s.nomusic || (s.paused && s.cfg.Sound.PauseMasterVolume == 0) || s.bgm.freqmul == 0 || s.motifPauseMusic()
+	s.bgm.SetPaused(bgmPause)
 
 	if s.paused {
 		// Apply BGM pause volume once per pause, even when the original BGM volume is 0.
@@ -2494,6 +2495,30 @@ func (s *System) debugPaused() bool {
 	return s.paused && !s.frameStepFlag && s.oldTickCount < s.tickCount
 }
 
+func (s *System) motifPauseGame() bool {
+	// Menu is open
+	if s.motif.me.active {
+		return true
+	}
+	// Challenger screen triggered
+	// TODO: Maybe this should always pause instead of having a "time" parameter
+	if s.motif.ch.active && s.motif.ch.counter >= s.motif.ChallengerInfo.Pause.Time {
+		return true
+	}
+	return false
+}
+
+func (s *System) matchPaused() bool {
+	return s.debugPaused() || s.motifPauseGame()
+}
+
+func (s *System) motifPauseMusic() bool {
+	if s.motif.ch.active && s.motif.ch.counter >= s.motif.ChallengerInfo.Pause.Time {
+		return true
+	}
+	return false
+}
+
 // "Tick frames" are the frames where most of the game logic happens
 func (s *System) tickFrame() bool {
 	return (!s.paused || s.frameStepFlag) && s.oldTickCount < s.tickCount
@@ -2518,6 +2543,10 @@ func (s *System) tickInterpolation() float32 {
 		return Clamp(progress, 0, 1)
 	}
 	return 1
+}
+
+func (s *System) uiTick() bool {
+	return s.tickFrame() || s.debugPaused() || s.motif.me.active || s.motif.ch.active
 }
 
 func (s *System) addFrameTime(t float32) bool {
@@ -2666,19 +2695,18 @@ func (s *System) screenright() float32 {
 	return float32(s.stage.screenright) * s.stage.localscl
 }
 
+// Core game logic. Chars, stage, projectiles, etc
+// The part that can rewind and fast forward during rollbacks
 func (s *System) action() {
+	if s.matchPaused() {
+		return
+	}
+
+	// TODO: This and all "cueDraw" could also be separated from action()
 	s.clearSpriteData()
 
 	var x, y, scl float32 = s.cam.Pos[0], s.cam.Pos[1], s.cam.Scale / s.cam.BaseScale()
 	s.cam.ResetTracking()
-	uiTick := s.tickFrame() || s.debugPaused() || s.motif.me.active
-	if uiTick {
-		if s.escPending {
-			s.esc = true
-			s.escPending = false
-		}
-		s.uiFrameCounter++
-	}
 
 	// Update round state
 	// This is also reflected on characters (intros, win poses)
@@ -2861,28 +2889,37 @@ func (s *System) action() {
 		}
 	}
 
-	if uiTick {
-		// Update motif
-		// Needs to happen at the very end or pause toggles will get out of sync
-		// https://github.com/ikemen-engine/Ikemen-GO/issues/3080
-		s.motif.step()
+	return
+}
 
-		// Run motif
-		s.motif.act()
+func (s *System) uiAction() {
+	if !s.uiTick() {
+		return
+	}
 
-		// Common Lua calls
-		// Needs to happen after motif update or motif inputs will lag 1 frame
-		for _, key := range SortedKeys(sys.cfg.Common.Lua) {
-			for _, v := range sys.cfg.Common.Lua[key] {
-				if err := sys.luaLState.DoString(v); err != nil {
-					sys.luaLState.RaiseError("Error executing Lua code: %s\n%v", v, err.Error())
-				}
+	if s.escPending {
+		s.esc = true
+		s.escPending = false
+	}
+	s.uiFrameCounter++
+
+	// Step motif
+	// Needs to happen at the very end or pause toggles will get out of sync
+	// https://github.com/ikemen-engine/Ikemen-GO/issues/3080
+	s.motif.step()
+
+	// Run motif
+	s.motif.act()
+
+	// Common Lua calls
+	// Needs to happen after motif update or motif inputs will lag 1 frame
+	for _, key := range SortedKeys(sys.cfg.Common.Lua) {
+		for _, v := range sys.cfg.Common.Lua[key] {
+			if err := sys.luaLState.DoString(v); err != nil {
+				sys.luaLState.RaiseError("Error executing Lua code: %s\n%v", v, err.Error())
 			}
 		}
 	}
-
-	s.tickSound()
-	return
 }
 
 // Update all projectiles for all players
@@ -2925,9 +2962,10 @@ func (s *System) projectilePrune(pn int) {
 func (s *System) explodUpdate() {
 	// Checking for pause here fixes explods travelling too far while game is paused
 	// https://github.com/ikemen-engine/Ikemen-GO/issues/1729
-	if s.paused && !s.frameStepFlag {
-		return
-	}
+	// Update: this fix is no longer necessary after the sys.action()/sys.uiAction() refactor
+	//if s.paused && !s.frameStepFlag {
+	//	return
+	//}
 
 	// Update each explod in storage order
 	for i := range s.explods {
@@ -3834,6 +3872,18 @@ func (s *System) drawDebugText(logicState drawAspectState) {
 	//}
 }
 
+func (s *System) keepMatchRunning() bool {
+	// Match still in progress
+	if !s.endMatch {
+		return true
+	}
+	// Match ended, but fightscreen fade still needs time to complete
+	if s.fightScreen.round.fadeOut.isActive() {
+		return true
+	}
+	return false
+}
+
 // Starts and runs gameplay
 // Called to start each match, on hard reset with shift+F4,
 // and at the start of any round where a new character tags in for turns mode
@@ -3926,7 +3976,7 @@ func (s *System) runMatch() (reload bool) {
 	}
 
 	// Loop until end of match
-	for !s.endMatch || s.fightScreen.round.fadeOut.isActive() {
+	for s.keepMatchRunning() {
 		s.frameStepFlag = false
 
 		for _, v := range s.shortcutScripts {
@@ -3954,6 +4004,12 @@ func (s *System) runMatch() (reload bool) {
 
 		// Update game state
 		s.action()
+
+		// Update motif
+		s.uiAction()
+
+		// Step sounds after both the core game and motif have updated
+		s.tickSound()
 
 		debugInput()
 
@@ -4031,7 +4087,7 @@ func (s *System) runMatch() (reload bool) {
 			break
 		}
 
-		if s.endMatch && !s.fightScreen.round.fadeOut.isActive() {
+		if !s.keepMatchRunning() {
 			break
 		}
 

--- a/src/system.go
+++ b/src/system.go
@@ -2750,6 +2750,10 @@ func (s *System) action() {
 		}
 
 		// Start pause timers
+		// In Mugen, this seems to happen in the same frame the pause is called, after all chars run
+		// Explod pausing behavior backs it up, since they pause immediately in the same frame
+		// But the screen darkening only happens in the next frame and thus lasts 1 frame shorter than expected
+		// Ikemen's way is a bit more consistent, but causes https://github.com/ikemen-engine/Ikemen-GO/issues/3889
 		if s.supertimebuffer < 0 {
 			s.supertimebuffer = ^s.supertimebuffer
 			s.supertime = s.supertimebuffer

--- a/src/system.go
+++ b/src/system.go
@@ -6494,16 +6494,30 @@ func (l *Loader) load() {
 }
 
 func (l *Loader) reset() {
-	if l.state != LS_NotYet {
+	// Already idle
+	if l.state == LS_NotYet {
+		return
+	}
+
+	if l.state == LS_Loading {
 		// Ensure the loader goroutine gets a cooperative cancel signal.
 		l.requestCancel()
 		l.state = LS_Cancel
 		<-l.loadExit
-		l.state = LS_NotYet
+	} else {
+		// Loader already stopped
+		// Don't wait on loadExit because that can hang if nothing is left to receive
+		select {
+		case <-l.loadExit:
+		default:
+		}
 	}
+	l.state = LS_NotYet
 	l.err = nil
 	l.cancelCh = nil
 	l.cancelOnce = sync.Once{}
+
+	// Drop palette selections from a cancelled load
 	for i := range sys.cgi {
 		keepPreloadedTurnsPal := sys.cfg.Config.TurnsLoading && sys.roundNo > 1 && sys.tmode[i&1] == TM_Turns
 		if sys.roundsExisted[i&1] == 0 && !keepPreloadedTurnsPal {

--- a/src/system.go
+++ b/src/system.go
@@ -2923,6 +2923,12 @@ func (s *System) projectilePrune(pn int) {
 
 // Update all explods for all players
 func (s *System) explodUpdate() {
+	// Checking for pause here fixes explods travelling too far while game is paused
+	// https://github.com/ikemen-engine/Ikemen-GO/issues/1729
+	if s.paused && !s.frameStepFlag {
+		return
+	}
+
 	// Update each explod in storage order
 	for i := range s.explods {
 		for _, e := range s.explods[i] {


### PR DESCRIPTION
Fixes:
- Fixed explods interpolating while game is paused
- Fixed characters treating the challenger screen as a regular pause, which allows their movement under some conditions
- Fixed explod PalFX being delayed under slow game speeds
- Fixed explod PalFX interpolation timer stepping differently from the regular timer
- VS screen loading sometimes hanging
- Adjusted how explods are paused and unpaused
- Projectile pause status is now checked once per logic frame instead of constantly
- Partially revert previous helper binding change
- Fixes #1693 
- Fixes #1729 
- Fixes #3684 
- Fixes #3914 
- Fixes #3915 
- Fixes #3922
- Reintroduces #3889 

Refactor:
- Decouple motif from sys.action(). This leaves sys.action() for only the "fighting game" part of the engine
- Unified explod removal logic a bit. Changed where removeOnChangeState is applied