### PR TITLE
fix: rollback match hanging before victory screen

### DIFF
--- a/src/rollback.go
+++ b/src/rollback.go
@@ -45,6 +45,7 @@ func (rs *RollbackSystem) hijackRunMatch() bool {
 	var running bool
 
 	// Loop until end of match
+	// Not "sys.keepMatchRunning()" because rollback loop ends earlier than local loop
 	for !sys.endMatch {
 		rs.session.now = time.Now().UnixMilli()
 		err := rs.session.backend.Idle(
@@ -70,6 +71,8 @@ func (rs *RollbackSystem) hijackRunMatch() bool {
 		if sys.esc || !running {
 			break
 		}
+
+		sys.tickSound()
 
 		sys.renderFrame()
 
@@ -232,6 +235,9 @@ func (rs *RollbackSystem) simulateFrame() bool {
 
 	// Update game state
 	sys.action()
+
+	// Update motif state
+	sys.uiAction()
 
 	// if rs.handleFlags() {
 	//	return true

--- a/src/rollback.go
+++ b/src/rollback.go
@@ -32,7 +32,7 @@ type RollbackProperties struct {
 }
 
 // TODO: Merge with system.go
-func (rs *RollbackSystem) hijackRunMatch(s *System) bool {
+func (rs *RollbackSystem) hijackRunMatch() bool {
 	// Shared part up until this point already handled by sys.runMatch()
 
 	// Reset variables
@@ -45,7 +45,7 @@ func (rs *RollbackSystem) hijackRunMatch(s *System) bool {
 	var running bool
 
 	// Loop until end of match
-	for !s.endMatch {
+	for !sys.endMatch {
 		rs.session.now = time.Now().UnixMilli()
 		err := rs.session.backend.Idle(
 			int(math.Max(0, float64(rs.session.next-rs.session.now-1))))
@@ -54,29 +54,29 @@ func (rs *RollbackSystem) hijackRunMatch(s *System) bool {
 		}
 
 		// Desync/disconnect callbacks may request a session abort outside the normal input path.
-		if s.esc {
+		if sys.esc {
 			break
 		}
 
 		// Sync speculative inputs and run a speculative frame
-		running = rs.runFrame(s)
+		running = rs.runFrame()
 
-		if s.fightLoopEnd && !s.postMatchFlg {
+		if sys.fightLoopEnd && !sys.postMatchFlg {
 			break
 		}
 
 		rs.session.next = rs.session.now + 1000/60
 
-		if s.esc || !running {
+		if sys.esc || !running {
 			break
 		}
 
-		s.renderFrame()
+		sys.renderFrame()
 
 		//rs.session.loopTimer.usToWaitThisLoop()
-		running = s.update()
+		running = sys.update()
 
-		if s.esc || !running {
+		if sys.esc || !running {
 			break
 		}
 	}
@@ -153,11 +153,11 @@ func (rs *RollbackSystem) postMatchSetup() {
 
 // Called once per frame by the main game loop
 // Responsible for collecting local inputs and driving the GGPO backend forward
-func (rs *RollbackSystem) runFrame(s *System) bool {
+func (rs *RollbackSystem) runFrame() bool {
 	var buffer []byte
 	var ggpoerr error
 
-	if s.esc {
+	if sys.esc {
 		return false
 	}
 
@@ -195,7 +195,7 @@ func (rs *RollbackSystem) runFrame(s *System) bool {
 			}
 
 			// Commit this frame to GGPO even if this frame exits gameplay.
-			keepRunning := rs.simulateFrame(s)
+			keepRunning := rs.simulateFrame()
 
 			defer func() {
 				if re := recover(); re != nil {
@@ -211,7 +211,7 @@ func (rs *RollbackSystem) runFrame(s *System) bool {
 			if err != nil {
 				panic(err)
 			}
-			if s.esc || !keepRunning {
+			if sys.esc || !keepRunning {
 				return false
 			}
 		}
@@ -222,8 +222,8 @@ func (rs *RollbackSystem) runFrame(s *System) bool {
 
 // Contains the logic for a single frame of the game
 // Called by both runFrame for speculative execution, and AdvanceFrame for confirmed execution
-func (rs *RollbackSystem) simulateFrame(s *System) bool {
-	s.frameStepFlag = false
+func (rs *RollbackSystem) simulateFrame() bool {
+	sys.frameStepFlag = false
 
 	// If next round
 	if !sys.runNextRound() {
@@ -231,40 +231,40 @@ func (rs *RollbackSystem) simulateFrame(s *System) bool {
 	}
 
 	// Update game state
-	s.action()
+	sys.action()
 
-	// if rs.handleFlags(s) {
+	// if rs.handleFlags() {
 	//	return true
 	// }
 
-	if !rs.updateEvents(s) {
+	if !rs.updateEvents() {
 		return false
 	}
 
 	// Break if finished
-	if s.fightLoopEnd && !s.postMatchFlg {
+	if sys.fightLoopEnd && !sys.postMatchFlg {
 		return false
 	}
 
 	// Update system; break if update returns false (game ended)
-	//if !s.update() {
+	//if !sys.update() {
 	//	return false
 	//}
 
 	// If end match selected from menu/end of attract mode match/etc
-	if s.endMatch {
-		s.esc = true
+	if sys.endMatch {
+		sys.esc = true
 		return false
-	} else if s.esc {
-		s.endMatch = s.netConnection != nil
+	} else if sys.esc {
+		sys.endMatch = sys.netConnection != nil
 		return false
 	}
 	return true
 }
 
-func (rs *RollbackSystem) updateEvents(s *System) bool {
-	if !s.addFrameTime(s.turbo) {
-		if !s.eventUpdate() {
+func (rs *RollbackSystem) updateEvents() bool {
+	if !sys.addFrameTime(sys.turbo) {
+		if !sys.eventUpdate() {
 			return false
 		}
 		return false
@@ -751,7 +751,7 @@ func (r *RollbackSession) AdvanceFrame(flags int) {
 			r.netTime++
 		}
 		// As in runFrame(): commit rollback re-simulated frames to GGPO even if this frame exits gameplay.
-		_ = sys.rollback.simulateFrame(&sys)
+		_ = sys.rollback.simulateFrame()
 		defer func() {
 			if re := recover(); re != nil {
 				if r.config.DesyncTest {

--- a/src/system.go
+++ b/src/system.go
@@ -4038,7 +4038,7 @@ func (s *System) runMatch() (reload bool) {
 	// Now switch to rollback if applicable
 	// TODO: More merging so we don't hijack this function at all
 	if s.rollback.session != nil || s.cfg.Netplay.Rollback.DesyncTestFrames > 0 {
-		return s.rollback.hijackRunMatch(s)
+		return s.rollback.hijackRunMatch()
 	}
 
 	// Loop until end of match


### PR DESCRIPTION
- Also fixed rollback loop missing sys.tickSound()
- Removed leftover and unnecessary "sys" arguments in rollback code since that's a global variable
- Fixes #3940 