### PR TITLE
fix: compatibility with poor AIR syntax

### DIFF
--- a/src/anim.go
+++ b/src/anim.go
@@ -1171,8 +1171,6 @@ func (at AnimationTable) readAction(sff *Sff, pal *PaletteList, lines []string, 
 				}
 				return existing
 			}
-			// Store the new animation in the table.
-			at.anims[no] = a
 			// Recursive logic until we find a non-empty animation
 			// If the current action is empty, we attempt to copy the very next action found in the file
 			logged := false
@@ -1187,6 +1185,8 @@ func (at AnimationTable) readAction(sff *Sff, pal *PaletteList, lines []string, 
 				}
 				(*i)++
 			}
+			// Store only now that the animation is fully resolved or confirmed empty
+			at.anims[no] = a
 			return a
 		} else {
 			// No action found on this line, advance to the next one


### PR DESCRIPTION
- If two duplicate "begin action" headers are found right next to each other and the first one is empty, the parser will now correctly fall through to the second action
- Fixes https://discord.com/channels/233345562261323776/282927929548210177/1546090444897910794