### PR TITLE
fix: guard and recovery frame timing

### DIFF
--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -10653,7 +10653,7 @@ func (sc stateTypeSet) Run(c *Char, _ []int32) bool {
 		case stateTypeSet_statetype:
 			crun.ss.changeStateType(StateType(exp[0].evalI(c)))
 		case stateTypeSet_movetype:
-			crun.changeMoveType(MoveType(exp[0].evalI(c)), true)
+			crun.ss.changeMoveType(MoveType(exp[0].evalI(c)))
 		case stateTypeSet_physics:
 			crun.ss.physics = StateType(exp[0].evalI(c))
 		}

--- a/src/bytecode.go
+++ b/src/bytecode.go
@@ -10653,7 +10653,7 @@ func (sc stateTypeSet) Run(c *Char, _ []int32) bool {
 		case stateTypeSet_statetype:
 			crun.ss.changeStateType(StateType(exp[0].evalI(c)))
 		case stateTypeSet_movetype:
-			crun.ss.changeMoveType(MoveType(exp[0].evalI(c)))
+			crun.changeMoveType(MoveType(exp[0].evalI(c)), true)
 		case stateTypeSet_physics:
 			crun.ss.physics = StateType(exp[0].evalI(c))
 		}
@@ -15532,10 +15532,7 @@ func (sb *StateBytecode) init(c *Char) {
 
 	// MoveType
 	if sb.moveType != MT_U {
-		if !c.ss.storeMoveType {
-			c.ss.prevMoveType = c.ss.moveType
-		}
-		c.ss.moveType = sb.moveType
+		c.changeMoveType(sb.moveType, !c.ss.storeMoveType)
 	}
 	c.ss.storeMoveType = false
 

--- a/src/char.go
+++ b/src/char.go
@@ -3200,6 +3200,7 @@ func (ss *StateState) changeStateType(t StateType) {
 
 func (ss *StateState) changeMoveType(t MoveType) {
 	ss.prevMoveType = ss.moveType
+	ss.cancelPendingMoveType()
 	ss.moveType = t
 }
 func (ss *StateState) deferMoveTypeChange(t MoveType) {
@@ -3236,7 +3237,6 @@ func (c *Char) changeMoveType(t MoveType, updatePrev bool) {
 
 func (ss *StateState) clear() {
 	ss.deferMoveType = false
-	ss.cancelPendingMoveType()
 	ss.changeStateType(ST_S)
 	ss.changeMoveType(MT_I)
 	ss.physics = ST_N
@@ -11018,7 +11018,7 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 				if !hd.KeepState && getter.stateChange1(hd.p2stateno, pn) {
 					// In Mugen, using p2stateno forces movetype to H
 					// https://github.com/ikemen-engine/Ikemen-GO/issues/2466
-					getter.changeMoveType(MT_H, true)
+					getter.ss.changeMoveType(MT_H)
 					getter.setCtrl(false)
 					p2s = true
 					getter.hoverIdx = -1
@@ -12621,7 +12621,7 @@ func (c *Char) tick() {
 	if c.csf(CSF_gethit) && !c.hoverKeepState && !c.ghv.keepstate {
 		// This flag prevents prevMoveType from being changed twice
 		c.ss.storeMoveType = true
-		c.changeMoveType(MT_H, true)
+		c.ss.changeMoveType(MT_H)
 		//if c.hitPauseTime > 0 {
 		//	c.ss.clearHitPauseExecutionToggleFlags()
 		//}

--- a/src/char.go
+++ b/src/char.go
@@ -3177,16 +3177,19 @@ func newCharGlobalInfo() CharGlobalInfo {
 
 // StateState contains the state variables like stateNo, prevStateNo, time, stateType, moveType, and physics of the current state.
 type StateState struct {
-	stateType     StateType
-	prevStateType StateType
-	moveType      MoveType
-	prevMoveType  MoveType
-	storeMoveType bool
-	physics       StateType
-	ps            []int32
-	no, prevno    int32
-	time          int32
-	sb            StateBytecode
+	stateType       StateType
+	prevStateType   StateType
+	moveType        MoveType
+	prevMoveType    MoveType
+	storeMoveType   bool
+	pendingMoveType MoveType
+	moveTypePending bool
+	deferMoveType   bool
+	physics         StateType
+	ps              []int32
+	no, prevno      int32
+	time            int32
+	sb              StateBytecode
 	//hitPauseExecutionToggleFlags [MaxPlayerNo][]bool // Flags if an sctrl runs during a hit pause on the current tick.
 }
 
@@ -3199,8 +3202,41 @@ func (ss *StateState) changeMoveType(t MoveType) {
 	ss.prevMoveType = ss.moveType
 	ss.moveType = t
 }
+func (ss *StateState) deferMoveTypeChange(t MoveType) {
+	ss.pendingMoveType = t
+	ss.moveTypePending = true
+}
+
+func (ss *StateState) cancelPendingMoveType() {
+	ss.pendingMoveType = MT_U
+	ss.moveTypePending = false
+}
+
+func (ss *StateState) commitPendingMoveType() {
+	if !ss.moveTypePending {
+		return
+	}
+	ss.moveType = ss.pendingMoveType
+	ss.cancelPendingMoveType()
+}
+
+// changeMoveType applies runtime MoveType changes. During the recovery frame,
+// H -> I is deferred when control is restored after negative states have run
+func (c *Char) changeMoveType(t MoveType, updatePrev bool) {
+	if updatePrev {
+		c.ss.prevMoveType = c.ss.moveType
+	}
+	if c.ss.deferMoveType && c.ss.moveType == MT_H && t == MT_I && c.scf(SCF_ctrl) {
+		c.ss.deferMoveTypeChange(t)
+		return
+	}
+	c.ss.cancelPendingMoveType()
+	c.ss.moveType = t
+}
 
 func (ss *StateState) clear() {
+	ss.deferMoveType = false
+	ss.cancelPendingMoveType()
 	ss.changeStateType(ST_S)
 	ss.changeMoveType(MT_I)
 	ss.physics = ST_N
@@ -6563,6 +6599,12 @@ func (c *Char) stateChange1(no int32, pn int) bool {
 		sys.appendToConsole(c.warn() + fmt.Sprintf("state machine stuck in loop (stopped after %v loops): %v -> %v -> %v", sys.changeStateNest, c.ss.prevno, c.ss.no, no))
 		LogMessage("Maximum ChangeState loops: %v, %v, %v -> %v -> %v", sys.changeStateNest, c.name, c.ss.prevno, c.ss.no, no)
 		return false
+	}
+
+	// A state change outside the deferred recovery phase supersedes any
+	// H -> I transition that was waiting for the next tick.
+	if !c.ss.deferMoveType {
+		c.ss.cancelPendingMoveType()
 	}
 
 	c.ss.prevno = c.ss.no
@@ -10976,7 +11018,7 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 				if !hd.KeepState && getter.stateChange1(hd.p2stateno, pn) {
 					// In Mugen, using p2stateno forces movetype to H
 					// https://github.com/ikemen-engine/Ikemen-GO/issues/2466
-					getter.ss.changeMoveType(MT_H)
+					getter.changeMoveType(MT_H, true)
 					getter.setCtrl(false)
 					p2s = true
 					getter.hoverIdx = -1
@@ -11176,10 +11218,6 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 				if ghv.hittime < 0 {
 					ghv.hittime = 0
 				}
-				// This compensates for characters being able to guard one frame sooner in Ikemen than in Mugen
-				if c.stWgi().ikemenver[0] == 0 && c.stWgi().ikemenver[1] == 0 && ghv.hittime > 0 {
-					ghv.hittime += 1
-				}
 				if getterInCombo {
 					ghv.hitcount++
 				} else {
@@ -11323,6 +11361,8 @@ func (c *Char) hitResultCheck(getter *Char, proj *Projectile) (hitResult int32) 
 		if !p2s && !getter.csf(CSF_gethit) {
 			getter.stchtmp = false
 		}
+		// A new hit supersedes a deferred recovery transition
+		getter.ss.cancelPendingMoveType()
 		// Flag enemy as getting hit
 		getter.setCSF(CSF_gethit)
 		getter.ghv.frame = true
@@ -11923,6 +11963,11 @@ func (c *Char) actionRun() {
 	if c.minus != 3 || c.csf(CSF_destroy) || c.scf(SCF_disabled) {
 		return
 	}
+	// Deferred MoveType changes are only armed after negative states have run.
+	c.ss.deferMoveType = false
+	ctrlAtCurrentStart := c.scf(SCF_ctrl)
+	stateAtCurrentStart := c.ss.no
+
 	// Run state -4
 	c.minus = -4
 	if sb, ok := c.gi().states[-4]; ok {
@@ -11952,6 +11997,12 @@ func (c *Char) actionRun() {
 		}
 		// Change into buffered state
 		c.stateChange2()
+
+		//  If a character is still uncontrollable and in MoveType H here, defer a later H -> I transition
+		ctrlAtCurrentStart = c.scf(SCF_ctrl)
+		stateAtCurrentStart = c.ss.no
+		c.ss.deferMoveType = c.ss.moveType == MT_H && !ctrlAtCurrentStart
+
 		// Run current state
 		c.minus = 0
 		c.ss.sb.run(c)
@@ -11959,7 +12010,15 @@ func (c *Char) actionRun() {
 
 	// Guarding instructions
 	c.unsetSCF(SCF_guard)
-	if ((c.scf(SCF_ctrl) || c.ss.no == 52) &&
+	guardCtrl := c.scf(SCF_ctrl)
+	landingGuard := c.ss.no == 52
+	if !c.pauseBool {
+		// Control acquired by Current State cannot retroactively make this frame
+		// guardable. Control lost by Current State must also be respected.
+		guardCtrl = ctrlAtCurrentStart && c.scf(SCF_ctrl)
+		landingGuard = landingGuard || stateAtCurrentStart == 52 && c.scf(SCF_ctrl)
+	}
+	if ((guardCtrl || landingGuard) &&
 		c.ss.moveType == MT_I || c.inGuardState()) && c.cmd != nil &&
 		(c.cmd[0].Buffer.Bb > 0 || c.asf(ASF_autoguard)) &&
 		(c.ss.stateType == ST_S && !c.asf(ASF_nostandguard) ||
@@ -12123,10 +12182,9 @@ func (c *Char) actionRun() {
 					c.ghv.down_recovertime = c.gi().data.liedown.time
 					// Mugen specifically resets this one for some reason
 					c.ghv.fall_envshake_time = 0
-					// In Mugen, when returning to idle, characters cannot act until the next frame
-					// To account for this, combos in Mugen linger one frame longer than they normally would in a fighting game
-					// Ikemen's "fake combo" code used to replicate this behavior
-					// After guarding was adjusted so that chars could guard when returning to idle, the fake combo code became obsolete
+					// In Mugen, when returning to idle, characters cannot act until the next frame.
+					// Ikemen keeps MoveType H through that recovery frame, so hit and combo data
+					// remain valid until the character actually gets an input opportunity.
 					// https://github.com/ikemen-engine/Ikemen-GO/issues/597
 					//if c.comboExtraFrameWindow <= 0 {
 					//	c.fakeReceivedHits = 0
@@ -12187,6 +12245,8 @@ func (c *Char) actionRun() {
 	}
 
 	c.acttmp += int8(Btoi(!c.pause() && !c.hitPause())) - int8(Btoi(c.hitPause()))
+	// State changes after this point are outside the recovery deferral phase
+	c.ss.deferMoveType = false
 	// Signal that "actionRun" has finished
 	c.minus = 1
 }
@@ -12561,7 +12621,7 @@ func (c *Char) tick() {
 	if c.csf(CSF_gethit) && !c.hoverKeepState && !c.ghv.keepstate {
 		// This flag prevents prevMoveType from being changed twice
 		c.ss.storeMoveType = true
-		c.ss.changeMoveType(MT_H)
+		c.changeMoveType(MT_H, true)
 		//if c.hitPauseTime > 0 {
 		//	c.ss.clearHitPauseExecutionToggleFlags()
 		//}
@@ -13320,6 +13380,10 @@ func (cl *CharList) commandUpdate() {
 }
 
 func (cl *CharList) updateRunOrder() {
+	// Commit deferred MoveType changes before using MoveType to determine run order.
+	for _, c := range cl.runOrder {
+		c.ss.commitPendingMoveType()
+	}
 	// Decide priority of each player
 	getPriority := func(c *Char) int {
 		// Any character with runfirst flag


### PR DESCRIPTION
Fixes #3916

・Prevent Ctrl gained during the current state from enabling guard on the same frame. 
・Keep MoveType = H until the next tick when recovering after negative states have already run. 
・Remove the legacy hittime + 1 compensation, which is no longer needed.

Guard evaluation still happens after state processing, so the MUGEN behavior where a character can guard on the first frame of an attack remains fixed.