### PR TITLE
fix: close replay file after recording, exclude replays from rollback sync test

### DIFF
--- a/src/netplay.go
+++ b/src/netplay.go
@@ -255,6 +255,11 @@ func (nc *NetConnection) Close() {
 		close(nc.recvEnd)
 		nc.recvEnd = nil
 	}
+	if nc.recording != nil {
+		nc.recording.Close()
+		nc.recording = nil
+		nc.headerWritten = false
+	}
 	nc.conn = nil
 	nc.uiInputDebounced = false
 }

--- a/src/resources/defaultConfig.ini
+++ b/src/resources/defaultConfig.ini
@@ -373,13 +373,14 @@ Rollback.LogsEnabled           = 0
 ; Force complete stage data in rollback save states. This costs extra memory and
 ; CPU. Stages detected as mutable does this even when SaveStageData is disabled.
 Rollback.SaveStageData         = 0
-; Use detailed GameState checksums for rollback save-state validation.
-; Useful for determinism testing; combine with DesyncTestFrames > 0.
+; Netplay/offline sync test: enable detailed GameState checksums.
+; Does not enable either mode; pair with DesyncTestFrames for offline checks.
 Rollback.DesyncTest            = 0
-; Number of frames between local rollback synchronization checks (1-8).
+; Offline sync test only: enable it and re-simulate every N frames (1-8).
+; Pair with DesyncTest=1 to detect state mismatches; 0 disables the test.
 Rollback.DesyncTestFrames      = 0
-; Use RNG inputs instead of controller inputs in the local synchronization test.
-; Has an effect only when DesyncTestFrames > 0.
+; Offline sync test only: use AI-generated inputs instead of controller input.
+; Requires DesyncTestFrames > 0.
 Rollback.DesyncTestAI          = 0
 ; List of saved IP addresses that will populate the netplay connection menu
 ; IP.<name> = <IP address>

--- a/src/script.go
+++ b/src/script.go
@@ -5914,12 +5914,11 @@ func systemScriptInit(l *lua.LState) {
 				sys.rollback.session.recording.Close()
 				sys.rollback.session.recording = nil
 			}
-		} else {
-			if sys.netConnection != nil && sys.netConnection.recording != nil {
-				sys.netConnection.recording.Close()
-				sys.netConnection.recording = nil
-				sys.netConnection.headerWritten = false
-			}
+		}
+		if sys.netConnection != nil && sys.netConnection.recording != nil {
+			sys.netConnection.recording.Close()
+			sys.netConnection.recording = nil
+			sys.netConnection.headerWritten = false
 		}
 		return 0
 	})

--- a/src/system.go
+++ b/src/system.go
@@ -1600,6 +1600,14 @@ func (s *System) netplay() bool {
 	return s.rollback.session != nil || s.netConnection != nil || s.replayFile != nil
 }
 
+func (s *System) usesRollbackMatch() bool {
+	if s.replayFile != nil {
+		return false
+	}
+	return s.rollback.session != nil ||
+		(s.netConnection == nil && s.cfg.Netplay.Rollback.DesyncTestFrames > 0)
+}
+
 func (s *System) escExit() bool {
 	return s.esc && (!s.sel.gameParams.PauseMenu || !s.cfg.Config.EscOpensMenu ||
 		(s.motif.AttractMode.Enabled && s.credits == 0))
@@ -4031,7 +4039,7 @@ func (s *System) runMatch() (reload bool) {
 
 	if s.cfg.Config.TurnsLoading {
 		s.startNextTurnsPreload()
-		if (s.rollback.session != nil || s.cfg.Netplay.Rollback.DesyncTestFrames > 0) && !s.finishTurnsPreloadForRollback() {
+		if s.usesRollbackMatch() && !s.finishTurnsPreloadForRollback() {
 			return false
 		}
 	}
@@ -4042,7 +4050,7 @@ func (s *System) runMatch() (reload bool) {
 
 	// Now switch to rollback if applicable
 	// TODO: More merging so we don't hijack this function at all
-	if s.rollback.session != nil || s.cfg.Netplay.Rollback.DesyncTestFrames > 0 {
+	if s.usesRollbackMatch() {
 		return s.rollback.hijackRunMatch()
 	}
 


### PR DESCRIPTION
* Fixes not being able to delete replay after recording
* Fixes crash when loading replay with DesyncTestFrames > 0