### PR TITLE
fix: allow excluding lua files from autoload, select screen fixes

### DIFF
--- a/external/script/main.lua
+++ b/external/script/main.lua
@@ -3986,7 +3986,11 @@ end
 local t_modules = {}
 for _, v in ipairs(getDirectoryFiles('external/mods')) do
 	if v:lower():match('%.([^%.\\/]-)$') == 'lua' then
-		table.insert(t_modules, v)
+		local fileName = v:match("[^/\\]+$") or v
+		-- Lua files prefixed with '-' are excluded from autoloading
+		if not fileName:match("^%-") then
+			table.insert(t_modules, v)
+		end
 	end
 end
 

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -2714,44 +2714,6 @@ function start.f_selectScreen()
 			animUpdate(item.anim)
 		end
 		batchDraw(staticDrawList)
-		--draw done cursors
-		for side = 1, 2 do
-			local persist = motif.select_info['p' .. side].cursor.persist 
-			local totalSelected = #start.p[side].t_selected
-			local drawnCells = {} -- Track drawn cells to avoid duplicates
-			for k, v in pairs(start.p[side].t_selected) do
-				if v.cursor ~= nil then
-					--get cell coordinates
-					local x = v.cursor[1]
-					local y = v.cursor[2]
-					local t = start.t_grid[y + 1][x + 1]
-					--retrieve proper cell coordinates in case of random selection
-					--TODO: doesn't work with slot feature
-					--if (t.char == 'randomselect' or t.hidden == 3) --[[and not gameOption('Options.Team.Duplicates')]] then
-					--	x = start.f_getCharData(v.ref).col - 1
-					--	y = start.f_getCharData(v.ref).row - 1
-					--	t = start.t_grid[y + 1][x + 1]
-					--end
-					--render only if cell is not hidden
-					if t.hidden ~= 1 and t.hidden ~= 2 then
-						local shouldDraw = false
-						if main.coop or persist then
-							shouldDraw = true
-						end
-						if start.p[side].selEnd and k == totalSelected then
-							shouldDraw = true
-						end
-						if shouldDraw then
-							local cellKey = x .. ',' .. y
-							if not drawnCells[cellKey] then
-								start.f_drawCursor(v.pn, x, y, 'done', true)
-								drawnCells[cellKey] = true
-							end
-						end
-					end
-				end
-			end
-		end
 		--team and select menu
 		if blinkCount < motif.select_info.p2.cursor.switchtime then
 			blinkCount = blinkCount + 1
@@ -2811,6 +2773,42 @@ function start.f_selectScreen()
 						end
 						if v.selectState < 4 and start.f_selGrid(start.c[v.player].cell + 1).hidden ~= 1 and not start.c[v.player].blink then
 							start.f_drawCursor(v.player, start.c[v.player].selX, start.c[v.player].selY, cursorState, false)
+						end
+					end
+				end
+			end
+			--draw done cursors
+			local persist = motif.select_info['p' .. side].cursor.persist
+			local totalSelected = #start.p[side].t_selected
+			local drawnCells = {} -- Track drawn cells to avoid duplicates
+			for k, v in pairs(start.p[side].t_selected) do
+				if v.cursor ~= nil then
+					--get cell coordinates
+					local x = v.cursor[1]
+					local y = v.cursor[2]
+					local t = start.t_grid[y + 1][x + 1]
+					--retrieve proper cell coordinates in case of random selection
+					--TODO: doesn't work with slot feature
+					--if (t.char == 'randomselect' or t.hidden == 3) --[[and not gameOption('Options.Team.Duplicates')]] then
+					--	x = start.f_getCharData(v.ref).col - 1
+					--	y = start.f_getCharData(v.ref).row - 1
+					--	t = start.t_grid[y + 1][x + 1]
+					--end
+					--render only if cell is not hidden
+					if t.hidden ~= 1 and t.hidden ~= 2 then
+						local shouldDraw = false
+						if main.coop or persist then
+							shouldDraw = true
+						end
+						if start.p[side].selEnd and k == totalSelected then
+							shouldDraw = true
+						end
+						if shouldDraw then
+							local cellKey = x .. ',' .. y
+							if not drawnCells[cellKey] then
+								start.f_drawCursor(v.pn, x, y, 'done', true)
+								drawnCells[cellKey] = true
+							end
 						end
 					end
 				end

--- a/external/script/start.lua
+++ b/external/script/start.lua
@@ -2766,44 +2766,52 @@ function start.f_selectScreen()
 				--for each player with active controls
 				for k, v in ipairs(start.p[side].t_selCmd) do
 					local member = main.f_tableLength(start.p[side].t_selected) + k
+					local activeMember = true
 					if main.coop and (side == 1 or gameMode('versuscoop')) then
 						member = k
+						if motif.select_info.coopqueue then
+							activeMember = (k == main.f_tableLength(start.p[side].t_selected) + 1)
+						end
 					end
 					--member selection
 					local drawUpdateFlag
-					v.selectState, drawUpdateFlag = start.f_selectMenu(side, v.cmd, v.player, member, v.selectState)
+					if activeMember then
+						v.selectState, drawUpdateFlag = start.f_selectMenu(side, v.cmd, v.player, member, v.selectState)
+					end
 					if drawUpdateFlag then
 						start.needUpdateDrawList = true
 					end
 					--draw active cursor
-					if side == 2 and motif.select_info.p2.cursor.blink then
-						local sameCell = false
-						for _, v2 in ipairs(start.p[1].t_selCmd) do							
-							if start.c[v.player].cell == start.c[v2.player].cell and v.selectState == 0 and v2.selectState == 0 then
-								if blinkCount == 0 then
-									start.c[v.player].blink = not start.c[v.player].blink
+					if activeMember then
+						if side == 2 and motif.select_info.p2.cursor.blink then
+							local sameCell = false
+							for _, v2 in ipairs(start.p[1].t_selCmd) do							
+								if start.c[v.player].cell == start.c[v2.player].cell and v.selectState == 0 and v2.selectState == 0 then
+									if blinkCount == 0 then
+										start.c[v.player].blink = not start.c[v.player].blink
+									end
+									sameCell = true
+									break
 								end
-								sameCell = true
-								break
+							end
+							if not sameCell then
+								start.c[v.player].blink = false
 							end
 						end
-						if not sameCell then
-							start.c[v.player].blink = false
+						local cursorState = 'active'
+						if v.selectState > 0 and motif.select_info.paletteselect > 0 then
+							local cursorData = motif.select_info['p' .. side].cursor
+							if cursorData.preview and cursorData.preview.default and 
+							(cursorData.preview.default.anim ~= -1 or cursorData.preview.default.spr[1] ~= -1) then
+							--cursorState when palmenu is active
+								cursorState = 'preview'
+							else
+								cursorState = 'done'
+							end
 						end
-					end
-					local cursorState = 'active'
-					if v.selectState > 0 and motif.select_info.paletteselect > 0 then
-						local cursorData = motif.select_info['p' .. side].cursor
-						if cursorData.preview and cursorData.preview.default and 
-						(cursorData.preview.default.anim ~= -1 or cursorData.preview.default.spr[1] ~= -1) then
-						--cursorState when palmenu is active
-							cursorState = 'preview'
-						else
-							cursorState = 'done'
+						if v.selectState < 4 and start.f_selGrid(start.c[v.player].cell + 1).hidden ~= 1 and not start.c[v.player].blink then
+							start.f_drawCursor(v.player, start.c[v.player].selX, start.c[v.player].selY, cursorState, false)
 						end
-					end
-					if v.selectState < 4 and start.f_selGrid(start.c[v.player].cell + 1).hidden ~= 1 and not start.c[v.player].blink then
-						start.f_drawCursor(v.player, start.c[v.player].selX, start.c[v.player].selY, cursorState, false)
 					end
 				end
 			end

--- a/src/motif.go
+++ b/src/motif.go
@@ -762,6 +762,7 @@ type SelectInfoProperties struct {
 	} `ini:"teammenu"`
 	Timer         TimerProperties `ini:"timer"`
 	PaletteSelect int32           `ini:"paletteselect"`
+	CoopQueue     bool            `ini:"coopqueue" default:"false"`
 }
 
 type VsScreenProperties struct {

--- a/src/resources/defaultMotif.ini
+++ b/src/resources/defaultMotif.ini
@@ -659,6 +659,8 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	; 1 to allow cursor to skip over empty boxes (lookup for first valid slot)
 	searchemptyboxesup = 0
 	searchemptyboxesdown = 0
+	; 1 to allow character selection queuing in coop modes, useful for screenpacks without multiple portraits
+	coopqueue = 0
 
 	cell.size = 27, 27
 	; In Mugen spacing accepts only x value which is used for both coordinates


### PR DESCRIPTION
- Allow Lua files prefixed with `-` to be excluded from autoloading.
for example, `-module.lua` will be ignored when loading modules from `external/mods`.
- Add a new `coopqueue` parameter for character selection queuing in coop modes, allowing screenpacks with a single portrait to work as intended, fixes: https://discord.com/channels/233345562261323776/233363722934943744/1546936528578814003
- Fix a one-frame cursor blink when switching between selected members.

Screenpack PR:
https://github.com/ikemen-engine/Ikemen-GO-Screenpack/pull/80