### PR TITLE
fix: align stage WebM muting and volume with existing controls

### DIFF
--- a/src/resources/defaultMotif.ini
+++ b/src/resources/defaultMotif.ini
@@ -2973,7 +2973,7 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 	no.active.window = 
 	no.active.localcoord = 320, 240
 
-	; If set to 0, stops all player sounds and prevents new ones from starting.
+	; If set to 0, stops all player sounds, prevents new ones, and mutes stage video audio.
 	sounds.enabled = 0
 	; Enables legacy (Mugen) bare bones continue screen functionality.
 	legacymode.enabled = 1
@@ -3075,7 +3075,7 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 
 [Victory Screen]
 	enabled = 0
-	; If set to 0, stops all player sounds and prevents new ones from starting.
+	; If set to 0, stops all player sounds, prevents new ones, and mutes stage video audio.
 	sounds.enabled = 0
 	; Enables victory screen for CPU-controlled team side.
 	cpu.enabled = 1
@@ -3333,6 +3333,7 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 
 [Win Screen]
 	enabled = 1
+	; If set to 0, stops all player sounds, prevents new ones, and mutes stage video audio.
 	sounds.enabled = 0
 
 	fadein.time = 32
@@ -3406,6 +3407,7 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 
 [Survival Results Screen]
 	enabled = 1
+	; If set to 0, stops all player sounds, prevents new ones, and mutes stage video audio.
 	sounds.enabled = 0
 
 	roundstowin = 5
@@ -3465,6 +3467,7 @@ Welcome to I.K.E.M.E.N GO engine! (%s - %s)
 
 [Time Attack Results Screen]
 	enabled = 1
+	; If set to 0, stops all player sounds, prevents new ones, and mutes stage video audio.
 	sounds.enabled = 0
 
 	fadein.time = 32

--- a/src/system.go
+++ b/src/system.go
@@ -158,6 +158,7 @@ type SystemStateVars struct {
 // Do not create more than 1.
 var sys = System{
 	soundMixer: &beep.Mixer{},
+	videoMixer: &beep.Mixer{},
 	bgm:        *newBgm(),
 	//soundChannels: newSoundChannels(16), // Lazy allocation in Request()
 	allPalFX: newPalFX(),
@@ -223,6 +224,7 @@ type System struct {
 	debugRef            [2]int // player number, helper index
 	debugLastID         int32
 	soundMixer          *beep.Mixer
+	videoMixer          *beep.Mixer
 	bgm                 Bgm
 	matchMusicSel       []*bgMusic
 	pauseVolumeApplied  bool
@@ -473,6 +475,7 @@ func (s *System) init(w, h int32) *lua.LState {
 	speaker = &SDLSpeaker{}
 	speaker.Init(beep.SampleRate(sys.cfg.Sound.SampleRate), audioOutLen)
 	speaker.Play(NewNormalizer(s.soundMixer))
+	speaker.Play(s.videoMixer)
 	l := lua.NewState()
 	l.Options.IncludeGoStackTrace = true
 	l.OpenLibs()
@@ -1016,6 +1019,16 @@ func (s *System) tickSound() {
 	if !s.noCharSoundFlg {
 		for i := range sys.charSoundChannels {
 			sys.charSoundChannels[i].Tick()
+		}
+	}
+
+	// Stage video audio follows character muting, including post-match sounds.enabled.
+	if s.stage != nil {
+		for _, b := range s.stage.bg {
+			if b != nil && b.video != nil {
+				b.video.muted = s.noCharSoundFlg || s.nomusic
+				b.video.updateAudioVolume()
+			}
 		}
 	}
 
@@ -2323,7 +2336,10 @@ func (s *System) clearMatchSound() {
 
 func (s *System) clearAllSound() {
 	s.soundChannels.StopAll()
-	s.soundMixer.Clear()
+	WithSpeakerLock(func() {
+		s.soundMixer.Clear()
+		s.videoMixer.Clear()
+	})
 	s.clearMatchSound()
 }
 

--- a/src/video_ffmpeg.go
+++ b/src/video_ffmpeg.go
@@ -38,6 +38,7 @@ type bgVideo struct {
 	flag            BgVideoScaleFilter
 	playing         bool
 	visible         bool
+	muted           bool
 	videoCtrl       *beep.Ctrl
 	videoVol        *effects.Volume
 	audioSampleRate beep.SampleRate
@@ -206,7 +207,7 @@ func (bgv *bgVideo) Open(filename string, volume int, sm BgVideoScaleMode, sf Bg
 	if len(audioStreams) > 0 {
 		if err := audioStreams[0].Open(); err == nil {
 			bgv.audioStream = audioStreams[0]
-			// Build an independent chain mixed into sys.soundMixer
+			// Bypass WAV normalization: video audio uses BGM/master volume only.
 			bgv.audioSampleRate = beep.SampleRate(audioStreams[0].SampleRate())
 			rs := &reisenAudioStreamer{ch: bgv.audioBuffer}
 			bgv.videoVol = &effects.Volume{Streamer: rs, Base: 2}
@@ -216,7 +217,7 @@ func (bgv *bgVideo) Open(filename string, volume int, sm BgVideoScaleMode, sf Bg
 			bgv.videoCtrl = &beep.Ctrl{Streamer: resampler, Paused: true} // start paused until SetPlaying(true)
 
 			WithSpeakerLock(func() {
-				sys.soundMixer.Add(bgv.videoCtrl)
+				sys.videoMixer.Add(bgv.videoCtrl)
 			})
 
 			bgv.inMixer = true
@@ -490,6 +491,8 @@ func (bgv *bgVideo) Tick() error {
 
 // SetPlaying toggles decode/audio production and (re)anchors the pacing clock.
 func (bgv *bgVideo) SetPlaying(on bool) {
+	// Refresh even when playback state is unchanged (e.g. volume menu changes).
+	bgv.updateAudioVolume()
 	// If the decode goroutine has already exited (EOF or Close), do not try to
 	// "resume" a dead stream (can happen on pause/unpause or BGCtrl toggles).
 	if bgv.done != nil {
@@ -512,7 +515,7 @@ func (bgv *bgVideo) SetPlaying(on bool) {
 		// Ensure we're attached to the mixer (it may have been cleared).
 		if bgv.videoCtrl != nil && !bgv.inMixer {
 			WithSpeakerLock(func() {
-				sys.soundMixer.Add(bgv.videoCtrl)
+				sys.videoMixer.Add(bgv.videoCtrl)
 			})
 			bgv.inMixer = true
 		}
@@ -706,20 +709,23 @@ func (bgv *bgVideo) updateAudioVolume() {
 		return
 	}
 	// Match BGM.UpdateVolume logic:
+	volume := Min(bgv.volume, sys.cfg.Sound.MaxBGMVolume)
 	vol := -5 + float64(sys.cfg.Sound.BGMVolume)*0.06*
 		(float64(sys.cfg.Sound.MasterVolume)/100.0)*
-		(float64(bgv.volume)/100.0)
+		(float64(volume)/100.0)
 	if vol >= 1 {
 		vol = 1
 	}
-	silent := vol <= -5
+	_, noMusic := sys.cmdFlags["-nomusic"]
+	_, noSound := sys.cmdFlags["-nosound"]
+	silent := vol <= -5 || bgv.muted || !bgv.visible || noMusic || noSound
 	WithSpeakerLock(func() {
 		bgv.videoVol.Volume = vol
 		bgv.videoVol.Silent = silent
 	})
 }
 
-// MixerCleared should be called when sys.soundMixer.Clear() is executed,
+// MixerCleared should be called when sys.videoMixer.Clear() is executed,
 // so the next SetPlaying(true) can re-attach this stream.
 func (bgv *bgVideo) MixerCleared() {
 	bgv.inMixer = false


### PR DESCRIPTION
Honor motif sounds.enabled for stage WebM audio and apply BGM/master volume without additional SFX scaling.
Fixes https://github.com/ikemen-engine/Ikemen-GO/issues/3981
Fixes https://github.com/ikemen-engine/Ikemen-GO/discussions/3983