### PR TITLE
fix: split cueDraw from action

### DIFF
--- a/src/char.go
+++ b/src/char.go
@@ -12425,6 +12425,7 @@ func (c *Char) update() {
 		}
 		c.finalDefense = float64(((float32(c.gi().defenceBase) * customDefense * c.superDefenseMul * c.fallDefenseMul) / 100))
 	}
+
 	// Update position interpolation
 	if c.acttmp > 0 {
 		spd := sys.tickInterpolation()
@@ -12437,6 +12438,7 @@ func (c *Char) update() {
 			}
 		}
 	}
+
 	// KO sound echo
 	if c.koEchoTimer > 0 {
 		if !c.scf(SCF_ko) || sys.gsf(GSF_nokosnd) {
@@ -12453,6 +12455,19 @@ func (c *Char) update() {
 			}
 			c.koEchoTimer++
 		}
+	}
+
+	if sys.tickNextFrame() {
+		// Reset interpolation reference position
+		c.oldPos = c.pos
+		//c.dustOldPos = c.pos // We need this one separated because PosAdd and such change oldPos
+
+		// Reset pushed flag
+		// This flag is used to prevent position interpolation when chars push each other
+		c.pushed = false
+
+		// Signal that all tasks have finished
+		c.minus = 3
 	}
 }
 
@@ -12651,13 +12666,14 @@ func (c *Char) tick() {
 			c.ghv.down_recovertime -= RandI(1, (c.ghv.down_recovertime+1)/2)
 		}
 	}
-	// Reset pushed flag
-	// This flag is apparently used to prevent position interpolation when chars push each other
-	c.pushed = false
 }
 
 // Prepare collision boxes and debug text for drawing
 func (c *Char) cueDebugDraw() {
+	// Known issue: positions and player pushing resolve on different tick conditions,
+	// so Clsn can briefly draw a "moved but not pushed" overlap at slow game speeds
+	// Using oldPos here would fix it, but it's also a bit of a hack and the issue is harmless
+	// The alternative is far more dangerous: reordering globalCollision() and such functions
 	x := c.pos[0] * c.localscl
 	y := c.pos[1] * c.localscl
 	xoff := x + c.offsetX()*c.localscl
@@ -12666,6 +12682,7 @@ func (c *Char) cueDebugDraw() {
 	ys := c.clsnScale[1]
 	angle := c.clsnAngle * c.facing
 	nhbtxt := ""
+
 	// Debug Clsn display
 	if sys.clsnDisplay {
 		if c.curFrame != nil {
@@ -12825,6 +12842,7 @@ func (c *Char) cueDebugDraw() {
 		// Add crosshair
 		sys.debugch.Add([][4]float32{{-1, -1, 1, 1}}, x, y, 1, 1, 0)
 	}
+
 	// Prepare information for debug text
 	if sys.debugDisplay {
 		// Add debug Clsn text
@@ -13116,12 +13134,6 @@ func (c *Char) cueDraw() {
 				sys.reflectionList.add(rs)
 			}
 		}
-	}
-	if sys.tickNextFrame() {
-		// Signal that all tasks have finished
-		c.minus = 3
-		c.oldPos = c.pos
-		//c.dustOldPos = c.pos // We need this one separated because PosAdd and such change oldPos
 	}
 }
 

--- a/src/rollback.go
+++ b/src/rollback.go
@@ -72,8 +72,9 @@ func (rs *RollbackSystem) hijackRunMatch() bool {
 			break
 		}
 
+		// These are outside runFrame(), so they won't be needlessly executed during a rollback
 		sys.tickSound()
-
+		sys.cueDraw()
 		sys.renderFrame()
 
 		//rs.session.loopTimer.usToWaitThisLoop()

--- a/src/system.go
+++ b/src/system.go
@@ -915,19 +915,7 @@ func (s *System) renderFrame() {
 	}
 	defer s.restoreAspectState(logicState)
 
-	if !s.frameSkip {
-		x, y, scl := s.cam.Pos[0], s.cam.Pos[1], s.cam.Scale/s.cam.BaseScale()
-		dx, dy, dscl := s.zoom.apply(x, y, scl)
-		s.draw(dx, dy, dscl)
-	}
-
-	// Lua
-	if !s.frameSkip {
-		s.luaFlushDrawQueue()
-		// Fullscreen fades are the final scene pass, after all deferred Lua UI.
-		s.fightScreen.drawFade()
-		s.motif.drawFade()
-	} else {
+	if s.frameSkip {
 		// Keep pause-menu logic responsive even when this render frame is skipped.
 		// Any queued draw ops are discarded below because this frame is not being rendered.
 		if s.motif.me.active {
@@ -935,15 +923,24 @@ func (s *System) renderFrame() {
 		}
 		// On skipped frames, discard queued draws to avoid buildup.
 		s.luaDiscardDrawQueue()
+		return
 	}
+
+	x, y, scl := s.cam.Pos[0], s.cam.Pos[1], s.cam.Scale/s.cam.BaseScale()
+	dx, dy, dscl := s.zoom.apply(x, y, scl)
+	s.draw(dx, dy, dscl)
+
+	// Lua
+	s.luaFlushDrawQueue()
+	// Fullscreen fades are the final scene pass, after all deferred Lua UI.
+	s.fightScreen.drawFade()
+	s.motif.drawFade()
 
 	// Render top elements
-	if !s.frameSkip {
-		s.drawTop()
-	}
+	s.drawTop()
 
 	// Render debug elements
-	if !s.frameSkip && s.debugDisplay {
+	if s.debugDisplay {
 		// Re-mask fight-only frames before drawing full-resolution debug panels.
 		if s.middleOfMatch() && !s.motifOverlayActive() {
 			s.motif.drawAspectBars()
@@ -2740,6 +2737,26 @@ func (s *System) clearSpriteData() {
 	}
 }
 
+// Centralized call of every cueDraw()
+func (s *System) cueDraw() {
+	// No need to cue when we won't render
+	if s.frameSkip {
+		return
+	}
+
+	// Start fresh each frame
+	s.clearSpriteData()
+
+	for i := range s.projs {
+		for _, p := range s.projs[i] {
+			p.cueDraw()
+		}
+	}
+
+	s.charList.cueDraw()
+	s.explodCueDraw()
+}
+
 func (s *System) screenleft() float32 {
 	return float32(s.stage.screenleft) * s.stage.localscl
 }
@@ -2754,9 +2771,6 @@ func (s *System) action() {
 	if s.matchPaused() {
 		return
 	}
-
-	// TODO: This and all "cueDraw" could also be separated from action()
-	s.clearSpriteData()
 
 	var x, y, scl float32 = s.cam.Pos[0], s.cam.Pos[1], s.cam.Scale / s.cam.BaseScale()
 	s.cam.ResetTracking()
@@ -2879,18 +2893,9 @@ func (s *System) action() {
 	}
 	s.charList.xScreenBound()
 
-	for i := range s.projs {
-		for _, p := range s.projs[i] {
-			p.cueDraw()
-		}
-	}
-
-	s.charList.cueDraw()
-
 	// Note: Explod update must happen after hit detection. Because hit sparks are also explods
 	s.explodUpdate()
 	s.charTextsUpdate()
-	s.explodCueDraw()
 
 	// Adjust game speed
 	if s.tickNextFrame() && !s.motif.me.active {
@@ -4168,7 +4173,8 @@ func (s *System) runMatch() (reload bool) {
 			break
 		}
 
-		// Render frame
+		// Cue sprites, then render
+		s.cueDraw()
 		s.renderFrame()
 
 		// Update system. Break if update returns false (engine shutdown).


### PR DESCRIPTION
- Sprite cuing now happens independently of game logic
- Makes rolling back frames more efficient, since we no longer uselessly cue/clear sprite data in every one of those frames
- Fixed char position interpolation acting strange at low game speeds
- Fixes #3945 