### PR TITLE
fix: encode AI sync-test inputs correctly

### DIFF
--- a/src/rollback.go
+++ b/src/rollback.go
@@ -282,7 +282,7 @@ func (rs *RollbackSystem) updateEvents() bool {
 func getAIInputs(player int) []byte {
 	var ib InputBits
 	ib.SetInputAI(player)
-	return writeI32(int32(ib))
+	return append(encodeInputs(ib), make([]byte, 6)...)
 }
 
 func (ib *InputBits) SetInputAI(in int) {


### PR DESCRIPTION
Make DesyncTestAI produce the 8-byte input format expected by GGPO’s local sync test.